### PR TITLE
fix(cli): bump Go toolchain floor to 1.26.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You need both the **binary** and the **Printing Press skills**. The skills (`/pr
 
 The binary alone works (research, generation, verification, scoring) but skips the curated agent loop. The skills alone have nothing to call. Install both.
 
-**Prerequisites:** [Go 1.26.4 or newer](https://go.dev/dl/), [Claude Code](https://claude.ai/code) or another `skills`-supported agent, and Node/npm for `npx`. The skills are tested with Claude Code; install for Codex with `--agent codex` when you want to try the same slash-command workflow there. **Use Claude Code for the best-tested experience.**
+**Prerequisites:** [Go 1.26.5 or newer](https://go.dev/dl/), [Claude Code](https://claude.ai/code) or another `skills`-supported agent, and Node/npm for `npx`. The skills are tested with Claude Code; install for Codex with `--agent codex` when you want to try the same slash-command workflow there. **Use Claude Code for the best-tested experience.**
 
 ### 1. Install
 
@@ -54,7 +54,7 @@ npx -y skills@latest list -g -a codex --json
 
 See [docs/CODEX.md](docs/CODEX.md) for the Codex-specific notes.
 
-Verify with `cli-printing-press --version`. If install fails, confirm Go 1.26.4 or newer is installed, Node/npm is installed for `npx`, and `$GOPATH/bin` is on your `PATH`.
+Verify with `cli-printing-press --version`. If install fails, confirm Go 1.26.5 or newer is installed, Node/npm is installed for `npx`, and `$GOPATH/bin` is on your `PATH`.
 
 Older releases installed a generator binary named `printing-press`. That legacy
 entrypoint still works for compatibility, but the canonical generator command is
@@ -529,7 +529,7 @@ Each newly published CLI ships a root `AGENTS.md` operating guide, a research ma
 ## Limitations
 
 - **Technical capability is not legal permission.** Before generating a CLI for any service, review its Terms of Service. Many services explicitly prohibit automated access. Using this tool against such services may violate their terms or applicable law. You are responsible for ensuring your use is authorized.
-- **Requires Go 1.26.4 or newer and an agent that can load open-agent-skills.** Claude Code is the tested path; Codex installation is documented but may lag Claude Code behavior. No standalone distribution today; the slash command is the supported entry point for Claude Code.
+- **Requires Go 1.26.5 or newer and an agent that can load open-agent-skills.** Claude Code is the tested path; Codex installation is documented but may lag Claude Code behavior. No standalone distribution today; the slash command is the supported entry point for Claude Code.
 - **Generated CLIs are domain-shaped, not vendor-replacements.** A `<api>-pp-cli` covers the agent power-user surface, not every back-office knob a vendor's official CLI ships.
 - **Browser-sniff requires manual capture.** You point a browser at the site (or import a HAR); the press doesn't crawl autonomously.
 - **Live verify is read-only.** Phase 5 runs GET only and never mutates. Real write-path coverage lives in unit tests and the dogfood structural checks.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mvanhorn/cli-printing-press/v4
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/chromedp/chromedp v0.15.1

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -263,7 +263,7 @@ resources:
 
 	const modulePath = "github.com/mvanhorn/printing-press-library/library/sales-and-crm/tenderned"
 	require.NoError(t, os.MkdirAll(outputDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "go.mod"), []byte("module "+modulePath+"\n\ngo 1.26.4\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "go.mod"), []byte("module "+modulePath+"\n\ngo 1.26.5\n"), 0o644))
 
 	cmd := newGenerateCmd()
 	cmd.SetArgs([]string{

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -679,7 +679,7 @@ func TestRunGoVulnCheckUsesPinnedDefaultCommandWithModuleToolchain(t *testing.T)
 		t.Skip("fake shell go binary is Unix-only")
 	}
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.26.4\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.26.5\n"), 0o644))
 
 	fakeBin := t.TempDir()
 	callsPath := filepath.Join(t.TempDir(), "go-calls.txt")
@@ -701,7 +701,7 @@ exit 42
 
 	calls, err := os.ReadFile(callsPath)
 	require.NoError(t, err)
-	assert.Equal(t, "args=run "+govulncheck.ToolModule+" ./...\ntoolchain=go1.26.4\n", string(calls))
+	assert.Equal(t, "args=run "+govulncheck.ToolModule+" ./...\ntoolchain=go1.26.5\n", string(calls))
 	assert.NotContains(t, string(calls), "-show")
 	assert.NotContains(t, string(calls), "verbose")
 }

--- a/internal/cli/verify_skill_test.go
+++ b/internal/cli/verify_skill_test.go
@@ -815,7 +815,7 @@ func Execute() error { return (&cobra.Command{Use: "`+name+`-pp-cli"}).Execute()
 `), 0o644))
 
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
-		[]byte("module github.com/example/"+name+"-pp-cli\n\ngo 1.26.4\n"), 0o644))
+		[]byte("module github.com/example/"+name+"-pp-cli\n\ngo 1.26.5\n"), 0o644))
 
 	manifest := fmt.Sprintf(`{"api_name":%q,"cli_name":%q,"category":%q}`,
 		name, name+"-pp-cli", category)

--- a/internal/generator/go_version_test.go
+++ b/internal/generator/go_version_test.go
@@ -17,10 +17,10 @@ func TestGoDirectiveVersionFromRuntime(t *testing.T) {
 		version string
 		want    string
 	}{
-		{name: "patch", version: "go1.26.4", want: "1.26.4"},
+		{name: "patch", version: "go1.26.5", want: "1.26.5"},
 		{name: "minor", version: "go1.26", want: "1.26.0"},
 		{name: "devel", version: "devel go1.27-abc123", want: "1.27.0"},
-		{name: "suffix", version: "go1.26.4 X:cacheprog", want: "1.26.4"},
+		{name: "suffix", version: "go1.26.5 X:cacheprog", want: "1.26.5"},
 		{name: "unknown", version: "unknown", want: ""},
 	}
 

--- a/internal/generator/install_section.go
+++ b/internal/generator/install_section.go
@@ -38,7 +38,7 @@ const canonicalSkillInstallSectionStartFormat = "## Prerequisites: Install the C
 // canonicalSkillInstallSectionGoFallbackFormat is appended only once the
 // public-library category is known. Before publish, the category-agnostic installer is
 // the only canonical path; emitting library/other/<slug> creates drift.
-const canonicalSkillInstallSectionGoFallbackFormat = "If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.4 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:\n" +
+const canonicalSkillInstallSectionGoFallbackFormat = "If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.5 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:\n" +
 	"\n" +
 	"```bash\n" +
 	"go install github.com/mvanhorn/printing-press-library/library/%[2]s/%[1]s/cmd/%[1]s-pp-cli@latest\n" +

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -53,7 +53,7 @@ npx -y @mvanhorn/printing-press-library install {{.Name}} --agent claude-code --
 {{ if .Category}}
 ### Without Node (Go fallback)
 
-If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.4 or newer):
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.5 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/{{.Category}}/{{.Name}}/cmd/{{.Name}}-pp-cli@latest

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -34,7 +34,7 @@ This skill drives the `{{.Name}}-pp-cli` binary. **You must verify the CLI is in
 2. Verify: `{{.Name}}-pp-cli --version`
 3. Ensure the reported install directory is on `$PATH` for the agent/runtime that will invoke this skill.
 {{ if .Category}}
-If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.4 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.5 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/{{.Category}}/{{.Name}}/cmd/{{.Name}}-pp-cli@latest

--- a/internal/generator/validate_test.go
+++ b/internal/generator/validate_test.go
@@ -113,7 +113,7 @@ exit 0
 	require.NoError(t, err)
 	assert.Contains(t, string(calls), "mod tidy\n")
 	assert.Contains(t, string(calls), "run "+govulncheck.ToolModule+" ./...\n")
-	assert.Contains(t, string(calls), "toolchain=go1.26.4\n")
+	assert.Contains(t, string(calls), "toolchain=go1.26.5\n")
 	assert.NotContains(t, string(calls), "-show")
 	assert.NotContains(t, string(calls), "verbose")
 }

--- a/internal/govulncheck/govulncheck_test.go
+++ b/internal/govulncheck/govulncheck_test.go
@@ -25,16 +25,16 @@ func TestGoRunArgsUsesDefaultMode(t *testing.T) {
 
 func TestToolchainEnvPrefersToolchainDirective(t *testing.T) {
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.25.0\ntoolchain go1.26.4\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.25.0\ntoolchain go1.26.5\n"), 0o644))
 
-	assert.Equal(t, []string{"GOTOOLCHAIN=go1.26.4"}, ToolchainEnv(dir))
+	assert.Equal(t, []string{"GOTOOLCHAIN=go1.26.5"}, ToolchainEnv(dir))
 }
 
 func TestToolchainEnvFallsBackToPatchLevelGoDirective(t *testing.T) {
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.26.4\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.26.5\n"), 0o644))
 
-	assert.Equal(t, []string{"GOTOOLCHAIN=go1.26.4"}, ToolchainEnv(dir))
+	assert.Equal(t, []string{"GOTOOLCHAIN=go1.26.5"}, ToolchainEnv(dir))
 }
 
 func TestToolchainEnvIgnoresLanguageOnlyGoDirective(t *testing.T) {

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -324,8 +324,8 @@ func TestSetupContractsStayQuietInHealthyEnvironment(t *testing.T) {
 
 			output, err := runSkillSetupContract(t, skill, setupContractOptions{
 				includeGo:       true,
-				goInstalled:     "1.26.4",
-				goBinary:        "1.26.4",
+				goInstalled:     "1.26.5",
+				goBinary:        "1.26.5",
 				diskAvailableKB: "4194304",
 			})
 
@@ -347,14 +347,14 @@ func TestSetupContractsWarnOnOldGoToolchain(t *testing.T) {
 			output, err := runSkillSetupContract(t, skill, setupContractOptions{
 				includeGo:       true,
 				goInstalled:     "1.25.0",
-				goBinary:        "1.26.4",
+				goBinary:        "1.26.5",
 				diskAvailableKB: "4194304",
 			})
 
 			require.NoError(t, err, output)
 			assert.Contains(t, output, "[go-toolchain-old]")
 			assert.Contains(t, output, "PRESS_GO_INSTALLED=1.25.0")
-			assert.Contains(t, output, "PRESS_GO_REQUIRED=1.26.4")
+			assert.Contains(t, output, "PRESS_GO_REQUIRED=1.26.5")
 		})
 	}
 }
@@ -369,13 +369,13 @@ func TestSetupContractsBlockOldGoWhenToolchainLocal(t *testing.T) {
 			output, err := runSkillSetupContract(t, skill, setupContractOptions{
 				includeGo:       true,
 				goInstalled:     "1.25.0",
-				goBinary:        "1.26.4",
+				goBinary:        "1.26.5",
 				goToolchain:     "local",
 				diskAvailableKB: "4194304",
 			})
 
 			require.Error(t, err, output)
-			assert.Contains(t, output, "[setup-error] Go 1.26.4 or newer is required")
+			assert.Contains(t, output, "[setup-error] Go 1.26.5 or newer is required")
 			assert.NotContains(t, output, "[go-toolchain-old]")
 		})
 	}
@@ -390,8 +390,8 @@ func TestSetupContractsWarnOnLowDisk(t *testing.T) {
 
 			output, err := runSkillSetupContract(t, skill, setupContractOptions{
 				includeGo:       true,
-				goInstalled:     "1.26.4",
-				goBinary:        "1.26.4",
+				goInstalled:     "1.26.5",
+				goBinary:        "1.26.5",
 				diskAvailableKB: "1048576",
 			})
 
@@ -412,8 +412,8 @@ func TestSetupContractsBlockCriticallyLowDisk(t *testing.T) {
 
 			output, err := runSkillSetupContract(t, skill, setupContractOptions{
 				includeGo:       true,
-				goInstalled:     "1.26.4",
-				goBinary:        "1.26.4",
+				goInstalled:     "1.26.5",
+				goBinary:        "1.26.5",
 				diskAvailableKB: "1024",
 			})
 
@@ -802,7 +802,7 @@ func TestImportRewriteHandlesCRLFGoMod(t *testing.T) {
 	t.Parallel()
 
 	staging := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(staging, "go.mod"), []byte("module github.com/mvanhorn/printing-press-library/library/productivity/sample\r\n\r\ngo 1.26.4\r\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(staging, "go.mod"), []byte("module github.com/mvanhorn/printing-press-library/library/productivity/sample\r\n\r\ngo 1.26.5\r\n"), 0o644))
 	require.NoError(t, os.MkdirAll(filepath.Join(staging, "internal", "cli"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(staging, "internal", "cli", "root.go"), []byte("package cli\r\n\r\nimport \"github.com/mvanhorn/printing-press-library/library/productivity/sample/internal/client\"\r\n\r\nvar _ = client.New\r\n"), 0o644))
 
@@ -1433,7 +1433,7 @@ func runSkillSetupContract(t *testing.T, skill setupSkill, opts setupContractOpt
 	t.Helper()
 
 	if opts.goInstalled == "" {
-		opts.goInstalled = "1.26.4"
+		opts.goInstalled = "1.26.5"
 	}
 	if opts.goBinary == "" {
 		opts.goBinary = opts.goInstalled
@@ -1469,16 +1469,16 @@ echo "fake 9999999 0 ${PP_FAKE_DF_AVAIL_KB:-4194304} 0% /"
 case "$1" in
   env)
     if [ "$2" = "GOVERSION" ]; then
-      echo "go${PP_FAKE_GO_INSTALLED:-1.26.4}"
+      echo "go${PP_FAKE_GO_INSTALLED:-1.26.5}"
       exit 0
     fi
     exit 0
     ;;
   version)
     if [ "$#" -ge 2 ]; then
-      echo "$2: go${PP_FAKE_GO_BINARY:-1.26.4}"
+      echo "$2: go${PP_FAKE_GO_BINARY:-1.26.5}"
     else
-      echo "go version go${PP_FAKE_GO_INSTALLED:-1.26.4} test/amd64"
+      echo "go version go${PP_FAKE_GO_INSTALLED:-1.26.5} test/amd64"
     fi
     exit 0
     ;;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,7 +20,7 @@ umask 022
 
 readonly PROJECT_NAME="CLI Printing Press"
 readonly BINARY_NAME="cli-printing-press"
-readonly GO_MIN_VERSION="1.26.4"
+readonly GO_MIN_VERSION="1.26.5"
 readonly GO_INSTALL_TARGET="github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest"
 readonly SKILL_SOURCE="mvanhorn/cli-printing-press/skills"
 readonly SKILLS_PACKAGE="skills@latest"

--- a/skills/printing-press-amend/SKILL.md
+++ b/skills/printing-press-amend/SKILL.md
@@ -88,7 +88,7 @@ if ! command -v go >/dev/null 2>&1; then
   echo "[setup-error] Go toolchain not found."
   echo ""
   echo "This Printing Press flow runs Go-based build or validation commands."
-  echo "Install Go 1.26.4 or newer from https://go.dev/dl/, then verify with:"
+  echo "Install Go 1.26.5 or newer from https://go.dev/dl/, then verify with:"
   echo "  go version"
   echo "Then re-run this skill."
   echo ""

--- a/skills/printing-press-import/SKILL.md
+++ b/skills/printing-press-import/SKILL.md
@@ -55,7 +55,7 @@ if ! command -v go >/dev/null 2>&1; then
   echo "[setup-error] Go toolchain not found."
   echo ""
   echo "This Printing Press flow runs Go-based build or validation commands."
-  echo "Install Go 1.26.4 or newer from https://go.dev/dl/, then verify with:"
+  echo "Install Go 1.26.5 or newer from https://go.dev/dl/, then verify with:"
   echo "  go version"
   echo "Then re-run this skill."
   echo ""

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -111,7 +111,7 @@ if ! command -v go >/dev/null 2>&1; then
   echo "[setup-error] Go toolchain not found."
   echo ""
   echo "This Printing Press flow runs Go-based build or validation commands."
-  echo "Install Go 1.26.4 or newer from https://go.dev/dl/, then verify with:"
+  echo "Install Go 1.26.5 or newer from https://go.dev/dl/, then verify with:"
   echo "  go version"
   echo "Then re-run this skill."
   echo ""

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -215,7 +215,7 @@ if ! command -v go >/dev/null 2>&1; then
   echo "[setup-error] Go toolchain not found."
   echo ""
   echo "This Printing Press flow runs Go-based build or validation commands."
-  echo "Install Go 1.26.4 or newer from https://go.dev/dl/, then verify with:"
+  echo "Install Go 1.26.5 or newer from https://go.dev/dl/, then verify with:"
   echo "  go version"
   echo "Then re-run this skill."
   echo ""

--- a/skills/printing-press-score/SKILL.md
+++ b/skills/printing-press-score/SKILL.md
@@ -26,7 +26,7 @@ Score generated CLIs against the Steinberger bar. Supports rescoring, scoring by
 
 ## Prerequisites
 
-- Go 1.26.4 or newer installed
+- Go 1.26.5 or newer installed
 - `cli-printing-press` binary on PATH (install with `go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest`)
 
 ## Step 0: Setup

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -213,7 +213,7 @@ elif ! _resolve_press_bin >/dev/null; then
       echo "Install it in your terminal:"
       echo "  go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest"
     else
-      echo "Go 1.26.4 or newer is also not installed. Install Go from https://go.dev/dl/, then:"
+      echo "Go 1.26.5 or newer is also not installed. Install Go from https://go.dev/dl/, then:"
       echo "  go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest"
     fi
     echo ""
@@ -233,7 +233,7 @@ if ! command -v go >/dev/null 2>&1; then
   echo "[setup-error] Go toolchain not found."
   echo ""
   echo "The Printing Press generator runs Go-based quality gates after generation."
-  echo "Install Go 1.26.4 or newer from https://go.dev/dl/, then verify with:"
+  echo "Install Go 1.26.5 or newer from https://go.dev/dl/, then verify with:"
   echo "  go version"
   echo "Then re-run /printing-press."
   echo ""

--- a/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/go.mod
+++ b/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/go.mod
@@ -1,8 +1,8 @@
 module ble-desk-lamp-pp-cli
 
-go 1.26.4
+go 1.26.5
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/mark3labs/mcp-go v0.47.0

--- a/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/go.mod
+++ b/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/go.mod
@@ -1,8 +1,8 @@
 module ble-opaque-binary-pp-cli
 
-go 1.26.4
+go 1.26.5
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/mark3labs/mcp-go v0.47.0

--- a/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/go.mod
+++ b/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/go.mod
@@ -1,8 +1,8 @@
 module ble-session-appliance-pp-cli
 
-go 1.26.4
+go 1.26.5
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/mark3labs/mcp-go v0.47.0

--- a/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/go.mod
+++ b/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/go.mod
@@ -1,8 +1,8 @@
 module ble-temperature-sensor-pp-cli
 
-go 1.26.4
+go 1.26.5
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/mark3labs/mcp-go v0.47.0

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
@@ -1,8 +1,8 @@
 module golden-api-cookie-auth-pp-cli
 
-go 1.26.4
+go 1.26.5
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/gorilla/websocket v1.5.3

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/go.mod
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/go.mod
@@ -1,8 +1,8 @@
 module printing-press-golden-pp-cli
 
-go 1.26.4
+go 1.26.5
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/spf13/cobra v1.9.1


### PR DESCRIPTION
## Summary
Fresh prints and setup checks now target Go 1.26.5, so newly generated CLIs no longer inherit the vulnerable 1.26.4 floor from GO-2026-5856. The root module, installer guidance, skill preflights, generated README/SKILL fallback text, govulncheck toolchain assertions, and golden generated `go.mod` outputs now agree on the patched floor.

Fixes #3505.

## Validation
- `go mod tidy`
- `go fmt ./...`
- `go test ./...` (`6763` passed in `43` packages)
- `scripts/golden.sh verify` (`31` cases)
- `scripts/verify-generator-output.sh` (`10` cases)
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `git diff --check`
- `rg "1\\.26\\.4|go1\\.26\\.4" go.mod README.md scripts skills internal testdata/golden` (no current-floor matches)

## Post-Deploy Monitoring & Validation
No additional production monitoring is required; this is a generator/toolchain floor update validated by tests, golden output, and generated-module builds. Watch the PR CI/golden/generator-output checks and the first post-merge fresh print for `go 1.26.5` and `toolchain go1.26.5` in generated `go.mod` files. Failure signals are any stale `1.26.4` current-floor output or govulncheck running under the old toolchain. Owner: maintainer merging this PR. Validation window: PR CI plus the first post-merge generation run.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
