### PR TITLE
fix(cli): harden browser-session auth imports

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -608,6 +608,36 @@ components:
       x-prefix: Klaviyo-API-Key
 ```
 
+### `x-auth-basic-username` / `x-auth-basic-password`
+
+Declares the literal username or password half for HTTP Basic auth schemes
+where only the other half should be supplied by the user.
+
+Parsed field: `APISpec.Auth.Format`
+
+Rules:
+- Optional.
+- Only read for OpenAPI `http` security schemes with `scheme: basic`.
+- Must be a string.
+- Leading and trailing whitespace is trimmed.
+- When only `x-auth-basic-username` is present, the parser stores
+  `"Basic <username>:{token}"` in `Auth.Format`.
+- When only `x-auth-basic-password` is present, the parser stores
+  `"Basic {token}:<password>"` in `Auth.Format`.
+- If both are present or both are absent, the normal Basic auth format remains
+  `"Basic {username}:{password}"`.
+
+Example:
+
+```yaml
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+      x-auth-basic-username: API_KEY
+```
+
 ### `x-auth-env-vars`
 
 Overrides the generated credential environment variable names.

--- a/internal/generator/auth0_spa_test.go
+++ b/internal/generator/auth0_spa_test.go
@@ -45,6 +45,10 @@ func TestGenerateAuth0SPAEmitsCDPLoginCmd(t *testing.T) {
 		"auth.go should enable the Fetch domain for outbound interception")
 	assert.Contains(t, authGo, "EventRequestPaused",
 		"auth.go should listen for paused requests to read the Authorization header")
+	assert.Contains(t, authGo, "auth0SPACaptureURL()",
+		"auth.go should derive a navigation target from the spec")
+	assert.Contains(t, authGo, "chromedp.Navigate(captureURL)",
+		"CDP capture should navigate the controlled tab so the Fetch interceptor observes that tab's authenticated traffic")
 
 	// --auth0-spa flag must be wired.
 	assert.Contains(t, authGo, `"auth0-spa"`,

--- a/internal/generator/auth_cookies_file_test.go
+++ b/internal/generator/auth_cookies_file_test.go
@@ -41,6 +41,7 @@ func TestCookieAuthLoginEmitsCookiesFileImport(t *testing.T) {
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -82,6 +83,17 @@ func TestLoadCookiesFromFileAcceptsRawCookieHeader(t *testing.T) {
 		t.Fatalf("Cookies len = %d, want 2", len(got.Cookies))
 	}
 }
+
+func TestLoadCookiesFromFileRejectsEmptyStorageState(t *testing.T) {
+	path := t.TempDir() + "/state.json"
+	if err := os.WriteFile(path, []byte(` + "`" + `{"cookies":[]}` + "`" + `), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := loadCookiesFromFile(path, ".example.com")
+	if err == nil || !strings.Contains(err.Error(), "empty cookies array") {
+		t.Fatalf("err = %v, want empty cookies array error", err)
+	}
+}
 `
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "cookies_file_test.go"), []byte(cliTest), 0o600))
 	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestLoadCookiesFromFile")
@@ -114,6 +126,7 @@ func TestSessionHandshakeLoginEmitsCookiesFileImport(t *testing.T) {
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -134,8 +147,19 @@ func TestLoadSessionCookiesFromFileRejectsBareTLDMatch(t *testing.T) {
 		t.Fatalf("Cookies = %#v, want one scoped cookie", got)
 	}
 }
+
+func TestLoadSessionCookiesFromFileRejectsEmptyStorageState(t *testing.T) {
+	path := t.TempDir() + "/state.json"
+	if err := os.WriteFile(path, []byte(` + "`" + `{"cookies":[]}` + "`" + `), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := loadSessionCookiesFromFile(path, ".query1.example.com")
+	if err == nil || !strings.Contains(err.Error(), "empty cookies array") {
+		t.Fatalf("err = %v, want empty cookies array error", err)
+	}
+}
 `
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "session_cookies_file_test.go"), []byte(cliTest), 0o600))
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestLoadSessionCookiesFromFileRejectsBareTLDMatch")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestLoadSessionCookiesFromFile")
 	requireGeneratedCompiles(t, outputDir)
 }

--- a/internal/generator/auth_cookies_file_test.go
+++ b/internal/generator/auth_cookies_file_test.go
@@ -1,0 +1,112 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCookieAuthLoginEmitsCookiesFileImport(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("cookiefile")
+	apiSpec.BaseURL = "https://www.example.com"
+	apiSpec.Auth = spec.AuthConfig{
+		Type:         "cookie",
+		Header:       "Cookie",
+		In:           "cookie",
+		CookieDomain: ".example.com",
+		Cookies:      []string{"session_id", "csrf"},
+		EnvVars:      []string{"COOKIEFILE_SESSION"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "cookiefile-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	authGo := readGeneratedFile(t, outputDir, "internal", "cli", "auth.go")
+	assert.Contains(t, authGo, `"cookies-file"`)
+	assert.Contains(t, authGo, "loadCookiesFromFile(cookiesFile, domain)")
+	assert.Contains(t, authGo, "parseCookieHeaderCookies")
+	assert.Contains(t, authGo, "cookieDomainMatches")
+	assert.Contains(t, authGo, "client.WriteCookieJarFromMap(domain, jarCookies)")
+
+	readme := readGeneratedFile(t, outputDir, "README.md")
+	assert.Contains(t, readme, "auth login --cookies-file storage-state.json")
+
+	cliTest := `package cli
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoadCookiesFromFileFiltersPlaywrightState(t *testing.T) {
+	path := t.TempDir() + "/state.json"
+	data := []byte(` + "`" + `{"cookies":[
+		{"name":"session_id","value":"abc","domain":".example.com","path":"/","secure":true,"httpOnly":true},
+		{"name":"other","value":"drop","domain":".not-example.com","path":"/"}
+	]}` + "`" + `)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadCookiesFromFile(path, ".example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Header != "session_id=abc" {
+		t.Fatalf("Header = %q, want session_id=abc", got.Header)
+	}
+	if len(got.Cookies) != 1 || got.Cookies[0].Name != "session_id" {
+		t.Fatalf("Cookies = %#v, want one filtered session cookie", got.Cookies)
+	}
+}
+
+func TestLoadCookiesFromFileAcceptsRawCookieHeader(t *testing.T) {
+	path := t.TempDir() + "/cookies.txt"
+	if err := os.WriteFile(path, []byte("Cookie: session_id=abc; csrf=def"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadCookiesFromFile(path, ".example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Header != "session_id=abc; csrf=def" {
+		t.Fatalf("Header = %q", got.Header)
+	}
+	if len(got.Cookies) != 2 {
+		t.Fatalf("Cookies len = %d, want 2", len(got.Cookies))
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "cookies_file_test.go"), []byte(cliTest), 0o600))
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestLoadCookiesFromFile")
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestSessionHandshakeLoginEmitsCookiesFileImport(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := canonicalSessionHandshakeSpec()
+	apiSpec.Auth.CookieDomain = ""
+	require.NoError(t, apiSpec.Validate())
+	require.Equal(t, ".query1.example.com", apiSpec.Auth.CookieDomain)
+
+	outputDir := filepath.Join(t.TempDir(), "sessionfile-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	authGo := readGeneratedFile(t, outputDir, "internal", "cli", "auth.go")
+	assert.Contains(t, authGo, "newAuthLoginCmd(flags)")
+	assert.Contains(t, authGo, `"cookies-file"`)
+	assert.Contains(t, authGo, "loadSessionCookiesFromFile")
+	assert.Contains(t, authGo, `c.Session.ImportSession("https://query1.example.com", imported, "")`)
+	assert.Contains(t, authGo, "c.Session.EnsureToken()")
+
+	sessionGo := readGeneratedFile(t, outputDir, "internal", "client", "session.go")
+	assert.Contains(t, sessionGo, "strings.TrimPrefix(ck.Domain, \".\")")
+
+	requireGeneratedCompiles(t, outputDir)
+}

--- a/internal/generator/auth_cookies_file_test.go
+++ b/internal/generator/auth_cookies_file_test.go
@@ -48,6 +48,7 @@ func TestLoadCookiesFromFileFiltersPlaywrightState(t *testing.T) {
 	path := t.TempDir() + "/state.json"
 	data := []byte(` + "`" + `{"cookies":[
 		{"name":"session_id","value":"abc","domain":".example.com","path":"/","secure":true,"httpOnly":true},
+		{"name":"tld","value":"drop","domain":".com","path":"/"},
 		{"name":"other","value":"drop","domain":".not-example.com","path":"/"}
 	]}` + "`" + `)
 	if err := os.WriteFile(path, data, 0o600); err != nil {
@@ -102,11 +103,39 @@ func TestSessionHandshakeLoginEmitsCookiesFileImport(t *testing.T) {
 	assert.Contains(t, authGo, "newAuthLoginCmd(flags)")
 	assert.Contains(t, authGo, `"cookies-file"`)
 	assert.Contains(t, authGo, "loadSessionCookiesFromFile")
+	assert.Contains(t, authGo, `strings.Contains(candidate, ".") && strings.HasSuffix(target, "."+candidate)`)
 	assert.Contains(t, authGo, `c.Session.ImportSession("https://query1.example.com", imported, "")`)
 	assert.Contains(t, authGo, "c.Session.EnsureToken()")
 
 	sessionGo := readGeneratedFile(t, outputDir, "internal", "client", "session.go")
 	assert.Contains(t, sessionGo, "strings.TrimPrefix(ck.Domain, \".\")")
 
+	cliTest := `package cli
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoadSessionCookiesFromFileRejectsBareTLDMatch(t *testing.T) {
+	path := t.TempDir() + "/state.json"
+	data := []byte(` + "`" + `{"cookies":[
+		{"name":"session","value":"drop","domain":".com","path":"/"},
+		{"name":"crumb","value":"abc","domain":".query1.example.com","path":"/"}
+	]}` + "`" + `)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadSessionCookiesFromFile(path, ".query1.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Name != "crumb" {
+		t.Fatalf("Cookies = %#v, want one scoped cookie", got)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "session_cookies_file_test.go"), []byte(cliTest), 0o600))
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestLoadSessionCookiesFromFileRejectsBareTLDMatch")
 	requireGeneratedCompiles(t, outputDir)
 }

--- a/internal/generator/client_cookie_jar_seed_test.go
+++ b/internal/generator/client_cookie_jar_seed_test.go
@@ -64,10 +64,12 @@ func TestCookieAuthClientSeedsJar(t *testing.T) {
 	runtimeTest := `package client
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -138,6 +140,42 @@ func TestLooksLikeCookieJarRejectsJWT(t *testing.T) {
 	}
 	if !looksLikeCookieJar("session_id=abc") {
 		t.Fatalf("a single legit name=value cookie must still pass the gate")
+	}
+}
+
+func TestWriteCookieJarReplacesWWWShadow(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	path := cookieJarPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	stale := []persistedCookie{{
+		Name:   "session_id",
+		Value:  "",
+		Domain: ".www.cookieseed.example",
+		Path:   "/",
+		Secure: true,
+	}}
+	data, err := json.Marshal(stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCookieJarFromMap(".cookieseed.example", map[string]string{"session_id": "fresh"}); err != nil {
+		t.Fatal(err)
+	}
+	afterData, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var after []persistedCookie
+	if err := json.Unmarshal(afterData, &after); err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != 1 || after[0].Domain != ".cookieseed.example" || after[0].Value != "fresh" {
+		t.Fatalf("shadowing www cookie was not replaced: %#v", after)
 	}
 }
 `

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -1932,7 +1932,10 @@ func loadCookiesFromFile(path string, domain string) (importedCookieFile, error)
 			HTTPOnly bool    `json:"httpOnly"`
 		} `json:"cookies"`
 	}
-	if err := json.Unmarshal(data, &state); err == nil && len(state.Cookies) > 0 {
+	if err := json.Unmarshal(data, &state); err == nil {
+		if len(state.Cookies) == 0 {
+			return importedCookieFile{}, fmt.Errorf("cookies file contains an empty cookies array")
+		}
 		parts := make([]string, 0, len(state.Cookies))
 		cookies := make([]*http.Cookie, 0, len(state.Cookies))
 		for _, c := range state.Cookies {

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -117,6 +117,7 @@ func requiredAuthCookies() []string {
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 	var browserFlag bool
 	var profileFlag string
+	var cookiesFile string
 
 	cmd := &cobra.Command{
 		Use:   "login",
@@ -125,6 +126,7 @@ func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 
 Use --chrome to read cookies from Chrome for {{.Auth.CookieDomain}}.
 Use --browser as an alias for --chrome.
+Use --cookies-file to import Playwright storage-state JSON or a raw Cookie header file.
 Requires a cookie extraction tool (pycookiecheat, cookies, or cookie-scoop-cli).
 
 If you have multiple Chrome profiles, pycookiecheat and cookie-scoop-cli can
@@ -132,13 +134,20 @@ auto-detect which profile is logged in. Use --profile to select a specific
 profile by name when the installed backend supports it.`,
 		Example: `  {{.Name}}-pp-cli auth login --chrome
   {{.Name}}-pp-cli auth login --browser
+  {{.Name}}-pp-cli auth login --cookies-file storage-state.json
   {{.Name}}-pp-cli auth login --chrome --profile "Work"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !browserFlag {
-				fmt.Fprintln(cmd.OutOrStdout(), "Use --chrome or --browser to authenticate from your browser session:")
+			w := cmd.OutOrStdout()
+			domain := "{{.Auth.CookieDomain}}"
+			if !browserFlag && cookiesFile == "" {
+				fmt.Fprintln(w, "Use --chrome, --browser, or --cookies-file to authenticate from your browser session:")
 				fmt.Fprintf(cmd.OutOrStdout(), "  {{.Name}}-pp-cli auth login --chrome\n")
 				fmt.Fprintf(cmd.OutOrStdout(), "  {{.Name}}-pp-cli auth login --browser\n")
+				fmt.Fprintf(cmd.OutOrStdout(), "  {{.Name}}-pp-cli auth login --cookies-file storage-state.json\n")
 				return nil
+			}
+			if browserFlag && cookiesFile != "" {
+				return authErr(fmt.Errorf("choose either --chrome/--browser or --cookies-file, not both"))
 			}
 
 {{- with $canonicalEnvVar}}
@@ -148,9 +157,6 @@ profile by name when the installed backend supports it.`,
 				return nil
 			}
 {{- end}}
-
-			w := cmd.OutOrStdout()
-			domain := "{{.Auth.CookieDomain}}"
 
 			// Step 0: Try press-auth, the dedicated cookie capture companion.
 			// press-auth spawns its own controlled Chrome window so users do
@@ -163,6 +169,17 @@ profile by name when the installed backend supports it.`,
 			// are already on disk.
 			var cookies string
 			fromPressAuth := false
+			fromCookiesFile := false
+			if cookiesFile != "" {
+				imported, err := loadCookiesFromFile(cookiesFile, domain)
+				if err != nil {
+					return authErr(err)
+				}
+				cookies = imported.Header
+				fromCookiesFile = true
+				fmt.Fprintf(w, "Loaded cookies from %s for %s.\n", cookiesFile, domain)
+			}
+			if !fromCookiesFile {
 			if pressAuthPath, err := exec.LookPath("press-auth"); err == nil {
 				paCookies, paErr := tryPressAuth(pressAuthPath, domain)
 				if paErr == nil && paCookies != "" {
@@ -176,8 +193,9 @@ profile by name when the installed backend supports it.`,
 					fmt.Fprintf(w, "\n  press-auth login %s --login-url <login-url>\n\n", domain)
 				}
 			}
+			}
 
-			if !fromPressAuth {
+			if !fromPressAuth && !fromCookiesFile {
 			// Step 1: Detect cookie extraction tool
 			tool, err := detectCookieTool()
 			if err != nil {
@@ -424,6 +442,7 @@ profile by name when the installed backend supports it.`,
 	cmd.Flags().BoolVar(&browserFlag, "chrome", false, "Read cookies from Chrome")
 	cmd.Flags().BoolVar(&browserFlag, "browser", false, "Alias for --chrome")
 	cmd.Flags().StringVar(&profileFlag, "profile", "", "Chrome profile name (e.g. \"Work\", \"Personal\")")
+	cmd.Flags().StringVar(&cookiesFile, "cookies-file", "", "Import cookies from a Playwright storage-state JSON file or raw Cookie header file")
 	return cmd
 }
 {{- else if $hasAuth0SPA}}
@@ -495,7 +514,7 @@ when the CDP path is not available (other machine, headless server, etc.).`,
 				return nil
 			}
 
-			token, err := captureAuth0SPABearer(cmd.Context(), debugPort, targetOrigin, captureTimeout, w)
+			token, err := captureAuth0SPABearer(cmd.Context(), debugPort, targetOrigin, auth0SPACaptureURL(), captureTimeout, w)
 			if err != nil {
 				fmt.Fprintln(w, red("Could not capture a bearer from Chrome via CDP."))
 				fmt.Fprintln(w, "")
@@ -545,7 +564,19 @@ when the CDP path is not available (other machine, headless server, etc.).`,
 // the Auth0 SPA SDK actively hides the token from window-scope access, and
 // any extraction script would be brittle across SDK versions. Intercepting
 // the outbound header is the SDK's own injection point and is stable.
-func captureAuth0SPABearer(parent context.Context, debugPort int, targetOrigin string, timeout time.Duration, w io.Writer) (string, error) {
+func auth0SPACaptureURL() string {
+	baseURL := strings.TrimRight("{{.BaseURL}}", "/")
+	path := strings.TrimSpace("{{.HealthCheckPath}}")
+	if path == "" {
+		return baseURL
+	}
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return path
+	}
+	return baseURL + "/" + strings.TrimLeft(path, "/")
+}
+
+func captureAuth0SPABearer(parent context.Context, debugPort int, targetOrigin string, captureURL string, timeout time.Duration, w io.Writer) (string, error) {
 	if timeout <= 0 {
 		timeout = 90 * time.Second
 	}
@@ -601,6 +632,12 @@ func captureAuth0SPABearer(parent context.Context, debugPort int, targetOrigin s
 	fmt.Fprintf(w, "Attaching to Chrome at %s (waiting up to %s for an authenticated request)...\n", remoteURL, timeout)
 	if err := chromedp.Run(ctx, fetch.Enable()); err != nil {
 		return "", fmt.Errorf("enabling Fetch domain: %w", err)
+	}
+	if captureURL != "" {
+		fmt.Fprintf(w, "Navigating controlled tab to %s to trigger authenticated traffic...\n", captureURL)
+		if err := chromedp.Run(ctx, chromedp.Navigate(captureURL)); err != nil {
+			return "", fmt.Errorf("navigating controlled tab: %w", err)
+		}
 	}
 
 	select {
@@ -1872,6 +1909,98 @@ func extractViaCookiesCLI(domain string) (string, error) {
 	result := strings.TrimSpace(out.String())
 	result = strings.TrimPrefix(result, "Cookie: ")
 	return result, nil
+}
+
+type importedCookieFile struct {
+	Header  string
+	Cookies []*http.Cookie
+}
+
+func loadCookiesFromFile(path string, domain string) (importedCookieFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return importedCookieFile{}, fmt.Errorf("reading cookies file: %w", err)
+	}
+	var state struct {
+		Cookies []struct {
+			Name     string  `json:"name"`
+			Value    string  `json:"value"`
+			Domain   string  `json:"domain"`
+			Path     string  `json:"path"`
+			Expires  float64 `json:"expires"`
+			Secure   bool    `json:"secure"`
+			HTTPOnly bool    `json:"httpOnly"`
+		} `json:"cookies"`
+	}
+	if err := json.Unmarshal(data, &state); err == nil && len(state.Cookies) > 0 {
+		parts := make([]string, 0, len(state.Cookies))
+		cookies := make([]*http.Cookie, 0, len(state.Cookies))
+		for _, c := range state.Cookies {
+			if !cookieDomainMatches(c.Domain, domain) {
+				continue
+			}
+			name := strings.TrimSpace(c.Name)
+			if name == "" {
+				continue
+			}
+			path := c.Path
+			if path == "" {
+				path = "/"
+			}
+			ck := &http.Cookie{
+				Name:     name,
+				Value:    c.Value,
+				Domain:   c.Domain,
+				Path:     path,
+				Secure:   c.Secure,
+				HttpOnly: c.HTTPOnly,
+			}
+			if c.Expires > 0 {
+				ck.Expires = time.Unix(int64(c.Expires), 0)
+			}
+			cookies = append(cookies, ck)
+			parts = append(parts, name+"="+c.Value)
+		}
+		if len(parts) == 0 {
+			return importedCookieFile{}, fmt.Errorf("cookies file contains no cookies for %s", domain)
+		}
+		return importedCookieFile{Header: strings.Join(parts, "; "), Cookies: cookies}, nil
+	}
+	header := trimCookieHeaderPrefix(string(data))
+	if header == "" {
+		return importedCookieFile{}, fmt.Errorf("cookies file is empty")
+	}
+	return importedCookieFile{Header: header, Cookies: parseCookieHeaderCookies(header)}, nil
+}
+
+func trimCookieHeaderPrefix(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= len("Cookie:") && strings.EqualFold(s[:len("Cookie:")], "Cookie:") {
+		return strings.TrimSpace(s[len("Cookie:"):])
+	}
+	return s
+}
+
+func parseCookieHeaderCookies(header string) []*http.Cookie {
+	parts := strings.Split(header, ";")
+	cookies := make([]*http.Cookie, 0, len(parts))
+	for _, part := range parts {
+		name, value, ok := strings.Cut(strings.TrimSpace(part), "=")
+		if !ok || strings.TrimSpace(name) == "" {
+			continue
+		}
+		cookies = append(cookies, &http.Cookie{Name: strings.TrimSpace(name), Value: strings.TrimSpace(value), Path: "/"})
+	}
+	return cookies
+}
+
+func cookieDomainMatches(cookieDomain string, targetDomain string) bool {
+	target := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(targetDomain)), ".")
+	if target == "" {
+		return true
+	}
+	candidate := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(cookieDomain)), ".")
+	return candidate == target || strings.HasSuffix(candidate, "."+target) || strings.HasSuffix(target, "."+candidate)
 }
 
 // parseCookieString splits a "name1=value1; name2=value2" string into a map.

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -2000,7 +2000,7 @@ func cookieDomainMatches(cookieDomain string, targetDomain string) bool {
 		return true
 	}
 	candidate := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(cookieDomain)), ".")
-	return candidate == target || strings.HasSuffix(candidate, "."+target) || strings.HasSuffix(target, "."+candidate)
+	return candidate == target || strings.HasSuffix(candidate, "."+target) || (strings.Contains(candidate, ".") && strings.HasSuffix(target, "."+candidate))
 }
 
 // parseCookieString splits a "name1=value1; name2=value2" string into a map.

--- a/internal/generator/templates/auth_simple.go.tmpl
+++ b/internal/generator/templates/auth_simple.go.tmpl
@@ -268,7 +268,7 @@ func sessionCookieDomainMatches(cookieDomain string, targetDomain string) bool {
 		return true
 	}
 	candidate := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(cookieDomain)), ".")
-	return candidate == target || strings.HasSuffix(candidate, "."+target) || strings.HasSuffix(target, "."+candidate)
+	return candidate == target || strings.HasSuffix(candidate, "."+target) || (strings.Contains(candidate, ".") && strings.HasSuffix(target, "."+candidate))
 }
 
 {{- end}}

--- a/internal/generator/templates/auth_simple.go.tmpl
+++ b/internal/generator/templates/auth_simple.go.tmpl
@@ -208,7 +208,10 @@ func loadSessionCookiesFromFile(path string, domain string) ([]*http.Cookie, err
 			HTTPOnly bool    `json:"httpOnly"`
 		} `json:"cookies"`
 	}
-	if err := json.Unmarshal(data, &state); err == nil && len(state.Cookies) > 0 {
+	if err := json.Unmarshal(data, &state); err == nil {
+		if len(state.Cookies) == 0 {
+			return nil, fmt.Errorf("cookies file contains an empty cookies array")
+		}
 		cookies := make([]*http.Cookie, 0, len(state.Cookies))
 		for _, c := range state.Cookies {
 			if !sessionCookieDomainMatches(c.Domain, domain) {

--- a/internal/generator/templates/auth_simple.go.tmpl
+++ b/internal/generator/templates/auth_simple.go.tmpl
@@ -10,18 +10,31 @@ package cli
 {{- $basicAuthEnvVars := basicAuthEnvVars .Auth}}
 
 import (
+{{- if eq .Auth.Type "session_handshake"}}
+	"encoding/json"
+{{- end}}
 	"fmt"
+{{- if eq .Auth.Type "session_handshake"}}
+	"net/http"
+{{- end}}
 {{- if or .Auth.KeyURL .WebsiteURL}}
 	"os/exec"
 	"runtime"
 {{- end}}
-{{- if .Auth.EnvVars}}
+{{- if or .Auth.EnvVars (eq .Auth.Type "session_handshake")}}
 	"os"
 {{- end}}
+{{- if eq .Auth.Type "session_handshake"}}
+	"strings"
+	"time"
+{{- end}}
 
+	"github.com/spf13/cobra"
+{{- if eq .Auth.Type "session_handshake"}}
+	"{{modulePath}}/internal/client"
+{{- end}}
 	"{{modulePath}}/internal/cliutil"
 	"{{modulePath}}/internal/config"
-	"github.com/spf13/cobra"
 )
 
 func newAuthCmd(flags *rootFlags) *cobra.Command {
@@ -31,6 +44,9 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 		RunE:  parentNoSubcommandRunE(flags),
 	}
 
+{{ if eq .Auth.Type "session_handshake"}}
+	cmd.AddCommand(newAuthLoginCmd(flags))
+{{ end -}}
 	cmd.AddCommand(newAuthSetupCmd(flags))
 	cmd.AddCommand(newAuthStatusCmd(flags))
 {{- if $authSetTokenAvailable}}
@@ -134,6 +150,128 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 	cmd.Flags().BoolVar(&launch, "launch", false, "Open the setup URL in your default browser")
 	return cmd
 }
+
+{{- if eq .Auth.Type "session_handshake"}}
+
+func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
+	var cookiesFile string
+	cmd := &cobra.Command{
+		Use:     "login",
+		Short:   "Import a browser session for the session handshake",
+		Example: "  {{.Name}}-pp-cli auth login --cookies-file storage-state.json",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w := cmd.OutOrStdout()
+			if strings.TrimSpace(cookiesFile) == "" {
+				fmt.Fprintln(w, "Import browser-session cookies from Playwright storage-state JSON or a raw Cookie header file:")
+				fmt.Fprintf(w, "  {{.Name}}-pp-cli auth login --cookies-file storage-state.json\n")
+				return nil
+			}
+			imported, err := loadSessionCookiesFromFile(cookiesFile, "{{.Auth.CookieDomain}}")
+			if err != nil {
+				return authErr(err)
+			}
+			cfg, err := config.Load(flags.configPath)
+			if err != nil {
+				return configErr(err)
+			}
+			c := client.New(cfg, flags.timeout, flags.rateLimit)
+			if c.Session == nil {
+				return authErr(fmt.Errorf("session handshake manager is not configured"))
+			}
+			if err := c.Session.ImportSession("{{.BaseURL}}", imported, ""); err != nil {
+				return authErr(err)
+			}
+			if _, err := c.Session.EnsureToken(); err != nil {
+				return authErr(fmt.Errorf("fetching session token with imported cookies: %w", err))
+			}
+			fmt.Fprintf(w, "%s Imported browser-session cookies and refreshed the session token.\n", green("OK"))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&cookiesFile, "cookies-file", "", "Import cookies from a Playwright storage-state JSON file or raw Cookie header file")
+	return cmd
+}
+
+func loadSessionCookiesFromFile(path string, domain string) ([]*http.Cookie, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading cookies file: %w", err)
+	}
+	var state struct {
+		Cookies []struct {
+			Name     string  `json:"name"`
+			Value    string  `json:"value"`
+			Domain   string  `json:"domain"`
+			Path     string  `json:"path"`
+			Expires  float64 `json:"expires"`
+			Secure   bool    `json:"secure"`
+			HTTPOnly bool    `json:"httpOnly"`
+		} `json:"cookies"`
+	}
+	if err := json.Unmarshal(data, &state); err == nil && len(state.Cookies) > 0 {
+		cookies := make([]*http.Cookie, 0, len(state.Cookies))
+		for _, c := range state.Cookies {
+			if !sessionCookieDomainMatches(c.Domain, domain) {
+				continue
+			}
+			name := strings.TrimSpace(c.Name)
+			if name == "" {
+				continue
+			}
+			path := c.Path
+			if path == "" {
+				path = "/"
+			}
+			ck := &http.Cookie{Name: name, Value: c.Value, Domain: c.Domain, Path: path, Secure: c.Secure, HttpOnly: c.HTTPOnly}
+			if c.Expires > 0 {
+				ck.Expires = time.Unix(int64(c.Expires), 0)
+			}
+			cookies = append(cookies, ck)
+		}
+		if len(cookies) == 0 {
+			return nil, fmt.Errorf("cookies file contains no cookies for %s", domain)
+		}
+		return cookies, nil
+	}
+	header := trimSessionCookieHeaderPrefix(string(data))
+	cookies := parseSessionCookieHeaderCookies(header)
+	if len(cookies) == 0 {
+		return nil, fmt.Errorf("cookies file is empty")
+	}
+	return cookies, nil
+}
+
+func trimSessionCookieHeaderPrefix(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= len("Cookie:") && strings.EqualFold(s[:len("Cookie:")], "Cookie:") {
+		return strings.TrimSpace(s[len("Cookie:"):])
+	}
+	return s
+}
+
+func parseSessionCookieHeaderCookies(header string) []*http.Cookie {
+	parts := strings.Split(header, ";")
+	cookies := make([]*http.Cookie, 0, len(parts))
+	for _, part := range parts {
+		name, value, ok := strings.Cut(strings.TrimSpace(part), "=")
+		if !ok || strings.TrimSpace(name) == "" {
+			continue
+		}
+		cookies = append(cookies, &http.Cookie{Name: strings.TrimSpace(name), Value: strings.TrimSpace(value), Path: "/"})
+	}
+	return cookies
+}
+
+func sessionCookieDomainMatches(cookieDomain string, targetDomain string) bool {
+	target := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(targetDomain)), ".")
+	if target == "" {
+		return true
+	}
+	candidate := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(cookieDomain)), ".")
+	return candidate == target || strings.HasSuffix(candidate, "."+target) || strings.HasSuffix(target, "."+candidate)
+}
+
+{{- end}}
 
 {{- if or .Auth.KeyURL .WebsiteURL}}
 

--- a/internal/generator/templates/cookiejar.go.tmpl
+++ b/internal/generator/templates/cookiejar.go.tmpl
@@ -208,6 +208,19 @@ func mergeAndWriteCookieRows(path string, rows []persistedCookie) error {
 		idx[r.Domain+"|"+r.Path+"|"+r.Name] = i
 	}
 	for _, r := range rows {
+		filtered := all[:0]
+		for _, existing := range all {
+			if shouldReplaceShadowingCookie(existing, r) {
+				delete(idx, existing.Domain+"|"+existing.Path+"|"+existing.Name)
+				continue
+			}
+			filtered = append(filtered, existing)
+		}
+		all = filtered
+		idx = make(map[string]int, len(all))
+		for i, existing := range all {
+			idx[existing.Domain+"|"+existing.Path+"|"+existing.Name] = i
+		}
 		key := r.Domain + "|" + r.Path + "|" + r.Name
 		if i, ok := idx[key]; ok {
 			all[i] = r
@@ -224,6 +237,18 @@ func mergeAndWriteCookieRows(path string, rows []persistedCookie) error {
 		return err
 	}
 	return os.WriteFile(path, data, 0o600)
+}
+
+func shouldReplaceShadowingCookie(existing, incoming persistedCookie) bool {
+	if existing.Name != incoming.Name || existing.Path != incoming.Path {
+		return false
+	}
+	return normalizedWWWCookieDomain(existing.Domain) == normalizedWWWCookieDomain(incoming.Domain)
+}
+
+func normalizedWWWCookieDomain(domain string) string {
+	domain = strings.TrimPrefix(strings.ToLower(strings.TrimSpace(domain)), ".")
+	return strings.TrimPrefix(domain, "www.")
 }
 
 func (j *cookieJar) loadFromDisk() {

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -318,7 +318,13 @@ This CLI uses your browser session for authentication. Log in to {{.Auth.CookieD
 {{.Name}}-pp-cli auth login --chrome
 ```
 
-Requires a cookie extraction tool. Install one:
+Or import an existing browser capture:
+
+```bash
+{{.Name}}-pp-cli auth login --cookies-file storage-state.json
+```
+
+`--cookies-file` accepts Playwright storage-state JSON or a raw `Cookie:` header text file. The Chrome path requires a cookie extraction tool. Install one:
 
 ```bash
 pip install pycookiecheat          # Python (recommended)
@@ -326,6 +332,15 @@ brew install barnardb/cookies/cookies  # Homebrew
 ```
 
 When your session expires, run `auth login --chrome` again.
+{{- else if eq .Auth.Type "session_handshake"}}
+
+### 2. Authenticate
+
+This CLI uses a browser-backed session handshake. Import browser cookies from Playwright storage-state JSON or a raw `Cookie:` header text file:
+
+```bash
+{{.Name}}-pp-cli auth login --cookies-file storage-state.json
+```
 {{- end}}
 
 ### {{if and (ne .Auth.Type "") (ne .Auth.Type "none")}}3{{else}}2{{end}}. Verify Setup

--- a/internal/generator/templates/session_handshake.go.tmpl
+++ b/internal/generator/templates/session_handshake.go.tmpl
@@ -200,7 +200,18 @@ func (m *SessionManager) ImportSession(cookieDomain string, cookies []*http.Cook
 	if err != nil {
 		return fmt.Errorf("invalid cookie domain: %w", err)
 	}
-	m.jar.SetCookies(u, cookies)
+	for _, ck := range cookies {
+		if ck == nil {
+			continue
+		}
+		target := u
+		if ck.Domain != "" {
+			if parsed, err := url.Parse("https://" + strings.TrimPrefix(ck.Domain, ".")); err == nil {
+				target = parsed
+			}
+		}
+		m.jar.SetCookies(target, []*http.Cookie{ck})
+	}
 	m.mu.Lock()
 	m.token = token
 	m.mu.Unlock()

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -285,7 +285,20 @@ This CLI uses a browser session. Log in to {{.Auth.CookieDomain}} in Chrome, the
 {{.Name}}-pp-cli auth login --chrome
 ```
 
-Requires a cookie extraction tool (`pycookiecheat` via pip, or `cookies` via Homebrew).
+Or import an existing browser capture:
+
+```bash
+{{.Name}}-pp-cli auth login --cookies-file storage-state.json
+```
+
+`--cookies-file` accepts Playwright storage-state JSON or a raw `Cookie:` header text file. The Chrome path requires a cookie extraction tool (`pycookiecheat` via pip, or `cookies` via Homebrew).
+{{- else if eq .Auth.Type "session_handshake"}}
+
+This CLI uses a browser-backed session handshake. Import browser cookies from Playwright storage-state JSON or a raw `Cookie:` header text file:
+
+```bash
+{{.Name}}-pp-cli auth login --cookies-file storage-state.json
+```
 {{- else}}
 
 No authentication required.

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -1981,7 +1981,7 @@ func describedBasicCredentialConstant(description, field string) string {
 		}
 	}
 	parts := strings.Fields(value)
-	if len(parts) == 0 {
+	if len(parts) != 1 {
 		return ""
 	}
 	candidate := strings.Trim(parts[0], "`'\"")
@@ -1994,7 +1994,8 @@ func describedBasicCredentialConstant(description, field string) string {
 func looksLikeBasicConstant(value string) bool {
 	lower := strings.ToLower(strings.TrimSpace(value))
 	switch lower {
-	case "", "a", "an", "the", "your", "you", "username", "password", "key", "secret", "token":
+	case "", "a", "an", "the", "your", "you", "username", "password", "key", "secret", "token",
+		"always", "required", "provided", "required.", "optional", "empty", "blank":
 		return false
 	}
 	for _, r := range value {

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -49,6 +49,8 @@ const (
 	extensionAuthDescription       = "x-auth-description"
 	extensionAuthCompanion         = "x-auth-companion"
 	extensionAuthSubtype           = "x-auth-subtype"
+	extensionAuthBasicUsername     = "x-auth-basic-username"
+	extensionAuthBasicPassword     = "x-auth-basic-password"
 	extensionOAuthDeviceFlow       = "x-oauth-device-flow"
 	extensionOAuthRefreshTokenMech = "x-oauth-refresh-token-mechanism"
 	extensionSpeakeasyExample      = "x-speakeasy-example"
@@ -1133,6 +1135,7 @@ func mapAuthWithDescriptionInference(doc *openapi3.T, name string, allowDescript
 			if xFmt := stringExtension(scheme.Extensions, "x-auth-format"); xFmt != "" {
 				auth.Format = xFmt
 			}
+			applyBasicAuthConstantHints(&auth, scheme.Extensions, scheme.Description)
 		}
 	case "apikey":
 		auth.Type = "api_key"
@@ -1878,10 +1881,23 @@ func applyAuthEnvVarDefaults(auth *spec.AuthConfig, envPrefix string) {
 		if auth.Type == "cookie" || strings.EqualFold(auth.In, "cookie") {
 			envVar.Kind = spec.AuthEnvVarKindHarvested
 		}
-		if authFormatIsBasic(auth.Format) && i == 0 {
+		if authFormatIsBasic(auth.Format) && i == 0 && basicAuthFirstPlaceholderIsPublic(auth.Format) {
 			envVar.Sensitive = false
 		}
 		auth.EnvVarSpecs = append(auth.EnvVarSpecs, envVar)
+	}
+}
+
+func basicAuthFirstPlaceholderIsPublic(format string) bool {
+	matches := authFormatPlaceholderRE.FindAllStringSubmatch(format, -1)
+	if len(matches) == 0 || len(matches[0]) < 2 {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(matches[0][1])) {
+	case "username", "user":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -1914,6 +1930,80 @@ func basicAuthEnvVarsFromFormat(format, envPrefix string) []string {
 
 func authFormatIsBasic(format string) bool {
 	return strings.Contains(strings.ToLower(format), "basic ")
+}
+
+func applyBasicAuthConstantHints(auth *spec.AuthConfig, extensions map[string]any, description string) {
+	if auth == nil || !authFormatIsBasic(auth.Format) {
+		return
+	}
+	username := stringExtension(extensions, extensionAuthBasicUsername)
+	password := stringExtension(extensions, extensionAuthBasicPassword)
+	if username == "" && password == "" {
+		username = describedBasicCredentialConstant(description, "username")
+		password = describedBasicCredentialConstant(description, "password")
+	}
+	switch {
+	case username != "" && password == "":
+		auth.Format = "Basic " + username + ":{token}"
+	case password != "" && username == "":
+		auth.Format = "Basic {token}:" + password
+	}
+}
+
+func describedBasicCredentialConstant(description, field string) string {
+	description = strings.TrimSpace(description)
+	field = strings.ToLower(strings.TrimSpace(field))
+	if description == "" || field == "" {
+		return ""
+	}
+	pattern := regexp.MustCompile(`(?i)` + "`?" + regexp.QuoteMeta(field) + "`?" + `\s*(?:is|=|:)\s*([^,.;\n]+)`)
+	match := pattern.FindStringSubmatch(description)
+	if len(match) < 2 {
+		return ""
+	}
+	value := strings.TrimSpace(match[1])
+	if value == "" {
+		return ""
+	}
+	if strings.HasPrefix(value, "`") {
+		if end := strings.Index(value[1:], "`"); end >= 0 {
+			return strings.TrimSpace(value[1 : 1+end])
+		}
+	}
+	if strings.HasPrefix(value, `"`) {
+		if end := strings.Index(value[1:], `"`); end >= 0 {
+			return strings.TrimSpace(value[1 : 1+end])
+		}
+	}
+	if strings.HasPrefix(value, "'") {
+		if end := strings.Index(value[1:], "'"); end >= 0 {
+			return strings.TrimSpace(value[1 : 1+end])
+		}
+	}
+	parts := strings.Fields(value)
+	if len(parts) == 0 {
+		return ""
+	}
+	candidate := strings.Trim(parts[0], "`'\"")
+	if candidate == "" || !looksLikeBasicConstant(candidate) {
+		return ""
+	}
+	return candidate
+}
+
+func looksLikeBasicConstant(value string) bool {
+	lower := strings.ToLower(strings.TrimSpace(value))
+	switch lower {
+	case "", "a", "an", "the", "your", "you", "username", "password", "key", "secret", "token":
+		return false
+	}
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func applyAuthVarsRichOverride(auth *spec.AuthConfig, extensions map[string]any, path string) {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -5510,6 +5510,103 @@ paths:
 	}, parsed.Auth.EnvVarSpecs[1])
 }
 
+func TestOpenAPIHTTPBasicAuthSupportsConstantUsername(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Intervals ICU
+  version: "1.0.0"
+servers:
+  - url: https://intervals.icu
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+      x-auth-basic-username: API_KEY
+security:
+  - basicAuth: []
+paths:
+  /api/v1/athlete:
+    get:
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Basic API_KEY:{token}", parsed.Auth.Format)
+	assert.Equal(t, []string{"INTERVALS_ICU_TOKEN"}, parsed.Auth.EnvVars)
+	require.Len(t, parsed.Auth.EnvVarSpecs, 1)
+	assert.True(t, parsed.Auth.EnvVarSpecs[0].Sensitive)
+}
+
+func TestOpenAPIHTTPBasicAuthInfersConstantUsernameFromDescription(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Mailgun
+  version: "1.0.0"
+servers:
+  - url: https://api.mailgun.net
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+      description: Username is api, Password is your API key.
+security:
+  - basicAuth: []
+paths:
+  /v3/domains:
+    get:
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Basic api:{token}", parsed.Auth.Format)
+	assert.Equal(t, []string{"MAILGUN_TOKEN"}, parsed.Auth.EnvVars)
+}
+
+func TestOpenAPIHTTPBasicAuthSupportsConstantPassword(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Maxio
+  version: "1.0.0"
+servers:
+  - url: https://subdomain.chargify.com
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+      description: The ` + "`username`" + ` is a Maxio Chargify API key. The ` + "`password`" + ` is ` + "`x`" + `.
+security:
+  - basicAuth: []
+paths:
+  /subscriptions.json:
+    get:
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Basic {token}:x", parsed.Auth.Format)
+	assert.Equal(t, []string{"MAXIO_TOKEN"}, parsed.Auth.EnvVars)
+	require.Len(t, parsed.Auth.EnvVarSpecs, 1)
+	assert.True(t, parsed.Auth.EnvVarSpecs[0].Sensitive)
+}
+
 func TestOpenAPIAPIKeyAuthorizationHonorsAuthFormat(t *testing.T) {
 	t.Parallel()
 

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -5574,6 +5574,37 @@ paths:
 	assert.Equal(t, []string{"MAILGUN_TOKEN"}, parsed.Auth.EnvVars)
 }
 
+func TestOpenAPIHTTPBasicAuthDoesNotInferProseUsernameFromDescription(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Example API
+  version: "1.0.0"
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+      description: Username is always required. Password is your API key.
+security:
+  - basicAuth: []
+paths:
+  /v1/account:
+    get:
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Basic {username}:{password}", parsed.Auth.Format)
+	assert.Equal(t, []string{"EXAMPLE_USERNAME", "EXAMPLE_PASSWORD"}, parsed.Auth.EnvVars)
+}
+
 func TestOpenAPIHTTPBasicAuthSupportsConstantPassword(t *testing.T) {
 	t.Parallel()
 

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -4047,7 +4047,7 @@ func (s *APISpec) NormalizeAuthEnvVarSpecs() {
 	}
 }
 
-// NormalizeCookieDomain backfills Auth.CookieDomain for cookie/composed auth
+// NormalizeCookieDomain backfills Auth.CookieDomain for browser-session auth
 // when no explicit domain came from the spec field, the x-auth-cookie-domain
 // extension, or the sniffer's bound domain. The browser cookie-capture path
 // (`auth login --chrome`) reads cookies scoped to this domain; an empty value
@@ -4059,7 +4059,7 @@ func (s *APISpec) NormalizeCookieDomain() {
 		return
 	}
 	switch strings.ToLower(strings.TrimSpace(s.Auth.Type)) {
-	case "cookie", "composed":
+	case "cookie", "composed", "session_handshake":
 	default:
 		return
 	}

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -5521,6 +5521,12 @@ func TestNormalizeCookieDomain(t *testing.T) {
 			wantDomain: ".app.example.com",
 		},
 		{
+			name:       "session handshake derives domain too",
+			authType:   "session_handshake",
+			baseURL:    "https://query1.finance.example",
+			wantDomain: ".query1.finance.example",
+		},
+		{
 			name:       "explicit cookie_domain is preserved",
 			authType:   "cookie",
 			baseURL:    "https://www.factor75.com",

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
@@ -63,6 +63,7 @@ func requiredAuthCookies() []string {
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 	var browserFlag bool
 	var profileFlag string
+	var cookiesFile string
 
 	cmd := &cobra.Command{
 		Use:   "login",
@@ -71,6 +72,7 @@ func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 
 Use --chrome to read cookies from Chrome for .cookie-auth.example.
 Use --browser as an alias for --chrome.
+Use --cookies-file to import Playwright storage-state JSON or a raw Cookie header file.
 Requires a cookie extraction tool (pycookiecheat, cookies, or cookie-scoop-cli).
 
 If you have multiple Chrome profiles, pycookiecheat and cookie-scoop-cli can
@@ -78,22 +80,26 @@ auto-detect which profile is logged in. Use --profile to select a specific
 profile by name when the installed backend supports it.`,
 		Example: `  golden-api-cookie-auth-pp-cli auth login --chrome
   golden-api-cookie-auth-pp-cli auth login --browser
+  golden-api-cookie-auth-pp-cli auth login --cookies-file storage-state.json
   golden-api-cookie-auth-pp-cli auth login --chrome --profile "Work"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !browserFlag {
-				fmt.Fprintln(cmd.OutOrStdout(), "Use --chrome or --browser to authenticate from your browser session:")
+			w := cmd.OutOrStdout()
+			domain := ".cookie-auth.example"
+			if !browserFlag && cookiesFile == "" {
+				fmt.Fprintln(w, "Use --chrome, --browser, or --cookies-file to authenticate from your browser session:")
 				fmt.Fprintf(cmd.OutOrStdout(), "  golden-api-cookie-auth-pp-cli auth login --chrome\n")
 				fmt.Fprintf(cmd.OutOrStdout(), "  golden-api-cookie-auth-pp-cli auth login --browser\n")
+				fmt.Fprintf(cmd.OutOrStdout(), "  golden-api-cookie-auth-pp-cli auth login --cookies-file storage-state.json\n")
 				return nil
+			}
+			if browserFlag && cookiesFile != "" {
+				return authErr(fmt.Errorf("choose either --chrome/--browser or --cookies-file, not both"))
 			}
 			// Check if already authenticated via env var
 			if v := os.Getenv("COOKIE_AUTH_SESSION"); v != "" {
 				fmt.Fprintf(cmd.OutOrStdout(), "Already authenticated via %s env var.\n", "COOKIE_AUTH_SESSION")
 				return nil
 			}
-
-			w := cmd.OutOrStdout()
-			domain := ".cookie-auth.example"
 
 			// Step 0: Try press-auth, the dedicated cookie capture companion.
 			// press-auth spawns its own controlled Chrome window so users do
@@ -106,21 +112,33 @@ profile by name when the installed backend supports it.`,
 			// are already on disk.
 			var cookies string
 			fromPressAuth := false
-			if pressAuthPath, err := exec.LookPath("press-auth"); err == nil {
-				paCookies, paErr := tryPressAuth(pressAuthPath, domain)
-				if paErr == nil && paCookies != "" {
-					fmt.Fprintf(w, "Loaded cookies via press-auth for %s.\n", domain)
-					cookies = paCookies
-					fromPressAuth = true
-				} else if paErr != nil {
-					fmt.Fprintf(w, "press-auth returned an error: %v\n", paErr)
-					fmt.Fprintln(w, "Falling back to other extraction methods.")
-					fmt.Fprintln(w, "If you haven't logged in yet, run:")
-					fmt.Fprintf(w, "\n  press-auth login %s --login-url <login-url>\n\n", domain)
+			fromCookiesFile := false
+			if cookiesFile != "" {
+				imported, err := loadCookiesFromFile(cookiesFile, domain)
+				if err != nil {
+					return authErr(err)
+				}
+				cookies = imported.Header
+				fromCookiesFile = true
+				fmt.Fprintf(w, "Loaded cookies from %s for %s.\n", cookiesFile, domain)
+			}
+			if !fromCookiesFile {
+				if pressAuthPath, err := exec.LookPath("press-auth"); err == nil {
+					paCookies, paErr := tryPressAuth(pressAuthPath, domain)
+					if paErr == nil && paCookies != "" {
+						fmt.Fprintf(w, "Loaded cookies via press-auth for %s.\n", domain)
+						cookies = paCookies
+						fromPressAuth = true
+					} else if paErr != nil {
+						fmt.Fprintf(w, "press-auth returned an error: %v\n", paErr)
+						fmt.Fprintln(w, "Falling back to other extraction methods.")
+						fmt.Fprintln(w, "If you haven't logged in yet, run:")
+						fmt.Fprintf(w, "\n  press-auth login %s --login-url <login-url>\n\n", domain)
+					}
 				}
 			}
 
-			if !fromPressAuth {
+			if !fromPressAuth && !fromCookiesFile {
 				// Step 1: Detect cookie extraction tool
 				tool, err := detectCookieTool()
 				if err != nil {
@@ -233,6 +251,7 @@ profile by name when the installed backend supports it.`,
 	cmd.Flags().BoolVar(&browserFlag, "chrome", false, "Read cookies from Chrome")
 	cmd.Flags().BoolVar(&browserFlag, "browser", false, "Alias for --chrome")
 	cmd.Flags().StringVar(&profileFlag, "profile", "", "Chrome profile name (e.g. \"Work\", \"Personal\")")
+	cmd.Flags().StringVar(&cookiesFile, "cookies-file", "", "Import cookies from a Playwright storage-state JSON file or raw Cookie header file")
 	return cmd
 }
 func cookieToolSupportsProfiles(tool string) bool {
@@ -919,6 +938,98 @@ func extractViaCookiesCLI(domain string) (string, error) {
 	result := strings.TrimSpace(out.String())
 	result = strings.TrimPrefix(result, "Cookie: ")
 	return result, nil
+}
+
+type importedCookieFile struct {
+	Header  string
+	Cookies []*http.Cookie
+}
+
+func loadCookiesFromFile(path string, domain string) (importedCookieFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return importedCookieFile{}, fmt.Errorf("reading cookies file: %w", err)
+	}
+	var state struct {
+		Cookies []struct {
+			Name     string  `json:"name"`
+			Value    string  `json:"value"`
+			Domain   string  `json:"domain"`
+			Path     string  `json:"path"`
+			Expires  float64 `json:"expires"`
+			Secure   bool    `json:"secure"`
+			HTTPOnly bool    `json:"httpOnly"`
+		} `json:"cookies"`
+	}
+	if err := json.Unmarshal(data, &state); err == nil && len(state.Cookies) > 0 {
+		parts := make([]string, 0, len(state.Cookies))
+		cookies := make([]*http.Cookie, 0, len(state.Cookies))
+		for _, c := range state.Cookies {
+			if !cookieDomainMatches(c.Domain, domain) {
+				continue
+			}
+			name := strings.TrimSpace(c.Name)
+			if name == "" {
+				continue
+			}
+			path := c.Path
+			if path == "" {
+				path = "/"
+			}
+			ck := &http.Cookie{
+				Name:     name,
+				Value:    c.Value,
+				Domain:   c.Domain,
+				Path:     path,
+				Secure:   c.Secure,
+				HttpOnly: c.HTTPOnly,
+			}
+			if c.Expires > 0 {
+				ck.Expires = time.Unix(int64(c.Expires), 0)
+			}
+			cookies = append(cookies, ck)
+			parts = append(parts, name+"="+c.Value)
+		}
+		if len(parts) == 0 {
+			return importedCookieFile{}, fmt.Errorf("cookies file contains no cookies for %s", domain)
+		}
+		return importedCookieFile{Header: strings.Join(parts, "; "), Cookies: cookies}, nil
+	}
+	header := trimCookieHeaderPrefix(string(data))
+	if header == "" {
+		return importedCookieFile{}, fmt.Errorf("cookies file is empty")
+	}
+	return importedCookieFile{Header: header, Cookies: parseCookieHeaderCookies(header)}, nil
+}
+
+func trimCookieHeaderPrefix(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= len("Cookie:") && strings.EqualFold(s[:len("Cookie:")], "Cookie:") {
+		return strings.TrimSpace(s[len("Cookie:"):])
+	}
+	return s
+}
+
+func parseCookieHeaderCookies(header string) []*http.Cookie {
+	parts := strings.Split(header, ";")
+	cookies := make([]*http.Cookie, 0, len(parts))
+	for _, part := range parts {
+		name, value, ok := strings.Cut(strings.TrimSpace(part), "=")
+		if !ok || strings.TrimSpace(name) == "" {
+			continue
+		}
+		cookies = append(cookies, &http.Cookie{Name: strings.TrimSpace(name), Value: strings.TrimSpace(value), Path: "/"})
+	}
+	return cookies
+}
+
+func cookieDomainMatches(cookieDomain string, targetDomain string) bool {
+	target := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(targetDomain)), ".")
+	if target == "" {
+		return true
+	}
+	candidate := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(cookieDomain)), ".")
+	return candidate == target || strings.HasSuffix(candidate, "."+target) || strings.HasSuffix(target, "."+candidate)
 }
 
 // parseCookieString splits a "name1=value1; name2=value2" string into a map.

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
@@ -1029,7 +1029,7 @@ func cookieDomainMatches(cookieDomain string, targetDomain string) bool {
 		return true
 	}
 	candidate := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(cookieDomain)), ".")
-	return candidate == target || strings.HasSuffix(candidate, "."+target) || strings.HasSuffix(target, "."+candidate)
+	return candidate == target || strings.HasSuffix(candidate, "."+target) || (strings.Contains(candidate, ".") && strings.HasSuffix(target, "."+candidate))
 }
 
 // parseCookieString splits a "name1=value1; name2=value2" string into a map.

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
@@ -961,7 +961,10 @@ func loadCookiesFromFile(path string, domain string) (importedCookieFile, error)
 			HTTPOnly bool    `json:"httpOnly"`
 		} `json:"cookies"`
 	}
-	if err := json.Unmarshal(data, &state); err == nil && len(state.Cookies) > 0 {
+	if err := json.Unmarshal(data, &state); err == nil {
+		if len(state.Cookies) == 0 {
+			return importedCookieFile{}, fmt.Errorf("cookies file contains an empty cookies array")
+		}
 		parts := make([]string, 0, len(state.Cookies))
 		cookies := make([]*http.Cookie, 0, len(state.Cookies))
 		for _, c := range state.Cookies {

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/cookiejar.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/cookiejar.go
@@ -208,6 +208,19 @@ func mergeAndWriteCookieRows(path string, rows []persistedCookie) error {
 		idx[r.Domain+"|"+r.Path+"|"+r.Name] = i
 	}
 	for _, r := range rows {
+		filtered := all[:0]
+		for _, existing := range all {
+			if shouldReplaceShadowingCookie(existing, r) {
+				delete(idx, existing.Domain+"|"+existing.Path+"|"+existing.Name)
+				continue
+			}
+			filtered = append(filtered, existing)
+		}
+		all = filtered
+		idx = make(map[string]int, len(all))
+		for i, existing := range all {
+			idx[existing.Domain+"|"+existing.Path+"|"+existing.Name] = i
+		}
 		key := r.Domain + "|" + r.Path + "|" + r.Name
 		if i, ok := idx[key]; ok {
 			all[i] = r
@@ -224,6 +237,18 @@ func mergeAndWriteCookieRows(path string, rows []persistedCookie) error {
 		return err
 	}
 	return os.WriteFile(path, data, 0o600)
+}
+
+func shouldReplaceShadowingCookie(existing, incoming persistedCookie) bool {
+	if existing.Name != incoming.Name || existing.Path != incoming.Path {
+		return false
+	}
+	return normalizedWWWCookieDomain(existing.Domain) == normalizedWWWCookieDomain(incoming.Domain)
+}
+
+func normalizedWWWCookieDomain(domain string) string {
+	domain = strings.TrimPrefix(strings.ToLower(strings.TrimSpace(domain)), ".")
+	return strings.TrimPrefix(domain, "www.")
 }
 
 func (j *cookieJar) loadFromDisk() {


### PR DESCRIPTION
## Summary
- add generated `auth login --cookies-file` support for cookie/composed browser-session CLIs, accepting Playwright storage-state JSON or raw Cookie header files
- add session-handshake cookie import that seeds the generated session manager and refreshes the crumb/session token
- keep imported cookie domains durable by deriving session cookie domains, preserving per-cookie domains, and replacing stale same-name apex/www cookie shadows
- make Auth0 SPA CDP capture navigate the controlled tab to a generated capture URL so Fetch watches the logged-in traffic path instead of a blank new tab
- support HTTP Basic constant username/password hints from OpenAPI extensions and conservative prose inference

## Issue Coverage
Fixes #3339.
Fixes #2922.
Fixes #2605.
Partially addresses #2512 by adding file/manual browser-session import paths and stale apex/www cookie reconciliation; broader residual auth UX follow-up remains in that umbrella issue.
Partially addresses #2560 by adding session-handshake cookie/session file import into the generated session manager; main already had the base session-file reader wiring.

## Validation
- `go test ./...`
- `go test ./internal/openapi ./internal/spec ./internal/generator -run 'TestOpenAPIHTTPBasicAuth(SupportsConstantUsername|InfersConstantUsernameFromDescription|SupportsConstantPassword|DefaultsToUsernamePasswordEnvVars)|TestNormalizeCookieDomain|TestCookieAuthLoginEmitsCookiesFileImport|TestSessionHandshakeLoginEmitsCookiesFileImport|TestGenerateAuth0SPAEmitsCDPLoginCmd|TestGenerateAuth0SPAWithoutEnvVarOmitsUnusedOSImport|TestCookieAuthClientSeedsJar' -count=1`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh generate-golden-api generate-golden-api-rich-auth generate-golden-api-cookie-auth`
- `git diff --check`