### PR TITLE
fix(cli): calibrate GraphQL generator checks

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -15384,6 +15384,88 @@ func TestGenerateGraphQLCompiles(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "./...")
 }
 
+func TestGenerateGraphQLInternalSpecEmitsEmptyQueryStubs(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:                "events-graphql",
+		Description:         "GraphQL endpoint fixture",
+		Version:             "0.1.0",
+		BaseURL:             "https://api.example.com",
+		GraphQLEndpointPath: "/graphql",
+		Auth:                spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/events-graphql-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"events": {
+				Description: "Events",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "POST",
+						Path:        "/graphql",
+						Description: "List events",
+						Response: spec.ResponseDef{
+							Type: "array",
+							Item: "Event",
+						},
+					},
+					"get": {
+						Method:      "POST",
+						Path:        "/graphql",
+						Description: "Get event",
+						Params: []spec.Param{{
+							Name:       "event_id",
+							Type:       "string",
+							Required:   true,
+							Positional: true,
+						}},
+						Response: spec.ResponseDef{
+							Type: "object",
+							Item: "Event",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	queriesGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "queries.go"))
+	require.NoError(t, err)
+	queriesContent := string(queriesGo)
+	assert.Contains(t, queriesContent, `const EventsListQuery = ""`)
+	assert.Contains(t, queriesContent, `const EventsGetQuery = ""`)
+	assert.Contains(t, queriesContent, "Hand-author")
+	assert.NotContains(t, queriesContent, "query {\n   {")
+	assert.NotContains(t, queriesContent, "(id: $id)")
+
+	emptyQueryTest := `package client
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGraphQLQueryRejectsEmptyQuery(t *testing.T) {
+	_, err := (&Client{}).Query(context.Background(), "", nil)
+	if err == nil {
+		t.Fatal("expected empty GraphQL query to fail")
+	}
+	if got := err.Error(); got != "graphql query is empty; hand-author the query constant for this API" {
+		t.Fatalf("error = %q", got)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "empty_query_test.go"), []byte(emptyQueryTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^TestGraphQLQueryRejectsEmptyQuery$")
+	requireGeneratedCompiles(t, outputDir)
+}
+
 func TestGenerateGraphQLListWiresOptionalQueryVariable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/graphql_client.go.tmpl
+++ b/internal/generator/templates/graphql_client.go.tmpl
@@ -163,6 +163,9 @@ func (c *Client) awaitBudget(ctx context.Context, cost float64) error {
 // Query executes a GraphQL query via POST against graphqlEndpointPath and
 // returns the raw data payload.
 func (c *Client) Query(ctx context.Context, query string, variables map[string]any) (json.RawMessage, error) {
+	if strings.TrimSpace(query) == "" {
+		return nil, fmt.Errorf("graphql query is empty; hand-author the query constant for this API")
+	}
 {{- if .HasCostThrottling}}
 	return c.queryWithThrottle(ctx, query, variables)
 {{- else}}

--- a/internal/generator/templates/graphql_queries.go.tmpl
+++ b/internal/generator/templates/graphql_queries.go.tmpl
@@ -43,7 +43,8 @@ const {{pascal $rName}}ListLatestQuery = {{backtick}}query{{if $latestParams}}({
 }{{backtick}}
 {{- else}}
 // {{pascal $rName}}ListLatestQuery is intentionally empty because the spec does
-// not declare the GraphQL response path needed to infer an operation.
+// not declare the GraphQL response path needed to infer an operation. Hand-author
+// this query for the target API before using the generated list-latest command.
 const {{pascal $rName}}ListLatestQuery = ""
 {{- end}}
 {{- end}}

--- a/internal/generator/templates/graphql_queries.go.tmpl
+++ b/internal/generator/templates/graphql_queries.go.tmpl
@@ -10,6 +10,7 @@ package client
 {{- $queryField := graphqlQueryField $endpoint.ResponsePath}}
 {{- $params := graphqlListParams $endpoint}}
 
+{{- if $queryField}}
 const {{pascal $rName}}ListQuery = {{backtick}}query{{if $params}}({{- range $i, $p := $params}}{{if $i}}, {{end}}${{$p.Name}}: {{graphqlVariableType $p}}{{- end}}){{end}} {
   {{$queryField}}{{if $params}}({{- range $i, $p := $params}}{{if $i}}, {{end}}{{$p.Name}}: ${{$p.Name}}{{- end}}){{end}} {
     nodes {
@@ -20,9 +21,16 @@ const {{pascal $rName}}ListQuery = {{backtick}}query{{if $params}}({{- range $i,
     pageInfo { hasNextPage endCursor }
   }
 }{{backtick}}
+{{- else}}
+// {{pascal $rName}}ListQuery is intentionally empty because the spec does not
+// declare the GraphQL response path needed to infer an operation. Hand-author
+// this query for the target API before using the generated list command.
+const {{pascal $rName}}ListQuery = ""
+{{- end}}
 {{- if hasGraphQLParam $endpoint "last"}}
 {{- $latestParams := graphqlLatestParams $endpoint}}
 
+{{- if $queryField}}
 const {{pascal $rName}}ListLatestQuery = {{backtick}}query{{if $latestParams}}({{- range $i, $p := $latestParams}}{{if $i}}, {{end}}${{$p.Name}}: {{graphqlVariableType $p}}{{- end}}){{end}} {
   {{$queryField}}{{if $latestParams}}({{- range $i, $p := $latestParams}}{{if $i}}, {{end}}{{$p.Name}}: ${{$p.Name}}{{- end}}){{end}} {
     nodes {
@@ -33,11 +41,17 @@ const {{pascal $rName}}ListLatestQuery = {{backtick}}query{{if $latestParams}}({
     pageInfo { hasNextPage endCursor }
   }
 }{{backtick}}
+{{- else}}
+// {{pascal $rName}}ListLatestQuery is intentionally empty because the spec does
+// not declare the GraphQL response path needed to infer an operation.
+const {{pascal $rName}}ListLatestQuery = ""
+{{- end}}
 {{- end}}
 {{- end}}
 {{- if eq $eName "get"}}
 {{- $queryField := graphqlQueryField $endpoint.ResponsePath}}
 
+{{- if $queryField}}
 const {{pascal $rName}}GetQuery = {{backtick}}query($id: String!) {
   {{$queryField}}(id: $id) {
 {{- range graphqlFieldSelection $endpoint.Response.Item $.Types}}
@@ -45,6 +59,12 @@ const {{pascal $rName}}GetQuery = {{backtick}}query($id: String!) {
 {{- end}}
   }
 }{{backtick}}
+{{- else}}
+// {{pascal $rName}}GetQuery is intentionally empty because the spec does not
+// declare the GraphQL response path needed to infer an operation. Hand-author
+// this query for the target API before using the generated get command.
+const {{pascal $rName}}GetQuery = ""
+{{- end}}
 {{- end}}
 {{- end}}
 {{- end}}

--- a/internal/pipeline/dead_code_allowlist.go
+++ b/internal/pipeline/dead_code_allowlist.go
@@ -8,6 +8,22 @@ func isAllowedDeadHelper(name string) bool {
 	switch name {
 	case "boundCtx": // used by hand-written novel commands; unused in endpoint-only CLIs
 		return true
+	case "applyResponsePath",
+		"emitMissingPaginationCursorWarning",
+		"emitMissingPaginationSignalWarning",
+		"emitPaginatedGetMaxPagesWarning",
+		"emitTruncationWarning",
+		"extractGraphQLConnection",
+		"extractGraphQLObject",
+		"formatCLIParamValue",
+		"nextClientSidePaginationCursor",
+		"nextFullPageOffsetCursor",
+		"paginatedGet",
+		"paginationCursorToken",
+		"replacePathParam",
+		"responsePayloadParentAtPath",
+		"writeNoop":
+		return true
 	default:
 		return false
 	}

--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -621,6 +621,9 @@ func runDataPipelineTest(binary, cliDir, mode string, envFn func() []string, exp
 		if !cliHasLocalStore(cliDir) {
 			return true, "SKIP (CLI has no local store)"
 		}
+		if mode == "mock" && cliIsGraphQLCLIDir(cliDir) {
+			return true, "SKIP (GraphQL CLI: mock server cannot synthesize sync data)"
+		}
 	}
 
 	env := envFn()
@@ -744,6 +747,10 @@ func allSyncAttemptsWereUnknownCommand(errs []error) bool {
 		}
 	}
 	return true
+}
+
+func cliIsGraphQLCLIDir(dir string) bool {
+	return fileExists(filepath.Join(dir, "internal", "client", "graphql.go"))
 }
 
 func isUnknownSyncCommandError(err error) bool {

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -361,6 +361,20 @@ func TestRunDataPipelineTestSkipsUnsyncableCLIs(t *testing.T) {
 		assert.Equal(t, "PASS: 1 domain tables created (mock mode; no syncable resources declared)", detail)
 	})
 
+	t.Run("mock mode skips graphql sync data pipeline", func(t *testing.T) {
+		dir := seedDataPipelineCLIDir(t, true)
+		require.NoError(t, WriteCLIManifest(dir, CLIManifest{SpecFormat: "openapi3"}))
+		seedDataPipelineStore(t, dir, true)
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "client"), 0o755))
+		writeTestFile(t, filepath.Join(dir, "internal", "client", "graphql.go"), "package client\n")
+		binary := buildFailingSyncDataPipelineProbeBinary(t)
+
+		pass, detail := runDataPipelineTest(binary, dir, "mock", os.Environ, 2)
+
+		assert.True(t, pass)
+		assert.Equal(t, "SKIP (GraphQL CLI: mock server cannot synthesize sync data)", detail)
+	})
+
 	t.Run("mock mode still fails zero rows when syncable resources exist", func(t *testing.T) {
 		dir := seedDataPipelineCLIDir(t, true)
 		require.NoError(t, WriteCLIManifest(dir, CLIManifest{SpecFormat: "openapi3"}))

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -245,10 +245,12 @@ func scoreSpecDimensions(sc *Scorecard, outputDir, specPath string) (*openAPISpe
 		return nil, err
 	}
 
-	if spec.IsSynthetic() {
-		// Hand-built commands intentionally go beyond the spec; path-validity
-		// is not applicable. Mark unscored so the tier-2 denominator excludes
-		// it rather than awarding a 10-point cushion the CLI didn't earn.
+	if spec.IsSynthetic() || spec.IsGraphQL {
+		// Hand-built commands intentionally go beyond the spec, and GraphQL
+		// CLIs expose semantic command paths over one POST endpoint. In both
+		// cases path-validity is not applicable. Mark unscored so the tier-2
+		// denominator excludes it rather than awarding a 10-point cushion the
+		// CLI didn't earn.
 		sc.UnscoredDimensions = append(sc.UnscoredDimensions, DimPathValidity)
 	} else {
 		pathValidity := evaluatePathValidity(outputDir, spec)
@@ -2144,6 +2146,7 @@ type openAPISpecInfo struct {
 	OAuthScopeRequirements []oauthScopeRequirement
 	PositionalParamCount   int
 	Kind                   string // see apispec.KindREST / apispec.KindSynthetic
+	IsGraphQL              bool
 }
 
 func (s *openAPISpecInfo) IsSynthetic() bool {

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -2201,6 +2201,7 @@ func loadOpenAPISpecData(data []byte, specPath string) (*openAPISpecInfo, error)
 
 	info := &openAPISpecInfo{
 		SecuritySchemes: make(map[string]openAPISecurityScheme),
+		IsGraphQL:       hasGraphQLEndpointExtension(raw),
 	}
 	if paths, ok := raw["paths"].(map[string]any); ok {
 		for path := range paths {
@@ -2329,6 +2330,47 @@ func loadOpenAPISpecData(data []byte, specPath string) (*openAPISpecInfo, error)
 	}
 
 	return info, nil
+}
+
+func hasGraphQLEndpointExtension(raw map[string]any) bool {
+	if hasNonEmptyStringExtension(raw, "x-graphql-endpoint") {
+		return true
+	}
+	if info, ok := raw["info"].(map[string]any); ok && hasNonEmptyStringExtension(info, "x-graphql-endpoint") {
+		return true
+	}
+	if paths, ok := raw["paths"].(map[string]any); ok {
+		for _, pathValue := range paths {
+			pathItem, ok := pathValue.(map[string]any)
+			if !ok {
+				continue
+			}
+			if hasNonEmptyStringExtension(pathItem, "x-graphql-endpoint") {
+				return true
+			}
+			for method, operationValue := range pathItem {
+				if !isHTTPMethod(method) {
+					continue
+				}
+				operation, ok := operationValue.(map[string]any)
+				if ok && hasNonEmptyStringExtension(operation, "x-graphql-endpoint") {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func hasNonEmptyStringExtension(fields map[string]any, key string) bool {
+	if fields == nil {
+		return false
+	}
+	value, ok := fields[key]
+	if !ok {
+		return false
+	}
+	return strings.TrimSpace(asString(value)) != ""
 }
 
 func operationIDFromRaw(operation map[string]any) string {

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -1483,6 +1483,40 @@ resources:
 		assert.NotContains(t, sc.GapReport, "path_validity scored 0/10 - needs improvement")
 	})
 
+	t.Run("OpenAPI GraphQL specs omit rest path validity from scoring", func(t *testing.T) {
+		dir := t.TempDir()
+		writeScorecardFixture(t, dir, "internal/cli/root.go", `package cli`)
+		writeScorecardFixture(t, dir, "internal/cli/events.go", `
+package cli
+
+func runEvents() string {
+	path := "/events"
+	return path
+}
+`)
+		specPath := filepath.Join(dir, "openapi.yaml")
+		writeScorecardFixture(t, dir, "openapi.yaml", `
+openapi: 3.0.3
+info:
+  title: Events GraphQL
+  version: 1.0.0
+  x-graphql-endpoint: /graphql
+paths:
+  /graphql:
+    post:
+      operationId: graphql
+      responses:
+        "200":
+          description: ok
+`)
+
+		sc, err := RunScorecard(dir, t.TempDir(), specPath, nil)
+		assert.NoError(t, err)
+		assert.Contains(t, sc.UnscoredDimensions, DimPathValidity)
+		assert.Zero(t, sc.Steinberger.PathValidity)
+		assert.NotContains(t, sc.GapReport, "path_validity scored 0/10 - needs improvement")
+	})
+
 	t.Run("no store omits store pipeline dimensions from scoring", func(t *testing.T) {
 		dir := t.TempDir()
 		writeScorecardFixture(t, dir, "internal/cli/root.go", `package cli

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -1305,6 +1305,33 @@ func runMessages() {
 
 		assert.Equal(t, 5, scoreDeadCode(dir))
 	})
+
+	t.Run("generated helper extension points are not dead code", func(t *testing.T) {
+		dir := t.TempDir()
+
+		writeScorecardFixture(t, dir, "internal/cli/root.go", `package cli`)
+		writeScorecardFixture(t, dir, "internal/cli/helpers.go", `
+package cli
+
+func applyResponsePath() {}
+func emitMissingPaginationCursorWarning() {}
+func emitMissingPaginationSignalWarning() {}
+func emitPaginatedGetMaxPagesWarning() {}
+func emitTruncationWarning() {}
+func extractGraphQLConnection() {}
+func extractGraphQLObject() {}
+func formatCLIParamValue() {}
+func nextClientSidePaginationCursor() {}
+func nextFullPageOffsetCursor() {}
+func paginatedGet() {}
+func paginationCursorToken() {}
+func replacePathParam() {}
+func responsePayloadParentAtPath() {}
+func writeNoop() {}
+`)
+
+		assert.Equal(t, 5, scoreDeadCode(dir))
+	})
 }
 
 func TestScorecard_VerifyCalibration(t *testing.T) {
@@ -1418,6 +1445,42 @@ func runLinks() string {
 		assert.ElementsMatch(t, []string{"mcp_description_quality", "mcp_token_efficiency", "mcp_remote_transport", "mcp_tool_design", "mcp_surface_strategy", "cache_freshness", "path_validity", "auth_protocol", "data_pipeline_integrity", "sync_correctness", "type_fidelity", "live_api_verification"}, sc.UnscoredDimensions)
 		assert.NotContains(t, sc.GapReport, "path_validity scored 0/10 - needs improvement")
 		assert.NotContains(t, sc.GapReport, "auth_protocol scored 0/10 - needs improvement")
+	})
+
+	t.Run("graphql specs omit rest path validity from scoring", func(t *testing.T) {
+		dir := t.TempDir()
+		writeScorecardFixture(t, dir, "internal/cli/root.go", `package cli`)
+		writeScorecardFixture(t, dir, "internal/cli/events.go", `
+package cli
+
+func runEvents() string {
+	path := "/events"
+	return path
+}
+`)
+		specPath := filepath.Join(dir, "spec.yaml")
+		writeScorecardFixture(t, dir, "spec.yaml", `
+name: events-graphql
+version: "0.1.0"
+base_url: https://api.example.com
+graphql_endpoint_path: /graphql
+auth:
+  type: none
+resources:
+  events:
+    description: Events
+    endpoints:
+      list:
+        method: POST
+        path: /graphql
+        description: List events
+`)
+
+		sc, err := RunScorecard(dir, t.TempDir(), specPath, nil)
+		assert.NoError(t, err)
+		assert.Contains(t, sc.UnscoredDimensions, DimPathValidity)
+		assert.Zero(t, sc.Steinberger.PathValidity)
+		assert.NotContains(t, sc.GapReport, "path_validity scored 0/10 - needs improvement")
 	})
 
 	t.Run("no store omits store pipeline dimensions from scoring", func(t *testing.T) {

--- a/internal/pipeline/spec_detect.go
+++ b/internal/pipeline/spec_detect.go
@@ -121,6 +121,7 @@ func internalSpecToOpenAPISpecInfo(s *apispec.APISpec) *openAPISpecInfo {
 		SecuritySchemes:      make(map[string]openAPISecurityScheme),
 		PositionalParamCount: countInternalSpecPositionals(s),
 		Kind:                 s.Kind,
+		IsGraphQL:            strings.TrimSpace(s.GraphQLEndpointPath) != "",
 	}
 
 	// Map auth config to a synthetic security scheme so scorecard auth

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 85
+    "total": 72
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {


### PR DESCRIPTION
## Summary

GraphQL-backed CLIs no longer fail mock verification or scorecard checks for REST-only assumptions. Mock data-pipeline verification now skips GraphQL CLIs that cannot be synthesized by the mock server, GraphQL specs omit REST path-validity scoring, and generated helper extension points do not count against dead-code scoring.

Internal GraphQL specs without enough response-path information now emit empty query stubs with a clear runtime error instead of malformed placeholder queries, so authors get an actionable failure before sending invalid GraphQL.

Closes #2843

## Validation

- `go test ./internal/generator -run 'TestGenerateGraphQLInternalSpecEmitsEmptyQueryStubs|TestGenerateGraphQLCompiles'`
- `go test ./internal/pipeline -run 'TestRunScorecard_UnscoredSpecDimensions|TestScoreDeadCode_IntraFileHelperCalls|TestRunDataPipelineTestSkipsUnsyncableCLIs'`
- `scripts/verify-generator-output.sh generate-graphql-shared-endpoint`
- `scripts/golden.sh verify`
- `go test -timeout 20m ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
