### PR TITLE
fix(cli): persist OAuth token expiry in generated credentials

### DIFF
--- a/internal/generator/auth_env_precedence_test.go
+++ b/internal/generator/auth_env_precedence_test.go
@@ -204,7 +204,12 @@ func TestEnvSourcedCredentialsStayOutOfConfigSave(t *testing.T) {
 			t.Fatalf("credentials.toml leaked env value %q after SaveTokens:\n%s", leaked, afterTokensText)
 		}
 	}
-	for _, want := range []string{"refreshed-access-token", "refreshed-refresh-token"} {
+	for _, want := range []string{
+		"refreshed-access-token",
+		"refreshed-refresh-token",
+		"token_expiry",
+		"2030-01-02T03:04:05Z",
+	} {
 		if !strings.Contains(afterTokensText, want) {
 			t.Fatalf("credentials.toml missing %q after SaveTokens:\n%s", want, afterTokensText)
 		}
@@ -213,6 +218,25 @@ func TestEnvSourcedCredentialsStayOutOfConfigSave(t *testing.T) {
 		if strings.Contains(afterTokensText, stale) {
 			t.Fatalf("credentials.toml kept stale value %q after SaveTokens:\n%s", stale, afterTokensText)
 		}
+	}
+
+	reloaded, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() after SaveTokens error = %v", err)
+	}
+	if !reloaded.TokenExpiry.Equal(expiry) {
+		t.Fatalf("reloaded TokenExpiry = %s, want %s", reloaded.TokenExpiry.Format(time.RFC3339), expiry.Format(time.RFC3339))
+	}
+
+	if err := cfg.SaveTokens(cfg.ClientID, cfg.ClientSecret, "zero-expiry-access-token", "zero-expiry-refresh-token", time.Time{}); err != nil {
+		t.Fatalf("SaveTokens() zero expiry error = %v", err)
+	}
+	zeroExpiryData, err := os.ReadFile(credentialsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(credentials.toml) after zero expiry SaveTokens error = %v", err)
+	}
+	if strings.Contains(string(zeroExpiryData), "token_expiry") {
+		t.Fatalf("credentials.toml wrote token_expiry for zero expiry:\n%s", string(zeroExpiryData))
 	}
 }
 

--- a/internal/generator/oauth2_refresh_test.go
+++ b/internal/generator/oauth2_refresh_test.go
@@ -171,6 +171,7 @@ import (
 	"testing"
 	"time"
 
+	"__MODULE_PATH__/internal/cliutil"
 	"__MODULE_PATH__/internal/config"
 )
 
@@ -312,6 +313,16 @@ func TestOAuth2RefreshAfterUnauthorizedPersistsRotatedTokens(t *testing.T) {
 		if !strings.Contains(credentialsText, want) {
 			t.Fatalf("credentials.toml missing %q after 401 refresh:\n%s", want, credentialsText)
 		}
+	}
+	reloadedCreds, _, err := cliutil.LoadCredentials()
+	if err != nil {
+		t.Fatalf("LoadCredentials() after 401 refresh error = %v", err)
+	}
+	if reloadedCreds == nil || reloadedCreds.TokenExpiry.IsZero() {
+		t.Fatalf("reloaded TokenExpiry is zero after 401 refresh")
+	}
+	if want := time.Now().Add(50 * time.Minute); reloadedCreds.TokenExpiry.Before(want) {
+		t.Fatalf("reloaded TokenExpiry = %s is earlier than expected minimum %s", reloadedCreds.TokenExpiry, want)
 	}
 }
 `, "__MODULE_PATH__", modulePath)

--- a/internal/generator/oauth2_refresh_test.go
+++ b/internal/generator/oauth2_refresh_test.go
@@ -52,7 +52,7 @@ func TestGenerateOAuth2RefreshAuth(t *testing.T) {
 	assert.Contains(t, skill, "This CLI uses OAuth2 with refresh-token rotation.")
 
 	writeOAuth2RefreshRuntimeTest(t, outputDir)
-	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^TestOAuth2RefreshTokenUsedBeforeRequest$")
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^TestOAuth2Refresh(TokenUsedBeforeRequest|AfterUnauthorizedPersistsRotatedTokens)$")
 }
 
 func TestOAuth2RefreshDefaultsEnvVars(t *testing.T) {
@@ -165,7 +165,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -224,6 +226,92 @@ func TestOAuth2RefreshTokenUsedBeforeRequest(t *testing.T) {
 	}
 	if cfg.AuthSource != "oauth2_refresh" {
 		t.Fatalf("auth source = %q, want oauth2_refresh", cfg.AuthSource)
+	}
+}
+
+func TestOAuth2RefreshAfterUnauthorizedPersistsRotatedTokens(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "data")
+	t.Setenv("OAUTH2_REFRESH_DATA_DIR", dataDir)
+
+	var apiCalls int
+	var tokenCalls int
+	handleToken := func(w http.ResponseWriter, r *http.Request) {
+		tokenCalls++
+		if r.Method != http.MethodPost {
+			t.Fatalf("token request method = %s, want POST", r.Method)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("refresh_token"); got != "refresh-123" {
+			t.Fatalf("refresh_token = %q, want refresh-123", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `+"`"+`{"access_token":"access-after-401","refresh_token":"refresh-after-401","expires_in":3600}`+"`"+`)
+	}
+	handleResource := func(w http.ResponseWriter, r *http.Request) {
+		apiCalls++
+		switch apiCalls {
+		case 1:
+			if got := r.Header.Get("Authorization"); got != "Bearer stale-access" {
+				t.Fatalf("first Authorization = %q, want Bearer stale-access", got)
+			}
+			http.Error(w, "expired token", http.StatusUnauthorized)
+		case 2:
+			if got := r.Header.Get("Authorization"); got != "Bearer access-after-401" {
+				t.Fatalf("retry Authorization = %q, want Bearer access-after-401", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `+"`"+`{"ok":true}`+"`"+`)
+		default:
+			t.Fatalf("unexpected API call %d", apiCalls)
+		}
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			handleToken(w, r)
+		case "/resource":
+			handleResource(w, r)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		BaseURL:      srv.URL,
+		TokenURL:     srv.URL + "/token",
+		AccessToken:  "stale-access",
+		RefreshToken: "refresh-123",
+		ClientID:     "client-123",
+		ClientSecret: "secret-123",
+		TokenExpiry:  time.Now().Add(time.Hour),
+		Path:         filepath.Join(t.TempDir(), "config.toml"),
+	}
+	c := New(cfg, time.Second, 0)
+	c.HTTPClient = srv.Client()
+
+	if _, err := c.Get(context.Background(), "/resource", nil); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if apiCalls != 2 {
+		t.Fatalf("api calls = %d, want 2", apiCalls)
+	}
+	if tokenCalls != 1 {
+		t.Fatalf("token calls = %d, want 1", tokenCalls)
+	}
+
+	credentialsPath := filepath.Join(dataDir, "credentials.toml")
+	credentialsData, err := os.ReadFile(credentialsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(credentials.toml) error = %v", err)
+	}
+	credentialsText := string(credentialsData)
+	for _, want := range []string{"access-after-401", "refresh-after-401", "token_expiry"} {
+		if !strings.Contains(credentialsText, want) {
+			t.Fatalf("credentials.toml missing %q after 401 refresh:\n%s", want, credentialsText)
+		}
 	}
 }
 `, "__MODULE_PATH__", modulePath)

--- a/internal/generator/security_suppressions_test.go
+++ b/internal/generator/security_suppressions_test.go
@@ -37,7 +37,7 @@ func TestGeneratedInfraSecuritySuppressionsAreExplicit(t *testing.T) {
 
 	credentialsGo := readGenerated(t, outputDir, "internal", "cliutil", "credentials.go")
 	assert.Contains(t, credentialsGo, `os.ReadFile(filepath.Clean(path)) // #nosec G304 -- app-owned credentials path from cliutil.DataDir.`)
-	assert.Contains(t, credentialsGo, `toml.Marshal(creds) // #nosec G117 -- credentials are intentionally persisted to a 0600 private file.`)
+	assert.Contains(t, credentialsGo, `toml.Marshal(credentialsFileFrom(creds)) // #nosec G117 -- credentials are intentionally persisted to a 0600 private file.`)
 
 	pathsGo := readGenerated(t, outputDir, "internal", "cliutil", "paths.go")
 	assert.Contains(t, pathsGo, `os.ReadFile(filepath.Clean(primary)) // #nosec G304 -- app-derived config/data path.`)

--- a/internal/generator/templates/cliutil_credentials.go.tmpl
+++ b/internal/generator/templates/cliutil_credentials.go.tmpl
@@ -36,6 +36,38 @@ type Credentials struct {
 {{- end}}
 }
 
+func credentialsFileFrom(creds *Credentials) map[string]interface{} {
+	values := map[string]interface{}{}
+	if creds == nil {
+		return values
+	}
+	setStringCredential(values, "auth_header", creds.AuthHeaderVal)
+	setStringCredential(values, "access_token", creds.AccessToken)
+	setStringCredential(values, "refresh_token", creds.RefreshToken)
+	setTimeCredential(values, "token_expiry", creds.TokenExpiry)
+{{- if .BearerRefresh.Enabled}}
+	setTimeCredential(values, "bearer_token_refreshed_at", creds.BearerTokenRefreshedAt)
+{{- end}}
+	setStringCredential(values, "client_id", creds.ClientID)
+	setStringCredential(values, "client_secret", creds.ClientSecret)
+{{- range .CredentialFields}}
+	setStringCredential(values, "{{.Tag}}", creds.{{.GoField}})
+{{- end}}
+	return values
+}
+
+func setStringCredential(values map[string]interface{}, key string, value string) {
+	if value != "" {
+		values[key] = value
+	}
+}
+
+func setTimeCredential(values map[string]interface{}, key string, value time.Time) {
+	if !value.IsZero() {
+		values[key] = value
+	}
+}
+
 func credentialsPath() (string, error) {
 	dir, err := DataDir()
 	if err != nil {
@@ -105,7 +137,7 @@ func SaveCredentials(creds *Credentials) error {
 	if err != nil {
 		return err
 	}
-	data, err := toml.Marshal(creds) // #nosec G117 -- credentials are intentionally persisted to a 0600 private file.
+	data, err := toml.Marshal(credentialsFileFrom(creds)) // #nosec G117 -- credentials are intentionally persisted to a 0600 private file.
 	if err != nil {
 		return fmt.Errorf("marshaling credentials: %w", err)
 	}

--- a/internal/generator/templates/cliutil_credentials.go.tmpl
+++ b/internal/generator/templates/cliutil_credentials.go.tmpl
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -22,17 +24,17 @@ var (
 )
 
 type Credentials struct {
-	AuthHeaderVal string `toml:"auth_header,omitempty"`
-	AccessToken   string `toml:"access_token,omitempty"`
-	RefreshToken  string `toml:"refresh_token,omitempty"`
-	TokenExpiry   time.Time `toml:"token_expiry,omitempty"`
+	AuthHeaderVal string `toml:"auth_header"`
+	AccessToken   string `toml:"access_token"`
+	RefreshToken  string `toml:"refresh_token"`
+	TokenExpiry   time.Time `toml:"token_expiry"`
 {{- if .BearerRefresh.Enabled}}
-	BearerTokenRefreshedAt time.Time `toml:"bearer_token_refreshed_at,omitempty"`
+	BearerTokenRefreshedAt time.Time `toml:"bearer_token_refreshed_at"`
 {{- end}}
-	ClientID     string `toml:"client_id,omitempty"`
-	ClientSecret string `toml:"client_secret,omitempty"`
+	ClientID     string `toml:"client_id"`
+	ClientSecret string `toml:"client_secret"`
 {{- range .CredentialFields}}
-	{{.GoField}} string `toml:"{{.Tag}},omitempty"`
+	{{.GoField}} string `toml:"{{.Tag}}"`
 {{- end}}
 }
 
@@ -41,31 +43,29 @@ func credentialsFileFrom(creds *Credentials) map[string]interface{} {
 	if creds == nil {
 		return values
 	}
-	setStringCredential(values, "auth_header", creds.AuthHeaderVal)
-	setStringCredential(values, "access_token", creds.AccessToken)
-	setStringCredential(values, "refresh_token", creds.RefreshToken)
-	setTimeCredential(values, "token_expiry", creds.TokenExpiry)
-{{- if .BearerRefresh.Enabled}}
-	setTimeCredential(values, "bearer_token_refreshed_at", creds.BearerTokenRefreshedAt)
-{{- end}}
-	setStringCredential(values, "client_id", creds.ClientID)
-	setStringCredential(values, "client_secret", creds.ClientSecret)
-{{- range .CredentialFields}}
-	setStringCredential(values, "{{.Tag}}", creds.{{.GoField}})
-{{- end}}
+	credsValue := reflect.ValueOf(*creds)
+	credsType := credsValue.Type()
+	for i := 0; i < credsType.NumField(); i++ {
+		key := credentialTomlKey(credsType.Field(i))
+		if key == "" {
+			continue
+		}
+		value := credsValue.Field(i)
+		if value.IsZero() {
+			continue
+		}
+		values[key] = value.Interface()
+	}
 	return values
 }
 
-func setStringCredential(values map[string]interface{}, key string, value string) {
-	if value != "" {
-		values[key] = value
+func credentialTomlKey(field reflect.StructField) string {
+	tag := field.Tag.Get("toml")
+	key, _, _ := strings.Cut(tag, ",")
+	if key == "-" {
+		return ""
 	}
-}
-
-func setTimeCredential(values map[string]interface{}, key string, value time.Time) {
-	if !value.IsZero() {
-		values[key] = value
-	}
+	return key
 }
 
 func credentialsPath() (string, error) {


### PR DESCRIPTION
## Intent

Issue: Fixes #3504

Generated OAuth CLIs passed a non-zero expiry into `SaveTokens`, but `credentials.toml` omitted `token_expiry`. Later CLI processes then loaded a zero expiry and could not proactively refresh before using the stale access token.

The issue also mentioned the 401 refresh path. Current `main` already persists the refreshed access token and rotated refresh token pair there, so this PR keeps that path covered as a regression contract while fixing the still-reproducible expiry persistence gap.

## Approach

Marshal generated credentials through a small credentials-file representation that only writes non-empty string credentials and non-zero time credentials. That keeps zero expiries omitted while preserving non-zero `TokenExpiry` as a real TOML datetime that `LoadCredentials` can read back into generated `Config.TokenExpiry`.

I also expanded generated-output runtime coverage so:

- `SaveTokens` writes and reloads `token_expiry` for a non-zero expiry.
- zero expiry does not create a misleading `token_expiry` key.
- the 401 retry refresh path persists the refreshed access token and rotated refresh token.

## Scope

Primary area: generated OAuth credentials persistence

Why this belongs in this repo: the bug is emitted by Printing Press templates and affects generated printed CLIs. The fix belongs in the generator/template output rather than in one generated CLI copy.

## Risk

This touches generated credential-file serialization for all generated CLIs that use the shared credentials helper. The intended behavior change is limited to `token_expiry`: non-zero expiries are now written to `credentials.toml`, while zero expiries stay omitted.

The credentials TOML key order may differ because the write path now filters fields before marshaling. TOML consumers should not depend on key order, and generated-output plus golden checks passed without expected fixture updates.

## Output Contract

Generated-output evidence:

- Runtime generated config coverage verifies `SaveTokens` writes `token_expiry`, reloads it into `Config.TokenExpiry`, and omits it for zero expiry.
- Runtime generated client coverage verifies a 401 refresh persists the refreshed access token and rotated refresh token pair.
- OAuth auth-code, client-credentials, and device-code generated modules were regenerated, tidied, and built.
- Golden verification passed with no fixture updates required.

## Verification

- `GOCACHE=.gotmp/go-build go test ./internal/generator -run '^TestConfigSaveTokensDoesNotPersistEnvSourcedCredentials$|^TestGeneratedInfraSecuritySuppressionsAreExplicit$' -count=1 -v`
- `GOCACHE=.gotmp/go-build go test ./internal/generator -run '^TestGenerateOAuth2RefreshAuth$' -count=1 -v`
- `GOCACHE=.gotmp/go-build scripts/golden.sh verify`
- `GOCACHE=.gotmp/go-build scripts/verify-generator-output.sh generate-golden-api-oauth2-authcode generate-golden-api-oauth2-cc generate-golden-api-oauth2-device-code`
- `GOCACHE=.gotmp/go-build go test ./...`

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
