### PR TITLE
fix(dogfood): honor pp:typed-exit-codes on live happy-path

### DIFF
--- a/internal/generator/templates/teach.go.tmpl
+++ b/internal/generator/templates/teach.go.tmpl
@@ -885,6 +885,11 @@ func newTeachPatternCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "teach-pattern",
 		Short: "Install a manual generalization pattern (query_template, resource_template, entity_kind)",
+		// Underspecified invocation intentionally exits 2 (usage error).
+		// Declaring it lets `verify` and live-dogfood score the Execute cell
+		// honestly instead of masking a FAIL, and keeps this local-write
+		// command out of the "could mutate anything" MCP bucket.
+		Annotations: map[string]string{"pp:typed-exit-codes": "0,2", "mcp:local-write": "true"},
 		Long: `Adds one row to search_patterns. The recall path uses patterns to
 substitute live query entities into a resource template, so a pattern
 with query_template="items in {entity}" and

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -64,6 +64,7 @@ const reasonFileFixtureRequired = "file fixture required"
 const reasonRequiredParamFixture = "blocked-fixture: required API parameter"
 const reasonFeatureAbsentFixture = "blocked-fixture: feature absent for runner credentials"
 const reasonNoErrorPathProbeAnnotation = "no-error-path-probe annotation"
+const reasonDeclaredTypedExit = "declared typed-exit-code; synthetic happy-path insufficient"
 const reasonInteractiveCommand = "interactive command requires human input"
 
 // dogfoodEnvVar is the env signal every live-dogfood subprocess
@@ -1349,13 +1350,17 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 		} else if featureAbsentReason := liveDogfoodFeatureAbsentFixtureReason(happyRun); featureAbsentReason != "" {
 			happyResult.Status = LiveDogfoodStatusSkip
 			happyResult.Reason = featureAbsentReason
+		} else if typedExitReason := liveDogfoodDeclaredTypedExitReason(command, happyRun.exitCode); typedExitReason != "" {
+			happyResult.Status = LiveDogfoodStatusSkip
+			happyResult.Reason = typedExitReason
 		}
 		results = append(results, happyResult)
 
 		if happyResult.Status == LiveDogfoodStatusSkip &&
 			(happyResult.Reason == reasonUnavailableRunnerCredentials ||
 				happyResult.Reason == reasonRequiredParamFixture ||
-				happyResult.Reason == reasonFeatureAbsentFixture) {
+				happyResult.Reason == reasonFeatureAbsentFixture ||
+				happyResult.Reason == reasonDeclaredTypedExit) {
 			jsonResult := skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, happyResult.Reason)
 			jsonResult.FixtureSource = fixtureSource
 			results = append(results, jsonResult)
@@ -2293,6 +2298,43 @@ func classifyLiveDogfoodFailure(t LiveDogfoodTestResult) string {
 		return "exit_nonzero"
 	}
 	return "other"
+}
+
+// liveDogfoodDeclaredTypedExitReason returns a skip reason when the happy-path
+// run exited non-zero with a code the command explicitly declares as a typed
+// exit — via the pp:typed-exit-codes annotation or a documented "Exit codes:"
+// help block. LLM-fired local-write commands such as `teach`, `teach-pattern`,
+// `teach-playbook`, and `playbook amend` intentionally exit 2 when invoked
+// underspecified (they need an authored query/resource/playbook that the
+// generic runner cannot synthesize). A declared typed exit means the command
+// behaved as designed, so the happy-path probe is a skip, not a failure —
+// mirroring how `cli-printing-press verify` already honors typed exit codes.
+func liveDogfoodDeclaredTypedExitReason(command liveDogfoodCommand, exitCode int) string {
+	if exitCode == 0 {
+		return ""
+	}
+	if liveDogfoodTypedSuccessCodes(command)[exitCode] {
+		return reasonDeclaredTypedExit
+	}
+	return ""
+}
+
+// liveDogfoodTypedSuccessCodes resolves a command's declared exit-code set from
+// its annotations first, then from a documented "Exit codes:" help block. It
+// returns nil (not {0:true}) when nothing is declared, so only explicitly
+// declared non-zero codes are treated as typed exits by the caller.
+func liveDogfoodTypedSuccessCodes(command liveDogfoodCommand) map[int]bool {
+	if command.Annotations != nil {
+		if raw := strings.TrimSpace(command.Annotations[typedExitCodesAnnotation]); raw != "" {
+			if codes, ok := parseTypedExitCodesAnnotation(raw); ok {
+				return codes
+			}
+		}
+	}
+	if codes, ok := parseExitCodesFromHelp(command.Help); ok {
+		return codes
+	}
+	return nil
 }
 
 // resolveLiveDogfoodAcceptanceIdentity finds the marker's api_name, run_id,

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -2097,6 +2097,56 @@ func TestLiveDogfoodRequiredParamFixtureReason(t *testing.T) {
 	}
 }
 
+func TestLiveDogfoodDeclaredTypedExitReason(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		command  liveDogfoodCommand
+		exitCode int
+		want     string
+	}{
+		{
+			name:     "annotated typed exit is skipped",
+			command:  liveDogfoodCommand{Annotations: map[string]string{typedExitCodesAnnotation: "0,2"}},
+			exitCode: 2,
+			want:     reasonDeclaredTypedExit,
+		},
+		{
+			name:     "exit 0 is never a typed-exit skip",
+			command:  liveDogfoodCommand{Annotations: map[string]string{typedExitCodesAnnotation: "0,2"}},
+			exitCode: 0,
+			want:     "",
+		},
+		{
+			name:     "undeclared non-zero exit is not skipped",
+			command:  liveDogfoodCommand{Annotations: map[string]string{typedExitCodesAnnotation: "0,2"}},
+			exitCode: 1,
+			want:     "",
+		},
+		{
+			name:     "no annotation and no help block is not skipped",
+			command:  liveDogfoodCommand{},
+			exitCode: 2,
+			want:     "",
+		},
+		{
+			name:     "documented Exit codes help block is honored",
+			command:  liveDogfoodCommand{Help: "Usage:\n  x\n\nExit codes:\n  0  ok\n  2  usage\n"},
+			exitCode: 2,
+			want:     reasonDeclaredTypedExit,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := liveDogfoodDeclaredTypedExitReason(tc.command, tc.exitCode)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestLiveDogfoodFeatureAbsentFixtureReason(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

The default-on self-learning loop (v4.28.0) ships LLM-fired local-write commands — `teach`, `teach-pattern`, `teach-playbook`, `playbook amend` — that **intentionally exit 2** when invoked underspecified (they need an authored query/resource/playbook the generic runner can't synthesize). `teach`, `teach-playbook`, and `playbook amend` already declare `pp:typed-exit-codes: "0,2"` for exactly this reason.

The **live dogfood** runner, however, only treated exit 0 as a happy-path pass. It ran these commands bare, they exited 2 as designed, and it scored that (plus the follow-on `json_fidelity` check) as **FAIL** — 8 guaranteed failures per self-learning CLI.

Because `publish validate` / the publish live gate reruns **full live dogfood**, this makes every self-learning CLI **unpublishable**. It also fails Phase 5 in the main `/printing-press` flow.

## Fix

`cli-printing-press verify` already honors a command's declared `pp:typed-exit-codes`. This makes **live dogfood** do the same:

- When a happy-path run exits non-zero with a code the command declares — via the `pp:typed-exit-codes` annotation **or** a documented `Exit codes:` help block — the probe is a **SKIP**, not a FAIL, and the paired `json_fidelity` check skips with it. This mirrors the existing `required-param` / `feature-absent` fixture skips.
- Annotate `newTeachPatternCmd` with `pp:typed-exit-codes: "0,2"` (the only one of the four loop write-commands that lacked it).

Skips don't count as failures, so the loop's write commands no longer sink the matrix, while genuinely-broken commands (undeclared non-zero exits) still fail.

## Validation

- New unit test `TestLiveDogfoodDeclaredTypedExitReason` (5 cases: annotated skip, exit-0 never skipped, undeclared non-zero still fails, no-annotation not skipped, documented `Exit codes:` help block honored).
- `go build ./...`, `go vet ./internal/pipeline/`, and `go test ./internal/pipeline/` all pass.
- End-to-end: a reprinted CLI (blacklane) that failed **full live dogfood 80/94** (8 learn write-command failures) now passes **86/86** with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
