### PR TITLE
fix(cli): drop dangling ": " from APIError.Error() on empty response body

### DIFF
--- a/internal/generator/client_apierror_empty_body_test.go
+++ b/internal/generator/client_apierror_empty_body_test.go
@@ -1,0 +1,52 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGeneratedAPIErrorOmitsSeparatorOnEmptyBody pins #2945: the emitted
+// APIError.Error() must drop the trailing ": " when the response body is empty.
+// It asserts inside the generated module, so it exercises the emitted Error()
+// at runtime rather than the template text.
+func TestGeneratedAPIErrorOmitsSeparatorOnEmptyBody(t *testing.T) {
+	apiSpec := minimalSpec("apierror-empty-body")
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const clientTest = `package client
+
+import "testing"
+
+func TestAPIErrorSeparatorGuardOnEmptyBody(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		body       string
+		want       string
+	}{
+		{"empty body", 401, "", "GET /items returned HTTP 401"},
+		{"whitespace-only body", 401, "  \n\t ", "GET /items returned HTTP 401"},
+		{"non-empty body preserved", 404, "{\"error\":\"not_found\"}", "GET /items returned HTTP 404: {\"error\":\"not_found\"}"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &APIError{Method: "GET", Path: "/items", StatusCode: tc.statusCode, Body: tc.body}
+			if got := e.Error(); got != tc.want {
+				t.Fatalf("APIError.Error() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "client", "apierror_empty_body_test.go"),
+		[]byte(clientTest), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "TestAPIErrorSeparatorGuardOnEmptyBody", "-count=1")
+}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -328,7 +328,11 @@ type APIError struct {
 }
 
 func (e *APIError) Error() string {
-	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
+	msg := fmt.Sprintf("%s %s returned HTTP %d", e.Method, e.Path, e.StatusCode)
+	if strings.TrimSpace(e.Body) != "" {
+		msg += ": " + e.Body
+	}
+	return msg
 }
 
 func rejectUnresolvedPathParams(path string, allowedTemplateVars map[string]string) error {

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -55,7 +55,11 @@ type APIError struct {
 }
 
 func (e *APIError) Error() string {
-	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
+	msg := fmt.Sprintf("%s %s returned HTTP %d", e.Method, e.Path, e.StatusCode)
+	if strings.TrimSpace(e.Body) != "" {
+		msg += ": " + e.Body
+	}
+	return msg
 }
 
 func rejectUnresolvedPathParams(path string, allowedTemplateVars map[string]string) error {

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -55,7 +55,11 @@ type APIError struct {
 }
 
 func (e *APIError) Error() string {
-	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
+	msg := fmt.Sprintf("%s %s returned HTTP %d", e.Method, e.Path, e.StatusCode)
+	if strings.TrimSpace(e.Body) != "" {
+		msg += ": " + e.Body
+	}
+	return msg
 }
 
 func rejectUnresolvedPathParams(path string, allowedTemplateVars map[string]string) error {

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -60,7 +60,11 @@ type APIError struct {
 }
 
 func (e *APIError) Error() string {
-	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
+	msg := fmt.Sprintf("%s %s returned HTTP %d", e.Method, e.Path, e.StatusCode)
+	if strings.TrimSpace(e.Body) != "" {
+		msg += ": " + e.Body
+	}
+	return msg
 }
 
 func rejectUnresolvedPathParams(path string, allowedTemplateVars map[string]string) error {

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -55,7 +55,11 @@ type APIError struct {
 }
 
 func (e *APIError) Error() string {
-	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
+	msg := fmt.Sprintf("%s %s returned HTTP %d", e.Method, e.Path, e.StatusCode)
+	if strings.TrimSpace(e.Body) != "" {
+		msg += ": " + e.Body
+	}
+	return msg
 }
 
 func rejectUnresolvedPathParams(path string, allowedTemplateVars map[string]string) error {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -56,7 +56,11 @@ type APIError struct {
 }
 
 func (e *APIError) Error() string {
-	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
+	msg := fmt.Sprintf("%s %s returned HTTP %d", e.Method, e.Path, e.StatusCode)
+	if strings.TrimSpace(e.Body) != "" {
+		msg += ": " + e.Body
+	}
+	return msg
 }
 
 func rejectUnresolvedPathParams(path string, allowedTemplateVars map[string]string) error {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -158,7 +158,11 @@ type APIError struct {
 }
 
 func (e *APIError) Error() string {
-	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
+	msg := fmt.Sprintf("%s %s returned HTTP %d", e.Method, e.Path, e.StatusCode)
+	if strings.TrimSpace(e.Body) != "" {
+		msg += ": " + e.Body
+	}
+	return msg
 }
 
 func rejectUnresolvedPathParams(path string, allowedTemplateVars map[string]string) error {


### PR DESCRIPTION
## Intent

Every generated CLI's `APIError.Error()` builds its message with `fmt.Sprintf("%s %s returned HTTP %d: %s", ...)` unconditionally. When the HTTP response has an empty body (a 401/403/204/5xx with no payload), the trailing `%s` expands to an empty string and the message ends with a dangling `": "` separator: `GET /items returned HTTP 401: `. The `": "` only makes sense when there is a body to separate.

Issue: Fixes #2945

## Approach

Build the base message first, then append `": " + body` only when the body is non-empty. Whitespace-only bodies (a lone newline some servers return) count as empty via `strings.TrimSpace`, so they do not leave a separator with nothing after it. A non-empty body keeps the existing `HTTP %d: %s` format byte-for-byte, so only the empty and whitespace cases change.

```go
msg := fmt.Sprintf("%s %s returned HTTP %d", e.Method, e.Path, e.StatusCode)
if strings.TrimSpace(e.Body) != "" {
    msg += ": " + e.Body
}
return msg
```

`strings` is already imported in the client template, so the emitted import block does not change.

## Scope

Primary area: generator, the client error template `internal/generator/templates/client.go.tmpl` (the `APIError.Error()` method emitted into every printed CLI).

Why this belongs in this repo: the dangling separator is emitted by the generator into every printed CLI, so it is a machine defect rather than a per-CLI quirk. The issue observed the same byte-identical line across independent prints (asaas, focus-nfe, Stripe) on their empty-body error paths (401 on invalid auth, some 4xx and HEAD responses). Fixing the template fixes the whole class in one place.

## Risk

The change alters the emitted error string only for the empty and whitespace-only body cases, where the trailing `": "` is dropped. Any error with a non-empty body is unchanged. No error semantics change: exit codes, status codes, and the structured fields on `APIError` are untouched; only the human-readable `Error()` string is affected.

Two other templates compose a similar `returned HTTP %d: %s` message on the OAuth token-endpoint failure path (`auth_client_credentials.go.tmpl`, `oauth_device.go.tmpl`). The issue marks mirroring the guard there as optional and names `APIError.Error()` as the primary case, so this PR leaves those for a separate follow-up to keep the diff minimal.

## Output Contract

This changes emitted Go in the client (`APIError.Error()`), so the six golden `client.go` fixtures that carry that method are updated in lockstep.

Evidence:
- New `internal/generator/client_apierror_empty_body_test.go` generates a CLI, writes a test into the generated module, and asserts the emitted `Error()` across empty, whitespace-only, and non-empty bodies. It runs the emitted code, not the template text, and fails on the pre-fix template (the empty and whitespace cases render the dangling separator).
- The six updated goldens are byte-identical to fresh generator output: regenerating `generate-golden-api` and diffing its `internal/client/client.go` against the committed golden produces no difference.

## Verification

- `go test ./internal/generator/ -run TestGeneratedAPIErrorOmitsSeparatorOnEmptyBody` passes on the fix and fails on the pre-fix template (verified by reverting the template line and re-running).
- `go vet ./internal/generator/` clean; `gofmt` clean on the changed Go.
- Regenerated `generate-golden-api` and confirmed the emitted `client.go` matches the committed golden byte-for-byte.
- `scripts/golden.sh verify` not run locally (`jq` unavailable on this machine). The golden impact is the same mechanical guard applied to the template and the fixtures, and CI's golden job confirms.
- Full `internal/generator` package run: the only failures are pre-existing credential and config file-permission tests on this Windows checkout, verified identical on clean `main` via a baseline diff of the same targeted test. This change introduces none.

- [x] Generator/template change: verified generated output, including emitted-code assertions and compiled generated CLI output
- [x] Generator/template change: covered the affected variant shape (empty and whitespace-only body), not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites; `APIError.Error()` is the single emitter of this string

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
