### PR TITLE
fix(generator): auto-detect all Chrome channels in auth login --chrome

### DIFF
--- a/internal/generator/auth_chrome_channel_test.go
+++ b/internal/generator/auth_chrome_channel_test.go
@@ -51,9 +51,9 @@ func TestCookieAuthEmitsChannelAwareDiscovery(t *testing.T) {
 	requireGeneratedCompiles(t, outputDir)
 }
 
-// The refresh path's cookie-DB fallback must resolve the profile across channels
-// like login, otherwise `auth refresh` clobbers a Beta session with stable
-// cookies (or none, for a Beta-only user).
+// A browser-session cookie CLI must persist the channel/profile chosen at login
+// and have `auth refresh`'s cookie-DB fallback re-read it, otherwise refresh
+// clobbers a Beta session with stable cookies (or none, for a Beta-only user).
 func TestCookieAuthRefreshResolvesChannel(t *testing.T) {
 	t.Parallel()
 
@@ -66,10 +66,33 @@ func TestCookieAuthRefreshResolvesChannel(t *testing.T) {
 	require.NoError(t, New(apiSpec, outputDir).Generate())
 
 	authGo := readGeneratedFile(t, outputDir, "internal", "cli", "auth.go")
+	// Login persists the resolved profile location.
+	assert.Contains(t, authGo, "loginProfileLocation = profile.profileLocation()")
+	assert.Contains(t, authGo, "cfg.ChromeProfile = loginProfileLocation")
+	// Refresh re-reads it (no more blind empty-profile extraction).
 	_, refresh, found := strings.Cut(authGo, "func refreshStoredBrowserCookies")
 	require.True(t, found, "expected refreshStoredBrowserCookies in generated auth.go")
-	assert.Contains(t, refresh, "resolveChromeProfile(w, strings.NewReader(\"\")")
+	assert.Contains(t, refresh, "savedProfile = cfg.ChromeProfile")
 	assert.NotContains(t, refresh, "extractCookies(tool, domain, chromeProfile{})")
+
+	// The persisted field exists in config with an omitempty tag.
+	configGo := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+	assert.Contains(t, configGo, "ChromeProfile string")
+	assert.Contains(t, configGo, "chrome_profile,omitempty")
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
+// A cookie CLI without a browser-session refresh must NOT carry the
+// chrome_profile field — it is scoped to the refresh feature that uses it.
+func TestCookieAuthWithoutRefreshOmitsChromeProfileField(t *testing.T) {
+	t.Parallel()
+
+	outputDir := filepath.Join(t.TempDir(), "chromechannoref-pp-cli")
+	require.NoError(t, New(chromeChannelSpec("chromechannoref"), outputDir).Generate())
+
+	configGo := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+	assert.NotContains(t, configGo, "ChromeProfile")
 }
 
 // Compile a runtime test into the generated CLI proving chromeChannelDirs picks

--- a/internal/generator/auth_chrome_channel_test.go
+++ b/internal/generator/auth_chrome_channel_test.go
@@ -74,6 +74,9 @@ func TestCookieAuthRefreshResolvesChannel(t *testing.T) {
 	require.True(t, found, "expected refreshStoredBrowserCookies in generated auth.go")
 	assert.Contains(t, refresh, "savedProfile = cfg.ChromeProfile")
 	assert.NotContains(t, refresh, "extractCookies(tool, domain, chromeProfile{})")
+	// A saved-but-unresolvable profile fails loudly instead of silently
+	// switching channels.
+	assert.Contains(t, refresh, "could not be resolved; re-run auth login --chrome")
 
 	// The persisted field exists in config with an omitempty tag.
 	configGo := readGeneratedFile(t, outputDir, "internal", "config", "config.go")

--- a/internal/generator/auth_chrome_channel_test.go
+++ b/internal/generator/auth_chrome_channel_test.go
@@ -126,7 +126,29 @@ func TestProfileLocationChannelQualified(t *testing.T) {
 		t.Fatalf("profileLocation() bare = %q, want Default", got)
 	}
 }
+
+// With a "Default" profile in both Stable and Beta, bare "Default" resolves to
+// stable, and the channel-qualified form selects Beta's cookie DB.
+func TestResolveProfileByNameDisambiguatesChannel(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	base, dirs := chromeChannelBase(t, home)
+	for _, ch := range []string{"Chrome", "Chrome Beta"} {
+		if err := os.MkdirAll(filepath.Join(base, dirs[ch], "Default"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stable, err := resolveProfileByName("Default")
+	if err != nil || stable.Channel != "Chrome" {
+		t.Fatalf(` + "`" + `resolveProfileByName("Default") = %#v, err=%v; want stable channel` + "`" + `, stable, err)
+	}
+	beta, err := resolveProfileByName("Chrome Beta/Default")
+	if err != nil || beta.Channel != "Chrome Beta" || beta.DataDir != filepath.Join(base, dirs["Chrome Beta"]) {
+		t.Fatalf(` + "`" + `resolveProfileByName("Chrome Beta/Default") = %#v, err=%v; want Beta channel` + "`" + `, beta, err)
+	}
+}
 `
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "chrome_channel_test.go"), []byte(runtimeTest), 0o600))
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestChromeChannelDirs|TestProfileLocation")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestChromeChannelDirs|TestProfileLocation|TestResolveProfileByNameDisambiguatesChannel")
 }

--- a/internal/generator/auth_chrome_channel_test.go
+++ b/internal/generator/auth_chrome_channel_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func chromeChannelSpec(name string) *spec.APISpec {
+	apiSpec := minimalSpec(name)
+	apiSpec.BaseURL = "https://www.example.com"
+	apiSpec.Auth = spec.AuthConfig{
+		Type:         "cookie",
+		Header:       "Cookie",
+		In:           "cookie",
+		CookieDomain: ".example.com",
+		Cookies:      []string{"session_id"},
+		EnvVars:      []string{name + "_SESSION"},
+	}
+	return apiSpec
+}
+
+// The generated cookie-auth flow must enumerate every installed Chrome channel
+// rather than hardcode the stable data dir, so a Beta-only user authenticates
+// without a flag. Assert the emitted helper shape and drop the old single-dir one.
+func TestCookieAuthEmitsChannelAwareDiscovery(t *testing.T) {
+	t.Parallel()
+
+	outputDir := filepath.Join(t.TempDir(), "chromechan-pp-cli")
+	require.NoError(t, New(chromeChannelSpec("chromechan"), outputDir).Generate())
+
+	authGo := readGeneratedFile(t, outputDir, "internal", "cli", "auth.go")
+	assert.Contains(t, authGo, "func chromeChannelDirs()")
+	// chromeChannelStable is the max-width const, so gofmt leaves exactly one
+	// space before "=" — a stable anchor for the typed channel labels.
+	assert.Contains(t, authGo, `chromeChannelStable = "Chrome"`)
+	assert.Contains(t, authGo, "chromeChannelBeta")
+	assert.Contains(t, authGo, `filepath.Join(base, "Chrome Beta")`)
+	assert.Contains(t, authGo, `filepath.Join(base, "google-chrome-beta")`)
+	assert.Contains(t, authGo, "func (p chromeProfile) profileLocation()")
+	// The single-channel helper must be gone so no caller silently reads stable.
+	assert.NotContains(t, authGo, "func chromeDataDir()")
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
+// Compile a runtime test into the generated CLI proving chromeChannelDirs picks
+// up a Beta-only install and orders stable ahead of Beta when both exist.
+func TestGeneratedChromeChannelDirsFindsBetaOnly(t *testing.T) {
+	t.Parallel()
+
+	outputDir := filepath.Join(t.TempDir(), "chromechanrt-pp-cli")
+	require.NoError(t, New(chromeChannelSpec("chromechanrt"), outputDir).Generate())
+
+	const runtimeTest = `package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// chromeChannelBase mirrors chromeChannelDirs' per-OS root so the test can plant
+// fake channel dirs under a temp HOME.
+func chromeChannelBase(t *testing.T, home string) (string, map[string]string) {
+	t.Helper()
+	switch runtime.GOOS {
+	case "darwin":
+		base := filepath.Join(home, "Library", "Application Support", "Google")
+		return base, map[string]string{"Chrome": "Chrome", "Chrome Beta": "Chrome Beta"}
+	case "linux":
+		base := filepath.Join(home, ".config")
+		return base, map[string]string{"Chrome": "google-chrome", "Chrome Beta": "google-chrome-beta"}
+	default:
+		t.Skipf("channel path layout not asserted on %s", runtime.GOOS)
+		return "", nil
+	}
+}
+
+func TestChromeChannelDirsBetaOnlyAndOrdering(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	base, dirs := chromeChannelBase(t, home)
+
+	// Only Beta installed: it must be discovered on its own.
+	betaDir := filepath.Join(base, dirs["Chrome Beta"])
+	if err := os.MkdirAll(betaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := chromeChannelDirs()
+	if err != nil {
+		t.Fatalf("chromeChannelDirs() error = %v", err)
+	}
+	if len(got) != 1 || got[0].Channel != "Chrome Beta" || got[0].DataDir != betaDir {
+		t.Fatalf("beta-only: got %#v, want single Chrome Beta at %s", got, betaDir)
+	}
+
+	// With stable also present, stable must sort first.
+	stableDir := filepath.Join(base, dirs["Chrome"])
+	if err := os.MkdirAll(stableDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err = chromeChannelDirs()
+	if err != nil {
+		t.Fatalf("chromeChannelDirs() error = %v", err)
+	}
+	if len(got) != 2 || got[0].Channel != "Chrome" || got[1].Channel != "Chrome Beta" {
+		t.Fatalf("both: got %#v, want [Chrome, Chrome Beta]", got)
+	}
+}
+
+func TestProfileLocationChannelQualified(t *testing.T) {
+	p := chromeProfile{Channel: "Chrome Beta", Dir: "Default"}
+	if got := p.profileLocation(); got != "Chrome Beta/Default" {
+		t.Fatalf("profileLocation() = %q, want Chrome Beta/Default", got)
+	}
+	bare := chromeProfile{Dir: "Default"}
+	if got := bare.profileLocation(); got != "Default" {
+		t.Fatalf("profileLocation() bare = %q, want Default", got)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "chrome_channel_test.go"), []byte(runtimeTest), 0o600))
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestChromeChannelDirs|TestProfileLocation")
+}

--- a/internal/generator/auth_chrome_channel_test.go
+++ b/internal/generator/auth_chrome_channel_test.go
@@ -5,6 +5,7 @@ package generator
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
@@ -48,6 +49,27 @@ func TestCookieAuthEmitsChannelAwareDiscovery(t *testing.T) {
 	assert.NotContains(t, authGo, "func chromeDataDir()")
 
 	requireGeneratedCompiles(t, outputDir)
+}
+
+// The refresh path's cookie-DB fallback must resolve the profile across channels
+// like login, otherwise `auth refresh` clobbers a Beta session with stable
+// cookies (or none, for a Beta-only user).
+func TestCookieAuthRefreshResolvesChannel(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := chromeChannelSpec("chromechanrefresh")
+	apiSpec.Auth.RequiresBrowserSession = true
+	apiSpec.Auth.BrowserSessionValidationPath = "/api/me"
+	apiSpec.Auth.BrowserSessionValidationMethod = "GET"
+
+	outputDir := filepath.Join(t.TempDir(), "chromechanrefresh-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	authGo := readGeneratedFile(t, outputDir, "internal", "cli", "auth.go")
+	_, refresh, found := strings.Cut(authGo, "func refreshStoredBrowserCookies")
+	require.True(t, found, "expected refreshStoredBrowserCookies in generated auth.go")
+	assert.Contains(t, refresh, "resolveChromeProfile(w, strings.NewReader(\"\")")
+	assert.NotContains(t, refresh, "extractCookies(tool, domain, chromeProfile{})")
 }
 
 // Compile a runtime test into the generated CLI proving chromeChannelDirs picks

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -93,13 +93,48 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 }
 
 {{- if $hasCookieBrowserAuth}}
+// Chrome release-channel display labels. All Google Chrome channels share one
+// macOS "Chrome Safe Storage" Keychain key, so these only select the data-dir
+// path and label prompts — they carry no decryption identity.
+const (
+	chromeChannelStable = "Chrome"
+	chromeChannelBeta   = "Chrome Beta"
+	chromeChannelDev    = "Chrome Dev"
+	chromeChannelCanary = "Chrome Canary"
+)
+
+// chromeChannelOrder is the channel preference order (most stable first); it
+// breaks ties when two channels' profiles are otherwise ranked equal.
+var chromeChannelOrder = []string{chromeChannelStable, chromeChannelBeta, chromeChannelDev, chromeChannelCanary}
+
+func channelRank(channel string) int {
+	for i, c := range chromeChannelOrder {
+		if c == channel {
+			return i
+		}
+	}
+	return len(chromeChannelOrder)
+}
+
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
+	Channel             string   // channel display name (e.g. "Chrome", "Chrome Beta")
+	DataDir             string   // channel user-data dir the profile lives under
 	Dir                 string   // directory name (e.g. "Default", "Profile 1")
 	DisplayName         string   // human-readable name from Preferences
 	CookieCount         int      // number of cookies matching the target domain
 	RequiredCookieCount int      // number of required credential cookies present
 	MissingCookies      []string // required credential cookies not present
+}
+
+// profileLocation is a channel-qualified profile identifier ("Chrome Beta/Default")
+// so same-named profiles from different Chrome channels stay distinguishable in
+// prompts and logs.
+func (p chromeProfile) profileLocation() string {
+	if p.Channel == "" {
+		return p.Dir
+	}
+	return p.Channel + "/" + p.Dir
 }
 
 func requiredAuthCookies() []string {
@@ -220,9 +255,9 @@ profile by name when the installed backend supports it.`,
 			}
 
 			// Step 2: Resolve which Chrome profile to use when the backend can honor it
-			profileDir := ""
+			var profile chromeProfile
 			if cookieToolSupportsProfiles(tool.name) {
-				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
+				profile, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 				if err != nil {
 					loginURL := "https://" + strings.TrimPrefix(domain, ".")
 					fmt.Fprintln(w, "")
@@ -236,14 +271,14 @@ profile by name when the installed backend supports it.`,
 				}
 			}
 
-			if profileDir != "" {
-				fmt.Fprintf(w, "Reading cookies from Chrome profile %q for %s...\n", profileDir, domain)
+			if profile.Dir != "" {
+				fmt.Fprintf(w, "Reading cookies from Chrome profile %q for %s...\n", profile.profileLocation(), domain)
 			} else {
 				fmt.Fprintf(w, "Reading cookies for %s...\n", domain)
 			}
 
 			// Step 3: Extract cookies from the resolved profile
-			cookies, err = extractCookies(tool, domain, profileDir)
+			cookies, err = extractCookies(tool, domain, profile)
 			if err != nil {
 				return authErr(fmt.Errorf("extracting cookies: %w", err))
 			}
@@ -913,7 +948,7 @@ func refreshStoredBrowserCookies(cfg *config.Config, w io.Writer) error {
 			}
 			return toolErr
 		}
-		cookies, err = extractCookies(tool, domain, "")
+		cookies, err = extractCookies(tool, domain, chromeProfile{})
 		if err != nil {
 			return fmt.Errorf("extracting cookies: %w", err)
 		}
@@ -1379,34 +1414,95 @@ func newAuthLogoutCmd(flags *rootFlags) *cobra.Command {
 // --- Chrome profile discovery ---
 
 {{- if $hasCookieBrowserAuth}}
-// chromeDataDir returns the Chrome user data directory for the current OS.
-func chromeDataDir() (string, error) {
+// chromeChannelDir pairs a Chrome release channel's display name with its
+// on-disk user-data directory.
+type chromeChannelDir struct {
+	Channel string
+	DataDir string
+}
+
+// chromeChannelDirs returns the user-data directories of every installed Google
+// Chrome release channel (stable, Beta, Dev, Canary), stable-first. Only
+// directories that exist on disk are returned, so a user who runs only Chrome
+// Beta still authenticates without a flag. All Google Chrome channels share one
+// macOS "Chrome Safe Storage" Keychain key, so only the data-dir path differs
+// per channel — cookie decryption needs no per-channel handling.
+func chromeChannelDirs() ([]chromeChannelDir, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
+	var candidates []chromeChannelDir
 	switch runtime.GOOS {
 	case "darwin":
-		return filepath.Join(home, "Library", "Application Support", "Google", "Chrome"), nil
+		base := filepath.Join(home, "Library", "Application Support", "Google")
+		candidates = []chromeChannelDir{
+			{chromeChannelStable, filepath.Join(base, "Chrome")},
+			{chromeChannelBeta, filepath.Join(base, "Chrome Beta")},
+			{chromeChannelDev, filepath.Join(base, "Chrome Dev")},
+			{chromeChannelCanary, filepath.Join(base, "Chrome Canary")},
+		}
 	case "linux":
-		return filepath.Join(home, ".config", "google-chrome"), nil
+		base := filepath.Join(home, ".config")
+		candidates = []chromeChannelDir{
+			{chromeChannelStable, filepath.Join(base, "google-chrome")},
+			{chromeChannelBeta, filepath.Join(base, "google-chrome-beta")},
+			{chromeChannelDev, filepath.Join(base, "google-chrome-unstable")},
+		}
 	case "windows":
 		localAppData := os.Getenv("LOCALAPPDATA")
 		if localAppData == "" {
 			localAppData = filepath.Join(home, "AppData", "Local")
 		}
-		return filepath.Join(localAppData, "Google", "Chrome", "User Data"), nil
+		base := filepath.Join(localAppData, "Google")
+		candidates = []chromeChannelDir{
+			{chromeChannelStable, filepath.Join(base, "Chrome", "User Data")},
+			{chromeChannelBeta, filepath.Join(base, "Chrome Beta", "User Data")},
+			{chromeChannelDev, filepath.Join(base, "Chrome Dev", "User Data")},
+			{chromeChannelCanary, filepath.Join(base, "Chrome SxS", "User Data")},
+		}
 	default:
-		return "", fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+		return nil, fmt.Errorf("unsupported OS: %s", runtime.GOOS)
 	}
+
+	existing := make([]chromeChannelDir, 0, len(candidates))
+	for _, c := range candidates {
+		if info, err := os.Stat(c.DataDir); err == nil && info.IsDir() {
+			existing = append(existing, c)
+		}
+	}
+	if len(existing) == 0 {
+		return nil, fmt.Errorf("no Chrome user data directory found")
+	}
+	return existing, nil
+}
+
+// chromeProfileDirNames returns the profile subdirectory names ("Default",
+// "Profile 1", ...) under a channel's data dir. A read error yields no names so
+// one unreadable channel never sinks discovery across the others.
+func chromeProfileDirNames(dataDir string) []string {
+	entries, err := os.ReadDir(dataDir)
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if name := entry.Name(); name == "Default" || strings.HasPrefix(name, "Profile ") {
+			names = append(names, name)
+		}
+	}
+	return names
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
 // When requiredCookies is non-empty, profiles with those credential cookies rank
 // ahead of profiles that only have guest, analytics, or challenge cookies.
 func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
-	dataDir, err := chromeDataDir()
+	channelDirs, err := chromeChannelDirs()
 	if err != nil {
 		return nil, err
 	}
@@ -1414,54 +1510,48 @@ func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromePr
 		return nil, fmt.Errorf("sqlite3 not found")
 	}
 
-	entries, err := os.ReadDir(dataDir)
-	if err != nil {
-		return nil, fmt.Errorf("cannot read Chrome data directory: %w", err)
-	}
-
 	// Match domain for SQLite query — host_key uses leading dot (e.g. ".notion.so")
 	domainPattern := "%" + strings.TrimPrefix(domain, ".") + "%"
 
 	var profiles []chromeProfile
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		if name != "Default" && !strings.HasPrefix(name, "Profile ") {
-			continue
-		}
+	for _, ch := range channelDirs {
+		for _, name := range chromeProfileDirNames(ch.DataDir) {
+			profilePath := filepath.Join(ch.DataDir, name)
+			cookiesDB := filepath.Join(profilePath, "Cookies")
+			if _, err := os.Stat(cookiesDB); err != nil {
+				continue
+			}
 
-		profilePath := filepath.Join(dataDir, name)
-		cookiesDB := filepath.Join(profilePath, "Cookies")
-		if _, err := os.Stat(cookiesDB); err != nil {
-			continue
+			displayName := readProfileDisplayName(filepath.Join(profilePath, "Preferences"))
+			if displayName == "" {
+				displayName = name
+			}
+
+			count, requiredCount, missing := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
+
+			profiles = append(profiles, chromeProfile{
+				Channel:             ch.Channel,
+				DataDir:             ch.DataDir,
+				Dir:                 name,
+				DisplayName:         displayName,
+				CookieCount:         count,
+				RequiredCookieCount: requiredCount,
+				MissingCookies:      missing,
+			})
 		}
-
-		displayName := readProfileDisplayName(filepath.Join(profilePath, "Preferences"))
-		if displayName == "" {
-			displayName = name
-		}
-
-		count, requiredCount, missing := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
-
-		profiles = append(profiles, chromeProfile{
-			Dir:                 name,
-			DisplayName:         displayName,
-			CookieCount:         count,
-			RequiredCookieCount: requiredCount,
-			MissingCookies:      missing,
-		})
 	}
 
 	// Sort: profiles with credential cookies first, then by total cookie count,
-	// then by directory name for deterministic prompts.
+	// then by channel preference and directory name for deterministic prompts.
 	sort.Slice(profiles, func(i, j int) bool {
 		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
 			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
 		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
+		}
+		if ri, rj := channelRank(profiles[i].Channel), channelRank(profiles[j].Channel); ri != rj {
+			return ri < rj
 		}
 		return profiles[i].Dir < profiles[j].Dir
 	})
@@ -1583,7 +1673,7 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (chromeProfile, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
@@ -1592,7 +1682,7 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
-		return "", nil
+		return chromeProfile{}, nil
 	}
 
 	// Prefer profiles that have all required credential cookies. A profile with
@@ -1621,7 +1711,7 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	}
 
 	if len(withCookies) == 0 {
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+		return chromeProfile{}, fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	}
 	return chooseChromeProfile(w, r, domain, withCookies, false)
 }
@@ -1634,20 +1724,20 @@ func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCooki
 		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
 			continue
 		}
-		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.profileLocation(), strings.Join(p.MissingCookies, ", "))
 		return
 	}
 }
 
-func chooseChromeProfile(w io.Writer, r io.Reader, domain string, profiles []chromeProfile, matchedRequired bool) (string, error) {
+func chooseChromeProfile(w io.Writer, r io.Reader, domain string, profiles []chromeProfile, matchedRequired bool) (chromeProfile, error) {
 	switch len(profiles) {
 	case 1:
 		if matchedRequired {
-			fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, required cookies present)\n", profiles[0].DisplayName, profiles[0].Dir)
+			fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, required cookies present)\n", profiles[0].DisplayName, profiles[0].profileLocation())
 		} else {
-			fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", profiles[0].DisplayName, profiles[0].Dir)
+			fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", profiles[0].DisplayName, profiles[0].profileLocation())
 		}
-		return profiles[0].Dir, nil
+		return profiles[0], nil
 	default:
 		// Multiple profiles have cookies.
 		// Non-interactive: pick the profile with the most cookies (already sorted).
@@ -1656,20 +1746,20 @@ func chooseChromeProfile(w io.Writer, r io.Reader, domain string, profiles []chr
 			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
 			selected := profiles[0]
 			if matchedRequired {
-				fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, required cookies present, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+				fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, required cookies present, %d cookies)\n", selected.DisplayName, selected.profileLocation(), selected.CookieCount)
 			} else {
-				fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+				fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.profileLocation(), selected.CookieCount)
 			}
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
-			return selected.Dir, nil
+			return selected, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
 		for i, p := range profiles {
 			if matchedRequired {
-				fmt.Fprintf(w, "  %d. %s (%s, required cookies present, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+				fmt.Fprintf(w, "  %d. %s (%s, required cookies present, %d cookies)\n", i+1, p.DisplayName, p.profileLocation(), p.CookieCount)
 			} else {
-				fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+				fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.profileLocation(), p.CookieCount)
 			}
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
@@ -1686,39 +1776,34 @@ func chooseChromeProfile(w io.Writer, r io.Reader, domain string, profiles []chr
 			choice = 1
 		}
 		selected := profiles[choice-1]
-		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
-		return selected.Dir, nil
+		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.profileLocation())
+		return selected, nil
 	}
 }
 
-// resolveProfileByName finds a Chrome profile directory by its display name.
-func resolveProfileByName(name string) (string, error) {
-	dataDir, err := chromeDataDir()
+// resolveProfileByName finds a Chrome profile by its display or directory name,
+// searching every installed channel (stable first). The first match wins, so a
+// name present in multiple channels resolves to the stable one.
+func resolveProfileByName(name string) (chromeProfile, error) {
+	channelDirs, err := chromeChannelDirs()
 	if err != nil {
-		return "", err
-	}
-
-	entries, err := os.ReadDir(dataDir)
-	if err != nil {
-		return "", err
+		return chromeProfile{}, err
 	}
 
 	lowerName := strings.ToLower(name)
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		dirName := entry.Name()
-		if dirName != "Default" && !strings.HasPrefix(dirName, "Profile ") {
-			continue
-		}
-		displayName := readProfileDisplayName(filepath.Join(dataDir, dirName, "Preferences"))
-		if strings.ToLower(displayName) == lowerName || strings.ToLower(dirName) == lowerName {
-			return dirName, nil
+	for _, ch := range channelDirs {
+		for _, dirName := range chromeProfileDirNames(ch.DataDir) {
+			displayName := readProfileDisplayName(filepath.Join(ch.DataDir, dirName, "Preferences"))
+			if strings.ToLower(displayName) == lowerName || strings.ToLower(dirName) == lowerName {
+				if displayName == "" {
+					displayName = dirName
+				}
+				return chromeProfile{Channel: ch.Channel, DataDir: ch.DataDir, Dir: dirName, DisplayName: displayName}, nil
+			}
 		}
 	}
 
-	return "", fmt.Errorf("Chrome profile %q not found", name)
+	return chromeProfile{}, fmt.Errorf("Chrome profile %q not found", name)
 }
 
 // --- Cookie extraction tools ---
@@ -1803,30 +1888,34 @@ func detectCookieTool() (cookieTool, error) {
 }
 
 // extractCookies shells out to the detected tool and returns a Cookie header value string.
-// profileDir selects which Chrome profile to read from (e.g. "Default", "Profile 1").
-func extractCookies(tool cookieTool, domain, profileDir string) (string, error) {
+// profile selects which Chrome profile (and channel) to read from; a zero profile
+// lets the tool fall back to the stable channel's default cookie file.
+func extractCookies(tool cookieTool, domain string, profile chromeProfile) (string, error) {
 	switch tool.name {
 	case "pycookiecheat":
-		return extractViaPycookiecheat(tool, domain, profileDir)
+		return extractViaPycookiecheat(tool, domain, profile)
 	case "pycookiecheat-cli":
-		return extractViaPycookiecheatCLI(tool, domain, profileDir)
+		return extractViaPycookiecheatCLI(tool, domain, profile)
 	case "cookies":
 		return extractViaCookiesCLI(domain)
 	case "cookie-scoop":
-		return extractViaCookieScoop(domain, profileDir)
+		// cookie-scoop resolves the data dir itself and only knows the stable
+		// channel, so it cannot read a Beta/Dev/Canary profile. Fail loudly
+		// instead of silently reading the same-named stable profile.
+		if profile.Channel != "" && profile.Channel != chromeChannelStable {
+			return "", fmt.Errorf("cookie-scoop can only read the stable Chrome channel; install pycookiecheat to read the %s profile", profile.Channel)
+		}
+		return extractViaCookieScoop(domain, profile.Dir)
 	default:
 		return "", fmt.Errorf("unknown cookie tool: %s", tool.name)
 	}
 }
 
-func extractViaPycookiecheat(tool cookieTool, domain, profileDir string) (string, error) {
+func extractViaPycookiecheat(tool cookieTool, domain string, profile chromeProfile) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" {
-		dataDir, err := chromeDataDir()
-		if err == nil {
-			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")
-		}
+	if profile.Dir != "" && profile.DataDir != "" {
+		cookiePath = filepath.Join(profile.DataDir, profile.Dir, "Cookies")
 	}
 
 	var script string
@@ -1864,15 +1953,11 @@ func extractViaPycookiecheat(tool cookieTool, domain, profileDir string) (string
 	return strings.Join(parts, "; "), nil
 }
 
-func extractViaPycookiecheatCLI(tool cookieTool, domain, profileDir string) (string, error) {
+func extractViaPycookiecheatCLI(tool cookieTool, domain string, profile chromeProfile) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	var args []string
-	if profileDir != "" {
-		dataDir, err := chromeDataDir()
-		if err != nil {
-			return "", err
-		}
-		args = append(args, "-c", filepath.Join(dataDir, profileDir, "Cookies"))
+	if profile.Dir != "" && profile.DataDir != "" {
+		args = append(args, "-c", filepath.Join(profile.DataDir, profile.Dir, "Cookies"))
 	}
 	args = append(args, "https://"+cleanDomain)
 

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -974,10 +974,16 @@ func refreshStoredBrowserCookies(cfg *config.Config, w io.Writer) error {
 			savedProfile = cfg.ChromeProfile
 {{- end}}
 			p, perr := resolveChromeProfile(w, strings.NewReader(""), domain, savedProfile, requiredAuthCookies())
-			if perr != nil && savedProfile != "" {
-				p, perr = resolveChromeProfile(w, strings.NewReader(""), domain, "", requiredAuthCookies())
-			}
-			if perr == nil {
+			if perr != nil {
+				// A profile recorded at login that no longer resolves must fail
+				// loudly: silently rediscovering could pick a different channel and
+				// re-save its cookies over the stored session. With no saved
+				// profile, discovery just found nothing usable — fall through to
+				// the tool's default, matching pre-channel behavior.
+				if savedProfile != "" {
+					return fmt.Errorf("saved Chrome profile %q for %s could not be resolved; re-run auth login --chrome: %w", savedProfile, domain, perr)
+				}
+			} else {
 				profile = p
 			}
 		}

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -476,7 +476,7 @@ profile by name when the installed backend supports it.`,
 
 	cmd.Flags().BoolVar(&browserFlag, "chrome", false, "Read cookies from Chrome")
 	cmd.Flags().BoolVar(&browserFlag, "browser", false, "Alias for --chrome")
-	cmd.Flags().StringVar(&profileFlag, "profile", "", "Chrome profile name (e.g. \"Work\", \"Personal\")")
+	cmd.Flags().StringVar(&profileFlag, "profile", "", "Chrome profile name, or channel-qualified (e.g. \"Work\", \"Chrome Beta/Default\")")
 	cmd.Flags().StringVar(&cookiesFile, "cookies-file", "", "Import cookies from a Playwright storage-state JSON file or raw Cookie header file")
 	return cmd
 }
@@ -1794,11 +1794,16 @@ func resolveProfileByName(name string) (chromeProfile, error) {
 	for _, ch := range channelDirs {
 		for _, dirName := range chromeProfileDirNames(ch.DataDir) {
 			displayName := readProfileDisplayName(filepath.Join(ch.DataDir, dirName, "Preferences"))
-			if strings.ToLower(displayName) == lowerName || strings.ToLower(dirName) == lowerName {
-				if displayName == "" {
-					displayName = dirName
+			candidate := chromeProfile{Channel: ch.Channel, DataDir: ch.DataDir, Dir: dirName, DisplayName: displayName}
+			// Accept the channel-qualified form ("Chrome Beta/Default") too, so
+			// the identifier printed in prompts is a valid --profile value and a
+			// user with a Default profile in several channels can pick a
+			// non-stable one (bare "Default" matches stable first).
+			if strings.ToLower(displayName) == lowerName || strings.ToLower(dirName) == lowerName || strings.ToLower(candidate.profileLocation()) == lowerName {
+				if candidate.DisplayName == "" {
+					candidate.DisplayName = dirName
 				}
-				return chromeProfile{Channel: ch.Channel, DataDir: ch.DataDir, Dir: dirName, DisplayName: displayName}, nil
+				return candidate, nil
 			}
 		}
 	}

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -205,6 +205,11 @@ profile by name when the installed backend supports it.`,
 			var cookies string
 			fromPressAuth := false
 			fromCookiesFile := false
+{{- if .Auth.RequiresBrowserSession}}
+			// Channel-qualified profile this session came from; persisted below so
+			// `auth refresh`'s cookie-DB fallback re-reads the same channel.
+			var loginProfileLocation string
+{{- end}}
 			if cookiesFile != "" {
 				imported, err := loadCookiesFromFile(cookiesFile, domain)
 				if err != nil {
@@ -273,6 +278,9 @@ profile by name when the installed backend supports it.`,
 
 			if profile.Dir != "" {
 				fmt.Fprintf(w, "Reading cookies from Chrome profile %q for %s...\n", profile.profileLocation(), domain)
+{{- if .Auth.RequiresBrowserSession}}
+				loginProfileLocation = profile.profileLocation()
+{{- end}}
 			} else {
 				fmt.Fprintf(w, "Reading cookies for %s...\n", domain)
 			}
@@ -371,6 +379,9 @@ profile by name when the installed backend supports it.`,
 			if err != nil {
 				return configErr(err)
 			}
+{{- if .Auth.RequiresBrowserSession}}
+			cfg.ChromeProfile = loginProfileLocation
+{{- end}}
 
 			if err := cfg.SaveTokens("", "", composed, "", time.Time{}); err != nil {
 				return configErr(fmt.Errorf("saving auth: %w", err))
@@ -436,6 +447,9 @@ profile by name when the installed backend supports it.`,
 			if err != nil {
 				return configErr(err)
 			}
+{{- if .Auth.RequiresBrowserSession}}
+			cfg.ChromeProfile = loginProfileLocation
+{{- end}}
 
 			if err := cfg.SaveTokens("", "", cookies, "", time.Time{}); err != nil {
 				return configErr(fmt.Errorf("saving cookies: %w", err))
@@ -948,15 +962,22 @@ func refreshStoredBrowserCookies(cfg *config.Config, w io.Writer) error {
 			}
 			return toolErr
 		}
-		// Resolve the profile across all installed channels, mirroring login, so
-		// refresh reads (and re-saves) the channel the user logged in with rather
-		// than silently clobbering the stored session with stable/Default cookies
-		// — or, for a Beta-only user, with nothing. The empty reader keeps this
-		// unattended: discovery auto-selects the best-ranked profile and never
-		// blocks on a prompt.
+		// Re-read the channel the user logged in with rather than clobbering the
+		// stored session with another channel's cookies. Prefer the profile saved
+		// at login; if it is gone, or none was saved, fall back to cross-channel
+		// discovery. The empty reader keeps this unattended: discovery
+		// auto-selects the best-ranked profile and never blocks on a prompt.
 		var profile chromeProfile
 		if cookieToolSupportsProfiles(tool.name) {
-			if p, perr := resolveChromeProfile(w, strings.NewReader(""), domain, "", requiredAuthCookies()); perr == nil {
+			savedProfile := ""
+{{- if .Auth.RequiresBrowserSession}}
+			savedProfile = cfg.ChromeProfile
+{{- end}}
+			p, perr := resolveChromeProfile(w, strings.NewReader(""), domain, savedProfile, requiredAuthCookies())
+			if perr != nil && savedProfile != "" {
+				p, perr = resolveChromeProfile(w, strings.NewReader(""), domain, "", requiredAuthCookies())
+			}
+			if perr == nil {
 				profile = p
 			}
 		}

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -948,7 +948,19 @@ func refreshStoredBrowserCookies(cfg *config.Config, w io.Writer) error {
 			}
 			return toolErr
 		}
-		cookies, err = extractCookies(tool, domain, chromeProfile{})
+		// Resolve the profile across all installed channels, mirroring login, so
+		// refresh reads (and re-saves) the channel the user logged in with rather
+		// than silently clobbering the stored session with stable/Default cookies
+		// — or, for a Beta-only user, with nothing. The empty reader keeps this
+		// unattended: discovery auto-selects the best-ranked profile and never
+		// blocks on a prompt.
+		var profile chromeProfile
+		if cookieToolSupportsProfiles(tool.name) {
+			if p, perr := resolveChromeProfile(w, strings.NewReader(""), domain, "", requiredAuthCookies()); perr == nil {
+				profile = p
+			}
+		}
+		cookies, err = extractCookies(tool, domain, profile)
 		if err != nil {
 			return fmt.Errorf("extracting cookies: %w", err)
 		}

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -32,6 +32,13 @@ type Config struct {
 	AuthHeaderVal  string `{{configTag .Config.Format}}:"auth_header"`
 	Headers        map[string]string `{{configTag .Config.Format}}:"headers,omitempty"`
 	AuthSource     string `{{configTag .Config.Format}}:"-"`
+{{- if .Auth.RequiresBrowserSession}}
+	// ChromeProfile records the channel-qualified Chrome profile
+	// ("Chrome Beta/Default") chosen at login so `auth refresh`'s cookie-DB
+	// fallback re-reads that channel instead of rediscovering and possibly
+	// re-saving another channel's cookies.
+	ChromeProfile  string `{{configTag .Config.Format}}:"chrome_profile,omitempty"`
+{{- end}}
 {{- if .HasAuthCommand}}
 	CredentialSource string `{{configTag .Config.Format}}:"-"`
 	AgentcookieManaged bool `{{configTag .Config.Format}}:"-"`
@@ -1352,6 +1359,9 @@ type persistedConfig struct {
 	BasePath string `{{configTag .Config.Format}}:"base_path"`
 {{- end}}
 	Headers map[string]string `{{configTag .Config.Format}}:"headers,omitempty"`
+{{- if .Auth.RequiresBrowserSession}}
+	ChromeProfile string `{{configTag .Config.Format}}:"chrome_profile,omitempty"`
+{{- end}}
 {{- if .HasRequiredRoles}}
 	AuthRole string `{{configTag .Config.Format}}:"auth_role,omitempty"`
 {{- end}}
@@ -1376,6 +1386,9 @@ func (c *Config) persisted() persistedConfig {
 		BasePath: c.BasePath,
 {{- end}}
 		Headers: c.Headers,
+{{- if .Auth.RequiresBrowserSession}}
+		ChromeProfile: c.ChromeProfile,
+{{- end}}
 {{- if .HasRequiredRoles}}
 		AuthRole: c.AuthRole,
 {{- end}}

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
@@ -285,7 +285,7 @@ profile by name when the installed backend supports it.`,
 
 	cmd.Flags().BoolVar(&browserFlag, "chrome", false, "Read cookies from Chrome")
 	cmd.Flags().BoolVar(&browserFlag, "browser", false, "Alias for --chrome")
-	cmd.Flags().StringVar(&profileFlag, "profile", "", "Chrome profile name (e.g. \"Work\", \"Personal\")")
+	cmd.Flags().StringVar(&profileFlag, "profile", "", "Chrome profile name, or channel-qualified (e.g. \"Work\", \"Chrome Beta/Default\")")
 	cmd.Flags().StringVar(&cookiesFile, "cookies-file", "", "Import cookies from a Playwright storage-state JSON file or raw Cookie header file")
 	return cmd
 }
@@ -823,11 +823,16 @@ func resolveProfileByName(name string) (chromeProfile, error) {
 	for _, ch := range channelDirs {
 		for _, dirName := range chromeProfileDirNames(ch.DataDir) {
 			displayName := readProfileDisplayName(filepath.Join(ch.DataDir, dirName, "Preferences"))
-			if strings.ToLower(displayName) == lowerName || strings.ToLower(dirName) == lowerName {
-				if displayName == "" {
-					displayName = dirName
+			candidate := chromeProfile{Channel: ch.Channel, DataDir: ch.DataDir, Dir: dirName, DisplayName: displayName}
+			// Accept the channel-qualified form ("Chrome Beta/Default") too, so
+			// the identifier printed in prompts is a valid --profile value and a
+			// user with a Default profile in several channels can pick a
+			// non-stable one (bare "Default" matches stable first).
+			if strings.ToLower(displayName) == lowerName || strings.ToLower(dirName) == lowerName || strings.ToLower(candidate.profileLocation()) == lowerName {
+				if candidate.DisplayName == "" {
+					candidate.DisplayName = dirName
 				}
-				return chromeProfile{Channel: ch.Channel, DataDir: ch.DataDir, Dir: dirName, DisplayName: displayName}, nil
+				return candidate, nil
 			}
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
@@ -39,13 +39,48 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 	return cmd
 }
 
+// Chrome release-channel display labels. All Google Chrome channels share one
+// macOS "Chrome Safe Storage" Keychain key, so these only select the data-dir
+// path and label prompts — they carry no decryption identity.
+const (
+	chromeChannelStable = "Chrome"
+	chromeChannelBeta   = "Chrome Beta"
+	chromeChannelDev    = "Chrome Dev"
+	chromeChannelCanary = "Chrome Canary"
+)
+
+// chromeChannelOrder is the channel preference order (most stable first); it
+// breaks ties when two channels' profiles are otherwise ranked equal.
+var chromeChannelOrder = []string{chromeChannelStable, chromeChannelBeta, chromeChannelDev, chromeChannelCanary}
+
+func channelRank(channel string) int {
+	for i, c := range chromeChannelOrder {
+		if c == channel {
+			return i
+		}
+	}
+	return len(chromeChannelOrder)
+}
+
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
+	Channel             string   // channel display name (e.g. "Chrome", "Chrome Beta")
+	DataDir             string   // channel user-data dir the profile lives under
 	Dir                 string   // directory name (e.g. "Default", "Profile 1")
 	DisplayName         string   // human-readable name from Preferences
 	CookieCount         int      // number of cookies matching the target domain
 	RequiredCookieCount int      // number of required credential cookies present
 	MissingCookies      []string // required credential cookies not present
+}
+
+// profileLocation is a channel-qualified profile identifier ("Chrome Beta/Default")
+// so same-named profiles from different Chrome channels stay distinguishable in
+// prompts and logs.
+func (p chromeProfile) profileLocation() string {
+	if p.Channel == "" {
+		return p.Dir
+	}
+	return p.Channel + "/" + p.Dir
 }
 
 func requiredAuthCookies() []string {
@@ -163,9 +198,9 @@ profile by name when the installed backend supports it.`,
 				}
 
 				// Step 2: Resolve which Chrome profile to use when the backend can honor it
-				profileDir := ""
+				var profile chromeProfile
 				if cookieToolSupportsProfiles(tool.name) {
-					profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
+					profile, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 					if err != nil {
 						loginURL := "https://" + strings.TrimPrefix(domain, ".")
 						fmt.Fprintln(w, "")
@@ -179,14 +214,14 @@ profile by name when the installed backend supports it.`,
 					}
 				}
 
-				if profileDir != "" {
-					fmt.Fprintf(w, "Reading cookies from Chrome profile %q for %s...\n", profileDir, domain)
+				if profile.Dir != "" {
+					fmt.Fprintf(w, "Reading cookies from Chrome profile %q for %s...\n", profile.profileLocation(), domain)
 				} else {
 					fmt.Fprintf(w, "Reading cookies for %s...\n", domain)
 				}
 
 				// Step 3: Extract cookies from the resolved profile
-				cookies, err = extractCookies(tool, domain, profileDir)
+				cookies, err = extractCookies(tool, domain, profile)
 				if err != nil {
 					return authErr(fmt.Errorf("extracting cookies: %w", err))
 				}
@@ -408,34 +443,95 @@ func newAuthLogoutCmd(flags *rootFlags) *cobra.Command {
 }
 
 // --- Chrome profile discovery ---
-// chromeDataDir returns the Chrome user data directory for the current OS.
-func chromeDataDir() (string, error) {
+// chromeChannelDir pairs a Chrome release channel's display name with its
+// on-disk user-data directory.
+type chromeChannelDir struct {
+	Channel string
+	DataDir string
+}
+
+// chromeChannelDirs returns the user-data directories of every installed Google
+// Chrome release channel (stable, Beta, Dev, Canary), stable-first. Only
+// directories that exist on disk are returned, so a user who runs only Chrome
+// Beta still authenticates without a flag. All Google Chrome channels share one
+// macOS "Chrome Safe Storage" Keychain key, so only the data-dir path differs
+// per channel — cookie decryption needs no per-channel handling.
+func chromeChannelDirs() ([]chromeChannelDir, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
+	var candidates []chromeChannelDir
 	switch runtime.GOOS {
 	case "darwin":
-		return filepath.Join(home, "Library", "Application Support", "Google", "Chrome"), nil
+		base := filepath.Join(home, "Library", "Application Support", "Google")
+		candidates = []chromeChannelDir{
+			{chromeChannelStable, filepath.Join(base, "Chrome")},
+			{chromeChannelBeta, filepath.Join(base, "Chrome Beta")},
+			{chromeChannelDev, filepath.Join(base, "Chrome Dev")},
+			{chromeChannelCanary, filepath.Join(base, "Chrome Canary")},
+		}
 	case "linux":
-		return filepath.Join(home, ".config", "google-chrome"), nil
+		base := filepath.Join(home, ".config")
+		candidates = []chromeChannelDir{
+			{chromeChannelStable, filepath.Join(base, "google-chrome")},
+			{chromeChannelBeta, filepath.Join(base, "google-chrome-beta")},
+			{chromeChannelDev, filepath.Join(base, "google-chrome-unstable")},
+		}
 	case "windows":
 		localAppData := os.Getenv("LOCALAPPDATA")
 		if localAppData == "" {
 			localAppData = filepath.Join(home, "AppData", "Local")
 		}
-		return filepath.Join(localAppData, "Google", "Chrome", "User Data"), nil
+		base := filepath.Join(localAppData, "Google")
+		candidates = []chromeChannelDir{
+			{chromeChannelStable, filepath.Join(base, "Chrome", "User Data")},
+			{chromeChannelBeta, filepath.Join(base, "Chrome Beta", "User Data")},
+			{chromeChannelDev, filepath.Join(base, "Chrome Dev", "User Data")},
+			{chromeChannelCanary, filepath.Join(base, "Chrome SxS", "User Data")},
+		}
 	default:
-		return "", fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+		return nil, fmt.Errorf("unsupported OS: %s", runtime.GOOS)
 	}
+
+	existing := make([]chromeChannelDir, 0, len(candidates))
+	for _, c := range candidates {
+		if info, err := os.Stat(c.DataDir); err == nil && info.IsDir() {
+			existing = append(existing, c)
+		}
+	}
+	if len(existing) == 0 {
+		return nil, fmt.Errorf("no Chrome user data directory found")
+	}
+	return existing, nil
+}
+
+// chromeProfileDirNames returns the profile subdirectory names ("Default",
+// "Profile 1", ...) under a channel's data dir. A read error yields no names so
+// one unreadable channel never sinks discovery across the others.
+func chromeProfileDirNames(dataDir string) []string {
+	entries, err := os.ReadDir(dataDir)
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if name := entry.Name(); name == "Default" || strings.HasPrefix(name, "Profile ") {
+			names = append(names, name)
+		}
+	}
+	return names
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
 // When requiredCookies is non-empty, profiles with those credential cookies rank
 // ahead of profiles that only have guest, analytics, or challenge cookies.
 func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
-	dataDir, err := chromeDataDir()
+	channelDirs, err := chromeChannelDirs()
 	if err != nil {
 		return nil, err
 	}
@@ -443,54 +539,48 @@ func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromePr
 		return nil, fmt.Errorf("sqlite3 not found")
 	}
 
-	entries, err := os.ReadDir(dataDir)
-	if err != nil {
-		return nil, fmt.Errorf("cannot read Chrome data directory: %w", err)
-	}
-
 	// Match domain for SQLite query — host_key uses leading dot (e.g. ".notion.so")
 	domainPattern := "%" + strings.TrimPrefix(domain, ".") + "%"
 
 	var profiles []chromeProfile
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		if name != "Default" && !strings.HasPrefix(name, "Profile ") {
-			continue
-		}
+	for _, ch := range channelDirs {
+		for _, name := range chromeProfileDirNames(ch.DataDir) {
+			profilePath := filepath.Join(ch.DataDir, name)
+			cookiesDB := filepath.Join(profilePath, "Cookies")
+			if _, err := os.Stat(cookiesDB); err != nil {
+				continue
+			}
 
-		profilePath := filepath.Join(dataDir, name)
-		cookiesDB := filepath.Join(profilePath, "Cookies")
-		if _, err := os.Stat(cookiesDB); err != nil {
-			continue
+			displayName := readProfileDisplayName(filepath.Join(profilePath, "Preferences"))
+			if displayName == "" {
+				displayName = name
+			}
+
+			count, requiredCount, missing := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
+
+			profiles = append(profiles, chromeProfile{
+				Channel:             ch.Channel,
+				DataDir:             ch.DataDir,
+				Dir:                 name,
+				DisplayName:         displayName,
+				CookieCount:         count,
+				RequiredCookieCount: requiredCount,
+				MissingCookies:      missing,
+			})
 		}
-
-		displayName := readProfileDisplayName(filepath.Join(profilePath, "Preferences"))
-		if displayName == "" {
-			displayName = name
-		}
-
-		count, requiredCount, missing := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
-
-		profiles = append(profiles, chromeProfile{
-			Dir:                 name,
-			DisplayName:         displayName,
-			CookieCount:         count,
-			RequiredCookieCount: requiredCount,
-			MissingCookies:      missing,
-		})
 	}
 
 	// Sort: profiles with credential cookies first, then by total cookie count,
-	// then by directory name for deterministic prompts.
+	// then by channel preference and directory name for deterministic prompts.
 	sort.Slice(profiles, func(i, j int) bool {
 		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
 			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
 		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
+		}
+		if ri, rj := channelRank(profiles[i].Channel), channelRank(profiles[j].Channel); ri != rj {
+			return ri < rj
 		}
 		return profiles[i].Dir < profiles[j].Dir
 	})
@@ -612,7 +702,7 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (chromeProfile, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
@@ -621,7 +711,7 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
-		return "", nil
+		return chromeProfile{}, nil
 	}
 
 	// Prefer profiles that have all required credential cookies. A profile with
@@ -650,7 +740,7 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	}
 
 	if len(withCookies) == 0 {
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+		return chromeProfile{}, fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	}
 	return chooseChromeProfile(w, r, domain, withCookies, false)
 }
@@ -663,20 +753,20 @@ func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCooki
 		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
 			continue
 		}
-		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.profileLocation(), strings.Join(p.MissingCookies, ", "))
 		return
 	}
 }
 
-func chooseChromeProfile(w io.Writer, r io.Reader, domain string, profiles []chromeProfile, matchedRequired bool) (string, error) {
+func chooseChromeProfile(w io.Writer, r io.Reader, domain string, profiles []chromeProfile, matchedRequired bool) (chromeProfile, error) {
 	switch len(profiles) {
 	case 1:
 		if matchedRequired {
-			fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, required cookies present)\n", profiles[0].DisplayName, profiles[0].Dir)
+			fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, required cookies present)\n", profiles[0].DisplayName, profiles[0].profileLocation())
 		} else {
-			fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", profiles[0].DisplayName, profiles[0].Dir)
+			fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", profiles[0].DisplayName, profiles[0].profileLocation())
 		}
-		return profiles[0].Dir, nil
+		return profiles[0], nil
 	default:
 		// Multiple profiles have cookies.
 		// Non-interactive: pick the profile with the most cookies (already sorted).
@@ -685,20 +775,20 @@ func chooseChromeProfile(w io.Writer, r io.Reader, domain string, profiles []chr
 			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
 			selected := profiles[0]
 			if matchedRequired {
-				fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, required cookies present, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+				fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, required cookies present, %d cookies)\n", selected.DisplayName, selected.profileLocation(), selected.CookieCount)
 			} else {
-				fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+				fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.profileLocation(), selected.CookieCount)
 			}
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
-			return selected.Dir, nil
+			return selected, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
 		for i, p := range profiles {
 			if matchedRequired {
-				fmt.Fprintf(w, "  %d. %s (%s, required cookies present, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+				fmt.Fprintf(w, "  %d. %s (%s, required cookies present, %d cookies)\n", i+1, p.DisplayName, p.profileLocation(), p.CookieCount)
 			} else {
-				fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+				fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.profileLocation(), p.CookieCount)
 			}
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
@@ -715,39 +805,34 @@ func chooseChromeProfile(w io.Writer, r io.Reader, domain string, profiles []chr
 			choice = 1
 		}
 		selected := profiles[choice-1]
-		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
-		return selected.Dir, nil
+		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.profileLocation())
+		return selected, nil
 	}
 }
 
-// resolveProfileByName finds a Chrome profile directory by its display name.
-func resolveProfileByName(name string) (string, error) {
-	dataDir, err := chromeDataDir()
+// resolveProfileByName finds a Chrome profile by its display or directory name,
+// searching every installed channel (stable first). The first match wins, so a
+// name present in multiple channels resolves to the stable one.
+func resolveProfileByName(name string) (chromeProfile, error) {
+	channelDirs, err := chromeChannelDirs()
 	if err != nil {
-		return "", err
-	}
-
-	entries, err := os.ReadDir(dataDir)
-	if err != nil {
-		return "", err
+		return chromeProfile{}, err
 	}
 
 	lowerName := strings.ToLower(name)
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		dirName := entry.Name()
-		if dirName != "Default" && !strings.HasPrefix(dirName, "Profile ") {
-			continue
-		}
-		displayName := readProfileDisplayName(filepath.Join(dataDir, dirName, "Preferences"))
-		if strings.ToLower(displayName) == lowerName || strings.ToLower(dirName) == lowerName {
-			return dirName, nil
+	for _, ch := range channelDirs {
+		for _, dirName := range chromeProfileDirNames(ch.DataDir) {
+			displayName := readProfileDisplayName(filepath.Join(ch.DataDir, dirName, "Preferences"))
+			if strings.ToLower(displayName) == lowerName || strings.ToLower(dirName) == lowerName {
+				if displayName == "" {
+					displayName = dirName
+				}
+				return chromeProfile{Channel: ch.Channel, DataDir: ch.DataDir, Dir: dirName, DisplayName: displayName}, nil
+			}
 		}
 	}
 
-	return "", fmt.Errorf("Chrome profile %q not found", name)
+	return chromeProfile{}, fmt.Errorf("Chrome profile %q not found", name)
 }
 
 // --- Cookie extraction tools ---
@@ -832,30 +917,34 @@ func detectCookieTool() (cookieTool, error) {
 }
 
 // extractCookies shells out to the detected tool and returns a Cookie header value string.
-// profileDir selects which Chrome profile to read from (e.g. "Default", "Profile 1").
-func extractCookies(tool cookieTool, domain, profileDir string) (string, error) {
+// profile selects which Chrome profile (and channel) to read from; a zero profile
+// lets the tool fall back to the stable channel's default cookie file.
+func extractCookies(tool cookieTool, domain string, profile chromeProfile) (string, error) {
 	switch tool.name {
 	case "pycookiecheat":
-		return extractViaPycookiecheat(tool, domain, profileDir)
+		return extractViaPycookiecheat(tool, domain, profile)
 	case "pycookiecheat-cli":
-		return extractViaPycookiecheatCLI(tool, domain, profileDir)
+		return extractViaPycookiecheatCLI(tool, domain, profile)
 	case "cookies":
 		return extractViaCookiesCLI(domain)
 	case "cookie-scoop":
-		return extractViaCookieScoop(domain, profileDir)
+		// cookie-scoop resolves the data dir itself and only knows the stable
+		// channel, so it cannot read a Beta/Dev/Canary profile. Fail loudly
+		// instead of silently reading the same-named stable profile.
+		if profile.Channel != "" && profile.Channel != chromeChannelStable {
+			return "", fmt.Errorf("cookie-scoop can only read the stable Chrome channel; install pycookiecheat to read the %s profile", profile.Channel)
+		}
+		return extractViaCookieScoop(domain, profile.Dir)
 	default:
 		return "", fmt.Errorf("unknown cookie tool: %s", tool.name)
 	}
 }
 
-func extractViaPycookiecheat(tool cookieTool, domain, profileDir string) (string, error) {
+func extractViaPycookiecheat(tool cookieTool, domain string, profile chromeProfile) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" {
-		dataDir, err := chromeDataDir()
-		if err == nil {
-			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")
-		}
+	if profile.Dir != "" && profile.DataDir != "" {
+		cookiePath = filepath.Join(profile.DataDir, profile.Dir, "Cookies")
 	}
 
 	var script string
@@ -893,15 +982,11 @@ func extractViaPycookiecheat(tool cookieTool, domain, profileDir string) (string
 	return strings.Join(parts, "; "), nil
 }
 
-func extractViaPycookiecheatCLI(tool cookieTool, domain, profileDir string) (string, error) {
+func extractViaPycookiecheatCLI(tool cookieTool, domain string, profile chromeProfile) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	var args []string
-	if profileDir != "" {
-		dataDir, err := chromeDataDir()
-		if err != nil {
-			return "", err
-		}
-		args = append(args, "-c", filepath.Join(dataDir, profileDir, "Cookies"))
+	if profile.Dir != "" && profile.DataDir != "" {
+		args = append(args, "-c", filepath.Join(profile.DataDir, profile.Dir, "Cookies"))
 	}
 	args = append(args, "https://"+cleanDomain)
 


### PR DESCRIPTION
## Summary

Before: a user who runs only Chrome Beta (or Dev/Canary) could not authenticate a printed CLI with `auth login --chrome`. Profile discovery looked only at the stable channel's user-data directory, found nothing, and the CLI reported "not logged in" despite a valid session sitting in the Beta profile. Now every installed Google Chrome channel is searched automatically — no flag.

Profiles are discovered across all installed channels, ranked together by the existing required-cookie / cookie-count heuristic, and channel-qualified in prompts (`Chrome Beta/Default`) so two same-named `Default` profiles stay distinct. `--profile <name>` resolves across channels too.

**Why it stayed small:** all Google Chrome channels share one macOS `Chrome Safe Storage` Keychain key (verified against yt-dlp and browser_cookie3), so cookie *decryption* needs no per-channel handling — only the data-dir path differs. pycookiecheat's default already fetches the shared key; pointing it at the right channel's `Cookies` file is the whole change.

**Scope:** the `cookies` (barnardb) and `cookie-scoop` fallback tools can only read stable's `Default`; cookie-scoop now fails loudly for a non-stable profile rather than silently reading the wrong channel. Full multi-channel extraction lands on the recommended pycookiecheat path. press-auth's own controlled-login window is unaffected — it logs in through a fresh temp profile, so channel selection never applied to it.

This is a machine (generator template) change, so it benefits every future printed CLI on next regen.

## Validation

- New generated-output test compiles a runtime test **into** a generated CLI, proving `chromeChannelDirs()` picks up a Beta-only install and orders stable ahead of Beta when both exist.
- `go test ./...` — 6882 pass · golden verify — 32/32 · `verify-generator-output.sh generate-golden-api-cookie-auth` — compiles clean · `go vet` + `golangci-lint` — clean.

Fixes #3523

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
