### PR TITLE
fix(skills): block proposal PR fallback for real artifact work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,14 @@ Every commit and PR title must include one of the allowed scopes. GitHub squash-
 - If unsure whether a PR is exempt, keep the template.
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the human-facing contributor guide and AI / automation disclosure definitions.
 
+## PR intent: implementation, publish, or proposal
+A request to generate, fix, or implement means produce the requested artifact, not a docs-only, plan, proposal, or spec PR. Do not substitute one PR shape for another:
+- **Implementation PR** (this repo): code, skill, generator, template, CLI, or test changes that make the requested behavior real.
+- **Library publish PR** (`mvanhorn/printing-press-library`, via `/printing-press-publish`): a generated CLI tree, or the explicit blocked-API journal entry described below.
+- **Proposal / spec / plan PR**: docs-only description of intended future work.
+
+When implementation or generation is blocked, report the exact blocker and stop. Do not open a docs-only, plan, proposal, or spec PR here or in `printing-press-library` unless the user explicitly requested that shape, or explicitly authorizes that fallback after seeing the blocker. Plan documents stay local (see "Plan documents stay local" below).
+
 ## Automated code review with Greptile
 
 Every PR gets automated Greptile review alongside CI. Resolve every Greptile finding before calling a PR ready: P0 and P1 comments block merge, and P2 comments need either a fix or a concrete reply explaining why the deferral is intentional. Do not use the score alone as the gate.

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -342,6 +342,31 @@ func TestPrintingPressSkillDistinguishesBearerFromRawAPIKey(t *testing.T) {
 	assert.Contains(t, block, "name: X-API-Key")
 }
 
+func TestSkillsProhibitProposalFallbackForRequestedArtifacts(t *testing.T) {
+	collapse := func(s string) string {
+		return strings.Join(strings.Fields(s), " ")
+	}
+
+	agents := collapse(readContractFile(t, filepath.Join("..", "..", "AGENTS.md")))
+	agentsBlock := substringBetween(t, agents, "## PR intent: implementation, publish, or proposal", "## Automated code review with Greptile")
+	assert.Contains(t, agentsBlock, "A request to generate, fix, or implement means produce the requested artifact, not a docs-only, plan, proposal, or spec PR.")
+	assert.Contains(t, agentsBlock, "Do not substitute one PR shape for another")
+	assert.Contains(t, agentsBlock, "When implementation or generation is blocked, report the exact blocker and stop.")
+	assert.Contains(t, agentsBlock, "Do not open a docs-only, plan, proposal, or spec PR here or in `printing-press-library` unless the user explicitly requested that shape")
+
+	publish := collapse(readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md")))
+	publishBlock := substringBetween(t, publish, "## PR shape guard", "## Direct User Invocation Required")
+	assert.Contains(t, publishBlock, "This skill opens only a generated CLI publish PR or, with `--blocked-api-journal`, a `blocked-apis.json` journal PR.")
+	assert.Contains(t, publishBlock, "It never opens a docs-only, plan, proposal, or spec PR as a substitute for a CLI that is not ready to publish.")
+	assert.Contains(t, publishBlock, "If generation, validation, or live testing is blocked, report the exact blocker and stop.")
+
+	printingPress := collapse(readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md")))
+	holdBlock := substringBetween(t, printingPress, "### Hold-path menu", "#### If \"Run retro\"")
+	assert.Contains(t, holdBlock, "A hold is not permission to change PR shape.")
+	assert.Contains(t, holdBlock, "Do not substitute a docs-only, plan, proposal, or spec PR for the requested generated CLI.")
+	assert.Contains(t, holdBlock, "The only public-library PR this menu may lead to is the explicit `blocked-apis.json` journal option")
+}
+
 func TestPrintingPressSkillRunERequiredInputContract(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md"))
 	template := substringBetween(t, skill, "#### Verify-friendly RunE template", "If the command reads a file or directory")

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -26,6 +26,14 @@ Publish a generated CLI from your local library to the [printing-press-library](
 /printing-press publish
 ```
 
+## PR shape guard
+
+This skill opens only a generated CLI publish PR or, with
+`--blocked-api-journal`, a `blocked-apis.json` journal PR. It never opens a
+docs-only, plan, proposal, or spec PR as a substitute for a CLI that is not
+ready to publish. If generation, validation, or live testing is blocked, report
+the exact blocker and stop.
+
 ## Direct User Invocation Required
 
 Publishing can fork `mvanhorn/printing-press-library`, push a branch, and open or

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -4705,6 +4705,8 @@ End normally. The CLI is in `$PRESS_LIBRARY/<api>` and the user can run `/printi
 
 The CLI did not promote to library. The working copy is at `$CLI_WORK_DIR`; manuscripts and proofs are archived. Hold runs are the highest-value retro signal — something blocked the machine from reaching ship, and that signal is most valuable while session context is fresh.
 
+A hold is not permission to change PR shape. Do not substitute a docs-only, plan, proposal, or spec PR for the requested generated CLI. The only public-library PR this menu may lead to is the explicit `blocked-apis.json` journal option; otherwise report the blocker through the menu and stop.
+
 Before rendering the menu, decide whether this hold should offer a blocked-API journal entry. Offer journaling only when the one-line hold reason is a reachability or buildability blocker that would likely repeat for another user before a machine or upstream change, for example browser-clearance barriers, Cloudflare Turnstile, login/session surfaces that a pure-HTTP printed CLI cannot replay, unreachable official specs, or an upstream API that cannot be called from generated code. Do not offer journaling for ordinary fix-loop failures, local setup problems, missing credentials, temporary network outages, test flakes, or quality issues that polish can plausibly fix.
 
 Present via `AskUserQuestion`:


### PR DESCRIPTION
## Summary

Requests to generate, fix, implement, or publish now have an explicit artifact-shape guard. Agents must produce the real requested artifact, or report the exact blocker and stop, instead of silently substituting a docs-only, plan, proposal, or spec PR.

This pins the guard in three places: the repo-wide conventions, the publish skill's PR creation path, and the `/printing-press` hold menu. The contract test locks those phrases so future skill edits cannot remove the fallback ban by accident.

Closes #3364

## Validation

- `go test ./internal/pipeline -run TestSkillsProhibitProposalFallbackForRequestedArtifacts -count=1` passed.
- `go build -o ./cli-printing-press ./cmd/cli-printing-press` passed, then the local binary was removed.
- `go fmt ./internal/pipeline` passed.
- `go test -p 1 ./...` completed with unrelated live-dogfood failures: `TestDogfoodLiveQuickPassWithSkipsWritesAcceptance`, `TestRunLiveDogfoodProcessRetriesTransientAuth401`, and `TestResolveCommandPositionalsMixedStoreAndCompanionSourceIsUntagged`.
- `scripts/golden.sh verify` failed in `verify-runtime-matrix` before this diff's surface: the structural-pass verify command returned `verdict: FAIL`, so `structural-fail.json` was not written.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
