### PR TITLE
fix(skills): detect old Go toolchain and low disk at preflight

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -119,6 +119,134 @@ func TestPrintingPressSetupContractLeavesFreshRepoLocalBinaryAlone(t *testing.T)
 	assert.NotContains(t, goLog, "build -o ./cli-printing-press ./cmd/cli-printing-press")
 }
 
+func TestPrintingPressSetupContractWarnsOnOldGoToolchain(t *testing.T) {
+	t.Parallel()
+
+	output, _, err := runPressSetupContract(t, pressSetupContractOpts{
+		localVersion:  "4.23.0",
+		sourceVersion: "4.23.0",
+		binBuildGo:    "1.26.4",
+		goEnv:         map[string]string{"GOVERSION": "go1.24.0", "GOTOOLCHAIN": "auto"},
+		extraEnv:      []string{"PRINTING_PRESS_DISK_WARN_KB=0", "PRINTING_PRESS_DISK_FAIL_KB=0"},
+	})
+
+	require.NoError(t, err, output) // GOTOOLCHAIN=auto downloads on demand: advisory, not a hard gate
+	assert.Contains(t, output, "[go-toolchain-old] go1.24.0 is older than the generator build toolchain go1.26.4")
+	assert.Contains(t, output, "PRESS_GO_INSTALLED=1.24.0")
+	assert.Contains(t, output, "PRESS_GO_REQUIRED=1.26.4")
+	assert.NotContains(t, output, "[setup-error]")
+}
+
+func TestPrintingPressSetupContractBlocksOldGoUnderLocalToolchain(t *testing.T) {
+	t.Parallel()
+
+	output, _, err := runPressSetupContract(t, pressSetupContractOpts{
+		localVersion:  "4.23.0",
+		sourceVersion: "4.23.0",
+		binBuildGo:    "1.26.4",
+		goEnv:         map[string]string{"GOVERSION": "go1.24.0", "GOTOOLCHAIN": "local"},
+		extraEnv:      []string{"PRINTING_PRESS_DISK_WARN_KB=0", "PRINTING_PRESS_DISK_FAIL_KB=0"},
+	})
+
+	require.Error(t, err, "GOTOOLCHAIN=local disables auto-download, so an old Go is a hard gate")
+	assert.Contains(t, output, "[setup-error] Go go1.24.0 is older than the generator build toolchain go1.26.4")
+	assert.Contains(t, output, "GOTOOLCHAIN=local")
+	assert.NotContains(t, output, "[go-toolchain-old]")
+}
+
+func TestPrintingPressSetupContractAllowsCurrentGoToolchain(t *testing.T) {
+	t.Parallel()
+
+	output, _, err := runPressSetupContract(t, pressSetupContractOpts{
+		localVersion:  "4.23.0",
+		sourceVersion: "4.23.0",
+		binBuildGo:    "1.26.4",
+		goEnv:         map[string]string{"GOVERSION": "go1.26.4", "GOTOOLCHAIN": "auto"},
+		extraEnv:      []string{"PRINTING_PRESS_DISK_WARN_KB=0", "PRINTING_PRESS_DISK_FAIL_KB=0"},
+	})
+
+	require.NoError(t, err, output)
+	assert.NotContains(t, output, "[go-toolchain-old]")
+	assert.NotContains(t, output, "[setup-error]")
+	assert.Contains(t, output, "PRINTING_PRESS_BIN=")
+}
+
+func TestPrintingPressSetupContractWarnsOnLowDisk(t *testing.T) {
+	t.Parallel()
+
+	// Warn threshold above any real free space forces the advisory; a 1 KiB
+	// fail floor keeps it from escalating to the hard gate.
+	output, _, err := runPressSetupContract(t, pressSetupContractOpts{
+		localVersion:  "4.23.0",
+		sourceVersion: "4.23.0",
+		extraEnv:      []string{"PRINTING_PRESS_DISK_WARN_KB=999999999999", "PRINTING_PRESS_DISK_FAIL_KB=1"},
+	})
+
+	require.NoError(t, err, output)
+	assert.Contains(t, output, "[low-disk]")
+	assert.Contains(t, output, "PRESS_DISK_AVAIL_KB=")
+	assert.NotContains(t, output, "[setup-error]")
+}
+
+func TestPrintingPressSetupContractBlocksOnCriticallyLowDisk(t *testing.T) {
+	t.Parallel()
+
+	// Fail floor above any real free space forces the hard gate.
+	output, _, err := runPressSetupContract(t, pressSetupContractOpts{
+		localVersion:  "4.23.0",
+		sourceVersion: "4.23.0",
+		extraEnv:      []string{"PRINTING_PRESS_DISK_FAIL_KB=999999999999"},
+	})
+
+	require.Error(t, err, "critically low disk is a hard gate")
+	assert.Contains(t, output, "[setup-error]")
+	assert.Contains(t, output, "need more space")
+}
+
+// TestPreflightEnvironmentGatesPresentInContracts locks the Go-toolchain and
+// disk gates into every flow that does heavy Go/clone work, so a future edit
+// cannot silently drop one. The canonical interpretation lives in
+// references/setup-checks.md (asserted last).
+func TestPreflightEnvironmentGatesPresentInContracts(t *testing.T) {
+	t.Parallel()
+
+	read := func(parts ...string) string {
+		return readContractFile(t, filepath.Join(append([]string{"..", "..", "skills"}, parts...)...))
+	}
+
+	// Flows that resolve a binary get the full toolchain-currency + disk gate.
+	for _, skill := range []string{"printing-press", "printing-press-amend", "printing-press-polish", "printing-press-publish"} {
+		t.Run(skill, func(t *testing.T) {
+			body := read(skill, "SKILL.md")
+			assert.Contains(t, body, "[go-toolchain-old]", "missing Go-currency advisory")
+			assert.Contains(t, body, "PRESS_GO_REQUIRED=", "missing Go-currency marker")
+			assert.Contains(t, body, "GOTOOLCHAIN", "missing GOTOOLCHAIN=local hard gate")
+			assert.Contains(t, body, "[low-disk]", "missing low-disk advisory")
+			assert.Contains(t, body, "PRESS_DISK_AVAIL_KB=", "missing disk marker")
+			assert.Contains(t, body, "df -Pk", "missing df disk probe")
+		})
+	}
+
+	// amend/polish/publish/import additionally hard-gate a missing Go toolchain
+	// before heavy work (printing-press already had this check upstream).
+	for _, skill := range []string{"printing-press-amend", "printing-press-polish", "printing-press-publish", "printing-press-import"} {
+		body := read(skill, "SKILL.md")
+		assert.Contains(t, body, "[setup-error] Go toolchain not found.", "%s missing Go-presence gate", skill)
+	}
+
+	// import does heavy clone/build work but resolves no binary, so it carries
+	// the disk gate without the binary-relative currency check.
+	imp := read("printing-press-import", "SKILL.md")
+	assert.Contains(t, imp, "[low-disk]", "import missing low-disk advisory")
+	assert.Contains(t, imp, "df -Pk", "import missing df disk probe")
+
+	// The shared reference documents both new signals.
+	checks := read("printing-press", "references", "setup-checks.md")
+	for _, marker := range []string{"[go-toolchain-old]", "PRESS_GO_INSTALLED", "[low-disk]", "PRESS_DISK_AVAIL_KB"} {
+		assert.Contains(t, checks, marker, "setup-checks.md missing %s handling", marker)
+	}
+}
+
 func TestSkillsEnforceCurrencyFloor(t *testing.T) {
 	const floorURL = "https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/supported-versions.txt"
 
@@ -1000,7 +1128,36 @@ func extractContractBlock(t *testing.T, content string) string {
 	return content[startIdx : startIdx+endIdx]
 }
 
+// pressSetupContractOpts configures the fake environment the printing-press
+// setup contract runs against.
+type pressSetupContractOpts struct {
+	localVersion  string            // version the repo-local cli-printing-press binary reports
+	sourceVersion string            // version.go value (drives rebuild + the binary `go build` writes)
+	goEnv         map[string]string // values returned for `go env <KEY>` (e.g. GOVERSION, GOTOOLCHAIN)
+	binBuildGo    string            // value for `go version <binary>` ("go<binBuildGo>"); empty => no output
+	extraEnv      []string          // appended to the contract's environment
+}
+
+// runPrintingPressSetupContract runs the contract with the default fake `go`
+// (no toolchain-version or disk signals) for the binary-resolution tests.
 func runPrintingPressSetupContract(t *testing.T, localVersion, sourceVersion string) (output string, goLog string) {
+	t.Helper()
+	out, log, err := runPressSetupContract(t, pressSetupContractOpts{
+		localVersion:  localVersion,
+		sourceVersion: sourceVersion,
+		// Neutralize the disk gate so these binary-focused tests do not depend
+		// on the runner's free space.
+		extraEnv: []string{"PRINTING_PRESS_DISK_WARN_KB=0", "PRINTING_PRESS_DISK_FAIL_KB=0"},
+	})
+	require.NoError(t, err, out)
+	return out, log
+}
+
+// runPressSetupContract runs the real printing-press setup contract block in a
+// hermetic temp repo with a fake `go` and binary. It returns the contract's
+// combined output, the fake `go` invocation log, and the process exit error so
+// callers can assert hard-gate (non-zero) behavior.
+func runPressSetupContract(t *testing.T, opts pressSetupContractOpts) (output string, goLog string, runErr error) {
 	t.Helper()
 
 	root := t.TempDir()
@@ -1014,38 +1171,13 @@ func runPrintingPressSetupContract(t *testing.T, localVersion, sourceVersion str
 	require.NoError(t, os.WriteFile(filepath.Join(repo, "go.mod"), []byte("module example.com/press\n\ngo 1.20\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(repo, "internal", "version", "version.go"), []byte(`package version
 
-var Version = "`+sourceVersion+`" // x-release-please-version
+var Version = "`+opts.sourceVersion+`" // x-release-please-version
 `), 0o644))
-	writeExecutable(t, filepath.Join(repo, "cli-printing-press"), versionScript(localVersion))
+	writeExecutable(t, filepath.Join(repo, "cli-printing-press"), versionScript(opts.localVersion))
 
 	goLogPath := filepath.Join(root, "go.log")
 	require.NoError(t, os.WriteFile(goLogPath, nil, 0o644))
-	writeExecutable(t, filepath.Join(fakeBin, "go"), `#!/bin/sh
-echo "$@" >> "$GO_LOG"
-if [ "$1" = "run" ]; then
-  exit 0
-fi
-if [ "$1" = "build" ]; then
-  out=""
-  while [ "$#" -gt 0 ]; do
-    if [ "$1" = "-o" ]; then
-      shift
-      out="$1"
-      break
-    fi
-    shift
-  done
-  if [ -z "$out" ]; then
-    echo "missing -o" >&2
-    exit 1
-  fi
-  cat > "$out" <<'__PP_FAKE_BINARY__'
-`+versionScript(sourceVersion)+`__PP_FAKE_BINARY__
-  chmod +x "$out"
-  exit 0
-fi
-exit 0
-`)
+	writeExecutable(t, filepath.Join(fakeBin, "go"), fakeGoScript(opts))
 
 	gitInit := exec.Command("git", "init")
 	gitInit.Dir = repo
@@ -1068,11 +1200,66 @@ exit 0
 		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"PRINTING_PRESS_HOME="+filepath.Join(home, "printing-press"),
 	)
+	cmd.Env = append(cmd.Env, opts.extraEnv...)
 	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, string(out))
-	logBytes, err := os.ReadFile(goLogPath)
-	require.NoError(t, err)
-	return string(out), string(logBytes)
+	logBytes, readErr := os.ReadFile(goLogPath)
+	require.NoError(t, readErr)
+	return string(out), string(logBytes), err
+}
+
+// fakeGoScript builds a `go` stub covering every subcommand the setup contract
+// invokes: `env GOVERSION`/`GOTOOLCHAIN`, `version <binary>`, `run` (stdlib
+// smoke test), and `build -o` (stale-binary rebuild).
+func fakeGoScript(opts pressSetupContractOpts) string {
+	goVersion := opts.goEnv["GOVERSION"]
+	goToolchain := opts.goEnv["GOTOOLCHAIN"]
+	binVersionLine := ":" // no-op keeps the `if` body non-empty when no build version is configured
+	if opts.binBuildGo != "" {
+		binVersionLine = `printf '%s: go` + opts.binBuildGo + `\n' "$(basename "$2")"`
+	}
+	return `#!/bin/sh
+echo "$@" >> "$GO_LOG"
+case "$1" in
+env)
+  case "$2" in
+  GOVERSION) printf '%s\n' "` + goVersion + `" ;;
+  GOTOOLCHAIN) printf '%s\n' "` + goToolchain + `" ;;
+  *) printf '\n' ;;
+  esac
+  exit 0
+  ;;
+version)
+  if [ -n "$2" ] && [ "$2" != "--json" ]; then
+    ` + binVersionLine + `
+  fi
+  exit 0
+  ;;
+run)
+  exit 0
+  ;;
+build)
+  out=""
+  shift
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+      shift
+      out="$1"
+      break
+    fi
+    shift
+  done
+  if [ -z "$out" ]; then
+    echo "missing -o" >&2
+    exit 1
+  fi
+  cat > "$out" <<'__PP_FAKE_BINARY__'
+` + versionScript(opts.sourceVersion) + `__PP_FAKE_BINARY__
+  chmod +x "$out"
+  exit 0
+  ;;
+esac
+exit 0
+`
 }
 
 func versionScript(version string) string {

--- a/skills/printing-press-amend/SKILL.md
+++ b/skills/printing-press-amend/SKILL.md
@@ -99,6 +99,70 @@ PRESS_CURRENT="$PRESS_RUNSTATE/current"
 
 mkdir -p "$PRESS_RUNSTATE" "$PRESS_LIBRARY" "$PRESS_MANUSCRIPTS" "$PRESS_CURRENT"
 
+# --- Go toolchain present (regenerating a CLI compiles it with Go) ---
+if ! command -v go >/dev/null 2>&1; then
+  echo ""
+  echo "[setup-error] Go toolchain not found."
+  echo "The Printing Press compiles regenerated CLIs with Go. Install Go from https://go.dev/dl/, verify with 'go version', then re-run."
+  echo ""
+  return 1 2>/dev/null || exit 1
+fi
+
+# --- Go toolchain currency (fail-open unless GOTOOLCHAIN=local) ---
+# Generated modules carry a `go <build-version>` directive matching the version
+# the generator binary was compiled with. A user Go older than that forces a
+# toolchain download (GOTOOLCHAIN=auto) or a hard "go.mod requires go >= X"
+# failure (GOTOOLCHAIN=local/offline) minutes into a run. Detect it now. Skip
+# silently if either version is unparseable or no binary is resolved.
+if command -v go >/dev/null 2>&1 && [ -n "$PRINTING_PRESS_BIN" ]; then
+  _pp_user_go="$(go env GOVERSION 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1)"
+  _pp_bin_go="$(go version "$PRINTING_PRESS_BIN" 2>/dev/null | grep -oE 'go[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1 | sed -E 's/^go//')"
+  if [ -n "$_pp_user_go" ] && [ -n "$_pp_bin_go" ] && \
+     [ "$(awk -v a="$_pp_user_go" -v b="$_pp_bin_go" 'BEGIN{split(a,x,".");split(b,y,".");for(i=1;i<=3;i++){if((x[i]+0)<(y[i]+0)){print 1;exit}if((x[i]+0)>(y[i]+0)){print 0;exit}}print 0}')" = "1" ]; then
+    if [ "$(go env GOTOOLCHAIN 2>/dev/null)" = "local" ]; then
+      echo ""
+      echo "[setup-error] Go go$_pp_user_go is older than the generator build toolchain go$_pp_bin_go, and GOTOOLCHAIN=local disables the automatic toolchain download."
+      echo "Generated modules need go$_pp_bin_go to build. Install Go $_pp_bin_go or newer from https://go.dev/dl/ (or unset GOTOOLCHAIN), then re-run."
+      echo ""
+      return 1 2>/dev/null || exit 1
+    fi
+    echo ""
+    echo "[go-toolchain-old] go$_pp_user_go is older than the generator build toolchain go$_pp_bin_go"
+    echo "PRESS_GO_INSTALLED=$_pp_user_go"
+    echo "PRESS_GO_REQUIRED=$_pp_bin_go"
+    echo ""
+  fi
+fi
+
+# --- Disk preflight (fail-open unless critically low) ---
+# Generation writes thousands of files, compiles the module, and populates the
+# module cache; publish/import clone multi-GB repos. A nearly-full volume fails
+# deep into the run with an opaque "no space left on device". Warn early;
+# hard-stop only when space is critically low. Thresholds env-tunable for CI.
+_pp_disk_warn_kb="${PRINTING_PRESS_DISK_WARN_KB:-3145728}"   # 3 GiB
+_pp_disk_fail_kb="${PRINTING_PRESS_DISK_FAIL_KB:-524288}"    # 512 MiB
+_pp_disk_target="$PRESS_HOME"
+while [ -n "$_pp_disk_target" ] && [ "$_pp_disk_target" != "/" ] && [ ! -d "$_pp_disk_target" ]; do
+  _pp_disk_target="$(dirname "$_pp_disk_target")"
+done
+[ -d "$_pp_disk_target" ] || _pp_disk_target="$HOME"
+_pp_disk_avail_kb="$(df -Pk "$_pp_disk_target" 2>/dev/null | awk 'NR==2{print $4}')"
+if printf '%s' "$_pp_disk_avail_kb" | grep -qE '^[0-9]+$'; then
+  if [ "$_pp_disk_avail_kb" -lt "$_pp_disk_fail_kb" ]; then
+    echo ""
+    echo "[setup-error] Only $((_pp_disk_avail_kb / 1024)) MiB free on the volume holding $_pp_disk_target; generation and compilation need more space."
+    echo "Free up space (at least $((_pp_disk_fail_kb / 1024)) MiB, ideally a few GiB) and re-run."
+    echo ""
+    return 1 2>/dev/null || exit 1
+  elif [ "$_pp_disk_avail_kb" -lt "$_pp_disk_warn_kb" ]; then
+    echo ""
+    echo "[low-disk] $((_pp_disk_avail_kb / 1024)) MiB free on the volume holding $_pp_disk_target"
+    echo "PRESS_DISK_AVAIL_KB=$_pp_disk_avail_kb"
+    echo "PRESS_DISK_WARN_KB=$_pp_disk_warn_kb"
+    echo ""
+  fi
+fi
+
 # --- Currency-floor check (standalone, fail-open) ---
 # Hard-stop on binaries below the published supported floor so amend does not
 # regenerate CLIs with since-fixed bugs. Repo checkouts build from source and
@@ -141,6 +205,8 @@ fi
 <!-- PRESS_SETUP_CONTRACT_END -->
 
 After running the setup contract, capture the `PRINTING_PRESS_BIN=<abs-path>` line from stdout. **Every subsequent `cli-printing-press ...` invocation in this skill must use that absolute path** (substitute the value, not the literal `$PRINTING_PRESS_BIN` token) — `export PATH` above only affects the single Bash tool call it runs in, so later calls open a fresh shell where bare `cli-printing-press` resolves against the user's default `PATH` and a stale global can shadow the local build.
+
+If the setup contract printed a `[setup-error]` line (missing Go toolchain; Go older than the generator's build toolchain under `GOTOOLCHAIN=local`; or critically low disk), it already exited non-zero — surface the message verbatim and stop; do not capture scope, regenerate, or open a PR. If it printed a `[go-toolchain-old]` or `[low-disk]` advisory, surface that one-line note to the user once and continue.
 
 After capturing the binary path, check binary version compatibility. Read the `min-binary-version` field from this skill's YAML frontmatter. Run `<PRINTING_PRESS_BIN> version --json` and parse the version from the output. Compare it to `min-binary-version` using semver rules. If the installed binary is older than the minimum, stop immediately and tell the user: "cli-printing-press binary vX.Y.Z is older than the minimum required vA.B.C. Run `go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest` to update."
 

--- a/skills/printing-press-import/SKILL.md
+++ b/skills/printing-press-import/SKILL.md
@@ -49,7 +49,50 @@ PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
 PRESS_LIBRARY="$PRESS_HOME/library"
 PRESS_MANUSCRIPTS="$PRESS_HOME/manuscripts"
 SCRIPTS_DIR="$(dirname "${BASH_SOURCE[0]:-$0}")/references"
+
+# --- Go toolchain present (Phase 4 compiles the imported CLI with Go) ---
+if ! command -v go >/dev/null 2>&1; then
+  echo ""
+  echo "[setup-error] Go toolchain not found."
+  echo "Import compiles the imported CLI (Phase 4) with Go. Install Go from https://go.dev/dl/, verify with 'go version', then re-run."
+  echo ""
+  return 1 2>/dev/null || exit 1
+fi
+
+# --- Disk preflight (fail-open unless critically low) ---
+# Import clones the library CLI tree (multi-GB with --clone), rewrites it, and
+# compiles it. A nearly-full volume fails deep into the run with an opaque "no
+# space left on device". Warn early; hard-stop only when space is critically
+# low. Thresholds env-tunable for CI.
+_pp_disk_warn_kb="${PRINTING_PRESS_DISK_WARN_KB:-3145728}"   # 3 GiB
+_pp_disk_fail_kb="${PRINTING_PRESS_DISK_FAIL_KB:-524288}"    # 512 MiB
+_pp_disk_target="$PRESS_HOME"
+while [ -n "$_pp_disk_target" ] && [ "$_pp_disk_target" != "/" ] && [ ! -d "$_pp_disk_target" ]; do
+  _pp_disk_target="$(dirname "$_pp_disk_target")"
+done
+[ -d "$_pp_disk_target" ] || _pp_disk_target="$HOME"
+_pp_disk_avail_kb="$(df -Pk "$_pp_disk_target" 2>/dev/null | awk 'NR==2{print $4}')"
+if printf '%s' "$_pp_disk_avail_kb" | grep -qE '^[0-9]+$'; then
+  if [ "$_pp_disk_avail_kb" -lt "$_pp_disk_fail_kb" ]; then
+    echo ""
+    echo "[setup-error] Only $((_pp_disk_avail_kb / 1024)) MiB free on the volume holding $_pp_disk_target; import clone and compilation need more space."
+    echo "Free up space (at least $((_pp_disk_fail_kb / 1024)) MiB, ideally a few GiB) and re-run."
+    echo ""
+    return 1 2>/dev/null || exit 1
+  elif [ "$_pp_disk_avail_kb" -lt "$_pp_disk_warn_kb" ]; then
+    echo ""
+    echo "[low-disk] $((_pp_disk_avail_kb / 1024)) MiB free on the volume holding $_pp_disk_target"
+    echo "PRESS_DISK_AVAIL_KB=$_pp_disk_avail_kb"
+    echo "PRESS_DISK_WARN_KB=$_pp_disk_warn_kb"
+    echo ""
+  fi
+fi
 ```
+
+If the setup block printed a `[setup-error]` line (missing Go toolchain or
+critically low disk), it already exited non-zero — surface the message verbatim
+and stop; do not proceed to resolve, clone, or build. If it printed a
+`[low-disk]` advisory, surface the free-space note to the user once and continue.
 
 The four reference scripts live alongside this SKILL.md under
 `references/`:

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -67,9 +67,73 @@ if [ -z "$PRINTING_PRESS_BIN" ]; then
   return 1 2>/dev/null || exit 1
 fi
 echo "PRINTING_PRESS_BIN=$PRINTING_PRESS_BIN"
+
+# --- Go toolchain present (polish compiles and vets the CLI with Go) ---
+if ! command -v go >/dev/null 2>&1; then
+  echo ""
+  echo "[setup-error] Go toolchain not found."
+  echo "Polish compiles, vets, and re-verifies the CLI with Go. Install Go from https://go.dev/dl/, verify with 'go version', then re-run."
+  echo ""
+  return 1 2>/dev/null || exit 1
+fi
+
+# --- Go toolchain currency (fail-open unless GOTOOLCHAIN=local) ---
+# Generated modules carry a `go <build-version>` directive matching the version
+# the generator binary was compiled with. A user Go older than that forces a
+# toolchain download (GOTOOLCHAIN=auto) or a hard "go.mod requires go >= X"
+# failure (GOTOOLCHAIN=local/offline) minutes into a run. Detect it now. Skip
+# silently if either version is unparseable or no binary is resolved.
+if command -v go >/dev/null 2>&1 && [ -n "$PRINTING_PRESS_BIN" ]; then
+  _pp_user_go="$(go env GOVERSION 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1)"
+  _pp_bin_go="$(go version "$PRINTING_PRESS_BIN" 2>/dev/null | grep -oE 'go[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1 | sed -E 's/^go//')"
+  if [ -n "$_pp_user_go" ] && [ -n "$_pp_bin_go" ] && \
+     [ "$(awk -v a="$_pp_user_go" -v b="$_pp_bin_go" 'BEGIN{split(a,x,".");split(b,y,".");for(i=1;i<=3;i++){if((x[i]+0)<(y[i]+0)){print 1;exit}if((x[i]+0)>(y[i]+0)){print 0;exit}}print 0}')" = "1" ]; then
+    if [ "$(go env GOTOOLCHAIN 2>/dev/null)" = "local" ]; then
+      echo ""
+      echo "[setup-error] Go go$_pp_user_go is older than the generator build toolchain go$_pp_bin_go, and GOTOOLCHAIN=local disables the automatic toolchain download."
+      echo "Generated modules need go$_pp_bin_go to build. Install Go $_pp_bin_go or newer from https://go.dev/dl/ (or unset GOTOOLCHAIN), then re-run."
+      echo ""
+      return 1 2>/dev/null || exit 1
+    fi
+    echo ""
+    echo "[go-toolchain-old] go$_pp_user_go is older than the generator build toolchain go$_pp_bin_go"
+    echo "PRESS_GO_INSTALLED=$_pp_user_go"
+    echo "PRESS_GO_REQUIRED=$_pp_bin_go"
+    echo ""
+  fi
+fi
+
+# --- Disk preflight (fail-open unless critically low) ---
+# Polish recompiles and re-verifies the CLI and populates the module cache. A
+# nearly-full volume fails deep into the run with an opaque "no space left on
+# device". Warn early; hard-stop only when space is critically low. Thresholds
+# env-tunable for CI.
+_pp_disk_warn_kb="${PRINTING_PRESS_DISK_WARN_KB:-3145728}"   # 3 GiB
+_pp_disk_fail_kb="${PRINTING_PRESS_DISK_FAIL_KB:-524288}"    # 512 MiB
+_pp_disk_target="$PRESS_HOME"
+while [ -n "$_pp_disk_target" ] && [ "$_pp_disk_target" != "/" ] && [ ! -d "$_pp_disk_target" ]; do
+  _pp_disk_target="$(dirname "$_pp_disk_target")"
+done
+[ -d "$_pp_disk_target" ] || _pp_disk_target="$HOME"
+_pp_disk_avail_kb="$(df -Pk "$_pp_disk_target" 2>/dev/null | awk 'NR==2{print $4}')"
+if printf '%s' "$_pp_disk_avail_kb" | grep -qE '^[0-9]+$'; then
+  if [ "$_pp_disk_avail_kb" -lt "$_pp_disk_fail_kb" ]; then
+    echo ""
+    echo "[setup-error] Only $((_pp_disk_avail_kb / 1024)) MiB free on the volume holding $_pp_disk_target; recompilation and verification need more space."
+    echo "Free up space (at least $((_pp_disk_fail_kb / 1024)) MiB, ideally a few GiB) and re-run."
+    echo ""
+    return 1 2>/dev/null || exit 1
+  elif [ "$_pp_disk_avail_kb" -lt "$_pp_disk_warn_kb" ]; then
+    echo ""
+    echo "[low-disk] $((_pp_disk_avail_kb / 1024)) MiB free on the volume holding $_pp_disk_target"
+    echo "PRESS_DISK_AVAIL_KB=$_pp_disk_avail_kb"
+    echo "PRESS_DISK_WARN_KB=$_pp_disk_warn_kb"
+    echo ""
+  fi
+fi
 ```
 
-After setup, capture `PRINTING_PRESS_BIN=<abs-path>` and use that absolute path for every `cli-printing-press ...` invocation in this skill. Check binary version compatibility by reading the `min-binary-version` field from this skill's YAML frontmatter, running `"$PRINTING_PRESS_BIN" version --json`, and parsing the version from the output. Compare it to `min-binary-version` using semver rules. If the installed binary is older than the minimum, stop immediately and tell the user: "cli-printing-press binary vX.Y.Z is older than the minimum required vA.B.C. Run `go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest` to update."
+After setup, capture `PRINTING_PRESS_BIN=<abs-path>` and use that absolute path for every `cli-printing-press ...` invocation in this skill. If the setup block printed a `[setup-error]` line (missing Go toolchain; Go older than the generator's build toolchain under `GOTOOLCHAIN=local`; or critically low disk), it already exited non-zero — surface the message verbatim and stop. If it printed a `[go-toolchain-old]` or `[low-disk]` advisory, surface that one-line note to the user once and continue. Check binary version compatibility by reading the `min-binary-version` field from this skill's YAML frontmatter, running `"$PRINTING_PRESS_BIN" version --json`, and parsing the version from the output. Compare it to `min-binary-version` using semver rules. If the installed binary is older than the minimum, stop immediately and tell the user: "cli-printing-press binary vX.Y.Z is older than the minimum required vA.B.C. Run `go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest` to update."
 
 ### Public-library hint
 

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -217,10 +217,76 @@ PRESS_MANUSCRIPTS="$PRESS_HOME/manuscripts"
 PRESS_CURRENT="$PRESS_RUNSTATE/current"
 
 mkdir -p "$PRESS_RUNSTATE" "$PRESS_LIBRARY" "$PRESS_MANUSCRIPTS" "$PRESS_CURRENT"
+
+# --- Go toolchain present (the publish live gate compiles the CLI with Go) ---
+if ! command -v go >/dev/null 2>&1; then
+  echo ""
+  echo "[setup-error] Go toolchain not found."
+  echo "Publishing compiles the CLI and runs govulncheck with Go. Install Go from https://go.dev/dl/, verify with 'go version', then re-run."
+  echo ""
+  return 1 2>/dev/null || exit 1
+fi
+
+# --- Go toolchain currency (fail-open unless GOTOOLCHAIN=local) ---
+# Generated modules carry a `go <build-version>` directive matching the version
+# the generator binary was compiled with. A user Go older than that forces a
+# toolchain download (GOTOOLCHAIN=auto) or a hard "go.mod requires go >= X"
+# failure (GOTOOLCHAIN=local/offline) minutes into a run. Detect it now. Skip
+# silently if either version is unparseable or no binary is resolved.
+if command -v go >/dev/null 2>&1 && [ -n "$PRINTING_PRESS_BIN" ]; then
+  _pp_user_go="$(go env GOVERSION 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1)"
+  _pp_bin_go="$(go version "$PRINTING_PRESS_BIN" 2>/dev/null | grep -oE 'go[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1 | sed -E 's/^go//')"
+  if [ -n "$_pp_user_go" ] && [ -n "$_pp_bin_go" ] && \
+     [ "$(awk -v a="$_pp_user_go" -v b="$_pp_bin_go" 'BEGIN{split(a,x,".");split(b,y,".");for(i=1;i<=3;i++){if((x[i]+0)<(y[i]+0)){print 1;exit}if((x[i]+0)>(y[i]+0)){print 0;exit}}print 0}')" = "1" ]; then
+    if [ "$(go env GOTOOLCHAIN 2>/dev/null)" = "local" ]; then
+      echo ""
+      echo "[setup-error] Go go$_pp_user_go is older than the generator build toolchain go$_pp_bin_go, and GOTOOLCHAIN=local disables the automatic toolchain download."
+      echo "Generated modules need go$_pp_bin_go to build. Install Go $_pp_bin_go or newer from https://go.dev/dl/ (or unset GOTOOLCHAIN), then re-run."
+      echo ""
+      return 1 2>/dev/null || exit 1
+    fi
+    echo ""
+    echo "[go-toolchain-old] go$_pp_user_go is older than the generator build toolchain go$_pp_bin_go"
+    echo "PRESS_GO_INSTALLED=$_pp_user_go"
+    echo "PRESS_GO_REQUIRED=$_pp_bin_go"
+    echo ""
+  fi
+fi
+
+# --- Disk preflight (fail-open unless critically low) ---
+# Publish clones the library (multi-GB), compiles the CLI, and runs govulncheck.
+# A nearly-full volume fails deep into the run with an opaque "no space left on
+# device". Warn early; hard-stop only when space is critically low. Thresholds
+# env-tunable for CI.
+_pp_disk_warn_kb="${PRINTING_PRESS_DISK_WARN_KB:-3145728}"   # 3 GiB
+_pp_disk_fail_kb="${PRINTING_PRESS_DISK_FAIL_KB:-524288}"    # 512 MiB
+_pp_disk_target="$PRESS_HOME"
+while [ -n "$_pp_disk_target" ] && [ "$_pp_disk_target" != "/" ] && [ ! -d "$_pp_disk_target" ]; do
+  _pp_disk_target="$(dirname "$_pp_disk_target")"
+done
+[ -d "$_pp_disk_target" ] || _pp_disk_target="$HOME"
+_pp_disk_avail_kb="$(df -Pk "$_pp_disk_target" 2>/dev/null | awk 'NR==2{print $4}')"
+if printf '%s' "$_pp_disk_avail_kb" | grep -qE '^[0-9]+$'; then
+  if [ "$_pp_disk_avail_kb" -lt "$_pp_disk_fail_kb" ]; then
+    echo ""
+    echo "[setup-error] Only $((_pp_disk_avail_kb / 1024)) MiB free on the volume holding $_pp_disk_target; publish clone and compilation need more space."
+    echo "Free up space (at least $((_pp_disk_fail_kb / 1024)) MiB, ideally a few GiB) and re-run."
+    echo ""
+    return 1 2>/dev/null || exit 1
+  elif [ "$_pp_disk_avail_kb" -lt "$_pp_disk_warn_kb" ]; then
+    echo ""
+    echo "[low-disk] $((_pp_disk_avail_kb / 1024)) MiB free on the volume holding $_pp_disk_target"
+    echo "PRESS_DISK_AVAIL_KB=$_pp_disk_avail_kb"
+    echo "PRESS_DISK_WARN_KB=$_pp_disk_warn_kb"
+    echo ""
+  fi
+fi
 ```
 <!-- PRESS_SETUP_CONTRACT_END -->
 
 After running the setup contract, capture the `PRINTING_PRESS_BIN=<abs-path>` line from stdout. **Every subsequent `cli-printing-press ...` invocation in this skill must use that absolute path** (substitute the value, not the literal `$PRINTING_PRESS_BIN` token) — `export PATH` above only affects the single Bash tool call it runs in, so later calls open a fresh shell where bare `cli-printing-press` resolves against the user's default `PATH` and a stale global can shadow the local build.
+
+If the setup contract printed a `[setup-error]` line (missing Go toolchain; Go older than the generator's build toolchain under `GOTOOLCHAIN=local`; or critically low disk), it already exited non-zero — surface the message verbatim and stop; do not clone, package, or open a PR. If it printed a `[go-toolchain-old]` or `[low-disk]` advisory, surface that one-line note to the user once and continue.
 
 After capturing the binary path, check binary version compatibility. Read the `min-binary-version` field from this skill's YAML frontmatter. Run `<PRINTING_PRESS_BIN> version --json` and parse the version from the output. Compare it to `min-binary-version` using semver rules. If the installed binary is older than the minimum, stop immediately and tell the user: "cli-printing-press binary vX.Y.Z is older than the minimum required vA.B.C. Run `go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest` to update."
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -364,6 +364,62 @@ PRESS_CURRENT="$PRESS_RUNSTATE/current"
 
 mkdir -p "$PRESS_RUNSTATE" "$PRESS_LIBRARY" "$PRESS_MANUSCRIPTS" "$PRESS_CURRENT"
 
+# --- Go toolchain currency (fail-open unless GOTOOLCHAIN=local) ---
+# Generated modules carry a `go <build-version>` directive matching the version
+# the generator binary was compiled with. A user Go older than that forces a
+# toolchain download (GOTOOLCHAIN=auto) or a hard "go.mod requires go >= X"
+# failure (GOTOOLCHAIN=local/offline) minutes into a run. Detect it now. The
+# comparison is self-contained (inline awk) so it can be lifted verbatim into the
+# other flows' contracts. Skip silently if either version is unparseable.
+if command -v go >/dev/null 2>&1 && [ -n "$PRINTING_PRESS_BIN" ]; then
+  _pp_user_go="$(go env GOVERSION 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1)"
+  _pp_bin_go="$(go version "$PRINTING_PRESS_BIN" 2>/dev/null | grep -oE 'go[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1 | sed -E 's/^go//')"
+  if [ -n "$_pp_user_go" ] && [ -n "$_pp_bin_go" ] && \
+     [ "$(awk -v a="$_pp_user_go" -v b="$_pp_bin_go" 'BEGIN{split(a,x,".");split(b,y,".");for(i=1;i<=3;i++){if((x[i]+0)<(y[i]+0)){print 1;exit}if((x[i]+0)>(y[i]+0)){print 0;exit}}print 0}')" = "1" ]; then
+    if [ "$(go env GOTOOLCHAIN 2>/dev/null)" = "local" ]; then
+      echo ""
+      echo "[setup-error] Go go$_pp_user_go is older than the generator build toolchain go$_pp_bin_go, and GOTOOLCHAIN=local disables the automatic toolchain download."
+      echo "Generated modules need go$_pp_bin_go to build. Install Go $_pp_bin_go or newer from https://go.dev/dl/ (or unset GOTOOLCHAIN), then re-run."
+      echo ""
+      return 1 2>/dev/null || exit 1
+    fi
+    echo ""
+    echo "[go-toolchain-old] go$_pp_user_go is older than the generator build toolchain go$_pp_bin_go"
+    echo "PRESS_GO_INSTALLED=$_pp_user_go"
+    echo "PRESS_GO_REQUIRED=$_pp_bin_go"
+    echo ""
+  fi
+fi
+
+# --- Disk preflight (fail-open unless critically low) ---
+# Generation writes thousands of files, compiles the module, and populates the
+# module cache; publish/import clone multi-GB repos. A nearly-full volume fails
+# deep into the run with an opaque "no space left on device". Warn early;
+# hard-stop only when space is critically low. Thresholds env-tunable for CI.
+_pp_disk_warn_kb="${PRINTING_PRESS_DISK_WARN_KB:-3145728}"   # 3 GiB
+_pp_disk_fail_kb="${PRINTING_PRESS_DISK_FAIL_KB:-524288}"    # 512 MiB
+_pp_disk_target="$PRESS_HOME"
+while [ -n "$_pp_disk_target" ] && [ "$_pp_disk_target" != "/" ] && [ ! -d "$_pp_disk_target" ]; do
+  _pp_disk_target="$(dirname "$_pp_disk_target")"
+done
+[ -d "$_pp_disk_target" ] || _pp_disk_target="$HOME"
+_pp_disk_avail_kb="$(df -Pk "$_pp_disk_target" 2>/dev/null | awk 'NR==2{print $4}')"
+if printf '%s' "$_pp_disk_avail_kb" | grep -qE '^[0-9]+$'; then
+  if [ "$_pp_disk_avail_kb" -lt "$_pp_disk_fail_kb" ]; then
+    echo ""
+    echo "[setup-error] Only $((_pp_disk_avail_kb / 1024)) MiB free on the volume holding $_pp_disk_target; generation and compilation need more space."
+    echo "Free up space (at least $((_pp_disk_fail_kb / 1024)) MiB, ideally a few GiB) and re-run."
+    echo ""
+    return 1 2>/dev/null || exit 1
+  elif [ "$_pp_disk_avail_kb" -lt "$_pp_disk_warn_kb" ]; then
+    echo ""
+    echo "[low-disk] $((_pp_disk_avail_kb / 1024)) MiB free on the volume holding $_pp_disk_target"
+    echo "PRESS_DISK_AVAIL_KB=$_pp_disk_avail_kb"
+    echo "PRESS_DISK_WARN_KB=$_pp_disk_warn_kb"
+    echo ""
+  fi
+fi
+
 # --- Latest-version advisory (fail-open) ---
 # Repo checkouts track origin/main because their skills and local binary come
 # from the checkout. Standalone installs track the latest released Go module.
@@ -535,7 +591,7 @@ CODEX_CONSECUTIVE_FAILURES=0
 ```
 <!-- PRESS_SETUP_CONTRACT_END -->
 
-**MANDATORY: Read and apply [references/setup-checks.md](references/setup-checks.md) immediately after the setup contract bash block runs, before any other action.** It handles the contract output signals: `[setup-error]` (refuse to run, surface the install instructions), optional `[local-binary-stale]` / `[local-binary-rebuilt]` repo-mode rebuild markers, `[repo-upgrade-available]` (interactive `AskUserQuestion` prompt + optional repo pull), `PRESS_REPO_MODE=<true|false>` plus the targeted global open-agent-skills freshness check, the min-binary-version compatibility check (hard stop if binary is too old), `[upgrade-required]` (hard gate below the published currency floor — interactive upgrade-or-abort, no skip), `[upgrade-available]` (interactive `AskUserQuestion` prompt + optional standalone binary upgrade), `[browser-tools-missing]` (interactive `AskUserQuestion` prompt + optional install of browser-use and/or agent-browser), and the `PRINTING_PRESS_BIN=<abs-path>` marker plus optional `[binary-shadow]` warning (capture the path; use it for every subsequent generator invocation). Skipping the reference will cause the skill to proceed with a missing or out-of-date binary, run with stale global skill text when the session is managed by open-agent-skills, hit a mid-flight install prompt if browser-sniff is later needed, or invoke the wrong binary because a stale global or the public catalog installer on `PATH` shadowed the local build. Do not skip.
+**MANDATORY: Read and apply [references/setup-checks.md](references/setup-checks.md) immediately after the setup contract bash block runs, before any other action.** It handles the contract output signals: `[setup-error]` (refuse to run, surface the install instructions), optional `[local-binary-stale]` / `[local-binary-rebuilt]` repo-mode rebuild markers, `[repo-upgrade-available]` (interactive `AskUserQuestion` prompt + optional repo pull), `PRESS_REPO_MODE=<true|false>` plus the targeted global open-agent-skills freshness check, the min-binary-version compatibility check (hard stop if binary is too old), `[upgrade-required]` (hard gate below the published currency floor — interactive upgrade-or-abort, no skip), `[upgrade-available]` (interactive `AskUserQuestion` prompt + optional standalone binary upgrade), `[browser-tools-missing]` (interactive `AskUserQuestion` prompt + optional install of browser-use and/or agent-browser), `[go-toolchain-old]` (advisory: the installed Go is older than the generator's build toolchain — surface and continue), `[low-disk]` (advisory: the workspace volume is low on free space — surface and continue), and the `PRINTING_PRESS_BIN=<abs-path>` marker plus optional `[binary-shadow]` warning (capture the path; use it for every subsequent generator invocation). Skipping the reference will cause the skill to proceed with a missing or out-of-date binary, run with stale global skill text when the session is managed by open-agent-skills, hit a mid-flight install prompt if browser-sniff is later needed, or invoke the wrong binary because a stale global or the public catalog installer on `PATH` shadowed the local build. Do not skip.
 
 **Absolute-path rule.** The preflight contract always emits `PRINTING_PRESS_BIN=<absolute path>` to stdout. Capture this value and substitute it (the resolved absolute path, not the literal `$PRINTING_PRESS_BIN` token) for every subsequent `cli-printing-press ...` invocation in this skill, references, and any sub-skill you delegate to. The `export PATH=...` line inside the contract only affects the single Bash tool call it runs in; later Bash tool calls open fresh shells and resolve bare `cli-printing-press` against the user's default `PATH`, where a stale globally-installed binary (`$HOME/go/bin/cli-printing-press`, Homebrew copy, etc.) will silently shadow the local build the preflight just chose. Bash code examples below are written `cli-printing-press generate ...` for readability — replace `cli-printing-press` with the captured absolute path each time you actually run one.
 

--- a/skills/printing-press/references/setup-checks.md
+++ b/skills/printing-press/references/setup-checks.md
@@ -1,6 +1,6 @@
 # Setup Checks
 
-Post-contract checks the skill must run after executing the bash setup contract block in `SKILL.md`. These handle the contract output signals: `[setup-error]`, optional `[local-binary-stale]` / `[local-binary-rebuilt]` repo-mode rebuild markers, `[repo-upgrade-available]`, the always-emitted `PRINTING_PRESS_BIN=<abs-path>` and `PRESS_REPO_MODE=<true|false>` markers, the global open-agent-skills freshness check, the `min-binary-version` compatibility check, `[upgrade-required]`, `[upgrade-available]`, `[browser-tools-missing]`, and optional `[binary-shadow]` advisory.
+Post-contract checks the skill must run after executing the bash setup contract block in `SKILL.md`. These handle the contract output signals: `[setup-error]`, optional `[local-binary-stale]` / `[local-binary-rebuilt]` repo-mode rebuild markers, `[repo-upgrade-available]`, the always-emitted `PRINTING_PRESS_BIN=<abs-path>` and `PRESS_REPO_MODE=<true|false>` markers, the global open-agent-skills freshness check, the `min-binary-version` compatibility check, `[upgrade-required]`, `[upgrade-available]`, `[browser-tools-missing]`, the `[go-toolchain-old]` and `[low-disk]` environment advisories, and optional `[binary-shadow]` advisory.
 
 Apply these in order. The preamble below runs unconditionally; each numbered section after it is conditional — do nothing if its trigger isn't present.
 
@@ -280,3 +280,39 @@ Surface a single-line note to the user before continuing — informational only,
 Then continue. Do not modify or remove the global. The note exists so the user can reconcile the divergence on their own time (typically with `go install ...@latest` once they want the new version everywhere).
 
 If no `[binary-shadow]` line was emitted, skip the advisory and continue.
+
+## 8. Go toolchain currency advisory
+
+The contract compares the user's `go env GOVERSION` against the Go version the resolved generator binary was built with (`go version "$PRINTING_PRESS_BIN"`). Generated modules carry a `go <build-version>` directive matching that build toolchain, so an older user Go cannot build them without a toolchain download. The check emits at most one signal:
+
+- A hard `[setup-error]` (handled by section 1) only when the user's Go is older **and** `GOTOOLCHAIN=local` is set — auto-download is disabled, so the build will certainly fail. The contract has already exited non-zero; surface the message verbatim.
+- A soft `[go-toolchain-old]` advisory when the user's Go is older but `GOTOOLCHAIN` permits the automatic download (the default `auto`). Parse the follow-up lines:
+
+  - `PRESS_GO_INSTALLED=<installed Go version>`
+  - `PRESS_GO_REQUIRED=<generator build Go version>`
+
+  Surface a single-line note before continuing — informational only, do not prompt:
+
+  > "Note: your Go toolchain is go`<installed>`, older than the generator's build toolchain go`<required>`. Generation will download a matching toolchain on first build (needs network); if `GOTOOLCHAIN=local` or you are offline, install Go `<required>`+ first."
+
+  Then continue. The advisory is fail-open because `GOTOOLCHAIN=auto` (the Go default) downloads the required toolchain on demand; the note exists so a failed download mid-generation is not a surprise.
+
+If neither line was emitted (Go is current, or either version was unparseable), skip this section entirely.
+
+## 9. Low-disk advisory
+
+The contract checks free space on the volume holding the workspace (`PRESS_HOME`) before long generation/clone/build work. It emits at most one signal:
+
+- A hard `[setup-error]` (handled by section 1) when free space is below the critical floor (default 512 MiB) — generation plus `go build` plus the module cache cannot fit. The contract has already exited non-zero; surface the message verbatim.
+- A soft `[low-disk]` advisory when free space is below the warn threshold (default 3 GiB) but above the critical floor. Parse the follow-up lines:
+
+  - `PRESS_DISK_AVAIL_KB=<available kilobytes>`
+  - `PRESS_DISK_WARN_KB=<warn threshold in kilobytes>`
+
+  Surface a single-line note before continuing — informational only, do not prompt:
+
+  > "Note: only `<avail>` MiB free on the workspace volume. A full generate + build + publish run can need a few GiB; free space if the run fails with a disk error."
+
+  Then continue. Both thresholds are tunable via `PRINTING_PRESS_DISK_WARN_KB` / `PRINTING_PRESS_DISK_FAIL_KB` for small CI runners.
+
+If neither line was emitted (ample free space, or `df` output was unparseable), skip this section entirely.


### PR DESCRIPTION
## Intent

Generation and publish flows could fail **minutes into a run** — after thousands of files are written or a multi-GB clone — when two environment prerequisites went undetected at preflight:

- The user's Go was older than the generator's build toolchain (generated modules carry a `go <build-version>` directive, so an old Go triggers a toolchain download or a hard `go.mod requires go >= X` failure deep into a quality gate).
- The workspace volume was nearly full, failing later with an opaque `no space left on device`.

The setup contracts already detect a missing binary and a missing `go`, but not Go *currency* or free *disk*.

Issue: Closes #3365

## Approach

Two fail-open preflight gates added to the generation/build/publish setup contracts (`printing-press`, `printing-press-amend`, `printing-press-polish`, `printing-press-publish`, `printing-press-import`):

- **Go toolchain currency** — compare `go env GOVERSION` against the resolved binary's build toolchain (`go version "$PRINTING_PRESS_BIN"`). Soft `[go-toolchain-old]` advisory by default (the default `GOTOOLCHAIN=auto` downloads the needed toolchain on demand); hard `[setup-error]` only under `GOTOOLCHAIN=local`, where auto-download is disabled and the build will certainly fail. Skips silently when either version is unparseable.
- **Disk** — `df -Pk` on the volume holding the workspace. Soft `[low-disk]` advisory below ~3 GiB; hard `[setup-error]` below a critical ~512 MiB floor. Thresholds are env-tunable (`PRINTING_PRESS_DISK_WARN_KB` / `PRINTING_PRESS_DISK_FAIL_KB`) for small CI runners.
- A `go`-presence hard gate was added to `publish`/`import` (both `go build` later but did not check up front).

The new `[go-toolchain-old]` / `[low-disk]` signals (and their hard `[setup-error]` variants) are documented **once** in the shared `references/setup-checks.md` rather than duplicating prose per skill; the inline contract bash is the self-contained signal emitter, matching how every existing signal (`[setup-error]`, `[upgrade-required]`, …) is handled. A drift-lock test asserts every contract carries the gates.

## Scope

Primary area: skills / preflight setup contracts + the shared `setup-checks.md` reference.

Why this belongs in this repo: the setup contracts are machine-level skill artifacts shared across all generation/publish flows. The fix generalizes (no API/site specifics) and improves every future run, which is exactly a machine change rather than a printed-CLI fix.

## Catalog Justification

N/A — no `catalog/*.yaml` or `catalog/specs/**` changes.

## Risk

Low and fail-open by design:
- Both checks skip silently on unparseable input (`go env` / `df` returning unexpected output) and never block on a transient probe failure.
- The only **hard** stops fire under conditions that would otherwise fail the run anyway: an old Go with `GOTOOLCHAIN=local` (auto-download disabled), and a critically low disk (< ~512 MiB). Both thresholds are env-tunable.
- New env knobs are additive and default to sensible values.
- Cross-contract parity is locked by `TestPreflightEnvironmentGatesPresentInContracts` so a gate can't be silently dropped from one flow.
- No generator, template, manifest, MCP, scorecard, catalog, or printed-CLI output changed.

## Output Contract

N/A — no templates, generated files, manifests, command output, MCP schemas, scorecard output, catalog rendering, or pipeline artifacts changed. The change adds two new **preflight stdout signals** to the skill setup contracts; these are documented in `references/setup-checks.md` and locked by tests in `internal/pipeline/contracts_test.go`. No golden fixture references the affected skill files (verified by grep).

## Verification

- `go test ./internal/pipeline/` — **PASS**. Covers the existing contract parity / currency-floor / setup-block tests plus 6 new gate behavior tests (old-Go advisory, old-Go hard gate under `GOTOOLCHAIN=local`, current-Go pass, low-disk advisory, critically-low-disk hard gate) and a new cross-contract drift-lock test.
- `gofmt -l internal/pipeline/contracts_test.go` — clean; `go vet ./internal/pipeline/` — clean.
- Static audit: every `internal/cli` skill-content assertion targets strings untouched by this change (the two `setup-checks.md` assertions still hold); confirmed by grep.
- Full `go test ./...`, `golangci-lint`, and `scripts/golden.sh verify` could **not be completed on the dev machine** because its disk is critically low (~2 GiB) — the repo's heavy generator/CLI-linking tests hit `no space left on device` (the exact condition this PR detects). CI will run the full matrix. No generator/template/output files changed, so no golden drift is expected.

- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output — N/A (no generator/template change)
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures — N/A
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates — N/A

## AI / Automation Disclosure

- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
