### PR TITLE
fix(skills): route description review fixes through research

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -391,6 +391,35 @@ func TestPrintingPressSkillRequiresPerCommandTimeoutBoundary(t *testing.T) {
 	assert.Contains(t, review, "Files that only use `flags.newClient()` / generated `internal/client`")
 }
 
+func TestPrintingPressSkillRoutesNovelFeatureDescriptionFixesThroughResearchJSON(t *testing.T) {
+	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md"))
+	skillReview := substringBetween(t, skill, "## Phase 4.8: Agentic SKILL Review", "## Phase 4.9: README/SKILL/AGENTS Correctness Audit")
+	docsReview := substringBetween(t, skill, "## Phase 4.9: README/SKILL/AGENTS Correctness Audit", "## Phase 4.85: Agentic Output Review")
+	codeReview := substringBetween(t, skill, "## Phase 4.95: Local Code Review", "**Native timeout-boundary check.**")
+
+	for name, block := range map[string]string{
+		"skill review": skillReview,
+		"docs review":  docsReview,
+		"code review":  codeReview,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Contains(t, block, "research.json")
+			assert.Contains(t, block, "novel_features[].description")
+			assert.Contains(t, block, "novel_features_built")
+			assert.Contains(t, block, `README "Unique Features"`)
+			assert.Contains(t, block, `SKILL "Unique Capabilities"`)
+			assert.Contains(t, block, "internal/cli/root.go")
+			assert.Contains(t, block, "internal/cli/which.go")
+			assert.Contains(t, block, "internal/mcp/tools.go")
+			assert.Contains(t, block, ".printing-press.json")
+		})
+	}
+
+	assert.Contains(t, skillReview, "Do not patch only\nREADME.md or SKILL.md")
+	assert.Contains(t, docsReview, "Do not patch only\nREADME.md, SKILL.md, or AGENTS.md")
+	assert.Contains(t, codeReview, "do not patch those files directly")
+}
+
 func TestPrintingPressSkillRequiresScanAndFilterCaps(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md"))
 	block := substringBetween(t, skill, "13. **Scan-and-filter caps**", "#### Verify-friendly RunE template")

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -395,7 +395,7 @@ func TestPrintingPressSkillRoutesNovelFeatureDescriptionFixesThroughResearchJSON
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md"))
 	skillReview := substringBetween(t, skill, "## Phase 4.8: Agentic SKILL Review", "## Phase 4.9: README/SKILL/AGENTS Correctness Audit")
 	docsReview := substringBetween(t, skill, "## Phase 4.9: README/SKILL/AGENTS Correctness Audit", "## Phase 4.85: Agentic Output Review")
-	codeReview := substringBetween(t, skill, "## Phase 4.95: Local Code Review", "**Native timeout-boundary check.**")
+	codeReview := substringUntilNextHeader(t, skill, "## Phase 4.95: Local Code Review", "##")
 
 	for name, block := range map[string]string{
 		"skill review": skillReview,
@@ -405,6 +405,7 @@ func TestPrintingPressSkillRoutesNovelFeatureDescriptionFixesThroughResearchJSON
 		t.Run(name, func(t *testing.T) {
 			assert.Contains(t, block, "research.json")
 			assert.Contains(t, block, "novel_features[].description")
+			assert.Contains(t, block, "novel_features[].narrative")
 			assert.Contains(t, block, "novel_features_built")
 			assert.Contains(t, block, `README "Unique Features"`)
 			assert.Contains(t, block, `SKILL "Unique Capabilities"`)
@@ -1022,6 +1023,19 @@ func extractContractBlock(t *testing.T, content string) string {
 
 	endIdx := strings.Index(content[startIdx:], end)
 	require.NotEqual(t, -1, endIdx, "missing contract end marker")
+
+	return content[startIdx : startIdx+endIdx]
+}
+
+func substringUntilNextHeader(t *testing.T, content, start, headerPrefix string) string {
+	t.Helper()
+
+	startIdx := strings.Index(content, start)
+	require.NotEqual(t, -1, startIdx, "missing start marker %q", start)
+	startIdx += len(start)
+
+	endIdx := strings.Index(content[startIdx:], "\n"+headerPrefix+" ")
+	require.NotEqual(t, -1, endIdx, "missing next header after %q", start)
 
 	return content[startIdx : startIdx+endIdx]
 }

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -3857,6 +3857,18 @@ Use the Agent tool (general-purpose or a dedicated reviewer) with this prompt co
 >
 > Return a list of findings. For each: check name, severity (error/warning), line number, one-sentence fix. If SKILL passes all seven checks, return "PASS — no findings."
 
+**Description source-of-truth fix path.** When a finding says a novel-feature
+description, capability summary, or surrounding narrative content is inaccurate,
+fix the source text in `$RESEARCH_DIR/research.json`
+(`novel_features[].description`, `novel_features[].narrative`, or the matching
+`novel_features_built` entry) and regenerate/sync from there. Do not patch only
+README.md or SKILL.md for content-level description fixes: the same description
+fans out to README "Unique Features", SKILL "Unique Capabilities",
+`internal/cli/root.go` Highlights, `internal/cli/which.go`,
+`internal/mcp/tools.go`, and `.printing-press.json`. Flag, command, auth,
+example, and structural findings that are not generated from research.json keep
+their current local fix path.
+
 ### Gate
 
 - If the reviewer returns PASS, proceed to Phase 5.
@@ -3894,6 +3906,18 @@ Use the Agent tool or review directly with this prompt contract:
 >
 > Return findings with file, line, severity, and fix. If both files are correct, return `PASS — README/SKILL correctness verified`.
 
+**Description source-of-truth fix path.** When a finding says a novel-feature
+description, capability summary, or surrounding narrative content is inaccurate,
+fix the source text in `$RESEARCH_DIR/research.json`
+(`novel_features[].description`, `novel_features[].narrative`, or the matching
+`novel_features_built` entry) and regenerate/sync from there. Do not patch only
+README.md, SKILL.md, or AGENTS.md for content-level description fixes: the same
+description fans out to README "Unique Features", SKILL "Unique Capabilities",
+`internal/cli/root.go` Highlights, `internal/cli/which.go`,
+`internal/mcp/tools.go`, and `.printing-press.json`. Flag, command, auth,
+example, and structural findings that are not generated from research.json keep
+their current local fix path.
+
 **Gate:** Any error finding is fix-before-Phase-5. Warnings may proceed only when they are explicitly explained in the acceptance report.
 
 ## Phase 4.85: Agentic Output Review
@@ -3918,6 +3942,16 @@ The sub-skill carries `context: fork` so the reviewer agent's diagnostic chatter
 **Runs after Phase 4.85, before Phase 5.** Reviews the printed CLI source for security and correctness issues *before* any PR exists. This is the cheapest fix window in the pipeline — session context is hot, no PR feedback round-trip, no CI comments to chase. Catching issues here means they never become PR-time review comments, which is the wrong fix window for the same problems.
 
 **Target.** The generated CLI and MCP source under `$CLI_WORK_DIR`. In scope: `internal/cli/`, `internal/mcp/` (excluding `cobratree/`), `internal/store/`, `internal/client/`, and `cmd/`. **Out of scope:** `internal/cliutil/` and `internal/mcp/cobratree/` — these are generator-reserved packages. Any finding there is a machine bug; route to retro, do not patch in place.
+
+**Generated description source-of-truth.** If review flags inaccurate
+novel-feature description text in generated code surfaces such as
+`internal/cli/root.go` Highlights, `internal/cli/which.go`, or
+`internal/mcp/tools.go`, do not patch those files directly. Fix the source text
+in `$RESEARCH_DIR/research.json` (`novel_features[].description`,
+`novel_features[].narrative`, or the matching `novel_features_built` entry) and
+regenerate/sync so README "Unique Features", SKILL "Unique Capabilities",
+root help Highlights, which output, MCP tools, and `.printing-press.json` stay
+aligned. Non-description code findings keep the normal Phase 4.95 autofix path.
 
 **Native timeout-boundary check.** Before reviewer dispatch, scan every hand-written file under `internal/cli/` that imports a sibling internal package (`internal/<api>/`, `internal/source/<name>/`, `internal/recipes/`, `internal/phgraphql/`, etc.) and makes live requests. Each such command file must call `boundCtx(cmd.Context(), flags)` and pass that context into the sibling client or store query path before the first request. Files that only use `flags.newClient()` / generated `internal/client` are already covered by `client.New(cfg, flags.timeout, ...)` and should not be flagged for missing `boundCtx`.
 


### PR DESCRIPTION
## Summary

Agentic review findings for inaccurate novel-feature descriptions now point agents back to `research.json` instead of generated README/SKILL or code surfaces. The Phase 4.8, Phase 4.9, and Phase 4.95 guidance names the downstream surfaces that fan out from that source so a content fix survives regeneration and keeps README, SKILL, help highlights, which output, MCP tools, and `.printing-press.json` aligned.

A contract test locks that guidance into the printing-press skill.

## Validation

- `go test ./internal/pipeline -run 'TestPrintingPressSkill(RoutesNovelFeatureDescriptionFixesThroughResearchJSON|RequiresPerCommandTimeoutBoundary|RequiresScanAndFilterCaps)'`
- `go test ./internal/pipeline`
- `go test ./...` attempted twice; both runs were interrupted after several quiet minutes without completion.

Closes #3383

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
