### PR TITLE
fix(cli): rebuild stale live dogfood binaries

### DIFF
--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -304,14 +304,13 @@ func refreshLiveCheckStageBinary(cliDir, name string) (LiveCheckBinaryRefresh, e
 		return refresh, nil
 	}
 
-	cmdDir, err := findCLICommandDir(cliDir)
-	if err != nil {
+	if _, err := findCLICommandDir(cliDir); err != nil {
 		refresh.Action = "skipped"
 		refresh.Reason = "no CLI command directory found"
 		return refresh, nil
 	}
 
-	newestSource, ok, err := newestLiveCheckSourceModTime(cliDir, cmdDir)
+	newestSource, ok, err := newestLiveCheckSourceModTime(cliDir)
 	if err != nil {
 		refresh.Action = "failed"
 		refresh.Reason = err.Error()
@@ -424,36 +423,34 @@ func liveCheckExistingStageBinaryPath(cliDir, name string) (string, string) {
 	return "", ""
 }
 
-func newestLiveCheckSourceModTime(cliDir, cmdDir string) (time.Time, bool, error) {
+func newestLiveCheckSourceModTime(cliDir string) (time.Time, bool, error) {
 	var newest time.Time
 	found := false
-	for _, root := range []string{cmdDir, filepath.Join(cliDir, "internal")} {
-		if _, err := os.Stat(root); err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return time.Time{}, false, err
+	err := filepath.WalkDir(cliDir, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
 		}
-		err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
-			if walkErr != nil {
-				return walkErr
-			}
-			if entry.IsDir() || filepath.Ext(path) != ".go" {
-				return nil
-			}
-			info, err := entry.Info()
-			if err != nil {
-				return err
-			}
-			if !found || info.ModTime().After(newest) {
-				newest = info.ModTime()
-				found = true
+		if entry.IsDir() {
+			if path != cliDir && entry.Name() == ".git" {
+				return filepath.SkipDir
 			}
 			return nil
-		})
-		if err != nil {
-			return time.Time{}, false, err
 		}
+		if filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !found || info.ModTime().After(newest) {
+			newest = info.ModTime()
+			found = true
+		}
+		return nil
+	})
+	if err != nil {
+		return time.Time{}, false, err
 	}
 	return newest, found, nil
 }

--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/artifacts"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/platform"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/shellargs"
+	"golang.org/x/mod/modfile"
 )
 
 // LiveStatus is the outcome of one feature's live check.
@@ -304,13 +305,14 @@ func refreshLiveCheckStageBinary(cliDir, name string) (LiveCheckBinaryRefresh, e
 		return refresh, nil
 	}
 
-	if _, err := findCLICommandDir(cliDir); err != nil {
+	cmdDir, err := findCLICommandDir(cliDir)
+	if err != nil {
 		refresh.Action = "skipped"
 		refresh.Reason = "no CLI command directory found"
 		return refresh, nil
 	}
 
-	newestSource, ok, err := newestLiveCheckSourceModTime(cliDir)
+	newestSource, ok, err := newestLiveCheckSourceModTime(cliDir, cmdDir)
 	if err != nil {
 		refresh.Action = "failed"
 		refresh.Reason = err.Error()
@@ -423,15 +425,37 @@ func liveCheckExistingStageBinaryPath(cliDir, name string) (string, string) {
 	return "", ""
 }
 
-func newestLiveCheckSourceModTime(cliDir string) (time.Time, bool, error) {
+func newestLiveCheckSourceModTime(cliDir, cmdDir string) (time.Time, bool, error) {
+	newest, found, err := newestLiveCheckSourceUnder(cliDir)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	mayUseExternal, err := liveCheckMayUseExternalLocalModules(cliDir)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	if !mayUseExternal {
+		return newest, found, nil
+	}
+	graphNewest, graphFound, err := newestLiveCheckBuildGraphModTime(cmdDir)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	if graphFound && (!found || graphNewest.After(newest)) {
+		return graphNewest, true, nil
+	}
+	return newest, found, nil
+}
+
+func newestLiveCheckSourceUnder(root string) (time.Time, bool, error) {
 	var newest time.Time
 	found := false
-	err := filepath.WalkDir(cliDir, func(path string, entry os.DirEntry, walkErr error) error {
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
 		if entry.IsDir() {
-			if path != cliDir && entry.Name() == ".git" {
+			if path != root && entry.Name() == ".git" {
 				return filepath.SkipDir
 			}
 			return nil
@@ -451,6 +475,122 @@ func newestLiveCheckSourceModTime(cliDir string) (time.Time, bool, error) {
 	})
 	if err != nil {
 		return time.Time{}, false, err
+	}
+	return newest, found, nil
+}
+
+func liveCheckMayUseExternalLocalModules(cliDir string) (bool, error) {
+	data, err := os.ReadFile(filepath.Join(cliDir, "go.mod"))
+	if err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+	if err == nil {
+		file, err := modfile.Parse("go.mod", data, nil)
+		if err != nil {
+			return false, err
+		}
+		for _, replacement := range file.Replace {
+			path := filepath.FromSlash(replacement.New.Path)
+			if replacement.New.Version == "" && (filepath.IsAbs(path) || path == "." || path == ".." || strings.HasPrefix(path, "."+string(os.PathSeparator)) || strings.HasPrefix(path, ".."+string(os.PathSeparator))) {
+				return true, nil
+			}
+		}
+	}
+	for dir := cliDir; ; dir = filepath.Dir(dir) {
+		if _, err := os.Stat(filepath.Join(dir, "go.work")); err == nil {
+			return true, nil
+		} else if !os.IsNotExist(err) {
+			return false, err
+		}
+		if filepath.Dir(dir) == dir {
+			break
+		}
+	}
+	return false, nil
+}
+
+func newestLiveCheckBuildGraphModTime(cmdDir string) (time.Time, bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "list", "-deps", "-json", "./"+filepath.Base(cmdDir))
+	cmd.Dir = filepath.Dir(cmdDir)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return time.Time{}, false, fmt.Errorf("listing CLI build dependencies: %w\n%s", err, string(exitErr.Stderr))
+		}
+		return time.Time{}, false, fmt.Errorf("listing CLI build dependencies: %w", err)
+	}
+
+	type buildPackage struct {
+		Dir          string
+		GoFiles      []string
+		CgoFiles     []string
+		CFiles       []string
+		CXXFiles     []string
+		MFiles       []string
+		HFiles       []string
+		FFiles       []string
+		SFiles       []string
+		SwigFiles    []string
+		SwigCXXFiles []string
+		SysoFiles    []string
+		EmbedFiles   []string
+		Module       *struct {
+			Main    bool
+			Replace *struct {
+				Version string
+			}
+		}
+	}
+
+	var newest time.Time
+	found := false
+	seen := make(map[string]bool)
+	decoder := json.NewDecoder(bytes.NewReader(out))
+	for {
+		var pkg buildPackage
+		if err := decoder.Decode(&pkg); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return time.Time{}, false, fmt.Errorf("decoding CLI build dependencies: %w", err)
+		}
+		if pkg.Module == nil || (!pkg.Module.Main && (pkg.Module.Replace == nil || pkg.Module.Replace.Version != "")) {
+			continue
+		}
+		files := append([]string{}, pkg.GoFiles...)
+		files = append(files, pkg.CgoFiles...)
+		files = append(files, pkg.CFiles...)
+		files = append(files, pkg.CXXFiles...)
+		files = append(files, pkg.MFiles...)
+		files = append(files, pkg.HFiles...)
+		files = append(files, pkg.FFiles...)
+		files = append(files, pkg.SFiles...)
+		files = append(files, pkg.SwigFiles...)
+		files = append(files, pkg.SwigCXXFiles...)
+		files = append(files, pkg.SysoFiles...)
+		files = append(files, pkg.EmbedFiles...)
+		for _, name := range files {
+			path := name
+			if !filepath.IsAbs(path) {
+				path = filepath.Join(pkg.Dir, path)
+			}
+			path = filepath.Clean(path)
+			if seen[path] {
+				continue
+			}
+			seen[path] = true
+			info, err := os.Stat(path)
+			if err != nil {
+				return time.Time{}, false, err
+			}
+			if !found || info.ModTime().After(newest) {
+				newest = info.ModTime()
+				found = true
+			}
+		}
 	}
 	return newest, found, nil
 }

--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -334,27 +334,9 @@ func refreshLiveCheckStageBinary(cliDir, name string) (LiveCheckBinaryRefresh, e
 		return refresh, nil
 	}
 
-	tmp, err := os.CreateTemp(filepath.Dir(stagePath), "."+filepath.Base(stagePath)+".rebuild-*")
-	if err != nil {
-		refresh.Action = "failed"
-		return refresh, fmt.Errorf("creating staged rebuild temp file: %w", err)
-	}
-	tmpPath := tmp.Name()
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		refresh.Action = "failed"
-		return refresh, fmt.Errorf("closing staged rebuild temp file: %w", err)
-	}
-	_ = os.Remove(tmpPath)
-	defer func() { _ = os.Remove(tmpPath) }()
-
-	if err := buildCLITo(cliDir, tmpPath); err != nil {
+	if err := rebuildLiveCheckBinary(cliDir, stagePath); err != nil {
 		refresh.Action = "failed"
 		return refresh, err
-	}
-	if err := replaceLiveCheckStageBinary(tmpPath, stagePath); err != nil {
-		refresh.Action = "failed"
-		return refresh, fmt.Errorf("replacing staged binary: %w", err)
 	}
 	refresh.Action = "rebuilt"
 	refresh.BinaryPath = stagePath
@@ -362,7 +344,29 @@ func refreshLiveCheckStageBinary(cliDir, name string) (LiveCheckBinaryRefresh, e
 	return refresh, nil
 }
 
-func replaceLiveCheckStageBinary(src, dst string) error {
+func rebuildLiveCheckBinary(cliDir, binaryPath string) error {
+	tmp, err := os.CreateTemp(filepath.Dir(binaryPath), "."+filepath.Base(binaryPath)+".rebuild-*")
+	if err != nil {
+		return fmt.Errorf("creating binary rebuild temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("closing binary rebuild temp file: %w", err)
+	}
+	_ = os.Remove(tmpPath)
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if err := buildCLITo(cliDir, tmpPath); err != nil {
+		return err
+	}
+	if err := replaceLiveCheckBinary(tmpPath, binaryPath); err != nil {
+		return fmt.Errorf("replacing binary: %w", err)
+	}
+	return nil
+}
+
+func replaceLiveCheckBinary(src, dst string) error {
 	if runtime.GOOS != "windows" {
 		return os.Rename(src, dst)
 	}

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -444,6 +444,9 @@ func liveDogfoodBinaryPath(dir, name string) (string, func(), error) {
 		return "", func() {}, fmt.Errorf("rebuilding staged binary: %s", refresh.Reason)
 	}
 	if path, err := resolveBinaryPath(dir, name); err == nil {
+		if err := refreshLiveDogfoodBinary(dir, path); err != nil {
+			return "", func() {}, fmt.Errorf("rebuilding stale live dogfood binary: %w", err)
+		}
 		return path, func() {}, nil
 	} else if strings.TrimSpace(name) != "" {
 		return "", func() {}, err
@@ -458,6 +461,28 @@ func liveDogfoodBinaryPath(dir, name string) (string, func(), error) {
 		return "", func() {}, err
 	}
 	return path, func() { _ = os.Remove(path) }, nil
+}
+
+func refreshLiveDogfoodBinary(cliDir, binaryPath string) error {
+	binaryInfo, err := os.Stat(binaryPath)
+	if err != nil {
+		return err
+	}
+	cmdDir, err := findCLICommandDir(cliDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	newestSource, ok, err := newestLiveCheckSourceModTime(cliDir, cmdDir)
+	if err != nil {
+		return err
+	}
+	if !ok || !binaryInfo.ModTime().Before(newestSource) {
+		return nil
+	}
+	return rebuildLiveCheckBinary(cliDir, binaryPath)
 }
 
 func discoverLiveDogfoodCommands(binaryPath string) ([]liveDogfoodCommand, error) {

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -468,13 +468,14 @@ func refreshLiveDogfoodBinary(cliDir, binaryPath string) error {
 	if err != nil {
 		return err
 	}
-	if _, err := findCLICommandDir(cliDir); err != nil {
+	cmdDir, err := findCLICommandDir(cliDir)
+	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 		return err
 	}
-	newestSource, ok, err := newestLiveCheckSourceModTime(cliDir)
+	newestSource, ok, err := newestLiveCheckSourceModTime(cliDir, cmdDir)
 	if err != nil {
 		return err
 	}

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -468,14 +468,13 @@ func refreshLiveDogfoodBinary(cliDir, binaryPath string) error {
 	if err != nil {
 		return err
 	}
-	cmdDir, err := findCLICommandDir(cliDir)
-	if err != nil {
+	if _, err := findCLICommandDir(cliDir); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 		return err
 	}
-	newestSource, ok, err := newestLiveCheckSourceModTime(cliDir, cmdDir)
+	newestSource, ok, err := newestLiveCheckSourceModTime(cliDir)
 	if err != nil {
 		return err
 	}

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -1011,6 +1011,40 @@ func TestLiveDogfoodBinaryPathRebuildsStaleRootBinary(t *testing.T) {
 	assert.Equal(t, "current source", string(out))
 }
 
+func TestLiveDogfoodBinaryPathRebuildsForSourceOutsideCmdAndInternal(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the stale root binary; skip on Windows")
+	}
+
+	dir := t.TempDir()
+	binaryName := "fixture-pp-cli"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/live-dogfood-module-source-test\n\ngo 1.23\n"), 0o644))
+	cmdDir := filepath.Join(dir, "cmd", binaryName)
+	require.NoError(t, os.MkdirAll(cmdDir, 0o755))
+	mainPath := filepath.Join(cmdDir, "main.go")
+	require.NoError(t, os.WriteFile(mainPath, []byte("package main\n\nimport (\n\t\"fmt\"\n\t\"example.com/live-dogfood-module-source-test/pkg/version\"\n)\n\nfunc main() { fmt.Print(version.Value) }\n"), 0o644))
+	packageDir := filepath.Join(dir, "pkg", "version")
+	require.NoError(t, os.MkdirAll(packageDir, 0o755))
+	packagePath := filepath.Join(packageDir, "version.go")
+	require.NoError(t, os.WriteFile(packagePath, []byte("package version\n\nconst Value = \"current package source\"\n"), 0o644))
+
+	rootPath := writeStubBinary(t, dir, binaryName, `echo "stale root"`)
+	oldTime := time.Now().Add(-2 * time.Hour)
+	newTime := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(rootPath, oldTime, oldTime))
+	require.NoError(t, os.Chtimes(mainPath, oldTime, oldTime))
+	require.NoError(t, os.Chtimes(packagePath, newTime, newTime))
+
+	path, cleanup, err := liveDogfoodBinaryPath(dir, binaryName)
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+	require.Equal(t, rootPath, path)
+
+	out, err := exec.Command(path).CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Equal(t, "current package source", string(out))
+}
+
 func TestLiveDogfoodBinaryPathKeepsFreshRootBinary(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fresh root binary; skip on Windows")

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -977,6 +977,109 @@ func main() {
 	assert.Equal(t, LiveDogfoodStatusPass, happy.Status)
 }
 
+func TestLiveDogfoodBinaryPathRebuildsStaleRootBinary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the stale root binary; skip on Windows")
+	}
+
+	dir := t.TempDir()
+	binaryName := "fixture-pp-cli"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/live-dogfood-root-refresh-test\n\ngo 1.23\n"), 0o644))
+	cmdDir := filepath.Join(dir, "cmd", binaryName)
+	require.NoError(t, os.MkdirAll(cmdDir, 0o755))
+	mainPath := filepath.Join(cmdDir, "main.go")
+	require.NoError(t, os.WriteFile(mainPath, []byte("package main\n\nimport \"fmt\"\n\nfunc main() { fmt.Print(\"current source\") }\n"), 0o644))
+	internalDir := filepath.Join(dir, "internal", "fixture")
+	require.NoError(t, os.MkdirAll(internalDir, 0o755))
+	internalPath := filepath.Join(internalDir, "fixture.go")
+	require.NoError(t, os.WriteFile(internalPath, []byte("package fixture\n"), 0o644))
+
+	rootPath := writeStubBinary(t, dir, binaryName, `echo "stale root"`)
+	oldTime := time.Now().Add(-2 * time.Hour)
+	newTime := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(rootPath, oldTime, oldTime))
+	require.NoError(t, os.Chtimes(mainPath, oldTime, oldTime))
+	require.NoError(t, os.Chtimes(internalPath, newTime, newTime))
+
+	path, cleanup, err := liveDogfoodBinaryPath(dir, binaryName)
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+	require.Equal(t, rootPath, path)
+
+	out, err := exec.Command(path).CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Equal(t, "current source", string(out))
+}
+
+func TestLiveDogfoodBinaryPathKeepsFreshRootBinary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fresh root binary; skip on Windows")
+	}
+
+	dir := t.TempDir()
+	binaryName := "fixture-pp-cli"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/live-dogfood-root-fresh-test\n\ngo 1.23\n"), 0o644))
+	cmdDir := filepath.Join(dir, "cmd", binaryName)
+	require.NoError(t, os.MkdirAll(cmdDir, 0o755))
+	mainPath := filepath.Join(cmdDir, "main.go")
+	require.NoError(t, os.WriteFile(mainPath, []byte("package main\n\nfunc main() {}\n"), 0o644))
+
+	rootPath := writeStubBinary(t, dir, binaryName, `echo "fresh root"`)
+	oldTime := time.Now().Add(-2 * time.Hour)
+	freshTime := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(mainPath, oldTime, oldTime))
+	require.NoError(t, os.Chtimes(rootPath, freshTime, freshTime))
+
+	path, cleanup, err := liveDogfoodBinaryPath(dir, binaryName)
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+	require.Equal(t, rootPath, path)
+
+	out, err := exec.Command(path).CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Equal(t, "fresh root\n", string(out))
+	contents, err := os.ReadFile(rootPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(contents), `echo "fresh root"`)
+}
+
+func TestLiveDogfoodBinaryPathReportsCommandDirectoryErrors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the root binary; skip on Windows")
+	}
+
+	dir := t.TempDir()
+	binaryName := "fixture-pp-cli"
+	rootPath := writeStubBinary(t, dir, binaryName, `echo "existing root"`)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd"), []byte("not a directory"), 0o644))
+
+	_, _, err := liveDogfoodBinaryPath(dir, binaryName)
+	require.ErrorContains(t, err, "rebuilding stale live dogfood binary")
+
+	out, runErr := exec.Command(rootPath).CombinedOutput()
+	require.NoError(t, runErr, string(out))
+	assert.Equal(t, "existing root\n", string(out))
+}
+
+func TestLiveDogfoodBinaryPathKeepsBinaryWithoutSourceTree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the root binary; skip on Windows")
+	}
+
+	dir := t.TempDir()
+	binaryName := "fixture-pp-cli"
+	rootPath := writeStubBinary(t, dir, binaryName, `echo "binary only"`)
+
+	path, cleanup, err := liveDogfoodBinaryPath(dir, binaryName)
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+	require.Equal(t, rootPath, path)
+
+	out, err := exec.Command(path).CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Equal(t, "binary only\n", string(out))
+}
+
 func TestRunLiveDogfoodDoesNotLeaveFallbackDogfoodBinary(t *testing.T) {
 	dir := t.TempDir()
 	binaryName := "fixture-pp-cli"

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -988,11 +988,11 @@ func TestLiveDogfoodBinaryPathRebuildsStaleRootBinary(t *testing.T) {
 	cmdDir := filepath.Join(dir, "cmd", binaryName)
 	require.NoError(t, os.MkdirAll(cmdDir, 0o755))
 	mainPath := filepath.Join(cmdDir, "main.go")
-	require.NoError(t, os.WriteFile(mainPath, []byte("package main\n\nimport \"fmt\"\n\nfunc main() { fmt.Print(\"current source\") }\n"), 0o644))
+	require.NoError(t, os.WriteFile(mainPath, []byte("package main\n\nimport (\n\t\"fmt\"\n\t\"example.com/live-dogfood-root-refresh-test/internal/fixture\"\n)\n\nfunc main() { fmt.Print(fixture.Value) }\n"), 0o644))
 	internalDir := filepath.Join(dir, "internal", "fixture")
 	require.NoError(t, os.MkdirAll(internalDir, 0o755))
 	internalPath := filepath.Join(internalDir, "fixture.go")
-	require.NoError(t, os.WriteFile(internalPath, []byte("package fixture\n"), 0o644))
+	require.NoError(t, os.WriteFile(internalPath, []byte("package fixture\n\nconst Value = \"current source\"\n"), 0o644))
 
 	rootPath := writeStubBinary(t, dir, binaryName, `echo "stale root"`)
 	oldTime := time.Now().Add(-2 * time.Hour)
@@ -1043,6 +1043,43 @@ func TestLiveDogfoodBinaryPathRebuildsForSourceOutsideCmdAndInternal(t *testing.
 	out, err := exec.Command(path).CombinedOutput()
 	require.NoError(t, err, string(out))
 	assert.Equal(t, "current package source", string(out))
+}
+
+func TestLiveDogfoodBinaryPathRebuildsForLocalReplaceDependency(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the stale root binary; skip on Windows")
+	}
+
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "fixture-cli")
+	sharedDir := filepath.Join(parent, "shared")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+	binaryName := "fixture-pp-cli"
+	require.NoError(t, os.WriteFile(filepath.Join(sharedDir, "go.mod"), []byte("module example.com/live-dogfood-shared\n\ngo 1.23\n"), 0o644))
+	sharedPath := filepath.Join(sharedDir, "version.go")
+	require.NoError(t, os.WriteFile(sharedPath, []byte("package shared\n\nconst Value = \"current shared source\"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/live-dogfood-local-replace-test\n\ngo 1.23\n\nrequire example.com/live-dogfood-shared v0.0.0\n\nreplace example.com/live-dogfood-shared => ../shared\n"), 0o644))
+	cmdDir := filepath.Join(dir, "cmd", binaryName)
+	require.NoError(t, os.MkdirAll(cmdDir, 0o755))
+	mainPath := filepath.Join(cmdDir, "main.go")
+	require.NoError(t, os.WriteFile(mainPath, []byte("package main\n\nimport (\n\t\"fmt\"\n\tshared \"example.com/live-dogfood-shared\"\n)\n\nfunc main() { fmt.Print(shared.Value) }\n"), 0o644))
+
+	rootPath := writeStubBinary(t, dir, binaryName, `echo "stale root"`)
+	oldTime := time.Now().Add(-2 * time.Hour)
+	newTime := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(rootPath, oldTime, oldTime))
+	require.NoError(t, os.Chtimes(mainPath, oldTime, oldTime))
+	require.NoError(t, os.Chtimes(sharedPath, newTime, newTime))
+
+	path, cleanup, err := liveDogfoodBinaryPath(dir, binaryName)
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+	require.Equal(t, rootPath, path)
+
+	out, err := exec.Command(path).CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Equal(t, "current shared source", string(out))
 }
 
 func TestLiveDogfoodBinaryPathKeepsFreshRootBinary(t *testing.T) {

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -4263,7 +4263,9 @@ cookie-auth CLI you could not exercise.
 The live dogfood runner enumerates the CLI's `agent-context` command tree,
 runs help, happy-path, JSON-fidelity, and error-path checks where applicable,
 captures subprocess exit codes directly without shell pipes, and emits a
-structured report with pass/fail/skipped counts. Save the JSON report to:
+structured report with pass/fail/skipped counts. Before running the matrix, it
+atomically rebuilds a selected binary that is older than the CLI's Go sources;
+binaries at least as new as the sources are reused. Save the JSON report to:
 
 `$PROOFS_DIR/<stamp>-dogfood-results.json`
 


### PR DESCRIPTION
## Summary

Live dogfood now rebuilds a selected runnable binary when it predates the printed CLI's Go sources, so scorer results cannot come from a stale root artifact. Fresh binaries and binary-only CLIs remain unchanged, while malformed source layouts fail explicitly instead of silently running uncertain code. Staged and root refreshes share the same atomic replacement path.

Closes #3574

## Verification

- `go test ./internal/pipeline -run '^Test(LiveDogfoodBinaryPath|RunLiveDogfoodRefreshesStageBinaryBeforeResolving|LiveCheck_RebuildsStaleStageBinaryBeforeSampling|LiveCheck_SkipsStageRebuildWhen)' -count=1` (8 passed)
- `go test ./...` (6,870 passed)
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run --new-from-rev=origin/main ./...`
- `git diff --check`

Full-tree lint still reports one pre-existing `modernize` finding in untouched `internal/googlediscovery/parser.go`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
