### PR TITLE
fix(cli): route browser cookie auth through jar path

### DIFF
--- a/internal/generator/browser_cookie_auth_test.go
+++ b/internal/generator/browser_cookie_auth_test.go
@@ -1,0 +1,49 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+)
+
+func TestIsBrowserCookieAuthRequiresCookiePlacement(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		auth spec.AuthConfig
+		want bool
+	}{
+		{
+			name: "browser cookie auth",
+			auth: spec.AuthConfig{Type: "cookie", In: "cookie", Header: "Cookie"},
+			want: true,
+		},
+		{
+			name: "empty header browser cookie auth",
+			auth: spec.AuthConfig{Type: "cookie", In: "cookie"},
+			want: true,
+		},
+		{
+			name: "cookie typed header credential",
+			auth: spec.AuthConfig{Type: "cookie", In: "header", Header: "Cookie"},
+			want: false,
+		},
+		{
+			name: "named cookie auth",
+			auth: spec.AuthConfig{Type: "cookie", In: "cookie", Header: "session_id"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isBrowserCookieAuth(tt.auth); got != tt.want {
+				t.Fatalf("isBrowserCookieAuth() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/generator/browser_cookie_auth_test.go
+++ b/internal/generator/browser_cookie_auth_test.go
@@ -37,7 +37,6 @@ func TestIsBrowserCookieAuthRequiresCookiePlacement(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/generator/client_redirect_auth_test.go
+++ b/internal/generator/client_redirect_auth_test.go
@@ -78,6 +78,28 @@ func TestClientCheckRedirectReappliesAuth(t *testing.T) {
 		require.NotContains(t, closure, "req.Header.Set(",
 			"query-param auth must not stamp any auth header on redirect")
 	})
+
+	t.Run("browser cookie auth uses jar redirect path", func(t *testing.T) {
+		t.Parallel()
+		apiSpec := minimalSpec("redirect-cookie")
+		apiSpec.Auth = spec.AuthConfig{
+			Type:         "cookie",
+			Header:       "Cookie",
+			In:           "cookie",
+			CookieDomain: ".example.com",
+			Cookies:      []string{"session_id", "csrf_token"},
+			EnvVars:      []string{"REDIRECT_COOKIE_SESSION"},
+		}
+		client := generateClientSource(t, apiSpec)
+		closure := checkRedirectClosureBody(t, client)
+
+		require.Contains(t, closure, "Cookie-auth redirects: Go's http.Client + http.CookieJar handle",
+			"browser cookie auth must use the jar redirect branch, not the named in:cookie branch")
+		require.NotContains(t, closure, `ck.Name != "Cookie"`,
+			"browser cookie auth must not treat the Cookie header name as a cookie name when stripping redirects")
+		require.NotContains(t, closure, `req.AddCookie(ck)`,
+			"browser cookie auth redirects must not re-add preserved real cookies to cross-host redirects")
+	})
 }
 
 // checkRedirectClosureBody extracts the body of the CheckRedirect closure

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1135,6 +1135,7 @@ func authParameterName(auth spec.AuthConfig) string {
 
 func isBrowserCookieAuth(auth spec.AuthConfig) bool {
 	return strings.TrimSpace(auth.Type) == "cookie" &&
+		strings.EqualFold(strings.TrimSpace(auth.In), "cookie") &&
 		(strings.TrimSpace(auth.Header) == "" || strings.EqualFold(strings.TrimSpace(auth.Header), "Cookie"))
 }
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -270,6 +270,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"pathKindEnvSuffix":                   pathKindEnvSuffix,
 		"authPlacement":                       authPlacement,
 		"authParameterName":                   authParameterName,
+		"isBrowserCookieAuth":                 isBrowserCookieAuth,
 		"authCommandShort":                    authCommandShort,
 		"authHarvestedEnvHint":                authHarvestedEnvHint,
 		"oauth2AccessTokenAuth":               oauth2AccessTokenAuth,
@@ -1130,6 +1131,11 @@ func authParameterName(auth spec.AuthConfig) string {
 		return "api_key"
 	}
 	return "Authorization"
+}
+
+func isBrowserCookieAuth(auth spec.AuthConfig) bool {
+	return strings.TrimSpace(auth.Type) == "cookie" &&
+		(strings.TrimSpace(auth.Header) == "" || strings.EqualFold(strings.TrimSpace(auth.Header), "Cookie"))
 }
 
 func authCommandShort(api *spec.APISpec) string {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2961,6 +2961,7 @@ func TestGenerateCookieAuthAttachesRealRequestHeader(t *testing.T) {
 	cookieSpec.Auth = spec.AuthConfig{
 		Type:         "cookie",
 		Header:       "Cookie",
+		In:           "cookie",
 		CookieDomain: ".example.com",
 		Cookies:      []string{"session_id"},
 		EnvVars:      []string{"GENUINECOOKIE_COOKIES"},
@@ -2970,8 +2971,13 @@ func TestGenerateCookieAuthAttachesRealRequestHeader(t *testing.T) {
 	cookieClient := readGeneratedFile(t, cookieDir, "internal", "client", "client.go")
 	assert.NotContains(t, cookieClient, `req.Header.Set("Cookie", authHeader)`,
 		"genuine cookie auth must rely on the jar, not set a Cookie header on the wire")
+	assert.NotContains(t, cookieClient, `req.AddCookie(&http.Cookie{Name: "Cookie"`,
+		"genuine cookie auth with in:cookie/header Cookie must not treat Cookie as a cookie name")
+	assert.NotContains(t, cookieClient, `"  Cookie: %s=%s\n", "Cookie"`,
+		"genuine cookie auth dry-run must not preview the Cookie header name as a cookie name")
 	assert.Contains(t, cookieClient, "the cookie jar is the sole source of outbound",
 		"genuine cookie auth should keep the jar-only comment block")
+	requireGeneratedCompiles(t, cookieDir)
 }
 
 // TestGenerateCookieAuthDerivesCookieDomainFromBaseURL verifies that a

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -537,7 +537,7 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 {{- else if and .Auth .Auth.In (eq .Auth.In "query")}}
 		// Auth lives on URL query; Go preserves the query on relative
 		// redirects, so nothing to re-derive.
-{{- else if and .Auth .Auth.In (eq .Auth.In "cookie")}}
+{{- else if and .Auth .Auth.In (eq .Auth.In "cookie") (not (isBrowserCookieAuth .Auth))}}
 		// The auth cookie set on the initial request is carried verbatim by Go
 		// on same-host redirects, so re-adding it here would double the Cookie
 		// header (the same hazard the cookie-jar branch below avoids). Only the
@@ -1440,7 +1440,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			q := req.URL.Query()
 			q.Set("{{if .Auth.Header}}{{.Auth.Header}}{{else}}api_key{{end}}", authHeader)
 			req.URL.RawQuery = q.Encode()
-{{- else if and .Auth .Auth.In (eq .Auth.In "cookie")}}
+{{- else if and .Auth .Auth.In (eq .Auth.In "cookie") (not (isBrowserCookieAuth .Auth))}}
 			req.AddCookie(&http.Cookie{Name: "{{if .Auth.Header}}{{.Auth.Header}}{{else}}api_key{{end}}", Value: authHeader})
 {{- else if eq .Auth.Type "cookie"}}
 {{- if and .Auth.Header (ne .Auth.Header "Cookie")}}
@@ -1755,7 +1755,7 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 		fmt.Fprintf(os.Stderr, "  %s: %s\n", "{{.Auth.TokenParamName}}", maskToken(authHeader))
 	}
 {{- end}}
-{{- else if and .Auth .Auth.In (eq .Auth.In "cookie")}}
+{{- else if and .Auth .Auth.In (eq .Auth.In "cookie") (not (isBrowserCookieAuth .Auth))}}
 	if authHeader != "" {
 		// in:cookie auth ships on the Cookie header; preview it as such so the
 		// dry run matches the live wire format.


### PR DESCRIPTION
## Summary
- Route browser-sniffed cookie auth (`type: cookie`, `header: Cookie`, `in: cookie`) through the cookie-jar branch instead of the named `in:cookie` API-key branch.
- Preserve named API-key cookie behavior while preventing generated clients from emitting `AddCookie(Name: "Cookie")`, `Cookie: Cookie=...` dry-run previews, or redirect cookie preservation loops for browser cookie auth.
- Add generated-output coverage for live request emission, dry-run preview, cross-host redirect handling, and generated compile behavior.

Closes #3360

## Verification
- `go test ./internal/generator -run 'TestGenerateCookieAuthAttachesRealRequestHeader|TestClientCheckRedirectReappliesAuth|TestGenerateAPIKeyCookieInjectionUsesAddCookie|TestCookieAuthClientSeedsJar'`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go test ./internal/generator`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `git diff --check`

## Notes
- `go test ./...` was run and completed with unrelated `internal/pipeline` failures. Three passed on targeted rerun; `TestResolveCommandPositionalsMixedStoreAndCompanionSourceIsUntagged` still failed in isolation with `blocked-fixture: required API parameter`, outside the generator/auth scope of this PR.
