### PR TITLE
chore(skills): ignore private project skill installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,12 +26,11 @@ CLAUDE.local.md
 AGENTS.override.md
 .claude/settings.local.json
 
-# Local project-scoped agent skill/plugin installs. These let private or
+# Local project-scoped agent skill installs. These let private or
 # experimental skills live next to this checkout without being published from
 # this public repo. Note: the repo's own tracked skills live in root `skills/`,
 # which is intentionally NOT ignored here.
 .claude/skills/
-.claude/plugins/
 .skills/
 .agents/skills/
 .codex/skills/

--- a/.gitignore
+++ b/.gitignore
@@ -33,10 +33,11 @@ AGENTS.override.md
 .claude/skills/
 .claude/plugins/
 .skills/
-.agents/
-.codex/
-.cursor/
-.gemini/
+.agents/skills/
+.codex/skills/
+.cursor/skills/
+.gemini/skills/
+skills-lock.json
 
 # Planning documents stay local — this is a public repo and plans
 # frequently describe in-progress, unreleased, or third-party work.

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ AGENTS.override.md
 .codex/skills/
 .cursor/skills/
 .gemini/skills/
-skills-lock.json
+/skills-lock.json
 
 # Planning documents stay local — this is a public repo and plans
 # frequently describe in-progress, unreleased, or third-party work.


### PR DESCRIPTION
## Summary

Project-scoped private agent skills can live beside this public CLI checkout without showing up as untracked files or getting committed by accident.

This narrows the local-agent ignore block to project skill install locations plus the repo-root `/skills-lock.json`. Plugin directories are intentionally left visible because this project install flow is only using skills.

## Verification

- `git diff --check`
- `git check-ignore -v .claude/skills/example .agents/skills/example .codex/skills/example .cursor/skills/example .gemini/skills/example skills-lock.json`
- Confirmed plugin paths and nested `skills/example/skills-lock.json` are not ignored

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
