### PR TITLE
fix(cli): use unstamped generated CLI version defaults

### DIFF
--- a/internal/generator/templates/agents.md.tmpl
+++ b/internal/generator/templates/agents.md.tmpl
@@ -59,7 +59,7 @@ For install, auth, examples, and longer product guidance, read `README.md` and `
 
 ## Release Ledger
 
-`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints may carry blank skeletons, but the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
+`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints carry an unstamped runtime version such as `0.0.0-dev`; the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
 
 ## Local Customizations
 

--- a/internal/generator/templates/agents_device.md.tmpl
+++ b/internal/generator/templates/agents_device.md.tmpl
@@ -33,7 +33,7 @@ Commands with a `physical-effect` or `configuration-risk` safety class require `
 
 ## Release Ledger
 
-`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints may carry blank skeletons, but the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
+`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints carry an unstamped runtime version such as `0.0.0-dev`; the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
 
 ## Local Customizations
 

--- a/internal/generator/templates/plan_root.go.tmpl
+++ b/internal/generator/templates/plan_root.go.tmpl
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "0.0.0-dev"
 
 // Execute runs the CLI.
 func Execute() error {

--- a/internal/generator/templates/version.go.tmpl
+++ b/internal/generator/templates/version.go.tmpl
@@ -10,7 +10,7 @@ import (
 )
 
 // version is the printed CLI's version, overridable at build time via ldflags.
-var version = "1.0.0"
+var version = "0.0.0-dev"
 
 // newVersionCmd prints the CLI name and version. Shared by the HTTP and device
 // generators so both printed-CLI shapes carry an identical version command.

--- a/internal/generator/version_cmd_name_test.go
+++ b/internal/generator/version_cmd_name_test.go
@@ -22,6 +22,8 @@ func TestVersionCommandUsesRootNameInGeneratedRoot(t *testing.T) {
 	content, err := os.ReadFile(versionPath)
 	require.NoError(t, err)
 	src := string(content)
+	require.Contains(t, src, `var version = "0.0.0-dev"`,
+		"fresh generated source must not claim a release version before the library ledger stamps it")
 
 	re := regexp.MustCompile(`(?s)func newVersionCmd\(\) \*cobra.Command \{.*?\n\}`)
 	fn := re.FindString(src)

--- a/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/AGENTS.md
+++ b/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/AGENTS.md
@@ -33,7 +33,7 @@ Commands with a `physical-effect` or `configuration-risk` safety class require `
 
 ## Release Ledger
 
-`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints may carry blank skeletons, but the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
+`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints carry an unstamped runtime version such as `0.0.0-dev`; the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
 
 ## Local Customizations
 

--- a/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/AGENTS.md
+++ b/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/AGENTS.md
@@ -33,7 +33,7 @@ Commands with a `physical-effect` or `configuration-risk` safety class require `
 
 ## Release Ledger
 
-`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints may carry blank skeletons, but the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
+`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints carry an unstamped runtime version such as `0.0.0-dev`; the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
 
 ## Local Customizations
 

--- a/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/AGENTS.md
+++ b/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/AGENTS.md
@@ -33,7 +33,7 @@ Commands with a `physical-effect` or `configuration-risk` safety class require `
 
 ## Release Ledger
 
-`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints may carry blank skeletons, but the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
+`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints carry an unstamped runtime version such as `0.0.0-dev`; the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
 
 ## Local Customizations
 

--- a/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/AGENTS.md
+++ b/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/AGENTS.md
@@ -33,7 +33,7 @@ Commands with a `physical-effect` or `configuration-risk` safety class require `
 
 ## Release Ledger
 
-`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints may carry blank skeletons, but the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
+`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints carry an unstamped runtime version such as `0.0.0-dev`; the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
 
 ## Local Customizations
 

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/AGENTS.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/AGENTS.md
@@ -57,7 +57,7 @@ For install, auth, examples, and longer product guidance, read `README.md` and `
 
 ## Release Ledger
 
-`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints may carry blank skeletons, but the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
+`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints carry an unstamped runtime version such as `0.0.0-dev`; the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
 
 ## Local Customizations
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/AGENTS.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/AGENTS.md
@@ -57,7 +57,7 @@ For install, auth, examples, and longer product guidance, read `README.md` and `
 
 ## Release Ledger
 
-`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints may carry blank skeletons, but the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
+`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints carry an unstamped runtime version such as `0.0.0-dev`; the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
 
 ## Local Customizations
 

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/AGENTS.md
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/AGENTS.md
@@ -37,7 +37,7 @@ For install, auth, examples, and longer product guidance, read `README.md` and `
 
 ## Release Ledger
 
-`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints may carry blank skeletons, but the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
+`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints carry an unstamped runtime version such as `0.0.0-dev`; the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
 
 ## Local Customizations
 

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/AGENTS.md
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/AGENTS.md
@@ -57,7 +57,7 @@ For install, auth, examples, and longer product guidance, read `README.md` and `
 
 ## Release Ledger
 
-`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints may carry blank skeletons, but the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
+`CHANGELOG.md` and `.printing-press-release.json` are the public library's per-CLI release ledger. Fresh prints carry an unstamped runtime version such as `0.0.0-dev`; the final `YYYY.M.N` CLI release version is assigned only after a publish PR merges in `mvanhorn/printing-press-library`. Do not hand-bump those files or edit `var version = ...` for release bookkeeping; preserve existing ledger files on reprint and let the library workflow stamp the next release.
 
 ## Local Customizations
 


### PR DESCRIPTION
## Summary

Freshly generated CLIs now report an unmistakably unstamped runtime version before they enter the public-library release ledger. This avoids open publish PRs looking like they already carry a real `1.0.0` release while preserving the post-merge library workflow as the source of truth for `YYYY.M.N` CalVer stamping.

The generated agent guidance now names that split directly: fresh prints carry `0.0.0-dev`, and `printing-press-library` assigns the final per-CLI release version after merge.

## Validation

- `go test ./internal/generator ./internal/cli -count=1`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh generate-golden-api generate-learn-loop-api generate-device-ble`
- `go test ./...`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
