### PR TITLE
feat(generator): surface sub-resources in MCP context taxonomy

### DIFF
--- a/internal/generator/domain_context_subresources_test.go
+++ b/internal/generator/domain_context_subresources_test.go
@@ -1,0 +1,136 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// summaryByName finds a ResourceSummary by its (possibly dotted) name.
+func summaryByName(t *testing.T, ctx DomainContext, name string) ResourceSummary {
+	t.Helper()
+	for _, rs := range ctx.Resources {
+		if rs.Name == name {
+			return rs
+		}
+	}
+	require.Failf(t, "resource summary not found", "no entry named %q in %+v", name, ctx.Resources)
+	return ResourceSummary{}
+}
+
+// TestBuildDomainContext_SubResourcesSurfacedAsOwnEntries verifies that a
+// resource carrying SubResources (including nested-within-nested) emits one
+// dotted-name taxonomy entry per sub-resource, with the sub-resource's own
+// endpoints and an honest writable flag, while top-level entries stay intact.
+func TestBuildDomainContext_SubResourcesSurfacedAsOwnEntries(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("plane")
+	apiSpec.Resources = map[string]spec.Resource{
+		// Workspace-level "issues": genuinely read-only (get/search only).
+		"issues": {
+			Description: "Search work items",
+			Endpoints: map[string]spec.Endpoint{
+				"get-workspace-work-item": {Method: "GET", Path: "/issues/{id}"},
+				"search-work-items":       {Method: "GET", Path: "/issues/search"},
+			},
+		},
+		// Top-level "projects" with full CRUD, and a project-scoped "issues"
+		// sub-resource holding the work-item CRUD, itself nesting "comments".
+		"projects": {
+			Description: "Manage projects",
+			Endpoints: map[string]spec.Endpoint{
+				"list":     {Method: "GET", Path: "/projects"},
+				"retrieve": {Method: "GET", Path: "/projects/{id}"},
+				"create":   {Method: "POST", Path: "/projects"},
+				"update":   {Method: "PATCH", Path: "/projects/{id}"},
+				"delete":   {Method: "DELETE", Path: "/projects/{id}"},
+			},
+			SubResources: map[string]spec.Resource{
+				"issues": {
+					Description: "Manage work items",
+					Endpoints: map[string]spec.Endpoint{
+						"list-work-items":   {Method: "GET", Path: "/projects/{pid}/issues"},
+						"create-work-item":  {Method: "POST", Path: "/projects/{pid}/issues"},
+						"update-work-item":  {Method: "PATCH", Path: "/projects/{pid}/issues/{id}"},
+						"delete-work-item":  {Method: "DELETE", Path: "/projects/{pid}/issues/{id}"},
+					},
+					SubResources: map[string]spec.Resource{
+						// Nested-within-nested: read-only comments.
+						"comments": {
+							Description: "List work-item comments",
+							Endpoints: map[string]spec.Endpoint{
+								"list-comments": {Method: "GET", Path: "/projects/{pid}/issues/{id}/comments"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	g := &Generator{
+		Spec: apiSpec,
+		profile: &profiler.APIProfile{
+			SyncableResources: []profiler.SyncableResource{{Name: "projects", Path: "/projects"}},
+			SearchableFields:  map[string][]string{"issues": {"name"}},
+		},
+	}
+
+	ctx := g.buildDomainContext()
+
+	// Sub-resource surfaced as its own dotted entry with its own endpoints.
+	pi := summaryByName(t, ctx, "projects.issues")
+	assert.Equal(t, []string{"create-work-item", "delete-work-item", "list-work-items", "update-work-item"}, pi.Endpoints)
+	assert.True(t, pi.Writable, "projects.issues has POST/PATCH/DELETE -> writable")
+
+	// Nested-within-nested surfaced too, read-only -> not writable.
+	pic := summaryByName(t, ctx, "projects.issues.comments")
+	assert.Equal(t, []string{"list-comments"}, pic.Endpoints)
+	assert.False(t, pic.Writable, "comments are GET-only -> not writable")
+
+	// Top-level entries unchanged: names bare, endpoints identical, and the
+	// workspace-level read-only "issues" stays honestly non-writable.
+	proj := summaryByName(t, ctx, "projects")
+	assert.Equal(t, []string{"create", "delete", "list", "retrieve", "update"}, proj.Endpoints)
+	assert.True(t, proj.Writable)
+	assert.True(t, proj.Syncable)
+
+	wi := summaryByName(t, ctx, "issues")
+	assert.Equal(t, []string{"get-workspace-work-item", "search-work-items"}, wi.Endpoints)
+	assert.False(t, wi.Writable, "workspace issues are GET-only -> not writable")
+	assert.True(t, wi.Searchable)
+
+	// syncable/searchable are omit-over-guess for sub-entries (profiler keys by
+	// bare top-level name; a dotted name is never a key).
+	assert.False(t, pi.Syncable)
+	assert.False(t, pi.Searchable)
+
+	// Separator sanity: no resource/sub-resource key in this fixture contains
+	// the '.' separator, so dotted names are unambiguous.
+	for _, rs := range ctx.Resources {
+		if rs.Name != "projects.issues" && rs.Name != "projects.issues.comments" {
+			assert.NotContains(t, rs.Name, ".", "unexpected dot in a non-qualified name %q", rs.Name)
+		}
+	}
+}
+
+// TestBuildDomainContext_NoSubResourcesIsFlat verifies a spec with no
+// sub-resources produces exactly the top-level entries, unchanged — the
+// byte-identical guarantee for sub-resource-free CLIs.
+func TestBuildDomainContext_NoSubResourcesIsFlat(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("hn") // minimalSpec has one resource "items" with a "list" GET
+	g := &Generator{Spec: apiSpec, profile: &profiler.APIProfile{}}
+
+	ctx := g.buildDomainContext()
+
+	require.Len(t, ctx.Resources, 1)
+	assert.Equal(t, "items", ctx.Resources[0].Name)
+	assert.Equal(t, []string{"list"}, ctx.Resources[0].Endpoints)
+	assert.False(t, ctx.Resources[0].Writable, "GET-only resource is not writable")
+}

--- a/internal/generator/domain_context_subresources_test.go
+++ b/internal/generator/domain_context_subresources_test.go
@@ -53,10 +53,10 @@ func TestBuildDomainContext_SubResourcesSurfacedAsOwnEntries(t *testing.T) {
 				"issues": {
 					Description: "Manage work items",
 					Endpoints: map[string]spec.Endpoint{
-						"list-work-items":   {Method: "GET", Path: "/projects/{pid}/issues"},
-						"create-work-item":  {Method: "POST", Path: "/projects/{pid}/issues"},
-						"update-work-item":  {Method: "PATCH", Path: "/projects/{pid}/issues/{id}"},
-						"delete-work-item":  {Method: "DELETE", Path: "/projects/{pid}/issues/{id}"},
+						"list-work-items":  {Method: "GET", Path: "/projects/{pid}/issues"},
+						"create-work-item": {Method: "POST", Path: "/projects/{pid}/issues"},
+						"update-work-item": {Method: "PATCH", Path: "/projects/{pid}/issues/{id}"},
+						"delete-work-item": {Method: "DELETE", Path: "/projects/{pid}/issues/{id}"},
 					},
 					SubResources: map[string]spec.Resource{
 						// Nested-within-nested: read-only comments.

--- a/internal/generator/domain_context_subresources_test.go
+++ b/internal/generator/domain_context_subresources_test.go
@@ -134,3 +134,44 @@ func TestBuildDomainContext_NoSubResourcesIsFlat(t *testing.T) {
 	assert.Equal(t, []string{"list"}, ctx.Resources[0].Endpoints)
 	assert.False(t, ctx.Resources[0].Writable, "GET-only resource is not writable")
 }
+
+// TestBuildDomainContext_ReadOnlyParentWritableChild verifies the inverse of the
+// nested-comments case that resourceHasMutation's "and vice versa" comment claims:
+// a GET-only PARENT carrying a mutating CHILD keeps the parent read-only while the
+// child is writable — writability never flows upward from a sub-resource. It also
+// exercises the PUT arm of the mutation switch, which the main fixture does not.
+func TestBuildDomainContext_ReadOnlyParentWritableChild(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("plane")
+	apiSpec.Resources = map[string]spec.Resource{
+		// Read-only parent: get/list only, no mutating endpoint of its own.
+		"catalog": {
+			Description: "Browse the catalog",
+			Endpoints: map[string]spec.Endpoint{
+				"list":     {Method: "GET", Path: "/catalog"},
+				"retrieve": {Method: "GET", Path: "/catalog/{id}"},
+			},
+			SubResources: map[string]spec.Resource{
+				// Mutating child, reached via a PUT (upsert-style).
+				"settings": {
+					Description: "Manage catalog settings",
+					Endpoints: map[string]spec.Endpoint{
+						"replace-settings": {Method: "PUT", Path: "/catalog/{id}/settings"},
+					},
+				},
+			},
+		},
+	}
+
+	g := &Generator{Spec: apiSpec, profile: &profiler.APIProfile{}}
+	ctx := g.buildDomainContext()
+
+	parent := summaryByName(t, ctx, "catalog")
+	assert.Equal(t, []string{"list", "retrieve"}, parent.Endpoints)
+	assert.False(t, parent.Writable, "GET-only parent must not inherit its child's writability")
+
+	child := summaryByName(t, ctx, "catalog.settings")
+	assert.Equal(t, []string{"replace-settings"}, child.Endpoints)
+	assert.True(t, child.Writable, "child with a PUT endpoint is writable")
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -118,6 +118,7 @@ type ResourceSummary struct {
 	Endpoints   []string `json:"endpoints"`
 	Syncable    bool     `json:"syncable,omitempty"`
 	Searchable  bool     `json:"searchable,omitempty"`
+	Writable    bool     `json:"writable,omitempty"`
 }
 
 // PlaybookEntry is a domain-specific insight for agents.
@@ -2027,6 +2028,21 @@ func safeDisplayURL(value string) string {
 	return parsed.String()
 }
 
+// resourceHasMutation reports whether the resource has any mutating endpoint
+// (POST/PUT/PATCH/DELETE) directly on itself. Each sub-resource is surfaced as
+// its own taxonomy entry and evaluated independently, so this deliberately does
+// NOT recurse into r.SubResources — a read-only parent must not inherit a
+// child's writability, and vice versa.
+func resourceHasMutation(r spec.Resource) bool {
+	for _, e := range r.Endpoints {
+		switch strings.ToUpper(e.Method) {
+		case "POST", "PUT", "PATCH", "DELETE":
+			return true
+		}
+	}
+	return false
+}
+
 // buildDomainContext constructs structured domain knowledge for MCP agents
 // from the spec and profiler output. This is front-loaded context that prevents
 // agents from wasting tokens discovering what the API is about.
@@ -2046,18 +2062,39 @@ func (g *Generator) buildDomainContext() DomainContext {
 			syncSet[sr.Name] = true
 		}
 
-		for rName, r := range g.Spec.Resources {
+		// addResourceSummaries emits one ResourceSummary for the resource named
+		// `name` (dotted path for sub-resources, e.g. "projects.issues") and
+		// then recurses into its sub-resources. syncable/searchable are looked
+		// up by the qualified name: the profiler keys those maps by bare
+		// top-level name, so a dotted name is never a key and correctly resolves
+		// to false (omit-over-guess) for sub-entries.
+		var addResourceSummaries func(name string, r spec.Resource)
+		addResourceSummaries = func(name string, r spec.Resource) {
 			rs := ResourceSummary{
-				Name:        rName,
+				Name:        name,
 				Description: naming.OneLine(r.Description),
-				Syncable:    syncSet[rName],
-				Searchable:  len(g.profile.SearchableFields[rName]) > 0,
+				Syncable:    syncSet[name],
+				Searchable:  len(g.profile.SearchableFields[name]) > 0,
+				Writable:    resourceHasMutation(r),
 			}
 			for eName := range r.Endpoints {
 				rs.Endpoints = append(rs.Endpoints, eName)
 			}
 			sort.Strings(rs.Endpoints)
 			ctx.Resources = append(ctx.Resources, rs)
+
+			subNames := make([]string, 0, len(r.SubResources))
+			for subName := range r.SubResources {
+				subNames = append(subNames, subName)
+			}
+			sort.Strings(subNames)
+			for _, subName := range subNames {
+				addResourceSummaries(name+"."+subName, r.SubResources[subName])
+			}
+		}
+
+		for rName, r := range g.Spec.Resources {
+			addResourceSummaries(rName, r)
 		}
 		sort.Slice(ctx.Resources, func(i, j int) bool {
 			return ctx.Resources[i].Name < ctx.Resources[j].Name

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -1380,6 +1380,9 @@ func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToo
 {{- if .Searchable}}
 				"searchable": true,
 {{- end}}
+{{- if .Writable}}
+				"writable": true,
+{{- end}}
 			},
 {{- end}}
 		},

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
@@ -796,6 +796,7 @@ func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToo
 				"name":        "items",
 				"description": "Manage items",
 				"endpoints":   []string{"list"},
+				"writable":    true,
 			},
 			{
 				"name":        "quotes",
@@ -803,6 +804,7 @@ func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToo
 				"endpoints":   []string{"create", "delete", "get", "list", "update", "update-status"},
 				"syncable":    true,
 				"searchable":  true,
+				"writable":    true,
 			},
 		},
 		"query_tips": []string{

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
@@ -911,6 +911,19 @@ func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToo
 				"endpoints":   []string{"create", "get", "list"},
 				"syncable":    true,
 				"searchable":  true,
+				"writable":    true,
+			},
+			{
+				"name":        "projects.avatar",
+				"description": "Manage avatar",
+				"endpoints":   []string{"upload-project"},
+				"writable":    true,
+			},
+			{
+				"name":        "projects.tasks",
+				"description": "Manage tasks",
+				"endpoints":   []string{"list-project", "update-project"},
+				"writable":    true,
 			},
 			{
 				"name":        "public",
@@ -921,6 +934,16 @@ func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToo
 				"name":        "reports",
 				"description": "Manage reports",
 				"endpoints":   []string{},
+			},
+			{
+				"name":        "reports.export",
+				"description": "Manage export",
+				"endpoints":   []string{"report-year"},
+			},
+			{
+				"name":        "reports.summary",
+				"description": "Manage summary",
+				"endpoints":   []string{"get-report-year"},
 			},
 		},
 		"query_tips": []string{

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
@@ -744,6 +744,7 @@ func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToo
 				"endpoints":   []string{"create", "find"},
 				"syncable":    true,
 				"searchable":  true,
+				"writable":    true,
 			},
 		},
 		"query_tips": []string{


### PR DESCRIPTION
## Intent

The MCP `context` tool — described as *"Get API domain context: resource taxonomy … Call this first."* — builds its `resources[]` taxonomy from each resource's **top-level** endpoints only. Any CRUD defined under a **sub-resource** is therefore invisible on the first-contact surface, so an agent reading the "call this first" taxonomy can conclude a resource is read-only when it is not.

Concretely: a project-scoped work-item resource whose create/update/delete live under `projects → issues` shows up in `context` only via workspace-level get/search entries; the mutating operations never appear. This is already observable in-repo — the `generate-golden-api` fixture's sub-only `reports` resource renders `"endpoints": []`.

Issue: N/A (self-reported)

## Approach

`buildDomainContext` walked only `r.Endpoints`. It now recurses over `r.SubResources`, emitting **one `ResourceSummary` per sub-resource** named by its path-qualified key (e.g. `projects.issues`), carrying that sub-resource's own endpoints. Sub-resources are surfaced under their honest structural path — no semantic remapping onto tag-derived namesakes, no command-tree change, no un-hiding.

Each entry also gains a coarse, honest `writable` flag: true iff the entry has an endpoint whose method is POST/PUT/PATCH/DELETE, computed from that entry's **own** endpoints only (never recursed). `syncable`/`searchable` are looked up by the qualified name, which is not a profiler map key, so sub-entries omit rather than guess those flags.

## Scope

Primary area: `internal/generator` (engine introspection) + the MCP tools template.

Why this belongs in this repo: it is a generic engine behavior — every generated CLI with sub-resources gets a complete, name-scannable `context` taxonomy. No per-API or Plane-specific policy is added; it is picked up by a plain regen.

## Risk

Strictly additive. Top-level entries keep their bare names and identical endpoint lists — existing lines are untouched (top-level resources that have a mutating endpoint do gain an additive `"writable": true` line, which is the only change to a pre-existing entry). CLIs with **no** sub-resources are byte-identical. The `writable` flag is `omitempty`, so read-only entries emit nothing new. No change to the cobra command tree, path parser, auth, or publish flow.

## Output Contract

Template + regenerated goldens.

- Template: one conditional (`{{- if .Writable}} "writable": true, {{- end}}`) in the `context` `resources` block, matching the adjacent `syncable`/`searchable` conditionals.
- Golden evidence: `scripts/golden.sh` updated three sub-resource-bearing fixtures (`generate-golden-api`, `generate-fastapi-operationids`, `generate-public-param-names`) — diff is `+`-only. `generate-golden-api` now surfaces `reports.export` / `reports.summary` (previously the sub-only `reports` rendered `"endpoints": []`) and `projects.*` sub-entries with `writable`.
- Emitted-code assertion: new unit tests in `internal/generator/domain_context_subresources_test.go` assert the dotted sub-entry, its endpoints, the per-entry `writable` (including a read-only-parent/writable-child case and a nested-within-nested case), omit-over-guess for `syncable`/`searchable`, and byte-identity for a sub-resource-free spec.

## Verification

- [x] Generator/template change: verified generated output — `GOTOOLCHAIN=go1.26.4 go test ./internal/generator/ -run TestBuildDomainContext` green (3/3); `scripts/golden.sh verify` green for the three affected `tools.go` goldens.
- [x] Generator/template change: covered the affected fallback/variant shapes — GET-only sub-resource (no `writable`), read-only parent + writable child, nested-within-nested, and a no-sub-resource byte-identity case.
- [x] Generator/template change: checked emitted definitions and call sites — `resourceHasMutation` and the qualified-name `syncable`/`searchable` lookup verified against the template's `.DomainContext.Resources` render.
- Additionally generated the real Plane OpenAPI spec end-to-end: the produced `internal/mcp/tools.go` now lists `projects.issues` with the full work-item CRUD (`create-work-item`, `list-work-items`, `update-work-item`, `create-work-item-comment`, …) and `"writable": true`, while the workspace-level `issues`/`work-items` entries stay read/search-only.

## AI / Automation Disclosure

- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it line-by-line before submission
