### PR TITLE
fix(cli): redact credential tokens from proof samples

### DIFF
--- a/internal/artifacts/pii.go
+++ b/internal/artifacts/pii.go
@@ -197,6 +197,8 @@ var piiJSONScalarKeys = map[string]bool{
 }
 
 var piiJSONKeyNeedleRE = regexp.MustCompile(`(?i)"(?:access[_ -]?token|address1?|address2|api[_ -]?key|api[_ -]?token|billing[_ -]?address|card[_ -]?last[_ -]?4|client[_ -]?secret|csrf(?:[_ -]?token)?|customer[_ -]?(?:email|name)|email|first[_ -]?name|full[_ -]?name|invoice(?:[_ -]?number)?|last[_ -]?name|last[_ -]?4|mobile|name|password|phone(?:[_ -]?number)?|postal[_ -]?code|refresh[_ -]?token|secret|session(?:[_ -]?token)?|shipping[_ -]?address|street(?:[_ -]?address)?|token|websocket[_ -]?url|zip)"\s*:`)
+var piiJSONCredentialKeyNeedleRE = regexp.MustCompile(`(?i)"(?:auth(?:entication)?[_ -]?token|[^"\r\n]*sso[^"\r\n]*token)"\s*:`)
+var piiCredentialJWTPattern = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b`)
 
 // RedactPIIText returns text with customer-PII shapes replaced before the
 // text is written to durable artifacts. JSON input preserves non-PII fields
@@ -223,7 +225,7 @@ func RedactPIIJSONKeys(text string) (string, bool) {
 	if strings.TrimSpace(text) == "" {
 		return text, false
 	}
-	if !piiJSONKeyNeedleRE.MatchString(text) {
+	if !piiJSONKeyNeedleRE.MatchString(text) && !piiJSONCredentialKeyNeedleRE.MatchString(text) {
 		return text, false
 	}
 	var parsed any
@@ -305,7 +307,7 @@ func redactPIIJSONLines(text string) (string, bool) {
 }
 
 func redactPIIJSONValue(value any, key string, redactStringPatterns bool) (any, bool) {
-	if key != "" && piiJSONScalarKeys[normalizePIIJSONKey(key)] {
+	if key != "" && isPIIJSONScalarKey(key) {
 		return PIIRedactedSentinel, true
 	}
 
@@ -351,7 +353,7 @@ func redactPIIJSONKeyFragments(text string) (string, bool) {
 			return match
 		}
 		key, err := strconv.Unquote(`"` + pair[1] + `"`)
-		if err != nil || !piiJSONScalarKeys[normalizePIIJSONKey(key)] {
+		if err != nil || !isPIIJSONScalarKey(key) {
 			return match
 		}
 		changed = true
@@ -373,12 +375,42 @@ func normalizePIIJSONKey(key string) string {
 	return key
 }
 
+func isPIIJSONScalarKey(key string) bool {
+	normalized := normalizePIIJSONKey(key)
+	return piiJSONScalarKeys[normalized] ||
+		normalized == "authtoken" ||
+		normalized == "authenticationtoken" ||
+		(strings.HasSuffix(normalized, "token") && hasPIISSOKeySegment(key))
+}
+
+func hasPIISSOKeySegment(key string) bool {
+	lower := strings.ToLower(key)
+	for offset := 0; offset < len(lower); {
+		relative := strings.Index(lower[offset:], "sso")
+		if relative == -1 {
+			return false
+		}
+		idx := offset + relative
+		if idx == 0 || strings.ContainsRune("_- ", rune(key[idx-1])) ||
+			(key[idx] >= 'A' && key[idx] <= 'Z' && key[idx-1] >= 'a' && key[idx-1] <= 'z') {
+			return true
+		}
+		offset = idx + len("sso")
+	}
+	return false
+}
+
+// RedactPIIJWTs removes JWT-shaped credentials before callers truncate text.
+func RedactPIIJWTs(text string) string {
+	return piiCredentialJWTPattern.ReplaceAllString(text, PIIRedactedSentinel)
+}
+
 func redactPIIPatterns(text string) string {
 	redacted := text
 	for _, det := range piiDetectors {
 		redacted = redactDetectorMatches(det, redacted)
 	}
-	return redacted
+	return RedactPIIJWTs(redacted)
 }
 
 func redactDetectorMatches(det piiDetector, text string) string {

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -40,6 +40,25 @@ func TestRedactPIIText_RedactsJSONCredentialsAndPII(t *testing.T) {
 	require.Contains(t, got, `"status":"ok"`)
 }
 
+func TestRedactPIIText_RedactsCredentialKeyVariantsAndJWTs(t *testing.T) {
+	jwt := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImxpdmVAdXNlci5jb20ifQ.signature"
+	got := RedactPIIText(`{"authentication_token":"auth-secret","new_sso_auth_token":"` + jwt + `","id":42,"created_at":"2026-07-13T12:34:56Z","status":"active"}`)
+
+	require.NotContains(t, got, "auth-secret")
+	require.NotContains(t, got, jwt)
+	require.Contains(t, got, `"authentication_token":"<redacted>"`)
+	require.Contains(t, got, `"new_sso_auth_token":"<redacted>"`)
+	require.Contains(t, got, `"id":42`)
+	require.Contains(t, got, `"created_at":"2026-07-13T12:34:56Z"`)
+	require.Contains(t, got, `"status":"active"`)
+}
+
+func TestRedactPIIText_RedactsJWTOutsideCredentialField(t *testing.T) {
+	jwt := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature"
+
+	require.Equal(t, "bearer "+PIIRedactedSentinel, RedactPIIText("bearer "+jwt))
+}
+
 func TestRedactPIIText_LeavesStructuralJSONUnchanged(t *testing.T) {
 	input := `{"id":42,"status":"active"}`
 
@@ -64,6 +83,12 @@ func TestRedactPIIJSONKeys_RedactsCredentialKeys(t *testing.T) {
 		"api key",
 		"apikey",
 		"access_token",
+		"auth_token",
+		"authentication_token",
+		"new_sso_auth_token",
+		"ssoToken",
+		"newSsoAuthToken",
+		"newSSOAuthToken",
 		"refresh_token",
 		"client_secret",
 		"secret",
@@ -87,11 +112,16 @@ func TestRedactPIIJSONKeys_RedactsCredentialKeys(t *testing.T) {
 }
 
 func TestRedactPIIJSONKeys_LeavesCredentialCountersUnchanged(t *testing.T) {
-	input := `{"token_count":5,"status":"ok"}`
-	got, changed := RedactPIIJSONKeys(input)
+	for _, input := range []string{
+		`{"token_count":5,"status":"ok"}`,
+		`{"lesson_token":"chapter-3","status":"ok"}`,
+		`{"lessonToken":"chapter-3","status":"ok"}`,
+	} {
+		got, changed := RedactPIIJSONKeys(input)
 
-	require.False(t, changed)
-	require.Equal(t, input, got)
+		require.False(t, changed)
+		require.Equal(t, input, got)
+	}
 }
 
 func TestRedactPIIJSONKeys_RedactsNDJSON(t *testing.T) {

--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -798,6 +798,7 @@ func sampleOutputParts(parts ...string) string {
 	capRemaining := outputSampleMaxBytes
 	truncated := false
 	for _, part := range parts {
+		part = artifacts.RedactPIIJWTs(part)
 		if redacted, ok := artifacts.RedactPIIJSONKeys(part); ok {
 			part = redacted
 		}

--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -824,6 +824,9 @@ func sampleOutputParts(parts ...string) string {
 		captureRemaining -= len(part)
 	}
 	sample := artifacts.RedactPIIText(rawSample.String())
+	if truncated || captureRemaining == 0 {
+		sample = redactPartialJWTTail(sample)
+	}
 	if len(sample) > outputSampleMaxBytes {
 		sample = truncateUTF8(sample, outputSampleMaxBytes)
 		sample = completePartialRedactionSentinel(sample)
@@ -833,6 +836,12 @@ func sampleOutputParts(parts ...string) string {
 		return sample + "…[truncated]"
 	}
 	return sample
+}
+
+var partialJWTTailRE = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]*(?:\.[A-Za-z0-9_-]*){0,2}$`)
+
+func redactPartialJWTTail(sample string) string {
+	return partialJWTTailRE.ReplaceAllString(sample, artifacts.PIIRedactedSentinel)
 }
 
 func completePartialRedactionSentinel(sample string) string {

--- a/internal/pipeline/live_check_test.go
+++ b/internal/pipeline/live_check_test.go
@@ -684,6 +684,16 @@ func TestLiveCheck_OutputSampleRedactsLongJWTAcrossTruncationBoundary(t *testing
 	require.Contains(t, got, artifacts.PIIRedactedSentinel)
 }
 
+func TestLiveCheck_OutputSampleRedactsSplitJWTAcrossTruncationBoundary(t *testing.T) {
+	header := "eyJ" + strings.Repeat("a", 32)
+	payloadAndSignature := "." + strings.Repeat("b", sampleRedactionLookaheadBytes+32) + ".signature"
+	got := sampleOutputParts(strings.Repeat("x", outputSampleMaxBytes-8)+" "+header, payloadAndSignature)
+
+	require.Contains(t, got, "…[truncated]")
+	require.NotContains(t, got, "eyJ")
+	require.Contains(t, got, artifacts.PIIRedactedSentinel)
+}
+
 // TestLiveCheck_BinaryAutoDerivation verifies RunLiveCheck finds the binary
 // when BinaryName is empty by trying <base>-pp-cli then <base>.
 func TestLiveCheck_BinaryAutoDerivation(t *testing.T) {

--- a/internal/pipeline/live_check_test.go
+++ b/internal/pipeline/live_check_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/artifacts"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/platform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -672,6 +673,15 @@ func TestLiveCheck_OutputSampleRedactsPIIAcrossTruncationBoundary(t *testing.T) 
 	require.NotContains(t, got, "jane@gmail.com")
 	require.NotContains(t, got, "jane@")
 	require.Contains(t, got, "<redacted>")
+}
+
+func TestLiveCheck_OutputSampleRedactsLongJWTAcrossTruncationBoundary(t *testing.T) {
+	jwt := "eyJ" + strings.Repeat("a", sampleRedactionLookaheadBytes) + ".payload.signature"
+	got := sampleOutput(strings.Repeat("x", outputSampleMaxBytes-8) + " " + jwt)
+
+	require.Contains(t, got, "…[truncated]")
+	require.NotContains(t, got, "eyJ")
+	require.Contains(t, got, artifacts.PIIRedactedSentinel)
 }
 
 // TestLiveCheck_BinaryAutoDerivation verifies RunLiveCheck finds the binary


### PR DESCRIPTION
## Summary

Publish-bound dogfood proof samples now redact authentication and SSO token fields across snake-case, camelCase, and acronym-style keys. JWT-shaped credentials are scrubbed from each complete output part before the persisted sample is truncated, preventing a long token from leaving a visible prefix at the capture boundary. IDs, timestamps, and non-credential token fields remain unchanged.

Closes #3577

## Verification

- `go test ./internal/artifacts -count=1` (212 passed)
- focused `internal/pipeline` redaction and large-output tests (4 passed)
- `scripts/golden.sh verify` (32 cases passed)
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `git diff --check`
- `go test ./...` reached 5,355 passes with one transient large-output pipeline failure; that exact test passed on focused rerun
- `golangci-lint run ./...` reports one unchanged `modernize` finding in `internal/googlediscovery/parser.go:455`
