### PR TITLE
fix(skills): preserve runtime version layout on reprints

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -764,6 +764,32 @@ func TestPublishSkillSkipsCliSkillsMirrorRegen(t *testing.T) {
 	assert.NotContains(t, skill, "New CLIs keep the blank skeletons")
 }
 
+func TestPublishSkillReconcilesRuntimeVersionLayoutForReprints(t *testing.T) {
+	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md"))
+
+	copyIntoLibrary := strings.Index(skill, `mv "$PUBLISH_SWAP_DIR" "$DEST_CLI_DIR"`)
+	require.NotEqual(t, -1, copyIntoLibrary)
+	reconciliation := skill[copyIntoLibrary:]
+
+	assert.Contains(t, reconciliation, "runtime version declaration layout")
+	assert.Contains(t, reconciliation, `VERSION_DECL_DIFF="$(git diff --unified=0 upstream/main --`)
+	assert.Contains(t, reconciliation, `git diff --unified=0 upstream/main --`)
+	assert.Contains(t, reconciliation, "failed to compare runtime version declarations with upstream/main")
+	assert.Contains(t, reconciliation, `internal/cli/root.go`)
+	assert.Contains(t, reconciliation, `internal/cli/version.go`)
+	assert.Contains(t, reconciliation, `cmd/<api-slug>-pp-mcp/main.go`)
+	assert.Contains(t, reconciliation, `^[+-][[:space:]]*var version[[:space:]]*=`)
+	assert.Contains(t, reconciliation, "root.go declaration")
+	assert.Contains(t, reconciliation, "version.go declaration")
+	assert.Contains(t, reconciliation, "MCP main declaration")
+	assert.Contains(t, reconciliation, "no declaration")
+	assert.Contains(t, reconciliation, "Do not continue until the command prints no matching lines")
+	assert.Less(t,
+		strings.Index(reconciliation, "runtime version declaration layout"),
+		strings.Index(reconciliation, "# Verify this changed/new CLI builds"),
+		"version layout must be reconciled before the packaged CLI is verified")
+}
+
 func TestPublishSkillDisablesAutocrlfInManagedClone(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md"))
 	firstTimeSetup := substringBetween(t, skill, "### First-time setup", "### Subsequent publishes")

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -772,9 +772,11 @@ func TestPublishSkillReconcilesRuntimeVersionLayoutForReprints(t *testing.T) {
 	reconciliation := skill[copyIntoLibrary:]
 
 	assert.Contains(t, reconciliation, "runtime version declaration layout")
-	assert.Contains(t, reconciliation, `VERSION_DECL_DIFF="$(git diff --unified=0 upstream/main --`)
-	assert.Contains(t, reconciliation, `git diff --unified=0 upstream/main --`)
-	assert.Contains(t, reconciliation, "failed to compare runtime version declarations with upstream/main")
+	assert.Contains(t, reconciliation, `VERSION_DECL_BASE_REF=upstream/main`)
+	assert.Contains(t, reconciliation, `git rev-parse --verify --quiet "$VERSION_DECL_BASE_REF"`)
+	assert.Contains(t, reconciliation, `VERSION_DECL_BASE_REF=origin/main`)
+	assert.Contains(t, reconciliation, `VERSION_DECL_DIFF="$(git diff --unified=0 "$VERSION_DECL_BASE_REF" --`)
+	assert.Contains(t, reconciliation, "failed to compare runtime version declarations with ${VERSION_DECL_BASE_REF}")
 	assert.Contains(t, reconciliation, `internal/cli/root.go`)
 	assert.Contains(t, reconciliation, `internal/cli/version.go`)
 	assert.Contains(t, reconciliation, `cmd/<api-slug>-pp-mcp/main.go`)

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -883,6 +883,33 @@ mv "$PUBLISH_SWAP_DIR" "$DEST_CLI_DIR"
 rm -rf "$RELEASE_LEDGER_TMP"
 trap - EXIT
 
+# Reprints must preserve the base CLI's runtime version declaration layout as
+# well as its ledger files. Fresh prints can move `var version = ...` between
+# files, but the public library's release-ledger guard rejects those moves in a
+# normal publish PR because the post-merge release workflow owns version stamps.
+cd "$PUBLISH_REPO_DIR"
+VERSION_DECL_DIFF="$(git diff --unified=0 upstream/main -- \
+  "library/*/<api-slug>/internal/cli/root.go" \
+  "library/*/<api-slug>/internal/cli/version.go" \
+  "library/*/<api-slug>/cmd/<api-slug>-pp-mcp/main.go")" || {
+  echo "failed to compare runtime version declarations with upstream/main" >&2
+  exit 1
+}
+printf '%s\n' "$VERSION_DECL_DIFF" \
+  | grep -E '^[+-][[:space:]]*var version[[:space:]]*=' || true
+
+# If the command prints a change, reconcile the replacement to the base tree:
+# - A root.go declaration stays in root.go with the exact stamped value; remove
+#   only the duplicate declaration from version.go and keep its command code.
+# - A version.go declaration stays in version.go with the exact stamped value;
+#   remove any fresh declaration added elsewhere in the internal CLI package.
+# - An MCP main declaration stays in MCP main with the exact stamped value. If
+#   the base MCP main hardcodes the version instead, preserve that expression.
+# - If the base has no declaration in one of these runtime surfaces, preserve
+#   that no declaration layout and its existing literal/reference form. Do not
+#   introduce the fresh print's 0.0.0-dev declaration.
+# Re-run the diff command after editing. Do not continue until the command prints no matching lines.
+
 # Remove root-level binaries (should not be committed). publish package
 # already strips these before the copy; this rm -f is belt-and-suspenders
 # for the agent path. Cover the names local build paths can drop: bare slug,

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -888,11 +888,15 @@ trap - EXIT
 # files, but the public library's release-ledger guard rejects those moves in a
 # normal publish PR because the post-merge release workflow owns version stamps.
 cd "$PUBLISH_REPO_DIR"
-VERSION_DECL_DIFF="$(git diff --unified=0 upstream/main -- \
+VERSION_DECL_BASE_REF=upstream/main
+if ! git rev-parse --verify --quiet "$VERSION_DECL_BASE_REF" >/dev/null; then
+  VERSION_DECL_BASE_REF=origin/main
+fi
+VERSION_DECL_DIFF="$(git diff --unified=0 "$VERSION_DECL_BASE_REF" -- \
   "library/*/<api-slug>/internal/cli/root.go" \
   "library/*/<api-slug>/internal/cli/version.go" \
   "library/*/<api-slug>/cmd/<api-slug>-pp-mcp/main.go")" || {
-  echo "failed to compare runtime version declarations with upstream/main" >&2
+  echo "failed to compare runtime version declarations with ${VERSION_DECL_BASE_REF}" >&2
   exit 1
 }
 printf '%s\n' "$VERSION_DECL_DIFF" \


### PR DESCRIPTION
## Summary

Reprint replacements now catch runtime version-layout drift before the public library's release-ledger CI check. The publish flow compares the guarded CLI and MCP files with `upstream/main`, fails closed when that comparison cannot run, and directs publishers to preserve the base declaration or declaration-free shape without changing the stamped value.

## Validation

- `go test ./internal/pipeline -run 'TestPublishSkill(SkipsCliSkillsMirrorRegen|ReconcilesRuntimeVersionLayoutForReprints)' -count=1`
- `go test ./...` reached the unrelated 10-minute package timeout in `internal/generator`; the changed `internal/pipeline` package passed.

Closes #3572

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex GPT-5](https://img.shields.io/badge/GPT--5-000000)
