### PR TITLE
fix(cli): honor plan-mode dry runs

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -3476,9 +3476,25 @@ func TestGenerateCmdPlanDryRunWritesNoFiles(t *testing.T) {
 
 	stderr, err := runWithCapturedStderr(t, cmd.Execute)
 	require.NoError(t, err)
+	assert.Contains(t, stderr, "Commands:   1")
 	assert.Contains(t, stderr, "Contract:   lightweight scaffold, not a full Printing Press CLI")
 	_, err = os.Stat(outputDir)
 	assert.True(t, os.IsNotExist(err), "plan dry-run must not create output directory")
+
+	stdout, err := runWithCapturedStdout(t, func() error {
+		return printPlanDryRun(&generator.PlanSpec{
+			CLIName: "plan-dry-run",
+			Commands: []generator.PlanCommand{
+				{Name: "doctor", Description: "Check health"},
+				{Name: "version", Description: "Show version"},
+				{Name: "scan", Description: "Scan things"},
+			},
+		}, outputDir, planPath, 1)
+	})
+	require.NoError(t, err)
+	var dryRunSummary map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &dryRunSummary))
+	assert.Equal(t, float64(1), dryRunSummary["commands"])
 
 	writeOutputDir := filepath.Join(dir, "plan-write-output")
 	cmd = newGenerateCmd()

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -3459,6 +3459,40 @@ func TestGenerateCmdRejectsTrafficAnalysisWithPlan(t *testing.T) {
 	assert.Contains(t, err.Error(), "--traffic-analysis cannot be used with --plan")
 }
 
+func TestGenerateCmdPlanDryRunWritesNoFiles(t *testing.T) {
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "plan.md")
+	outputDir := filepath.Join(dir, "plan-output")
+	plan := "# Plan\n\n## Commands\n\n- `doctor` - Check health\n- `scan` - Scan things\n"
+	require.NoError(t, os.WriteFile(planPath, []byte(plan), 0o644))
+
+	cmd := newGenerateCmd()
+	cmd.SetArgs([]string{
+		"--plan", planPath,
+		"--name", "plan-dry-run",
+		"--output", outputDir,
+		"--dry-run",
+	})
+
+	stderr, err := runWithCapturedStderr(t, cmd.Execute)
+	require.NoError(t, err)
+	assert.Contains(t, stderr, "Contract:   lightweight scaffold, not a full Printing Press CLI")
+	_, err = os.Stat(outputDir)
+	assert.True(t, os.IsNotExist(err), "plan dry-run must not create output directory")
+
+	writeOutputDir := filepath.Join(dir, "plan-write-output")
+	cmd = newGenerateCmd()
+	cmd.SetArgs([]string{
+		"--plan", planPath,
+		"--name", "plan-dry-run",
+		"--output", writeOutputDir,
+	})
+
+	stderr, err = runWithCapturedStderr(t, cmd.Execute)
+	require.NoError(t, err)
+	assert.Contains(t, stderr, "Notice: plan mode emits a lightweight scaffold, not a full Printing Press CLI.")
+}
+
 func TestGenerateCmdHonorsExplicitOutput(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -281,13 +281,14 @@ func newGenerateCmd() *cobra.Command {
 				if len(planSpec.Commands) == 0 {
 					return &ExitError{Code: ExitInputError, Err: fmt.Errorf("plan contains no command definitions")}
 				}
+				planCommandCount := generator.GeneratedPlanCommandCount(planSpec.Commands)
 
 				absOut, _, snapshotDir, err := resolveGenerateOutputDir(outputDir, planSpec.CLIName, force, !dryRun)
 				if err != nil {
 					return err
 				}
 				if dryRun {
-					return printPlanDryRun(planSpec, absOut, planFile)
+					return printPlanDryRun(planSpec, absOut, planFile, planCommandCount)
 				}
 
 				if err := generator.GenerateFromPlan(planSpec, absOut); err != nil {
@@ -311,7 +312,7 @@ func newGenerateCmd() *cobra.Command {
 						"name":       planSpec.CLIName,
 						"output_dir": absOut,
 						"plan_file":  planFile,
-						"commands":   len(planSpec.Commands),
+						"commands":   planCommandCount,
 					}); err != nil {
 						return fmt.Errorf("encoding JSON: %w", err)
 					}
@@ -2445,12 +2446,12 @@ func printDryRun(apiSpec *spec.APISpec, absOut string, specFiles []string) error
 	return enc.Encode(summary)
 }
 
-func printPlanDryRun(planSpec *generator.PlanSpec, absOut, planFile string) error {
+func printPlanDryRun(planSpec *generator.PlanSpec, absOut, planFile string, commandCount int) error {
 	fmt.Fprintf(os.Stderr, "Dry run — plan parsed, no files will be generated\n")
 	fmt.Fprintf(os.Stderr, "  Plan file:  %s\n", planFile)
 	fmt.Fprintf(os.Stderr, "  CLI name:   %s\n", planSpec.CLIName)
 	fmt.Fprintf(os.Stderr, "  Output dir: %s\n", absOut)
-	fmt.Fprintf(os.Stderr, "  Commands:   %d\n", len(planSpec.Commands))
+	fmt.Fprintf(os.Stderr, "  Commands:   %d\n", commandCount)
 	fmt.Fprintln(os.Stderr, "  Contract:   lightweight scaffold, not a full Printing Press CLI")
 
 	summary := map[string]any{
@@ -2458,7 +2459,7 @@ func printPlanDryRun(planSpec *generator.PlanSpec, absOut, planFile string) erro
 		"name":       planSpec.CLIName,
 		"output_dir": absOut,
 		"plan_file":  planFile,
-		"commands":   len(planSpec.Commands),
+		"commands":   commandCount,
 		"contract":   "lightweight scaffold, not a full Printing Press CLI",
 	}
 	enc := json.NewEncoder(os.Stdout)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -282,9 +282,12 @@ func newGenerateCmd() *cobra.Command {
 					return &ExitError{Code: ExitInputError, Err: fmt.Errorf("plan contains no command definitions")}
 				}
 
-				absOut, _, snapshotDir, err := resolveGenerateOutputDir(outputDir, planSpec.CLIName, force, true)
+				absOut, _, snapshotDir, err := resolveGenerateOutputDir(outputDir, planSpec.CLIName, force, !dryRun)
 				if err != nil {
 					return err
+				}
+				if dryRun {
+					return printPlanDryRun(planSpec, absOut, planFile)
 				}
 
 				if err := generator.GenerateFromPlan(planSpec, absOut); err != nil {
@@ -302,6 +305,7 @@ func newGenerateCmd() *cobra.Command {
 				}
 
 				fmt.Fprintf(os.Stderr, "Generated %s at %s (from plan)\n", naming.CLI(planSpec.CLIName), absOut)
+				fmt.Fprintln(os.Stderr, "Notice: plan mode emits a lightweight scaffold, not a full Printing Press CLI. Use spec generation for store, MCP, manifest, and framework commands.")
 				if asJSON {
 					if err := json.NewEncoder(os.Stdout).Encode(map[string]any{
 						"name":       planSpec.CLIName,
@@ -2435,6 +2439,27 @@ func printDryRun(apiSpec *spec.APISpec, absOut string, specFiles []string) error
 		"spec_files":     specFiles,
 		"resource_count": resourceCount,
 		"endpoint_count": endpointCount,
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(summary)
+}
+
+func printPlanDryRun(planSpec *generator.PlanSpec, absOut, planFile string) error {
+	fmt.Fprintf(os.Stderr, "Dry run — plan parsed, no files will be generated\n")
+	fmt.Fprintf(os.Stderr, "  Plan file:  %s\n", planFile)
+	fmt.Fprintf(os.Stderr, "  CLI name:   %s\n", planSpec.CLIName)
+	fmt.Fprintf(os.Stderr, "  Output dir: %s\n", absOut)
+	fmt.Fprintf(os.Stderr, "  Commands:   %d\n", len(planSpec.Commands))
+	fmt.Fprintln(os.Stderr, "  Contract:   lightweight scaffold, not a full Printing Press CLI")
+
+	summary := map[string]any{
+		"dry_run":    true,
+		"name":       planSpec.CLIName,
+		"output_dir": absOut,
+		"plan_file":  planFile,
+		"commands":   len(planSpec.Commands),
+		"contract":   "lightweight scaffold, not a full Printing Press CLI",
 	}
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")

--- a/internal/cli/test_helpers_test.go
+++ b/internal/cli/test_helpers_test.go
@@ -109,3 +109,24 @@ func TestRunWithCapturedStdoutRestoresStdoutAfterPanic(t *testing.T) {
 	require.True(t, didPanic)
 	assert.True(t, restored, "stdout should be restored while unwinding a panic")
 }
+
+func TestRunWithCapturedStderrRestoresStderrAfterPanic(t *testing.T) {
+	origStderr := os.Stderr
+	var didPanic bool
+	var restored bool
+
+	func() {
+		defer func() {
+			didPanic = recover() != nil
+			restored = os.Stderr == origStderr
+			os.Stderr = origStderr
+		}()
+
+		_, _ = runWithCapturedStderr(t, func() error {
+			panic("boom")
+		})
+	}()
+
+	require.True(t, didPanic)
+	assert.True(t, restored, "stderr should be restored while unwinding a panic")
+}

--- a/internal/cli/test_helpers_test.go
+++ b/internal/cli/test_helpers_test.go
@@ -47,6 +47,38 @@ func runWithCapturedStdout(t *testing.T, fn func() error) (string, error) {
 	return out, execErr
 }
 
+func runWithCapturedStderr(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	origStderr := os.Stderr
+	os.Stderr = w
+
+	errCh := make(chan string, 1)
+	go func() {
+		defer r.Close()
+		out, _ := io.ReadAll(r)
+		errCh <- string(out)
+	}()
+
+	stderrRestored := false
+	restoreStderr := func() {
+		if stderrRestored {
+			return
+		}
+		w.Close()
+		os.Stderr = origStderr
+		stderrRestored = true
+	}
+	defer restoreStderr()
+
+	execErr := fn()
+	restoreStderr()
+
+	out := <-errCh
+	return out, execErr
+}
+
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 	out, err := runWithCapturedStdout(t, func() error {

--- a/internal/generator/plan_generate.go
+++ b/internal/generator/plan_generate.go
@@ -67,6 +67,11 @@ func (planStreamingData) Enabled() bool {
 	return false
 }
 
+var planScaffoldRootCommands = map[string]struct{}{
+	"doctor":  {},
+	"version": {},
+}
+
 // GenerateFromPlan creates a CLI scaffold from a parsed plan spec.
 func GenerateFromPlan(planSpec *PlanSpec, outputDir string) error {
 	cliName := planSpec.CLIName
@@ -262,11 +267,14 @@ func partitionCommands(commands []PlanCommand) (topLevel []PlanCommand, parents 
 
 	for _, cmd := range commands {
 		if parent := cmd.Parent(); parent != "" {
+			if isPlanScaffoldRootCommand(parent) {
+				continue
+			}
 			parentMap[parent] = append(parentMap[parent], cmd)
 			if parentDescs[parent] == "" {
 				parentDescs[parent] = parent + " commands"
 			}
-		} else {
+		} else if !isPlanScaffoldRootCommand(cmd.Leaf()) {
 			// Check if this command is also a parent of other commands
 			topLevel = append(topLevel, cmd)
 		}
@@ -308,6 +316,11 @@ func partitionCommands(commands []PlanCommand) (topLevel []PlanCommand, parents 
 	}
 
 	return filteredTopLevel, parents
+}
+
+func isPlanScaffoldRootCommand(name string) bool {
+	_, ok := planScaffoldRootCommands[strings.ToLower(strings.TrimSpace(name))]
+	return ok
 }
 
 // resolveOwnerForExisting returns the owner attribution for a regeneration

--- a/internal/generator/plan_generate.go
+++ b/internal/generator/plan_generate.go
@@ -72,6 +72,19 @@ var planScaffoldRootCommands = map[string]struct{}{
 	"version": {},
 }
 
+// GeneratedPlanCommandCount reports how many command files GenerateFromPlan
+// will emit for user-declared plan commands after scaffold-owned names are
+// filtered out.
+func GeneratedPlanCommandCount(commands []PlanCommand) int {
+	topLevel, parents := partitionCommands(commands)
+	count := len(topLevel)
+	for _, parent := range parents {
+		count++
+		count += len(parent.SubCommands)
+	}
+	return count
+}
+
 // GenerateFromPlan creates a CLI scaffold from a parsed plan spec.
 func GenerateFromPlan(planSpec *PlanSpec, outputDir string) error {
 	cliName := planSpec.CLIName

--- a/internal/generator/plan_generate_test.go
+++ b/internal/generator/plan_generate_test.go
@@ -276,3 +276,18 @@ func TestPartitionCommands(t *testing.T) {
 	assert.Equal(t, "config", parents[1].Name)
 	assert.Len(t, parents[1].SubCommands, 2)
 }
+
+func TestGeneratedPlanCommandCountSkipsScaffoldCommands(t *testing.T) {
+	t.Parallel()
+
+	commands := []PlanCommand{
+		{Name: "doctor", Description: "Check health"},
+		{Name: "doctor status", Description: "Check health status"},
+		{Name: "version", Description: "Show version"},
+		{Name: "scan", Description: "Scan things"},
+		{Name: "auth login", Description: "Log in"},
+		{Name: "auth logout", Description: "Log out"},
+	}
+
+	assert.Equal(t, 4, GeneratedPlanCommandCount(commands))
+}

--- a/internal/generator/plan_generate_test.go
+++ b/internal/generator/plan_generate_test.go
@@ -2,7 +2,6 @@ package generator
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -71,10 +70,42 @@ func TestGenerateFromPlan_BasicScaffold(t *testing.T) {
 	assert.Contains(t, string(recordGo), "not implemented")
 
 	// Verify it compiles
-	buildCmd := exec.Command("go", "build", "./...")
-	buildCmd.Dir = outputDir
-	buildOut, err := buildCmd.CombinedOutput()
-	require.NoError(t, err, "go build failed: %s", string(buildOut))
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestGenerateFromPlan_DeduplicatesScaffoldRootCommands(t *testing.T) {
+	t.Parallel()
+
+	planSpec := &PlanSpec{
+		CLIName:     "scaffold-collision",
+		Description: "Plan CLI with scaffold command collisions",
+		Commands: []PlanCommand{
+			{Name: "doctor", Description: "Check health"},
+			{Name: "doctor status", Description: "Check detailed health"},
+			{Name: "version", Description: "Print version"},
+			{Name: "scan", Description: "Scan things"},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(planSpec.CLIName))
+	require.NoError(t, os.MkdirAll(outputDir, 0o755))
+
+	require.NoError(t, GenerateFromPlan(planSpec, outputDir))
+
+	rootGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "root.go"))
+	require.NoError(t, err)
+	rootContent := string(rootGo)
+	assert.Equal(t, 1, strings.Count(rootContent, "rootCmd.AddCommand(newDoctorCmd())"))
+	assert.Equal(t, 1, strings.Count(rootContent, "rootCmd.AddCommand(newVersionCliCmd())"))
+	assert.NotContains(t, rootContent, "newVersionCmd()")
+	assert.Contains(t, rootContent, "newScanCmd()")
+
+	_, err = os.Stat(filepath.Join(outputDir, "internal", "cli", "version.go"))
+	assert.True(t, os.IsNotExist(err), "version should be provided by the scaffold root command")
+	_, err = os.Stat(filepath.Join(outputDir, "internal", "cli", "doctor_status.go"))
+	assert.True(t, os.IsNotExist(err), "doctor subcommands should be reserved for the scaffold root command")
+
+	requireGeneratedCompiles(t, outputDir)
 }
 
 func TestGenerateFromPlan_WithSubcommands(t *testing.T) {
@@ -118,10 +149,7 @@ func TestGenerateFromPlan_WithSubcommands(t *testing.T) {
 	assert.Contains(t, rootContent, "newDeployCmd()")
 
 	// Verify it compiles
-	buildCmd := exec.Command("go", "build", "./...")
-	buildCmd.Dir = outputDir
-	buildOut, err := buildCmd.CombinedOutput()
-	require.NoError(t, err, "go build failed: %s", string(buildOut))
+	requireGeneratedCompiles(t, outputDir)
 }
 
 func TestGenerateFromPlan_EmptyName(t *testing.T) {


### PR DESCRIPTION
## Summary
Plan mode now respects `--dry-run` before it claims or writes the output tree, so `generate --plan ... --dry-run` only reports what would happen. Plan-generated scaffolds now reserve scaffold-owned root commands such as `doctor` and `version`, including subcommand forms like `doctor status`, so emitted Cobra roots do not register duplicate command factories.

The command also states the plan-mode contract in output: plan mode emits a lightweight scaffold, not a full Printing Press CLI with store, MCP, manifest, and framework command machinery. Spec-mode generation is unchanged.

Closes #2671

## Validation
- `go test ./internal/cli -run 'TestGenerateCmd(PlanDryRunWritesNoFiles|RejectsTrafficAnalysisWithPlan)$'`
- `go test ./internal/generator -run 'TestGenerateFromPlan_(BasicScaffold|DeduplicatesScaffoldRootCommands|WithSubcommands|EmptyName)$'`
- `go test ./internal/cli ./internal/generator`
- Manual repro: plan dry-run wrote 0 files; non-dry-run emitted 1 `newDoctorCmd()` root registration and printed the lightweight scaffold notice.
- `scripts/verify-generator-output.sh`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`

Known unrelated gate results in this worktree:
- `go test ./...` failed outside this diff: `internal/pipeline` still fails `TestResolveCommandPositionalsMixedStoreAndCompanionSourceIsUntagged` in isolation. The initial full run also showed transient failures in two other pipeline tests and `TestPublishPackageDoesNotStageCompiledBinary`; the publish test passed when rerun alone.
- `scripts/golden.sh verify` passed all command-output/schema cases but failed `verify-runtime-matrix` because `structural-fail.json` was missing from the actual artifact directory.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
