### PR TITLE
fix(skills): don't substitute proposal/docs PRs for requested implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,14 @@ Every commit and PR title must include one of the allowed scopes. GitHub squash-
 - If unsure whether a PR is exempt, keep the template.
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the human-facing contributor guide and AI / automation disclosure definitions.
 
+## PR intent: implement vs publish vs propose
+A request to generate, fix, or implement means produce the real artifact — generator/CLI/template/library code plus tests — not a docs-only, plan, or proposal PR. Three distinct PR shapes exist; never substitute one for another:
+- **Implementation PR** (this repo): real machine/generator/CLI/template change with code + tests.
+- **Library publish PR** (`mvanhorn/printing-press-library`, via `/printing-press-publish`): a generated CLI tree.
+- **Proposal / spec / plan PR**: docs-only description of intended work.
+
+When implementation or generation is blocked, report the exact blocker and stop. Do not fall back to opening a docs-only/plan/proposal PR — here or in `printing-press-library` — unless the user explicitly asked for a proposal, or explicitly authorizes a docs/spec fallback after seeing the blocker. Plan documents stay local (see "Plan documents stay local" below).
+
 ## Automated code review with Greptile
 
 Every PR gets automated Greptile review alongside CI. Resolve every Greptile finding before calling a PR ready: P0 and P1 comments block merge, and P2 comments need either a fix or a concrete reply explaining why the deferral is intentional. Do not use the score alone as the gate.

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -343,6 +343,29 @@ func TestPrintingPressSkillDistinguishesBearerFromRawAPIKey(t *testing.T) {
 	assert.Contains(t, block, "name: X-API-Key")
 }
 
+// TestSkillsProhibitProposalPRFallback locks the guard that keeps agents from
+// substituting a docs-only / plan / proposal PR for the requested implementation,
+// generation, or publish work when a run is blocked. Content is whitespace-collapsed
+// so prose reflow does not break the assertions; only the wording is pinned.
+func TestSkillsProhibitProposalPRFallback(t *testing.T) {
+	collapse := func(s string) string { return strings.Join(strings.Fields(s), " ") }
+
+	agents := collapse(readContractFile(t, filepath.Join("..", "..", "AGENTS.md")))
+	assert.Contains(t, agents, "## PR intent: implement vs publish vs propose")
+	assert.Contains(t, agents, "never substitute one for another")
+	assert.Contains(t, agents, "When implementation or generation is blocked, report the exact blocker and stop.")
+
+	publish := collapse(readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md")))
+	assert.Contains(t, publish, "This skill opens a CLI publish PR — never a proposal PR")
+	assert.Contains(t, publish, "It never opens a docs-only, plan, or proposal PR.")
+	assert.Contains(t, publish, "Do not substitute a docs-only/plan/proposal PR as a fallback for the requested publish")
+
+	gen := collapse(readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md")))
+	assert.Contains(t, gen, "When a run is blocked, report the exact blocker and stop at the menu below")
+	assert.Contains(t, gen, "Do not substitute a docs-only, plan, or proposal PR")
+	assert.Contains(t, gen, "a proposal or spec PR is appropriate only when the user explicitly asked for one")
+}
+
 func TestPrintingPressSkillRunERequiredInputContract(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md"))
 	template := substringBetween(t, skill, "#### Verify-friendly RunE template", "If the command reads a file or directory")

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -26,6 +26,17 @@ Publish a generated CLI from your local library to the [printing-press-library](
 /printing-press publish
 ```
 
+## This skill opens a CLI publish PR — never a proposal PR
+
+This skill opens exactly one of two PR shapes against `printing-press-library`: a
+**CLI publish PR** carrying the generated CLI tree, or — only with
+`--blocked-api-journal` — a single `blocked-apis.json` **journal entry**. It never
+opens a docs-only, plan, or proposal PR. If the CLI is not publish-ready —
+validation fails, the live test cannot run, or generation is blocked — report the
+exact blocker and stop. Do not substitute a docs-only/plan/proposal PR as a
+fallback for the requested publish; a proposal or spec PR is appropriate only when
+the user explicitly asked for one.
+
 ## Direct User Invocation Required
 
 Publishing can fork `mvanhorn/printing-press-library`, push a branch, and open or

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -4714,6 +4714,8 @@ End normally. The CLI is in `$PRESS_LIBRARY/<api>` and the user can run `/printi
 
 The CLI did not promote to library. The working copy is at `$CLI_WORK_DIR`; manuscripts and proofs are archived. Hold runs are the highest-value retro signal — something blocked the machine from reaching ship, and that signal is most valuable while session context is fresh.
 
+When a run is blocked, report the exact blocker and stop at the menu below — those are the only valid outcomes. Do not substitute a docs-only, plan, or proposal PR (here or in `printing-press-library`) for the requested CLI generation; a proposal or spec PR is appropriate only when the user explicitly asked for one, or explicitly authorizes a docs/spec fallback after seeing the blocker.
+
 Before rendering the menu, decide whether this hold should offer a blocked-API journal entry. Offer journaling only when the one-line hold reason is a reachability or buildability blocker that would likely repeat for another user before a machine or upstream change, for example browser-clearance barriers, Cloudflare Turnstile, login/session surfaces that a pure-HTTP printed CLI cannot replay, unreachable official specs, or an upstream API that cannot be called from generated code. Do not offer journaling for ordinary fix-loop failures, local setup problems, missing credentials, temporary network outages, test flakes, or quality issues that polish can plausibly fix.
 
 Present via `AskUserQuestion`:


### PR DESCRIPTION
## Intent

Stop agents from substituting a docs-only / plan / proposal PR for requested implementation, generation, or publish work. In a live failure, an agent opened `printing-press-library` docs *plan* PRs instead of making the requested CLI/generator/library changes. The Printing Press surfaces three genuinely different PR shapes, but nothing named the distinction or forbade swapping one for another, so a blocked run could silently degrade into "write a plan and open a docs PR."

Issue: Refs #3364

## Approach

Add a single, consistently-worded guard at the points where the behavior goes wrong:

- **`AGENTS.md`** — a concise, always-loaded "PR intent: implement vs publish vs propose" section naming the three PR shapes (implementation PR / library publish PR / proposal-spec PR) and requiring: when implementation or generation is blocked, report the exact blocker and stop; do not fall back to a docs/plan/proposal PR unless the user explicitly asked for a proposal (or authorizes a docs/spec fallback after seeing the blocker).
- **`skills/printing-press-publish/SKILL.md`** — states up front that publish opens exactly one of two PR shapes (a CLI publish PR, or a `blocked-apis.json` journal entry with `--blocked-api-journal`) and never a docs/plan/proposal PR; if not publish-ready, report the blocker and stop. Self-contained wording (skills install standalone, so it does not rely on an AGENTS.md pointer).
- **`skills/printing-press/SKILL.md`** — in the hold/blocked flow, the only valid outcomes are the existing menu choices; do not substitute a docs/plan/proposal PR for the requested CLI generation.
- **`internal/pipeline/contracts_test.go`** — `TestSkillsProhibitProposalPRFallback` locks the guard wording across all three files (whitespace-collapsed so prose reflow doesn't break it).

## Scope

Primary area: skills + repo conventions (machine change).

Why this belongs in this repo: this is a behavior of the Printing Press skills themselves, not any one printed CLI. The guard is added to the machine so every future run inherits it, rather than fixing a single CLI or a single library PR after the fact.

## Catalog Justification

N/A

## Risk

Prose/instruction-only change plus one contract test. No generator, template, parser, MCP, auth, catalog, scorer, or release behavior is touched, so generated output is unchanged. The only failure mode is over-restriction — but the guard preserves the explicit-proposal and explicit-fallback escape hatches, so legitimately-requested proposal/spec PRs are still allowed.

## Output Contract

N/A — no templates, generated files, manifests, command output, MCP schemas, scorecard output, catalog rendering, or pipeline artifacts change. `scripts/golden.sh verify` was run anyway and passed (32 cases).

## Verification

- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates

Not applicable — this PR changes no generator/template code. Commands actually run:

- `go test ./...` — all packages pass except `TestGenerateBrowserChromeH3Transport`, which failed only with `no space left on device` during parallel CLI compilation and passes in isolation (`go test ./internal/generator -run TestGenerateBrowserChromeH3Transport` → ok). `internal/pipeline` (containing the new test) passes.
- `go test ./internal/pipeline -run TestSkillsProhibitProposalPRFallback` → PASS
- `scripts/golden.sh verify` → 32 cases pass
- `go fmt ./internal/pipeline/` and `go vet ./internal/pipeline/` → clean

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
