### PR TITLE
fix(cli): use default page size for bare --all offset pagination

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3376,7 +3376,7 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 				HasStore:      g.VisionSet.Store,
 				IsAsync:       isAsync,
 				Async:         asyncInfo,
-				PageSize:      g.paginationDefaultPageSize(),
+				PageSize:      g.paginationPageSizeForEndpoint(endpoint),
 				IsReadOnly:    endpointIsReadCommand(endpoint, eName),
 				APISpec:       g.Spec,
 			}
@@ -3436,7 +3436,7 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 					HasStore:      g.VisionSet.Store,
 					IsAsync:       isAsync,
 					Async:         asyncInfo,
-					PageSize:      g.paginationDefaultPageSize(),
+					PageSize:      g.paginationPageSizeForEndpoint(endpoint),
 					IsReadOnly:    endpointIsReadCommand(endpoint, eName),
 					APISpec:       g.Spec,
 				}
@@ -4604,7 +4604,7 @@ func (g *Generator) renderPromotedCommandFiles(promotedCommands []PromotedComman
 			// when ANY promoted command qualifies), so call ⊆ emit — no call to
 			// an unemitted helper.
 			HasResponseUnwrap: g.VisionSet.Store && !pc.Endpoint.UsesBinaryResponse() && endpointHasStatusDataEnvelope(pc.Endpoint, g.Spec.Types),
-			PageSize:          g.paginationDefaultPageSize(),
+			PageSize:          g.paginationPageSizeForEndpoint(pc.Endpoint),
 			Resource:          resource,
 			FuncPrefix:        pc.ResourceName,
 			IsReadOnly:        endpointIsReadCommand(pc.Endpoint, pc.EndpointName),
@@ -4625,6 +4625,80 @@ func (g *Generator) paginationDefaultPageSize() int {
 		return g.profile.Pagination.DefaultPageSize
 	}
 	return 100
+}
+
+func (g *Generator) paginationPageSizeForEndpoint(endpoint spec.Endpoint) int {
+	pageSize := g.paginationDefaultPageSize()
+	if endpoint.Pagination == nil || endpoint.Pagination.LimitParam == "" {
+		return pageSize
+	}
+	limitParam, ok := endpointParamByName(endpoint, endpoint.Pagination.LimitParam)
+	if !ok {
+		return pageSize
+	}
+	if defaultPageSize, ok := positiveIntValue(limitParam.Default); ok {
+		pageSize = defaultPageSize
+	}
+	if maxPageSize, ok := paramMaxInt(limitParam); ok && maxPageSize < pageSize {
+		pageSize = maxPageSize
+	}
+	if pageSize <= 0 {
+		return g.paginationDefaultPageSize()
+	}
+	return pageSize
+}
+
+func endpointParamByName(endpoint spec.Endpoint, name string) (spec.Param, bool) {
+	for _, param := range endpoint.Params {
+		if param.Name == name || param.URLName == name {
+			return param, true
+		}
+	}
+	return spec.Param{}, false
+}
+
+func positiveIntValue(value any) (int, bool) {
+	switch v := value.(type) {
+	case int:
+		if v > 0 {
+			return v, true
+		}
+	case int64:
+		if v > 0 && int64(int(v)) == v {
+			return int(v), true
+		}
+	case float64:
+		asInt := int(v)
+		if v > 0 && float64(asInt) == v {
+			return asInt, true
+		}
+	case string:
+		n, err := strconv.Atoi(strings.TrimSpace(v))
+		if err == nil && n > 0 {
+			return n, true
+		}
+	}
+	return 0, false
+}
+
+func paramMaxInt(param spec.Param) (int, bool) {
+	var max int
+	hasMax := false
+	if param.Maximum != nil && *param.Maximum > 0 {
+		max = int(*param.Maximum)
+		hasMax = true
+	}
+	if param.ExclusiveMaximum != nil && *param.ExclusiveMaximum > 0 {
+		exclusiveMax := int(*param.ExclusiveMaximum)
+		if float64(exclusiveMax) == *param.ExclusiveMaximum {
+			exclusiveMax--
+		}
+		if exclusiveMax > 0 && (!hasMax || exclusiveMax < max) {
+			max = exclusiveMax
+			hasMax = true
+		}
+	}
+	return max, hasMax
 }
 
 func (g *Generator) renderRootProjectFiles(promotedCommands []PromotedCommand, promotedResourceNames map[string]bool, renderedWorkflowConstructors, renderedInsightConstructors []string, novelCommandStubs []novelFeatureCommandRender) error {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -984,6 +984,7 @@ type endpointTemplateData struct {
 	HasStore      bool
 	IsAsync       bool
 	Async         AsyncJobInfo
+	PageSize      int
 	// IsReadOnly mirrors !endpointIsWriteCommand(endpoint, name). The
 	// emitted command sets Annotations["mcp:read-only"] = "true" when
 	// it's true so the cobratree MCP walker marks the tool with
@@ -3375,6 +3376,7 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 				HasStore:      g.VisionSet.Store,
 				IsAsync:       isAsync,
 				Async:         asyncInfo,
+				PageSize:      g.paginationDefaultPageSize(),
 				IsReadOnly:    endpointIsReadCommand(endpoint, eName),
 				APISpec:       g.Spec,
 			}
@@ -3434,6 +3436,7 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 					HasStore:      g.VisionSet.Store,
 					IsAsync:       isAsync,
 					Async:         asyncInfo,
+					PageSize:      g.paginationDefaultPageSize(),
 					IsReadOnly:    endpointIsReadCommand(endpoint, eName),
 					APISpec:       g.Spec,
 				}
@@ -4580,6 +4583,7 @@ func (g *Generator) renderPromotedCommandFiles(promotedCommands []PromotedComman
 			EffectiveTier     string
 			HasStore          bool
 			HasResponseUnwrap bool
+			PageSize          int
 			Resource          spec.Resource
 			FuncPrefix        string
 			IsReadOnly        bool
@@ -4600,6 +4604,7 @@ func (g *Generator) renderPromotedCommandFiles(promotedCommands []PromotedComman
 			// when ANY promoted command qualifies), so call ⊆ emit — no call to
 			// an unemitted helper.
 			HasResponseUnwrap: g.VisionSet.Store && !pc.Endpoint.UsesBinaryResponse() && endpointHasStatusDataEnvelope(pc.Endpoint, g.Spec.Types),
+			PageSize:          g.paginationDefaultPageSize(),
 			Resource:          resource,
 			FuncPrefix:        pc.ResourceName,
 			IsReadOnly:        endpointIsReadCommand(pc.Endpoint, pc.EndpointName),
@@ -4613,6 +4618,13 @@ func (g *Generator) renderPromotedCommandFiles(promotedCommands []PromotedComman
 	}
 
 	return nil
+}
+
+func (g *Generator) paginationDefaultPageSize() int {
+	if g != nil && g.profile != nil && g.profile.Pagination.DefaultPageSize > 0 {
+		return g.profile.Pagination.DefaultPageSize
+	}
+	return 100
 }
 
 func (g *Generator) renderRootProjectFiles(promotedCommands []PromotedCommand, promotedResourceNames map[string]bool, renderedWorkflowConstructors, renderedInsightConstructors []string, novelCommandStubs []novelFeatureCommandRender) error {

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/openapi"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/require"
 )
@@ -137,7 +138,7 @@ func TestPaginatedGetAcceptsNumericNextCursor(t *testing.T) {
 		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"meta":{"nextPage":2}}` + "`" + `),
 		json.RawMessage(` + "`" + `{"items":[{"id":"two"}],"meta":{}}` + "`" + `),
 	}}
-	data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "page", "limit", "meta.nextPage", "")
+	data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "page", "limit", 100, "meta.nextPage", "")
 	if err != nil {
 		t.Fatalf("paginatedGet returned error: %v", err)
 	}
@@ -160,7 +161,7 @@ func TestPaginatedGetStopsAtNumericZeroNextCursor(t *testing.T) {
 	client := &paginatedTestClient{responses: []json.RawMessage{
 		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"meta":{"nextPage":0}}` + "`" + `),
 	}}
-	data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "page", "limit", "meta.nextPage", "")
+	data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "page", "limit", 100, "meta.nextPage", "")
 	if err != nil {
 		t.Fatalf("paginatedGet returned error: %v", err)
 	}
@@ -181,7 +182,7 @@ func TestPaginatedGetWarnsForSinglePageNumericNextCursor(t *testing.T) {
 		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"meta":{"nextPage":2}}` + "`" + `),
 	}}
 	stderr := capturePaginatedStderr(t, func() {
-		_, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, false, "page", "page", "limit", "meta.nextPage", "")
+		_, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, false, "page", "page", "limit", 100, "meta.nextPage", "")
 		if err != nil {
 			t.Fatalf("paginatedGet returned error: %v", err)
 		}
@@ -196,7 +197,7 @@ func TestPaginatedGetWarnsForSinglePageHasMoreNumericPagination(t *testing.T) {
 		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"meta":{"has_more":true}}` + "`" + `),
 	}}
 	stderr := capturePaginatedStderr(t, func() {
-		_, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, false, "page", "page", "limit", "", "meta.has_more")
+		_, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, false, "page", "page", "limit", 100, "", "meta.has_more")
 		if err != nil {
 			t.Fatalf("paginatedGet returned error: %v", err)
 		}
@@ -211,7 +212,7 @@ func TestPaginatedGetWarnsWhenAllHasNoAdvanceSignal(t *testing.T) {
 		json.RawMessage(` + "`" + `[{"id":"one"}]` + "`" + `),
 	}}
 	stderr := capturePaginatedStderr(t, func() {
-		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "cursor", "cursor", "limit", "", "")
+		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "cursor", "cursor", "limit", 100, "", "")
 		if err != nil {
 			t.Fatalf("paginatedGet returned error: %v", err)
 		}
@@ -239,7 +240,7 @@ func TestPaginatedGetIncrementsNumericCursorWhenHasMoreHasNoBodyCursor(t *testin
 		json.RawMessage(` + "`" + `{"items":[{"id":"four"}],"meta":{"has_more":false}}` + "`" + `),
 	}}
 	stderr := capturePaginatedStderr(t, func() {
-		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "page", "limit", "", "meta.has_more")
+		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "page", "limit", 100, "", "meta.has_more")
 		if err != nil {
 			t.Fatalf("paginatedGet returned error: %v", err)
 		}
@@ -272,7 +273,7 @@ func TestPaginatedGetIncrementsNumericCursorWhenDeclaredBodyCursorIsMissing(t *t
 		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"meta":{"has_more":true}}` + "`" + `),
 		json.RawMessage(` + "`" + `{"items":[{"id":"two"}],"meta":{"has_more":false}}` + "`" + `),
 	}}
-	data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "page", "limit", "meta.nextPage", "meta.has_more")
+	data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "page", "limit", 100, "meta.nextPage", "meta.has_more")
 	if err != nil {
 		t.Fatalf("paginatedGet returned error: %v", err)
 	}
@@ -296,7 +297,7 @@ func TestPaginatedGetAdvancesOffsetCursorByLimitWhenHasMoreHasNoBodyCursor(t *te
 		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"meta":{"has_more":true}}` + "`" + `),
 		json.RawMessage(` + "`" + `{"items":[{"id":"two"}],"meta":{"has_more":false}}` + "`" + `),
 	}}
-	data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"100", "offset":"0"}, nil, true, "offset", "offset", "limit", "", "meta.has_more")
+	data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"100", "offset":"0"}, nil, true, "offset", "offset", "limit", 100, "", "meta.has_more")
 	if err != nil {
 		t.Fatalf("paginatedGet returned error: %v", err)
 	}
@@ -320,7 +321,7 @@ func TestPaginatedGetAdvancesOffsetAfterFullPageWithoutHasMore(t *testing.T) {
 		json.RawMessage(` + "`" + `{"items":[{"id":"one"},{"id":"two"}]}` + "`" + `),
 		json.RawMessage(` + "`" + `{"items":[{"id":"three"}]}` + "`" + `),
 	}}
-	data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"2", "offset":"0"}, nil, true, "offset", "offset", "limit", "", "")
+	data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"2", "offset":"0"}, nil, true, "offset", "offset", "limit", 100, "", "")
 	if err != nil {
 		t.Fatalf("paginatedGet returned error: %v", err)
 	}
@@ -345,7 +346,7 @@ func TestPaginatedGetAdvancesPageAfterFullPageWithoutHasMore(t *testing.T) {
 		json.RawMessage(` + "`" + `{"items":[{"id":"three"}]}` + "`" + `),
 	}}
 	stderr := capturePaginatedStderr(t, func() {
-		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"per_page":"2"}, nil, true, "page", "page", "per_page", "", "")
+		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"per_page":"2"}, nil, true, "page", "page", "per_page", 100, "", "")
 		if err != nil {
 			t.Fatalf("paginatedGet returned error: %v", err)
 		}
@@ -373,7 +374,7 @@ func TestPaginatedGetDoesNotWarnWhenOffsetShortPageHasNoSignal(t *testing.T) {
 		json.RawMessage(` + "`" + `{"items":[{"id":"one"}]}` + "`" + `),
 	}}
 	stderr := capturePaginatedStderr(t, func() {
-		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"2", "offset":"0"}, nil, true, "offset", "offset", "limit", "", "")
+		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"2", "offset":"0"}, nil, true, "offset", "offset", "limit", 100, "", "")
 		if err != nil {
 			t.Fatalf("paginatedGet returned error: %v", err)
 		}
@@ -398,7 +399,7 @@ func TestPaginatedGetStopsOffsetAtExplicitHasMoreFalseAfterFullPage(t *testing.T
 		json.RawMessage(` + "`" + `{"items":[{"id":"one"},{"id":"two"}],"meta":{"has_more":false}}` + "`" + `),
 		json.RawMessage(` + "`" + `{"items":[{"id":"three"}]}` + "`" + `),
 	}}
-	data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"2", "offset":"0"}, nil, true, "offset", "offset", "limit", "", "meta.has_more")
+	data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"2", "offset":"0"}, nil, true, "offset", "offset", "limit", 100, "", "meta.has_more")
 	if err != nil {
 		t.Fatalf("paginatedGet returned error: %v", err)
 	}
@@ -419,7 +420,7 @@ func TestPaginatedGetStopsOffsetAfterShortPageWithoutHasMore(t *testing.T) {
 		json.RawMessage(` + "`" + `{"items":[{"id":"one"}]}` + "`" + `),
 		json.RawMessage(` + "`" + `{"items":[{"id":"two"}]}` + "`" + `),
 	}}
-	data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"2", "offset":"0"}, nil, true, "offset", "offset", "limit", "", "")
+	data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"2", "offset":"0"}, nil, true, "offset", "offset", "limit", 100, "", "")
 	if err != nil {
 		t.Fatalf("paginatedGet returned error: %v", err)
 	}
@@ -440,7 +441,7 @@ func TestPaginatedGetWarnsWhenHasMorePageParamIsNonNumeric(t *testing.T) {
 		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"meta":{"has_more":true}}` + "`" + `),
 	}}
 	stderr := capturePaginatedStderr(t, func() {
-		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1", "page":"not-a-number"}, nil, true, "page", "page", "limit", "", "meta.has_more")
+		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1", "page":"not-a-number"}, nil, true, "page", "page", "limit", 100, "", "meta.has_more")
 		if err != nil {
 			t.Fatalf("paginatedGet returned error: %v", err)
 		}
@@ -470,7 +471,7 @@ func TestPaginatedGetStopsAtMaxPageSafetyLimit(t *testing.T) {
 	}
 	client := &paginatedTestClient{responses: responses}
 	stderr := capturePaginatedStderr(t, func() {
-		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "page", "limit", "", "meta.has_more")
+		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "page", "limit", 100, "", "meta.has_more")
 		if err != nil {
 			t.Fatalf("paginatedGet returned error: %v", err)
 		}
@@ -497,7 +498,7 @@ func TestPaginatedGetStopsAtMaxPageSafetyLimitForBodyCursor(t *testing.T) {
 	}
 	client := &paginatedTestClient{responses: responses}
 	stderr := capturePaginatedStderr(t, func() {
-		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "cursor", "cursor", "limit", "meta.next", "")
+		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "cursor", "cursor", "limit", 100, "meta.next", "")
 		if err != nil {
 			t.Fatalf("paginatedGet returned error: %v", err)
 		}
@@ -533,7 +534,7 @@ func TestPaginatedGetMergesDomainSpecificWrappedArrayWithMetadataArrays(t *testi
 			"cursor": null
 		}` + "`" + `),
 	}}
-	data, err := paginatedGet(context.Background(), client, "/charges", map[string]string{"limit":"1"}, nil, true, "cursor", "cursor", "limit", "cursor", "")
+	data, err := paginatedGet(context.Background(), client, "/charges", map[string]string{"limit":"1"}, nil, true, "cursor", "cursor", "limit", 100, "cursor", "")
 	if err != nil {
 		t.Fatalf("paginatedGet returned error: %v", err)
 	}
@@ -570,6 +571,111 @@ func containsAll(s string, needles ...string) bool {
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "paginated_get_issue1688_test.go"), []byte(behaviorTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "TestPaginatedGet")
+}
+
+func TestIssue3497BareAllOffsetUsesDefaultPageSize(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("issue3497-offset")
+	apiSpec.Resources = map[string]spec.Resource{
+		"records": {
+			Description: "Manage records",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/records",
+					Description: "List records",
+					Params: []spec.Param{
+						{Name: "limit", Type: "integer"},
+						{Name: "offset", Type: "integer"},
+					},
+					Pagination: &spec.Pagination{
+						Type:        "offset",
+						CursorParam: "offset",
+						LimitParam:  "limit",
+					},
+					Response: spec.ResponseDef{Type: "array", Item: "Record"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "issue3497-offset-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Export: true}
+	gen.profile = &profiler.APIProfile{
+		Pagination: profiler.PaginationProfile{
+			CursorParam:     "offset",
+			CursorType:      "offset",
+			PageSizeParam:   "limit",
+			DefaultPageSize: 2,
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	generatedCLISourceContaining(t, outputDir, `flagAll, "offset", "offset", "limit", 2, "", ""`)
+
+	behaviorTest := `package cli
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+type issue3497Client struct {
+	responses []json.RawMessage
+	params    []map[string]string
+}
+
+func (c *issue3497Client) GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	_ = ctx
+	copied := map[string]string{}
+	for k, v := range params {
+		copied[k] = v
+	}
+	c.params = append(c.params, copied)
+	if len(c.responses) == 0 {
+		return json.RawMessage(` + "`" + `[]` + "`" + `), nil
+	}
+	next := c.responses[0]
+	c.responses = c.responses[1:]
+	return next, nil
+}
+
+func TestIssue3497BareAllOffsetUsesDefaultPageSize(t *testing.T) {
+	client := &issue3497Client{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `[{"id":"one"},{"id":"two"}]` + "`" + `),
+		json.RawMessage(` + "`" + `[{"id":"three"}]` + "`" + `),
+	}}
+	data, err := paginatedGet(context.Background(), client, "/records", map[string]string{"limit":"0", "offset":"0"}, nil, true, "offset", "offset", "limit", 2, "", "")
+	if err != nil {
+		t.Fatalf("paginatedGet returned error: %v", err)
+	}
+	var got []map[string]string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d items, want 3; data=%s", len(got), data)
+	}
+	if len(client.params) != 2 {
+		t.Fatalf("got %d requests, want 2", len(client.params))
+	}
+	if _, ok := client.params[0]["limit"]; ok {
+		t.Fatalf("first request should strip unset limit=0, params=%v", client.params[0])
+	}
+	if client.params[0]["offset"] != "0" {
+		t.Fatalf("first request offset = %q, want 0", client.params[0]["offset"])
+	}
+	if client.params[1]["offset"] != "2" {
+		t.Fatalf("second request offset = %q, want 2", client.params[1]["offset"])
+	}
+}
+`
+	cliDir := filepath.Join(outputDir, "internal", "cli")
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "paginated_get_issue3497_test.go"), []byte(behaviorTest), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "^TestIssue3497BareAllOffsetUsesDefaultPageSize$", "-count=1")
 }
 
 func TestOpenAPINestedNextPageGeneratesPaginatedCommandSignal(t *testing.T) {
@@ -629,7 +735,7 @@ paths:
 		commandSrc.Write(src)
 		commandSrc.WriteByte('\n')
 	}
-	require.Contains(t, commandSrc.String(), `flagAll, "page", "page", "limit", "meta.nextPage", ""`,
+	require.Contains(t, commandSrc.String(), `flagAll, "page", "page", "limit", 100, "meta.nextPage", ""`,
 		"generated command must pass parser-detected nested nextPage to resolvePaginatedRead")
 }
 
@@ -687,6 +793,6 @@ paths:
 		commandSrc.Write(src)
 		commandSrc.WriteByte('\n')
 	}
-	require.Contains(t, commandSrc.String(), `flagAll, "page", "page", "limit", "", "has_more"`,
+	require.Contains(t, commandSrc.String(), `flagAll, "page", "page", "limit", 100, "", "has_more"`,
 		"generated command must pass has-more-only page pagination metadata to resolvePaginatedRead")
 }

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -662,11 +662,14 @@ func TestIssue3497BareAllOffsetUsesDefaultPageSize(t *testing.T) {
 	if len(client.params) != 2 {
 		t.Fatalf("got %d requests, want 2", len(client.params))
 	}
-	if _, ok := client.params[0]["limit"]; ok {
-		t.Fatalf("first request should strip unset limit=0, params=%v", client.params[0])
+	if client.params[0]["limit"] != "2" {
+		t.Fatalf("first request limit = %q, want 2; params=%v", client.params[0]["limit"], client.params[0])
 	}
 	if client.params[0]["offset"] != "0" {
 		t.Fatalf("first request offset = %q, want 0", client.params[0]["offset"])
+	}
+	if client.params[1]["limit"] != "2" {
+		t.Fatalf("second request limit = %q, want 2; params=%v", client.params[1]["limit"], client.params[1])
 	}
 	if client.params[1]["offset"] != "2" {
 		t.Fatalf("second request offset = %q, want 2", client.params[1]["offset"])

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -573,49 +573,66 @@ func containsAll(s string, needles ...string) bool {
 	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "TestPaginatedGet")
 }
 
-func TestIssue3497BareAllOffsetUsesDefaultPageSize(t *testing.T) {
+func TestIssue3497BareAllOffsetUsesEndpointPageSize(t *testing.T) {
 	t.Parallel()
 
-	apiSpec := minimalSpec("issue3497-offset")
-	apiSpec.Resources = map[string]spec.Resource{
-		"records": {
-			Description: "Manage records",
-			Endpoints: map[string]spec.Endpoint{
-				"list": {
-					Method:      "GET",
-					Path:        "/records",
-					Description: "List records",
-					Params: []spec.Param{
-						{Name: "limit", Type: "integer"},
-						{Name: "offset", Type: "integer"},
+	capped := 2.0
+	for _, tc := range []struct {
+		name       string
+		limitParam spec.Param
+	}{
+		{
+			name:       "default",
+			limitParam: spec.Param{Name: "limit", Type: "integer", Default: 2},
+		},
+		{
+			name:       "maximum",
+			limitParam: spec.Param{Name: "limit", Type: "integer", Maximum: &capped},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			apiSpec := minimalSpec("issue3497-offset-" + tc.name)
+			apiSpec.Resources = map[string]spec.Resource{
+				"records": {
+					Description: "Manage records",
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method:      "GET",
+							Path:        "/records",
+							Description: "List records",
+							Params: []spec.Param{
+								tc.limitParam,
+								{Name: "offset", Type: "integer"},
+							},
+							Pagination: &spec.Pagination{
+								Type:        "offset",
+								CursorParam: "offset",
+								LimitParam:  "limit",
+							},
+							Response: spec.ResponseDef{Type: "array", Item: "Record"},
+						},
 					},
-					Pagination: &spec.Pagination{
-						Type:        "offset",
-						CursorParam: "offset",
-						LimitParam:  "limit",
-					},
-					Response: spec.ResponseDef{Type: "array", Item: "Record"},
 				},
-			},
-		},
-	}
+			}
 
-	outputDir := filepath.Join(t.TempDir(), "issue3497-offset-pp-cli")
-	gen := New(apiSpec, outputDir)
-	gen.VisionSet = VisionTemplateSet{Export: true}
-	gen.profile = &profiler.APIProfile{
-		Pagination: profiler.PaginationProfile{
-			CursorParam:     "offset",
-			CursorType:      "offset",
-			PageSizeParam:   "limit",
-			DefaultPageSize: 2,
-		},
-	}
-	require.NoError(t, gen.Generate())
+			outputDir := filepath.Join(t.TempDir(), "issue3497-offset-"+tc.name+"-pp-cli")
+			gen := New(apiSpec, outputDir)
+			gen.VisionSet = VisionTemplateSet{Export: true}
+			gen.profile = &profiler.APIProfile{
+				Pagination: profiler.PaginationProfile{
+					CursorParam:     "offset",
+					CursorType:      "offset",
+					PageSizeParam:   "limit",
+					DefaultPageSize: 100,
+				},
+			}
+			require.NoError(t, gen.Generate())
 
-	generatedCLISourceContaining(t, outputDir, `flagAll, "offset", "offset", "limit", 2, "", ""`)
+			generatedCLISourceContaining(t, outputDir, `flagAll, "offset", "offset", "limit", 2, "", ""`)
 
-	behaviorTest := `package cli
+			behaviorTest := `package cli
 
 import (
 	"context"
@@ -676,9 +693,11 @@ func TestIssue3497BareAllOffsetUsesDefaultPageSize(t *testing.T) {
 	}
 }
 `
-	cliDir := filepath.Join(outputDir, "internal", "cli")
-	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "paginated_get_issue3497_test.go"), []byte(behaviorTest), 0o644))
-	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "^TestIssue3497BareAllOffsetUsesDefaultPageSize$", "-count=1")
+			cliDir := filepath.Join(outputDir, "internal", "cli")
+			require.NoError(t, os.WriteFile(filepath.Join(cliDir, "paginated_get_issue3497_test.go"), []byte(behaviorTest), 0o644))
+			runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "^TestIssue3497BareAllOffsetUsesDefaultPageSize$", "-count=1")
+		})
+	}
 }
 
 func TestOpenAPINestedNextPageGeneratesPaginatedCommandSignal(t *testing.T) {

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -327,7 +327,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", cmd.ErrOrStderr())
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")
@@ -345,7 +345,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
 {{- end}}
 {{- else}}
 			params := map[string]string{}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -201,7 +201,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", cmd.ErrOrStderr())
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")
@@ -219,7 +219,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
 {{- end}}
 {{- else}}
 {{- if not $deleteBodyWithoutParams}}

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -214,11 +214,11 @@ func resolveReadWithStrategyResponsePathAndJSONGuard(ctx context.Context, c *cli
 // or local store. When local, skips pagination and returns all synced data. The
 // headers argument carries per-endpoint required headers; pass nil when the
 // endpoint declares no overrides.
-func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam, nextCursorPath, hasMoreField string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
-	return resolvePaginatedReadWithStrategy(ctx, c, flags, "auto", resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, nextCursorPath, hasMoreField, hintWriter)
+func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+	return resolvePaginatedReadWithStrategy(ctx, c, flags, "auto", resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, hintWriter)
 }
 
-func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam, nextCursorPath, hasMoreField string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
 	if err := validateDataSourceStrategy(flags, strategy); err != nil {
 		return nil, DataProvenance{}, err
 	}
@@ -227,7 +227,7 @@ func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, fla
 		return data, attachFreshness(prov, flags), err
 	}
 	if strategy == "live" {
-		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, nextCursorPath, hasMoreField)
+		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
@@ -242,7 +242,7 @@ func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, fla
 		return data, attachFreshness(prov, flags), err
 
 	case "live":
-		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, nextCursorPath, hasMoreField)
+		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
@@ -252,7 +252,7 @@ func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, fla
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 
 	default: // "auto"
-		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, nextCursorPath, hasMoreField)
+		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
 		if err == nil {
 			if err := assertLiveJSONBody(data); err != nil {
 				return nil, DataProvenance{}, err

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1045,13 +1045,18 @@ func paginatedGet(ctx context.Context, c interface {
 	pageSize := 0
 	if paginationType == "offset" || paginationType == "page" {
 		pageSize = defaultPageSize
+		hasPositiveLimit := false
 		if limitParam != "" {
 			if limit, err := strconv.Atoi(clean[limitParam]); err == nil && limit > 0 {
 				pageSize = limit
+				hasPositiveLimit = true
 			}
 		}
 		if pageSize <= 0 {
 			pageSize = 100
+		}
+		if limitParam != "" && !hasPositiveLimit {
+			clean[limitParam] = strconv.Itoa(pageSize)
 		}
 	}
 

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1021,7 +1021,7 @@ func replacePathParam(path, name, value string) string {
 // endpoint has no per-endpoint header overrides.
 func paginatedGet(ctx context.Context, c interface {
 	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
-}, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
+}, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
 	// Cursor params are exempt from the "0"/"false" strip: offset-paginated
 	// APIs send offset=0 on the first page.
 	clean := map[string]string{}
@@ -1033,7 +1033,6 @@ func paginatedGet(ctx context.Context, c interface {
 			clean[k] = v
 		}
 	}
-
 	if !fetchAll {
 		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
@@ -1041,6 +1040,19 @@ func paginatedGet(ctx context.Context, c interface {
 		}
 		emitTruncationWarning(data, nextCursorPath, hasMoreField, paginationType)
 		return data, nil
+	}
+
+	pageSize := 0
+	if paginationType == "offset" || paginationType == "page" {
+		pageSize = defaultPageSize
+		if limitParam != "" {
+			if limit, err := strconv.Atoi(clean[limitParam]); err == nil && limit > 0 {
+				pageSize = limit
+			}
+		}
+		if pageSize <= 0 {
+			pageSize = 100
+		}
 	}
 
 	// Fetch all pages
@@ -1063,7 +1075,7 @@ func paginatedGet(ctx context.Context, c interface {
 		var items []json.RawMessage
 		if json.Unmarshal(data, &items) == nil {
 			allItems = append(allItems, items...)
-			if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, limitParam, len(items)); ok {
+			if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, pageSize, len(items)); ok {
 				if page >= paginatedGetMaxPages {
 					emitPaginatedGetMaxPagesWarning()
 					break
@@ -1103,7 +1115,7 @@ func paginatedGet(ctx context.Context, c interface {
 						var more bool
 						if json.Unmarshal(moreRaw, &more) == nil {
 							if more {
-								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, limitParam); ok {
+								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, pageSize); ok {
 									if page >= paginatedGetMaxPages {
 										emitPaginatedGetMaxPagesWarning()
 										break
@@ -1119,7 +1131,7 @@ func paginatedGet(ctx context.Context, c interface {
 					}
 				}
 				if !hasExplicitNoMore && nextCursorPath == "" && hasMoreField == "" {
-					if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, limitParam, itemCount); ok {
+					if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, pageSize, itemCount); ok {
 						if page >= paginatedGetMaxPages {
 							emitPaginatedGetMaxPagesWarning()
 							break
@@ -1149,18 +1161,17 @@ func paginatedGet(ctx context.Context, c interface {
 	return json.RawMessage(result), nil
 }
 
-func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationType, limitParam string, itemCount int) (string, bool) {
+func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationType string, pageSize, itemCount int) (string, bool) {
 	if (paginationType != "offset" && paginationType != "page") || itemCount == 0 {
 		return "", false
 	}
-	limit, err := strconv.Atoi(params[limitParam])
-	if err != nil || limit <= 0 || itemCount < limit {
+	if pageSize <= 0 || itemCount < pageSize {
 		return "", false
 	}
-	return nextClientSidePaginationCursor(params, cursorParam, paginationType, limitParam)
+	return nextClientSidePaginationCursor(params, cursorParam, paginationType, pageSize)
 }
 
-func nextClientSidePaginationCursor(params map[string]string, cursorParam, paginationType, limitParam string) (string, bool) {
+func nextClientSidePaginationCursor(params map[string]string, cursorParam, paginationType string, pageSize int) (string, bool) {
 	if cursorParam == "" {
 		return "", false
 	}
@@ -1184,11 +1195,10 @@ func nextClientSidePaginationCursor(params map[string]string, cursorParam, pagin
 		if err != nil {
 			return "", false
 		}
-		limit, err := strconv.Atoi(params[limitParam])
-		if err != nil || limit <= 0 {
+		if pageSize <= 0 {
 			return "", false
 		}
-		return strconv.Itoa(n + limit), true
+		return strconv.Itoa(n + pageSize), true
 	default:
 		return "", false
 	}

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -537,7 +537,7 @@ func replacePathParam(path, name, value string) string {
 // endpoint has no per-endpoint header overrides.
 func paginatedGet(ctx context.Context, c interface {
 	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
-}, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
+}, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
 	// Cursor params are exempt from the "0"/"false" strip: offset-paginated
 	// APIs send offset=0 on the first page.
 	clean := map[string]string{}
@@ -549,7 +549,6 @@ func paginatedGet(ctx context.Context, c interface {
 			clean[k] = v
 		}
 	}
-
 	if !fetchAll {
 		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
@@ -557,6 +556,19 @@ func paginatedGet(ctx context.Context, c interface {
 		}
 		emitTruncationWarning(data, nextCursorPath, hasMoreField, paginationType)
 		return data, nil
+	}
+
+	pageSize := 0
+	if paginationType == "offset" || paginationType == "page" {
+		pageSize = defaultPageSize
+		if limitParam != "" {
+			if limit, err := strconv.Atoi(clean[limitParam]); err == nil && limit > 0 {
+				pageSize = limit
+			}
+		}
+		if pageSize <= 0 {
+			pageSize = 100
+		}
 	}
 
 	// Fetch all pages
@@ -579,7 +591,7 @@ func paginatedGet(ctx context.Context, c interface {
 		var items []json.RawMessage
 		if json.Unmarshal(data, &items) == nil {
 			allItems = append(allItems, items...)
-			if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, limitParam, len(items)); ok {
+			if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, pageSize, len(items)); ok {
 				if page >= paginatedGetMaxPages {
 					emitPaginatedGetMaxPagesWarning()
 					break
@@ -619,7 +631,7 @@ func paginatedGet(ctx context.Context, c interface {
 						var more bool
 						if json.Unmarshal(moreRaw, &more) == nil {
 							if more {
-								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, limitParam); ok {
+								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, pageSize); ok {
 									if page >= paginatedGetMaxPages {
 										emitPaginatedGetMaxPagesWarning()
 										break
@@ -635,7 +647,7 @@ func paginatedGet(ctx context.Context, c interface {
 					}
 				}
 				if !hasExplicitNoMore && nextCursorPath == "" && hasMoreField == "" {
-					if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, limitParam, itemCount); ok {
+					if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, pageSize, itemCount); ok {
 						if page >= paginatedGetMaxPages {
 							emitPaginatedGetMaxPagesWarning()
 							break
@@ -665,18 +677,17 @@ func paginatedGet(ctx context.Context, c interface {
 	return json.RawMessage(result), nil
 }
 
-func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationType, limitParam string, itemCount int) (string, bool) {
+func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationType string, pageSize, itemCount int) (string, bool) {
 	if (paginationType != "offset" && paginationType != "page") || itemCount == 0 {
 		return "", false
 	}
-	limit, err := strconv.Atoi(params[limitParam])
-	if err != nil || limit <= 0 || itemCount < limit {
+	if pageSize <= 0 || itemCount < pageSize {
 		return "", false
 	}
-	return nextClientSidePaginationCursor(params, cursorParam, paginationType, limitParam)
+	return nextClientSidePaginationCursor(params, cursorParam, paginationType, pageSize)
 }
 
-func nextClientSidePaginationCursor(params map[string]string, cursorParam, paginationType, limitParam string) (string, bool) {
+func nextClientSidePaginationCursor(params map[string]string, cursorParam, paginationType string, pageSize int) (string, bool) {
 	if cursorParam == "" {
 		return "", false
 	}
@@ -700,11 +711,10 @@ func nextClientSidePaginationCursor(params map[string]string, cursorParam, pagin
 		if err != nil {
 			return "", false
 		}
-		limit, err := strconv.Atoi(params[limitParam])
-		if err != nil || limit <= 0 {
+		if pageSize <= 0 {
 			return "", false
 		}
-		return strconv.Itoa(n + limit), true
+		return strconv.Itoa(n + pageSize), true
 	default:
 		return "", false
 	}

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -561,13 +561,18 @@ func paginatedGet(ctx context.Context, c interface {
 	pageSize := 0
 	if paginationType == "offset" || paginationType == "page" {
 		pageSize = defaultPageSize
+		hasPositiveLimit := false
 		if limitParam != "" {
 			if limit, err := strconv.Atoi(clean[limitParam]); err == nil && limit > 0 {
 				pageSize = limit
+				hasPositiveLimit = true
 			}
 		}
 		if pageSize <= 0 {
 			pageSize = 100
+		}
+		if limitParam != "" && !hasPositiveLimit {
+			clean[limitParam] = strconv.Itoa(pageSize)
 		}
 	}
 

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -530,7 +530,7 @@ func newTabWriter(w io.Writer) *tabwriter.Writer {
 // endpoint has no per-endpoint header overrides.
 func paginatedGet(ctx context.Context, c interface {
 	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
-}, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
+}, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
 	// Cursor params are exempt from the "0"/"false" strip: offset-paginated
 	// APIs send offset=0 on the first page.
 	clean := map[string]string{}
@@ -542,7 +542,6 @@ func paginatedGet(ctx context.Context, c interface {
 			clean[k] = v
 		}
 	}
-
 	if !fetchAll {
 		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
@@ -550,6 +549,19 @@ func paginatedGet(ctx context.Context, c interface {
 		}
 		emitTruncationWarning(data, nextCursorPath, hasMoreField, paginationType)
 		return data, nil
+	}
+
+	pageSize := 0
+	if paginationType == "offset" || paginationType == "page" {
+		pageSize = defaultPageSize
+		if limitParam != "" {
+			if limit, err := strconv.Atoi(clean[limitParam]); err == nil && limit > 0 {
+				pageSize = limit
+			}
+		}
+		if pageSize <= 0 {
+			pageSize = 100
+		}
 	}
 
 	// Fetch all pages
@@ -572,7 +584,7 @@ func paginatedGet(ctx context.Context, c interface {
 		var items []json.RawMessage
 		if json.Unmarshal(data, &items) == nil {
 			allItems = append(allItems, items...)
-			if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, limitParam, len(items)); ok {
+			if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, pageSize, len(items)); ok {
 				if page >= paginatedGetMaxPages {
 					emitPaginatedGetMaxPagesWarning()
 					break
@@ -612,7 +624,7 @@ func paginatedGet(ctx context.Context, c interface {
 						var more bool
 						if json.Unmarshal(moreRaw, &more) == nil {
 							if more {
-								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, limitParam); ok {
+								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, pageSize); ok {
 									if page >= paginatedGetMaxPages {
 										emitPaginatedGetMaxPagesWarning()
 										break
@@ -628,7 +640,7 @@ func paginatedGet(ctx context.Context, c interface {
 					}
 				}
 				if !hasExplicitNoMore && nextCursorPath == "" && hasMoreField == "" {
-					if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, limitParam, itemCount); ok {
+					if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, pageSize, itemCount); ok {
 						if page >= paginatedGetMaxPages {
 							emitPaginatedGetMaxPagesWarning()
 							break
@@ -658,18 +670,17 @@ func paginatedGet(ctx context.Context, c interface {
 	return json.RawMessage(result), nil
 }
 
-func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationType, limitParam string, itemCount int) (string, bool) {
+func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationType string, pageSize, itemCount int) (string, bool) {
 	if (paginationType != "offset" && paginationType != "page") || itemCount == 0 {
 		return "", false
 	}
-	limit, err := strconv.Atoi(params[limitParam])
-	if err != nil || limit <= 0 || itemCount < limit {
+	if pageSize <= 0 || itemCount < pageSize {
 		return "", false
 	}
-	return nextClientSidePaginationCursor(params, cursorParam, paginationType, limitParam)
+	return nextClientSidePaginationCursor(params, cursorParam, paginationType, pageSize)
 }
 
-func nextClientSidePaginationCursor(params map[string]string, cursorParam, paginationType, limitParam string) (string, bool) {
+func nextClientSidePaginationCursor(params map[string]string, cursorParam, paginationType string, pageSize int) (string, bool) {
 	if cursorParam == "" {
 		return "", false
 	}
@@ -693,11 +704,10 @@ func nextClientSidePaginationCursor(params map[string]string, cursorParam, pagin
 		if err != nil {
 			return "", false
 		}
-		limit, err := strconv.Atoi(params[limitParam])
-		if err != nil || limit <= 0 {
+		if pageSize <= 0 {
 			return "", false
 		}
-		return strconv.Itoa(n + limit), true
+		return strconv.Itoa(n + pageSize), true
 	default:
 		return "", false
 	}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -554,13 +554,18 @@ func paginatedGet(ctx context.Context, c interface {
 	pageSize := 0
 	if paginationType == "offset" || paginationType == "page" {
 		pageSize = defaultPageSize
+		hasPositiveLimit := false
 		if limitParam != "" {
 			if limit, err := strconv.Atoi(clean[limitParam]); err == nil && limit > 0 {
 				pageSize = limit
+				hasPositiveLimit = true
 			}
 		}
 		if pageSize <= 0 {
 			pageSize = 100
+		}
+		if limitParam != "" && !hasPositiveLimit {
+			clean[limitParam] = strconv.Itoa(pageSize)
 		}
 	}
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -214,11 +214,11 @@ func resolveReadWithStrategyResponsePathAndJSONGuard(ctx context.Context, c *cli
 // or local store. When local, skips pagination and returns all synced data. The
 // headers argument carries per-endpoint required headers; pass nil when the
 // endpoint declares no overrides.
-func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam, nextCursorPath, hasMoreField string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
-	return resolvePaginatedReadWithStrategy(ctx, c, flags, "auto", resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, nextCursorPath, hasMoreField, hintWriter)
+func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+	return resolvePaginatedReadWithStrategy(ctx, c, flags, "auto", resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, hintWriter)
 }
 
-func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam, nextCursorPath, hasMoreField string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
 	if err := validateDataSourceStrategy(flags, strategy); err != nil {
 		return nil, DataProvenance{}, err
 	}
@@ -227,7 +227,7 @@ func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, fla
 		return data, attachFreshness(prov, flags), err
 	}
 	if strategy == "live" {
-		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, nextCursorPath, hasMoreField)
+		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
@@ -242,7 +242,7 @@ func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, fla
 		return data, attachFreshness(prov, flags), err
 
 	case "live":
-		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, nextCursorPath, hasMoreField)
+		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
@@ -252,7 +252,7 @@ func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, fla
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 
 	default: // "auto"
-		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, nextCursorPath, hasMoreField)
+		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
 		if err == nil {
 			if err := assertLiveJSONBody(data); err != nil {
 				return nil, DataProvenance{}, err

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -639,13 +639,18 @@ func paginatedGet(ctx context.Context, c interface {
 	pageSize := 0
 	if paginationType == "offset" || paginationType == "page" {
 		pageSize = defaultPageSize
+		hasPositiveLimit := false
 		if limitParam != "" {
 			if limit, err := strconv.Atoi(clean[limitParam]); err == nil && limit > 0 {
 				pageSize = limit
+				hasPositiveLimit = true
 			}
 		}
 		if pageSize <= 0 {
 			pageSize = 100
+		}
+		if limitParam != "" && !hasPositiveLimit {
+			clean[limitParam] = strconv.Itoa(pageSize)
 		}
 	}
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -615,7 +615,7 @@ func replacePathParam(path, name, value string) string {
 // endpoint has no per-endpoint header overrides.
 func paginatedGet(ctx context.Context, c interface {
 	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
-}, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
+}, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
 	// Cursor params are exempt from the "0"/"false" strip: offset-paginated
 	// APIs send offset=0 on the first page.
 	clean := map[string]string{}
@@ -627,7 +627,6 @@ func paginatedGet(ctx context.Context, c interface {
 			clean[k] = v
 		}
 	}
-
 	if !fetchAll {
 		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
@@ -635,6 +634,19 @@ func paginatedGet(ctx context.Context, c interface {
 		}
 		emitTruncationWarning(data, nextCursorPath, hasMoreField, paginationType)
 		return data, nil
+	}
+
+	pageSize := 0
+	if paginationType == "offset" || paginationType == "page" {
+		pageSize = defaultPageSize
+		if limitParam != "" {
+			if limit, err := strconv.Atoi(clean[limitParam]); err == nil && limit > 0 {
+				pageSize = limit
+			}
+		}
+		if pageSize <= 0 {
+			pageSize = 100
+		}
 	}
 
 	// Fetch all pages
@@ -657,7 +669,7 @@ func paginatedGet(ctx context.Context, c interface {
 		var items []json.RawMessage
 		if json.Unmarshal(data, &items) == nil {
 			allItems = append(allItems, items...)
-			if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, limitParam, len(items)); ok {
+			if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, pageSize, len(items)); ok {
 				if page >= paginatedGetMaxPages {
 					emitPaginatedGetMaxPagesWarning()
 					break
@@ -697,7 +709,7 @@ func paginatedGet(ctx context.Context, c interface {
 						var more bool
 						if json.Unmarshal(moreRaw, &more) == nil {
 							if more {
-								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, limitParam); ok {
+								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, pageSize); ok {
 									if page >= paginatedGetMaxPages {
 										emitPaginatedGetMaxPagesWarning()
 										break
@@ -713,7 +725,7 @@ func paginatedGet(ctx context.Context, c interface {
 					}
 				}
 				if !hasExplicitNoMore && nextCursorPath == "" && hasMoreField == "" {
-					if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, limitParam, itemCount); ok {
+					if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, pageSize, itemCount); ok {
 						if page >= paginatedGetMaxPages {
 							emitPaginatedGetMaxPagesWarning()
 							break
@@ -743,18 +755,17 @@ func paginatedGet(ctx context.Context, c interface {
 	return json.RawMessage(result), nil
 }
 
-func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationType, limitParam string, itemCount int) (string, bool) {
+func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationType string, pageSize, itemCount int) (string, bool) {
 	if (paginationType != "offset" && paginationType != "page") || itemCount == 0 {
 		return "", false
 	}
-	limit, err := strconv.Atoi(params[limitParam])
-	if err != nil || limit <= 0 || itemCount < limit {
+	if pageSize <= 0 || itemCount < pageSize {
 		return "", false
 	}
-	return nextClientSidePaginationCursor(params, cursorParam, paginationType, limitParam)
+	return nextClientSidePaginationCursor(params, cursorParam, paginationType, pageSize)
 }
 
-func nextClientSidePaginationCursor(params map[string]string, cursorParam, paginationType, limitParam string) (string, bool) {
+func nextClientSidePaginationCursor(params map[string]string, cursorParam, paginationType string, pageSize int) (string, bool) {
 	if cursorParam == "" {
 		return "", false
 	}
@@ -778,11 +789,10 @@ func nextClientSidePaginationCursor(params map[string]string, cursorParam, pagin
 		if err != nil {
 			return "", false
 		}
-		limit, err := strconv.Atoi(params[limitParam])
-		if err != nil || limit <= 0 {
+		if pageSize <= 0 {
 			return "", false
 		}
-		return strconv.Itoa(n + limit), true
+		return strconv.Itoa(n + pageSize), true
 	default:
 		return "", false
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
@@ -45,7 +45,7 @@ func newProjectsListCmd(flags *rootFlags) *cobra.Command {
 				"status": formatCLIParamValue(flagStatus),
 				"limit":  formatCLIParamValue(flagLimit),
 				"cursor": formatCLIParamValue(flagCursor),
-			}, nil, flagAll, "cursor", "cursor", "limit", "", "", cmd.ErrOrStderr())
+			}, nil, flagAll, "cursor", "cursor", "limit", 100, "", "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
@@ -45,7 +45,7 @@ func newProjectsListCmd(flags *rootFlags) *cobra.Command {
 				"status": formatCLIParamValue(flagStatus),
 				"limit":  formatCLIParamValue(flagLimit),
 				"cursor": formatCLIParamValue(flagCursor),
-			}, nil, flagAll, "cursor", "cursor", "limit", 100, "", "", cmd.ErrOrStderr())
+			}, nil, flagAll, "cursor", "cursor", "limit", 25, "", "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
@@ -53,7 +53,7 @@ func newProjectsTasksListProjectCmd(flags *rootFlags) *cobra.Command {
 				"priority": formatCLIParamValue(flagPriority),
 				"limit":    formatCLIParamValue(flagLimit),
 				"cursor":   formatCLIParamValue(flagCursor),
-			}, nil, flagAll, "cursor", "cursor", "limit", "", "", cmd.ErrOrStderr())
+			}, nil, flagAll, "cursor", "cursor", "limit", 100, "", "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
@@ -53,7 +53,7 @@ func newProjectsTasksListProjectCmd(flags *rootFlags) *cobra.Command {
 				"priority": formatCLIParamValue(flagPriority),
 				"limit":    formatCLIParamValue(flagLimit),
 				"cursor":   formatCLIParamValue(flagCursor),
-			}, nil, flagAll, "cursor", "cursor", "limit", 100, "", "", cmd.ErrOrStderr())
+			}, nil, flagAll, "cursor", "cursor", "limit", 50, "", "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_list.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_list.go
@@ -26,7 +26,7 @@ func newItemsListCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			c = c.WithTier("free")
-			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "auto", "items", path, map[string]string{}, nil, flagAll, "cursor", "cursor", "limit", "", "", cmd.ErrOrStderr())
+			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "auto", "items", path, map[string]string{}, nil, flagAll, "cursor", "cursor", "limit", 100, "", "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}


### PR DESCRIPTION
<!--
Maintainer-owned PRs may use a shorter body. Community PRs must keep these sections.
Write for reviewers: explain why this change is right, not every line that changed.
-->

## Intent

Fixes #3497.

Bare `--all` on generated offset/page-paginated list commands can stop after the first server-default page when `--limit` is unset. The unset limit is emitted as `0`, stripped from request params, and the generated helper then lacks a positive page size for client-side offset/page advancement.

## Approach

Thread the generator's default page size into generated paginated read helpers and command call sites. When `--all` is active for offset/page pagination, the generated helper now resolves the effective page size from:

1. an explicit positive limit param,
2. the generated default page size,
3. the existing `100` fallback.

The page-size fallback is only used for offset/page client-side advancement after the non-`--all` path returns, so cursor/token pagination behavior is unchanged.

## Scope

Primary area:

Generated CLI pagination helpers and their generated call sites.

Why this belongs in this repo:

This is a systemic generator/template bug in the Printing Press output. Fixing the generator updates future printed CLIs instead of patching one printed CLI.

## Risk

This changes generated helper signatures and generated call sites, so generated output fixtures are updated. The behavioral risk is limited to offset/page `--all` advancement when the limit is absent or non-positive; explicit positive `--limit` still wins, and cursor/token pagination still requires its body cursor/token signal.

## Output Contract

This PR changes generated Go output.

Generated-output evidence:

- Added a generated CLI regression test for the #3497 path. It verifies `limit:"0"` is stripped, `offset:"0"` is preserved, generated default page size `2` advances the second request to `offset=2`, and all three fixture items are returned.
- Updated golden fixtures for generated helper signatures, data-source helper signatures, and generated paginated command call sites.
- Ran generated-output verification and golden verification.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:

- `go test ./internal/generator -run 'Test(Issue3497BareAllOffsetUsesDefaultPageSize|PaginatedGet)' -count=1`
- `go test ./internal/generator -count=1`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`
- `go test ./...`

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
