### PR TITLE
fix(cli): skip soft lookup error probes

### DIFF
--- a/internal/generator/endpoint_error_path_probe_test.go
+++ b/internal/generator/endpoint_error_path_probe_test.go
@@ -37,6 +37,29 @@ func TestEndpointSkipsErrorPathProbe(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "untyped free-text query positional skips probe",
+			endpoint: spec.Endpoint{
+				Method: "GET",
+				Path:   "/images/search",
+				Params: []spec.Param{{Name: "q", Required: true, Positional: true}},
+			},
+			want: true,
+		},
+		{
+			name: "untyped JSON-described positional still gets probed",
+			endpoint: spec.Endpoint{
+				Method: "GET",
+				Path:   "/images/search",
+				Params: []spec.Param{{
+					Name:        "filter",
+					Required:    true,
+					Positional:  true,
+					Description: "{\"field\":\"value\"}",
+				}},
+			},
+			want: false,
+		},
+		{
 			name: "path positional still gets probed",
 			endpoint: spec.Endpoint{
 				Method: "GET",

--- a/internal/generator/endpoint_error_path_probe_test.go
+++ b/internal/generator/endpoint_error_path_probe_test.go
@@ -1,0 +1,180 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpointSkipsErrorPathProbe(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		endpoint spec.Endpoint
+		want     bool
+	}{
+		{
+			name: "GET with one required free-text query positional skips probe",
+			endpoint: spec.Endpoint{
+				Method: "GET",
+				Path:   "/images/search",
+				Params: []spec.Param{{Name: "q", Type: "string", Required: true, Positional: true}},
+			},
+			want: true,
+		},
+		{
+			name: "HEAD with one required free-text query positional skips probe",
+			endpoint: spec.Endpoint{
+				Method: "HEAD",
+				Path:   "/images/search",
+				Params: []spec.Param{{Name: "q", Type: "string", Required: true, Positional: true}},
+			},
+			want: true,
+		},
+		{
+			name: "path positional still gets probed",
+			endpoint: spec.Endpoint{
+				Method: "GET",
+				Path:   "/images/{id}",
+				Params: []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true, PathParam: true}},
+			},
+			want: false,
+		},
+		{
+			name: "required enum flag still gets probed",
+			endpoint: spec.Endpoint{
+				Method: "GET",
+				Path:   "/images/search",
+				Params: []spec.Param{
+					{Name: "q", Type: "string", Required: true, Positional: true},
+					{Name: "orientation", Type: "string", Required: true, Enum: []string{"landscape", "portrait"}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "formatted positional still gets probed",
+			endpoint: spec.Endpoint{
+				Method: "GET",
+				Path:   "/images/search",
+				Params: []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true, Format: "uuid"}},
+			},
+			want: false,
+		},
+		{
+			name: "multiple positionals still get probed",
+			endpoint: spec.Endpoint{
+				Method: "GET",
+				Path:   "/images/search",
+				Params: []spec.Param{
+					{Name: "collection", Type: "string", Required: true, Positional: true},
+					{Name: "q", Type: "string", Required: true, Positional: true},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "mutating verb still gets probed",
+			endpoint: spec.Endpoint{
+				Method: "POST",
+				Path:   "/images/search",
+				Params: []spec.Param{{Name: "q", Type: "string", Required: true, Positional: true}},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, endpointSkipsErrorPathProbe(tc.endpoint))
+		})
+	}
+}
+
+func TestGeneratedEndpointNoErrorPathProbeAnnotation(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("error-path-probe")
+	apiSpec.Resources["items"] = spec.Resource{
+		Description: "Items",
+		Endpoints: map[string]spec.Endpoint{
+			"list": {
+				Method:      "GET",
+				Path:        "/items",
+				Description: "List items",
+			},
+			"search": {
+				Method:      "GET",
+				Path:        "/items/search",
+				Description: "Search items by free text",
+				Params: []spec.Param{
+					{Name: "q", Type: "string", Required: true, Positional: true, Description: "Search query"},
+				},
+			},
+			"filtered": {
+				Method:      "GET",
+				Path:        "/items/filtered",
+				Description: "Search items with required validated filter",
+				Params: []spec.Param{
+					{Name: "q", Type: "string", Required: true, Positional: true, Description: "Search query"},
+					{Name: "orientation", Type: "string", Required: true, Enum: []string{"landscape", "portrait"}},
+				},
+			},
+			"get": {
+				Method:      "GET",
+				Path:        "/items/{id}",
+				Description: "Get one item",
+				Params: []spec.Param{
+					{Name: "id", Type: "string", Required: true, Positional: true, PathParam: true},
+				},
+			},
+		},
+	}
+	apiSpec.Resources["lookup"] = spec.Resource{
+		Description: "Lookup",
+		Endpoints: map[string]spec.Endpoint{
+			"similar": {
+				Method:      "GET",
+				Path:        "/similar",
+				Description: "Find similar records",
+				Params: []spec.Param{
+					{Name: "term", Type: "string", Required: true, Positional: true},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "error-path-probe-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	search := readEndpointProbeFile(t, outputDir, "items_search.go")
+	require.Contains(t, search, `"pp:no-error-path-probe": "true"`,
+		"free-text query positional endpoint should skip the live dogfood error_path probe")
+
+	promoted := readEndpointProbeFile(t, outputDir, "promoted_lookup.go")
+	require.Contains(t, promoted, `"pp:no-error-path-probe": "true"`,
+		"promoted free-text query positional endpoint should skip the live dogfood error_path probe")
+
+	filtered := readEndpointProbeFile(t, outputDir, "items_filtered.go")
+	require.NotContains(t, filtered, `"pp:no-error-path-probe"`,
+		"required enum flags still provide a real validation error path")
+
+	get := readEndpointProbeFile(t, outputDir, "items_get.go")
+	require.NotContains(t, get, `"pp:no-error-path-probe"`,
+		"path ID lookups should keep the normal error_path probe")
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func readEndpointProbeFile(t *testing.T, outputDir, name string) string {
+	t.Helper()
+	src, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", name))
+	require.NoError(t, err)
+	return string(src)
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -379,6 +379,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"endpointHasQueryFlags":        endpointHasQueryFlags,
 		"endpointHasRequestParams":     endpointHasRequestParams,
 		"endpointHasRequiredInput":     endpointHasRequiredInput,
+		"endpointSkipsErrorPathProbe":  endpointSkipsErrorPathProbe,
 		"endpointIsReadCommand":        endpointIsReadCommand,
 		"hasMultipartRequest":          hasMultipartRequest,
 		"formBodyMaps":                 formBodyMaps,
@@ -6295,6 +6296,52 @@ func endpointHasRequiredInput(endpoint spec.Endpoint) bool {
 		return strings.TrimSpace(bodyRequiredChecks(endpoint, "")) != ""
 	}
 	return false
+}
+
+// endpointSkipsErrorPathProbe reports whether live dogfood's synthesized
+// "__printing_press_invalid__" argument is not a meaningful invalid input for
+// this read command. Free-form string lookups and searches commonly return
+// HTTP 200 plus empty results, so the generator emits pp:no-error-path-probe
+// only when the command has exactly one required positional request parameter
+// and no locally validated required input surface.
+func endpointSkipsErrorPathProbe(endpoint spec.Endpoint) bool {
+	switch strings.ToUpper(strings.TrimSpace(endpoint.Method)) {
+	case "GET", "HEAD":
+	default:
+		return false
+	}
+	if endpointHasRequiredInput(endpoint) {
+		return false
+	}
+
+	var requestPositionals []spec.Param
+	for _, p := range orderedPositionalParams(endpoint) {
+		if p.PathParam || strings.Contains(endpoint.Path, "{"+p.Name+"}") {
+			return false
+		}
+		requestPositionals = append(requestPositionals, p)
+	}
+	if len(requestPositionals) != 1 {
+		return false
+	}
+	p := requestPositionals[0]
+	return p.Required && freeTextStringParam(p)
+}
+
+func freeTextStringParam(p spec.Param) bool {
+	if p.Type != "" && !strings.EqualFold(strings.TrimSpace(p.Type), "string") {
+		return false
+	}
+	if len(p.Enum) > 0 {
+		return false
+	}
+	if strings.TrimSpace(p.Format) != "" {
+		return false
+	}
+	if isJSONStringParam(p) {
+		return false
+	}
+	return true
 }
 
 // endpointHasRequestParams reports whether the endpoint passes any values in

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -6513,7 +6513,7 @@ func isComplexBodyField(p spec.Param) bool {
 }
 
 func isJSONStringParam(p spec.Param) bool {
-	if p.Type != "string" {
+	if p.Type != "" && !strings.EqualFold(strings.TrimSpace(p.Type), "string") {
 		return false
 	}
 

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -74,7 +74,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 		// TODO: replace placeholder example values before relying on this for live dogfood.
 {{- end}}
 		Example: {{printf "%q" $example}},
-		Annotations: map[string]string{ {{- if not .APISpec.IsLocalSQLiteSource}}"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, {{end}}"pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}},
+		Annotations: map[string]string{ {{- if not .APISpec.IsLocalSQLiteSource}}"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, {{end}}"pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if endpointSkipsErrorPathProbe .Endpoint}}, "pp:no-error-path-probe": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 {{- if endpointHasRequiredInput .Endpoint}}
 			// Bare invocation of a command with required input prints help

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -60,7 +60,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 		// TODO: replace placeholder example values before relying on this for live dogfood.
 {{- end}}
 		Example: {{printf "%q" $example}},
-		Annotations: map[string]string{ {{- if not .APISpec.IsLocalSQLiteSource}}"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, {{end}}"pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}},
+		Annotations: map[string]string{ {{- if not .APISpec.IsLocalSQLiteSource}}"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, {{end}}"pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if endpointSkipsErrorPathProbe .Endpoint}}, "pp:no-error-path-probe": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 {{- if endpointHasRequiredInput .Endpoint}}
 			// Bare invocation of a command with a required flag/body prints help


### PR DESCRIPTION
## Summary

Generated read commands that take a single free-text query positional now carry `pp:no-error-path-probe`, so live dogfood skips the invalid-argument probe for search and soft lookup shapes where arbitrary strings validly return empty results.

The generator predicate fails closed for path IDs, multiple positionals, mutating verbs, formatted or enum-constrained inputs, and commands with required locally validated flags.

Closes #3204.

## Validation

- `go test ./internal/generator -run 'TestEndpointSkipsErrorPathProbe|TestGeneratedEndpointNoErrorPathProbeAnnotation|TestEndpointHasRequiredInputMirrorsTemplateGates|TestMCPReadOnlyAnnotationEmission'`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `git diff --check`
