### PR TITLE
fix(ci): guard Go toolchain floor drift

### DIFF
--- a/.github/scripts/verify-supply-chain/scan_test.py
+++ b/.github/scripts/verify-supply-chain/scan_test.py
@@ -229,6 +229,59 @@ class GoEnvOverrideSignalTest(unittest.TestCase):
         self.assertEqual(findings, [])
 
 
+class SetupGoVersionSignalTest(unittest.TestCase):
+    def test_new_hardcoded_setup_go_version_blocks(self) -> None:
+        base = "jobs:\n  x:\n    steps:\n      - uses: actions/checkout@v6\n"
+        head = textwrap.dedent(
+            """
+            jobs:
+              x:
+                steps:
+                  - uses: actions/setup-go@v6
+                    with:
+                      go-version: '1.26.5'
+            """
+        )
+        findings = signals.signal_setup_go_uses_go_version_file(
+            _fc(".github/workflows/build.yml", base=base, head=head)
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].is_block())
+        self.assertEqual(findings[0].signal_id, "setup_go_hardcoded_version")
+
+    def test_go_version_file_does_not_block(self) -> None:
+        head = textwrap.dedent(
+            """
+            jobs:
+              x:
+                steps:
+                  - uses: actions/setup-go@v6
+                    with:
+                      go-version-file: go.mod
+            """
+        )
+        findings = signals.signal_setup_go_uses_go_version_file(
+            _fc(".github/workflows/build.yml", head=head)
+        )
+        self.assertEqual(findings, [])
+
+    def test_preexisting_literal_unchanged_does_not_re_fire(self) -> None:
+        wf = textwrap.dedent(
+            """
+            jobs:
+              x:
+                steps:
+                  - uses: actions/setup-go@v6
+                    with:
+                      go-version: '1.26.5'
+            """
+        )
+        findings = signals.signal_setup_go_uses_go_version_file(
+            _fc(".github/workflows/legacy.yml", base=wf, head=wf)
+        )
+        self.assertEqual(findings, [])
+
+
 # ---------------------------------------------------------------------------
 # Integration test
 # ---------------------------------------------------------------------------
@@ -311,6 +364,28 @@ class ScanIntegrationTest(unittest.TestCase):
         )
         self._commit("redirect GOPROXY")
         self.assertEqual(self._run_scan(), 1)
+
+    def test_hardcoded_setup_go_version_fails(self) -> None:
+        self._write(".github/workflows/baseline.yml", "on: push\n")
+        self._commit("baseline")
+        self._git("checkout", "-q", "-b", "feat/x")
+        self._write(
+            ".github/workflows/baseline.yml",
+            "on: push\njobs:\n  x:\n    steps:\n      - uses: actions/setup-go@v6\n        with:\n          go-version: '1.26.5'\n",
+        )
+        self._commit("hardcode setup-go version")
+        self.assertEqual(self._run_scan(), 1)
+
+    def test_go_version_file_setup_go_passes(self) -> None:
+        self._write(".github/workflows/baseline.yml", "on: push\n")
+        self._commit("baseline")
+        self._git("checkout", "-q", "-b", "feat/x")
+        self._write(
+            ".github/workflows/baseline.yml",
+            "on: push\njobs:\n  x:\n    steps:\n      - uses: actions/setup-go@v6\n        with:\n          go-version-file: go.mod\n",
+        )
+        self._commit("use shared setup-go version")
+        self.assertEqual(self._run_scan(), 0)
 
     def test_unrelated_changes_pass(self) -> None:
         """Touching Go source under internal/ but not any workflow → no findings."""

--- a/.github/scripts/verify-supply-chain/scan_test.py
+++ b/.github/scripts/verify-supply-chain/scan_test.py
@@ -249,6 +249,23 @@ class SetupGoVersionSignalTest(unittest.TestCase):
         self.assertTrue(findings[0].is_block())
         self.assertEqual(findings[0].signal_id, "setup_go_hardcoded_version")
 
+    def test_unquoted_two_segment_setup_go_version_blocks(self) -> None:
+        head = textwrap.dedent(
+            """
+            jobs:
+              x:
+                steps:
+                  - uses: actions/setup-go@v6
+                    with:
+                      go-version: 1.22
+            """
+        )
+        findings = signals.signal_setup_go_uses_go_version_file(
+            _fc(".github/workflows/build.yml", head=head)
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].is_block())
+
     def test_go_version_file_does_not_block(self) -> None:
         head = textwrap.dedent(
             """

--- a/.github/scripts/verify-supply-chain/signals.py
+++ b/.github/scripts/verify-supply-chain/signals.py
@@ -468,7 +468,7 @@ def signal_setup_go_uses_go_version_file(change: FileChange) -> list[Finding]:
     return [
         Finding(
             path=change.path,
-            line=_find_line_in(change.head_content, "go-version"),
+            line=_find_line_in(change.head_content, "go-version:"),
             severity="block",
             signal_id="setup_go_hardcoded_version",
             message=(

--- a/.github/scripts/verify-supply-chain/signals.py
+++ b/.github/scripts/verify-supply-chain/signals.py
@@ -258,8 +258,8 @@ def _walk_setup_go_version_literals(parsed: Any) -> list[str]:
             if not isinstance(with_block, dict):
                 continue
             version = with_block.get("go-version")
-            if isinstance(version, str):
-                found.append(version.strip())
+            if version is not None:
+                found.append(str(version).strip())
     return found
 
 

--- a/.github/scripts/verify-supply-chain/signals.py
+++ b/.github/scripts/verify-supply-chain/signals.py
@@ -11,8 +11,10 @@ the generator repo:
     cosign with OIDC, allowlist that specific workflow at that time.
   - R3 (replace directives in library/**/go.mod) — omitted.
   - R4 (GOPROXY/GOFLAGS/GONOSUMCHECK in workflows) — applied unchanged.
-  - R5 (npm lifecycle scripts) — omitted.
-  - R6 (module-path drift) — omitted.
+  - R5 (hard-coded actions/setup-go versions) — adapted to require
+    go-version-file: go.mod.
+  - R6 (npm lifecycle scripts) — omitted.
+  - R7 (module-path drift) — omitted.
 
 Detection strategy for R1/R2/R4: parse the YAML structurally with pyyaml
 (pre-installed on ubuntu-latest runners) and walk the parsed dict tree.
@@ -232,6 +234,35 @@ def _walk_go_env_overrides(parsed: Any) -> list[str]:
     return found
 
 
+def _walk_setup_go_version_literals(parsed: Any) -> list[str]:
+    """Return literal `go-version` values from actions/setup-go steps."""
+    found: list[str] = []
+    if not isinstance(parsed, dict):
+        return found
+    jobs = parsed.get("jobs")
+    if not isinstance(jobs, dict):
+        return found
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        steps = job.get("steps")
+        if not isinstance(steps, list):
+            continue
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            uses = step.get("uses")
+            if not isinstance(uses, str) or not uses.startswith("actions/setup-go"):
+                continue
+            with_block = step.get("with")
+            if not isinstance(with_block, dict):
+                continue
+            version = with_block.get("go-version")
+            if isinstance(version, str):
+                found.append(version.strip())
+    return found
+
+
 def _collect_go_env_from(env_block: Any, out: list[str]) -> None:
     if not isinstance(env_block, dict):
         return
@@ -407,6 +438,53 @@ def signal_go_env_override(change: FileChange) -> list[Finding]:
 
 
 # ---------------------------------------------------------------------------
+# R5: setup-go must read the repo-wide go.mod floor
+# ---------------------------------------------------------------------------
+
+
+def signal_setup_go_uses_go_version_file(change: FileChange) -> list[Finding]:
+    """R5. Go workflow versions must come from go.mod. Hard-coded setup-go
+    pins make emergency vulnerability bumps a multi-file hunt, and stale pins
+    can keep CI on a vulnerable standard library after go.mod moves forward.
+
+    Structural diff: fires only for literal pins newly introduced by the PR.
+    """
+    if not is_workflow(change.path) or change.head_content is None:
+        return []
+
+    head_literals = set(_walk_setup_go_version_literals(_parse_workflow(change.head_content)))
+    if not head_literals:
+        return []
+
+    base_literals: set[str] = set()
+    if change.base_content is not None:
+        base_literals = set(_walk_setup_go_version_literals(_parse_workflow(change.base_content)))
+
+    new_literals = sorted(head_literals - base_literals)
+    if not new_literals:
+        return []
+
+    literal = new_literals[0]
+    return [
+        Finding(
+            path=change.path,
+            line=_find_line_in(change.head_content, "go-version"),
+            severity="block",
+            signal_id="setup_go_hardcoded_version",
+            message=(
+                "Workflow pins actions/setup-go with `go-version: %s`. Go "
+                "toolchain floor bumps must be single-source so vulnerability "
+                "fixes do not leave stale workflow pins behind." % literal
+            ),
+            remediation=(
+                "Use `go-version-file: go.mod` in actions/setup-go and bump "
+                "the root go.mod directive when the repo-wide Go floor changes."
+            ),
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Signal dispatch
 # ---------------------------------------------------------------------------
 
@@ -415,6 +493,7 @@ ALL_SIGNALS = (
     signal_workflow_trust,
     signal_id_token_outside_allowlist,
     signal_go_env_override,
+    signal_setup_go_uses_go_version_file,
 )
 
 

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -68,7 +68,7 @@ jobs:
 
             for file in "${changed[@]}"; do
               case "$file" in
-                .github/workflows/main-ci.yml)
+                .github/workflows/main-ci.yml|scripts/verify-go-floor.py)
                   needs_build=true
                   needs_tests=true
                   needs_golden=true
@@ -114,6 +114,19 @@ jobs:
             echo "- golden: \`$needs_golden\`"
             echo "- generated-output: \`$needs_generated_output\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  go-floor:
+    name: go-floor
+    runs-on: ubuntu-latest
+    needs: classify
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Verify Go floor surfaces
+        run: python3 scripts/verify-go-floor.py
 
   full-build:
     name: full-build
@@ -300,6 +313,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - classify
+      - go-floor
       - full-build
       - full-test
       - full-golden
@@ -312,6 +326,10 @@ jobs:
         run: |
           if [[ "${{ needs.classify.result }}" != "success" ]]; then
             echo "change classification failed or was cancelled."
+            exit 1
+          fi
+          if [[ "${{ needs.go-floor.result }}" != "success" ]]; then
+            echo "go-floor failed or was cancelled."
             exit 1
           fi
           if [[ "${{ needs.classify.outputs.needs_build }}" == "true" && "${{ needs.classify.outputs.needs_tests }}" != "true" && "${{ needs.full-build.result }}" != "success" ]]; then
@@ -332,6 +350,7 @@ jobs:
           fi
 
           echo "Full-suite scope:"
+          echo "  go-floor=${{ needs.go-floor.result }}"
           echo "  build=${{ needs.classify.outputs.needs_build }} result=${{ needs.full-build.result }} (covered by full-test when tests=true)"
           echo "  tests=${{ needs.classify.outputs.needs_tests }} result=${{ needs.full-test.result }}"
           echo "  golden=${{ needs.classify.outputs.needs_golden }} result=${{ needs.full-golden.result }}"

--- a/scripts/verify-go-floor.py
+++ b/scripts/verify-go-floor.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Verify Go floor text and fixtures match the root go.mod directive."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+PATTERNS = [
+    re.compile(r"\bGo (?P<version>\d+\.\d+\.\d+) or newer\b"),
+    re.compile(r"\brequires Go (?P<version>\d+\.\d+\.\d+) or newer\b"),
+    re.compile(r"\bInstall Go (?P<version>\d+\.\d+\.\d+)"),
+    re.compile(r'GO_MIN_VERSION="(?P<version>\d+\.\d+\.\d+)"'),
+    re.compile(r"\bPRESS_GO_REQUIRED=(?P<version>\d+\.\d+\.\d+)"),
+    re.compile(r"\bPP_FAKE_GO_INSTALLED:-(?P<version>\d+\.\d+\.\d+)"),
+    re.compile(r"\bPP_FAKE_GO_BINARY:-(?P<version>\d+\.\d+\.\d+)"),
+    re.compile(r"\bgo version go(?P<version>\d+\.\d+\.\d+)"),
+    re.compile(r'\bgoInstalled:\s+"(?P<version>\d+\.\d+\.\d+)"'),
+    re.compile(r'\bgoBinary:\s+"(?P<version>\d+\.\d+\.\d+)"'),
+    re.compile(r"\btoolchain=go(?P<version>\d+\.\d+\.\d+)"),
+    re.compile(r"\\ngo (?P<version>\d+\.\d+\.\d+)\\n"),
+    re.compile(r"\\ntoolchain go(?P<version>\d+\.\d+\.\d+)\\n"),
+    re.compile(r"^go (?P<version>\d+\.\d+\.\d+)$", re.MULTILINE),
+    re.compile(r"^toolchain go(?P<version>\d+\.\d+\.\d+)$", re.MULTILINE),
+]
+
+
+PATHS = [
+    "README.md",
+    "scripts/install.sh",
+    "skills/printing-press/SKILL.md",
+    "skills/printing-press-amend/SKILL.md",
+    "skills/printing-press-import/SKILL.md",
+    "skills/printing-press-polish/SKILL.md",
+    "skills/printing-press-publish/SKILL.md",
+    "skills/printing-press-score/SKILL.md",
+    "internal/cli/generate_test.go",
+    "internal/cli/publish_test.go",
+    "internal/cli/verify_skill_test.go",
+    "internal/generator/go_version_test.go",
+    "internal/generator/install_section.go",
+    "internal/generator/templates/readme.md.tmpl",
+    "internal/generator/templates/skill.md.tmpl",
+    "internal/generator/validate_test.go",
+    "internal/govulncheck/govulncheck_test.go",
+    "internal/pipeline/contracts_test.go",
+]
+
+
+ALLOWED_OLD_FIXTURES = {
+    ("internal/govulncheck/govulncheck_test.go", "go 1.25.0"),
+    ("internal/pipeline/contracts_test.go", 'goInstalled:     "1.25.0"'),
+    ("internal/pipeline/contracts_test.go", "PRESS_GO_INSTALLED=1.25.0"),
+}
+
+
+def repo_go_floor() -> str:
+    content = (REPO_ROOT / "go.mod").read_text()
+    match = re.search(r"^go\s+(\d+\.\d+\.\d+)\s*$", content, re.MULTILINE)
+    if not match:
+        raise SystemExit("could not find patch-level go directive in go.mod")
+    return match.group(1)
+
+
+def iter_files() -> list[Path]:
+    files = [REPO_ROOT / path for path in PATHS]
+    files.extend((REPO_ROOT / "testdata/golden/expected").glob("**/go.mod"))
+    return sorted(files)
+
+
+def line_number(content: str, offset: int) -> int:
+    return content.count("\n", 0, offset) + 1
+
+
+def line_text(content: str, offset: int) -> str:
+    start = content.rfind("\n", 0, offset) + 1
+    end = content.find("\n", offset)
+    if end == -1:
+        end = len(content)
+    return content[start:end]
+
+
+def is_allowed_old_fixture(rel: Path, text: str) -> bool:
+    rel_text = rel.as_posix()
+    return any(rel_text == path and needle in text for path, needle in ALLOWED_OLD_FIXTURES)
+
+
+def main() -> int:
+    floor = repo_go_floor()
+    failures: list[str] = []
+
+    for path in iter_files():
+        if not path.exists():
+            failures.append(f"{path.relative_to(REPO_ROOT)}: missing expected Go-floor surface")
+            continue
+        content = path.read_text()
+        rel = path.relative_to(REPO_ROOT)
+        for pattern in PATTERNS:
+            for match in pattern.finditer(content):
+                version = match.group("version")
+                current_line = line_text(content, match.start())
+                if is_allowed_old_fixture(rel, current_line):
+                    continue
+                if version != floor:
+                    failures.append(
+                        f"{rel}:{line_number(content, match.start())}: expected {floor}, found {version}"
+                    )
+
+    if failures:
+        print("Go floor drift detected:")
+        for failure in failures:
+            print(f"  {failure}")
+        print("\nUpdate go.mod once, then update the reported surfaces to the same version.")
+        return 1
+
+    print(f"Go floor check passed: all tracked surfaces match {floor}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Go floor bumps in the Printing Press generator now have a dedicated drift check. `scripts/verify-go-floor.py` reads the root `go.mod` directive and verifies the installer, skills, generated README/SKILL templates, setup-contract fixtures, govulncheck fixtures, and golden go.mod/toolchain outputs that should move with that floor.

Main CI runs that verifier as a cheap `go-floor` job and folds it into the existing `build-and-test` aggregate, so future vulnerability bumps fail in one obvious place with exact stale-file locations. The supply-chain scanner also now blocks newly introduced hard-coded `actions/setup-go` `go-version:` pins; workflows should keep using `go-version-file: go.mod`.

## Validation

| Check | Result |
| --- | --- |
| `python3 scripts/verify-go-floor.py` | Pass |
| `python3 -m unittest scan_test` from `.github/scripts/verify-supply-chain` | Pass, 29 tests |
| `python3 .github/scripts/verify-supply-chain/scan.py --base-ref origin/main` | Pass, no findings |
| Focused generator Go floor tests for runtime parsing and generated go.mod | Pass |
| `git diff --check` and cached diff check | Pass |

I also started `go test ./...`; it stayed silent for several minutes and was interrupted locally to avoid hanging the session. The focused Go floor tests above passed.

## Related

Related: mvanhorn/cli-printing-press#3506
Related: mvanhorn/printing-press-library#1464
Related: mvanhorn/printing-press-library#1468

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
