### PR TITLE
fix(cli): order path-param positionals by URL path, not declaration order

### DIFF
--- a/internal/generator/first_command_example.go
+++ b/internal/generator/first_command_example.go
@@ -75,10 +75,7 @@ func commandExampleArgs(ep spec.Endpoint) string {
 
 func commandExampleArgParts(ep spec.Endpoint) []string {
 	var parts []string
-	for _, p := range ep.Params {
-		if !p.Positional {
-			continue
-		}
+	for _, p := range orderedPositionalParams(ep) {
 		val := exampleValue(p)
 		if val == "" {
 			val = "<" + p.Name + ">"
@@ -90,10 +87,8 @@ func commandExampleArgParts(ep spec.Endpoint) []string {
 
 func readmeExampleArgs(ep spec.Endpoint) []string {
 	var parts []string
-	for _, p := range ep.Params {
-		if p.Positional {
-			parts = append(parts, skillExamplePositionalValue(p))
-		}
+	for _, p := range orderedPositionalParams(ep) {
+		parts = append(parts, skillExamplePositionalValue(p))
 	}
 	return append(parts, requiredFlagExampleParts(ep)...)
 }

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -6743,12 +6743,50 @@ func csvItemTemplateLiteral(v any) string {
 	}
 }
 
-func positionalArgs(e spec.Endpoint) string {
-	var args []string
+// orderedPositionalParams returns an endpoint's positional params with the
+// path-param positionals sorted into URL-path order (left-to-right by where
+// each {placeholder} appears in Endpoint.Path). The OpenAPI parser appends path
+// params in parameters-array order, which some specs declare deepest-first
+// (Cloudflare lists project_name before account_id for
+// /accounts/{account_id}/pages/projects/{project_name}). Emitting them in that
+// order made commands accept <project_name> <account_id> — the reverse of the
+// URL and of the conventional parent-first ordering — so args passed in natural
+// path order routed each value into the wrong slot and 404'd. Only path-param
+// positionals are reordered, and only among the slots they already hold; any
+// non-path positional keeps its declared place.
+func orderedPositionalParams(e spec.Endpoint) []spec.Param {
+	positionals := make([]spec.Param, 0, len(e.Params))
 	for _, p := range e.Params {
 		if p.Positional {
-			args = append(args, "<"+p.Name+">")
+			positionals = append(positionals, p)
 		}
+	}
+	pathRank := func(p spec.Param) int { return strings.Index(e.Path, "{"+p.Name+"}") }
+
+	pathParams := make([]spec.Param, 0, len(positionals))
+	for _, p := range positionals {
+		if pathRank(p) >= 0 {
+			pathParams = append(pathParams, p)
+		}
+	}
+	sort.SliceStable(pathParams, func(i, j int) bool {
+		return pathRank(pathParams[i]) < pathRank(pathParams[j])
+	})
+
+	j := 0
+	for i, p := range positionals {
+		if pathRank(p) >= 0 {
+			positionals[i] = pathParams[j]
+			j++
+		}
+	}
+	return positionals
+}
+
+func positionalArgs(e spec.Endpoint) string {
+	var args []string
+	for _, p := range orderedPositionalParams(e) {
+		args = append(args, "<"+p.Name+">")
 	}
 	if len(args) > 0 {
 		return " " + strings.Join(args, " ")
@@ -6757,23 +6795,16 @@ func positionalArgs(e spec.Endpoint) string {
 }
 
 // positionalIndex returns the args[] slot a positional param fills at runtime.
-// Cobra populates args from CLI positionals in Positional-only declaration
-// order, but Endpoint.Params interleaves query/header params alongside path
-// params. The full-Params index drifts from the Positional ordinal as soon as
-// a non-positional param sits before a positional one (common when an OpenAPI
-// list endpoint declares query params before the path param) and the runtime
-// fails with "<name> is required" no matter what positional the user passes.
-// Returns -1 if name is not a positional param.
+// Cobra populates args from CLI positionals in the order they appear in the
+// command's Use string, which orderedPositionalParams fixes to URL-path order.
+// The slot therefore tracks that path order rather than the raw Endpoint.Params
+// order, which interleaves query/header params and may declare path params in
+// reverse path order. Returns -1 if name is not a positional param.
 func positionalIndex(e spec.Endpoint, name string) int {
-	idx := 0
-	for _, p := range e.Params {
-		if !p.Positional {
-			continue
-		}
+	for i, p := range orderedPositionalParams(e) {
 		if p.Name == name {
-			return idx
+			return i
 		}
-		idx++
 	}
 	return -1
 }

--- a/internal/generator/path_param_order_test.go
+++ b/internal/generator/path_param_order_test.go
@@ -1,0 +1,231 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/openapi"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMultiPathParamPositionalsFollowPathOrder pins #3369. When a spec declares
+// its path parameters deepest-first — the reverse of their URL path order, the
+// shape the OpenAPI parser produces from a parameters array that lists
+// project_name before account_id (Cloudflare's
+// /accounts/{account_id}/pages/projects/{project_name} does this) — the
+// generated command must still list and bind positionals in path order:
+//
+//	Use: "... <account_id> <project_name>"
+//	args[0] -> account_id, args[1] -> project_name
+//
+// Before the fix the command emitted "<project_name> <account_id>" with the
+// bindings reversed, so passing args in natural URL order routed each value
+// into the wrong path slot and returned a misleading 404 that did not point at
+// argument order.
+func TestMultiPathParamPositionalsFollowPathOrder(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "pathorder",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/pathorder-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"pages": {
+				Description: "Pages",
+				SubResources: map[string]spec.Resource{
+					"projects": {
+						Description: "Pages projects",
+						Endpoints: map[string]spec.Endpoint{
+							// Path params declared deepest-first (project_name
+							// before account_id), the reverse of their order in the
+							// URL path — exactly what the OpenAPI parser appends from
+							// a parameters array in that order.
+							"get-project": {
+								Method:      "GET",
+								Path:        "/accounts/{account_id}/pages/projects/{project_name}",
+								Description: "Get a pages project",
+								Params: []spec.Param{
+									{Name: "project_name", Type: "string", Required: true, Positional: true},
+									{Name: "account_id", Type: "string", Required: true, Positional: true},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	src, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "pages_projects_get-project.go"))
+	require.NoError(t, err)
+	body := string(src)
+
+	// Use string and Example list positionals in URL path order, not the
+	// reverse parameters-array order the spec declared.
+	assert.Contains(t, body, "<account_id> <project_name>",
+		"positionals must appear in URL path order in the Use/Example strings")
+	assert.NotContains(t, body, "<project_name> <account_id>",
+		"must not emit positionals in reverse path order")
+
+	// Bindings resolve each path param to the matching path-order arg slot.
+	assert.Contains(t, body, `path = replacePathParam(path, "account_id", args[0])`,
+		"first path param (account_id) binds to args[0]")
+	assert.Contains(t, body, `path = replacePathParam(path, "project_name", args[1])`,
+		"second path param (project_name) binds to args[1]")
+	assert.NotContains(t, body, `path = replacePathParam(path, "account_id", args[1])`,
+		"must not bind account_id to the deeper arg slot")
+	assert.NotContains(t, body, `path = replacePathParam(path, "project_name", args[0])`,
+		"must not bind project_name to the shallow arg slot")
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
+// TestMultiPathParamPositionalsFollowPathOrderFromOpenAPI is the end-to-end
+// counterpart: it proves the reversal originates in the OpenAPI parser (which
+// appends path params in parameters-array order) and that the generated command
+// is corrected to path order. Two operations keep the resource off the
+// single-endpoint promotion path so this exercises command_endpoint.go.tmpl.
+func TestMultiPathParamPositionalsFollowPathOrderFromOpenAPI(t *testing.T) {
+	t.Parallel()
+
+	yaml := `openapi: 3.0.0
+info:
+  title: Reverse Params
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /accounts/{account_id}/pages/projects/{project_name}:
+    get:
+      summary: Get a pages project
+      parameters:
+        - name: project_name
+          in: path
+          required: true
+          schema: {type: string}
+        - name: account_id
+          in: path
+          required: true
+          schema: {type: string}
+      responses:
+        "200": {description: ok}
+    delete:
+      summary: Delete a pages project
+      parameters:
+        - name: project_name
+          in: path
+          required: true
+          schema: {type: string}
+        - name: account_id
+          in: path
+          required: true
+          schema: {type: string}
+      responses:
+        "200": {description: ok}
+`
+	apiSpec, err := openapi.Parse([]byte(yaml))
+	require.NoError(t, err)
+	apiSpec.Owner = "test-owner"
+	apiSpec.OwnerName = "Test"
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	matches, err := filepath.Glob(filepath.Join(outputDir, "internal", "cli", "*.go"))
+	require.NoError(t, err)
+
+	var body string
+	for _, m := range matches {
+		data, readErr := os.ReadFile(m)
+		require.NoError(t, readErr)
+		if strings.Contains(string(data), `replacePathParam(path, "account_id"`) {
+			body = string(data)
+			break
+		}
+	}
+	require.NotEmpty(t, body, "expected a generated command that substitutes account_id")
+
+	assert.Contains(t, body, "<account_id> <project_name>",
+		"end-to-end: positionals must appear in URL path order")
+	assert.NotContains(t, body, "<project_name> <account_id>",
+		"end-to-end: must not emit positionals in reverse path order")
+	assert.Contains(t, body, `path = replacePathParam(path, "account_id", args[0])`,
+		"end-to-end: account_id binds to args[0]")
+	assert.Contains(t, body, `path = replacePathParam(path, "project_name", args[1])`,
+		"end-to-end: project_name binds to args[1]")
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
+// TestPromotedCommandMultiPathParamPositionalsFollowPathOrder covers the
+// promoted-command variant (command_promoted.go.tmpl), which emits a separate
+// file but shares the positional helpers. A single-endpoint resource with its
+// path params declared deepest-first must still promote to a command that lists
+// and binds them in URL path order.
+func TestPromotedCommandMultiPathParamPositionalsFollowPathOrder(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "promopathorder",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/promopathorder-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			// Single-endpoint resource — promotes to a top-level command.
+			// Path params declared deepest-first (project_name before
+			// account_id), the reverse of their URL path order.
+			"projects": {
+				Description: "Pages projects",
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method:      "GET",
+						Path:        "/accounts/{account_id}/pages/projects/{project_name}",
+						Description: "Get a pages project",
+						Params: []spec.Param{
+							{Name: "project_name", Type: "string", Required: true, Positional: true},
+							{Name: "account_id", Type: "string", Required: true, Positional: true},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	matches, err := filepath.Glob(filepath.Join(outputDir, "internal", "cli", "promoted_*.go"))
+	require.NoError(t, err)
+	require.Lenf(t, matches, 1, "expected exactly one promoted_*.go file, got %v", matches)
+	data, err := os.ReadFile(matches[0])
+	require.NoError(t, err)
+	body := string(data)
+
+	assert.Contains(t, body, "<account_id> <project_name>",
+		"promoted command: positionals must appear in URL path order")
+	assert.NotContains(t, body, "<project_name> <account_id>",
+		"promoted command: must not emit positionals in reverse path order")
+	assert.Contains(t, body, `path = replacePathParam(path, "account_id", args[0])`,
+		"promoted command: account_id binds to args[0]")
+	assert.Contains(t, body, `path = replacePathParam(path, "project_name", args[1])`,
+		"promoted command: project_name binds to args[1]")
+
+	requireGeneratedCompiles(t, outputDir)
+}


### PR DESCRIPTION
## Intent

Generated commands whose endpoint has two or more path params listed their positional arguments in parameters-array order, not URL-path order. For a spec that declares the deepest path param first (Cloudflare lists `project_name` before `account_id` for `/accounts/{account_id}/pages/projects/{project_name}`), the command came out as `project-get-project <project_name> <account_id>`. Passing arguments in natural URL order routed each value into the wrong path slot and returned a 404 that gave no hint that argument order was the cause.

Issue: Fixes #3369

## Approach

The OpenAPI parser appends path params in parameters-array order and never sorts them to URL-path order. Every site that emits positionals (the cobra `Use` string, the `args[]` bindings and length checks, and the CLI/README examples) iterated `Endpoint.Params` directly, so each inherited that order.

Added one helper, `orderedPositionalParams`, that sorts the path-param positionals into URL-path order (left to right by where each `{placeholder}` appears in `Endpoint.Path`). `positionalArgs`, `positionalIndex`, `commandExampleArgParts`, and `readmeExampleArgs` route through it, so the Use string, runtime bindings, and examples stay consistent. Only path-param positionals are reordered, and only among the slots they already occupy. Non-path positionals keep their declared place, and single-path-param or already-path-ordered commands are unchanged.

## Scope

Primary area: generator (`internal/generator`), the positional-arg ordering helpers shared by the endpoint and promoted-command templates.

Why this belongs in this repo: the reversal is emitted by the generator from any spec whose parameters array lists path params out of URL order, so it affects every printed CLI built from such a spec. GitHub `/repos/{owner}/{repo}`, Stripe `/v1/customers/{customer}/sources/{id}`, and Cloudflare all have nested path resources. It is not a per-CLI quirk.

## Catalog Justification

N/A

## Risk

The change reorders positional arguments in generated commands that have two or more path params declared out of path order. That is the fix (the prior order was wrong), so those commands' argument order changes by design. Commands with zero or one path param, and those already declared in path order, emit byte-identical output. The reordering is confined to path-param positionals. Non-path positionals keep their slots, so the html-request-params path and flag-exposed path params are unaffected.

## Output Contract

This changes generated command output (Use string, `args[]` bindings, examples) for the affected endpoint shape. Evidence:

- New `internal/generator/path_param_order_test.go` asserts the emitted code across three cases: a spec-literal endpoint command, an end-to-end `openapi.Parse` case proving the reversal originates in the parser, and a promoted-command case. All three compile the generated module via `requireGeneratedCompiles`. Each fails on the pre-fix code (reversed) and passes on the fix.
- Golden suite is unaffected: the only golden fixture with a two-path-param endpoint (`golden-api.yaml` `/projects/{projectId}/tasks/{taskId}`) declares its params in path order, so the stable sort leaves its output unchanged.

## Verification

- `go test ./internal/generator/` passes, including the three new red/green regression cases and the existing path-param positional-index suite.
- Full `go test ./...` run against this branch and against clean `main`: the branch introduces zero new failures (the branch-only failure set is empty on diff). The pre-existing failures on this Windows checkout are file-permission asserts and shell-out pipeline tests unrelated to this change.
- `go vet ./internal/generator/` clean. `gofmt` clean.
- `scripts/golden.sh verify` not run locally (`jq` unavailable on this machine). Golden impact is reasoned out above and is zero; CI golden confirms.

- [x] Generator/template change: verified generated output, including emitted-code assertions and compiled generated CLI output
- [x] Generator/template change: covered the affected variant shape (endpoint command, promoted command, end-to-end parse), not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites; all four positional emitters route through the one ordering helper

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
