### PR TITLE
fix(cli): keep local datastore MCP off HTTP endpoints

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -4397,7 +4397,7 @@ func TestGenerateMCPStoreGuidanceTestsPass(t *testing.T) {
 	gen.VisionSet = VisionTemplateSet{Store: true, Search: true, MCP: true}
 	require.NoError(t, gen.Generate())
 
-	runGoCommand(t, outputDir, "test", "./internal/mcp", "-run", "TestMCP(Search|SQL)(MissingStore|EmptyStore|DomainTable)")
+	runGoCommand(t, outputDir, "test", "./internal/mcp", "-run", "TestMCP(Search|SQL)(MissingStore|EmptyStore|DomainTable)|TestMCPLocalStoreMetaIncludesSyncedAt")
 }
 
 func TestGenerateMCPToolResultTextBudgetTestsPass(t *testing.T) {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -4397,7 +4397,7 @@ func TestGenerateMCPStoreGuidanceTestsPass(t *testing.T) {
 	gen.VisionSet = VisionTemplateSet{Store: true, Search: true, MCP: true}
 	require.NoError(t, gen.Generate())
 
-	runGoCommand(t, outputDir, "test", "./internal/mcp", "-run", "TestMCP(Search|SQL)(MissingStore|EmptyStore|DomainTable)|TestMCPLocalStoreMetaIncludesSyncedAt")
+	runGoCommand(t, outputDir, "test", "./internal/mcp", "-run", "TestMCP(Search|SQL)(MissingStore|EmptyStore|DomainTable)|TestMCPLocalStoreMetaIncludesOldestSyncedAt")
 }
 
 func TestGenerateMCPToolResultTextBudgetTestsPass(t *testing.T) {

--- a/internal/generator/mcp_local_datastore_test.go
+++ b/internal/generator/mcp_local_datastore_test.go
@@ -33,6 +33,7 @@ func TestGeneratedLocalSQLiteMCPUsesCobraMirrorInsteadOfHTTPTools(t *testing.T) 
 	require.NotContains(t, mcpSrc, `makeAPIHandler("GET", "/items"`)
 	require.Contains(t, mcpSrc, `func mcpLocalStoreMeta(db *store.Store)`)
 	require.Contains(t, mcpSrc, `"source": "local"`)
+	require.Contains(t, mcpSrc, `"oldest_synced_at"`)
 	require.Contains(t, mcpSrc, `"meta":         meta`)
 	require.Contains(t, mcpSrc, "cobratree.RegisterAll(s, cli.RootCmd(), cobratree.SiblingCLIPath)")
 

--- a/internal/generator/mcp_local_datastore_test.go
+++ b/internal/generator/mcp_local_datastore_test.go
@@ -1,0 +1,52 @@
+package generator
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedLocalSQLiteMCPUsesCobraMirrorInsteadOfHTTPTools(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("localstore")
+	apiSpec.Source = spec.SourceLocalSQLite
+	apiSpec.BaseURL = ""
+	apiSpec.Resources["domains"] = spec.Resource{
+		Description: "Manage domains",
+		Endpoints: map[string]spec.Endpoint{
+			"get":  {Method: "GET", Path: "/domains/{domain_id}", Description: "Get domain"},
+			"list": {Method: "GET", Path: "/domains", Description: "List domains"},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, Search: true, MCP: true}
+	require.NoError(t, gen.Generate())
+
+	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
+	require.NotContains(t, mcpSrc, `mcplib.NewTool("items_list"`)
+	require.NotContains(t, mcpSrc, `makeAPIHandler("GET", "/items"`)
+	require.Contains(t, mcpSrc, `func mcpLocalStoreMeta(db *store.Store)`)
+	require.Contains(t, mcpSrc, `"source": "local"`)
+	require.Contains(t, mcpSrc, `"meta":         meta`)
+	require.Contains(t, mcpSrc, "cobratree.RegisterAll(s, cli.RootCmd(), cobratree.SiblingCLIPath)")
+
+	commandSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_items.go")
+	require.NotContains(t, commandSrc, `"pp:endpoint"`)
+	require.Contains(t, commandSrc, `"pp:method": "GET"`)
+	require.Contains(t, commandSrc, `"pp:path": "/items"`)
+	require.Contains(t, commandSrc, `"mcp:read-only": "true"`)
+
+	resourceCommandSrc := readGeneratedFile(t, outputDir, "internal", "cli", "domains_list.go")
+	require.NotContains(t, resourceCommandSrc, `"pp:endpoint"`)
+	require.Contains(t, resourceCommandSrc, `"pp:method": "GET"`)
+	require.Contains(t, resourceCommandSrc, `"pp:path": "/domains"`)
+	require.Contains(t, resourceCommandSrc, `"mcp:read-only": "true"`)
+
+	requireGeneratedCompiles(t, outputDir)
+}

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -74,7 +74,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 		// TODO: replace placeholder example values before relying on this for live dogfood.
 {{- end}}
 		Example: {{printf "%q" $example}},
-		Annotations: map[string]string{"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, "pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}},
+		Annotations: map[string]string{ {{- if not .APISpec.IsLocalSQLiteSource}}"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, {{end}}"pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 {{- if endpointHasRequiredInput .Endpoint}}
 			// Bare invocation of a command with required input prints help

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -60,7 +60,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 		// TODO: replace placeholder example values before relying on this for live dogfood.
 {{- end}}
 		Example: {{printf "%q" $example}},
-		Annotations: map[string]string{"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, "pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}},
+		Annotations: map[string]string{ {{- if not .APISpec.IsLocalSQLiteSource}}"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, {{end}}"pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 {{- if endpointHasRequiredInput .Endpoint}}
 			// Bare invocation of a command with a required flag/body prints help

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -14,6 +14,10 @@ package mcp
 
 import (
 	"context"
+{{- if and (or .VisionSet.Search .VisionSet.Store) .APISpec.IsLocalSQLiteSource}}
+	"database/sql"
+	"errors"
+{{- end}}
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -56,7 +60,7 @@ func RegisterTools(s *server.MCPServer) {
 	// (<api>_search + <api>_execute). Endpoint-mirror tools are suppressed.
 	RegisterCodeOrchestrationTools(s)
 {{- else}}
-{{- if ne .MCP.EndpointTools "hidden"}}
+{{- if and (ne .MCP.EndpointTools "hidden") (not .APISpec.IsLocalSQLiteSource)}}
 {{- range $name, $resource := .Resources}}
 {{- range $eName, $endpoint := $resource.Endpoints}}
 {{- $isReadOnly := endpointIsReadCommand $endpoint $eName}}
@@ -862,6 +866,49 @@ func mcpStoreStatus(db *store.Store) (mcpStoreStatusKind, error) {
 	return mcpStoreStatusReady, nil
 }
 
+{{- if .APISpec.IsLocalSQLiteSource}}
+func mcpLocalStoreMeta(db *store.Store) (map[string]any, error) {
+	meta := map[string]any{"source": "local"}
+	lastSynced, err := mcpOldestSyncTime(db)
+	if err != nil {
+		return nil, err
+	}
+	if !lastSynced.IsZero() {
+		meta["synced_at"] = lastSynced.UTC().Format(time.RFC3339)
+	}
+	return meta, nil
+}
+
+func mcpOldestSyncTime(db *store.Store) (time.Time, error) {
+	if db == nil {
+		return time.Time{}, nil
+	}
+	var lastSynced sql.NullTime
+	err := db.DB().QueryRow(`SELECT last_synced_at FROM sync_state WHERE last_synced_at IS NOT NULL ORDER BY last_synced_at ASC LIMIT 1`).Scan(&lastSynced)
+	if err == nil {
+		if lastSynced.Valid {
+			return lastSynced.Time, nil
+		}
+		return time.Time{}, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) || mcpSyncStateUnavailable(err) {
+		return time.Time{}, nil
+	}
+	return time.Time{}, err
+}
+
+func mcpSyncStateUnavailable(err error) bool {
+	for err != nil {
+		msg := strings.ToLower(err.Error())
+		if strings.Contains(msg, "no such table") || strings.Contains(msg, "no such column") {
+			return true
+		}
+		err = errors.Unwrap(err)
+	}
+	return false
+}
+{{- end}}
+
 func mcpEmptyStoreNextStep() string {
 	return "Run {{.Name}}-pp-cli sync to populate the local SQLite store before using MCP search/sql."
 }
@@ -899,11 +946,23 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("reading store status: %v", err)), nil
 	}
+{{ if .APISpec.IsLocalSQLiteSource}}
+	meta, err := mcpLocalStoreMeta(db)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("reading store provenance: %v", err)), nil
+	}
 
+	return toolResultJSON(mcpSearchEnvelope(results, storeStatus, meta))
+{{ else}}
 	return toolResultJSON(mcpSearchEnvelope(results, storeStatus))
+{{- end}}
 }
 
+{{ if .APISpec.IsLocalSQLiteSource -}}
+func mcpSearchEnvelope(results []json.RawMessage, storeStatus mcpStoreStatusKind, meta map[string]any) map[string]any {
+{{ else -}}
 func mcpSearchEnvelope(results []json.RawMessage, storeStatus mcpStoreStatusKind) map[string]any {
+{{ end -}}
 	if results == nil {
 		results = []json.RawMessage{}
 	}
@@ -912,6 +971,9 @@ func mcpSearchEnvelope(results []json.RawMessage, storeStatus mcpStoreStatusKind
 		"results":      results,
 		"store_status": storeStatus,
 		"resumable":    false,
+{{- if .APISpec.IsLocalSQLiteSource}}
+		"meta":         meta,
+{{- end}}
 	}
 	if len(results) == 0 {
 		if storeStatus == mcpStoreStatusEmpty {
@@ -1132,11 +1194,23 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("reading store status: %v", err)), nil
 	}
+{{ if .APISpec.IsLocalSQLiteSource}}
+	meta, err := mcpLocalStoreMeta(db)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("reading store provenance: %v", err)), nil
+	}
 
+	return toolResultJSON(mcpSQLEnvelope(results, cols, storeStatus, meta))
+{{ else}}
 	return toolResultJSON(mcpSQLEnvelope(results, cols, storeStatus))
+{{- end}}
 }
 
+{{ if .APISpec.IsLocalSQLiteSource -}}
+func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus mcpStoreStatusKind, meta map[string]any) map[string]any {
+{{ else -}}
 func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus mcpStoreStatusKind) map[string]any {
+{{ end -}}
 	if rows == nil {
 		rows = []map[string]any{}
 	}
@@ -1146,6 +1220,9 @@ func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus mcpStor
 		"rows":         rows,
 		"store_status": storeStatus,
 		"resumable":    false,
+{{- if .APISpec.IsLocalSQLiteSource}}
+		"meta":         meta,
+{{- end}}
 	}
 	if len(rows) == 0 {
 		if storeStatus == mcpStoreStatusEmpty {

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -846,13 +846,21 @@ func openMCPReadOnlyStore(path string) (*store.Store, *mcplib.CallToolResult) {
 	}
 	db, err := store.OpenReadOnly(path)
 	if err != nil {
+{{- if .APISpec.IsLocalSQLiteSource}}
+		return nil, mcplib.NewToolResultError(fmt.Sprintf("opening local data store %s: %v. Run {{.Name}}-pp-cli sync to refresh the store before using MCP search/sql.", path, err))
+{{- else}}
 		return nil, mcplib.NewToolResultError(fmt.Sprintf("opening local data store %s: %v. Run {{.Name}}-pp-cli sync to refresh the store, or use live endpoint MCP tools for unsynced data.", path, err))
+{{- end}}
 	}
 	return db, nil
 }
 
 func mcpMissingStoreMessage(path string) string {
+{{- if .APISpec.IsLocalSQLiteSource}}
+	return fmt.Sprintf("No local data store found at %s. Run {{.Name}}-pp-cli sync before using MCP search/sql.", path)
+{{- else}}
 	return fmt.Sprintf("No local data store found at %s. Run {{.Name}}-pp-cli sync before using MCP search/sql, or use live endpoint MCP tools for unsynced data.", path)
+{{- end}}
 }
 
 func mcpStoreStatus(db *store.Store) (mcpStoreStatusKind, error) {
@@ -874,7 +882,7 @@ func mcpLocalStoreMeta(db *store.Store) (map[string]any, error) {
 		return nil, err
 	}
 	if !lastSynced.IsZero() {
-		meta["synced_at"] = lastSynced.UTC().Format(time.RFC3339)
+		meta["oldest_synced_at"] = lastSynced.UTC().Format(time.RFC3339)
 	}
 	return meta, nil
 }

--- a/internal/generator/templates/mcp_tools_test.go.tmpl
+++ b/internal/generator/templates/mcp_tools_test.go.tmpl
@@ -219,7 +219,7 @@ func TestMCPSearchEmptyStoreReturnsActionableEnvelope(t *testing.T) {
 
 {{- if and (or .VisionSet.Search .VisionSet.Store) .APISpec.IsLocalSQLiteSource}}
 
-func TestMCPLocalStoreMetaIncludesSyncedAt(t *testing.T) {
+func TestMCPLocalStoreMetaIncludesOldestSyncedAt(t *testing.T) {
 	resetMCPPathEnv(t)
 	path, err := mcpDBPath()
 	if err != nil {
@@ -243,8 +243,8 @@ func TestMCPLocalStoreMetaIncludesSyncedAt(t *testing.T) {
 	if meta["source"] != "local" {
 		t.Fatalf("meta.source = %#v, want local", meta["source"])
 	}
-	if meta["synced_at"] != syncedAt.Format(time.RFC3339) {
-		t.Fatalf("meta.synced_at = %#v, want %q", meta["synced_at"], syncedAt.Format(time.RFC3339))
+	if meta["oldest_synced_at"] != syncedAt.Format(time.RFC3339) {
+		t.Fatalf("meta.oldest_synced_at = %#v, want %q", meta["oldest_synced_at"], syncedAt.Format(time.RFC3339))
 	}
 }
 {{- end}}

--- a/internal/generator/templates/mcp_tools_test.go.tmpl
+++ b/internal/generator/templates/mcp_tools_test.go.tmpl
@@ -11,6 +11,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+{{- if and (or .VisionSet.Search .VisionSet.Store) .APISpec.IsLocalSQLiteSource}}
+	"time"
+{{- end}}
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -187,6 +190,9 @@ func TestMCPSearchEmptyStoreReturnsActionableEnvelope(t *testing.T) {
 		StoreStatus string            `json:"store_status"`
 		Resumable   bool              `json:"resumable"`
 		NextStep    string            `json:"next_step"`
+{{- if .APISpec.IsLocalSQLiteSource}}
+		Meta        map[string]any    `json:"meta"`
+{{- end}}
 	}
 	if err := json.Unmarshal([]byte(text), &envelope); err != nil {
 		t.Fatalf("empty-store result must be valid JSON: %v\n%s", err, text)
@@ -200,8 +206,45 @@ func TestMCPSearchEmptyStoreReturnsActionableEnvelope(t *testing.T) {
 	if envelope.Resumable {
 		t.Fatalf("empty-store envelope should not claim cursor support: %s", text)
 	}
+{{- if .APISpec.IsLocalSQLiteSource}}
+	if envelope.Meta["source"] != "local" {
+		t.Fatalf("empty-store meta.source = %#v, want local in %s", envelope.Meta["source"], text)
+	}
+{{- end}}
 	if !strings.Contains(envelope.NextStep, "sync") {
 		t.Fatalf("empty-store next_step should mention sync: %s", text)
+	}
+}
+{{- end}}
+
+{{- if and (or .VisionSet.Search .VisionSet.Store) .APISpec.IsLocalSQLiteSource}}
+
+func TestMCPLocalStoreMetaIncludesSyncedAt(t *testing.T) {
+	resetMCPPathEnv(t)
+	path, err := mcpDBPath()
+	if err != nil {
+		t.Fatalf("mcpDBPath() error = %v", err)
+	}
+	db, err := store.Open(path)
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer db.Close()
+
+	syncedAt := time.Date(2026, 6, 30, 12, 34, 56, 0, time.UTC)
+	if _, err := db.DB().Exec(`INSERT INTO sync_state(resource_type, last_synced_at, total_count) VALUES (?, ?, ?)`, "{{firstResource .Resources}}", syncedAt, 0); err != nil {
+		t.Fatalf("seed sync_state: %v", err)
+	}
+
+	meta, err := mcpLocalStoreMeta(db)
+	if err != nil {
+		t.Fatalf("mcpLocalStoreMeta() error = %v", err)
+	}
+	if meta["source"] != "local" {
+		t.Fatalf("meta.source = %#v, want local", meta["source"])
+	}
+	if meta["synced_at"] != syncedAt.Format(time.RFC3339) {
+		t.Fatalf("meta.synced_at = %#v, want %q", meta["synced_at"], syncedAt.Format(time.RFC3339))
 	}
 }
 {{- end}}
@@ -262,6 +305,9 @@ func TestMCPSQLEmptyStoreReturnsActionableEnvelope(t *testing.T) {
 		StoreStatus string             `json:"store_status"`
 		Resumable   bool               `json:"resumable"`
 		NextStep    string             `json:"next_step"`
+{{- if .APISpec.IsLocalSQLiteSource}}
+		Meta        map[string]any     `json:"meta"`
+{{- end}}
 	}
 	if err := json.Unmarshal([]byte(text), &envelope); err != nil {
 		t.Fatalf("empty-store SQL result must be valid JSON: %v\n%s", err, text)
@@ -278,6 +324,11 @@ func TestMCPSQLEmptyStoreReturnsActionableEnvelope(t *testing.T) {
 	if envelope.Resumable {
 		t.Fatalf("empty-store SQL envelope should not claim cursor support: %s", text)
 	}
+{{- if .APISpec.IsLocalSQLiteSource}}
+	if envelope.Meta["source"] != "local" {
+		t.Fatalf("empty-store SQL meta.source = %#v, want local in %s", envelope.Meta["source"], text)
+	}
+{{- end}}
 	if !strings.Contains(envelope.NextStep, "sync") {
 		t.Fatalf("empty-store SQL next_step should mention sync: %s", text)
 	}


### PR DESCRIPTION
## Summary

Local-datastore MCP endpoint tools no longer route through the generated HTTP client against the placeholder `base_url`. For `source: local-sqlite` specs, typed HTTP endpoint tools are suppressed and the Cobra mirror can expose the existing local commands instead, while search/sql MCP responses carry local-store provenance metadata.

`pp:endpoint` is also omitted from generated local-sqlite command annotations so the runtime MCP walker does not skip those commands as duplicate typed endpoint mirrors. HTTP-backed CLIs keep the existing `makeAPIHandler` path and endpoint annotations.

## Validation

- `go test ./internal/generator -run 'TestGeneratedLocalSQLiteMCPUsesCobraMirrorInsteadOfHTTPTools|TestGenerateMCP(StoreGuidanceTestsPass|SQLToolUsesReadOnlyStore|SQLToolSurfacesRowErrors)' -count=1`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go fmt ./...`
- `git diff --check`

Not run to completion: `go test ./...` was interrupted after stalling behind concurrent issue-worker test load; the focused generator, golden, and generated-output gates above passed.

Closes #2670
