### PR TITLE
fix: four generator/verifier gaps surfaced by a Wrike (multi-method spec) print run

### DIFF
--- a/internal/cli/verify_skill_bundled.py
+++ b/internal/cli/verify_skill_bundled.py
@@ -712,7 +712,16 @@ def _cli_invocation_from_tokens(
                 if use_str:
                     _, _, optional, variadic = parse_use(use_str)
                     if optional > 0 or variadic:
-                        break
+                        # The parent takes positionals, so this token is
+                        # probably an argument — but Cobra resolves
+                        # subcommand names BEFORE positionals, so descend
+                        # when the token maps to a real child in the
+                        # AddCommand graph (graph-only: the legacy
+                        # any-file leaf scan would false-positive on
+                        # unrelated commands sharing the token's name).
+                        trial_file, _, _ = resolve_command_path(cli_dir, cmd_path + [t])
+                        if trial_file is None:
+                            break
             # Verify adding this token still maps to a valid command. If the
             # extended path has no source match, this token is an argument.
             if cli_dir is not None:

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -306,6 +306,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"add":                                 func(a, b int) int { return a + b },
 		"chomp":                               func(s string) string { return strings.TrimRight(s, "\r\n") },
 		"staleAfterExpr":                      staleAfterExpr,
+		"responsePathCases":                   responsePathCases,
 		"oneline":                             naming.OneLine,
 		"composeMCPDesc":                      composeMCPDesc,
 		"composeMCPSubDesc":                   composeMCPSubDesc,
@@ -7681,6 +7682,45 @@ func staleAfterExpr(lit string) string {
 		return cacheDurationDefault
 	}
 	return goDurationExpr(d)
+}
+
+// respPathCase is one deduplicated switch case for sync.go.tmpl's
+// responsePathForResource: a unique (resource, path) key and the
+// ResponsePath of the first endpoint declaring it.
+type respPathCase struct {
+	Key          string
+	ResponsePath string
+}
+
+// responsePathCases returns one switch case per unique (resource, path)
+// pair that declares a ResponsePath. Ranging endpoints directly emits one
+// case per operation, so specs with multiple methods on the same path
+// (GET+PUT+DELETE /groups/{id}, as in Wrike's official OpenAPI) produced
+// duplicate switch cases that fail to compile. First endpoint wins when
+// operations on the same path disagree; output is sorted for deterministic
+// generation.
+func responsePathCases(resources map[string]spec.Resource) []respPathCase {
+	seen := map[string]string{}
+	var keys []string
+	for resourceName, resource := range resources {
+		for _, endpoint := range resource.Endpoints {
+			if endpoint.ResponsePath == "" {
+				continue
+			}
+			k := resourceName + "\x00" + endpoint.Path
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = endpoint.ResponsePath
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	out := make([]respPathCase, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, respPathCase{Key: k, ResponsePath: seen[k]})
+	}
+	return out
 }
 
 // goDurationExpr renders a time.Duration as a readable Go expression, preferring

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -3575,13 +3575,9 @@ var dataEnvelopeKeys = []string{"data", "Data", "result", "Result"}
 
 func responsePathForResource(resource, path string) []string {
 	switch resource + "\x00" + path {
-{{- range $resourceName, $resource := .Resources}}
-{{- range $endpointName, $endpoint := $resource.Endpoints}}
-{{- if $endpoint.ResponsePath}}
-	case {{printf "%q" (printf "%s\x00%s" $resourceName $endpoint.Path)}}:
-		return []string{ {{printf "%q" $endpoint.ResponsePath}} }
-{{- end}}
-{{- end}}
+{{- range $c := responsePathCases .Resources}}
+	case {{printf "%q" $c.Key}}:
+		return []string{ {{printf "%q" $c.ResponsePath}} }
 {{- end}}
 	}
 {{- if and .QuerySync .QuerySync.EnvelopeKey}}

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -263,6 +263,10 @@ type openAPISpec struct {
 
 type nestedDataEnvelopeFixture struct {
 	ArrayKey string
+	// DataIsArray marks single-level envelopes where `data` is itself the
+	// array ({"kind": ..., "data": [...]}, e.g. Wrike) rather than an
+	// object containing one (GitLab-style {"data": {"items": [...]}}).
+	DataIsArray bool
 }
 
 func (s *openAPISpec) IsSynthetic() bool {

--- a/internal/pipeline/dogfood_mock.go
+++ b/internal/pipeline/dogfood_mock.go
@@ -72,8 +72,8 @@ func detectNestedDataEnvelopeFixturesFromRaw(raw map[string]any) map[string]nest
 				continue
 			}
 			schema := selectedResponseSchemaFromRaw(operation, raw)
-			if key := nestedDataArrayKey(schema, raw); key != "" {
-				fixtures[path] = nestedDataEnvelopeFixture{ArrayKey: key}
+			if fixture, ok := dataEnvelopeFixture(schema, raw); ok {
+				fixtures[path] = fixture
 				break
 			}
 		}
@@ -145,6 +145,25 @@ func sortedSuccessStatuses(responses map[string]any) []string {
 	}
 	slices.Sort(statuses)
 	return statuses
+}
+
+// dataEnvelopeFixture classifies a success-response schema as a data
+// envelope. Two shapes qualify: single-level ({"data": [...]}, e.g. Wrike's
+// {kind, data} pairs) and nested ({"data": {"items": [...]}}). Without this,
+// the mock server serves bare arrays to CLIs whose sync extracts rows from
+// the declared envelope, and the data-pipeline check reports 0 rows.
+func dataEnvelopeFixture(schema map[string]any, root map[string]any) (nestedDataEnvelopeFixture, bool) {
+	resolved := resolveRawSchemaRef(schema, root)
+	if schemaType(resolved) == "object" {
+		dataSchema := resolveRawSchemaRef(schemaProperty(resolved, "data"), root)
+		if isRawArraySchema(dataSchema, root) {
+			return nestedDataEnvelopeFixture{DataIsArray: true}, true
+		}
+	}
+	if key := nestedDataArrayKey(schema, root); key != "" {
+		return nestedDataEnvelopeFixture{ArrayKey: key}, true
+	}
+	return nestedDataEnvelopeFixture{}, false
 }
 
 func nestedDataArrayKey(schema map[string]any, root map[string]any) string {

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -63,6 +63,7 @@ const reasonUnavailableRunnerCredentials = "unavailable for runner credentials"
 const reasonFileFixtureRequired = "file fixture required"
 const reasonRequiredParamFixture = "blocked-fixture: required API parameter"
 const reasonFeatureAbsentFixture = "blocked-fixture: feature absent for runner credentials"
+const reasonResolvedFixtureNotViable = "blocked-fixture: runner-resolved id not viable for endpoint"
 const reasonNoErrorPathProbeAnnotation = "no-error-path-probe annotation"
 const reasonInteractiveCommand = "interactive command requires human input"
 
@@ -503,6 +504,11 @@ var crossAPIListVerbs = map[string]bool{
 	"list": true, "all": true, "index": true,
 	"query": true, "find": true, "search": true,
 	"discover": true, "browse": true, "recent": true, "feed": true,
+	// The generator's own canonical name for GET-collection endpoints
+	// (emitted for specs whose list operations live at the resource root,
+	// e.g. Wrike's `tasks get-empty`). Without it the runner cannot
+	// recognize its own generator's list commands as companions.
+	"get-empty": true,
 }
 
 // cinemaListVerbs are domain-specific list verbs for media/cinema-class APIs
@@ -1022,6 +1028,111 @@ func companionSupportsLimit(companion liveDogfoodCommand, ctx resolveCtx) bool {
 // in order; see inline `// Path N:` comments for the priority list.
 // UseNumber() preserves large numeric ids (e.g., snowflake > 2^53) through
 // fmt.Sprint without scientific notation.
+// extractAlternateIDsFromJSON returns up to limit id-shaped strings in
+// stdout's object trees that differ from exclude, in document order. Used by
+// the happy-path fixture retry below.
+func extractAlternateIDsFromJSON(stdout, exclude string, limit int) []string {
+	dec := json.NewDecoder(strings.NewReader(stdout))
+	dec.UseNumber()
+	var root any
+	if err := dec.Decode(&root); err != nil {
+		return nil
+	}
+	var found []string
+	seen := map[string]bool{exclude: true}
+	var walk func(node any)
+	walk = func(node any) {
+		if len(found) >= limit {
+			return
+		}
+		switch v := node.(type) {
+		case []any:
+			for _, item := range v {
+				walk(item)
+			}
+		case map[string]any:
+			if id, ok := v["id"].(string); ok && id != "" && !seen[id] {
+				seen[id] = true
+				found = append(found, id)
+			}
+			for _, val := range v {
+				walk(val)
+			}
+		}
+	}
+	walk(root)
+	return found
+}
+
+// firstPositionalAfterPath returns the first non-flag token following the
+// command path — for a single-placeholder command, the resolved id.
+func firstPositionalAfterPath(args []string, pathLen int) string {
+	if pathLen > len(args) {
+		return ""
+	}
+	for _, a := range args[pathLen:] {
+		if !strings.HasPrefix(a, "-") {
+			return a
+		}
+	}
+	return ""
+}
+
+// retryHappyPathWithAlternateFixture re-runs a failed happy-path once with
+// the next candidate id from the list companion. Companions surface account
+// containers first (e.g. Wrike's space-root folder), which some
+// sub-endpoints reject with 4xx/5xx even though sibling entities work; one
+// bounded retry with a different id separates "this id is not a viable
+// subject" from "the command is broken". Only fires for runner-resolved,
+// single-placeholder commands.
+func retryHappyPathWithAlternateFixture(command liveDogfoodCommand, runArgs []string, ctx resolveCtx) ([]string, liveDogfoodRun, bool) {
+	placeholders := extractPositionalPlaceholders(liveDogfoodUsageSuffix(command.Help))
+	if len(placeholders) != 1 {
+		return nil, liveDogfoodRun{}, false
+	}
+	// Prefer the immediate parent's list companion; sub-resource verbs
+	// ("folders rollups get-folders-single") often have none, so fall back
+	// to the root resource's list ("folders" → get-empty) — the id-shaped
+	// positional refers to the root resource there.
+	var listCmd *liveDogfoodCommand
+	parentPath := command.Path[:len(command.Path)-1]
+	for _, candidate := range [][]string{parentPath, command.Path[:1]} {
+		if listCmd = findListCompanion(ctx.siblings[strings.Join(candidate, " ")]); listCmd != nil {
+			break
+		}
+	}
+	if listCmd == nil {
+		return nil, liveDogfoodRun{}, false
+	}
+	failedID := firstPositionalAfterPath(runArgs, len(command.Path))
+	if failedID == "" {
+		return nil, liveDogfoodRun{}, false
+	}
+	listArgs := append([]string{}, listCmd.Path...)
+	listArgs = append(listArgs, "--json")
+	listRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, listArgs, ctx.timeout)
+	if listRun.exitCode != 0 {
+		return nil, liveDogfoodRun{}, false
+	}
+	// Try up to 3 alternates: list companions can surface several
+	// non-viable system containers before a real entity (Wrike returns the
+	// account root AND the recycle-bin root ahead of user folders).
+	for _, altID := range extractAlternateIDsFromJSON(listRun.stdout, failedID, 3) {
+		retryArgs := make([]string, len(runArgs))
+		for i, a := range runArgs {
+			if a == failedID {
+				a = altID
+			}
+			retryArgs[i] = a
+		}
+		retryRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, retryArgs, ctx.timeout)
+		if retryRun.exitCode == 0 {
+			return retryArgs, retryRun, true
+		}
+	}
+	return nil, liveDogfoodRun{}, false
+}
+
 func extractFirstIDFromJSON(stdout string) (string, bool) {
 	dec := json.NewDecoder(strings.NewReader(stdout))
 	dec.UseNumber()
@@ -1306,6 +1417,10 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 
 	fixtureSkip := happyPathFileFixtureSkip(happyArgs, ctx.cliDir)
 	resolvedArgs, resolveSkipped, resolveReason, fixtureSource := resolveCommandPositionals(command, happyArgs, len(parsedHappyArgs.positionals), ctx)
+	// True when the command's positional IDs were filled by the runner's own
+	// resolver (companion/store) rather than pp:happy-args annotations.
+	runnerResolvedFixture := len(parsedHappyArgs.positionals) == 0 &&
+		len(extractPositionalPlaceholders(liveDogfoodUsageSuffix(command.Help))) > 0
 	syntheticParamSkip := ""
 	if fixtureSkip == "" && !resolveSkipped {
 		syntheticParamSkip = happyPathSyntheticParamFixtureSkip(command, resolvedArgs)
@@ -1335,6 +1450,13 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 		}
 
 		happyRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, runArgs, ctx.timeout)
+		if happyRun.exitCode != 0 && runnerResolvedFixture {
+			if altArgs, altRun, ok := retryHappyPathWithAlternateFixture(command, runArgs, ctx); ok {
+				runArgs = altArgs
+				happyRun = altRun
+				fixtureSource = "companion-alternate"
+			}
+		}
 		happyResult := liveDogfoodResult(commandName, LiveDogfoodTestHappy, runArgs, happyRun)
 		happyResult.FixtureSource = fixtureSource
 		if happyRun.exitCode == 0 {
@@ -1349,13 +1471,17 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 		} else if featureAbsentReason := liveDogfoodFeatureAbsentFixtureReason(happyRun); featureAbsentReason != "" {
 			happyResult.Status = LiveDogfoodStatusSkip
 			happyResult.Reason = featureAbsentReason
+		} else if notViableReason := liveDogfoodResolvedFixtureNotViableReason(happyRun, runnerResolvedFixture); notViableReason != "" {
+			happyResult.Status = LiveDogfoodStatusSkip
+			happyResult.Reason = notViableReason
 		}
 		results = append(results, happyResult)
 
 		if happyResult.Status == LiveDogfoodStatusSkip &&
 			(happyResult.Reason == reasonUnavailableRunnerCredentials ||
 				happyResult.Reason == reasonRequiredParamFixture ||
-				happyResult.Reason == reasonFeatureAbsentFixture) {
+				happyResult.Reason == reasonFeatureAbsentFixture ||
+				happyResult.Reason == reasonResolvedFixtureNotViable) {
 			jsonResult := skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, happyResult.Reason)
 			jsonResult.FixtureSource = fixtureSource
 			results = append(results, jsonResult)
@@ -1381,6 +1507,9 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 			} else if featureAbsentReason := liveDogfoodFeatureAbsentFixtureReason(jsonRun); featureAbsentReason != "" {
 				jsonResult.Status = LiveDogfoodStatusSkip
 				jsonResult.Reason = featureAbsentReason
+			} else if notViableReason := liveDogfoodResolvedFixtureNotViableReason(jsonRun, runnerResolvedFixture); notViableReason != "" {
+				jsonResult.Status = LiveDogfoodStatusSkip
+				jsonResult.Reason = notViableReason
 			}
 			results = append(results, jsonResult)
 		} else {
@@ -1978,6 +2107,37 @@ func liveDogfoodFeatureAbsentFixtureReason(run liveDogfoodRun) string {
 	}
 	if containsAnyOf(output, featureAbsentPhrases) {
 		return reasonFeatureAbsentFixture
+	}
+	return ""
+}
+
+// liveDogfoodResolvedFixtureNotViableReason classifies happy-path failures
+// where the runner substituted positional IDs it resolved itself (list
+// companion or local store — never user-annotated pp:happy-args) and the
+// live API rejected them with a not-found/invalid-request shape. The
+// resolved entity exists but is not a valid subject for this endpoint
+// (e.g. Wrike rejects its space-root folder on /folders/{id}/timelogs), a
+// fixture-viability gap rather than a CLI defect. Annotated or literal
+// args keep failing loudly; path validity is separately covered by mock
+// verify's path-param probes.
+func liveDogfoodResolvedFixtureNotViableReason(run liveDogfoodRun, runnerResolvedFixture bool) string {
+	if !runnerResolvedFixture || run.exitCode == 0 {
+		return ""
+	}
+	// 404 is always an id-viability shape. 400 qualifies only when the body
+	// names an id/not-found problem (Wrike's space-root rejection is
+	// `HTTP 400 "Invalid Folder ID"`). Plain 400s and every 403 stay visible
+	// failures — tier, permission, and validation problems must surface
+	// (see TestRunLiveDogfoodRequiresTierAbsentDoesNotSkip).
+	output := strings.ToLower(run.stdout + " " + run.stderr)
+	if strings.Contains(output, "http 404") {
+		return reasonResolvedFixtureNotViable
+	}
+	if strings.Contains(output, "http 400") {
+		if strings.Contains(output, "not found") ||
+			(strings.Contains(output, "invalid") && strings.Contains(output, "id")) {
+			return reasonResolvedFixtureNotViable
+		}
 	}
 	return ""
 }

--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -811,7 +812,34 @@ func isAuxiliaryPipelineTable(table string, totalTables int) bool {
 }
 
 // parseSQLOutput extracts non-empty, non-header lines from sql command output.
+// parseSQLJSONRows decodes `sql` output shaped as a JSON array of row
+// objects ([{"name":"tasks"},...]). Hand-written sql commands built on the
+// printed CLI's printJSON helper emit this shape instead of plain lines.
+func parseSQLJSONRows(out []byte) ([]map[string]any, bool) {
+	trimmed := bytes.TrimSpace(out)
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		return nil, false
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal(trimmed, &rows); err != nil {
+		return nil, false
+	}
+	return rows, true
+}
+
 func parseSQLOutput(out []byte) []string {
+	if rows, ok := parseSQLJSONRows(out); ok {
+		var tables []string
+		for _, row := range rows {
+			for _, v := range row {
+				if s, ok := v.(string); ok && s != "" {
+					tables = append(tables, s)
+					break
+				}
+			}
+		}
+		return tables
+	}
 	var tables []string
 	for line := range strings.SplitSeq(string(out), "\n") {
 		line = strings.TrimSpace(line)
@@ -840,6 +868,16 @@ func parseSQLOutput(out []byte) []string {
 
 // parseCountOutput extracts a numeric count from sql command output.
 func parseCountOutput(out []byte) int {
+	if rows, ok := parseSQLJSONRows(out); ok {
+		for _, row := range rows {
+			for _, v := range row {
+				if n, ok := v.(float64); ok {
+					return int(n)
+				}
+			}
+		}
+		return 0
+	}
 	for line := range strings.SplitSeq(string(out), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || line == "count(*)" || strings.HasPrefix(line, "---") {
@@ -965,6 +1003,21 @@ func nestedDataEnvelopeForPath(spec *openAPISpec, path string) (nestedDataEnvelo
 }
 
 func renderNestedDataEnvelopeFixture(fixture nestedDataEnvelopeFixture) string {
+	if fixture.DataIsArray {
+		// Single-level envelope: data IS the array (Wrike-style {kind, data}).
+		body := map[string]any{
+			"kind": "mock",
+			"data": []map[string]any{
+				{"id": "MOCK0001", "name": "mock-item-1", "title": "Mock Item", "state": "open", "created_at": "2026-03-27T00:00:00Z", "updated_at": "2026-03-27T00:00:00Z"},
+				{"id": "MOCK0002", "name": "mock-item-2", "title": "Mock Item 2", "state": "open", "created_at": "2026-03-27T00:00:00Z", "updated_at": "2026-03-27T00:00:00Z"},
+			},
+		}
+		data, err := json.Marshal(body)
+		if err != nil {
+			return `{"kind":"mock","data":[{"id":"MOCK0001","name":"mock-item-1"},{"id":"MOCK0002","name":"mock-item-2"}]}`
+		}
+		return string(data)
+	}
 	arrayKey := fixture.ArrayKey
 	if arrayKey == "" {
 		arrayKey = "items"

--- a/scripts/verify-skill/verify_skill.py
+++ b/scripts/verify-skill/verify_skill.py
@@ -712,7 +712,16 @@ def _cli_invocation_from_tokens(
                 if use_str:
                     _, _, optional, variadic = parse_use(use_str)
                     if optional > 0 or variadic:
-                        break
+                        # The parent takes positionals, so this token is
+                        # probably an argument — but Cobra resolves
+                        # subcommand names BEFORE positionals, so descend
+                        # when the token maps to a real child in the
+                        # AddCommand graph (graph-only: the legacy
+                        # any-file leaf scan would false-positive on
+                        # unrelated commands sharing the token's name).
+                        trial_file, _, _ = resolve_command_path(cli_dir, cmd_path + [t])
+                        if trial_file is None:
+                            break
             # Verify adding this token still maps to a valid command. If the
             # extended path has no source match, this token is an argument.
             if cli_dir is not None:


### PR DESCRIPTION
Four generator/verifier fixes found while printing a Wrike CLI (official OpenAPI spec, 137 paths / 199 operations). Each was a hard blocker or false-fail at a different pipeline stage; all were verified end-to-end on the Wrike run (generate gates green, verify PASS, verify-skill clean, full live matrix 594/594).

## 1. `fix(generator)`: duplicate switch cases in `responsePathForResource`

`sync.go.tmpl` emitted one case per *endpoint*, so specs with several methods on one path (`GET+PUT+DELETE /groups/{groupId}`) produced duplicate case constants — a compile failure that takes down every generate quality gate. New `responsePathCases` FuncMap helper dedupes by (resource, path), first endpoint wins, sorted for deterministic output.

## 2. `fix(verify)`: single-level data envelopes + JSON sql output

- The mock server had fixtures only for two-level envelopes (`{data:{items:[...]}}`). Single-level `{kind, data:[...]}` shapes got bare arrays, which the CLI's declared response-path extraction correctly rejected → "281 domain tables created but 0 rows after sync" despite a fully working sync. New `DataIsArray` fixture detection + render.
- `parseSQLOutput`/`parseCountOutput` assumed plain-line sql output; a hand-written `sql` command emitting JSON row arrays parsed as garbage names and 0 counts. Both parsers now try JSON first.

## 3. `fix(verify-skill)`: subcommand descent under optional-positional parents

The tokenizer refused to descend past parents like `export <resource> [id]`, classifying a real `export pull` subcommand as a positional and mis-attributing its flags ("--dir is declared elsewhere but not on export"). Cobra resolves subcommand names before positionals, so the tokenizer now descends when the token maps to a real child in the AddCommand graph (graph-only; the legacy leaf scan would false-positive). Bundled + canonical scripts updated in lockstep.

## 4. `fix(dogfood)`: live-matrix fixture viability for container-first APIs

- `crossAPIListVerbs` was missing **`get-empty` — the generator's own canonical name for GET-collection endpoints** — so the live runner could not recognize its own generator's list commands as companions.
- List companions surface account containers before real entities (Wrike returns the account root and recycle-bin root ahead of user folders), and some sub-endpoints reject them. Added a bounded retry (up to 3 alternate companion ids, with root-resource companion fallback for sub-resource verbs).
- New `blocked-fixture` skip classification for runner-resolved ids rejected with 404 / id-shaped 400s ("Invalid Folder ID"). Plain 400s and all 403s stay visible failures so tier/permission problems still surface (guarded by `TestRunLiveDogfoodRequiresTierAbsentDoesNotSkip`).

Wrike's full live matrix went **34 failed → 0 (594/594)** across these, with every prior failure manually verified command-functional using real ids.

## Testing

- `go test ./internal/generator/ ./internal/pipeline/ ./internal/cli/` — all green
- `python3 scripts/verify-skill/test_resolve_command_path.py` — 23/23
- `TestVerifySkillScriptInSync` passes (bundled/canonical lockstep)
- End-to-end: Wrike CLI generated, shipchecked (7/7 legs, 96/100), live-dogfooded (594/594 full) with these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXFFVDHVnL34ygcSo7otQu
