### PR TITLE
fix(cli): add examples to jobs commands

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -17132,6 +17132,52 @@ func TestGenerateWaitForJobBypassesResponseCache(t *testing.T) {
 		"WaitForJob must not call c.Get(ctx, path, nil); cached non-terminal status would lock the poll")
 }
 
+func TestGenerateJobsCommandsEmitExamples(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("asyncjobs")
+	apiSpec.Types = map[string]spec.TypeDef{
+		"RenderJob": {Fields: []spec.TypeField{
+			{Name: "job_id", Type: "string"},
+			{Name: "status", Type: "string"},
+		}},
+	}
+	apiSpec.Resources = map[string]spec.Resource{
+		"renders": {
+			Description: "Async render jobs",
+			Endpoints: map[string]spec.Endpoint{
+				"submit": {Method: "POST", Path: "/renders", Description: "Submit a render", Response: spec.ResponseDef{Type: "object", Item: "RenderJob"}},
+				"get":    {Method: "GET", Path: "/renders/{id}", Description: "Get a render", Response: spec.ResponseDef{Type: "object", Item: "RenderJob"}},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	jobsBody := readGeneratedFile(t, outputDir, "internal", "cli", "jobs.go")
+	for _, want := range []string{
+		"Example: `  asyncjobs-pp-cli jobs list --limit 10",
+		"Example:     `  asyncjobs-pp-cli jobs list --limit 10 --json`,",
+		"Example:     `  asyncjobs-pp-cli jobs get example-job-id --json`,",
+		"Example: `  asyncjobs-pp-cli jobs prune --older-than 168h --json`,",
+	} {
+		assert.Contains(t, jobsBody, want)
+	}
+
+	binaryPath := filepath.Join(outputDir, naming.CLI(apiSpec.Name))
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/"+naming.CLI(apiSpec.Name))
+	for _, args := range [][]string{
+		{"jobs", "--help"},
+		{"jobs", "list", "--help"},
+		{"jobs", "get", "--help"},
+		{"jobs", "prune", "--help"},
+	} {
+		stdout, _ := runGeneratedBinary(t, binaryPath, args...)
+		assert.Contains(t, stdout, "Examples:", "%v help should render an Examples section", args)
+	}
+}
+
 // TestGenerateMCPHandlerPreservesQueryPositionals proves the makeAPIHandler
 // body in generated MCP tools.go distinguishes real URL path placeholders
 // (e.g. /movie/{movieId}) from CLI positional args that map to query

--- a/internal/generator/templates/jobs.go.tmpl
+++ b/internal/generator/templates/jobs.go.tmpl
@@ -236,6 +236,8 @@ the CLI state directory's jobs.jsonl. This command lists, inspects, and prunes t
 
 Submit an async endpoint with --wait to block until completion; submit
 without --wait to get the job ID back immediately and track it later.`,
+		Example: `  {{.Name}}-pp-cli jobs list --limit 10
+  {{.Name}}-pp-cli jobs get example-job-id --json`,
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE:        parentNoSubcommandRunE(flags),
 	}
@@ -251,6 +253,7 @@ func newJobsListCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "list",
 		Short:       "List recent async jobs",
+		Example:     `  {{.Name}}-pp-cli jobs list --limit 10 --json`,
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rows, err := readJobRows()
@@ -289,6 +292,7 @@ func newJobsGetCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:         "get <job-id>",
 		Short:       "Show the latest state row for a job",
+		Example:     `  {{.Name}}-pp-cli jobs get example-job-id --json`,
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -318,8 +322,9 @@ func newJobsGetCmd(flags *rootFlags) *cobra.Command {
 func newJobsPruneCmd(flags *rootFlags) *cobra.Command {
 	var olderThan time.Duration
 	cmd := &cobra.Command{
-		Use:   "prune",
-		Short: "Remove job rows older than --older-than",
+		Use:     "prune",
+		Short:   "Remove job rows older than --older-than",
+		Example: `  {{.Name}}-pp-cli jobs prune --older-than 168h --json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rows, err := readJobRows()
 			if err != nil {

--- a/testdata/golden/expected/generate-async-job-api/async-job-api/internal/cli/jobs.go
+++ b/testdata/golden/expected/generate-async-job-api/async-job-api/internal/cli/jobs.go
@@ -237,6 +237,8 @@ the CLI state directory's jobs.jsonl. This command lists, inspects, and prunes t
 
 Submit an async endpoint with --wait to block until completion; submit
 without --wait to get the job ID back immediately and track it later.`,
+		Example: `  async-job-pp-cli jobs list --limit 10
+  async-job-pp-cli jobs get example-job-id --json`,
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE:        parentNoSubcommandRunE(flags),
 	}
@@ -252,6 +254,7 @@ func newJobsListCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "list",
 		Short:       "List recent async jobs",
+		Example:     `  async-job-pp-cli jobs list --limit 10 --json`,
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rows, err := readJobRows()
@@ -290,6 +293,7 @@ func newJobsGetCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:         "get <job-id>",
 		Short:       "Show the latest state row for a job",
+		Example:     `  async-job-pp-cli jobs get example-job-id --json`,
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -319,8 +323,9 @@ func newJobsGetCmd(flags *rootFlags) *cobra.Command {
 func newJobsPruneCmd(flags *rootFlags) *cobra.Command {
 	var olderThan time.Duration
 	cmd := &cobra.Command{
-		Use:   "prune",
-		Short: "Remove job rows older than --older-than",
+		Use:     "prune",
+		Short:   "Remove job rows older than --older-than",
+		Example: `  async-job-pp-cli jobs prune --older-than 168h --json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rows, err := readJobRows()
 			if err != nil {


### PR DESCRIPTION
## Summary
- add Cobra Examples for generated jobs, jobs list, jobs get, and jobs prune commands
- add generator coverage proving the emitted jobs help renders Examples sections
- update the async job golden fixture for the intentional generated output change

## Validation
- go test ./internal/generator -run 'TestGenerate(WaitForJobBypassesResponseCache|JobsCommandsEmitExamples)$'\n- scripts/verify-generator-output.sh generate-async-job-api\n- go test ./...\n- scripts/golden.sh verify\n- git diff --check\n\nPart of the #2636 closure plan, PR B.