### PR TITLE
fix(cli): honor pp:typed-exit-codes in live dogfood and complete learn-loop annotations

### DIFF
--- a/internal/generator/learn_mcp_parity_test.go
+++ b/internal/generator/learn_mcp_parity_test.go
@@ -159,6 +159,24 @@ func TestGenerateLearnMCPParity_LocalWriteAnnotations(t *testing.T) {
 	require.NotContains(t, forgetBlock, "mcp:local-write",
 		"learnings forget must not carry local-write hints")
 
+	// teach-pattern exits 2 via usageErr on missing required flags, just like
+	// its teach/teach-playbook siblings, and writes to the local store. It must
+	// declare both annotations so verify and the live-dogfood matrix score its
+	// Execute cell honestly.
+	teachPatternBlock := commandBlock(t, teachSrc, `Use:   "teach-pattern"`)
+	require.Regexp(t, `"pp:typed-exit-codes":\s+"0,2"`, teachPatternBlock,
+		"teach-pattern must declare pp:typed-exit-codes 0,2")
+	require.Regexp(t, `"mcp:local-write":\s+"true"`, teachPatternBlock,
+		"teach-pattern must carry the local-write annotation")
+
+	// teach-lookup is the same family: local-store writer, usageErr exit 2 on
+	// missing required flags. It must declare the same annotations.
+	teachLookupBlock := commandBlock(t, teachSrc, `Use:   "teach-lookup"`)
+	require.Regexp(t, `"pp:typed-exit-codes":\s+"0,2"`, teachLookupBlock,
+		"teach-lookup must declare pp:typed-exit-codes 0,2")
+	require.Regexp(t, `"mcp:local-write":\s+"true"`, teachLookupBlock,
+		"teach-lookup must carry the local-write annotation")
+
 	// learnings reject tombstones and can delete materialized rows: same.
 	candSrc := readEmitted(t, outputDir, "internal", "cli", "learnings_candidates.go")
 	confirmBlock := commandBlock(t, candSrc, `Use:   "confirm <id>"`)

--- a/internal/generator/templates/agents.md.tmpl
+++ b/internal/generator/templates/agents.md.tmpl
@@ -44,7 +44,7 @@ This CLI ships a self-capturing teach/recall loop backed by the local SQLite sto
 4. Use `learnings list` to inspect taught rows, `learnings forget "<question>"` to undo a bad teach, `learnings candidates` for the full open candidate set, and `learnings stats` for the loop's local metrics. `teach-pattern` and `teach-lookup` install manual generalization rules when one teach should cover a whole family (e.g. one country alias unlocks every per-country query).
 5. If `learnings confirm` is an unknown command, you are driving an older binary - ignore the candidates guidance and keep the rest of the flow.
 
-Annotations: `recall`, `learnings list`, `learnings candidates`, and `learnings stats` carry `mcp:read-only=true`; `teach`, `teach-playbook`, `playbook amend`, and `learnings confirm` carry `mcp:local-write=true` (writes land only in the CLI's own local store); `learnings forget` and `learnings reject` keep honest may-write/destructive defaults; `teach-pattern` and `teach-lookup` are unannotated.
+Annotations: `recall`, `learnings list`, `learnings candidates`, and `learnings stats` carry `mcp:read-only=true`; `teach`, `teach-playbook`, `playbook amend`, `learnings confirm`, `teach-pattern`, and `teach-lookup` carry `mcp:local-write=true` (writes land only in the CLI's own local store); `learnings forget` and `learnings reject` keep honest may-write/destructive defaults.
 
 ### Success definition
 

--- a/internal/generator/templates/teach.go.tmpl
+++ b/internal/generator/templates/teach.go.tmpl
@@ -885,6 +885,11 @@ func newTeachPatternCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "teach-pattern",
 		Short: "Install a manual generalization pattern (query_template, resource_template, entity_kind)",
+		// Missing required flags intentionally exit 2 via usageErr, matching the
+		// sibling teach/teach-playbook commands; declare it so both `verify` and
+		// the live-dogfood matrix score the Execute cell honestly instead of
+		// masking a FAIL. Writes land only in the CLI's own local store.
+		Annotations: map[string]string{"pp:typed-exit-codes": "0,2", "mcp:local-write": "true"},
 		Long: `Adds one row to search_patterns. The recall path uses patterns to
 substitute live query entities into a resource template, so a pattern
 with query_template="items in {entity}" and
@@ -970,6 +975,11 @@ func newTeachLookupCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "teach-lookup",
 		Short: "Install a manual entity-lookup row (kind, canonical, value)",
+		// Missing required flags intentionally exit 2 via usageErr, matching the
+		// sibling teach/teach-playbook commands; declare it so both `verify` and
+		// the live-dogfood matrix score the Execute cell honestly instead of
+		// masking a FAIL. Writes land only in the CLI's own local store.
+		Annotations: map[string]string{"pp:typed-exit-codes": "0,2", "mcp:local-write": "true"},
 		Long: `Adds one row to entity_lookups. Used by the recall path's pattern
 engine to substitute values for canonical names at substitution time.
 Computed kinds (lowercase, uppercase, kebab-case, capitalize-first, slug)

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -1258,6 +1258,11 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 	}
 
 	command.Help = help
+	// Success is exit 0 plus any code the command declares via
+	// pp:typed-exit-codes (or a command-level "Exit codes:" help block) — the
+	// same contract `verify` honors. Commands with no declaration keep the
+	// default {0}, so their happy/json verdicts are unchanged.
+	successCodes := liveDogfoodSuccessExitCodes(command)
 	mutating := liveDogfoodCommandMutates(command)
 	useDryRun := mutating && commandSupportsDryRun(command.Help)
 
@@ -1337,7 +1342,7 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 		happyRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, runArgs, ctx.timeout)
 		happyResult := liveDogfoodResult(commandName, LiveDogfoodTestHappy, runArgs, happyRun)
 		happyResult.FixtureSource = fixtureSource
-		if happyRun.exitCode == 0 {
+		if successCodes[happyRun.exitCode] {
 			happyResult.Status = LiveDogfoodStatusPass
 			happyResult.Reason = ""
 		} else if liveDogfoodUnavailableForRunner(happyRun) {
@@ -1372,6 +1377,13 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 					jsonResult.Status = LiveDogfoodStatusPass
 					jsonResult.Reason = ""
 				}
+			} else if successCodes[jsonRun.exitCode] {
+				// Declared non-zero typed exit (an intentional usage exit or a
+				// get-by-id not-found): the command behaved as designed and emits
+				// no JSON body to validate, so this is a pass rather than a
+				// json_fidelity failure.
+				jsonResult.Status = LiveDogfoodStatusPass
+				jsonResult.Reason = ""
 			} else if liveDogfoodUnavailableForRunner(jsonRun) {
 				jsonResult.Status = LiveDogfoodStatusSkip
 				jsonResult.Reason = reasonUnavailableRunnerCredentials
@@ -2293,6 +2305,26 @@ func classifyLiveDogfoodFailure(t LiveDogfoodTestResult) string {
 		return "exit_nonzero"
 	}
 	return "other"
+}
+
+// liveDogfoodSuccessExitCodes returns the exit codes that count as a successful
+// run for a command: exit 0 plus any code the command declares via the
+// pp:typed-exit-codes annotation, or a command-level "Exit codes:" help block.
+// This mirrors typedSuccessCodes (which `verify` uses) for the liveDogfoodCommand
+// type. A command with no declaration returns {0}, so its happy_path and
+// json_fidelity verdicts are unchanged.
+func liveDogfoodSuccessExitCodes(command liveDogfoodCommand) map[int]bool {
+	if command.Annotations != nil {
+		if raw := strings.TrimSpace(command.Annotations[typedExitCodesAnnotation]); raw != "" {
+			if codes, ok := parseTypedExitCodesAnnotation(raw); ok {
+				return codes
+			}
+		}
+	}
+	if codes, ok := parseExitCodesFromHelp(command.Help); ok {
+		return codes
+	}
+	return map[int]bool{0: true}
 }
 
 // resolveLiveDogfoodAcceptanceIdentity finds the marker's api_name, run_id,

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -2317,11 +2317,13 @@ func liveDogfoodSuccessExitCodes(command liveDogfoodCommand) map[int]bool {
 	if command.Annotations != nil {
 		if raw := strings.TrimSpace(command.Annotations[typedExitCodesAnnotation]); raw != "" {
 			if codes, ok := parseTypedExitCodesAnnotation(raw); ok {
+				codes[0] = true
 				return codes
 			}
 		}
 	}
 	if codes, ok := parseExitCodesFromHelp(command.Help); ok {
+		codes[0] = true
 		return codes
 	}
 	return map[int]bool{0: true}

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -5449,3 +5449,139 @@ func TestLiveDogfoodSkipsInteractiveAuthCommands(t *testing.T) {
 	assert.NotContains(t, names, "auth login")
 	assert.Contains(t, names, "tasks list", "non-auth commands must still be collected")
 }
+
+// TestLiveDogfoodSuccessExitCodes covers the helper that WU-1 (retro F1)
+// added: the success set is exit 0 plus any pp:typed-exit-codes the command
+// declares, or an "Exit codes:" help block, defaulting to {0}.
+func TestLiveDogfoodSuccessExitCodes(t *testing.T) {
+	t.Run("annotation wins", func(t *testing.T) {
+		codes := liveDogfoodSuccessExitCodes(liveDogfoodCommand{
+			Annotations: map[string]string{typedExitCodesAnnotation: "0,2"},
+		})
+		assert.True(t, codes[0])
+		assert.True(t, codes[2])
+		assert.False(t, codes[1])
+	})
+
+	t.Run("help block fallback when no annotation", func(t *testing.T) {
+		help := "Do a thing.\n\nExit codes:\n  0  success\n  3  not found\n\nFlags:\n      --json\n"
+		codes := liveDogfoodSuccessExitCodes(liveDogfoodCommand{Help: help})
+		assert.True(t, codes[0])
+		assert.True(t, codes[3])
+		assert.False(t, codes[2])
+	})
+
+	t.Run("default is exit 0 only", func(t *testing.T) {
+		codes := liveDogfoodSuccessExitCodes(liveDogfoodCommand{})
+		assert.Equal(t, map[int]bool{0: true}, codes)
+	})
+}
+
+// TestRunLiveDogfoodHonorsTypedExitCodes is WU-1's integration check: a command
+// that declares pp:typed-exit-codes and exits with a declared non-zero code on
+// its happy_path/json_fidelity probes scores PASS, while an otherwise-identical
+// command with no declaration still scores FAIL.
+func TestRunLiveDogfoodHonorsTypedExitCodes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir, binaryName := writeLiveDogfoodTypedExitFixture(t)
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	// Declared: `records verify` exits 2 and carries pp:typed-exit-codes "0,2".
+	declaredHappy := findResultByCommandKind(report, "records verify", LiveDogfoodTestHappy)
+	require.NotNil(t, declaredHappy, "expected records verify happy_path result")
+	assert.Equal(t, LiveDogfoodStatusPass, declaredHappy.Status, declaredHappy.Reason)
+	declaredJSON := findResultByCommandKind(report, "records verify", LiveDogfoodTestJSON)
+	require.NotNil(t, declaredJSON, "expected records verify json_fidelity result")
+	assert.Equal(t, LiveDogfoodStatusPass, declaredJSON.Status, declaredJSON.Reason)
+
+	// Undeclared: `items verify` exits 2 with no annotation and must still fail.
+	undeclaredHappy := findResultByCommandKind(report, "items verify", LiveDogfoodTestHappy)
+	require.NotNil(t, undeclaredHappy, "expected items verify happy_path result")
+	assert.Equal(t, LiveDogfoodStatusFail, undeclaredHappy.Status)
+	assert.Equal(t, "exit 2", undeclaredHappy.Reason)
+}
+
+func writeLiveDogfoodTypedExitFixture(t *testing.T) (dir string, binaryName string) {
+	t.Helper()
+
+	dir = t.TempDir()
+	binaryName = "fixture-pp-cli"
+	writeTestManifestForLiveDogfood(t, dir)
+
+	binPath := filepath.Join(dir, binaryName)
+	script := `#!/bin/sh
+set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"records","subcommands":[
+      {"name":"verify","annotations":{"pp:typed-exit-codes":"0,2"}}
+    ]},
+    {"name":"items","subcommands":[
+      {"name":"verify"}
+    ]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "records" ] && [ "$2" = "verify" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Verify records.
+
+Usage:
+  fixture-pp-cli records verify [flags]
+
+Examples:
+  fixture-pp-cli records verify
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "items" ] && [ "$2" = "verify" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Verify items.
+
+Usage:
+  fixture-pp-cli items verify [flags]
+
+Examples:
+  fixture-pp-cli items verify
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "records" ] && [ "$2" = "verify" ]; then
+  echo 'no records supplied; nothing to verify' >&2
+  exit 2
+fi
+
+if [ "$1" = "items" ] && [ "$2" = "verify" ]; then
+  echo 'no items supplied; nothing to verify' >&2
+  exit 2
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`
+	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755))
+	return dir, binaryName
+}

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -5475,6 +5475,21 @@ func TestLiveDogfoodSuccessExitCodes(t *testing.T) {
 		codes := liveDogfoodSuccessExitCodes(liveDogfoodCommand{})
 		assert.Equal(t, map[int]bool{0: true}, codes)
 	})
+
+	t.Run("exit 0 is always included even when the annotation omits it", func(t *testing.T) {
+		codes := liveDogfoodSuccessExitCodes(liveDogfoodCommand{
+			Annotations: map[string]string{typedExitCodesAnnotation: "2"},
+		})
+		assert.True(t, codes[0], "a normal exit-0 run must still count as success")
+		assert.True(t, codes[2])
+	})
+
+	t.Run("exit 0 is always included even when the help block omits it", func(t *testing.T) {
+		help := "Do a thing.\n\nExit codes:\n  3  not found\n\nFlags:\n      --json\n"
+		codes := liveDogfoodSuccessExitCodes(liveDogfoodCommand{Help: help})
+		assert.True(t, codes[0], "a normal exit-0 run must still count as success")
+		assert.True(t, codes[3])
+	})
 }
 
 // TestRunLiveDogfoodHonorsTypedExitCodes is WU-1's integration check: a command

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/AGENTS.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/AGENTS.md
@@ -43,7 +43,7 @@ This CLI ships a self-capturing teach/recall loop backed by the local SQLite sto
 4. Use `learnings list` to inspect taught rows, `learnings forget "<question>"` to undo a bad teach, `learnings candidates` for the full open candidate set, and `learnings stats` for the loop's local metrics. `teach-pattern` and `teach-lookup` install manual generalization rules when one teach should cover a whole family (e.g. one country alias unlocks every per-country query).
 5. If `learnings confirm` is an unknown command, you are driving an older binary - ignore the candidates guidance and keep the rest of the flow.
 
-Annotations: `recall`, `learnings list`, `learnings candidates`, and `learnings stats` carry `mcp:read-only=true`; `teach`, `teach-playbook`, `playbook amend`, and `learnings confirm` carry `mcp:local-write=true` (writes land only in the CLI's own local store); `learnings forget` and `learnings reject` keep honest may-write/destructive defaults; `teach-pattern` and `teach-lookup` are unannotated.
+Annotations: `recall`, `learnings list`, `learnings candidates`, and `learnings stats` carry `mcp:read-only=true`; `teach`, `teach-playbook`, `playbook amend`, `learnings confirm`, `teach-pattern`, and `teach-lookup` carry `mcp:local-write=true` (writes land only in the CLI's own local store); `learnings forget` and `learnings reject` keep honest may-write/destructive defaults.
 
 ### Success definition
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/AGENTS.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/AGENTS.md
@@ -43,7 +43,7 @@ This CLI ships a self-capturing teach/recall loop backed by the local SQLite sto
 4. Use `learnings list` to inspect taught rows, `learnings forget "<question>"` to undo a bad teach, `learnings candidates` for the full open candidate set, and `learnings stats` for the loop's local metrics. `teach-pattern` and `teach-lookup` install manual generalization rules when one teach should cover a whole family (e.g. one country alias unlocks every per-country query).
 5. If `learnings confirm` is an unknown command, you are driving an older binary - ignore the candidates guidance and keep the rest of the flow.
 
-Annotations: `recall`, `learnings list`, `learnings candidates`, and `learnings stats` carry `mcp:read-only=true`; `teach`, `teach-playbook`, `playbook amend`, and `learnings confirm` carry `mcp:local-write=true` (writes land only in the CLI's own local store); `learnings forget` and `learnings reject` keep honest may-write/destructive defaults; `teach-pattern` and `teach-lookup` are unannotated.
+Annotations: `recall`, `learnings list`, `learnings candidates`, and `learnings stats` carry `mcp:read-only=true`; `teach`, `teach-playbook`, `playbook amend`, `learnings confirm`, `teach-pattern`, and `teach-lookup` carry `mcp:local-write=true` (writes land only in the CLI's own local store); `learnings forget` and `learnings reject` keep honest may-write/destructive defaults.
 
 ### Success definition
 

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/AGENTS.md
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/AGENTS.md
@@ -43,7 +43,7 @@ This CLI ships a self-capturing teach/recall loop backed by the local SQLite sto
 4. Use `learnings list` to inspect taught rows, `learnings forget "<question>"` to undo a bad teach, `learnings candidates` for the full open candidate set, and `learnings stats` for the loop's local metrics. `teach-pattern` and `teach-lookup` install manual generalization rules when one teach should cover a whole family (e.g. one country alias unlocks every per-country query).
 5. If `learnings confirm` is an unknown command, you are driving an older binary - ignore the candidates guidance and keep the rest of the flow.
 
-Annotations: `recall`, `learnings list`, `learnings candidates`, and `learnings stats` carry `mcp:read-only=true`; `teach`, `teach-playbook`, `playbook amend`, and `learnings confirm` carry `mcp:local-write=true` (writes land only in the CLI's own local store); `learnings forget` and `learnings reject` keep honest may-write/destructive defaults; `teach-pattern` and `teach-lookup` are unannotated.
+Annotations: `recall`, `learnings list`, `learnings candidates`, and `learnings stats` carry `mcp:read-only=true`; `teach`, `teach-playbook`, `playbook amend`, `learnings confirm`, `teach-pattern`, and `teach-lookup` carry `mcp:local-write=true` (writes land only in the CLI's own local store); `learnings forget` and `learnings reject` keep honest may-write/destructive defaults.
 
 ### Success definition
 

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/teach.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/teach.go
@@ -885,6 +885,11 @@ func newTeachPatternCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "teach-pattern",
 		Short: "Install a manual generalization pattern (query_template, resource_template, entity_kind)",
+		// Missing required flags intentionally exit 2 via usageErr, matching the
+		// sibling teach/teach-playbook commands; declare it so both `verify` and
+		// the live-dogfood matrix score the Execute cell honestly instead of
+		// masking a FAIL. Writes land only in the CLI's own local store.
+		Annotations: map[string]string{"pp:typed-exit-codes": "0,2", "mcp:local-write": "true"},
 		Long: `Adds one row to search_patterns. The recall path uses patterns to
 substitute live query entities into a resource template, so a pattern
 with query_template="items in {entity}" and
@@ -970,6 +975,11 @@ func newTeachLookupCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "teach-lookup",
 		Short: "Install a manual entity-lookup row (kind, canonical, value)",
+		// Missing required flags intentionally exit 2 via usageErr, matching the
+		// sibling teach/teach-playbook commands; declare it so both `verify` and
+		// the live-dogfood matrix score the Execute cell honestly instead of
+		// masking a FAIL. Writes land only in the CLI's own local store.
+		Annotations: map[string]string{"pp:typed-exit-codes": "0,2", "mcp:local-write": "true"},
 		Long: `Adds one row to entity_lookups. Used by the recall path's pattern
 engine to substitute values for canonical names at substitution time.
 Computed kinds (lowercase, uppercase, kebab-case, capitalize-first, slug)


### PR DESCRIPTION
## Intent

`dogfood --live --level full` fails happy_path + json_fidelity for the generator-emitted learn-loop commands on every printed CLI, even though the commands are correct and `verify` scores them cleanly. The live matrix treats any non-zero exit as a failure and ignores the `pp:typed-exit-codes` annotation that `verify` already honors.

Issue: Closes #3471

## Approach

Two coupled changes, both under the `cli` scope:

1. **Scorer (`internal/pipeline/live_dogfood.go`).** The happy_path and json_fidelity legs now consult a command's declared success codes instead of hard-coding exit 0. A new `liveDogfoodSuccessExitCodes` helper mirrors `verify`'s existing `typedSuccessCodes`: success is exit 0 plus any code declared via `pp:typed-exit-codes` (or an `Exit codes:` help block). A command with no declaration keeps the default `{0}`, so its verdicts are unchanged and an undeclared non-zero exit still fails. This is the issue's preferred "honor typed-exit-codes the way verify does" route.

2. **Generator (`templates/teach.go.tmpl`).** Validating the scorer fix surfaced a companion gap: `teach-pattern` and `teach-lookup` were the only two learn-loop commands whose cobra `Annotations` field was omitted entirely, while their three siblings (`teach`, `teach-playbook`, `playbook amend`) already declare `pp:typed-exit-codes "0,2"` + `mcp:local-write "true"`. They're the same family — local-store writers that exit 2 via `usageErr` on missing required flags — so the scorer fix alone left `teach-pattern` red on every learn-loop CLI. Both commands now declare the same annotations. The `AGENTS.md` template annotation summary is updated to match.

I did not implement the backslash-line-continuation strip or the silent-`--quiet` json_fidelity skip from the issue's "two mechanisms" section. The typed-exit-codes route makes both unnecessary for the acceptance criteria — the commands are scored on their declared exit rather than on a fully-synthesized happy invocation. Glad to add either if a maintainer would rather the matrix run the commands to exit 0.

## Scope

Primary area: scorer (dogfood live matrix) + generator (learn-loop template).

Why this belongs in this repo: both are Printing Press behavior that affects **every** printed CLI — the live matrix scores all CLIs, and the learn loop is emitted into all of them from `templates/`. This is not a single-CLI fix.

## Risk

- The scorer change is guarded: only *declared* codes count as success. Undeclared non-zero exits still fail (covered by a negative test), so the matrix keeps its teeth.
- Accepting a declared exit 2 on happy_path means a command with genuinely-broken synthesized args but a `0,2` declaration would pass that leg. This is the tradeoff the issue explicitly endorses; error_path still exercises real error handling.
- Generator output changes: the emitted `teach.go` for every learn-loop CLI gains two annotations, and three golden `AGENTS.md` files change one summary line. Regenerated golden fixtures are included.

## Output Contract

Generator/template change. Evidence:
- Emitted-code assertions: `TestGenerateLearnMCPParity_LocalWriteAnnotations` now asserts both `teach-pattern` and `teach-lookup` carry `pp:typed-exit-codes "0,2"` and `mcp:local-write "true"`.
- Golden fixtures regenerated (`scripts/golden.sh update`): `generate-learn-loop-api/.../internal/cli/teach.go` (annotations added) and the `AGENTS.md` summary line across three cases. `scripts/golden.sh verify` passes 32/32.
- Scorer behavior: `TestLiveDogfoodSuccessExitCodes` (helper unit test) + `TestRunLiveDogfoodHonorsTypedExitCodes` (integration: declared exit 2 → PASS; undeclared exit 2 → FAIL).

## Verification

- `go build ./cmd/cli-printing-press` — clean
- `gofmt -l` on changed Go files — clean; `go vet ./...` — clean
- `go test ./...` — all packages pass (37 ok)
- `scripts/golden.sh verify` — 32/32 pass
- Real-world: full `dogfood --live --level full` against a live printed CLI (discogs, api_key auth) went from 14 failures (all typed-exit false-positives) to **193/193 pass, 0 fail** with zero hand-edits after this change.

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
