### PR TITLE
feat(generator): composite-aware ReconcilePartition seen-set + cascade

### DIFF
--- a/internal/generator/store_reconcile_composite_test.go
+++ b/internal/generator/store_reconcile_composite_test.go
@@ -134,6 +134,66 @@ func TestReconcilePartition_CompositeKeyPreservesLiveRows(t *testing.T) {
 		t.Fatalf("stale junction row survived; cascade must delete by the bare resource id")
 	}
 }
+
+// TestReconcilePartition_CompositeKeyCrossParent pins the per-partition
+// invariant that makes the bare-id seen-set test safe even though the same bare
+// id can appear under different parents (composite keys "child\x00A" and
+// "child\x00B"). ReconcilePartition is invoked once per parent — each call gets
+// only that parent's scope (the victim query filters on it) and that parent's
+// seen-set — so a child that is live under A but stale under B is correctly
+// swept in B's partition and kept in A's. The bare-id collision never produces
+// a cross-parent false-negative.
+func TestReconcilePartition_CompositeKeyCrossParent(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+	db := s.DB()
+
+	const childA = "child\x00A"
+	const childB = "child\x00B"
+	for _, r := range []struct{ id, data string }{
+		{childA, ` + "`" + `{"id":"child","scope":"A"}` + "`" + `},
+		{childB, ` + "`" + `{"id":"child","scope":"B"}` + "`" + `},
+	} {
+		if _, err := db.Exec(
+			` + "`" + `INSERT INTO resources (resource_type, id, data) VALUES (?, ?, ?)` + "`" + `,
+			"things", r.id, r.data,
+		); err != nil {
+			t.Fatalf("insert %q: %v", r.id, err)
+		}
+	}
+
+	cnt := func(id string) int {
+		var n int
+		if err := db.QueryRow(` + "`" + `SELECT COUNT(*) FROM resources WHERE id=?` + "`" + `, id).Scan(&n); err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		return n
+	}
+
+	// Partition B: B's live items do NOT include child (it was removed under B).
+	delB, err := s.ReconcilePartition("things", "$.scope", "B", []string{"other"}, "things", nil)
+	if err != nil {
+		t.Fatalf("reconcile B: %v", err)
+	}
+	// Partition A: child is still live under A.
+	delA, err := s.ReconcilePartition("things", "$.scope", "A", []string{"child"}, "things", nil)
+	if err != nil {
+		t.Fatalf("reconcile A: %v", err)
+	}
+
+	if cnt(childB) != 0 {
+		t.Fatalf("child under stale parent B survived; per-parent reconcile must sweep it (no cross-parent false-negative)")
+	}
+	if cnt(childA) != 1 {
+		t.Fatalf("child under live parent A deleted; it must be kept")
+	}
+	if delB != 1 || delA != 0 {
+		t.Fatalf("delB=%d delA=%d, want 1 and 0", delB, delA)
+	}
+}
 `
 	testPath := filepath.Join(outputDir, "internal", "store", "reconcile_composite_test.go")
 	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
@@ -141,5 +201,5 @@ func TestReconcilePartition_CompositeKeyPreservesLiveRows(t *testing.T) {
 	runGoCommandRequired(t, outputDir, "mod", "tidy")
 	// MUST fail before the template fix (live row mis-deleted, cascade orphan) and
 	// pass after.
-	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "TestReconcilePartition_CompositeKeyPreservesLiveRows", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "TestReconcilePartition_CompositeKey", "-count=1")
 }

--- a/internal/generator/store_reconcile_composite_test.go
+++ b/internal/generator/store_reconcile_composite_test.go
@@ -1,0 +1,145 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReconcilePartition_CompositeKeyPreservesLiveRows verifies that
+// ReconcilePartition treats parent-keyed dependent rows — whose storage id is the
+// NUL-composite "<id>\x00<parent>" that resourceStorageID builds — correctly:
+// seen-set membership is tested against the BARE id (the form sync collects into
+// seenIDs), and cascade junction deletes use the bare id (junction FKs never
+// carry the composite suffix). Before the fix the SQL victim filter
+// `id NOT IN reconcile_seen` compared the whole composite key against bare seen
+// ids, so every still-live composite row was mis-selected as a victim and hard
+// deleted on `sync --full`; the cascade delete then no-opped (composite id never
+// matched a bare junction FK), orphaning junction rows.
+func TestReconcilePartition_CompositeKeyPreservesLiveRows(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("reconcile-composite")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"things": {
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:   "GET",
+					Path:     "/things",
+					Response: spec.ResponseDef{Type: "array", Item: "Thing"},
+					IDField:  "id",
+				},
+				"get": {
+					Method:   "GET",
+					Path:     "/things/{thingId}",
+					Response: spec.ResponseDef{Type: "object", Item: "Thing"},
+					IDField:  "id",
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Thing": {
+			Fields: []spec.TypeField{
+				{Name: "id", Type: "string"},
+				{Name: "scope", Type: "string"},
+				{Name: "name", Type: "string"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "reconcile-composite-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	inlineTest := `package store
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestReconcilePartition_CompositeKeyPreservesLiveRows(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	db := s.DB()
+
+	// Composite storage ids: "<id>\x00<parent>" — the shape resourceStorageID
+	// builds for parent-keyed dependents. seenIDs from sync hold the BARE id.
+	const live = "child-live\x00parentA"
+	const stale = "child-stale\x00parentA"
+
+	resRows := []struct{ id, data string }{
+		{live, ` + "`" + `{"id":"child-live","scope":"wsA"}` + "`" + `},
+		{stale, ` + "`" + `{"id":"child-stale","scope":"wsA"}` + "`" + `},
+	}
+	for _, r := range resRows {
+		if _, err := db.Exec(
+			` + "`" + `INSERT INTO resources (resource_type, id, data) VALUES (?, ?, ?)` + "`" + `,
+			"things", r.id, r.data,
+		); err != nil {
+			t.Fatalf("insert %q: %v", r.id, err)
+		}
+	}
+
+	// Cascade junction keyed by the BARE child id; junction FKs never carry the
+	// NUL-composite suffix.
+	if _, err := db.Exec(` + "`" + `CREATE TABLE junc (thing_id TEXT, other TEXT)` + "`" + `); err != nil {
+		t.Fatalf("create junc: %v", err)
+	}
+	for _, fk := range []string{"child-live", "child-stale"} {
+		if _, err := db.Exec(` + "`" + `INSERT INTO junc (thing_id, other) VALUES (?, ?)` + "`" + `, fk, "x"); err != nil {
+			t.Fatalf("insert junc %q: %v", fk, err)
+		}
+	}
+
+	// seenIDs carries only the BARE live id. The live composite row must survive
+	// (its bare id was seen); only the stale row is a victim.
+	cascades := []CascadeJunction{{Table: "junc", FKColumn: "thing_id"}}
+	deleted, err := s.ReconcilePartition("things", "$.scope", "wsA", []string{"child-live"}, "things", cascades)
+	if err != nil {
+		t.Fatalf("ReconcilePartition returned error (want nil): %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1 (only the stale composite row)", deleted)
+	}
+
+	count := func(q string, args ...any) int {
+		var n int
+		if err := db.QueryRow(q, args...).Scan(&n); err != nil {
+			t.Fatalf("count %q: %v", q, err)
+		}
+		return n
+	}
+
+	if count(` + "`" + `SELECT COUNT(*) FROM resources WHERE resource_type='things' AND id=?` + "`" + `, live) != 1 {
+		t.Fatalf("live composite row deleted; it must be kept (its bare id was in seenIDs)")
+	}
+	if count(` + "`" + `SELECT COUNT(*) FROM resources WHERE resource_type='things' AND id=?` + "`" + `, stale) != 0 {
+		t.Fatalf("stale composite row survived; it must be reconciled away")
+	}
+	// Cascade must delete by the BARE fk: the stale child's junction row is gone,
+	// the live child's junction row is kept.
+	if count(` + "`" + `SELECT COUNT(*) FROM junc WHERE thing_id='child-live'` + "`" + `) != 1 {
+		t.Fatalf("live junction row deleted; cascade must not touch live rows")
+	}
+	if count(` + "`" + `SELECT COUNT(*) FROM junc WHERE thing_id='child-stale'` + "`" + `) != 0 {
+		t.Fatalf("stale junction row survived; cascade must delete by the bare resource id")
+	}
+}
+`
+	testPath := filepath.Join(outputDir, "internal", "store", "reconcile_composite_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "mod", "tidy")
+	// MUST fail before the template fix (live row mis-deleted, cascade orphan) and
+	// pass after.
+	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "TestReconcilePartition_CompositeKeyPreservesLiveRows", "-count=1")
+}

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -2219,39 +2219,25 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	}
 	defer tx.Rollback()
 
-	// Per-call seen-set staging. A TEMP TABLE is connection-scoped, not
-	// transaction-scoped: its lifetime is decoupled from this tx. We deliberately
-	// do not rely on either lifetime — CREATE ... IF NOT EXISTS is a no-op when the
-	// table survived a previous call (standard SQLite keeps it; a ROLLBACK does not
-	// drop it), and the unconditional DELETE that follows clears any rows a prior
-	// partition left behind. So the pair is correct whether or not the underlying
-	// driver (modernc.org/sqlite here) drops temp tables on rollback — we never
-	// assume a fresh table, only an empty one before insert.
-	if _, err := tx.Exec(`CREATE TEMP TABLE IF NOT EXISTS reconcile_seen (id TEXT PRIMARY KEY)`); err != nil {
-		return 0, fmt.Errorf("reconcile %s: temp: %w", resourceType, err)
-	}
-	if _, err := tx.Exec(`DELETE FROM reconcile_seen`); err != nil {
-		return 0, fmt.Errorf("reconcile %s: clear temp: %w", resourceType, err)
-	}
-	ins, err := tx.Prepare(`INSERT OR IGNORE INTO reconcile_seen (id) VALUES (?)`)
-	if err != nil {
-		return 0, err
-	}
+	// Seen-set membership is tested in Go, not SQL. Parent-keyed dependent rows
+	// carry a NUL-composite storage id ("<id>\x00<parent>", built by
+	// resourceStorageID) while seenIDs holds the BARE API ids sync enumerated, so
+	// each stored id must run through BareResourceID before the comparison. A SQL
+	// seen-set is not viable here: SQLite string functions treat the embedded NUL
+	// as a C-string terminator, so an instr/substr or `IN` test over a key
+	// containing "\x00" silently truncates and mis-matches. BareResourceID is a
+	// no-op for plain ids, so flat/non-composite partitions are unaffected.
+	seen := make(map[string]struct{}, len(seenIDs))
 	for _, id := range seenIDs {
-		if _, err := ins.Exec(id); err != nil {
-			ins.Close()
-			return 0, err
-		}
+		seen[id] = struct{}{}
 	}
-	ins.Close()
 
 	// CASE guards against a malformed-JSON row aborting the victim scan:
 	// a row we cannot parse is never a victim — it is skipped (never deleted).
 	rows, err := tx.Query(
 		`SELECT id FROM resources
 		 WHERE resource_type = ?
-		   AND (CASE WHEN json_valid(data) THEN json_extract(data, ?) END) = ?
-		   AND id NOT IN (SELECT id FROM reconcile_seen)`,
+		   AND (CASE WHEN json_valid(data) THEN json_extract(data, ?) END) = ?`,
 		resourceType, genericScopeJSONPath, scopeValue,
 	)
 	if err != nil {
@@ -2263,6 +2249,9 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 		if err := rows.Scan(&id); err != nil {
 			rows.Close()
 			return 0, err
+		}
+		if _, ok := seen[BareResourceID(id)]; ok {
+			continue // bare id was enumerated this run — keep the row
 		}
 		victims = append(victims, id)
 	}
@@ -2286,8 +2275,10 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 		if _, err := tx.Exec(`DELETE FROM resources WHERE resource_type = ? AND id = ?`, resourceType, id); err != nil {
 			return 0, fmt.Errorf("reconcile %s: generic delete: %w", resourceType, err)
 		}
+		// Cascade junction FKs hold the BARE entity id, never the NUL-composite
+		// storage key, so strip the suffix before matching (no-op for plain ids).
 		for _, c := range cascades {
-			if _, err := tx.Exec(fmt.Sprintf(`DELETE FROM "%s" WHERE "%s" = ?`, c.Table, c.FKColumn), id); err != nil {
+			if _, err := tx.Exec(fmt.Sprintf(`DELETE FROM "%s" WHERE "%s" = ?`, c.Table, c.FKColumn), BareResourceID(id)); err != nil {
 				return 0, fmt.Errorf("reconcile %s: cascade %s: %w", resourceType, c.Table, err)
 			}
 		}

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -2969,10 +2969,10 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 
 			totalCount += stored
-			// seenIDs are stored primary keys; extractID resolves the PK the same
-			// way UpsertBatch does. Assumes storageID==id (true for per_parent
-			// resources lacking a composite parent key; composite-key per_parent
-			// resources are out of scope this round).
+			// seenIDs carries BARE entity ids; extractID resolves the PK the same
+			// way UpsertBatch does. ReconcilePartition compares these against the
+			// stored keys via BareResourceID, so parent-keyed (NUL-composite)
+			// dependents reconcile correctly without composite seen ids here.
 			for _, it := range items {
 				if o, derr := store.DecodeJSONObject(it); derr == nil {
 					if id := extractID(dep.Name, o); id != "" {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -2020,10 +2020,10 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 
 			totalCount += stored
-			// seenIDs are stored primary keys; extractID resolves the PK the same
-			// way UpsertBatch does. Assumes storageID==id (true for per_parent
-			// resources lacking a composite parent key; composite-key per_parent
-			// resources are out of scope this round).
+			// seenIDs carries BARE entity ids; extractID resolves the PK the same
+			// way UpsertBatch does. ReconcilePartition compares these against the
+			// stored keys via BareResourceID, so parent-keyed (NUL-composite)
+			// dependents reconcile correctly without composite seen ids here.
 			for _, it := range items {
 				if o, derr := store.DecodeJSONObject(it); derr == nil {
 					if id := extractID(dep.Name, o); id != "" {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -2002,39 +2002,25 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	}
 	defer tx.Rollback()
 
-	// Per-call seen-set staging. A TEMP TABLE is connection-scoped, not
-	// transaction-scoped: its lifetime is decoupled from this tx. We deliberately
-	// do not rely on either lifetime — CREATE ... IF NOT EXISTS is a no-op when the
-	// table survived a previous call (standard SQLite keeps it; a ROLLBACK does not
-	// drop it), and the unconditional DELETE that follows clears any rows a prior
-	// partition left behind. So the pair is correct whether or not the underlying
-	// driver (modernc.org/sqlite here) drops temp tables on rollback — we never
-	// assume a fresh table, only an empty one before insert.
-	if _, err := tx.Exec(`CREATE TEMP TABLE IF NOT EXISTS reconcile_seen (id TEXT PRIMARY KEY)`); err != nil {
-		return 0, fmt.Errorf("reconcile %s: temp: %w", resourceType, err)
-	}
-	if _, err := tx.Exec(`DELETE FROM reconcile_seen`); err != nil {
-		return 0, fmt.Errorf("reconcile %s: clear temp: %w", resourceType, err)
-	}
-	ins, err := tx.Prepare(`INSERT OR IGNORE INTO reconcile_seen (id) VALUES (?)`)
-	if err != nil {
-		return 0, err
-	}
+	// Seen-set membership is tested in Go, not SQL. Parent-keyed dependent rows
+	// carry a NUL-composite storage id ("<id>\x00<parent>", built by
+	// resourceStorageID) while seenIDs holds the BARE API ids sync enumerated, so
+	// each stored id must run through BareResourceID before the comparison. A SQL
+	// seen-set is not viable here: SQLite string functions treat the embedded NUL
+	// as a C-string terminator, so an instr/substr or `IN` test over a key
+	// containing "\x00" silently truncates and mis-matches. BareResourceID is a
+	// no-op for plain ids, so flat/non-composite partitions are unaffected.
+	seen := make(map[string]struct{}, len(seenIDs))
 	for _, id := range seenIDs {
-		if _, err := ins.Exec(id); err != nil {
-			ins.Close()
-			return 0, err
-		}
+		seen[id] = struct{}{}
 	}
-	ins.Close()
 
 	// CASE guards against a malformed-JSON row aborting the victim scan:
 	// a row we cannot parse is never a victim — it is skipped (never deleted).
 	rows, err := tx.Query(
 		`SELECT id FROM resources
 		 WHERE resource_type = ?
-		   AND (CASE WHEN json_valid(data) THEN json_extract(data, ?) END) = ?
-		   AND id NOT IN (SELECT id FROM reconcile_seen)`,
+		   AND (CASE WHEN json_valid(data) THEN json_extract(data, ?) END) = ?`,
 		resourceType, genericScopeJSONPath, scopeValue,
 	)
 	if err != nil {
@@ -2046,6 +2032,9 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 		if err := rows.Scan(&id); err != nil {
 			rows.Close()
 			return 0, err
+		}
+		if _, ok := seen[BareResourceID(id)]; ok {
+			continue // bare id was enumerated this run — keep the row
 		}
 		victims = append(victims, id)
 	}
@@ -2069,8 +2058,10 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 		if _, err := tx.Exec(`DELETE FROM resources WHERE resource_type = ? AND id = ?`, resourceType, id); err != nil {
 			return 0, fmt.Errorf("reconcile %s: generic delete: %w", resourceType, err)
 		}
+		// Cascade junction FKs hold the BARE entity id, never the NUL-composite
+		// storage key, so strip the suffix before matching (no-op for plain ids).
 		for _, c := range cascades {
-			if _, err := tx.Exec(fmt.Sprintf(`DELETE FROM "%s" WHERE "%s" = ?`, c.Table, c.FKColumn), id); err != nil {
+			if _, err := tx.Exec(fmt.Sprintf(`DELETE FROM "%s" WHERE "%s" = ?`, c.Table, c.FKColumn), BareResourceID(id)); err != nil {
 				return 0, fmt.Errorf("reconcile %s: cascade %s: %w", resourceType, c.Table, err)
 			}
 		}

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1944,39 +1944,25 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	}
 	defer tx.Rollback()
 
-	// Per-call seen-set staging. A TEMP TABLE is connection-scoped, not
-	// transaction-scoped: its lifetime is decoupled from this tx. We deliberately
-	// do not rely on either lifetime — CREATE ... IF NOT EXISTS is a no-op when the
-	// table survived a previous call (standard SQLite keeps it; a ROLLBACK does not
-	// drop it), and the unconditional DELETE that follows clears any rows a prior
-	// partition left behind. So the pair is correct whether or not the underlying
-	// driver (modernc.org/sqlite here) drops temp tables on rollback — we never
-	// assume a fresh table, only an empty one before insert.
-	if _, err := tx.Exec(`CREATE TEMP TABLE IF NOT EXISTS reconcile_seen (id TEXT PRIMARY KEY)`); err != nil {
-		return 0, fmt.Errorf("reconcile %s: temp: %w", resourceType, err)
-	}
-	if _, err := tx.Exec(`DELETE FROM reconcile_seen`); err != nil {
-		return 0, fmt.Errorf("reconcile %s: clear temp: %w", resourceType, err)
-	}
-	ins, err := tx.Prepare(`INSERT OR IGNORE INTO reconcile_seen (id) VALUES (?)`)
-	if err != nil {
-		return 0, err
-	}
+	// Seen-set membership is tested in Go, not SQL. Parent-keyed dependent rows
+	// carry a NUL-composite storage id ("<id>\x00<parent>", built by
+	// resourceStorageID) while seenIDs holds the BARE API ids sync enumerated, so
+	// each stored id must run through BareResourceID before the comparison. A SQL
+	// seen-set is not viable here: SQLite string functions treat the embedded NUL
+	// as a C-string terminator, so an instr/substr or `IN` test over a key
+	// containing "\x00" silently truncates and mis-matches. BareResourceID is a
+	// no-op for plain ids, so flat/non-composite partitions are unaffected.
+	seen := make(map[string]struct{}, len(seenIDs))
 	for _, id := range seenIDs {
-		if _, err := ins.Exec(id); err != nil {
-			ins.Close()
-			return 0, err
-		}
+		seen[id] = struct{}{}
 	}
-	ins.Close()
 
 	// CASE guards against a malformed-JSON row aborting the victim scan:
 	// a row we cannot parse is never a victim — it is skipped (never deleted).
 	rows, err := tx.Query(
 		`SELECT id FROM resources
 		 WHERE resource_type = ?
-		   AND (CASE WHEN json_valid(data) THEN json_extract(data, ?) END) = ?
-		   AND id NOT IN (SELECT id FROM reconcile_seen)`,
+		   AND (CASE WHEN json_valid(data) THEN json_extract(data, ?) END) = ?`,
 		resourceType, genericScopeJSONPath, scopeValue,
 	)
 	if err != nil {
@@ -1988,6 +1974,9 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 		if err := rows.Scan(&id); err != nil {
 			rows.Close()
 			return 0, err
+		}
+		if _, ok := seen[BareResourceID(id)]; ok {
+			continue // bare id was enumerated this run — keep the row
 		}
 		victims = append(victims, id)
 	}
@@ -2011,8 +2000,10 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 		if _, err := tx.Exec(`DELETE FROM resources WHERE resource_type = ? AND id = ?`, resourceType, id); err != nil {
 			return 0, fmt.Errorf("reconcile %s: generic delete: %w", resourceType, err)
 		}
+		// Cascade junction FKs hold the BARE entity id, never the NUL-composite
+		// storage key, so strip the suffix before matching (no-op for plain ids).
 		for _, c := range cascades {
-			if _, err := tx.Exec(fmt.Sprintf(`DELETE FROM "%s" WHERE "%s" = ?`, c.Table, c.FKColumn), id); err != nil {
+			if _, err := tx.Exec(fmt.Sprintf(`DELETE FROM "%s" WHERE "%s" = ?`, c.Table, c.FKColumn), BareResourceID(id)); err != nil {
 				return 0, fmt.Errorf("reconcile %s: cascade %s: %w", resourceType, c.Table, err)
 			}
 		}

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -1991,10 +1991,10 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 
 			totalCount += stored
-			// seenIDs are stored primary keys; extractID resolves the PK the same
-			// way UpsertBatch does. Assumes storageID==id (true for per_parent
-			// resources lacking a composite parent key; composite-key per_parent
-			// resources are out of scope this round).
+			// seenIDs carries BARE entity ids; extractID resolves the PK the same
+			// way UpsertBatch does. ReconcilePartition compares these against the
+			// stored keys via BareResourceID, so parent-keyed (NUL-composite)
+			// dependents reconcile correctly without composite seen ids here.
 			for _, it := range items {
 				if o, derr := store.DecodeJSONObject(it); derr == nil {
 					if id := extractID(dep.Name, o); id != "" {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1890,39 +1890,25 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	}
 	defer tx.Rollback()
 
-	// Per-call seen-set staging. A TEMP TABLE is connection-scoped, not
-	// transaction-scoped: its lifetime is decoupled from this tx. We deliberately
-	// do not rely on either lifetime — CREATE ... IF NOT EXISTS is a no-op when the
-	// table survived a previous call (standard SQLite keeps it; a ROLLBACK does not
-	// drop it), and the unconditional DELETE that follows clears any rows a prior
-	// partition left behind. So the pair is correct whether or not the underlying
-	// driver (modernc.org/sqlite here) drops temp tables on rollback — we never
-	// assume a fresh table, only an empty one before insert.
-	if _, err := tx.Exec(`CREATE TEMP TABLE IF NOT EXISTS reconcile_seen (id TEXT PRIMARY KEY)`); err != nil {
-		return 0, fmt.Errorf("reconcile %s: temp: %w", resourceType, err)
-	}
-	if _, err := tx.Exec(`DELETE FROM reconcile_seen`); err != nil {
-		return 0, fmt.Errorf("reconcile %s: clear temp: %w", resourceType, err)
-	}
-	ins, err := tx.Prepare(`INSERT OR IGNORE INTO reconcile_seen (id) VALUES (?)`)
-	if err != nil {
-		return 0, err
-	}
+	// Seen-set membership is tested in Go, not SQL. Parent-keyed dependent rows
+	// carry a NUL-composite storage id ("<id>\x00<parent>", built by
+	// resourceStorageID) while seenIDs holds the BARE API ids sync enumerated, so
+	// each stored id must run through BareResourceID before the comparison. A SQL
+	// seen-set is not viable here: SQLite string functions treat the embedded NUL
+	// as a C-string terminator, so an instr/substr or `IN` test over a key
+	// containing "\x00" silently truncates and mis-matches. BareResourceID is a
+	// no-op for plain ids, so flat/non-composite partitions are unaffected.
+	seen := make(map[string]struct{}, len(seenIDs))
 	for _, id := range seenIDs {
-		if _, err := ins.Exec(id); err != nil {
-			ins.Close()
-			return 0, err
-		}
+		seen[id] = struct{}{}
 	}
-	ins.Close()
 
 	// CASE guards against a malformed-JSON row aborting the victim scan:
 	// a row we cannot parse is never a victim — it is skipped (never deleted).
 	rows, err := tx.Query(
 		`SELECT id FROM resources
 		 WHERE resource_type = ?
-		   AND (CASE WHEN json_valid(data) THEN json_extract(data, ?) END) = ?
-		   AND id NOT IN (SELECT id FROM reconcile_seen)`,
+		   AND (CASE WHEN json_valid(data) THEN json_extract(data, ?) END) = ?`,
 		resourceType, genericScopeJSONPath, scopeValue,
 	)
 	if err != nil {
@@ -1934,6 +1920,9 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 		if err := rows.Scan(&id); err != nil {
 			rows.Close()
 			return 0, err
+		}
+		if _, ok := seen[BareResourceID(id)]; ok {
+			continue // bare id was enumerated this run — keep the row
 		}
 		victims = append(victims, id)
 	}
@@ -1957,8 +1946,10 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 		if _, err := tx.Exec(`DELETE FROM resources WHERE resource_type = ? AND id = ?`, resourceType, id); err != nil {
 			return 0, fmt.Errorf("reconcile %s: generic delete: %w", resourceType, err)
 		}
+		// Cascade junction FKs hold the BARE entity id, never the NUL-composite
+		// storage key, so strip the suffix before matching (no-op for plain ids).
 		for _, c := range cascades {
-			if _, err := tx.Exec(fmt.Sprintf(`DELETE FROM "%s" WHERE "%s" = ?`, c.Table, c.FKColumn), id); err != nil {
+			if _, err := tx.Exec(fmt.Sprintf(`DELETE FROM "%s" WHERE "%s" = ?`, c.Table, c.FKColumn), BareResourceID(id)); err != nil {
 				return 0, fmt.Errorf("reconcile %s: cascade %s: %w", resourceType, c.Table, err)
 			}
 		}


### PR DESCRIPTION
## What

`ReconcilePartition` (the mark-and-sweep half of `sync --full` deletion mirroring) is now correct for **parent-keyed dependent resources** — those whose local storage id is the NUL-composite `"<id>\x00<parent>"` that `resourceStorageID` builds.

## The bug

Parent-keyed dependents store their primary key as `"<id>\x00<parent>"`, but `sync` collects `seenIDs` as the **bare** API ids (`extractID`, same as `UpsertBatch` keys on). `ReconcilePartition` filtered victims in SQL with `id NOT IN (SELECT id FROM reconcile_seen)`, comparing the whole composite storage key against the bare seen-set. Every still-live composite row therefore failed the membership test and was selected as a victim and **hard-deleted on `sync --full`**. The follow-up cascade junction delete (`DELETE FROM <junction> WHERE <fk> = <composite id>`) then no-opped, because junction FKs hold bare ids — **orphaning the junction rows**.

Flat / non-composite (top-level) partitions were unaffected: their storage id already equals the bare id.

## The fix

- Test seen-set membership in **Go** (`seen[BareResourceID(id)]`) instead of SQL. A SQL seen-set is not viable here: SQLite string functions treat the embedded NUL as a C-string terminator, so an `IN` / `instr` / `substr` test over a key containing `"\x00"` silently truncates and mis-matches. This also lets the `reconcile_seen` TEMP TABLE go away.
- Strip the composite suffix before cascade junction deletes (`BareResourceID(id)`).

`BareResourceID` is a no-op for plain ids, so flat / non-composite partitions keep their existing behavior exactly.

## Tests

- New `internal/generator/store_reconcile_composite_test.go`: generates → compiles → runs a store, asserts a live composite-keyed row **survives** reconcile while a stale one (and its bare-keyed junction row) is **swept**. Fails before this change (live row mis-deleted, `deleted=2`), passes after (`deleted=1`).
- Existing `TestReconcilePartition_MalformedJSONRow` (the json_valid CASE guard) still green.

Regenerates the affected `store.go` / `sync.go` goldens (5 files).