### PR TITLE
fix(skills): remove vendor-specific profile wording

### DIFF
--- a/internal/generator/templates/profile.go.tmpl
+++ b/internal/generator/templates/profile.go.tmpl
@@ -17,8 +17,8 @@ import (
 )
 
 // Profile is a named set of flag values saved for reuse across invocations.
-// HeyGen's "Beacon" pattern: one named context that a scheduled agent reuses
-// day after day with the same voice/format but different input each run.
+// Use a named profile when a scheduled or recurring workflow reuses the same
+// saved flags while providing different input each run.
 type Profile struct {
 	Name        string            `json:"name"`
 	Description string            `json:"description,omitempty"`

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -567,7 +567,7 @@ Unknown schemes are refused with a structured error naming the supported set. We
 
 ## Named Profiles
 
-A profile is a saved set of flag values, reused across invocations. Use it when a scheduled agent calls the same command every run with the same configuration - HeyGen's "Beacon" pattern.
+A profile is a saved set of flag values, reused across invocations. Use it when a scheduled or recurring agent reuses the same saved flags while providing different input each run.
 
 ```
 {{.Name}}-pp-cli profile save briefing --json

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/SKILL.md
@@ -148,7 +148,7 @@ Unknown schemes are refused with a structured error naming the supported set. We
 
 ## Named Profiles
 
-A profile is a saved set of flag values, reused across invocations. Use it when a scheduled agent calls the same command every run with the same configuration - HeyGen's "Beacon" pattern.
+A profile is a saved set of flag values, reused across invocations. Use it when a scheduled or recurring agent reuses the same saved flags while providing different input each run.
 
 ```
 printing-press-oauth2-pp-cli profile save briefing --json

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/SKILL.md
@@ -146,7 +146,7 @@ Unknown schemes are refused with a structured error naming the supported set. We
 
 ## Named Profiles
 
-A profile is a saved set of flag values, reused across invocations. Use it when a scheduled agent calls the same command every run with the same configuration - HeyGen's "Beacon" pattern.
+A profile is a saved set of flag values, reused across invocations. Use it when a scheduled or recurring agent reuses the same saved flags while providing different input each run.
 
 ```
 printing-press-rich-pp-cli profile save briefing --json

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
@@ -172,7 +172,7 @@ Unknown schemes are refused with a structured error naming the supported set. We
 
 ## Named Profiles
 
-A profile is a saved set of flag values, reused across invocations. Use it when a scheduled agent calls the same command every run with the same configuration - HeyGen's "Beacon" pattern.
+A profile is a saved set of flag values, reused across invocations. Use it when a scheduled or recurring agent reuses the same saved flags while providing different input each run.
 
 ```
 printing-press-golden-pp-cli profile save briefing --json

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/profile.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/profile.go
@@ -17,8 +17,8 @@ import (
 )
 
 // Profile is a named set of flag values saved for reuse across invocations.
-// HeyGen's "Beacon" pattern: one named context that a scheduled agent reuses
-// day after day with the same voice/format but different input each run.
+// Use a named profile when a scheduled or recurring workflow reuses the same
+// saved flags while providing different input each run.
 type Profile struct {
 	Name        string            `json:"name"`
 	Description string            `json:"description,omitempty"`

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/SKILL.md
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/SKILL.md
@@ -323,7 +323,7 @@ Unknown schemes are refused with a structured error naming the supported set. We
 
 ## Named Profiles
 
-A profile is a saved set of flag values, reused across invocations. Use it when a scheduled agent calls the same command every run with the same configuration - HeyGen's "Beacon" pattern.
+A profile is a saved set of flag values, reused across invocations. Use it when a scheduled or recurring agent reuses the same saved flags while providing different input each run.
 
 ```
 learn-loop-example-pp-cli profile save briefing --json

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/SKILL.md
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/SKILL.md
@@ -138,7 +138,7 @@ Unknown schemes are refused with a structured error naming the supported set. We
 
 ## Named Profiles
 
-A profile is a saved set of flag values, reused across invocations. Use it when a scheduled agent calls the same command every run with the same configuration - HeyGen's "Beacon" pattern.
+A profile is a saved set of flag values, reused across invocations. Use it when a scheduled or recurring agent reuses the same saved flags while providing different input each run.
 
 ```
 public-param-golden-pp-cli profile save briefing --json


### PR DESCRIPTION
## Intent

Remove source-domain wording from reusable generated profile guidance so freshly printed CLIs do not inherit an unrelated vendor/product example.

Issue: Fixes #3403

## Approach

This updates the profile guidance in the reusable skill template and the generated `Profile` type comment to describe scheduled/recurring profile reuse generically. The golden expected artifacts that emit this text were refreshed to prove the generated output contract.

## Scope

Primary area: generated CLI profile documentation/comments.

Why this belongs in this repo:

The affected wording comes from generator-owned templates in CLI Printing Press. Fixing the reusable templates ensures future printed CLIs receive the neutral wording instead of patching one generated CLI by hand.

## Risk

Low. This changes generated prose/comment text only. It does not alter profile storage, flags, command behavior, MCP schemas, auth, publish flow, verifier behavior, or scorecard output.

Future generated CLIs will inherit the neutral profile wording.

## Output Contract

This intentionally changes generated output in:

- emitted `SKILL.md` Named Profiles prose
- emitted `internal/cli/profile.go` `Profile` comment

Existing golden cases cover the generated `SKILL.md` variants, and `generate-golden-api` covers the emitted `profile.go` artifact. `scripts/verify-generator-output.sh generate-golden-api` also compiled the generated module successfully.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:

- `scripts/golden.sh verify` - passed, 30 case(s)
- `scripts/verify-generator-output.sh generate-golden-api` - passed, 1 case(s)
- `go test ./...` - passed
- `git diff --check` - passed
- `rg -n "HeyGen|Beacon|voice/format" internal/generator/templates testdata/golden/expected` - no matches

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
