### PR TITLE
feat(cli): add x-pp-example extension to override endpoint help examples

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -347,7 +347,8 @@ Rules:
   byte-for-byte.
 - Operation-level only. The value is the full invocation including the binary
   name (`<api-slug>-pp-cli <command> <args>`); the parser normalizes it to the
-  canonical two-space indent, so authors may omit the leading spaces.
+  canonical two-space indent on each line, so authors may omit the leading
+  spaces.
 - Use it instead of marking a param `required` to force it into the example —
   marking it required would also make the generated CLI flag mandatory, which a
   one-of endpoint must not be.

--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -46,6 +46,7 @@ in the same change as any new `Extensions["x-*"]` lookup in that file.
 | `x-live-dogfood-requires-tier` | path item or operation | `Endpoint.LiveDogfoodRequiresTier` | No |
 | `x-requires-role` | operation | `Endpoint.RequiresRole` | No |
 | `x-happy-args` | operation | `Endpoint.HappyArgs` | No |
+| `x-pp-example` | operation | `Endpoint.Example` (verbatim Cobra example override) | No |
 | `x-pp-resource` | operation | resource name override | No |
 | `x-pp-pagination` | operation | `Endpoint.Pagination` | No |
 | `x-pp-safe-probe` | operation | *skill guidance only; not parsed in parser.go* | No |
@@ -327,6 +328,44 @@ x-cache:
   commands:
     - name: dashboard
       resources: [quotes]
+```
+
+### `x-pp-example`
+
+Overrides the generated command's `--help` Example with a verbatim, authored
+invocation. The synthesized example only includes **required** params, so an
+endpoint whose params are all optional — the common "pass one of `channelId` /
+`handle` / `url`" shape — otherwise advertises a bare command the API rejects
+with a 4xx. That broken example also fails the live-dogfood happy-path and
+json-fidelity probes, which run the Example verbatim.
+
+Parsed field: `Endpoint.Example` (the same field the internal YAML spec sets via
+`example:`).
+
+Rules:
+- Optional. Endpoints without `x-pp-example` keep today's synthesized example
+  byte-for-byte.
+- Operation-level only. The value is the full invocation including the binary
+  name (`<api-slug>-pp-cli <command> <args>`); the parser normalizes it to the
+  canonical two-space indent, so authors may omit the leading spaces.
+- Use it instead of marking a param `required` to force it into the example —
+  marking it required would also make the generated CLI flag mandatory, which a
+  one-of endpoint must not be.
+- Whitespace-only values are ignored (treated as absent); non-string values warn
+  and are ignored.
+
+Example:
+
+```yaml
+paths:
+  /v1/youtube/channel:
+    get:
+      operationId: getYoutubeChannel
+      x-pp-example: "scrape-creators-pp-cli youtube list-channel --handle mkbhd"
+      parameters:
+        - { name: channelId, in: query, required: false, schema: { type: string } }
+        - { name: handle, in: query, required: false, schema: { type: string } }
+        - { name: url, in: query, required: false, schema: { type: string } }
 ```
 
 ### `x-pp-query`

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -69,6 +69,7 @@ const (
 	extensionPPPagination          = "x-pp-pagination"
 	extensionSyncWalker            = "x-pp-sync-walker"
 	extensionHappyArgs             = "x-happy-args"
+	extensionPPExample             = "x-pp-example"
 	extensionLiveDogfoodTier       = "x-live-dogfood-requires-tier"
 	extensionDispatchParam         = "x-pp-dispatch-param"
 	extensionPPResource            = "x-pp-resource"
@@ -3445,6 +3446,9 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) error {
 				endpoint.DataSourceStrategy = pathDataSourceStrategy
 			}
 			endpoint.HappyArgs = readHappyArgsExtension(op.Extensions, fmt.Sprintf("%s %q", strings.ToUpper(method), path))
+			if ex := readExampleExtension(op.Extensions, fmt.Sprintf("%s %q", strings.ToUpper(method), path)); ex != "" {
+				endpoint.Example = ex
+			}
 			endpoint.LiveDogfoodRequiresTier = readLiveDogfoodTierExtension(op.Extensions, fmt.Sprintf("%s %q", strings.ToUpper(method), path))
 			if endpoint.LiveDogfoodRequiresTier == "" {
 				endpoint.LiveDogfoodRequiresTier = pathLiveDogfoodTier
@@ -5424,6 +5428,38 @@ func readHappyArgsExtension(extensions map[string]any, context string) string {
 		return ""
 	}
 	return strings.TrimSpace(value)
+}
+
+// readExampleExtension reads an operation-level x-pp-example string and returns
+// it as the verbatim Cobra Example for the generated command, overriding the
+// synthesized example. It exists for all-optional "one-of" endpoints (pass one
+// of channelId / handle / url): the synthesized example only includes required
+// params, so such endpoints would otherwise advertise a bare command the API
+// rejects with a 4xx. Marking a param required to force it into the example
+// would wrongly make the CLI flag mandatory; x-pp-example fixes only the
+// example. Absent (the common case) returns "", preserving synthesis exactly.
+func readExampleExtension(extensions map[string]any, context string) string {
+	if extensions == nil {
+		return ""
+	}
+	raw, ok := extensions[extensionPPExample]
+	if !ok || raw == nil {
+		return ""
+	}
+	value, ok := raw.(string)
+	if !ok {
+		warnf("%s: %s must be a string, got %T; ignoring", context, extensionPPExample, raw)
+		return ""
+	}
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	// Endpoint.Example is emitted as the verbatim Cobra Example line, and
+	// synthesized examples carry a leading two-space indent. Normalize the
+	// authored value to the same indent so x-pp-example renders identically
+	// whether or not the author included the leading spaces.
+	return "  " + trimmed
 }
 
 func readLiveDogfoodTierExtension(extensions map[string]any, context string) string {

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -5459,7 +5459,11 @@ func readExampleExtension(extensions map[string]any, context string) string {
 	// synthesized examples carry a leading two-space indent. Normalize the
 	// authored value to the same indent so x-pp-example renders identically
 	// whether or not the author included the leading spaces.
-	return "  " + trimmed
+	lines := strings.Split(trimmed, "\n")
+	for i, line := range lines {
+		lines[i] = "  " + strings.TrimLeft(line, " ")
+	}
+	return strings.Join(lines, "\n")
 }
 
 func readLiveDogfoodTierExtension(extensions map[string]any, context string) string {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -7459,6 +7459,77 @@ paths:
 	require.Empty(t, songs.HappyArgs)
 }
 
+func TestParseExampleExtension(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: PP Example
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /channel:
+    get:
+      operationId: getChannel
+      x-pp-example: "  pp-example-pp-cli channel --handle mkbhd"
+      parameters:
+        - name: channelId
+          in: query
+          required: false
+          schema: { type: string }
+        - name: handle
+          in: query
+          required: false
+          schema: { type: string }
+      responses:
+        "200":
+          description: OK
+  /songs:
+    get:
+      operationId: listSongs
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	// x-pp-example overrides the synthesized (otherwise bare) example for an
+	// all-optional endpoint.
+	channel := findEndpoint(t, parsed, "/channel")
+	require.Equal(t, "  pp-example-pp-cli channel --handle mkbhd", channel.Example)
+
+	// Endpoints without the extension keep an empty Example so synthesis runs.
+	songs := findEndpoint(t, parsed, "/songs")
+	require.Empty(t, songs.Example)
+}
+
+func TestParseExampleExtensionWhitespaceOnly(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: PP Example Whitespace
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /channel:
+    get:
+      operationId: getChannel
+      x-pp-example: "   "
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	channel := findEndpoint(t, parsed, "/channel")
+	require.Empty(t, channel.Example)
+}
+
 func TestParseHappyArgsExtensionWhitespaceOnly(t *testing.T) {
 	t.Parallel()
 

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -7505,6 +7505,36 @@ paths:
 	require.Empty(t, songs.Example)
 }
 
+func TestParseExampleExtensionNormalizesBlockScalarLines(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: PP Example Block
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /channel:
+    get:
+      operationId: getChannel
+      x-pp-example: |
+        pp-example-pp-cli channel --handle mkbhd
+          pp-example-pp-cli channel --url https://example.com/channel/mkbhd
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	channel := findEndpoint(t, parsed, "/channel")
+	require.Equal(t, strings.Join([]string{
+		"  pp-example-pp-cli channel --handle mkbhd",
+		"  pp-example-pp-cli channel --url https://example.com/channel/mkbhd",
+	}, "\n"), channel.Example)
+}
+
 func TestParseExampleExtensionWhitespaceOnly(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Adds an operation-level `x-pp-example` OpenAPI extension that sets the verbatim Cobra `--help` Example for a generated endpoint command (parsed into the existing `Endpoint.Example`, the same field the internal YAML spec already sets via `example:`).

## Why

The synthesized example only includes **required** params. An endpoint whose params are all optional — the common "pass one of `channelId` / `handle` / `url`" shape (YouTube, Spotify, Rumble, and many social/media APIs) — emits a bare command the API rejects with a 4xx. That broken example also fails the live-dogfood happy-path and json-fidelity probes, which run the Example verbatim.

Surfaced while reprinting the Scrape Creators CLI: full live dogfood showed ~46 endpoints failing purely because their all-optional one-of examples were bare. The only prior workaround was marking a param `required`, which wrongly makes the generated CLI flag mandatory (breaking the one-of). `x-pp-example` fixes only the example.

## How

- New const `extensionPPExample = "x-pp-example"` + `readExampleExtension` (mirrors `readHappyArgsExtension`), wired into endpoint construction.
- Value is normalized to the canonical two-space indent so authors may omit leading spaces. Whitespace-only ignored; non-string warns and is ignored.

## Safety

- **Additive.** Endpoints without the extension keep today's synthesized example byte-for-byte.
- `go test ./...` green; `scripts/golden.sh verify` unchanged (32 cases, no churn); `scripts/verify-generator-output.sh` green (10 cases); gofmt + vet + golangci-lint clean.
- Tests: `TestParseExampleExtension` (+ whitespace variant); the existing `TestEndpointFixturesEmittedFromSpec` already covers `Endpoint.Example` → emitted command output.
- Docs: `docs/SPEC-EXTENSIONS.md` table row + section.

Maintainer-owned change (direct work).