### PR TITLE
fix(generator): stop mid-word truncation of root Short/Long

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -567,6 +567,40 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 			}
 			return string(runes[:max-1]) + "…"
 		},
+		// truncateWords clips a string to at most max runes WITHOUT ever
+		// cutting a word in half. It backs up from the cap to the last
+		// whitespace boundary before appending the ellipsis, so the result
+		// reads as "…over time" rather than the mid-word "…over t…" that a
+		// raw rune slice produces. Used for the root command's Short, where a
+		// length cap is reasonable but a mangled word in `<cli> --help` is not.
+		// If the text has no whitespace before the cap (a single long token),
+		// it falls back to a hard clip so the budget is still honored.
+		"truncateWords": func(max int, s string) string {
+			if max <= 0 {
+				return s
+			}
+			runes := []rune(s)
+			if len(runes) <= max {
+				return s
+			}
+			if max <= 1 {
+				return string(runes[:max])
+			}
+			// Reserve one rune for the ellipsis, then retreat to the last
+			// space so the final word stays whole.
+			cut := runes[:max-1]
+			boundary := -1
+			for i := len(cut) - 1; i >= 0; i-- {
+				if unicode.IsSpace(cut[i]) {
+					boundary = i
+					break
+				}
+			}
+			if boundary > 0 {
+				cut = cut[:boundary]
+			}
+			return strings.TrimRightFunc(string(cut), unicode.IsSpace) + "…"
+		},
 		"yamlDoubleQuoted": yamlDoubleQuoted,
 		// groupNovelFeatures clusters features by their Group field, preserving
 		// first-seen order of group names. Features with empty Group land in a

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -567,14 +567,8 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 			}
 			return string(runes[:max-1]) + "…"
 		},
-		// truncateWords clips a string to at most max runes WITHOUT ever
-		// cutting a word in half. It backs up from the cap to the last
-		// whitespace boundary before appending the ellipsis, so the result
-		// reads as "…over time" rather than the mid-word "…over t…" that a
-		// raw rune slice produces. Used for the root command's Short, where a
-		// length cap is reasonable but a mangled word in `<cli> --help` is not.
-		// If the text has no whitespace before the cap (a single long token),
-		// it falls back to a hard clip so the budget is still honored.
+		// truncateWords keeps root Short within budget without ending on a
+		// partial word. A single long token still hard-clips to honor the cap.
 		"truncateWords": func(max int, s string) string {
 			if max <= 0 {
 				return s
@@ -586,8 +580,6 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 			if max <= 1 {
 				return string(runes[:max])
 			}
-			// Reserve one rune for the ellipsis, then retreat to the last
-			// space so the final word stays whole.
 			cut := runes[:max-1]
 			boundary := -1
 			for i := len(cut) - 1; i >= 0; i-- {

--- a/internal/generator/root_long_test.go
+++ b/internal/generator/root_long_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -175,13 +176,14 @@ func runGoVet(t *testing.T, dir string) error {
 }
 
 // TestRootLongStaysUnderSizeBudget asserts that an absorb output with
-// ten novel features and a verbose headline does not produce a bloated
+// ten novel features and runaway descriptions does not produce a bloated
 // --help Long. Agents running --help on a wall-of-text CLI is the same
 // token-waste problem this change set is trying to solve — don't fix
 // one discovery-loop problem by creating a different one.
 //
-// Budget (enforced by truncate helper in the template):
-//   - Headline clipped to 120 runes
+// Budget (enforced in the template):
+//   - Headline: carried in full — Long is meant to be complete, so only the
+//     novel-feature wall-of-text is bounded, not the header line
 //   - Top 15 novel features (cap in Go; remaining dropped with overflow breadcrumb)
 //   - Each feature description clipped to 200 runes
 //
@@ -191,12 +193,15 @@ func runGoVet(t *testing.T, dir string) error {
 func TestRootLongStaysUnderSizeBudget(t *testing.T) {
 	t.Parallel()
 
-	longStr := strings.Repeat("x", 500) // intentionally over every cap
+	longStr := strings.Repeat("x", 500) // intentionally over the per-feature cap
 	apiSpec := minimalSpec("bounded")
 	outputDir := filepath.Join(t.TempDir(), "bounded-pp-cli")
 	gen := New(apiSpec, outputDir)
 	gen.Narrative = &ReadmeNarrative{
-		Headline: "A very verbose headline that exceeds the 120-rune budget: " + longStr,
+		// Normal-length headline: Long now carries headlines in full, so the
+		// runaway bound under test here is the per-feature description cap, not
+		// the header. (Headline handling is covered by the dice regression test.)
+		Headline: "A concise headline well within any reasonable budget",
 	}
 	// Ten features, each with a runaway description.
 	for i := range 10 {
@@ -342,4 +347,130 @@ func TestRootLongFallsBackWhenNoNarrative(t *testing.T) {
 		"fallback Long should still point at doctor")
 	assert.False(t, strings.Contains(content, "Highlights (not in the official API docs):"),
 		"fallback Long should not render a Highlights header when no novel features exist")
+}
+
+// rootField extracts the raw-string body of the named Cobra field (e.g.
+// "Short" or "Long") from generated root.go. Returns the content between the
+// opening backtick and the closing "`," — both Short and Long are emitted as
+// Go raw-string literals with backticks sanitized out of the interior, so the
+// first "`," after the field name is the unambiguous terminator.
+func rootField(t *testing.T, content, field string) string {
+	t.Helper()
+	marker := field + ": `"
+	start := strings.Index(content, marker)
+	require.NotEqualf(t, -1, start, "%s field should be rendered as a raw string", field)
+	start += len(marker)
+	end := strings.Index(content[start:], "`,")
+	require.NotEqualf(t, -1, end, "%s raw string should close", field)
+	return content[start : start+end]
+}
+
+// assertNoMidWordEllipsis fails if val ends with a U+2026 that was placed
+// mid-word — i.e. the visible text immediately before the ellipsis is the
+// prefix of a longer word in source. A word-boundary truncation (or no
+// truncation at all) passes; the broken "…over t…" case does not.
+func assertNoMidWordEllipsis(t *testing.T, name, val, source string) {
+	t.Helper()
+	trimmed := strings.TrimRight(val, " \n")
+	if !strings.HasSuffix(trimmed, "…") {
+		return // not truncated with an ellipsis → nothing to check
+	}
+	head := strings.TrimRightFunc(strings.TrimSuffix(trimmed, "…"), unicode.IsSpace)
+	tokens := strings.Fields(head)
+	require.NotEmptyf(t, tokens, "%s ends in just an ellipsis", name)
+	last := tokens[len(tokens)-1]
+	idx := strings.Index(source, last)
+	require.NotEqualf(t, -1, idx, "%s tail %q should originate from the source text", name, last)
+	after := idx + len(last)
+	if after >= len(source) {
+		return // the cut word is the final word of source → it is whole
+	}
+	next := []rune(source[after:])[0]
+	assert.Falsef(t, unicode.IsLetter(next) || unicode.IsDigit(next),
+		"%s ends mid-word with U+2026: %q is a partial word in the source headline", name, last)
+}
+
+// TestRootShortLongNeverTruncateMidWord reproduces the dice-pp-cli regression
+// (cli-printing-press v4.27.0): the root command's Short and Long were both
+// hard-clipped at a fixed rune count, slicing the headline at "over t…" — a
+// mid-word cut with a literal U+2026 baked into the emitted Go source, and
+// applied to Long even though long help is meant to be complete.
+//
+// Asserts: (1) Long carries the full headline verbatim, never truncated;
+// (2) neither Short nor Long ends a word mid-token with an ellipsis.
+func TestRootShortLongNeverTruncateMidWord(t *testing.T) {
+	t.Parallel()
+
+	headline := "Turn any dice.fm link into structured data, cache it locally, and watch on-sale, price, and availability changes over time — no app, no API key."
+
+	apiSpec := minimalSpec("dice")
+	outputDir := filepath.Join(t.TempDir(), "dice-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.Narrative = &ReadmeNarrative{Headline: headline}
+	// dice-pp-cli ships novel features, so Long takes the highlights branch —
+	// the exact path where the headline used to be hard-clipped at 120 runes.
+	gen.NovelFeatures = []NovelFeature{
+		{Command: "watch", Description: "Track on-sale, price, and availability changes over time"},
+		{Command: "cache", Description: "Cache any dice.fm link locally as structured data"},
+	}
+	require.NoError(t, gen.Generate())
+
+	rootGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "root.go"))
+	require.NoError(t, err)
+	content := string(rootGo)
+
+	short := rootField(t, content, "Short")
+	long := rootField(t, content, "Long")
+
+	// Long must carry the complete headline — long help is never truncated.
+	assert.Containsf(t, long, headline,
+		"Long should carry the full headline untruncated; got:\n%s", long)
+	// The exact mid-word artifact from the bug report must not appear anywhere.
+	assert.NotContains(t, content, "over t…",
+		"the reported mid-word truncation 'over t…' must never be emitted")
+
+	// Neither field may end a word mid-token with U+2026.
+	assertNoMidWordEllipsis(t, "Short", short, headline)
+	assertNoMidWordEllipsis(t, "Long", long, headline)
+
+	// Generated Go must still compile.
+	require.NoError(t, runGoVet(t, outputDir),
+		"generated root.go with full headline must be parseable Go")
+}
+
+// TestRootLongCarriesHeadlineWithoutNovelFeatures closes a gap where a CLI
+// with a narrative headline but no novel features and no CLIDescription fell
+// straight to the generic "Manage X resources" Long, silently dropping the
+// headline even though Short displayed it. Long should restate the headline
+// in full regardless of whether novel features exist.
+func TestRootLongCarriesHeadlineWithoutNovelFeatures(t *testing.T) {
+	t.Parallel()
+
+	headline := "Turn any dice.fm link into structured data and watch it over time — no app, no API key."
+
+	apiSpec := minimalSpec("dice")
+	outputDir := filepath.Join(t.TempDir(), "dice-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.Narrative = &ReadmeNarrative{Headline: headline}
+	// No NovelFeatures and no CLIDescription → the headline-only Long branch.
+	require.NoError(t, gen.Generate())
+
+	rootGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "root.go"))
+	require.NoError(t, err)
+	content := string(rootGo)
+
+	long := rootField(t, content, "Long")
+	assert.Containsf(t, long, headline,
+		"Long should carry the full headline even without novel features; got:\n%s", long)
+	// It must not silently fall back to the generic API restatement.
+	assert.NotContains(t, long, "Manage dice resources via the dice API.",
+		"Long should not drop to the generic fallback when a headline is present")
+	// Still points agents at --agent and doctor.
+	assert.Contains(t, long, "Add --agent to any command")
+	assert.Contains(t, long, "dice-pp-cli doctor")
+	// And never truncates mid-word.
+	assertNoMidWordEllipsis(t, "Long", long, headline)
+
+	require.NoError(t, runGoVet(t, outputDir),
+		"headline-only Long must produce parseable Go")
 }

--- a/internal/generator/root_long_test.go
+++ b/internal/generator/root_long_test.go
@@ -349,11 +349,6 @@ func TestRootLongFallsBackWhenNoNarrative(t *testing.T) {
 		"fallback Long should not render a Highlights header when no novel features exist")
 }
 
-// rootField extracts the raw-string body of the named Cobra field (e.g.
-// "Short" or "Long") from generated root.go. Returns the content between the
-// opening backtick and the closing "`," — both Short and Long are emitted as
-// Go raw-string literals with backticks sanitized out of the interior, so the
-// first "`," after the field name is the unambiguous terminator.
 func rootField(t *testing.T, content, field string) string {
 	t.Helper()
 	marker := field + ": `"
@@ -365,39 +360,27 @@ func rootField(t *testing.T, content, field string) string {
 	return content[start : start+end]
 }
 
-// assertNoMidWordEllipsis fails if val ends with a U+2026 that was placed
-// mid-word — i.e. the visible text immediately before the ellipsis is the
-// prefix of a longer word in source. A word-boundary truncation (or no
-// truncation at all) passes; the broken "…over t…" case does not.
 func assertNoMidWordEllipsis(t *testing.T, name, val, source string) {
 	t.Helper()
 	trimmed := strings.TrimRight(val, " \n")
 	if !strings.HasSuffix(trimmed, "…") {
-		return // not truncated with an ellipsis → nothing to check
+		return
 	}
 	head := strings.TrimRightFunc(strings.TrimSuffix(trimmed, "…"), unicode.IsSpace)
 	tokens := strings.Fields(head)
 	require.NotEmptyf(t, tokens, "%s ends in just an ellipsis", name)
 	last := tokens[len(tokens)-1]
-	idx := strings.Index(source, last)
+	idx := strings.LastIndex(source, last)
 	require.NotEqualf(t, -1, idx, "%s tail %q should originate from the source text", name, last)
 	after := idx + len(last)
 	if after >= len(source) {
-		return // the cut word is the final word of source → it is whole
+		return
 	}
 	next := []rune(source[after:])[0]
 	assert.Falsef(t, unicode.IsLetter(next) || unicode.IsDigit(next),
 		"%s ends mid-word with U+2026: %q is a partial word in the source headline", name, last)
 }
 
-// TestRootShortLongNeverTruncateMidWord reproduces the dice-pp-cli regression
-// (cli-printing-press v4.27.0): the root command's Short and Long were both
-// hard-clipped at a fixed rune count, slicing the headline at "over t…" — a
-// mid-word cut with a literal U+2026 baked into the emitted Go source, and
-// applied to Long even though long help is meant to be complete.
-//
-// Asserts: (1) Long carries the full headline verbatim, never truncated;
-// (2) neither Short nor Long ends a word mid-token with an ellipsis.
 func TestRootShortLongNeverTruncateMidWord(t *testing.T) {
 	t.Parallel()
 
@@ -407,8 +390,6 @@ func TestRootShortLongNeverTruncateMidWord(t *testing.T) {
 	outputDir := filepath.Join(t.TempDir(), "dice-pp-cli")
 	gen := New(apiSpec, outputDir)
 	gen.Narrative = &ReadmeNarrative{Headline: headline}
-	// dice-pp-cli ships novel features, so Long takes the highlights branch —
-	// the exact path where the headline used to be hard-clipped at 120 runes.
 	gen.NovelFeatures = []NovelFeature{
 		{Command: "watch", Description: "Track on-sale, price, and availability changes over time"},
 		{Command: "cache", Description: "Cache any dice.fm link locally as structured data"},
@@ -422,27 +403,43 @@ func TestRootShortLongNeverTruncateMidWord(t *testing.T) {
 	short := rootField(t, content, "Short")
 	long := rootField(t, content, "Long")
 
-	// Long must carry the complete headline — long help is never truncated.
 	assert.Containsf(t, long, headline,
 		"Long should carry the full headline untruncated; got:\n%s", long)
-	// The exact mid-word artifact from the bug report must not appear anywhere.
 	assert.NotContains(t, content, "over t…",
 		"the reported mid-word truncation 'over t…' must never be emitted")
 
-	// Neither field may end a word mid-token with U+2026.
 	assertNoMidWordEllipsis(t, "Short", short, headline)
 	assertNoMidWordEllipsis(t, "Long", long, headline)
 
-	// Generated Go must still compile.
 	require.NoError(t, runGoVet(t, outputDir),
 		"generated root.go with full headline must be parseable Go")
 }
 
-// TestRootLongCarriesHeadlineWithoutNovelFeatures closes a gap where a CLI
-// with a narrative headline but no novel features and no CLIDescription fell
-// straight to the generic "Manage X resources" Long, silently dropping the
-// headline even though Short displayed it. Long should restate the headline
-// in full regardless of whether novel features exist.
+func TestRootShortPreservesCLIDescriptionBudget(t *testing.T) {
+	t.Parallel()
+
+	description := "Manage detailed logistics workflows for field coordinators, finance reviewers, venue operators, supplier updates, and audit exports."
+
+	require.Greater(t, len([]rune(description)), 120)
+	require.LessOrEqual(t, len([]rune(description)), 200)
+
+	apiSpec := minimalSpec("logistics")
+	apiSpec.CLIDescription = description
+	outputDir := filepath.Join(t.TempDir(), "logistics-pp-cli")
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	rootGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "root.go"))
+	require.NoError(t, err)
+	content := string(rootGo)
+
+	short := rootField(t, content, "Short")
+	long := rootField(t, content, "Long")
+	assert.Equal(t, description, short)
+	assert.Contains(t, long, description)
+	assert.NotContains(t, short, "…")
+}
+
 func TestRootLongCarriesHeadlineWithoutNovelFeatures(t *testing.T) {
 	t.Parallel()
 
@@ -452,7 +449,6 @@ func TestRootLongCarriesHeadlineWithoutNovelFeatures(t *testing.T) {
 	outputDir := filepath.Join(t.TempDir(), "dice-pp-cli")
 	gen := New(apiSpec, outputDir)
 	gen.Narrative = &ReadmeNarrative{Headline: headline}
-	// No NovelFeatures and no CLIDescription → the headline-only Long branch.
 	require.NoError(t, gen.Generate())
 
 	rootGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "root.go"))
@@ -462,10 +458,8 @@ func TestRootLongCarriesHeadlineWithoutNovelFeatures(t *testing.T) {
 	long := rootField(t, content, "Long")
 	assert.Containsf(t, long, headline,
 		"Long should carry the full headline even without novel features; got:\n%s", long)
-	// It must not silently fall back to the generic API restatement.
 	assert.NotContains(t, long, "Manage dice resources via the dice API.",
 		"Long should not drop to the generic fallback when a headline is present")
-	// Still points agents at --agent and doctor.
 	assert.Contains(t, long, "Add --agent to any command")
 	assert.Contains(t, long, "dice-pp-cli doctor")
 	// And never truncates mid-word.

--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -177,8 +177,8 @@ func newRootCmd(flags *rootFlags) *cobra.Command {
 
        Short carries a length cap (it renders on one line); Long never does —
        long help is meant to be complete.
-         • Short: capped at a word boundary via truncateWords, so it never
-           cuts a word in half or bakes a mid-word "…" into the source.
+         • Short: capped at a word boundary via truncateWords, preserving
+           the legacy 200-rune CLIDescription budget and 120-rune headline budget.
          • Long header: the full CLIDescription / narrative headline, no cap.
          • Long per-feature: each description clipped to 200 runes — that is
            the wall-of-text bound, fitting typical novel-feature blurbs
@@ -190,7 +190,7 @@ func newRootCmd(flags *rootFlags) *cobra.Command {
        Full novel-feature details with examples live in README/SKILL; Long
        names the capabilities so an agent can pick the right subcommand. */}}
 {{- if .CLIDescription}}
-		Short: {{backtick}}{{goRawSafe (truncateWords 120 .CLIDescription)}}{{backtick}},
+		Short: {{backtick}}{{goRawSafe (truncateWords 200 .CLIDescription)}}{{backtick}},
 {{- else if and .Narrative .Narrative.Headline}}
 		Short: {{backtick}}{{humanName .Name}} CLI — {{goRawSafe (truncateWords 120 .Narrative.Headline)}}{{backtick}},
 {{- else}}

--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -175,25 +175,29 @@ func newRootCmd(flags *rootFlags) *cobra.Command {
        neuters that for CLIs with many novel features, which are exactly
        the CLIs that benefit most from the work.
 
-       Size is bounded two ways:
-         • per-line: headline truncated to 120 runes, each description to 200.
-           The 200-rune cap fits typical novel-feature descriptions
+       Short carries a length cap (it renders on one line); Long never does —
+       long help is meant to be complete.
+         • Short: capped at a word boundary via truncateWords, so it never
+           cuts a word in half or bakes a mid-word "…" into the source.
+         • Long header: the full CLIDescription / narrative headline, no cap.
+         • Long per-feature: each description clipped to 200 runes — that is
+           the wall-of-text bound, fitting typical novel-feature blurbs
            (~100-150 chars) so most lines render in full; Cobra wrap still
            handles narrow terminals.
-         • total: overflow beyond 15 features becomes a "…and N more" line
-           (NovelOverflowCount set in Go); stops runaway absorb outputs
-           from producing a wall of text in --help
+         • Long total: overflow beyond 15 features becomes a "…and N more"
+           line (NovelOverflowCount set in Go); stops runaway absorb outputs
+           from producing a wall of text in --help.
        Full novel-feature details with examples live in README/SKILL; Long
        names the capabilities so an agent can pick the right subcommand. */}}
 {{- if .CLIDescription}}
-		Short: {{backtick}}{{goRawSafe (truncate 200 .CLIDescription)}}{{backtick}},
+		Short: {{backtick}}{{goRawSafe (truncateWords 120 .CLIDescription)}}{{backtick}},
 {{- else if and .Narrative .Narrative.Headline}}
-		Short: {{backtick}}{{humanName .Name}} CLI — {{goRawSafe (truncate 120 .Narrative.Headline)}}{{backtick}},
+		Short: {{backtick}}{{humanName .Name}} CLI — {{goRawSafe (truncateWords 120 .Narrative.Headline)}}{{backtick}},
 {{- else}}
 		Short: "Manage {{.Name}} resources via the {{.Name}} API",
 {{- end}}
 {{- if .TopNovelFeatures}}
-		Long: {{backtick}}{{if .CLIDescription}}{{goRawSafe (truncate 200 .CLIDescription)}}{{else}}{{humanName .Name}} CLI{{if and .Narrative .Narrative.Headline}} — {{goRawSafe (truncate 120 .Narrative.Headline)}}{{end}}{{end}}
+		Long: {{backtick}}{{if .CLIDescription}}{{goRawSafe .CLIDescription}}{{else}}{{humanName .Name}} CLI{{if and .Narrative .Narrative.Headline}} — {{goRawSafe .Narrative.Headline}}{{end}}{{end}}
 
 Highlights (not in the official API docs):
 {{- range .TopNovelFeatures}}
@@ -207,7 +211,12 @@ Agent mode: add --agent to any command for JSON output + non-interactive mode.
 Health check: run '{{.Name}}-pp-cli doctor' to verify auth and connectivity.
 See README.md or the bundled SKILL.md for recipes.{{backtick}},
 {{- else if .CLIDescription}}
-		Long: {{backtick}}{{goRawSafe (truncate 200 .CLIDescription)}}
+		Long: {{backtick}}{{goRawSafe .CLIDescription}}
+
+Add --agent to any command for JSON output + non-interactive mode.
+Run '{{.Name}}-pp-cli doctor' to verify auth and connectivity.{{backtick}},
+{{- else if and .Narrative .Narrative.Headline}}
+		Long: {{backtick}}{{humanName .Name}} CLI — {{goRawSafe .Narrative.Headline}}
 
 Add --agent to any command for JSON output + non-interactive mode.
 Run '{{.Name}}-pp-cli doctor' to verify auth and connectivity.{{backtick}},


### PR DESCRIPTION
## Intent

Fix root command help text truncation so generated CLIs do not bake mid-word ellipses into `Short`, and so `Long` carries the complete generated description/headline instead of clipping it.

Issue:

N/A

## Approach

Add a word-boundary truncation helper for root `Short`, keep `Long` untruncated for the command header, and preserve the existing `CLIDescription` `Short` budget at 200 runes while keeping the narrative headline budget at 120. The follow-up maintainer commit also anchors the test helper with `strings.LastIndex` so repeated words cannot hide a mid-word truncation.

## Scope

Primary area:

Generator root command template and generator tests.

Why this belongs in this repo:

The observed symptom appears in printed CLIs, but the bug is emitted by the Printing Press generator template, so the fix needs to apply to every future generated CLI.

## Risk

This changes generated root command help text. `Long` may include more text than before because it now carries the full description/headline, while per-feature highlight descriptions remain capped to avoid runaway help output. Existing `CLIDescription` `Short` output in the 121-200 rune range is preserved.

## Output Contract

Generated `internal/cli/root.go` now emits:

- `Short`: word-boundary truncation, 200-rune budget for `CLIDescription`, 120-rune budget for narrative headlines.
- `Long`: full `CLIDescription` or narrative headline in the header, plus the existing capped highlights.

Evidence: emitted-code assertions in `internal/generator/root_long_test.go`, `scripts/golden.sh verify`, and `scripts/verify-generator-output.sh`.

## Verification

- [x] `go test ./internal/generator -run 'TestRoot(ShortLongNeverTruncateMidWord|ShortPreservesCLIDescriptionBudget|LongCarriesHeadlineWithoutNovelFeatures|LongStaysUnderSizeBudget)' -count=1`
- [x] `go fmt ./...`
- [x] `go test ./...`
- [x] `scripts/golden.sh verify`
- [x] `scripts/verify-generator-output.sh`
- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Note: one earlier `go test ./...` run failed only `internal/pipeline.TestHelpScanIndicatesSideEffect`; that isolated test passed immediately on rerun, and the subsequent full `go test ./...` passed.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
