### PR TITLE
fix(cli): defang full-shape example credentials in secret-scrubbing reference

### DIFF
--- a/skills/printing-press-retro/references/secret-scrubbing.md
+++ b/skills/printing-press-retro/references/secret-scrubbing.md
@@ -197,9 +197,9 @@ Examples:
 
 | Original (anti-pattern) | Redacted (correct) |
 |---|---|
-| `lin_api_a1b2c3d4e5f6789abcdef0123456789abcdef0123456` | `<REDACTED:linear-api-key:lin_a...0456:48ch>` |
-| `22eb323ac258d2e04c3bf9ade77b9c78-us6` | `<REDACTED:mailchimp-api-key:22eb...-us6:36ch>` |
-| `ghp_abc123def456ghi789jkl012mno345pqr678stu90` | `<REDACTED:github-pat:ghp_a...tu90:40ch>` |
+| `lin_api_a1b2c3d4e5f6...bcdef0123456` | `<REDACTED:linear-api-key:lin_a...0456:48ch>` |
+| `22eb323ac258...ade77b9c78-us6` | `<REDACTED:mailchimp-api-key:22eb...-us6:36ch>` |
+| `ghp_abc123def456...pqr678stu90` | `<REDACTED:github-pat:ghp_a...tu90:40ch>` |
 | `sk_live_51AbCdEf123456...XyZ` | `<REDACTED:stripe-live-key:sk_li...XyZ:N-ch>` |
 
 The first4 + last4 + length fragment preserves enough shape information for a


### PR DESCRIPTION
## Problem

The redaction-examples table in `skills/printing-press-retro/references/secret-scrubbing.md` uses complete, realistic token shapes as its "Original (anti-pattern)" column: a 40-char GitHub PAT, a 48-char Linear API key, and a Mailchimp key. They're fake, but regex-based secret scanners can't know that — the PAT matches the standard `ghp_[A-Za-z0-9]{36,}` pattern and the Mailchimp shape matches stock gitleaks rules.

Hit in the field (2026-07-07): a user's `~/.claude` auto-backup pipeline runs a pre-commit secret scan over installed skill files; the PAT row hard-blocked every backup commit until the file was hand-edited locally. Any consumer with a similar scan (gitleaks, trufflehog, GitHub push protection on a mirror) will hit the same wall, and a skill update silently re-breaks any local fix.

## Fix

Truncate the three example tokens with `...` — exactly the style the same table already uses for its Stripe row (`sk_live_51AbCdEf123456...XyZ`). The vendor prefix and shape stay teachable; the scanner patterns no longer match. The "Redacted (correct)" column is untouched. 3 lines changed, docs only.

https://claude.ai/code/session_011gB5B77NMtJbmpL1ZQqqGt