### PR TITLE
fix(cli): gate partial failure helpers by emitted callers

### DIFF
--- a/internal/generator/endpoint_is_write_test.go
+++ b/internal/generator/endpoint_is_write_test.go
@@ -400,6 +400,35 @@ func TestPromotedReadOnlyPOSTDoesNotEmitPartialFailureSupport(t *testing.T) {
 	requireGeneratedCompiles(t, outputDir)
 }
 
+func TestPartialFailureEmissionFlagsRecurseIntoNestedSubresources(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("nested-mutation")
+	apiSpec.Resources = map[string]spec.Resource{
+		"orgs": {
+			SubResources: map[string]spec.Resource{
+				"projects": {
+					SubResources: map[string]spec.Resource{
+						"tasks": {
+							Endpoints: map[string]spec.Endpoint{
+								"update": {
+									Method:      "PATCH",
+									Path:        "/orgs/{org_id}/projects/{project_id}/tasks/{task_id}",
+									Description: "Update a task",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	hasSupport, hasTypedErr := partialFailureEmissionFlags(apiSpec, nil, nil, false)
+	require.True(t, hasSupport, "nested mutation endpoints need partial-failure support")
+	require.True(t, hasTypedErr, "nested command_endpoint.go callers need partialFailureErr")
+}
+
 func TestPromotedCommandSubstitutesFlagPathParams(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/endpoint_is_write_test.go
+++ b/internal/generator/endpoint_is_write_test.go
@@ -357,6 +357,49 @@ func TestPromotedCommandVerbBranching(t *testing.T) {
 	}
 }
 
+func TestPromotedReadOnlyPOSTDoesNotEmitPartialFailureSupport(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("promoted-readonly-post")
+	apiSpec.Resources = map[string]spec.Resource{
+		"queries": {
+			Description: "Search queries",
+			Endpoints: map[string]spec.Endpoint{
+				"searchAll": {
+					Method:      "POST",
+					Path:        "/search-all",
+					Description: "Search collections by free text",
+					Body:        []spec.Param{{Name: "queryText", Type: "string"}},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "promoted-readonly-post-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet.Store = true
+	gen.VisionSet.MCP = true
+	require.NoError(t, gen.Generate())
+
+	promotedSrc := readPromotedCommandFile(t, outputDir)
+	require.Contains(t, promotedSrc, "c.PostQueryWithParams(")
+	require.NotContains(t, promotedSrc, "detectPartialFailure(")
+	require.NotContains(t, promotedSrc, "flags.allowPartialFailure")
+
+	helpers, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "helpers.go"))
+	require.NoError(t, err)
+	helpersSrc := string(helpers)
+	require.NotContains(t, helpersSrc, "func partialFailureErr(")
+	require.NotContains(t, helpersSrc, "type partialFailureReport struct")
+	require.NotContains(t, helpersSrc, "func detectPartialFailure(")
+
+	root, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "root.go"))
+	require.NoError(t, err)
+	require.NotContains(t, string(root), "allow-partial-failure")
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
 func TestPromotedCommandSubstitutesFlagPathParams(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -762,7 +762,8 @@ type HelperFlags struct {
 	HasClientFilters     bool // at least one docs-derived endpoint needs client-side response filtering
 	HasEmbeddedPaged     bool // at least one GET endpoint has detected embedded paged sub-resources → emit fetchEmbeddedPagedSubresource
 	HasResponseUnwrap    bool // at least one generated command can call extractResponseData
-	HasMutationEndpoints bool // spec has any non-GET/HEAD endpoint → emit partial-failure helpers + --allow-partial-failure flag
+	HasMutationEndpoints bool // emitted commands can detect partial failures → emit partial-failure support + --allow-partial-failure flag
+	HasPartialFailureErr bool // emitted command_endpoint.go command can call partialFailureErr
 	HasRequiredRoles     bool // spec has per-endpoint requires_role gates → emit persona helpers
 	HasCreateCommands    bool // spec has POST/PUT/PATCH write endpoints → emit create retry helpers
 }
@@ -818,6 +819,53 @@ func computeHelperFlags(s *spec.APISpec) HelperFlags {
 		scan(r)
 	}
 	return flags
+}
+
+func applyPartialFailureFlags(flags *HelperFlags, apiSpec *spec.APISpec, promotedCommands []PromotedCommand, promotedEndpointNames map[string]string, hasStore bool) {
+	flags.HasMutationEndpoints, flags.HasPartialFailureErr = partialFailureEmissionFlags(apiSpec, promotedCommands, promotedEndpointNames, hasStore)
+}
+
+func partialFailureEmissionFlags(apiSpec *spec.APISpec, promotedCommands []PromotedCommand, promotedEndpointNames map[string]string, hasStore bool) (bool, bool) {
+	hasSupport := false
+	hasTypedErr := false
+
+	for resourceName, originalResource := range apiSpec.Resources {
+		resource := withoutOptionsEndpoints(originalResource)
+		for endpointName, endpoint := range resource.Endpoints {
+			if promotedEndpointNames[resourceName] == endpointName {
+				continue
+			}
+			if isMutationMethod(endpoint.Method) {
+				hasSupport = true
+				hasTypedErr = true
+			}
+		}
+		for _, originalSubResource := range resource.SubResources {
+			subResource := withoutOptionsEndpoints(originalSubResource)
+			for _, endpoint := range subResource.Endpoints {
+				if isMutationMethod(endpoint.Method) {
+					hasSupport = true
+					hasTypedErr = true
+				}
+			}
+		}
+	}
+
+	for _, command := range promotedCommands {
+		if promotedCommandCanDetectPartialFailure(command, hasStore) {
+			hasSupport = true
+		}
+	}
+
+	return hasSupport, hasTypedErr
+}
+
+func promotedCommandCanDetectPartialFailure(command PromotedCommand, hasStore bool) bool {
+	if !hasStore || command.Endpoint.UsesBinaryResponse() || endpointIsReadCommand(command.Endpoint, command.EndpointName) {
+		return false
+	}
+	method := strings.ToUpper(strings.TrimSpace(command.Endpoint.Method))
+	return method == "POST" || method == "PUT" || method == "PATCH"
 }
 
 // isMutationMethod reports whether method is a mutation verb that reaches the
@@ -2223,6 +2271,7 @@ func (g *Generator) renderSingleFiles() error {
 			data = g.readmeData()
 		case "helpers.go.tmpl":
 			hFlags := computeHelperFlags(g.Spec)
+			applyPartialFailureFlags(&hFlags, g.Spec, g.PromotedCommands, g.PromotedEndpointNames, g.VisionSet.Store)
 			hFlags.HasDataLayer = g.VisionSet.Store
 			hFlags.HasSyncHelpers = g.hasGeneratedSyncImplementation()
 			hFlags.HasResponseUnwrap = g.VisionSet.Store && promotedCommandsCanUnwrapResponse(g.PromotedCommands, g.Spec.Types)
@@ -4492,6 +4541,7 @@ func (g *Generator) renderRootProjectFiles(promotedCommands []PromotedCommand, p
 	// undefined symbol when auth.go was skipped.
 	hasAuthCommand := g.shouldEmitAuth()
 	helperFlags := computeHelperFlags(g.Spec)
+	applyPartialFailureFlags(&helperFlags, g.Spec, promotedCommands, g.PromotedEndpointNames, g.VisionSet.Store)
 
 	rootData := struct {
 		*spec.APISpec

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -829,10 +829,11 @@ func partialFailureEmissionFlags(apiSpec *spec.APISpec, promotedCommands []Promo
 	hasSupport := false
 	hasTypedErr := false
 
-	for resourceName, originalResource := range apiSpec.Resources {
+	var scan func(spec.Resource, string)
+	scan = func(originalResource spec.Resource, promotedEndpointName string) {
 		resource := withoutOptionsEndpoints(originalResource)
 		for endpointName, endpoint := range resource.Endpoints {
-			if promotedEndpointNames[resourceName] == endpointName {
+			if promotedEndpointName == endpointName {
 				continue
 			}
 			if isMutationMethod(endpoint.Method) {
@@ -841,18 +842,18 @@ func partialFailureEmissionFlags(apiSpec *spec.APISpec, promotedCommands []Promo
 			}
 		}
 		for _, originalSubResource := range resource.SubResources {
-			subResource := withoutOptionsEndpoints(originalSubResource)
-			for _, endpoint := range subResource.Endpoints {
-				if isMutationMethod(endpoint.Method) {
-					hasSupport = true
-					hasTypedErr = true
-				}
-			}
+			scan(originalSubResource, "")
 		}
+	}
+
+	for resourceName, originalResource := range apiSpec.Resources {
+		scan(originalResource, promotedEndpointNames[resourceName])
 	}
 
 	for _, command := range promotedCommands {
 		if promotedCommandCanDetectPartialFailure(command, hasStore) {
+			// command_promoted.go.tmpl detects partial failures for store
+			// write-back only; it never calls partialFailureErr.
 			hasSupport = true
 		}
 	}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -325,6 +325,7 @@ func RequireRoleWith(flags *rootFlags, cfg *config.Config, cmdName string, requi
 {{- end}}
 
 {{- if .HasMutationEndpoints}}
+{{- if .HasPartialFailureErr}}
 // partialFailureErr signals that the upstream API returned a 2xx with a
 // body shape indicating some operations in a batch failed (e.g. Google
 // Ads `partialFailureError`, similar shapes from Drive batch, Sheets
@@ -333,6 +334,7 @@ func RequireRoleWith(flags *rootFlags, cfg *config.Config, cmdName string, requi
 // accepted but some ops failed".
 func partialFailureErr(err error) error { return &cliError{code: 6, err: err} }
 
+{{- end}}
 // partialFailureReport describes the structured detection result for a
 // mutate-style response body. Emitted in the envelope under
 // "partial_failure" so machine-readable callers can route per-operation


### PR DESCRIPTION
## Summary

Dogfood no longer flags `partialFailureErr` as dead for CLIs whose only POST endpoints are promoted read-only commands. Partial-failure helpers now follow the commands that can actually call them, so read-only promoted POST surfaces avoid both the unused helper and the unused `--allow-partial-failure` flag while mutating endpoint-template commands keep the existing partial-failure path.

Fixes #3467.

## Validation

- `go test ./internal/generator -run 'TestPromotedReadOnlyPOSTDoesNotEmitPartialFailureSupport|TestPromotedCommandVerbBranching|TestGeneratedOutput_MutatingCommandsHaveEnvelope' -count=1`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`
- `git diff --check`
- `go test ./...` was also run; one unrelated `internal/pipeline` fixture test failed once and passed on immediate isolated rerun with `go test ./internal/pipeline -run TestResolveCommandPositionalsMixedStoreAndCompanionSourceIsUntagged -count=1`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
