### PR TITLE
fix(cli): harden publish artifact staging

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -976,13 +976,13 @@ func TestPublishSkillCommitStageForceAddsIgnoredPackageArtifactsAndRejectsOutOfS
 		require.NoError(t, err, "git %v failed:\n%s", args, out)
 		return string(out)
 	}
-	runStageScript := func() (string, error) {
+	runStageScript := func(env ...string) (string, error) {
 		t.Helper()
 		const script = `set -euo pipefail
 PREEXISTING_MERGED_PATHS="${PREEXISTING_MERGED_PATHS:-}"
 git add -A library/
 git add -f "library/other/acme/"
-EXPECTED_STAGE_PREFIXES=$(printf '%s\n' "library/other/acme/" "$PREEXISTING_MERGED_PATHS" | sed '/^$/d' | sort -u)
+EXPECTED_STAGE_PREFIXES=$(printf '%s\n' "library/other/acme/" "$PREEXISTING_MERGED_PATHS" | sed '/^$/d; s#/*$#/#' | sort -u)
 UNEXPECTED_STAGED=$(git diff --cached --name-only | awk -v prefixes="$EXPECTED_STAGE_PREFIXES" '
 BEGIN { n = split(prefixes, p, "\n") }
 {
@@ -1003,6 +1003,7 @@ fi
 `
 		cmd := exec.Command("bash", "-c", script)
 		cmd.Dir = repo
+		cmd.Env = append(os.Environ(), env...)
 		out, err := cmd.CombinedOutput()
 		return string(out), err
 	}
@@ -1035,6 +1036,16 @@ fi
 
 	runGit("reset")
 	require.NoError(t, os.RemoveAll(filepath.Join(repo, "library", "other", "stale-fragment")))
+	siblingPath := filepath.Join(repo, "library", "other", "acme-extra", "README.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(siblingPath), 0o755))
+	require.NoError(t, os.WriteFile(siblingPath, []byte("# sibling\n"), 0o644))
+	out, err = runStageScript("PREEXISTING_MERGED_PATHS=library/other/acme")
+	require.Error(t, err)
+	assert.Contains(t, out, "publish staged paths outside the expected CLI scope")
+	assert.Contains(t, out, "library/other/acme-extra/README.md")
+
+	runGit("reset")
+	require.NoError(t, os.RemoveAll(filepath.Join(repo, "library", "other", "acme-extra")))
 	out, err = runStageScript()
 	require.NoError(t, err, out)
 

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -594,9 +594,12 @@ func TestPublishSkillSkipsCliSkillsMirrorRegen(t *testing.T) {
 	// no longer has an in-PR auto-fix path for either.
 	assert.Contains(t, skill, "Fail on changes to generated artifacts")
 	assert.Contains(t, skill, "Do NOT regenerate or commit `cli-skills/pp-<api-slug>/SKILL.md` or")
-	assert.Contains(t, skill, "git add library/")
-	assert.Contains(t, skill, `git add -f "library/<category>/<api-slug>/cmd/<api-slug>-pp-mcp/"`)
+	assert.Contains(t, skill, "git clean -fdq library/")
+	assert.Contains(t, skill, "git add -A library/")
+	assert.Contains(t, skill, `git add -f "library/<category>/<api-slug>/"`)
+	assert.Contains(t, skill, "UNEXPECTED_STAGED")
 	assert.Contains(t, skill, `git commit -m "feat(<api-slug>): add <api-slug>"`)
+	assert.NotContains(t, skill, `git add -f "library/<category>/<api-slug>/cmd/<api-slug>-pp-mcp/"`)
 	assert.NotContains(t, skill, "git add library/ cli-skills/")
 	assert.NotContains(t, skill, "git add library/ cli-skills/ registry.json")
 	assert.NotContains(t, skill, "REGISTRY_HAS_ENTRY")
@@ -961,6 +964,86 @@ func TestPublishSkillPRBodyIncludesStableNovelCommands(t *testing.T) {
 	assert.Contains(t, skill, "`Alongside print`")
 	assert.Contains(t, skill, "--body-file \"$PR_BODY_FILE\"")
 	assert.NotContains(t, skill, "--body \"<constructed PR body>\"")
+}
+
+func TestPublishSkillCommitStageForceAddsIgnoredPackageArtifactsAndRejectsOutOfScopeStaging(t *testing.T) {
+	repo := t.TempDir()
+	runGit := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v failed:\n%s", args, out)
+		return string(out)
+	}
+	runStageScript := func() (string, error) {
+		t.Helper()
+		const script = `set -euo pipefail
+PREEXISTING_MERGED_PATHS="${PREEXISTING_MERGED_PATHS:-}"
+git add -A library/
+git add -f "library/other/acme/"
+EXPECTED_STAGE_PREFIXES=$(printf '%s\n' "library/other/acme/" "$PREEXISTING_MERGED_PATHS" | sed '/^$/d' | sort -u)
+UNEXPECTED_STAGED=$(git diff --cached --name-only | awk -v prefixes="$EXPECTED_STAGE_PREFIXES" '
+BEGIN { n = split(prefixes, p, "\n") }
+{
+  matched = 0
+  for (i = 1; i <= n; i++) {
+    if (p[i] != "" && ($0 == p[i] || index($0, p[i]) == 1)) {
+      matched = 1
+      break
+    }
+  }
+  if (!matched) print
+}')
+if [ -n "$UNEXPECTED_STAGED" ]; then
+  echo "ERROR: publish staged paths outside the expected CLI scope:" >&2
+  printf '%s\n' "$UNEXPECTED_STAGED" | sed 's/^/- /' >&2
+  exit 1
+fi
+`
+		cmd := exec.Command("bash", "-c", script)
+		cmd.Dir = repo
+		out, err := cmd.CombinedOutput()
+		return string(out), err
+	}
+
+	runGit("init")
+	runGit("config", "user.email", "test@example.com")
+	runGit("config", "user.name", "Test User")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, ".gitignore"), []byte("*-pp-cli\n*-pp-mcp\n.manuscripts/\nworkflow-verify-report.json\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "README.md"), []byte("# fixture\n"), 0o644))
+	runGit("add", ".gitignore", "README.md")
+	runGit("commit", "-m", "base")
+
+	packageDir := filepath.Join(repo, "library", "other", "acme")
+	require.NoError(t, os.MkdirAll(filepath.Join(packageDir, "cmd", "acme-pp-cli"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(packageDir, "cmd", "acme-pp-cli", "main.go"), []byte("package main\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(packageDir, "cmd", "acme-pp-mcp"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(packageDir, "cmd", "acme-pp-mcp", "main.go"), []byte("package main\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(packageDir, ".manuscripts", "run-1", "research"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(packageDir, ".manuscripts", "run-1", "research", "brief.md"), []byte("# research\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(packageDir, "workflow-verify-report.json"), []byte("{}\n"), 0o644))
+
+	stalePath := filepath.Join(repo, "library", "other", "stale-fragment", "README.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(stalePath), 0o755))
+	require.NoError(t, os.WriteFile(stalePath, []byte("# stale\n"), 0o644))
+
+	out, err := runStageScript()
+	require.Error(t, err)
+	assert.Contains(t, out, "publish staged paths outside the expected CLI scope")
+	assert.Contains(t, out, "library/other/stale-fragment/README.md")
+
+	runGit("reset")
+	require.NoError(t, os.RemoveAll(filepath.Join(repo, "library", "other", "stale-fragment")))
+	out, err = runStageScript()
+	require.NoError(t, err, out)
+
+	staged := runGit("diff", "--cached", "--name-only")
+	assert.Contains(t, staged, "library/other/acme/cmd/acme-pp-cli/main.go")
+	assert.Contains(t, staged, "library/other/acme/cmd/acme-pp-mcp/main.go")
+	assert.Contains(t, staged, "library/other/acme/.manuscripts/run-1/research/brief.md")
+	assert.Contains(t, staged, "library/other/acme/workflow-verify-report.json")
+	assert.NotContains(t, staged, "library/other/stale-fragment/README.md")
 }
 
 func TestREADMEOutputContract(t *testing.T) {

--- a/internal/pipeline/renamecli.go
+++ b/internal/pipeline/renamecli.go
@@ -58,6 +58,9 @@ func RenameCLI(dir, oldCLIName, newCLIName, _ string) (int, error) {
 	if dirBase != oldCLIName && dirBase != naming.LibraryDirName(oldCLIName) {
 		return 0, fmt.Errorf("directory base %q does not match old CLI name %q", dirBase, oldCLIName)
 	}
+	if err := rejectStrayRenameSlugDirs(absDir, oldSlug, newSlug); err != nil {
+		return 0, err
+	}
 
 	filesModified := 0
 
@@ -151,6 +154,29 @@ func RenameCLI(dir, oldCLIName, newCLIName, _ string) (int, error) {
 	}
 
 	return filesModified, nil
+}
+
+func rejectStrayRenameSlugDirs(dir string, slugs ...string) error {
+	blocked := make(map[string]bool, len(slugs))
+	for _, slug := range slugs {
+		if slug != "" {
+			blocked[slug] = true
+		}
+	}
+	if len(blocked) == 0 {
+		return nil
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("reading rename directory: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && blocked[entry.Name()] {
+			return fmt.Errorf("stray top-level directory %q would make publish rename ambiguous; remove it before renaming", entry.Name())
+		}
+	}
+	return nil
 }
 
 func renameCLIContent(content, oldCLIName, newCLIName, oldMCPName, newMCPName, oldSlug, newSlug string) string {

--- a/internal/pipeline/renamecli_test.go
+++ b/internal/pipeline/renamecli_test.go
@@ -445,6 +445,33 @@ func main() {}
 		assert.Contains(t, err.Error(), "does not match")
 	})
 
+	t.Run("rejects stray old or new slug directories", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			strayDir string
+		}{
+			{name: "old slug", strayDir: "home-health"},
+			{name: "new slug", strayDir: "home-air-health"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				root := t.TempDir()
+				oldName := "home-health-pp-cli"
+				newName := "home-air-health-pp-cli"
+				cliDir := filepath.Join(root, "home-health")
+				require.NoError(t, os.MkdirAll(cliDir, 0o755))
+				writeTestCLITree(t, cliDir, oldName, "home-health")
+				require.NoError(t, os.MkdirAll(filepath.Join(cliDir, tt.strayDir), 0o755))
+
+				_, err := RenameCLI(cliDir, oldName, newName, "home-health")
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "stray top-level directory")
+				assert.Contains(t, err.Error(), tt.strayDir)
+			})
+		}
+	})
+
 	t.Run("works when dir base is slug but old-name is CLI name", func(t *testing.T) {
 		root := t.TempDir()
 		oldName := "dub-pp-cli"

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -622,11 +622,21 @@ if [ "$(jq -r .access $PUBLISH_CONFIG)" = "push" ]; then
   git fetch --filter=blob:none --depth 1 origin
   git checkout main
   git reset --hard origin/main
+  # Remove stale untracked library fragments from prior publish branches before
+  # copying this CLI. Ignored files hidden by a branch-local .gitignore can
+  # become ordinary untracked files after checkout, and a later broad library
+  # add must not sweep another CLI's leftovers into this PR.
+  git clean -fdq library/
 else
   # Fork: origin is the fork, upstream is canonical
   git fetch --filter=blob:none --depth 1 upstream
   git checkout main
   git reset --hard upstream/main
+  # Remove stale untracked library fragments from prior publish branches before
+  # copying this CLI. Ignored files hidden by a branch-local .gitignore can
+  # become ordinary untracked files after checkout, and a later broad library
+  # add must not sweep another CLI's leftovers into this PR.
+  git clean -fdq library/
   # Also sync origin (fork) so git push works cleanly
   git push origin main --force-with-lease 2>/dev/null || true
 fi
@@ -1263,15 +1273,37 @@ git checkout -B feat/<api-slug>
 
 ```bash
 cd "$PUBLISH_REPO_DIR"
-git add library/
-# The library .gitignore has a `*-pp-mcp` rule intended for the built MCP
-# binary, but the pattern also matches the generated MCP *source* directory
-# `cmd/<api-slug>-pp-mcp/`. A plain `git add library/` silently skips it, and
-# the PR then fails the "Validate MCPB manifest contract" CI check with
-# "cmd/<api-slug>-pp-mcp directory is missing". Force-add the source directory
-# so all MCP entry-point files ship. The built binary stays ignored because it
-# lives at the packaged CLI root, not under cmd/.
-git add -f "library/<category>/<api-slug>/cmd/<api-slug>-pp-mcp/" 2>/dev/null || true
+git add -A library/
+# The staged package has already stripped local binaries and passed the
+# mandatory secret/PII scans, so it is the source of truth for this publish.
+# Force-add the whole CLI directory after the broad add: destination-repo or
+# package-local .gitignore rules such as `*-pp-cli`, `*-pp-mcp`,
+# `/.manuscripts/`, or report filenames must not silently suppress required
+# publish artifacts under cmd/, .manuscripts/, or metadata files.
+git add -f "library/<category>/<api-slug>/"
+
+# Pre-commit scope guard: only this CLI's replacement plus any pre-existing
+# merged paths for the same slug may be staged. This catches stale untracked
+# fragments from previous publish branches before they leak into the wrong PR.
+EXPECTED_STAGE_PREFIXES=$(printf '%s\n' "library/<category>/<api-slug>/" "$PREEXISTING_MERGED_PATHS" | sed '/^$/d' | sort -u)
+UNEXPECTED_STAGED=$(git diff --cached --name-only | awk -v prefixes="$EXPECTED_STAGE_PREFIXES" '
+BEGIN { n = split(prefixes, p, "\n") }
+{
+  matched = 0
+  for (i = 1; i <= n; i++) {
+    if (p[i] != "" && ($0 == p[i] || index($0, p[i]) == 1)) {
+      matched = 1
+      break
+    }
+  }
+  if (!matched) print
+}')
+if [ -n "$UNEXPECTED_STAGED" ]; then
+  echo "ERROR: publish staged paths outside the expected CLI scope:" >&2
+  printf '%s\n' "$UNEXPECTED_STAGED" | sed 's/^/- /' >&2
+  echo "Reset the managed clone and rerun publish package before committing." >&2
+  exit 1
+fi
 git commit -m "feat(<api-slug>): add <api-slug>"
 ```
 

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -1285,7 +1285,7 @@ git add -f "library/<category>/<api-slug>/"
 # Pre-commit scope guard: only this CLI's replacement plus any pre-existing
 # merged paths for the same slug may be staged. This catches stale untracked
 # fragments from previous publish branches before they leak into the wrong PR.
-EXPECTED_STAGE_PREFIXES=$(printf '%s\n' "library/<category>/<api-slug>/" "$PREEXISTING_MERGED_PATHS" | sed '/^$/d' | sort -u)
+EXPECTED_STAGE_PREFIXES=$(printf '%s\n' "library/<category>/<api-slug>/" "$PREEXISTING_MERGED_PATHS" | sed '/^$/d; s#/*$#/#' | sort -u)
 UNEXPECTED_STAGED=$(git diff --cached --name-only | awk -v prefixes="$EXPECTED_STAGE_PREFIXES" '
 BEGIN { n = split(prefixes, p, "\n") }
 {


### PR DESCRIPTION
## Summary
Publish now force-adds the packaged CLI directory after the broad library add, so destination or package-local gitignore rules cannot silently drop required artifacts such as command source directories, `.manuscripts`, and workflow metadata. The publish path also cleans stale library fragments after resetting the managed clone and fails before commit if staged files fall outside the expected CLI slug scope.

Publish rename now rejects stray top-level old or new slug directories before moving the outer CLI directory, which prevents the mis-nested rename shape described in the issue.

Closes #2611

## Validation
- `go test ./internal/pipeline -run 'TestRenameCLI|TestPublishSkillSkipsCliSkillsMirrorRegen|TestPublishSkillCommitStageForceAddsIgnoredPackageArtifactsAndRejectsOutOfScopeStaging'`
- `go test ./internal/cli -run 'TestPublishPackageIncludesManuscripts|TestPublishPackageStripsRootBinaries|TestPublishManifestContractRequiresMCPMetadataFiles'`
- `go test ./...`
