### PR TITLE
test(ci): reduce test suite runtime

### DIFF
--- a/.github/workflows/golden.yml
+++ b/.github/workflows/golden.yml
@@ -16,10 +16,17 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
+        if: github.event.pull_request.base.ref != 'main'
         with:
           fetch-depth: 0
 
+      - name: Golden verification delegated to Main CI
+        if: github.event.pull_request.base.ref == 'main'
+        run: |
+          echo "Golden verification for pull requests targeting main runs in Main CI's full-golden job."
+
       - name: Check whether golden verification is needed
+        if: github.event.pull_request.base.ref != 'main'
         id: changes
         shell: bash
         run: |
@@ -44,23 +51,23 @@ jobs:
           echo "needs_golden=$needs_golden" >> "$GITHUB_OUTPUT"
 
       - name: Skip golden verification
-        if: steps.changes.outputs.needs_golden != 'true'
+        if: github.event.pull_request.base.ref != 'main' && steps.changes.outputs.needs_golden != 'true'
         run: |
           echo "Skipping golden verification: no generator, CLI, golden fixture, module, or golden workflow files changed."
 
       - uses: actions/setup-go@v6
-        if: steps.changes.outputs.needs_golden == 'true'
+        if: github.event.pull_request.base.ref != 'main' && steps.changes.outputs.needs_golden == 'true'
         with:
           go-version-file: go.mod
           cache: true
           cache-dependency-path: go.sum
 
       - name: Verify golden outputs
-        if: steps.changes.outputs.needs_golden == 'true'
+        if: github.event.pull_request.base.ref != 'main' && steps.changes.outputs.needs_golden == 'true'
         run: scripts/golden.sh verify
 
       - name: Dump golden diffs on failure
-        if: failure() && steps.changes.outputs.needs_golden == 'true'
+        if: failure() && github.event.pull_request.base.ref != 'main' && steps.changes.outputs.needs_golden == 'true'
         run: |
           echo "::group::Golden diff content"
           find .gotmp/golden/actual -name '*.diff' -print -exec cat {} \;

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -111,6 +111,12 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [[ "${{ github.base_ref }}" == "main" ]]; then
+            echo "Delegating Go tests to Main CI for main-targeted PRs."
+            echo "needs_tests=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           git fetch --no-tags --prune origin "${{ github.base_ref }}"
           mapfile -t changed < <(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD")
 
@@ -218,7 +224,7 @@ jobs:
       - name: Skip Go tests
         if: needs.test-changes.outputs.needs_tests != 'true'
         run: |
-          echo "Skipping Go tests: no Go, module, CI workflow, script, or testdata changes."
+          echo "Skipping Go tests in CI: no relevant changes, or this main-targeted PR is covered by Main CI."
 
       - name: Check test shards
         if: needs.test-changes.outputs.needs_tests == 'true'
@@ -246,6 +252,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          if [[ "${{ github.base_ref }}" == "main" ]]; then
+            echo "Delegating generated compile tests to Main CI for main-targeted PRs."
+            echo "needs_full=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           git fetch --no-tags --prune origin "${{ github.base_ref }}"
           mapfile -t changed < <(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD")
@@ -345,7 +357,7 @@ jobs:
       - name: Skip generated compile tests
         if: needs.generated-test-changes.outputs.needs_full != 'true'
         run: |
-          echo "Skipping generated compile tests: no generator, parser, pipeline, CLI, module, workflow, or testdata changes."
+          echo "Skipping generated compile tests in CI: no relevant changes, or this main-targeted PR is covered by Main CI."
 
       - name: Check generated compile shards
         if: needs.generated-test-changes.outputs.needs_full == 'true'

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -5,10 +5,11 @@ name: Main CI
 # trigger lets a branch protection rule require the stable build-and-test check
 # with "Require branches to be up to date before merging" enabled.
 #
-# The existing CI in lint.yml runs sharded, change-gated tests to keep PR
-# turnaround fast. This workflow is intentionally redundant as a single
-# load-bearing signal branch protection can pin against. Its expensive work is
-# split across parallel jobs, then folded into the stable build-and-test check.
+# For main-targeted PRs, lint.yml delegates duplicate Go/generated tests here
+# and keeps the faster lint/docs checks. This workflow is the load-bearing
+# build/test/golden/generated-output signal branch protection can pin against.
+# Its expensive work is split across parallel jobs, then folded into the stable
+# build-and-test check.
 on:
   push:
     branches: [main]
@@ -71,7 +72,6 @@ jobs:
                   needs_build=true
                   needs_tests=true
                   needs_golden=true
-                  needs_generated_output=true
                   ;;
                 *.go|go.mod|go.sum|cmd/*|internal/*)
                   needs_build=true
@@ -92,7 +92,7 @@ jobs:
               esac
 
               case "$file" in
-                .github/workflows/main-ci.yml|scripts/verify-generator-output.sh|cmd/*|internal/generator/*|internal/openapi/*|testdata/golden/cases/generate-*|testdata/golden/fixtures/*|go.mod|go.sum)
+                scripts/verify-generator-output.sh|cmd/*|internal/generator/*|internal/openapi/*|testdata/golden/cases/generate-*|testdata/golden/fixtures/*|go.mod|go.sum)
                   needs_generated_output=true
                   ;;
               esac
@@ -119,7 +119,9 @@ jobs:
     name: full-build
     runs-on: ubuntu-latest
     needs: classify
-    if: needs.classify.outputs.needs_build == 'true'
+    # Full tests compile every package already, so keep the standalone build
+    # only for future scopes that need build proof without running tests.
+    if: needs.classify.outputs.needs_build == 'true' && needs.classify.outputs.needs_tests != 'true'
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
@@ -141,19 +143,18 @@ jobs:
     needs: classify
     if: needs.classify.outputs.needs_tests == 'true'
     timeout-minutes: 20
-    # Shard the full (non-short) suite across the same package partition
-    # lint.yml uses so the queue's speculative re-run isn't pinned to one
-    # ~12m unsharded job. The union of the four shards is `go test ./...`;
-    # sharding by package is semantically identical because `go test`
-    # already runs each package in its own binary. fail-fast: false so one
-    # shard's failure still reports the others. The aggregate result feeds
-    # `build-and-test` via needs.full-test.result, so the required check
-    # name is unchanged.
+    # Shard the full (non-short) suite across package partitions, then split
+    # the slow single-package generator shard by top-level test name. The
+    # aggregate result feeds `build-and-test` via needs.full-test.result, so
+    # the required check name is unchanged.
     strategy:
       fail-fast: false
       matrix:
         include:
-          - shard: generator
+          - shard: generator-0
+          - shard: generator-1
+          - shard: generator-2
+          - shard: generator-3
           - shard: pipeline
           - shard: cli
           - shard: rest
@@ -173,9 +174,17 @@ jobs:
         run: |
           set -euo pipefail
 
+          run_partition=false
+          shard_index=0
+          shard_total=1
+
           case "${{ matrix.shard }}" in
-            generator)
-              packages=(./internal/generator/...)
+            generator-*)
+              packages=(./internal/generator)
+              run_partition=true
+              shard_index="${{ matrix.shard }}"
+              shard_index="${shard_index#generator-}"
+              shard_total=4
               ;;
             pipeline)
               packages=(./internal/pipeline/...)
@@ -197,7 +206,55 @@ jobs:
 
           # No -short: main-ci is the full-coverage gate, unlike lint.yml's
           # fast -short shards.
-          go test -timeout 15m "${packages[@]}"
+          if [[ "$run_partition" == "true" ]]; then
+            mapfile -t selected_tests < <(
+              go test -list '^(Test|Example)' "${packages[0]}" |
+                python3 -c 'import hashlib, sys; idx = int(sys.argv[1]); total = int(sys.argv[2]); [print(name) for name in (line.strip() for line in sys.stdin) if name.startswith(("Test", "Example")) and int(hashlib.sha256(name.encode()).hexdigest(), 16) % total == idx]' "$shard_index" "$shard_total"
+            )
+            if [[ "${#selected_tests[@]}" -eq 0 ]]; then
+              echo "No tests selected for shard ${{ matrix.shard }}."
+              exit 0
+            fi
+            pattern="$(
+              printf '%s\n' "${selected_tests[@]}" |
+                python3 -c 'import re, sys; names = [line.strip() for line in sys.stdin if line.strip()]; print("^(" + "|".join(re.escape(name) for name in names) + ")$")'
+            )"
+            echo "Selected ${#selected_tests[@]} top-level tests for shard ${{ matrix.shard }}."
+            set +e
+            go test -json -timeout 15m -run "$pattern" "${packages[@]}" 2>&1 | tee /tmp/go-test.json
+            status=${PIPESTATUS[0]}
+            set -e
+          else
+            set +e
+            go test -json -timeout 15m "${packages[@]}" 2>&1 | tee /tmp/go-test.json
+            status=${PIPESTATUS[0]}
+            set -e
+          fi
+
+          python3 - /tmp/go-test.json <<'PY'
+          import json
+          import sys
+
+          packages = {}
+          tests = 0
+          with open(sys.argv[1]) as events:
+              for line in events:
+                  try:
+                      event = json.loads(line)
+                  except Exception:
+                      continue
+                  if event.get("Action") == "pass" and event.get("Test"):
+                      tests += 1
+                  if event.get("Action") in {"pass", "fail"} and event.get("Test") is None:
+                      packages[event["Package"]] = event.get("Elapsed", 0)
+
+          print("Slowest Go packages:")
+          for pkg, elapsed in sorted(packages.items(), key=lambda item: -item[1])[:15]:
+              print(f"{elapsed:6.1f}s {pkg}")
+          print(f"test_pass_events {tests}")
+          PY
+
+          exit "$status"
 
   full-golden:
     name: full-golden
@@ -257,7 +314,7 @@ jobs:
             echo "change classification failed or was cancelled."
             exit 1
           fi
-          if [[ "${{ needs.classify.outputs.needs_build }}" == "true" && "${{ needs.full-build.result }}" != "success" ]]; then
+          if [[ "${{ needs.classify.outputs.needs_build }}" == "true" && "${{ needs.classify.outputs.needs_tests }}" != "true" && "${{ needs.full-build.result }}" != "success" ]]; then
             echo "full-build failed or was cancelled."
             exit 1
           fi
@@ -275,7 +332,7 @@ jobs:
           fi
 
           echo "Full-suite scope:"
-          echo "  build=${{ needs.classify.outputs.needs_build }} result=${{ needs.full-build.result }}"
+          echo "  build=${{ needs.classify.outputs.needs_build }} result=${{ needs.full-build.result }} (covered by full-test when tests=true)"
           echo "  tests=${{ needs.classify.outputs.needs_tests }} result=${{ needs.full-test.result }}"
           echo "  golden=${{ needs.classify.outputs.needs_golden }} result=${{ needs.full-golden.result }}"
           echo "  generated-output=${{ needs.classify.outputs.needs_generated_output }} result=${{ needs.generated_output_compile.result }}"

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -207,19 +207,19 @@ jobs:
           # No -short: main-ci is the full-coverage gate, unlike lint.yml's
           # fast -short shards.
           if [[ "$run_partition" == "true" ]]; then
-            mapfile -t selected_tests < <(
-              go test -list '^(Test|Example)' "${packages[0]}" |
-                python3 -c 'import hashlib, sys; idx = int(sys.argv[1]); total = int(sys.argv[2]); [print(name) for name in (line.strip() for line in sys.stdin) if name.startswith(("Test", "Example")) and int(hashlib.sha256(name.encode()).hexdigest(), 16) % total == idx]' "$shard_index" "$shard_total"
-            )
-            if [[ "${#selected_tests[@]}" -eq 0 ]]; then
+            test_list=/tmp/go-test-list.txt
+            selected_list=/tmp/go-test-selected.txt
+            go test -list '^(Test|Example)' "${packages[0]}" > "$test_list"
+            python3 -c 'import hashlib, sys; idx = int(sys.argv[1]); total = int(sys.argv[2]); [print(name) for name in (line.strip() for line in sys.stdin) if name.startswith(("Test", "Example")) and int(hashlib.sha256(name.encode()).hexdigest(), 16) % total == idx]' "$shard_index" "$shard_total" < "$test_list" > "$selected_list"
+            selected_count="$(awk 'NF { count++ } END { print count + 0 }' "$selected_list")"
+            if [[ "$selected_count" -eq 0 ]]; then
               echo "No tests selected for shard ${{ matrix.shard }}."
               exit 0
             fi
             pattern="$(
-              printf '%s\n' "${selected_tests[@]}" |
-                python3 -c 'import re, sys; names = [line.strip() for line in sys.stdin if line.strip()]; print("^(" + "|".join(re.escape(name) for name in names) + ")$")'
+              python3 -c 'import re, sys; names = [line.strip() for line in sys.stdin if line.strip()]; print("^(" + "|".join(re.escape(name) for name in names) + ")$")' < "$selected_list"
             )"
-            echo "Selected ${#selected_tests[@]} top-level tests for shard ${{ matrix.shard }}."
+            echo "Selected $selected_count top-level tests for shard ${{ matrix.shard }}."
             set +e
             go test -json -timeout 15m -run "$pattern" "${packages[@]}" 2>&1 | tee /tmp/go-test.json
             status=${PIPESTATUS[0]}

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -3851,6 +3851,12 @@ func TestApplyResearchAuthMetadataRejectsUnsafeCanonicalEnvVars(t *testing.T) {
 
 func runGoCommandForCLITest(t *testing.T, dir string, args ...string) {
 	t.Helper()
+	if testing.Short() && len(args) > 0 {
+		if args[0] == "build" || (len(args) >= 2 && args[0] == "mod" && args[1] == "tidy") {
+			t.Logf("skipping go %s in -short mode; full CI runs generated CLI compile coverage", strings.Join(args, " "))
+			return
+		}
+	}
 	cmd := exec.Command("go", args...)
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -86,6 +86,8 @@ type RenameResult struct {
 	Error         string `json:"error,omitempty"`
 }
 
+var runValidationForPublishPackage = runValidation
+
 func newPublishRenameCmd() *cobra.Command {
 	var dir string
 	var oldName string
@@ -269,7 +271,7 @@ func newPublishPackageCmd() *cobra.Command {
 			}
 
 			// Re-validate before packaging
-			vResult := runValidation(dir)
+			vResult := runValidationForPublishPackage(dir)
 			if !vResult.Passed {
 				if asJSON {
 					enc := json.NewEncoder(os.Stdout)

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -40,6 +40,22 @@ func publishCheckByName(t *testing.T, result ValidateResult, name string) CheckR
 	return CheckResult{}
 }
 
+func stubPublishPackageValidation(t *testing.T) {
+	t.Helper()
+	previous := runValidationForPublishPackage
+	runValidationForPublishPackage = func(dir string) ValidateResult {
+		return ValidateResult{
+			Passed:  true,
+			CLIName: "test-pp-cli",
+			APIName: "test",
+			Checks:  []CheckResult{{Name: "test validation stub", Passed: true}},
+		}
+	}
+	t.Cleanup(func() {
+		runValidationForPublishPackage = previous
+	})
+}
+
 func stubPublishIdentityCommands(t *testing.T, gitScript, ghScript string) {
 	t.Helper()
 	if runtime.GOOS == "windows" {
@@ -798,6 +814,7 @@ func TestPublishPackageBackfillsPatchesIndexForLegacyCLI(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 	require.NoFileExists(t, filepath.Join(cliDir, pipeline.PatchesIndexFilename))
 	require.NoDirExists(t, filepath.Join(cliDir, pipeline.PatchesDirName))
 
@@ -822,6 +839,7 @@ func TestPublishPackageRemovesBlankReleaseManifest(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 	require.NoError(t, os.WriteFile(filepath.Join(cliDir, pipeline.CLIReleaseManifestFilename), []byte(`{
   "schema_version": 1,
   "slug": "test",
@@ -847,6 +865,7 @@ func TestPublishPackagePreservesPopulatedReleaseManifest(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 	require.NoError(t, os.WriteFile(filepath.Join(cliDir, pipeline.CLIReleaseManifestFilename), []byte(`{
   "schema_version": 1,
   "slug": "test",
@@ -874,6 +893,7 @@ func TestPublishPackageNormalizesManifestCategoryToPublishCategory(t *testing.T)
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 
 	manifestPath := filepath.Join(cliDir, pipeline.CLIManifestFilename)
 	data, err := os.ReadFile(manifestPath)
@@ -978,6 +998,7 @@ func TestPublishPackageStripsBuildDir(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 
 	// Simulate autoBundleForHost output: build/ exists in the source
 	// dir with a host-platform .mcpb and a staged binary copy.
@@ -1009,6 +1030,7 @@ func TestPublishPackageStripsRootBinaries(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 
 	// Simulate an operator who ran `go build ./cmd/...` (or `make build` /
 	// `make build-mcp` without `-o bin/...`): binaries land at the CLI
@@ -1057,6 +1079,7 @@ func TestPublishPackageStripsRootShipcheckReports(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 
 	for _, name := range stagedShipcheckReportNames() {
 		require.NoError(t, os.WriteFile(filepath.Join(cliDir, name), []byte(`{"passed":true}`+"\n"), 0o644))
@@ -1103,6 +1126,7 @@ func TestPublishPackageFailsWhenManuscriptsCopyFails(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 
 	runID := "20260328-132022"
 	manuscriptFile := filepath.Join(home, "manuscripts", "test", runID, "research", "brief.md")
@@ -1129,6 +1153,7 @@ func TestPublishPackageIncludesManuscripts(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 
 	require.NoError(t, os.MkdirAll(filepath.Join(cliDir, ".manuscripts", "stale-run", "discovery"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(cliDir, ".manuscripts", "stale-run", "discovery", "stale-capture.har"), []byte("cookie: stale\n"), 0o644))
@@ -1191,6 +1216,7 @@ func TestPublishPackageCanIncludeRawCaptures(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 
 	runID := "20260329-100000"
 	researchDir := filepath.Join(home, "manuscripts", "test", runID, "research")
@@ -1222,6 +1248,7 @@ func TestPublishPackageFiltersEmbeddedManuscriptsFallback(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 
 	runID := "20260301-000000"
 	require.NoError(t, os.RemoveAll(filepath.Join(home, "manuscripts", "test")))
@@ -1274,6 +1301,7 @@ func TestPublishPackageRejectsVendorPrefixSecretsInStagedCLI(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "spec.json"), []byte("{\n  \"token\": \""+testSecret("sk", "-or-v1-", "abcdefghijklmnopqrstuvwxyz1234567890")+"\"\n}\n"), 0o644))
 
 	target := filepath.Join(t.TempDir(), "staging")
@@ -1293,6 +1321,7 @@ func TestPublishPackageRecordsAnnotatedPublicVendorPrefixSecrets(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 	publicKey := testSecret("AI", "za", "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234")
 	require.NoError(t, os.MkdirAll(filepath.Join(cliDir, "internal", "huckleberry"), 0o755))
 	require.NoError(t, os.WriteFile(
@@ -1328,6 +1357,7 @@ func TestPublishPackageRejectsSpecDeclaredCookieValuesInStagedCLI(t *testing.T) 
 			home := setLibraryTestEnv(t)
 			cliDir := filepath.Join(home, "library", "test-pp-cli")
 			writePublishableTestCLI(t, cliDir)
+			stubPublishPackageValidation(t)
 			require.NoError(t, os.WriteFile(filepath.Join(cliDir, "tools-manifest.json"), []byte(`{"auth":{"type":"`+authType+`","cookies":["session-id"]}}`+"\n"), 0o644))
 			require.NoError(t, os.WriteFile(filepath.Join(cliDir, "README.md"), []byte("Cookie: session-id=actuallyrealcookievaluexyz\n"), 0o644))
 
@@ -1351,6 +1381,7 @@ func TestPublishPackageRejectsPIIInStagedCLI(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 	// Plant real-shaped PII in a high-risk file
 	require.NoError(t, os.WriteFile(
 		filepath.Join(cliDir, "data.json"),
@@ -1375,6 +1406,7 @@ func TestPublishPackageAllowsReservedSyntheticPII(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 	require.NoError(t, os.WriteFile(
 		filepath.Join(cliDir, "data.json"),
 		[]byte(`{"customer_email": "alice@example.com", "docs_email": "team@app.test", "phone": "(415) 555-0123"}`+"\n"),
@@ -1406,6 +1438,7 @@ func TestPublishPackageRejectsPIIInManuscripts(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 	runID := "20260329-100000"
 	researchFile := filepath.Join(home, "manuscripts", "test", runID, "research", "captured.json")
 	require.NoError(t, os.MkdirAll(filepath.Dir(researchFile), 0o755))
@@ -1428,6 +1461,7 @@ func TestPublishPackageCombinesSecretAndPIIReports(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 	// Plant both a secret AND PII
 	require.NoError(t, os.WriteFile(
 		filepath.Join(cliDir, "spec.json"),
@@ -1457,6 +1491,7 @@ func TestPublishPackageRejectsVendorPrefixSecretsInManuscripts(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 	runID := "20260329-100000"
 	researchFile := filepath.Join(home, "manuscripts", "test", runID, "research", "openapi.json")
 	require.NoError(t, os.MkdirAll(filepath.Dir(researchFile), 0o755))
@@ -1535,6 +1570,7 @@ func TestPublishPackageDestWritesDirectly(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 
 	// Create manuscripts
 	runID := "20260329-100000"
@@ -1574,6 +1610,7 @@ func TestPublishPackageDestRemovesOldCLI(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 
 	// Create a dest with an existing CLI in a different category (slug-keyed)
 	destDir := filepath.Join(t.TempDir(), "publish-repo")
@@ -1607,6 +1644,7 @@ func TestPublishPackageDestRestoresOldCLIOnFailure(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
 
 	// Create manuscripts with an unreadable file to trigger copy failure
 	runID := "20260329-100000"

--- a/internal/cli/verify_skill_test.go
+++ b/internal/cli/verify_skill_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/generator"
@@ -944,17 +945,35 @@ func writeVerifySkillFixture(t *testing.T, dir string, files map[string]string, 
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".printing-press.json"), []byte(`{"cli_name":"fixture-pp-cli"}`), 0o644))
 }
 
-// buildPrintingPressBinary compiles the printing-press binary into a test
-// tempdir and returns its path. Built once per test because each test's
-// TempDir is fresh; Go's test cache ensures the compile is fast.
+var (
+	printingPressBinaryOnce sync.Once
+	printingPressBinaryPath string
+	printingPressBinaryErr  error
+)
+
+// buildPrintingPressBinary compiles the printing-press binary once for this
+// package's verify-skill subprocess tests and returns its path.
 func buildPrintingPressBinary(t *testing.T) string {
 	t.Helper()
-	out := filepath.Join(t.TempDir(), "printing-press")
-	cmd := exec.Command("go", "build", "-o", out, "./cmd/cli-printing-press")
-	// The test runs from internal/cli; go up to repo root.
-	cmd.Dir = "../.."
-	if buildOut, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("building printing-press: %v\n%s", err, string(buildOut))
-	}
-	return out
+
+	printingPressBinaryOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "printing-press-test-bin-*")
+		if err != nil {
+			printingPressBinaryErr = err
+			return
+		}
+
+		out := filepath.Join(dir, "printing-press")
+		cmd := exec.Command("go", "build", "-o", out, "./cmd/cli-printing-press")
+		// The test runs from internal/cli; go up to repo root.
+		cmd.Dir = "../.."
+		if buildOut, err := cmd.CombinedOutput(); err != nil {
+			printingPressBinaryErr = fmt.Errorf("building printing-press: %w\n%s", err, string(buildOut))
+			return
+		}
+		printingPressBinaryPath = out
+	})
+
+	require.NoError(t, printingPressBinaryErr)
+	return printingPressBinaryPath
 }


### PR DESCRIPTION
## Summary
- reuse the cli-printing-press test binary across verify-skill subprocess tests
- stub already-passed publish validation in package behavior tests while leaving validation tests on the real path
- split Main CI generator full tests into deterministic partitions and delegate duplicate Golden PR checks to Main CI

## Evidence

<img width="1540" height="722" alt="CleanShot 2026-06-30 at 15 22 07@2x" src="https://github.com/user-attachments/assets/218e987d-24ea-468d-af90-a6443fc5716c" />

## Local verification
- actionlint .github/workflows/main-ci.yml .github/workflows/golden.yml
- go test -short -count=1 ./internal/cli ./internal/generator
- go test -short -json -timeout 12m ./...
- go test -json -timeout 15m ./...
- scripts/golden.sh verify
- scripts/verify-generator-output.sh

## Timing notes
- Baseline short suite: 99s
- After short suite: 24s warm, 72s cold-ish with -count=1
- Baseline full suite: 148s and failing in pipeline
- After full suite: 37s and passing locally

CI timing measurement is pending on this PR run.