### PR TITLE
fix(generator): mark generated security suppressions

### DIFF
--- a/internal/generator/security_suppressions_test.go
+++ b/internal/generator/security_suppressions_test.go
@@ -1,0 +1,76 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedInfraSecuritySuppressionsAreExplicit(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("security")
+	apiSpec.Resources["items"] = spec.Resource{
+		Description: "Manage items",
+		Endpoints: map[string]spec.Endpoint{
+			"list": {
+				Method:     "GET",
+				Path:       "/account/keys",
+				Response:   spec.ResponseDef{Type: "array", Item: "Item"},
+				Pagination: &spec.Pagination{CursorParam: "cursor", LimitParam: "limit"},
+			},
+			"create": {
+				Method:   "POST",
+				Path:     "/account/keys",
+				Response: spec.ResponseDef{Type: "object"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	credentialsGo := readGenerated(t, outputDir, "internal", "cliutil", "credentials.go")
+	assert.Contains(t, credentialsGo, `os.ReadFile(filepath.Clean(path)) // #nosec G304 -- app-owned credentials path from cliutil.DataDir.`)
+	assert.Contains(t, credentialsGo, `toml.Marshal(creds) // #nosec G117 -- credentials are intentionally persisted to a 0600 private file.`)
+
+	pathsGo := readGenerated(t, outputDir, "internal", "cliutil", "paths.go")
+	assert.Contains(t, pathsGo, `os.ReadFile(filepath.Clean(primary)) // #nosec G304 -- app-derived config/data path.`)
+	assert.Contains(t, pathsGo, `os.ReadFile(filepath.Clean(legacy)) // #nosec G304 -- app-derived legacy config/data path.`)
+	assert.Contains(t, pathsGo, `_ = tmp.Close()`)
+
+	clientGo := readGenerated(t, outputDir, "internal", "client", "client.go")
+	assert.Contains(t, clientGo, `os.ReadFile(filepath.Clean(cacheFile)) // #nosec G304 -- app-derived cache path from sha256 cache key.`)
+	assert.Contains(t, clientGo, `_ = os.MkdirAll(c.cacheDir, 0o700)`)
+	assert.Contains(t, clientGo, `_ = os.WriteFile(cacheFile, []byte(data), 0o600)`)
+	assert.Contains(t, clientGo, `_ = resp.Body.Close()`)
+
+	cacheGo := readGenerated(t, outputDir, "internal", "cache", "cache.go")
+	assert.Contains(t, cacheGo, `os.ReadFile(filepath.Clean(path)) // #nosec G304 -- app-derived cache path from sha256 cache key.`)
+
+	shelloutGo := readGenerated(t, outputDir, "internal", "mcp", "cobratree", "shellout.go")
+	assert.Contains(t, shelloutGo, `exec.CommandContext(ctx, binPath, args...) // #nosec G204 -- trusted companion CLI path, args pre-tokenized.`)
+
+	syncGo := readGenerated(t, outputDir, "internal", "cli", "sync.go")
+	assert.Contains(t, syncGo, `paths := map[string]string{ // #nosec G101 -- endpoint paths, not credentials.`)
+
+	importGo := readGenerated(t, outputDir, "internal", "cli", "import.go")
+	assert.Contains(t, importGo, `os.Open(filepath.Clean(inputFile)) // #nosec G304 -- user-specified input file is this flag's documented purpose.`)
+
+	storeGo := readGenerated(t, outputDir, "internal", "store", "store.go")
+	assert.Contains(t, storeGo, `_ = db.Close()`)
+	assert.Contains(t, storeGo, `_ = rows.Close()`)
+}
+
+func readGenerated(t *testing.T, outputDir string, path ...string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(append([]string{outputDir}, path...)...))
+	require.NoError(t, err)
+	return string(data)
+}

--- a/internal/generator/templates/cache.go.tmpl
+++ b/internal/generator/templates/cache.go.tmpl
@@ -35,7 +35,7 @@ func (s *Store) Get(key string) (json.RawMessage, bool) {
 	if err != nil || time.Since(info.ModTime()) > s.TTL {
 		return nil, false
 	}
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 -- app-derived cache path from sha256 cache key.
 	if err != nil {
 		return nil, false
 	}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -779,7 +779,7 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 	if err != nil || time.Since(info.ModTime()) > 5*time.Minute {
 		return nil, {{if .HasHTMLExtraction}}"", {{end}}false
 	}
-	data, err := os.ReadFile(cacheFile)
+	data, err := os.ReadFile(filepath.Clean(cacheFile)) // #nosec G304 -- app-derived cache path from sha256 cache key.
 	if err != nil {
 		return nil, {{if .HasHTMLExtraction}}"", {{end}}false
 	}
@@ -792,9 +792,9 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) writeCache(path string, params map[string]string, data json.RawMessage{{if .HasHTMLExtraction}}, contentType string{{end}}) {
-	os.MkdirAll(c.cacheDir, 0o700)
+	_ = os.MkdirAll(c.cacheDir, 0o700)
 	cacheFile := filepath.Join(c.cacheDir, c.cacheKey(path, params)+".json")
-	os.WriteFile(cacheFile, []byte(data), 0o600)
+	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 {{- if .HasHTMLExtraction}}
 	c.writeCacheContentType(cacheFile, contentType)
 {{- end}}
@@ -807,7 +807,7 @@ type cacheMetadata struct {
 }
 
 func (c *Client) readCacheContentType(cacheFile string) string {
-	data, err := os.ReadFile(cacheFile + ".meta.json")
+	data, err := os.ReadFile(filepath.Clean(cacheFile + ".meta.json")) // #nosec G304 -- app-derived cache metadata path.
 	if err != nil {
 		return ""
 	}
@@ -1547,7 +1547,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		}
 
 		respBody, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if err != nil {
 			return nil, 0, fmt.Errorf("reading response: %w", err)
 		}
@@ -1845,12 +1845,12 @@ func (c *Client) persistedQueryHashes() map[string]string {
 	if path == "" {
 		return nil
 	}
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 -- app-owned persisted-query registry path.
 	if err != nil {
 		if c != nil && c.Config != nil && c.Config.Path != "" {
 			legacyPath := filepath.Join(filepath.Dir(c.Config.Path), "persisted-queries.json")
 			if legacyPath != path {
-				data, err = os.ReadFile(legacyPath)
+					data, err = os.ReadFile(filepath.Clean(legacyPath)) // #nosec G304 -- app-owned legacy persisted-query registry path.
 			}
 		}
 		if err != nil {

--- a/internal/generator/templates/cliutil_credentials.go.tmpl
+++ b/internal/generator/templates/cliutil_credentials.go.tmpl
@@ -53,7 +53,7 @@ func LoadCredentials() (*Credentials, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 -- app-owned credentials path from cliutil.DataDir.
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, false, nil
@@ -105,7 +105,7 @@ func SaveCredentials(creds *Credentials) error {
 	if err != nil {
 		return err
 	}
-	data, err := toml.Marshal(creds)
+	data, err := toml.Marshal(creds) // #nosec G117 -- credentials are intentionally persisted to a 0600 private file.
 	if err != nil {
 		return fmt.Errorf("marshaling credentials: %w", err)
 	}

--- a/internal/generator/templates/cliutil_paths.go.tmpl
+++ b/internal/generator/templates/cliutil_paths.go.tmpl
@@ -108,14 +108,14 @@ func CacheDir() (string, error) {
 }
 
 func ReadFileWithLegacyFallback(primary, legacy string) ([]byte, string, error) {
-	data, err := os.ReadFile(primary)
+	data, err := os.ReadFile(filepath.Clean(primary)) // #nosec G304 -- app-derived config/data path.
 	if err == nil {
 		return data, primary, nil
 	}
 	if !errors.Is(err, os.ErrNotExist) || legacy == "" || legacy == primary {
 		return nil, primary, err
 	}
-	data, legacyErr := os.ReadFile(legacy)
+	data, legacyErr := os.ReadFile(filepath.Clean(legacy)) // #nosec G304 -- app-derived legacy config/data path.
 	if legacyErr != nil {
 		return nil, legacy, legacyErr
 	}
@@ -133,12 +133,12 @@ func AtomicWritePrivateFile(path string, data []byte, fileMode, dirMode os.FileM
 	}
 	tmpPath := tmp.Name()
 	if err := tmp.Chmod(fileMode); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("securing temporary private file: %w", err)
 	}
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("writing temporary private file: %w", err)
 	}

--- a/internal/generator/templates/cobratree/shellout.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout.go.tmpl
@@ -259,7 +259,7 @@ func SplitShellArgs(s string) []string {
 // machine-readable channel. Stderr is included only in error text so post-run
 // telemetry or quota output cannot corrupt JSON results.
 func RunCLICommand(ctx context.Context, binPath string, args []string) (string, error) {
-	cmd := exec.CommandContext(ctx, binPath, args...)
+	cmd := exec.CommandContext(ctx, binPath, args...) // #nosec G204 -- trusted companion CLI path, args pre-tokenized.
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/generator/templates/import.go.tmpl
+++ b/internal/generator/templates/import.go.tmpl
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -48,7 +49,7 @@ but do not stop the import.`,
 			if inputFile == "-" || inputFile == "" {
 				reader = os.Stdin
 			} else {
-				f, err := os.Open(inputFile)
+				f, err := os.Open(filepath.Clean(inputFile)) // #nosec G304 -- user-specified input file is this flag's documented purpose.
 				if err != nil {
 					return fmt.Errorf("opening input file: %w", err)
 				}

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -162,7 +162,7 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 
 	s := &Store{db: db, path: dbPath}
 	if err := s.migrate(ctx); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("running migrations: %w", err)
 	}
 
@@ -770,13 +770,13 @@ func rebuildResourcesFTS(ctx context.Context, conn *sql.Conn) error {
 	for rows.Next() {
 		var r resourceRow
 		if err := rows.Scan(&r.id, &r.resourceType, &r.data); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return fmt.Errorf("scanning resource: %w", err)
 		}
 		resources = append(resources, r)
 	}
 	if err := rows.Err(); err != nil {
-		rows.Close()
+		_ = rows.Close()
 		return fmt.Errorf("reading resource rows: %w", err)
 	}
 	if err := rows.Close(); err != nil {
@@ -2247,7 +2247,7 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	for rows.Next() {
 		var id string
 		if err := rows.Scan(&id); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return 0, err
 		}
 		if _, ok := seen[BareResourceID(id)]; ok {
@@ -2255,7 +2255,7 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 		}
 		victims = append(victims, id)
 	}
-	rows.Close()
+	_ = rows.Close()
 	if err := rows.Err(); err != nil {
 		return 0, err
 	}
@@ -2332,10 +2332,10 @@ func (s *Store) ResolveByName(resourceType string, input string, matchFields ...
 			}
 		}
 		if err := rows.Err(); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return "", err
 		}
-		rows.Close()
+		_ = rows.Close()
 	}
 
 	switch len(matches) {

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -2491,7 +2491,7 @@ func describeResourceFailure(count int, label string, resources []string) string
 // For REST APIs this is typically "/<resource>". For non-REST APIs (e.g., Steam)
 // this preserves the actual endpoint path like "/ISteamApps/GetAppList/v2".
 func syncResourcePath(resource string) (string, error) {
-	paths := map[string]string{
+	paths := map[string]string{ // #nosec G101 -- endpoint paths, not credentials.
 {{- range .SyncableResources}}
 		"{{.Name}}": "{{.Path}}",
 {{- end}}

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -296,7 +296,7 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 	if err != nil || time.Since(info.ModTime()) > 5*time.Minute {
 		return nil, false
 	}
-	data, err := os.ReadFile(cacheFile)
+	data, err := os.ReadFile(filepath.Clean(cacheFile)) // #nosec G304 -- app-derived cache path from sha256 cache key.
 	if err != nil {
 		return nil, false
 	}
@@ -304,9 +304,9 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) writeCache(path string, params map[string]string, data json.RawMessage) {
-	os.MkdirAll(c.cacheDir, 0o700)
+	_ = os.MkdirAll(c.cacheDir, 0o700)
 	cacheFile := filepath.Join(c.cacheDir, c.cacheKey(path, params)+".json")
-	os.WriteFile(cacheFile, []byte(data), 0o600)
+	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 }
 
 // invalidateCache wholesale-removes the cache directory so the next read
@@ -618,7 +618,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		}
 
 		respBody, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if err != nil {
 			return nil, 0, fmt.Errorf("reading response: %w", err)
 		}

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -299,7 +299,7 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 	if err != nil || time.Since(info.ModTime()) > 5*time.Minute {
 		return nil, false
 	}
-	data, err := os.ReadFile(cacheFile)
+	data, err := os.ReadFile(filepath.Clean(cacheFile)) // #nosec G304 -- app-derived cache path from sha256 cache key.
 	if err != nil {
 		return nil, false
 	}
@@ -307,9 +307,9 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) writeCache(path string, params map[string]string, data json.RawMessage) {
-	os.MkdirAll(c.cacheDir, 0o700)
+	_ = os.MkdirAll(c.cacheDir, 0o700)
 	cacheFile := filepath.Join(c.cacheDir, c.cacheKey(path, params)+".json")
-	os.WriteFile(cacheFile, []byte(data), 0o600)
+	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 }
 
 // invalidateCache wholesale-removes the cache directory so the next read
@@ -606,7 +606,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		}
 
 		respBody, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if err != nil {
 			return nil, 0, fmt.Errorf("reading response: %w", err)
 		}

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -309,7 +309,7 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 	if err != nil || time.Since(info.ModTime()) > 5*time.Minute {
 		return nil, false
 	}
-	data, err := os.ReadFile(cacheFile)
+	data, err := os.ReadFile(filepath.Clean(cacheFile)) // #nosec G304 -- app-derived cache path from sha256 cache key.
 	if err != nil {
 		return nil, false
 	}
@@ -317,9 +317,9 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) writeCache(path string, params map[string]string, data json.RawMessage) {
-	os.MkdirAll(c.cacheDir, 0o700)
+	_ = os.MkdirAll(c.cacheDir, 0o700)
 	cacheFile := filepath.Join(c.cacheDir, c.cacheKey(path, params)+".json")
-	os.WriteFile(cacheFile, []byte(data), 0o600)
+	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 }
 
 // invalidateCache wholesale-removes the cache directory so the next read
@@ -616,7 +616,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		}
 
 		respBody, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if err != nil {
 			return nil, 0, fmt.Errorf("reading response: %w", err)
 		}

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -299,7 +299,7 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 	if err != nil || time.Since(info.ModTime()) > 5*time.Minute {
 		return nil, false
 	}
-	data, err := os.ReadFile(cacheFile)
+	data, err := os.ReadFile(filepath.Clean(cacheFile)) // #nosec G304 -- app-derived cache path from sha256 cache key.
 	if err != nil {
 		return nil, false
 	}
@@ -307,9 +307,9 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) writeCache(path string, params map[string]string, data json.RawMessage) {
-	os.MkdirAll(c.cacheDir, 0o700)
+	_ = os.MkdirAll(c.cacheDir, 0o700)
 	cacheFile := filepath.Join(c.cacheDir, c.cacheKey(path, params)+".json")
-	os.WriteFile(cacheFile, []byte(data), 0o600)
+	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 }
 
 // invalidateCache wholesale-removes the cache directory so the next read
@@ -606,7 +606,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		}
 
 		respBody, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if err != nil {
 			return nil, 0, fmt.Errorf("reading response: %w", err)
 		}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/import.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/import.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -48,7 +49,7 @@ but do not stop the import.`,
 			if inputFile == "-" || inputFile == "" {
 				reader = os.Stdin
 			} else {
-				f, err := os.Open(inputFile)
+				f, err := os.Open(filepath.Clean(inputFile)) // #nosec G304 -- user-specified input file is this flag's documented purpose.
 				if err != nil {
 					return fmt.Errorf("opening input file: %w", err)
 				}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -1696,7 +1696,7 @@ func describeResourceFailure(count int, label string, resources []string) string
 // For REST APIs this is typically "/<resource>". For non-REST APIs (e.g., Steam)
 // this preserves the actual endpoint path like "/ISteamApps/GetAppList/v2".
 func syncResourcePath(resource string) (string, error) {
-	paths := map[string]string{
+	paths := map[string]string{ // #nosec G101 -- endpoint paths, not credentials.
 		"currencies": "/currencies",
 		"projects":   "/projects",
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -300,7 +300,7 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 	if err != nil || time.Since(info.ModTime()) > 5*time.Minute {
 		return nil, false
 	}
-	data, err := os.ReadFile(cacheFile)
+	data, err := os.ReadFile(filepath.Clean(cacheFile)) // #nosec G304 -- app-derived cache path from sha256 cache key.
 	if err != nil {
 		return nil, false
 	}
@@ -308,9 +308,9 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) writeCache(path string, params map[string]string, data json.RawMessage) {
-	os.MkdirAll(c.cacheDir, 0o700)
+	_ = os.MkdirAll(c.cacheDir, 0o700)
 	cacheFile := filepath.Join(c.cacheDir, c.cacheKey(path, params)+".json")
-	os.WriteFile(cacheFile, []byte(data), 0o600)
+	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 }
 
 // invalidateCache wholesale-removes the cache directory so the next read
@@ -705,7 +705,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		}
 
 		respBody, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if err != nil {
 			return nil, 0, fmt.Errorf("reading response: %w", err)
 		}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
@@ -259,7 +259,7 @@ func SplitShellArgs(s string) []string {
 // machine-readable channel. Stderr is included only in error text so post-run
 // telemetry or quota output cannot corrupt JSON results.
 func RunCLICommand(ctx context.Context, binPath string, args []string) (string, error) {
-	cmd := exec.CommandContext(ctx, binPath, args...)
+	cmd := exec.CommandContext(ctx, binPath, args...) // #nosec G204 -- trusted companion CLI path, args pre-tokenized.
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -161,7 +161,7 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 
 	s := &Store{db: db, path: dbPath}
 	if err := s.migrate(ctx); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("running migrations: %w", err)
 	}
 
@@ -698,13 +698,13 @@ func rebuildResourcesFTS(ctx context.Context, conn *sql.Conn) error {
 	for rows.Next() {
 		var r resourceRow
 		if err := rows.Scan(&r.id, &r.resourceType, &r.data); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return fmt.Errorf("scanning resource: %w", err)
 		}
 		resources = append(resources, r)
 	}
 	if err := rows.Err(); err != nil {
-		rows.Close()
+		_ = rows.Close()
 		return fmt.Errorf("reading resource rows: %w", err)
 	}
 	if err := rows.Close(); err != nil {
@@ -2030,7 +2030,7 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	for rows.Next() {
 		var id string
 		if err := rows.Scan(&id); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return 0, err
 		}
 		if _, ok := seen[BareResourceID(id)]; ok {
@@ -2038,7 +2038,7 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 		}
 		victims = append(victims, id)
 	}
-	rows.Close()
+	_ = rows.Close()
 	if err := rows.Err(); err != nil {
 		return 0, err
 	}
@@ -2115,10 +2115,10 @@ func (s *Store) ResolveByName(resourceType string, input string, matchFields ...
 			}
 		}
 		if err := rows.Err(); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return "", err
 		}
-		rows.Close()
+		_ = rows.Close()
 	}
 
 	switch len(matches) {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -1690,7 +1690,7 @@ func describeResourceFailure(count int, label string, resources []string) string
 // For REST APIs this is typically "/<resource>". For non-REST APIs (e.g., Steam)
 // this preserves the actual endpoint path like "/ISteamApps/GetAppList/v2".
 func syncResourcePath(resource string) (string, error) {
-	paths := map[string]string{
+	paths := map[string]string{ // #nosec G101 -- endpoint paths, not credentials.
 		"gadgets": "/query",
 		"widgets": "/query",
 	}

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -158,7 +158,7 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 
 	s := &Store{db: db, path: dbPath}
 	if err := s.migrate(ctx); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("running migrations: %w", err)
 	}
 
@@ -592,13 +592,13 @@ func rebuildResourcesFTS(ctx context.Context, conn *sql.Conn) error {
 	for rows.Next() {
 		var r resourceRow
 		if err := rows.Scan(&r.id, &r.resourceType, &r.data); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return fmt.Errorf("scanning resource: %w", err)
 		}
 		resources = append(resources, r)
 	}
 	if err := rows.Err(); err != nil {
-		rows.Close()
+		_ = rows.Close()
 		return fmt.Errorf("reading resource rows: %w", err)
 	}
 	if err := rows.Close(); err != nil {
@@ -1972,7 +1972,7 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	for rows.Next() {
 		var id string
 		if err := rows.Scan(&id); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return 0, err
 		}
 		if _, ok := seen[BareResourceID(id)]; ok {
@@ -1980,7 +1980,7 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 		}
 		victims = append(victims, id)
 	}
-	rows.Close()
+	_ = rows.Close()
 	if err := rows.Err(); err != nil {
 		return 0, err
 	}
@@ -2057,10 +2057,10 @@ func (s *Store) ResolveByName(resourceType string, input string, matchFields ...
 			}
 		}
 		if err := rows.Err(); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return "", err
 		}
-		rows.Close()
+		_ = rows.Close()
 	}
 
 	switch len(matches) {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -1668,7 +1668,7 @@ func describeResourceFailure(count int, label string, resources []string) string
 // For REST APIs this is typically "/<resource>". For non-REST APIs (e.g., Steam)
 // this preserves the actual endpoint path like "/ISteamApps/GetAppList/v2".
 func syncResourcePath(resource string) (string, error) {
-	paths := map[string]string{
+	paths := map[string]string{ // #nosec G101 -- endpoint paths, not credentials.
 		"games": "/games",
 	}
 	if p, ok := paths[resource]; ok {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -158,7 +158,7 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 
 	s := &Store{db: db, path: dbPath}
 	if err := s.migrate(ctx); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("running migrations: %w", err)
 	}
 
@@ -586,13 +586,13 @@ func rebuildResourcesFTS(ctx context.Context, conn *sql.Conn) error {
 	for rows.Next() {
 		var r resourceRow
 		if err := rows.Scan(&r.id, &r.resourceType, &r.data); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return fmt.Errorf("scanning resource: %w", err)
 		}
 		resources = append(resources, r)
 	}
 	if err := rows.Err(); err != nil {
-		rows.Close()
+		_ = rows.Close()
 		return fmt.Errorf("reading resource rows: %w", err)
 	}
 	if err := rows.Close(); err != nil {
@@ -1918,7 +1918,7 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	for rows.Next() {
 		var id string
 		if err := rows.Scan(&id); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return 0, err
 		}
 		if _, ok := seen[BareResourceID(id)]; ok {
@@ -1926,7 +1926,7 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 		}
 		victims = append(victims, id)
 	}
-	rows.Close()
+	_ = rows.Close()
 	if err := rows.Err(); err != nil {
 		return 0, err
 	}
@@ -2003,10 +2003,10 @@ func (s *Store) ResolveByName(resourceType string, input string, matchFields ...
 			}
 		}
 		if err := rows.Err(); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return "", err
 		}
-		rows.Close()
+		_ = rows.Close()
 	}
 
 	switch len(matches) {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -1634,7 +1634,7 @@ func describeResourceFailure(count int, label string, resources []string) string
 // For REST APIs this is typically "/<resource>". For non-REST APIs (e.g., Steam)
 // this preserves the actual endpoint path like "/ISteamApps/GetAppList/v2".
 func syncResourcePath(resource string) (string, error) {
-	paths := map[string]string{
+	paths := map[string]string{ // #nosec G101 -- endpoint paths, not credentials.
 		"items": "/items",
 	}
 	if p, ok := paths[resource]; ok {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -400,7 +400,7 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 	if err != nil || time.Since(info.ModTime()) > 5*time.Minute {
 		return nil, false
 	}
-	data, err := os.ReadFile(cacheFile)
+	data, err := os.ReadFile(filepath.Clean(cacheFile)) // #nosec G304 -- app-derived cache path from sha256 cache key.
 	if err != nil {
 		return nil, false
 	}
@@ -408,9 +408,9 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) writeCache(path string, params map[string]string, data json.RawMessage) {
-	os.MkdirAll(c.cacheDir, 0o700)
+	_ = os.MkdirAll(c.cacheDir, 0o700)
 	cacheFile := filepath.Join(c.cacheDir, c.cacheKey(path, params)+".json")
-	os.WriteFile(cacheFile, []byte(data), 0o600)
+	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 }
 
 // invalidateCache wholesale-removes the cache directory so the next read
@@ -714,7 +714,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		}
 
 		respBody, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if err != nil {
 			return nil, 0, fmt.Errorf("reading response: %w", err)
 		}


### PR DESCRIPTION
## Summary
- emit narrow `#nosec` annotations for generated infra false positives in cache, cliutil credentials/paths, sync endpoint-path maps, import input files, and cobratree shellout
- make intentional best-effort cleanup and cache error discards explicit with `_ =` in generated client, cliutil, and store templates
- add generated-output regression coverage and update checked-in golden fixtures

Refs #2624
Refs #2625

## Testing
- `git diff --check`
- `PATH=/tmp/go/bin:$PATH GOLDEN_ALLOW_DIRTY=1 scripts/golden.sh update`
- GitHub Actions passed on prior commit before the golden update: `go-lint`, `generated-test`, `generated-output-compile`, full test shards
- Latest commit `6a30155e` is rerunning checks after resolving the Greptile thread and updating goldens
