### PR TITLE
fix(skills): raise supported version floor

### DIFF
--- a/supported-versions.txt
+++ b/supported-versions.txt
@@ -10,5 +10,5 @@
 # latest published release, so a typo above the newest version cannot brick
 # every install. Below the skill's frozen `min-binary-version` (the hard
 # compatibility floor) it has no effect — that floor always wins.
-min_supported=4.19.1
+min_supported=4.27.1
 reason=Releases below this version generate CLIs with since-fixed bugs; upgrade to regenerate cleanly.


### PR DESCRIPTION
## Summary

Generation preflight now hard-blocks binaries older than 4.27.1, the current release with the post-4.19 generator, auth, dogfood, and scorer fixes. Users below that floor will be routed through the existing upgrade-required path before generating or amending printed CLIs.

## Validation

- `rtk go test ./internal/pipeline -run TestSkillsEnforceCurrencyFloor`
- `rtk go test ./internal/generator`
- `rtk go test ./...` (first full run hit a transient `internal/generator` failure; targeted rerun and full rerun passed)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
