### PR TITLE
fix(cli): preserve reprint runtime version layout

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -165,7 +165,11 @@ func newVersionCmd() *cobra.Command {
 	mcpMainPath := filepath.Join(outputDir, "cmd", "legacyversion-pp-mcp", "main.go")
 	mcpMain, err := os.ReadFile(mcpMainPath)
 	require.NoError(t, err)
-	mcpMain = bytes.Replace(mcpMain, []byte(`var version = "0.0.0-dev"`), []byte(`var version = "2026.6.1"`), 1)
+	mcpMain = bytes.Replace(mcpMain, []byte(`// version is the printed MCP server's version, overridable at build time via ldflags.
+var version = "0.0.0-dev"
+
+`), nil, 1)
+	mcpMain = bytes.Replace(mcpMain, []byte("\t\tversion,\n"), []byte("\t\t\"2026.6.1\",\n"), 1)
 	require.NoError(t, os.WriteFile(mcpMainPath, mcpMain, 0o644))
 
 	runGenerate()
@@ -177,7 +181,8 @@ func newVersionCmd() *cobra.Command {
 	assert.Contains(t, string(rootSrc), "func newVersionCmd() *cobra.Command")
 	mcpMain, err = os.ReadFile(mcpMainPath)
 	require.NoError(t, err)
-	assert.Contains(t, string(mcpMain), `var version = "2026.6.1"`)
+	assert.NotContains(t, string(mcpMain), `var version =`)
+	assert.Contains(t, string(mcpMain), `"2026.6.1"`)
 
 	runGoCommandForCLITest(t, outputDir, "mod", "tidy")
 	runGoCommandForCLITest(t, outputDir, "build", "./...")

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -171,6 +171,8 @@ var version = "0.0.0-dev"
 `), nil, 1)
 	mcpMain = bytes.Replace(mcpMain, []byte("\t\tversion,\n"), []byte("\t\t\"2026.6.1\",\n"), 1)
 	require.NoError(t, os.WriteFile(mcpMainPath, mcpMain, 0o644))
+	require.NotContains(t, string(mcpMain), `var version =`,
+		"legacy MCP fixture must strip the generated version var before the second generate")
 
 	runGenerate()
 

--- a/internal/pipeline/regenmerge/merge_into_fresh.go
+++ b/internal/pipeline/regenmerge/merge_into_fresh.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -231,6 +232,10 @@ func preserveLegacyCLIRootVersionLayout(snapshotDir, freshDir string, report *Me
 }
 
 func preserveMCPMainVersionValues(snapshotDir, freshDir string, report *MergeReport) error {
+	rootVersionLiteral, rootHasVersion, err := readStringVarLiteral(filepath.Join(snapshotDir, "internal", "cli", "root.go"), "version")
+	if err != nil {
+		return err
+	}
 	for _, fc := range report.Files {
 		rel := filepath.ToSlash(fc.Path)
 		if !strings.HasPrefix(rel, "cmd/") || !strings.HasSuffix(rel, "-pp-mcp/main.go") {
@@ -240,9 +245,6 @@ func preserveMCPMainVersionValues(snapshotDir, freshDir string, report *MergeRep
 		if err != nil {
 			return err
 		}
-		if !ok {
-			continue
-		}
 		freshPath := filepath.Join(freshDir, rel)
 		if _, err := os.Stat(freshPath); err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
@@ -250,7 +252,24 @@ func preserveMCPMainVersionValues(snapshotDir, freshDir string, report *MergeRep
 			}
 			return err
 		}
-		if err := replaceStringVarLiteral(freshPath, "version", literal); err != nil {
+		if ok {
+			if err := replaceStringVarLiteral(freshPath, "version", literal); err != nil {
+				return err
+			}
+			continue
+		}
+		if rootHasVersion {
+			literal = rootVersionLiteral
+		} else {
+			literal, ok, err = readStringVarLiteral(freshPath, "version")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				continue
+			}
+		}
+		if err := inlineStringVarReferencesAndRemove(freshPath, "version", literal); err != nil {
 			return err
 		}
 	}
@@ -403,6 +422,64 @@ func appendGoSource(path, src string) error {
 	next := trailingWhitespaceRE.ReplaceAll(data, nil)
 	next = append(next, []byte("\n\n"+strings.TrimSpace(src)+"\n")...)
 	return writeFileAtomic(path, next)
+}
+
+func inlineStringVarReferencesAndRemove(path, name, literal string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, data, parser.SkipObjectResolution)
+	if err != nil {
+		return fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	declNameOffsets := map[int]struct{}{}
+	var references []int
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			valueSpec, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for _, ident := range valueSpec.Names {
+				if ident.Name == name {
+					declNameOffsets[fset.Position(ident.Pos()).Offset] = struct{}{}
+				}
+			}
+		}
+	}
+
+	ast.Inspect(file, func(node ast.Node) bool {
+		ident, ok := node.(*ast.Ident)
+		if !ok || ident.Name != name {
+			return true
+		}
+		offset := fset.Position(ident.Pos()).Offset
+		if _, isDeclName := declNameOffsets[offset]; isDeclName {
+			return true
+		}
+		references = append(references, offset)
+		return true
+	})
+	if len(references) == 0 {
+		return pruneDeclsFromGoFile(path, declSet{name: struct{}{}})
+	}
+
+	next := append([]byte{}, data...)
+	sort.Sort(sort.Reverse(sort.IntSlice(references)))
+	for _, offset := range references {
+		next = append(next[:offset], append([]byte(literal), next[offset+len(name):]...)...)
+	}
+	if err := writeFileAtomic(path, next); err != nil {
+		return err
+	}
+	return pruneDeclsFromGoFile(path, declSet{name: struct{}{}})
 }
 
 // pruneFreshDeclCollisions removes declarations from fresh-owned Go files when

--- a/internal/pipeline/regenmerge/merge_into_fresh.go
+++ b/internal/pipeline/regenmerge/merge_into_fresh.go
@@ -430,12 +430,13 @@ func inlineStringVarReferencesAndRemove(path, name, literal string) error {
 		return err
 	}
 	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, path, data, parser.SkipObjectResolution)
+	file, err := parser.ParseFile(fset, path, data, 0)
 	if err != nil {
 		return fmt.Errorf("parsing %s: %w", path, err)
 	}
 
 	declNameOffsets := map[int]struct{}{}
+	targetObjects := map[*ast.Object]struct{}{}
 	var references []int
 	for _, decl := range file.Decls {
 		gen, ok := decl.(*ast.GenDecl)
@@ -450,9 +451,15 @@ func inlineStringVarReferencesAndRemove(path, name, literal string) error {
 			for _, ident := range valueSpec.Names {
 				if ident.Name == name {
 					declNameOffsets[fset.Position(ident.Pos()).Offset] = struct{}{}
+					if ident.Obj != nil {
+						targetObjects[ident.Obj] = struct{}{}
+					}
 				}
 			}
 		}
+	}
+	if len(targetObjects) == 0 {
+		return nil
 	}
 
 	ast.Inspect(file, func(node ast.Node) bool {
@@ -462,6 +469,9 @@ func inlineStringVarReferencesAndRemove(path, name, literal string) error {
 		}
 		offset := fset.Position(ident.Pos()).Offset
 		if _, isDeclName := declNameOffsets[offset]; isDeclName {
+			return true
+		}
+		if _, matchesTarget := targetObjects[ident.Obj]; !matchesTarget {
 			return true
 		}
 		references = append(references, offset)

--- a/internal/pipeline/regenmerge/merge_into_fresh.go
+++ b/internal/pipeline/regenmerge/merge_into_fresh.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -430,13 +431,12 @@ func inlineStringVarReferencesAndRemove(path, name, literal string) error {
 		return err
 	}
 	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, path, data, 0)
+	file, err := parser.ParseFile(fset, path, data, parser.SkipObjectResolution)
 	if err != nil {
 		return fmt.Errorf("parsing %s: %w", path, err)
 	}
 
 	declNameOffsets := map[int]struct{}{}
-	targetObjects := map[*ast.Object]struct{}{}
 	var references []int
 	for _, decl := range file.Decls {
 		gen, ok := decl.(*ast.GenDecl)
@@ -451,32 +451,174 @@ func inlineStringVarReferencesAndRemove(path, name, literal string) error {
 			for _, ident := range valueSpec.Names {
 				if ident.Name == name {
 					declNameOffsets[fset.Position(ident.Pos()).Offset] = struct{}{}
-					if ident.Obj != nil {
-						targetObjects[ident.Obj] = struct{}{}
-					}
 				}
 			}
 		}
 	}
-	if len(targetObjects) == 0 {
+	if len(declNameOffsets) == 0 {
 		return nil
 	}
 
-	ast.Inspect(file, func(node ast.Node) bool {
-		ident, ok := node.(*ast.Ident)
-		if !ok || ident.Name != name {
-			return true
+	identDeclaresName := func(ident *ast.Ident) bool {
+		return ident != nil && ident.Name == name
+	}
+	fieldListDeclaresName := func(fields *ast.FieldList) bool {
+		if fields == nil {
+			return false
+		}
+		for _, field := range fields.List {
+			if slices.ContainsFunc(field.Names, identDeclaresName) {
+				return true
+			}
+		}
+		return false
+	}
+	exprsDeclareName := func(exprs []ast.Expr) bool {
+		for _, expr := range exprs {
+			if ident, ok := expr.(*ast.Ident); ok && identDeclaresName(ident) {
+				return true
+			}
+		}
+		return false
+	}
+	addReference := func(ident *ast.Ident, shadowed bool) {
+		if shadowed || !identDeclaresName(ident) {
+			return
 		}
 		offset := fset.Position(ident.Pos()).Offset
 		if _, isDeclName := declNameOffsets[offset]; isDeclName {
-			return true
-		}
-		if _, matchesTarget := targetObjects[ident.Obj]; !matchesTarget {
-			return true
+			return
 		}
 		references = append(references, offset)
-		return true
-	})
+	}
+
+	var collectExpr func(ast.Expr, bool)
+	collectExpr = func(expr ast.Expr, shadowed bool) {
+		ast.Inspect(expr, func(node ast.Node) bool {
+			switch n := node.(type) {
+			case nil:
+				return true
+			case *ast.SelectorExpr:
+				collectExpr(n.X, shadowed)
+				return false
+			case *ast.KeyValueExpr:
+				if _, keyIsIdent := n.Key.(*ast.Ident); !keyIsIdent {
+					collectExpr(n.Key, shadowed)
+				}
+				collectExpr(n.Value, shadowed)
+				return false
+			case *ast.Ident:
+				addReference(n, shadowed)
+			}
+			return true
+		})
+	}
+	collectExprs := func(exprs []ast.Expr, shadowed bool) {
+		for _, expr := range exprs {
+			collectExpr(expr, shadowed)
+		}
+	}
+
+	var collectBlock func(*ast.BlockStmt, bool)
+	var collectStmt func(ast.Stmt, bool) bool
+	collectBlock = func(block *ast.BlockStmt, shadowed bool) {
+		if block == nil {
+			return
+		}
+		blockShadowed := shadowed
+		for _, stmt := range block.List {
+			if collectStmt(stmt, blockShadowed) {
+				blockShadowed = true
+			}
+		}
+	}
+	collectStmt = func(stmt ast.Stmt, shadowed bool) bool {
+		switch s := stmt.(type) {
+		case *ast.AssignStmt:
+			collectExprs(s.Rhs, shadowed)
+			return s.Tok == token.DEFINE && exprsDeclareName(s.Lhs)
+		case *ast.DeclStmt:
+			gen, ok := s.Decl.(*ast.GenDecl)
+			if !ok {
+				return false
+			}
+			declaresName := false
+			for _, spec := range gen.Specs {
+				valueSpec, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				collectExprs(valueSpec.Values, shadowed)
+				for _, ident := range valueSpec.Names {
+					if identDeclaresName(ident) {
+						declaresName = true
+					}
+				}
+			}
+			return declaresName
+		case *ast.ExprStmt:
+			collectExpr(s.X, shadowed)
+		case *ast.ReturnStmt:
+			collectExprs(s.Results, shadowed)
+		case *ast.IfStmt:
+			stmtShadowed := shadowed
+			if s.Init != nil && collectStmt(s.Init, shadowed) {
+				stmtShadowed = true
+			}
+			collectExpr(s.Cond, stmtShadowed)
+			collectBlock(s.Body, stmtShadowed)
+			if s.Else != nil {
+				switch elseNode := s.Else.(type) {
+				case *ast.BlockStmt:
+					collectBlock(elseNode, stmtShadowed)
+				case *ast.IfStmt:
+					collectStmt(elseNode, stmtShadowed)
+				}
+			}
+		case *ast.ForStmt:
+			stmtShadowed := shadowed
+			if s.Init != nil && collectStmt(s.Init, shadowed) {
+				stmtShadowed = true
+			}
+			if s.Cond != nil {
+				collectExpr(s.Cond, stmtShadowed)
+			}
+			if s.Post != nil {
+				collectStmt(s.Post, stmtShadowed)
+			}
+			collectBlock(s.Body, stmtShadowed)
+		case *ast.RangeStmt:
+			collectExpr(s.X, shadowed)
+			bodyShadowed := shadowed
+			if s.Tok == token.DEFINE && exprsDeclareName([]ast.Expr{s.Key, s.Value}) {
+				bodyShadowed = true
+			}
+			collectBlock(s.Body, bodyShadowed)
+		case *ast.BlockStmt:
+			collectBlock(s, shadowed)
+		}
+		return false
+	}
+
+	for _, decl := range file.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			shadowed := fieldListDeclaresName(d.Recv) ||
+				fieldListDeclaresName(d.Type.Params) ||
+				fieldListDeclaresName(d.Type.Results)
+			collectBlock(d.Body, shadowed)
+		case *ast.GenDecl:
+			if d.Tok == token.VAR {
+				for _, spec := range d.Specs {
+					valueSpec, ok := spec.(*ast.ValueSpec)
+					if !ok {
+						continue
+					}
+					collectExprs(valueSpec.Values, false)
+				}
+			}
+		}
+	}
 	if len(references) == 0 {
 		return pruneDeclsFromGoFile(path, declSet{name: struct{}{}})
 	}

--- a/internal/pipeline/regenmerge/merge_into_fresh_test.go
+++ b/internal/pipeline/regenmerge/merge_into_fresh_test.go
@@ -209,6 +209,42 @@ func main() {
 	assert.Contains(t, string(got), `_ = "2.0.0"`)
 }
 
+func TestInlineStringVarReferencesAndRemoveSkipsLocalBindings(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.go")
+	require.NoError(t, os.WriteFile(path, []byte(`package main
+
+var version = "0.0.0-dev"
+
+func mcpVersion() string { return "local" }
+
+func localParameter(version string) string {
+	return version
+}
+
+func localShortDecl() string {
+	version := mcpVersion()
+	return version
+}
+
+func main() {
+	_ = version
+}
+`), 0o644))
+
+	require.NoError(t, inlineStringVarReferencesAndRemove(path, "version", `"1.2.3"`))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	gotSrc := string(got)
+	assert.NotContains(t, gotSrc, `var version =`)
+	assert.Contains(t, gotSrc, `func localParameter(version string) string`)
+	assert.Contains(t, gotSrc, `version := mcpVersion()`)
+	assert.Contains(t, gotSrc, `_ = "1.2.3"`)
+}
+
 func TestMergeIntoFreshTreePrunesOnlyCollidingNameFromMultiNameValueSpec(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/regenmerge/merge_into_fresh_test.go
+++ b/internal/pipeline/regenmerge/merge_into_fresh_test.go
@@ -128,10 +128,15 @@ func newVersionCmd() string { return version }
 		"the published runtime version value stays in root.go")
 }
 
-func TestPreserveMCPMainVersionValuesSkipsMissingSnapshotVersion(t *testing.T) {
+func TestPreserveMCPMainVersionValuesRemovesFreshVarWhenSnapshotHasNoMCPVersion(t *testing.T) {
 	t.Parallel()
 
 	snap, fresh := makeMergeFixture(t)
+	require.NoError(t, os.MkdirAll(filepath.Join(snap, "internal", "cli"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(snap, "internal", "cli", "root.go"), []byte(`package cli
+
+var version = "1.2.3"
+`), 0o644))
 	staleRel := "cmd/stale-pp-mcp/main.go"
 	currentRel := "cmd/current-pp-mcp/main.go"
 	for _, rel := range []string{staleRel, currentRel} {
@@ -145,6 +150,10 @@ func main() {}
 	require.NoError(t, os.WriteFile(filepath.Join(fresh, staleRel), []byte(`package main
 
 var version = "2.0.0"
+
+func main() {
+	_ = version
+}
 `), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(snap, currentRel), []byte(`package main
 
@@ -165,6 +174,39 @@ var version = "2.0.0"
 	require.NoError(t, err)
 	assert.Contains(t, string(got), `var version = "1.2.3"`,
 		"a missing snapshot version in one MCP file must not skip later MCP files")
+	got, err = os.ReadFile(filepath.Join(fresh, staleRel))
+	require.NoError(t, err)
+	assert.NotContains(t, string(got), `var version =`)
+	assert.Contains(t, string(got), `_ = "1.2.3"`)
+}
+
+func TestPreserveMCPMainVersionValuesFallsBackToFreshLiteral(t *testing.T) {
+	t.Parallel()
+
+	snap, fresh := makeMergeFixture(t)
+	rel := "cmd/stale-pp-mcp/main.go"
+	require.NoError(t, os.MkdirAll(filepath.Join(snap, filepath.Dir(rel)), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(fresh, filepath.Dir(rel)), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(snap, rel), []byte(`package main
+
+func main() {}
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(fresh, rel), []byte(`package main
+
+var version = "2.0.0"
+
+func main() {
+	_ = version
+}
+`), 0o644))
+
+	report := &MergeReport{Files: []FileClassification{{Path: rel}}}
+	require.NoError(t, preserveMCPMainVersionValues(snap, fresh, report))
+
+	got, err := os.ReadFile(filepath.Join(fresh, rel))
+	require.NoError(t, err)
+	assert.NotContains(t, string(got), `var version =`)
+	assert.Contains(t, string(got), `_ = "2.0.0"`)
 }
 
 func TestMergeIntoFreshTreePrunesOnlyCollidingNameFromMultiNameValueSpec(t *testing.T) {


### PR DESCRIPTION
## Summary
Reprinting an older published CLI now keeps the public library's runtime-version ledger stable even when the old MCP binary did not have its own `var version` declaration. The force-regenerate merge path preserves an existing MCP version var when one was already published, but otherwise removes the freshly emitted var and inlines the published CLI version literal so release-ledger checks do not see an added version source.

Closes #3382

## Validation
- `go test ./internal/pipeline/regenmerge -run 'TestPreserveMCPMainVersionValues' -count=1`
- `go test ./internal/cli -run 'TestGenerateCmdForcePreservesLegacyRootVersionLayout' -count=1`
- `go test ./internal/pipeline/regenmerge ./internal/cli -count=1`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
