### PR TITLE
fix(skills): preflight Go currency and disk space

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -1256,6 +1256,18 @@ func writeExecutable(t *testing.T, path, content string) {
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
 }
 
+func linkHostToolIfNeeded(t *testing.T, dir, name string) {
+	t.Helper()
+
+	target := filepath.Join(dir, name)
+	if _, err := os.Stat(target); err == nil {
+		return
+	}
+	hostPath, err := exec.LookPath(name)
+	require.NoError(t, err)
+	require.NoError(t, os.Symlink(hostPath, target))
+}
+
 type setupSkill struct {
 	name string
 	path string
@@ -1284,6 +1296,8 @@ func goRequiredSetupSkills() []setupSkill {
 }
 
 func goCurrencySetupSkills() []setupSkill {
+	// printing-press-import resolves PRINTING_PRESS_BIN after setup, once the
+	// imported CLI has been selected, so setup cannot compare Go currency yet.
 	return []setupSkill{
 		{name: "printing-press", path: filepath.Join("..", "..", "skills", "printing-press", "SKILL.md")},
 		{name: "printing-press-amend", path: filepath.Join("..", "..", "skills", "printing-press-amend", "SKILL.md")},
@@ -1362,6 +1376,13 @@ esac
 exit 0
 `)
 	}
+	pathValue := fakeBin + string(os.PathListSeparator) + "/usr/bin:/bin:/usr/sbin:/sbin"
+	if !opts.includeGo {
+		for _, tool := range []string{"awk", "dirname", "git", "head", "sed"} {
+			linkHostToolIfNeeded(t, fakeBin, tool)
+		}
+		pathValue = fakeBin
+	}
 
 	gitInit := exec.Command("git", "init")
 	gitInit.Dir = repo
@@ -1375,7 +1396,7 @@ exit 0
 	env := append(os.Environ(),
 		"ARGUMENTS=",
 		"HOME="+home,
-		"PATH="+fakeBin+string(os.PathListSeparator)+"/usr/bin:/bin:/usr/sbin:/sbin",
+		"PATH="+pathValue,
 		"PRINTING_PRESS_HOME="+pressHome,
 		"PP_FAKE_GO_INSTALLED="+opts.goInstalled,
 		"PP_FAKE_GO_BINARY="+opts.goBinary,

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -300,6 +300,131 @@ func TestPrintingPressSkillPreflightChecksGoToolchain(t *testing.T) {
 	assert.Contains(t, block, `https://go.dev/dl/`)
 }
 
+func TestSetupContractsRequireGoToolchain(t *testing.T) {
+	t.Parallel()
+
+	for _, skill := range goRequiredSetupSkills() {
+		t.Run(skill.name, func(t *testing.T) {
+			t.Parallel()
+
+			output, err := runSkillSetupContract(t, skill, setupContractOptions{includeGo: false})
+
+			require.Error(t, err, output)
+			assert.Contains(t, output, "[setup-error] Go toolchain not found.")
+		})
+	}
+}
+
+func TestSetupContractsStayQuietInHealthyEnvironment(t *testing.T) {
+	t.Parallel()
+
+	for _, skill := range diskCheckedSetupSkills() {
+		t.Run(skill.name, func(t *testing.T) {
+			t.Parallel()
+
+			output, err := runSkillSetupContract(t, skill, setupContractOptions{
+				includeGo:       true,
+				goInstalled:     "1.26.4",
+				goBinary:        "1.26.4",
+				diskAvailableKB: "4194304",
+			})
+
+			require.NoError(t, err, output)
+			assert.NotContains(t, output, "[setup-error]")
+			assert.NotContains(t, output, "[go-toolchain-old]")
+			assert.NotContains(t, output, "[low-disk]")
+		})
+	}
+}
+
+func TestSetupContractsWarnOnOldGoToolchain(t *testing.T) {
+	t.Parallel()
+
+	for _, skill := range goCurrencySetupSkills() {
+		t.Run(skill.name, func(t *testing.T) {
+			t.Parallel()
+
+			output, err := runSkillSetupContract(t, skill, setupContractOptions{
+				includeGo:       true,
+				goInstalled:     "1.25.0",
+				goBinary:        "1.26.4",
+				diskAvailableKB: "4194304",
+			})
+
+			require.NoError(t, err, output)
+			assert.Contains(t, output, "[go-toolchain-old]")
+			assert.Contains(t, output, "PRESS_GO_INSTALLED=1.25.0")
+			assert.Contains(t, output, "PRESS_GO_REQUIRED=1.26.4")
+		})
+	}
+}
+
+func TestSetupContractsBlockOldGoWhenToolchainLocal(t *testing.T) {
+	t.Parallel()
+
+	for _, skill := range goCurrencySetupSkills() {
+		t.Run(skill.name, func(t *testing.T) {
+			t.Parallel()
+
+			output, err := runSkillSetupContract(t, skill, setupContractOptions{
+				includeGo:       true,
+				goInstalled:     "1.25.0",
+				goBinary:        "1.26.4",
+				goToolchain:     "local",
+				diskAvailableKB: "4194304",
+			})
+
+			require.Error(t, err, output)
+			assert.Contains(t, output, "[setup-error] Go 1.26.4 or newer is required")
+			assert.NotContains(t, output, "[go-toolchain-old]")
+		})
+	}
+}
+
+func TestSetupContractsWarnOnLowDisk(t *testing.T) {
+	t.Parallel()
+
+	for _, skill := range diskCheckedSetupSkills() {
+		t.Run(skill.name, func(t *testing.T) {
+			t.Parallel()
+
+			output, err := runSkillSetupContract(t, skill, setupContractOptions{
+				includeGo:       true,
+				goInstalled:     "1.26.4",
+				goBinary:        "1.26.4",
+				diskAvailableKB: "1048576",
+			})
+
+			require.NoError(t, err, output)
+			assert.Contains(t, output, "[low-disk]")
+			assert.Contains(t, output, "PRESS_DISK_AVAIL_KB=1048576")
+			assert.Contains(t, output, "PRESS_DISK_WARN_KB=3145728")
+		})
+	}
+}
+
+func TestSetupContractsBlockCriticallyLowDisk(t *testing.T) {
+	t.Parallel()
+
+	for _, skill := range diskCheckedSetupSkills() {
+		t.Run(skill.name, func(t *testing.T) {
+			t.Parallel()
+
+			output, err := runSkillSetupContract(t, skill, setupContractOptions{
+				includeGo:       true,
+				goInstalled:     "1.26.4",
+				goBinary:        "1.26.4",
+				diskAvailableKB: "1024",
+			})
+
+			require.Error(t, err, output)
+			assert.Contains(t, output, "[setup-error] Critically low disk space")
+			assert.Contains(t, output, "PRESS_DISK_AVAIL_KB=1024")
+			assert.Contains(t, output, "PRESS_DISK_FAIL_KB=524288")
+		})
+	}
+}
+
 func TestPrintingPressSkillPreflightSmokeTestsGoStdlib(t *testing.T) {
 	skillPath := filepath.Join("..", "..", "skills", "printing-press", "SKILL.md")
 	full := readContractFile(t, skillPath)
@@ -1129,6 +1254,172 @@ func writeExecutable(t *testing.T, path, content string) {
 	t.Helper()
 
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+}
+
+type setupSkill struct {
+	name string
+	path string
+}
+
+type setupContractOptions struct {
+	includeGo       bool
+	goInstalled     string
+	goBinary        string
+	goToolchain     string
+	diskAvailableKB string
+}
+
+func goRequiredSetupSkills() []setupSkill {
+	// Issue #3365 is scoped to the generation/build/publish/import flows that
+	// can fail late after writing generated files or cloning library repos.
+	// printing-press-score has a setup contract too, but it is intentionally
+	// outside this preflight-hardening selector.
+	return []setupSkill{
+		{name: "printing-press", path: filepath.Join("..", "..", "skills", "printing-press", "SKILL.md")},
+		{name: "printing-press-amend", path: filepath.Join("..", "..", "skills", "printing-press-amend", "SKILL.md")},
+		{name: "printing-press-polish", path: filepath.Join("..", "..", "skills", "printing-press-polish", "SKILL.md")},
+		{name: "printing-press-publish", path: filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md")},
+		{name: "printing-press-import", path: filepath.Join("..", "..", "skills", "printing-press-import", "SKILL.md")},
+	}
+}
+
+func goCurrencySetupSkills() []setupSkill {
+	return []setupSkill{
+		{name: "printing-press", path: filepath.Join("..", "..", "skills", "printing-press", "SKILL.md")},
+		{name: "printing-press-amend", path: filepath.Join("..", "..", "skills", "printing-press-amend", "SKILL.md")},
+		{name: "printing-press-polish", path: filepath.Join("..", "..", "skills", "printing-press-polish", "SKILL.md")},
+		{name: "printing-press-publish", path: filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md")},
+	}
+}
+
+func diskCheckedSetupSkills() []setupSkill {
+	return goRequiredSetupSkills()
+}
+
+func runSkillSetupContract(t *testing.T, skill setupSkill, opts setupContractOptions) (string, error) {
+	t.Helper()
+
+	if opts.goInstalled == "" {
+		opts.goInstalled = "1.26.4"
+	}
+	if opts.goBinary == "" {
+		opts.goBinary = opts.goInstalled
+	}
+	if opts.diskAvailableKB == "" {
+		opts.diskAvailableKB = "4194304"
+	}
+
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	fakeBin := filepath.Join(root, "bin")
+	home := filepath.Join(root, "home")
+	pressHome := filepath.Join(home, "printing-press")
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, "cmd", "cli-printing-press"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, "internal", "version"), 0o755))
+	require.NoError(t, os.MkdirAll(fakeBin, 0o755))
+	require.NoError(t, os.MkdirAll(home, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "go.mod"), []byte("module example.com/press\n\ngo 1.20\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "internal", "version", "version.go"), []byte(`package version
+
+var Version = "4.23.0" // x-release-please-version
+`), 0o644))
+	writeExecutable(t, filepath.Join(repo, "cli-printing-press"), versionScript("4.23.0"))
+	writeExecutable(t, filepath.Join(fakeBin, "cli-printing-press"), versionScript("4.23.0"))
+	writeExecutable(t, filepath.Join(fakeBin, "curl"), "#!/bin/sh\nexit 1\n")
+	writeExecutable(t, filepath.Join(fakeBin, "shasum"), "#!/bin/sh\ncat >/dev/null\necho \"0123456789abcdef  -\"\n")
+	writeExecutable(t, filepath.Join(fakeBin, "df"), `#!/bin/sh
+echo "Filesystem 1024-blocks Used Available Capacity Mounted on"
+echo "fake 9999999 0 ${PP_FAKE_DF_AVAIL_KB:-4194304} 0% /"
+`)
+	if opts.includeGo {
+		writeExecutable(t, filepath.Join(fakeBin, "go"), `#!/bin/sh
+case "$1" in
+  env)
+    if [ "$2" = "GOVERSION" ]; then
+      echo "go${PP_FAKE_GO_INSTALLED:-1.26.4}"
+      exit 0
+    fi
+    exit 0
+    ;;
+  version)
+    if [ "$#" -ge 2 ]; then
+      echo "$2: go${PP_FAKE_GO_BINARY:-1.26.4}"
+    else
+      echo "go version go${PP_FAKE_GO_INSTALLED:-1.26.4} test/amd64"
+    fi
+    exit 0
+    ;;
+  run)
+    exit 0
+    ;;
+  list)
+    exit 1
+    ;;
+  build)
+    exit 0
+    ;;
+esac
+exit 0
+`)
+	}
+
+	gitInit := exec.Command("git", "init")
+	gitInit.Dir = repo
+	gitInitOutput, err := gitInit.CombinedOutput()
+	require.NoError(t, err, string(gitInitOutput))
+
+	contract := setupBlockForSkill(t, skill.path)
+	scriptPath := filepath.Join(root, "setup-contract.sh")
+	writeExecutable(t, scriptPath, "#!/bin/sh\n"+contract)
+
+	env := append(os.Environ(),
+		"ARGUMENTS=",
+		"HOME="+home,
+		"PATH="+fakeBin+string(os.PathListSeparator)+"/usr/bin:/bin:/usr/sbin:/sbin",
+		"PRINTING_PRESS_HOME="+pressHome,
+		"PP_FAKE_GO_INSTALLED="+opts.goInstalled,
+		"PP_FAKE_GO_BINARY="+opts.goBinary,
+		"PP_FAKE_DF_AVAIL_KB="+opts.diskAvailableKB,
+	)
+	if opts.goToolchain != "" {
+		env = append(env, "GOTOOLCHAIN="+opts.goToolchain)
+	} else {
+		env = append(env, "GOTOOLCHAIN=auto")
+	}
+
+	cmd := exec.Command("bash", scriptPath)
+	cmd.Dir = repo
+	cmd.Env = env
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func setupBlockForSkill(t *testing.T, path string) string {
+	t.Helper()
+
+	full := readContractFile(t, path)
+	var block string
+	if strings.Contains(full, "<!-- PRESS_SETUP_CONTRACT_START -->") {
+		block = extractContractBlock(t, full)
+	} else {
+		block = firstBashBlockAfter(t, full, "## Setup")
+	}
+	block = strings.ReplaceAll(block, "```bash\n", "")
+	block = strings.ReplaceAll(block, "\n```", "")
+	return block
+}
+
+func firstBashBlockAfter(t *testing.T, content, marker string) string {
+	t.Helper()
+
+	start := strings.Index(content, marker)
+	require.NotEqual(t, -1, start, "missing setup marker %q", marker)
+	fenceStart := strings.Index(content[start:], "```bash\n")
+	require.NotEqual(t, -1, fenceStart, "missing setup bash fence after %q", marker)
+	fenceStart = start + fenceStart + len("```bash\n")
+	fenceEnd := strings.Index(content[fenceStart:], "\n```")
+	require.NotEqual(t, -1, fenceEnd, "missing setup bash fence end after %q", marker)
+	return content[fenceStart : fenceStart+fenceEnd]
 }
 
 func substringBetween(t *testing.T, content, start, end string) string {

--- a/skills/printing-press-amend/SKILL.md
+++ b/skills/printing-press-amend/SKILL.md
@@ -83,7 +83,58 @@ if [ "$_press_repo" = "true" ]; then
 else
   PRINTING_PRESS_BIN="$(command -v cli-printing-press 2>/dev/null || true)"
 fi
+if ! command -v go >/dev/null 2>&1; then
+  echo ""
+  echo "[setup-error] Go toolchain not found."
+  echo ""
+  echo "This Printing Press flow runs Go-based build or validation commands."
+  echo "Install Go 1.26.4 or newer from https://go.dev/dl/, then verify with:"
+  echo "  go version"
+  echo "Then re-run this skill."
+  echo ""
+  return 1 2>/dev/null || exit 1
+fi
 echo "PRINTING_PRESS_BIN=$PRINTING_PRESS_BIN"
+
+_pp_semver_lt() {
+  awk -v a="$1" -v b="$2" 'BEGIN {
+    split(a, x, "."); split(b, y, ".")
+    for (i = 1; i <= 3; i++) {
+      if ((x[i] + 0) < (y[i] + 0)) exit 0
+      if ((x[i] + 0) > (y[i] + 0)) exit 1
+    }
+    exit 1
+  }'
+}
+
+_pp_go_version_norm() {
+  printf '%s\n' "$1" | sed -nE 's/.*go([0-9]+)\.([0-9]+)(\.([0-9]+))?.*/\1.\2.\4/p' | awk -F. 'NF >= 2 { printf "%d.%d.%d\n", $1, $2, ($3 == "" ? 0 : $3) }'
+}
+
+_pp_check_go_currency() {
+  _pp_go_installed="$(_pp_go_version_norm "$(go env GOVERSION 2>/dev/null)")"
+  _pp_go_required="$(_pp_go_version_norm "$(go version "$PRINTING_PRESS_BIN" 2>/dev/null)")"
+  if [ -z "$_pp_go_installed" ] || [ -z "$_pp_go_required" ] || ! _pp_semver_lt "$_pp_go_installed" "$_pp_go_required"; then
+    return 0
+  fi
+
+  echo ""
+  if [ "${GOTOOLCHAIN:-auto}" = "local" ]; then
+    echo "[setup-error] Go $_pp_go_required or newer is required by this cli-printing-press binary (installed: $_pp_go_installed)."
+    echo "GOTOOLCHAIN=local disables automatic toolchain downloads, so later Go quality gates would fail."
+    echo "Install Go $_pp_go_required or newer from https://go.dev/dl/, or unset GOTOOLCHAIN."
+    echo ""
+    return 1
+  fi
+
+  echo "[go-toolchain-old] Go $_pp_go_required or newer is required by this cli-printing-press binary (installed: $_pp_go_installed)."
+  echo "PRESS_GO_INSTALLED=$_pp_go_installed"
+  echo "PRESS_GO_REQUIRED=$_pp_go_required"
+  echo "Default GOTOOLCHAIN behavior may download the required toolchain during Go commands."
+  echo ""
+  return 0
+}
+_pp_check_go_currency || { return 1 2>/dev/null || exit 1; }
 
 PRESS_BASE="$(basename "$_scope_dir" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_-]/-/g; s/^-+//; s/-+$//')"
 if [ -z "$PRESS_BASE" ]; then
@@ -96,6 +147,46 @@ PRESS_RUNSTATE="$PRESS_HOME/.runstate/$PRESS_SCOPE"
 PRESS_LIBRARY="$PRESS_HOME/library"
 PRESS_MANUSCRIPTS="$PRESS_HOME/manuscripts"
 PRESS_CURRENT="$PRESS_RUNSTATE/current"
+
+_pp_check_disk_space() {
+  _pp_disk_warn_kb="${PRINTING_PRESS_DISK_WARN_KB:-3145728}"
+  _pp_disk_fail_kb="${PRINTING_PRESS_DISK_FAIL_KB:-524288}"
+  case "$_pp_disk_warn_kb$_pp_disk_fail_kb" in
+    ""|*[!0-9]*) return 0 ;;
+  esac
+
+  _pp_disk_path="$PRESS_HOME"
+  while [ ! -e "$_pp_disk_path" ] && [ "$_pp_disk_path" != "/" ]; do
+    _pp_disk_path="$(dirname "$_pp_disk_path")"
+  done
+
+  _pp_disk_avail_kb="$(df -Pk "$_pp_disk_path" 2>/dev/null | awk 'NR == 2 { print $4; exit }')"
+  case "$_pp_disk_avail_kb" in
+    ""|*[!0-9]*) return 0 ;;
+  esac
+
+  if [ "$_pp_disk_avail_kb" -lt "$_pp_disk_fail_kb" ]; then
+    echo ""
+    echo "[setup-error] Critically low disk space on the Printing Press workspace volume."
+    echo "PRESS_DISK_PATH=$_pp_disk_path"
+    echo "PRESS_DISK_AVAIL_KB=$_pp_disk_avail_kb"
+    echo "PRESS_DISK_FAIL_KB=$_pp_disk_fail_kb"
+    echo "Free disk space or set PRINTING_PRESS_HOME to a volume with more room, then re-run this skill."
+    echo ""
+    return 1
+  fi
+
+  if [ "$_pp_disk_avail_kb" -lt "$_pp_disk_warn_kb" ]; then
+    echo ""
+    echo "[low-disk] Printing Press workspace volume is low on free space."
+    echo "PRESS_DISK_PATH=$_pp_disk_path"
+    echo "PRESS_DISK_AVAIL_KB=$_pp_disk_avail_kb"
+    echo "PRESS_DISK_WARN_KB=$_pp_disk_warn_kb"
+    echo "This flow may need several GiB for generated files, Go build cache, module downloads, or repository clones."
+    echo ""
+  fi
+}
+_pp_check_disk_space || { return 1 2>/dev/null || exit 1; }
 
 mkdir -p "$PRESS_RUNSTATE" "$PRESS_LIBRARY" "$PRESS_MANUSCRIPTS" "$PRESS_CURRENT"
 
@@ -141,6 +232,8 @@ fi
 <!-- PRESS_SETUP_CONTRACT_END -->
 
 After running the setup contract, capture the `PRINTING_PRESS_BIN=<abs-path>` line from stdout. **Every subsequent `cli-printing-press ...` invocation in this skill must use that absolute path** (substitute the value, not the literal `$PRINTING_PRESS_BIN` token) — `export PATH` above only affects the single Bash tool call it runs in, so later calls open a fresh shell where bare `cli-printing-press` resolves against the user's default `PATH` and a stale global can shadow the local build.
+
+If setup emitted `[go-toolchain-old]` or `[low-disk]`, surface the advisory to the user and continue unless setup also emitted `[setup-error]`. `[go-toolchain-old]` means later Go commands may download the required toolchain or fail when downloads are blocked; `[low-disk]` means this run may need several GiB for generated files, Go build cache, module downloads, or repository clones.
 
 After capturing the binary path, check binary version compatibility. Read the `min-binary-version` field from this skill's YAML frontmatter. Run `<PRINTING_PRESS_BIN> version --json` and parse the version from the output. Compare it to `min-binary-version` using semver rules. If the installed binary is older than the minimum, stop immediately and tell the user: "cli-printing-press binary vX.Y.Z is older than the minimum required vA.B.C. Run `go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest` to update."
 

--- a/skills/printing-press-import/SKILL.md
+++ b/skills/printing-press-import/SKILL.md
@@ -49,6 +49,58 @@ PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
 PRESS_LIBRARY="$PRESS_HOME/library"
 PRESS_MANUSCRIPTS="$PRESS_HOME/manuscripts"
 SCRIPTS_DIR="$(dirname "${BASH_SOURCE[0]:-$0}")/references"
+
+if ! command -v go >/dev/null 2>&1; then
+  echo ""
+  echo "[setup-error] Go toolchain not found."
+  echo ""
+  echo "This Printing Press flow runs Go-based build or validation commands."
+  echo "Install Go 1.26.4 or newer from https://go.dev/dl/, then verify with:"
+  echo "  go version"
+  echo "Then re-run this skill."
+  echo ""
+  return 1 2>/dev/null || exit 1
+fi
+
+_pp_check_disk_space() {
+  _pp_disk_warn_kb="${PRINTING_PRESS_DISK_WARN_KB:-3145728}"
+  _pp_disk_fail_kb="${PRINTING_PRESS_DISK_FAIL_KB:-524288}"
+  case "$_pp_disk_warn_kb$_pp_disk_fail_kb" in
+    ""|*[!0-9]*) return 0 ;;
+  esac
+
+  _pp_disk_path="$PRESS_HOME"
+  while [ ! -e "$_pp_disk_path" ] && [ "$_pp_disk_path" != "/" ]; do
+    _pp_disk_path="$(dirname "$_pp_disk_path")"
+  done
+
+  _pp_disk_avail_kb="$(df -Pk "$_pp_disk_path" 2>/dev/null | awk 'NR == 2 { print $4; exit }')"
+  case "$_pp_disk_avail_kb" in
+    ""|*[!0-9]*) return 0 ;;
+  esac
+
+  if [ "$_pp_disk_avail_kb" -lt "$_pp_disk_fail_kb" ]; then
+    echo ""
+    echo "[setup-error] Critically low disk space on the Printing Press workspace volume."
+    echo "PRESS_DISK_PATH=$_pp_disk_path"
+    echo "PRESS_DISK_AVAIL_KB=$_pp_disk_avail_kb"
+    echo "PRESS_DISK_FAIL_KB=$_pp_disk_fail_kb"
+    echo "Free disk space or set PRINTING_PRESS_HOME to a volume with more room, then re-run this skill."
+    echo ""
+    return 1
+  fi
+
+  if [ "$_pp_disk_avail_kb" -lt "$_pp_disk_warn_kb" ]; then
+    echo ""
+    echo "[low-disk] Printing Press workspace volume is low on free space."
+    echo "PRESS_DISK_PATH=$_pp_disk_path"
+    echo "PRESS_DISK_AVAIL_KB=$_pp_disk_avail_kb"
+    echo "PRESS_DISK_WARN_KB=$_pp_disk_warn_kb"
+    echo "This flow may need several GiB for generated files, Go build cache, module downloads, or repository clones."
+    echo ""
+  fi
+}
+_pp_check_disk_space || { return 1 2>/dev/null || exit 1; }
 ```
 
 The four reference scripts live alongside this SKILL.md under
@@ -58,6 +110,8 @@ The four reference scripts live alongside this SKILL.md under
 - `import-backup.sh <api-slug>` (prints zip path on stdout)
 - `import-rewrite.sh <staging> <api-slug>`
 - `import-place.sh <staging> <api-slug>`
+
+If setup emitted `[low-disk]`, surface the advisory to the user and continue unless setup also emitted `[setup-error]`. `[low-disk]` means this run may need several GiB for repository clones, staged files, backups, Go build cache, or module downloads.
 
 ## Phase 1 — Resolve the CLI
 

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -50,6 +50,46 @@ Can also be run standalone on any CLI in `$PRESS_LIBRARY/`.
 PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
 PRESS_LIBRARY="$PRESS_HOME/library"
 
+_pp_check_disk_space() {
+  _pp_disk_warn_kb="${PRINTING_PRESS_DISK_WARN_KB:-3145728}"
+  _pp_disk_fail_kb="${PRINTING_PRESS_DISK_FAIL_KB:-524288}"
+  case "$_pp_disk_warn_kb$_pp_disk_fail_kb" in
+    ""|*[!0-9]*) return 0 ;;
+  esac
+
+  _pp_disk_path="$PRESS_HOME"
+  while [ ! -e "$_pp_disk_path" ] && [ "$_pp_disk_path" != "/" ]; do
+    _pp_disk_path="$(dirname "$_pp_disk_path")"
+  done
+
+  _pp_disk_avail_kb="$(df -Pk "$_pp_disk_path" 2>/dev/null | awk 'NR == 2 { print $4; exit }')"
+  case "$_pp_disk_avail_kb" in
+    ""|*[!0-9]*) return 0 ;;
+  esac
+
+  if [ "$_pp_disk_avail_kb" -lt "$_pp_disk_fail_kb" ]; then
+    echo ""
+    echo "[setup-error] Critically low disk space on the Printing Press workspace volume."
+    echo "PRESS_DISK_PATH=$_pp_disk_path"
+    echo "PRESS_DISK_AVAIL_KB=$_pp_disk_avail_kb"
+    echo "PRESS_DISK_FAIL_KB=$_pp_disk_fail_kb"
+    echo "Free disk space or set PRINTING_PRESS_HOME to a volume with more room, then re-run this skill."
+    echo ""
+    return 1
+  fi
+
+  if [ "$_pp_disk_avail_kb" -lt "$_pp_disk_warn_kb" ]; then
+    echo ""
+    echo "[low-disk] Printing Press workspace volume is low on free space."
+    echo "PRESS_DISK_PATH=$_pp_disk_path"
+    echo "PRESS_DISK_AVAIL_KB=$_pp_disk_avail_kb"
+    echo "PRESS_DISK_WARN_KB=$_pp_disk_warn_kb"
+    echo "This flow may need several GiB for generated files, Go build cache, module downloads, or repository clones."
+    echo ""
+  fi
+}
+_pp_check_disk_space || { return 1 2>/dev/null || exit 1; }
+
 # Mid-pipeline callers may pass printing_press_bin: <abs-path> in the args
 # bundle. Prefer it so forked polish runs keep using the parent skill's
 # preflight-selected binary instead of re-resolving through PATH.
@@ -66,10 +106,63 @@ if [ -z "$PRINTING_PRESS_BIN" ]; then
   echo "Install with:  go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest"
   return 1 2>/dev/null || exit 1
 fi
+if ! command -v go >/dev/null 2>&1; then
+  echo ""
+  echo "[setup-error] Go toolchain not found."
+  echo ""
+  echo "This Printing Press flow runs Go-based build or validation commands."
+  echo "Install Go 1.26.4 or newer from https://go.dev/dl/, then verify with:"
+  echo "  go version"
+  echo "Then re-run this skill."
+  echo ""
+  return 1 2>/dev/null || exit 1
+fi
 echo "PRINTING_PRESS_BIN=$PRINTING_PRESS_BIN"
+
+_pp_semver_lt() {
+  awk -v a="$1" -v b="$2" 'BEGIN {
+    split(a, x, "."); split(b, y, ".")
+    for (i = 1; i <= 3; i++) {
+      if ((x[i] + 0) < (y[i] + 0)) exit 0
+      if ((x[i] + 0) > (y[i] + 0)) exit 1
+    }
+    exit 1
+  }'
+}
+
+_pp_go_version_norm() {
+  printf '%s\n' "$1" | sed -nE 's/.*go([0-9]+)\.([0-9]+)(\.([0-9]+))?.*/\1.\2.\4/p' | awk -F. 'NF >= 2 { printf "%d.%d.%d\n", $1, $2, ($3 == "" ? 0 : $3) }'
+}
+
+_pp_check_go_currency() {
+  _pp_go_installed="$(_pp_go_version_norm "$(go env GOVERSION 2>/dev/null)")"
+  _pp_go_required="$(_pp_go_version_norm "$(go version "$PRINTING_PRESS_BIN" 2>/dev/null)")"
+  if [ -z "$_pp_go_installed" ] || [ -z "$_pp_go_required" ] || ! _pp_semver_lt "$_pp_go_installed" "$_pp_go_required"; then
+    return 0
+  fi
+
+  echo ""
+  if [ "${GOTOOLCHAIN:-auto}" = "local" ]; then
+    echo "[setup-error] Go $_pp_go_required or newer is required by this cli-printing-press binary (installed: $_pp_go_installed)."
+    echo "GOTOOLCHAIN=local disables automatic toolchain downloads, so later Go quality gates would fail."
+    echo "Install Go $_pp_go_required or newer from https://go.dev/dl/, or unset GOTOOLCHAIN."
+    echo ""
+    return 1
+  fi
+
+  echo "[go-toolchain-old] Go $_pp_go_required or newer is required by this cli-printing-press binary (installed: $_pp_go_installed)."
+  echo "PRESS_GO_INSTALLED=$_pp_go_installed"
+  echo "PRESS_GO_REQUIRED=$_pp_go_required"
+  echo "Default GOTOOLCHAIN behavior may download the required toolchain during Go commands."
+  echo ""
+  return 0
+}
+_pp_check_go_currency || { return 1 2>/dev/null || exit 1; }
 ```
 
-After setup, capture `PRINTING_PRESS_BIN=<abs-path>` and use that absolute path for every `cli-printing-press ...` invocation in this skill. Check binary version compatibility by reading the `min-binary-version` field from this skill's YAML frontmatter, running `"$PRINTING_PRESS_BIN" version --json`, and parsing the version from the output. Compare it to `min-binary-version` using semver rules. If the installed binary is older than the minimum, stop immediately and tell the user: "cli-printing-press binary vX.Y.Z is older than the minimum required vA.B.C. Run `go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest` to update."
+After setup, capture `PRINTING_PRESS_BIN=<abs-path>` and use that absolute path for every `cli-printing-press ...` invocation in this skill. If setup emitted `[go-toolchain-old]` or `[low-disk]`, surface the advisory to the user and continue unless setup also emitted `[setup-error]`. `[go-toolchain-old]` means later Go commands may download the required toolchain or fail when downloads are blocked; `[low-disk]` means this run may need several GiB for generated files, Go build cache, module downloads, or repository clones.
+
+Check binary version compatibility by reading the `min-binary-version` field from this skill's YAML frontmatter, running `"$PRINTING_PRESS_BIN" version --json`, and parsing the version from the output. Compare it to `min-binary-version` using semver rules. If the installed binary is older than the minimum, stop immediately and tell the user: "cli-printing-press binary vX.Y.Z is older than the minimum required vA.B.C. Run `go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest` to update."
 
 ### Public-library hint
 

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -202,7 +202,58 @@ if [ "$_press_repo" = "true" ]; then
 else
   PRINTING_PRESS_BIN="$(command -v cli-printing-press 2>/dev/null || true)"
 fi
+if ! command -v go >/dev/null 2>&1; then
+  echo ""
+  echo "[setup-error] Go toolchain not found."
+  echo ""
+  echo "This Printing Press flow runs Go-based build or validation commands."
+  echo "Install Go 1.26.4 or newer from https://go.dev/dl/, then verify with:"
+  echo "  go version"
+  echo "Then re-run this skill."
+  echo ""
+  return 1 2>/dev/null || exit 1
+fi
 echo "PRINTING_PRESS_BIN=$PRINTING_PRESS_BIN"
+
+_pp_semver_lt() {
+  awk -v a="$1" -v b="$2" 'BEGIN {
+    split(a, x, "."); split(b, y, ".")
+    for (i = 1; i <= 3; i++) {
+      if ((x[i] + 0) < (y[i] + 0)) exit 0
+      if ((x[i] + 0) > (y[i] + 0)) exit 1
+    }
+    exit 1
+  }'
+}
+
+_pp_go_version_norm() {
+  printf '%s\n' "$1" | sed -nE 's/.*go([0-9]+)\.([0-9]+)(\.([0-9]+))?.*/\1.\2.\4/p' | awk -F. 'NF >= 2 { printf "%d.%d.%d\n", $1, $2, ($3 == "" ? 0 : $3) }'
+}
+
+_pp_check_go_currency() {
+  _pp_go_installed="$(_pp_go_version_norm "$(go env GOVERSION 2>/dev/null)")"
+  _pp_go_required="$(_pp_go_version_norm "$(go version "$PRINTING_PRESS_BIN" 2>/dev/null)")"
+  if [ -z "$_pp_go_installed" ] || [ -z "$_pp_go_required" ] || ! _pp_semver_lt "$_pp_go_installed" "$_pp_go_required"; then
+    return 0
+  fi
+
+  echo ""
+  if [ "${GOTOOLCHAIN:-auto}" = "local" ]; then
+    echo "[setup-error] Go $_pp_go_required or newer is required by this cli-printing-press binary (installed: $_pp_go_installed)."
+    echo "GOTOOLCHAIN=local disables automatic toolchain downloads, so later Go quality gates would fail."
+    echo "Install Go $_pp_go_required or newer from https://go.dev/dl/, or unset GOTOOLCHAIN."
+    echo ""
+    return 1
+  fi
+
+  echo "[go-toolchain-old] Go $_pp_go_required or newer is required by this cli-printing-press binary (installed: $_pp_go_installed)."
+  echo "PRESS_GO_INSTALLED=$_pp_go_installed"
+  echo "PRESS_GO_REQUIRED=$_pp_go_required"
+  echo "Default GOTOOLCHAIN behavior may download the required toolchain during Go commands."
+  echo ""
+  return 0
+}
+_pp_check_go_currency || { return 1 2>/dev/null || exit 1; }
 
 PRESS_BASE="$(basename "$_scope_dir" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_-]/-/g; s/^-+//; s/-+$//')"
 if [ -z "$PRESS_BASE" ]; then
@@ -216,11 +267,53 @@ PRESS_LIBRARY="$PRESS_HOME/library"
 PRESS_MANUSCRIPTS="$PRESS_HOME/manuscripts"
 PRESS_CURRENT="$PRESS_RUNSTATE/current"
 
+_pp_check_disk_space() {
+  _pp_disk_warn_kb="${PRINTING_PRESS_DISK_WARN_KB:-3145728}"
+  _pp_disk_fail_kb="${PRINTING_PRESS_DISK_FAIL_KB:-524288}"
+  case "$_pp_disk_warn_kb$_pp_disk_fail_kb" in
+    ""|*[!0-9]*) return 0 ;;
+  esac
+
+  _pp_disk_path="$PRESS_HOME"
+  while [ ! -e "$_pp_disk_path" ] && [ "$_pp_disk_path" != "/" ]; do
+    _pp_disk_path="$(dirname "$_pp_disk_path")"
+  done
+
+  _pp_disk_avail_kb="$(df -Pk "$_pp_disk_path" 2>/dev/null | awk 'NR == 2 { print $4; exit }')"
+  case "$_pp_disk_avail_kb" in
+    ""|*[!0-9]*) return 0 ;;
+  esac
+
+  if [ "$_pp_disk_avail_kb" -lt "$_pp_disk_fail_kb" ]; then
+    echo ""
+    echo "[setup-error] Critically low disk space on the Printing Press workspace volume."
+    echo "PRESS_DISK_PATH=$_pp_disk_path"
+    echo "PRESS_DISK_AVAIL_KB=$_pp_disk_avail_kb"
+    echo "PRESS_DISK_FAIL_KB=$_pp_disk_fail_kb"
+    echo "Free disk space or set PRINTING_PRESS_HOME to a volume with more room, then re-run this skill."
+    echo ""
+    return 1
+  fi
+
+  if [ "$_pp_disk_avail_kb" -lt "$_pp_disk_warn_kb" ]; then
+    echo ""
+    echo "[low-disk] Printing Press workspace volume is low on free space."
+    echo "PRESS_DISK_PATH=$_pp_disk_path"
+    echo "PRESS_DISK_AVAIL_KB=$_pp_disk_avail_kb"
+    echo "PRESS_DISK_WARN_KB=$_pp_disk_warn_kb"
+    echo "This flow may need several GiB for generated files, Go build cache, module downloads, or repository clones."
+    echo ""
+  fi
+}
+_pp_check_disk_space || { return 1 2>/dev/null || exit 1; }
+
 mkdir -p "$PRESS_RUNSTATE" "$PRESS_LIBRARY" "$PRESS_MANUSCRIPTS" "$PRESS_CURRENT"
 ```
 <!-- PRESS_SETUP_CONTRACT_END -->
 
 After running the setup contract, capture the `PRINTING_PRESS_BIN=<abs-path>` line from stdout. **Every subsequent `cli-printing-press ...` invocation in this skill must use that absolute path** (substitute the value, not the literal `$PRINTING_PRESS_BIN` token) — `export PATH` above only affects the single Bash tool call it runs in, so later calls open a fresh shell where bare `cli-printing-press` resolves against the user's default `PATH` and a stale global can shadow the local build.
+
+If setup emitted `[go-toolchain-old]` or `[low-disk]`, surface the advisory to the user and continue unless setup also emitted `[setup-error]`. `[go-toolchain-old]` means later Go commands may download the required toolchain or fail when downloads are blocked; `[low-disk]` means this run may need several GiB for generated files, Go build cache, module downloads, or repository clones.
 
 After capturing the binary path, check binary version compatibility. Read the `min-binary-version` field from this skill's YAML frontmatter. Run `<PRINTING_PRESS_BIN> version --json` and parse the version from the output. Compare it to `min-binary-version` using semver rules. If the installed binary is older than the minimum, stop immediately and tell the user: "cli-printing-press binary vX.Y.Z is older than the minimum required vA.B.C. Run `go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest` to update."
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -324,6 +324,39 @@ fi
 echo "PRINTING_PRESS_BIN=$PRINTING_PRESS_BIN"
 echo "PRESS_REPO_MODE=$_press_repo"
 
+_pp_go_version_norm() {
+  printf '%s\n' "$1" | sed -nE 's/.*go([0-9]+)\.([0-9]+)(\.([0-9]+))?.*/\1.\2.\4/p' | awk -F. 'NF >= 2 { printf "%d.%d.%d\n", $1, $2, ($3 == "" ? 0 : $3) }'
+}
+
+_pp_check_go_currency() {
+  if [ -z "${PRINTING_PRESS_BIN:-}" ] || ! command -v go >/dev/null 2>&1; then
+    return 0
+  fi
+
+  _pp_go_installed="$(_pp_go_version_norm "$(go env GOVERSION 2>/dev/null)")"
+  _pp_go_required="$(_pp_go_version_norm "$(go version "$PRINTING_PRESS_BIN" 2>/dev/null)")"
+  if [ -z "$_pp_go_installed" ] || [ -z "$_pp_go_required" ] || ! _semver_lt "$_pp_go_installed" "$_pp_go_required"; then
+    return 0
+  fi
+
+  echo ""
+  if [ "${GOTOOLCHAIN:-auto}" = "local" ]; then
+    echo "[setup-error] Go $_pp_go_required or newer is required by this cli-printing-press binary (installed: $_pp_go_installed)."
+    echo "GOTOOLCHAIN=local disables automatic toolchain downloads, so later Go quality gates would fail."
+    echo "Install Go $_pp_go_required or newer from https://go.dev/dl/, or unset GOTOOLCHAIN."
+    echo ""
+    return 1
+  fi
+
+  echo "[go-toolchain-old] Go $_pp_go_required or newer is required by this cli-printing-press binary (installed: $_pp_go_installed)."
+  echo "PRESS_GO_INSTALLED=$_pp_go_installed"
+  echo "PRESS_GO_REQUIRED=$_pp_go_required"
+  echo "Default GOTOOLCHAIN behavior may download the required toolchain during Go commands."
+  echo ""
+  return 0
+}
+_pp_check_go_currency || { return 1 2>/dev/null || exit 1; }
+
 # Shadow detector (advisory). When a local build is in use, surface any
 # differing global so the user can see at a glance that the two binaries
 # disagree. Detect-only: the absolute path emitted above is the one the
@@ -361,6 +394,46 @@ PRESS_RUNSTATE="$PRESS_HOME/.runstate/$PRESS_SCOPE"
 PRESS_LIBRARY="$PRESS_HOME/library"
 PRESS_MANUSCRIPTS="$PRESS_HOME/manuscripts"
 PRESS_CURRENT="$PRESS_RUNSTATE/current"
+
+_pp_check_disk_space() {
+  _pp_disk_warn_kb="${PRINTING_PRESS_DISK_WARN_KB:-3145728}"
+  _pp_disk_fail_kb="${PRINTING_PRESS_DISK_FAIL_KB:-524288}"
+  case "$_pp_disk_warn_kb$_pp_disk_fail_kb" in
+    ""|*[!0-9]*) return 0 ;;
+  esac
+
+  _pp_disk_path="$PRESS_HOME"
+  while [ ! -e "$_pp_disk_path" ] && [ "$_pp_disk_path" != "/" ]; do
+    _pp_disk_path="$(dirname "$_pp_disk_path")"
+  done
+
+  _pp_disk_avail_kb="$(df -Pk "$_pp_disk_path" 2>/dev/null | awk 'NR == 2 { print $4; exit }')"
+  case "$_pp_disk_avail_kb" in
+    ""|*[!0-9]*) return 0 ;;
+  esac
+
+  if [ "$_pp_disk_avail_kb" -lt "$_pp_disk_fail_kb" ]; then
+    echo ""
+    echo "[setup-error] Critically low disk space on the Printing Press workspace volume."
+    echo "PRESS_DISK_PATH=$_pp_disk_path"
+    echo "PRESS_DISK_AVAIL_KB=$_pp_disk_avail_kb"
+    echo "PRESS_DISK_FAIL_KB=$_pp_disk_fail_kb"
+    echo "Free disk space or set PRINTING_PRESS_HOME to a volume with more room, then re-run /printing-press."
+    echo ""
+    return 1
+  fi
+
+  if [ "$_pp_disk_avail_kb" -lt "$_pp_disk_warn_kb" ]; then
+    echo ""
+    echo "[low-disk] Printing Press workspace volume is low on free space."
+    echo "PRESS_DISK_PATH=$_pp_disk_path"
+    echo "PRESS_DISK_AVAIL_KB=$_pp_disk_avail_kb"
+    echo "PRESS_DISK_WARN_KB=$_pp_disk_warn_kb"
+    echo "Generation may need several GiB for generated files, Go build cache, and module downloads."
+    echo ""
+  fi
+}
+_pp_check_disk_space || { return 1 2>/dev/null || exit 1; }
 
 mkdir -p "$PRESS_RUNSTATE" "$PRESS_LIBRARY" "$PRESS_MANUSCRIPTS" "$PRESS_CURRENT"
 
@@ -535,7 +608,7 @@ CODEX_CONSECUTIVE_FAILURES=0
 ```
 <!-- PRESS_SETUP_CONTRACT_END -->
 
-**MANDATORY: Read and apply [references/setup-checks.md](references/setup-checks.md) immediately after the setup contract bash block runs, before any other action.** It handles the contract output signals: `[setup-error]` (refuse to run, surface the install instructions), optional `[local-binary-stale]` / `[local-binary-rebuilt]` repo-mode rebuild markers, `[repo-upgrade-available]` (interactive `AskUserQuestion` prompt + optional repo pull), `PRESS_REPO_MODE=<true|false>` plus the targeted global open-agent-skills freshness check, the min-binary-version compatibility check (hard stop if binary is too old), `[upgrade-required]` (hard gate below the published currency floor — interactive upgrade-or-abort, no skip), `[upgrade-available]` (interactive `AskUserQuestion` prompt + optional standalone binary upgrade), `[browser-tools-missing]` (interactive `AskUserQuestion` prompt + optional install of browser-use and/or agent-browser), and the `PRINTING_PRESS_BIN=<abs-path>` marker plus optional `[binary-shadow]` warning (capture the path; use it for every subsequent generator invocation). Skipping the reference will cause the skill to proceed with a missing or out-of-date binary, run with stale global skill text when the session is managed by open-agent-skills, hit a mid-flight install prompt if browser-sniff is later needed, or invoke the wrong binary because a stale global or the public-library installer on `PATH` shadowed the local build. Do not skip.
+**MANDATORY: Read and apply [references/setup-checks.md](references/setup-checks.md) immediately after the setup contract bash block runs, before any other action.** It handles the contract output signals: `[setup-error]` (refuse to run, surface the install instructions), optional `[local-binary-stale]` / `[local-binary-rebuilt]` repo-mode rebuild markers, `[go-toolchain-old]` / `[low-disk]` advisories, `[repo-upgrade-available]` (interactive `AskUserQuestion` prompt + optional repo pull), `PRESS_REPO_MODE=<true|false>` plus the targeted global open-agent-skills freshness check, the min-binary-version compatibility check (hard stop if binary is too old), `[upgrade-required]` (hard gate below the published currency floor — interactive upgrade-or-abort, no skip), `[upgrade-available]` (interactive `AskUserQuestion` prompt + optional standalone binary upgrade), `[browser-tools-missing]` (interactive `AskUserQuestion` prompt + optional install of browser-use and/or agent-browser), and the `PRINTING_PRESS_BIN=<abs-path>` marker plus optional `[binary-shadow]` warning (capture the path; use it for every subsequent generator invocation). Skipping the reference will cause the skill to proceed with a missing or out-of-date binary, run with stale global skill text when the session is managed by open-agent-skills, hit a mid-flight install prompt if browser-sniff is later needed, or invoke the wrong binary because a stale global or the public-library installer on `PATH` shadowed the local build. Do not skip.
 
 **Absolute-path rule.** The preflight contract always emits `PRINTING_PRESS_BIN=<absolute path>` to stdout. Capture this value and substitute it (the resolved absolute path, not the literal `$PRINTING_PRESS_BIN` token) for every subsequent `cli-printing-press ...` invocation in this skill, references, and any sub-skill you delegate to. The `export PATH=...` line inside the contract only affects the single Bash tool call it runs in; later Bash tool calls open fresh shells and resolve bare `cli-printing-press` against the user's default `PATH`, where a stale globally-installed binary (`$HOME/go/bin/cli-printing-press`, Homebrew copy, etc.) will silently shadow the local build the preflight just chose. Bash code examples below are written `cli-printing-press generate ...` for readability — replace `cli-printing-press` with the captured absolute path each time you actually run one.
 

--- a/skills/printing-press/references/setup-checks.md
+++ b/skills/printing-press/references/setup-checks.md
@@ -1,6 +1,6 @@
 # Setup Checks
 
-Post-contract checks the skill must run after executing the bash setup contract block in `SKILL.md`. These handle the contract output signals: `[setup-error]`, optional `[local-binary-stale]` / `[local-binary-rebuilt]` repo-mode rebuild markers, `[repo-upgrade-available]`, the always-emitted `PRINTING_PRESS_BIN=<abs-path>` and `PRESS_REPO_MODE=<true|false>` markers, the global open-agent-skills freshness check, the `min-binary-version` compatibility check, `[upgrade-required]`, `[upgrade-available]`, `[browser-tools-missing]`, and optional `[binary-shadow]` advisory.
+Post-contract checks the skill must run after executing the bash setup contract block in `SKILL.md`. These handle the contract output signals: `[setup-error]`, optional `[local-binary-stale]` / `[local-binary-rebuilt]` repo-mode rebuild markers, `[go-toolchain-old]`, `[low-disk]`, `[repo-upgrade-available]`, the always-emitted `PRINTING_PRESS_BIN=<abs-path>` and `PRESS_REPO_MODE=<true|false>` markers, the global open-agent-skills freshness check, the `min-binary-version` compatibility check, `[upgrade-required]`, `[upgrade-available]`, `[browser-tools-missing]`, and optional `[binary-shadow]` advisory.
 
 Apply these in order. The preamble below runs unconditionally; each numbered section after it is conditional — do nothing if its trigger isn't present.
 
@@ -16,13 +16,30 @@ This rule applies to *all* generator command references in the rest of this docu
 
 ## 1. Refusal: missing prerequisite
 
-If the setup contract output contains a line starting with `[setup-error]`, a required prerequisite is missing (the cli-printing-press binary or the Go toolchain) and the contract has already exited non-zero.
+If the setup contract output contains a line starting with `[setup-error]`, a required prerequisite or environment floor is missing (for example: the cli-printing-press binary, the Go toolchain, an old Go toolchain under `GOTOOLCHAIN=local`, an incomplete Go standard library, or critically low disk space) and the contract has already exited non-zero.
 
 **Stop the skill immediately.** Do not proceed to research, generation, or any other work. Surface the message the contract printed (it includes the exact install command or download URL) verbatim to the user.
 
 The user must install the missing prerequisite in their terminal before re-running. Do not offer to auto-install — the README's install flow is the source of truth for the binary, and silent auto-install hides failure modes (network, wrong GOPATH, no Go toolchain) inside an opaque skill invocation.
 
 If the contract output contains `[local-binary-stale]` followed by `[local-binary-rebuilt]`, continue setup. The repo-mode local binary was older than the checked-out source version and the contract rebuilt it before emitting `PRINTING_PRESS_BIN`. If `[local-binary-stale]` is followed by `[setup-error]`, this section's refusal rule applies.
+
+## 1.5. Environment advisories
+
+If the setup contract output contains a line starting with `[go-toolchain-old]`, the installed `go` is older than the toolchain used to build the resolved `cli-printing-press` binary. Parse the follow-up lines:
+
+- `PRESS_GO_INSTALLED=<installed Go version>`
+- `PRESS_GO_REQUIRED=<binary build Go version>`
+
+This is advisory by default because `GOTOOLCHAIN=auto` may download and use the required toolchain on the first Go command. Tell the user the later Go quality gates may download Go `<required>` or fail if the environment is offline or toolchain downloads are blocked. Do not stop the skill unless the setup contract also emitted `[setup-error]`.
+
+If the setup contract output contains a line starting with `[low-disk]`, the volume holding `PRINTING_PRESS_HOME` has less than the warning threshold free. Parse the follow-up lines:
+
+- `PRESS_DISK_PATH=<checked path>`
+- `PRESS_DISK_AVAIL_KB=<available KiB>`
+- `PRESS_DISK_WARN_KB=<warning threshold KiB>`
+
+This is advisory. Tell the user the current run may need several GiB for generated files, Go build cache, module downloads, or repository clones. Continue unless the setup contract also emitted `[setup-error]`. The thresholds can be tuned for small runners with `PRINTING_PRESS_DISK_WARN_KB` and `PRINTING_PRESS_DISK_FAIL_KB`; invalid threshold values make the disk probe skip silently.
 
 ## 2. Interactive repo upgrade prompt
 


### PR DESCRIPTION
## Summary

Generation, amend, polish, publish, and import setup now fail early for environment conditions that previously surfaced minutes later: missing Go, old Go when `GOTOOLCHAIN=local` disables downloads, and critically low workspace disk. Old Go under default toolchain behavior and low-but-not-critical disk now emit explicit advisories so the run can continue with the risk visible.

Closes #3365

## Details

- Adds Go toolchain currency checks against the resolved `cli-printing-press` binary build version for flows that invoke the binary.
- Adds workspace-volume disk checks using env-tunable warning and failure thresholds.
- Documents `[go-toolchain-old]` and `[low-disk]` handling in the shared setup-checks reference and in the non-main skills that emit those markers.
- Adds executable setup-contract tests with fake `go`, `df`, and `cli-printing-press` binaries across the scoped flows, including healthy, advisory, and hard-stop cases.

## Validation

- `go test ./internal/pipeline -run 'Test(SkillSetupBlocksMatchWorkspaceContract|SkillsEnforceCurrencyFloor|PrintingPressSetupContract|SetupContracts|PrintingPressSkillPreflight|PrintingPressSetupChecks)' -count=1` passed.
- `git diff --check` passed.
- `go test ./...` was started, but interrupted after several minutes with no output. The focused contract suite above covers this skill-only change directly.
