### PR TITLE
fix(cli): package manifest-selected manuscripts safely

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -270,8 +270,40 @@ func newPublishPackageCmd() *cobra.Command {
 				}
 			}
 
+			sourceManifest, _ := pipeline.ReadCLIManifest(dir)
+			preferredRunID := strings.TrimSpace(sourceManifest.RunID)
+			if preferredRunID != "" && !isSafeManuscriptRunID(preferredRunID) {
+				return &ExitError{Code: ExitInputError, Err: fmt.Errorf("manifest run_id must be a single path component")}
+			}
+			sourceCLIName := sourceManifest.CLIName
+			if sourceCLIName == "" {
+				sourceCLIName = filepath.Base(dir)
+			}
+			sourceAPIName := sourceManifest.APIName
+			if sourceAPIName == "" {
+				sourceAPIName = naming.TrimCLISuffix(sourceCLIName)
+			}
+			if !isSafeManuscriptPathComponent(sourceCLIName) || !isSafeManuscriptPathComponent(sourceAPIName) {
+				return &ExitError{Code: ExitInputError, Err: fmt.Errorf("manifest cli_name and api_name must be single path components")}
+			}
+			msDir, runID := findManuscriptsRun(sourceCLIName, sourceAPIName, preferredRunID)
+			embeddedMsDir := filepath.Join(dir, ".manuscripts")
+			if runID == "" && preferredRunID != "" && manuscriptRunExists(filepath.Join(embeddedMsDir, preferredRunID)) {
+				msDir = embeddedMsDir
+				runID = preferredRunID
+			}
+			if runID == "" {
+				msDir, runID = resolveManuscripts(sourceCLIName, sourceAPIName)
+			}
+			if runID == "" {
+				if embeddedRunID, err := findMostRecentRun(embeddedMsDir); err == nil && embeddedRunID != "" {
+					msDir = embeddedMsDir
+					runID = embeddedRunID
+				}
+			}
+
 			// Re-validate before packaging
-			vResult := runValidationForPublishPackage(dir)
+			vResult := runPackageValidation(dir, msDir, runID)
 			if !vResult.Passed {
 				if asJSON {
 					enc := json.NewEncoder(os.Stdout)
@@ -363,6 +395,12 @@ func newPublishPackageCmd() *cobra.Command {
 				cleanupOnFailure()
 				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("normalizing publish metadata: %w", err)}
 			}
+			if runID != "" && runID != sourceManifest.RunID {
+				if err := setPackagedManifestRunID(outCLIDir, runID); err != nil {
+					cleanupOnFailure()
+					return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("updating packaged manifest run_id: %w", err)}
+				}
+			}
 
 			// Strip build/ from the staged tree. autoBundleForHost writes
 			// host-platform .mcpb bundles + staged binaries there as a
@@ -430,13 +468,8 @@ func newPublishPackageCmd() *cobra.Command {
 				ModulePath: modulePath,
 			}
 
-			msDir, runID := resolveManuscripts(cliName, vResult.APIName)
-			if runID == "" {
-				embeddedMsDir := filepath.Join(dir, ".manuscripts")
-				if embeddedRunID, err := findMostRecentRun(embeddedMsDir); err == nil && embeddedRunID != "" {
-					msDir = embeddedMsDir
-					runID = embeddedRunID
-				}
+			if preferredRunID != "" && runID != "" && runID != preferredRunID {
+				fmt.Fprintf(os.Stderr, "warning: manifest manuscripts run %q not found; packaging fallback run %q\n", preferredRunID, runID)
 			}
 			if runID != "" {
 				result.RunID = runID
@@ -665,6 +698,68 @@ func resolveManuscripts(cliName, apiName string) (msDir string, runID string) {
 	}
 	// 3. Fuzzy resolve (strip suffixes, prefix match)
 	return resolveManuscriptDir(msRoot, apiName)
+}
+
+func findManuscriptsRun(cliName, apiName, runID string) (msDir string, foundRunID string) {
+	if runID == "" {
+		return "", ""
+	}
+	if apiName == "" {
+		apiName = naming.TrimCLISuffix(cliName)
+	}
+
+	msRoot := pipeline.PublishedManuscriptsRoot()
+	for _, dir := range []string{filepath.Join(msRoot, apiName), filepath.Join(msRoot, cliName)} {
+		if manuscriptRunExists(filepath.Join(dir, runID)) {
+			return dir, runID
+		}
+	}
+	if dir, _ := resolveManuscriptDir(msRoot, apiName); dir != "" && manuscriptRunExists(filepath.Join(dir, runID)) {
+		return dir, runID
+	}
+	return "", ""
+}
+
+func manuscriptRunExists(dir string) bool {
+	info, err := os.Stat(dir)
+	return err == nil && info.IsDir()
+}
+
+func isSafeManuscriptRunID(runID string) bool {
+	return isSafeManuscriptPathComponent(runID)
+}
+
+func isSafeManuscriptPathComponent(value string) bool {
+	return value != "" && value != "." && value != ".." && !filepath.IsAbs(value) &&
+		!strings.ContainsAny(value, `/\\`)
+}
+
+func runPackageValidation(dir, selectedManuscriptsDir, selectedRunID string) ValidateResult {
+	result := runValidationForPublishPackage(dir)
+	if selectedRunID == "" {
+		return result
+	}
+	manifest, err := pipeline.ReadCLIManifest(dir)
+	if err != nil {
+		return result
+	}
+	manifest.RunID = selectedRunID
+	for i := range result.Checks {
+		if result.Checks[i].Name != "phase5" {
+			continue
+		}
+		proofsDir := filepath.Join(selectedManuscriptsDir, selectedRunID, "proofs")
+		result.Checks[i] = checkPhase5GateAt(proofsDir, manifest)
+		result.Passed = true
+		for _, check := range result.Checks {
+			if !check.Passed {
+				result.Passed = false
+				break
+			}
+		}
+		break
+	}
+	return result
 }
 
 func runValidation(dir string) ValidateResult {
@@ -1126,6 +1221,33 @@ func normalizePackagedPublishMetadata(dir, category string) error {
 	return pipeline.EnsurePatchesDir(dir)
 }
 
+func setPackagedManifestRunID(dir, runID string) error {
+	manifestPath := filepath.Join(dir, pipeline.CLIManifestFilename)
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return err
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	encoded, err := json.Marshal(runID)
+	if err != nil {
+		return err
+	}
+	raw["run_id"] = encoded
+	updated, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return err
+	}
+	updated = append(updated, '\n')
+	info, err := os.Stat(manifestPath)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(manifestPath, updated, info.Mode())
+}
+
 func isPublishPrinterSentinel(printer string) bool {
 	return printer == "USER" || printer == "user"
 }
@@ -1172,7 +1294,10 @@ func checkPhase5Gate(dir string, manifest pipeline.CLIManifest) CheckResult {
 		return CheckResult{Name: "phase5", Passed: false, Error: "manifest missing run_id; cannot locate Phase 5 gate proof"}
 	}
 
-	proofsDir := phase5ProofsDir(dir, manifest)
+	return checkPhase5GateAt(phase5ProofsDir(dir, manifest), manifest)
+}
+
+func checkPhase5GateAt(proofsDir string, manifest pipeline.CLIManifest) CheckResult {
 	result := pipeline.ValidatePhase5Gate(proofsDir, manifest)
 	if !result.Passed {
 		return CheckResult{Name: "phase5", Passed: false, Error: result.Detail}
@@ -1186,11 +1311,11 @@ func phase5ProofsDir(dir string, manifest pipeline.CLIManifest) string {
 		filepath.Join(dir, ".manuscripts", runID, "proofs"),
 	}
 	msRoot := pipeline.PublishedManuscriptsRoot()
-	if manifest.CLIName != "" {
-		candidates = append(candidates, filepath.Join(msRoot, manifest.CLIName, runID, "proofs"))
-	}
 	if manifest.APIName != "" {
 		candidates = append(candidates, filepath.Join(msRoot, manifest.APIName, runID, "proofs"))
+	}
+	if manifest.CLIName != "" {
+		candidates = append(candidates, filepath.Join(msRoot, manifest.CLIName, runID, "proofs"))
 	}
 	for _, candidate := range candidates {
 		if info, err := os.Stat(candidate); err == nil && info.IsDir() {

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -1129,6 +1129,7 @@ func TestPublishPackageFailsWhenManuscriptsCopyFails(t *testing.T) {
 	stubPublishPackageValidation(t)
 
 	runID := "20260328-132022"
+	setPublishableTestRunID(t, cliDir, runID)
 	manuscriptFile := filepath.Join(home, "manuscripts", "test", runID, "research", "brief.md")
 	require.NoError(t, os.MkdirAll(filepath.Dir(manuscriptFile), 0o755))
 	require.NoError(t, os.WriteFile(manuscriptFile, []byte("brief"), 0o600))
@@ -1160,6 +1161,7 @@ func TestPublishPackageIncludesManuscripts(t *testing.T) {
 
 	// Create manuscripts at the archived location where publish package looks
 	runID := "20260329-100000"
+	setPublishableTestRunID(t, cliDir, runID)
 	researchDir := filepath.Join(home, "manuscripts", "test", runID, "research")
 	proofsDir := filepath.Join(home, "manuscripts", "test", runID, "proofs")
 	discoveryDir := filepath.Join(home, "manuscripts", "test", runID, "discovery")
@@ -1212,6 +1214,223 @@ func TestPublishPackageIncludesManuscripts(t *testing.T) {
 	assert.NoFileExists(t, filepath.Join(result.StagedDir, ".manuscripts", "stale-run", "discovery", "stale-capture.har"))
 }
 
+func TestPublishPackageUsesManifestRunInsteadOfNewerArchive(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	cliDir := filepath.Join(home, "library", "test-pp-cli")
+	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
+
+	manifestRunID := "20260711-203553-d9c009c7"
+	writeTestManifest(t, cliDir, pipeline.CLIManifest{
+		SchemaVersion:        pipeline.CurrentCLIManifestSchemaVersion,
+		PrintingPressVersion: "test-version",
+		APIName:              "test",
+		CLIName:              "test-pp-cli",
+		RunID:                manifestRunID,
+		Printer:              "tmchow",
+		PrinterName:          "Trevin Chow",
+		AuthType:             "none",
+	})
+
+	manifestBrief := filepath.Join(home, "manuscripts", "test", manifestRunID, "research", "brief.md")
+	staleProof := filepath.Join(home, "manuscripts", "test", "amend-2026-07-11T0357", "proofs", "stale.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(manifestBrief), 0o755))
+	require.NoError(t, os.WriteFile(manifestBrief, []byte("manifest run"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Dir(staleProof), 0o755))
+	require.NoError(t, os.WriteFile(staleProof, []byte("stale amend"), 0o644))
+
+	target := filepath.Join(t.TempDir(), "staging")
+	cmd := newPublishCmd()
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+
+	output, err := runWithCapturedStdout(t, cmd.Execute)
+	require.NoError(t, err)
+
+	var result PackageResult
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	assert.Equal(t, manifestRunID, result.RunID)
+	assert.FileExists(t, filepath.Join(result.StagedDir, ".manuscripts", manifestRunID, "research", "brief.md"))
+	assert.NoDirExists(t, filepath.Join(result.StagedDir, ".manuscripts", "amend-2026-07-11T0357"))
+}
+
+func TestPublishPackageWarnsWhenManifestRunFallsBack(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	cliDir := filepath.Join(home, "library", "test-pp-cli")
+	writePublishableTestCLI(t, cliDir)
+
+	require.NoError(t, os.RemoveAll(filepath.Join(home, "manuscripts", "test")))
+	fallbackRunID := "amend-2026-07-11T0357"
+	fallbackProofs := filepath.Join(home, "manuscripts", "test", fallbackRunID, "proofs")
+	writeTestPhase5GateMarker(t, fallbackProofs, pipeline.Phase5AcceptanceFilename, pipeline.Phase5GateMarker{
+		SchemaVersion: 1,
+		APIName:       "test",
+		RunID:         fallbackRunID,
+		Status:        "pass",
+		Level:         "full",
+		MatrixSize:    1,
+		TestsPassed:   1,
+		AuthContext:   pipeline.Phase5AuthContext{Type: "none"},
+	})
+
+	target := filepath.Join(t.TempDir(), "staging")
+	cmd := newPublishCmd()
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+
+	stderr, err := runWithCapturedStderr(t, cmd.Execute)
+	require.NoError(t, err)
+	assert.Contains(t, stderr, `manifest manuscripts run "20260301-000000" not found`)
+	assert.Contains(t, stderr, `packaging fallback run "amend-2026-07-11T0357"`)
+	stagedDir := filepath.Join(target, "library", "other", "test")
+	assert.FileExists(t, filepath.Join(stagedDir, ".manuscripts", fallbackRunID, "proofs", pipeline.Phase5AcceptanceFilename))
+	manifest, manifestErr := pipeline.ReadCLIManifest(stagedDir)
+	require.NoError(t, manifestErr)
+	assert.Equal(t, fallbackRunID, manifest.RunID)
+	assert.True(t, checkPhase5Gate(stagedDir, manifest).Passed)
+}
+
+func TestPublishPackageRejectsUnsafeManifestRunID(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	cliDir := filepath.Join(home, "library", "test-pp-cli")
+	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
+	setPublishableTestRunID(t, cliDir, "../outside")
+
+	target := filepath.Join(t.TempDir(), "staging")
+	cmd := newPublishCmd()
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "manifest run_id must be a single path component")
+	assert.NoDirExists(t, target)
+}
+
+func TestPublishPackageRejectsUnsafeManifestLookupNames(t *testing.T) {
+	for _, field := range []string{"api_name", "cli_name"} {
+		t.Run(field, func(t *testing.T) {
+			home := setLibraryTestEnv(t)
+			cliDir := filepath.Join(home, "library", "test-pp-cli")
+			writePublishableTestCLI(t, cliDir)
+			stubPublishPackageValidation(t)
+			manifest, err := pipeline.ReadCLIManifest(cliDir)
+			require.NoError(t, err)
+			if field == "api_name" {
+				manifest.APIName = "../outside"
+			} else {
+				manifest.CLIName = "../outside"
+			}
+			writeTestManifest(t, cliDir, manifest)
+
+			target := filepath.Join(t.TempDir(), "staging")
+			cmd := newPublishCmd()
+			cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+
+			err = cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "manifest cli_name and api_name must be single path components")
+			assert.NoDirExists(t, target)
+		})
+	}
+}
+
+func TestRunPackageValidationUsesSelectedFuzzyManuscriptDir(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	cliDir := filepath.Join(home, "library", "steam-web-pp-cli")
+	require.NoError(t, os.MkdirAll(cliDir, 0o755))
+	runID := "amend-2026-07-11T0357"
+	writeTestManifest(t, cliDir, pipeline.CLIManifest{
+		APIName: "steam-web",
+		CLIName: "steam-web-pp-cli",
+		RunID:   "missing-run",
+	})
+	selectedDir := filepath.Join(home, "manuscripts", "steam")
+	writeTestPhase5GateMarker(t, filepath.Join(selectedDir, runID, "proofs"), pipeline.Phase5AcceptanceFilename, pipeline.Phase5GateMarker{
+		SchemaVersion: 1,
+		APIName:       "steam-web",
+		RunID:         runID,
+		Status:        "pass",
+		Level:         "full",
+		MatrixSize:    1,
+		TestsPassed:   1,
+		AuthContext:   pipeline.Phase5AuthContext{Type: "none"},
+	})
+	previous := runValidationForPublishPackage
+	runValidationForPublishPackage = func(string) ValidateResult {
+		return ValidateResult{Checks: []CheckResult{{Name: "phase5", Passed: false, Error: "manifest run missing"}}}
+	}
+	t.Cleanup(func() { runValidationForPublishPackage = previous })
+
+	result := runPackageValidation(cliDir, selectedDir, runID)
+
+	assert.True(t, result.Passed)
+	assert.True(t, publishCheckByName(t, result, "phase5").Passed)
+}
+
+func TestPublishPackageNormalizesTrimmedManifestRunID(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	cliDir := filepath.Join(home, "library", "test-pp-cli")
+	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
+	setPublishableTestRunID(t, cliDir, " 20260301-000000 ")
+
+	target := filepath.Join(t.TempDir(), "staging")
+	cmd := newPublishCmd()
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	output, err := runWithCapturedStdout(t, cmd.Execute)
+	require.NoError(t, err)
+	var result PackageResult
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	manifest, err := pipeline.ReadCLIManifest(result.StagedDir)
+	require.NoError(t, err)
+	assert.Equal(t, "20260301-000000", manifest.RunID)
+}
+
+func TestPublishPackageRejectsFallbackWithMismatchedPhase5Proof(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	cliDir := filepath.Join(home, "library", "test-pp-cli")
+	writePublishableTestCLI(t, cliDir)
+
+	require.NoError(t, os.RemoveAll(filepath.Join(home, "manuscripts", "test")))
+	fallbackRunID := "amend-2026-07-11T0357"
+	fallbackProofs := filepath.Join(home, "manuscripts", "test", fallbackRunID, "proofs")
+	writeTestPhase5GateMarker(t, fallbackProofs, pipeline.Phase5AcceptanceFilename, pipeline.Phase5GateMarker{
+		SchemaVersion: 1,
+		APIName:       "test",
+		RunID:         "different-run",
+		Status:        "pass",
+		Level:         "full",
+		MatrixSize:    1,
+		TestsPassed:   1,
+		AuthContext:   pipeline.Phase5AuthContext{Type: "none"},
+	})
+
+	target := filepath.Join(t.TempDir(), "staging")
+	cmd := newPublishCmd()
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validation failed, cannot package")
+	assert.NoDirExists(t, target)
+}
+
+func TestPhase5ProofsDirPrefersCanonicalAPIArchive(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	runID := "20260711-203553-d9c009c7"
+	apiProofs := filepath.Join(home, "manuscripts", "test", runID, "proofs")
+	legacyProofs := filepath.Join(home, "manuscripts", "test-pp-cli", runID, "proofs")
+	require.NoError(t, os.MkdirAll(apiProofs, 0o755))
+	require.NoError(t, os.MkdirAll(legacyProofs, 0o755))
+
+	got := phase5ProofsDir(t.TempDir(), pipeline.CLIManifest{
+		APIName: "test",
+		CLIName: "test-pp-cli",
+		RunID:   runID,
+	})
+
+	assert.Equal(t, apiProofs, got)
+}
+
 func TestPublishPackageCanIncludeRawCaptures(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
@@ -1219,6 +1438,7 @@ func TestPublishPackageCanIncludeRawCaptures(t *testing.T) {
 	stubPublishPackageValidation(t)
 
 	runID := "20260329-100000"
+	setPublishableTestRunID(t, cliDir, runID)
 	researchDir := filepath.Join(home, "manuscripts", "test", runID, "research")
 	discoveryDir := filepath.Join(home, "manuscripts", "test", runID, "discovery")
 	require.NoError(t, os.MkdirAll(filepath.Join(researchDir, "test-browser-sniff-spec-samples"), 0o755))
@@ -1414,6 +1634,7 @@ func TestPublishPackageAllowsReservedSyntheticPII(t *testing.T) {
 	))
 
 	runID := "20260329-100000"
+	setPublishableTestRunID(t, cliDir, runID)
 	researchFile := filepath.Join(home, "manuscripts", "test", runID, "research", "captured.json")
 	require.NoError(t, os.MkdirAll(filepath.Dir(researchFile), 0o755))
 	require.NoError(t, os.WriteFile(
@@ -1440,6 +1661,7 @@ func TestPublishPackageRejectsPIIInManuscripts(t *testing.T) {
 	writePublishableTestCLI(t, cliDir)
 	stubPublishPackageValidation(t)
 	runID := "20260329-100000"
+	setPublishableTestRunID(t, cliDir, runID)
 	researchFile := filepath.Join(home, "manuscripts", "test", runID, "research", "captured.json")
 	require.NoError(t, os.MkdirAll(filepath.Dir(researchFile), 0o755))
 	require.NoError(t, os.WriteFile(researchFile, []byte(`{"recipient_email": "leak@gmail.com"}`+"\n"), 0o644))
@@ -1493,6 +1715,7 @@ func TestPublishPackageRejectsVendorPrefixSecretsInManuscripts(t *testing.T) {
 	writePublishableTestCLI(t, cliDir)
 	stubPublishPackageValidation(t)
 	runID := "20260329-100000"
+	setPublishableTestRunID(t, cliDir, runID)
 	researchFile := filepath.Join(home, "manuscripts", "test", runID, "research", "openapi.json")
 	require.NoError(t, os.MkdirAll(filepath.Dir(researchFile), 0o755))
 	require.NoError(t, os.WriteFile(researchFile, []byte("Authorization: Bearer "+testSecret("sk", "_live_", "1234567890abcdefghijklmnop")+"\n"), 0o644))
@@ -1574,6 +1797,7 @@ func TestPublishPackageDestWritesDirectly(t *testing.T) {
 
 	// Create manuscripts
 	runID := "20260329-100000"
+	setPublishableTestRunID(t, cliDir, runID)
 	researchDir := filepath.Join(home, "manuscripts", "test", runID, "research")
 	require.NoError(t, os.MkdirAll(researchDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(researchDir, "brief.md"), []byte("# Brief"), 0o644))
@@ -1648,6 +1872,7 @@ func TestPublishPackageDestRestoresOldCLIOnFailure(t *testing.T) {
 
 	// Create manuscripts with an unreadable file to trigger copy failure
 	runID := "20260329-100000"
+	setPublishableTestRunID(t, cliDir, runID)
 	manuscriptFile := filepath.Join(home, "manuscripts", "test", runID, "research", "brief.md")
 	require.NoError(t, os.MkdirAll(filepath.Dir(manuscriptFile), 0o755))
 	require.NoError(t, os.WriteFile(manuscriptFile, []byte("brief"), 0o600))
@@ -1896,6 +2121,14 @@ func newInsightCmd() *cobra.Command {
 		},
 	})
 	writePublishablePhase5Pass(t)
+}
+
+func setPublishableTestRunID(t *testing.T, cliDir, runID string) {
+	t.Helper()
+	manifest, err := pipeline.ReadCLIManifest(cliDir)
+	require.NoError(t, err)
+	manifest.RunID = runID
+	writeTestManifest(t, cliDir, manifest)
 }
 
 func writePublishablePhase5Pass(t *testing.T) {

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -641,7 +641,7 @@ func shouldSkipPublishableManuscriptFile(path string, info fs.FileInfo, opts Pub
 	if !info.IsDir() && info.Size() >= publishableManuscriptMaxCaptureBytes {
 		return true
 	}
-	if !info.IsDir() && strings.HasSuffix(strings.ToLower(filepath.Base(path)), ".pre-pii-scrub") {
+	if strings.HasSuffix(strings.ToLower(filepath.Base(path)), ".pre-pii-scrub") {
 		return true
 	}
 	if opts.IncludeRawCaptures {

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -641,6 +641,9 @@ func shouldSkipPublishableManuscriptFile(path string, info fs.FileInfo, opts Pub
 	if !info.IsDir() && info.Size() >= publishableManuscriptMaxCaptureBytes {
 		return true
 	}
+	if !info.IsDir() && strings.HasSuffix(strings.ToLower(filepath.Base(path)), ".pre-pii-scrub") {
+		return true
+	}
 	if opts.IncludeRawCaptures {
 		return false
 	}
@@ -659,7 +662,9 @@ func isRawBrowserSniffCapture(path string, info fs.FileInfo) bool {
 	parentPath := filepath.Dir(clean)
 
 	if pathHasComponent(parentPath, "discovery") {
-		if matched, _ := filepath.Match("probe-*.json", base); matched {
+		hyphenated, _ := filepath.Match("probe-*.json", base)
+		underscored, _ := filepath.Match("probe_*.json", base)
+		if hyphenated || underscored {
 			return true
 		}
 	}

--- a/internal/pipeline/publish_test.go
+++ b/internal/pipeline/publish_test.go
@@ -257,7 +257,9 @@ func TestCopyPublishableManuscriptDirExcludesRawBrowserSniffCaptures(t *testing.
 	require.NoError(t, os.MkdirAll(filepath.Join(src, "discovery", "v2", "bundles"), 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Join(src, "research", "squire-browser-sniff-spec-samples"), 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Join(src, "research"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "proofs"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "probe-001.json"), []byte(`{"email":"customer@gmail.com"}`+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "probe_users_show.json"), []byte(`{"email":"customer@gmail.com"}`+"\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "batch-01", "probe-002.json"), []byte(`{"email":"customer@gmail.com"}`+"\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "capture.har"), []byte("raw har"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "bundles", "app.js"), []byte("window.email='customer@gmail.com'"), 0o644))
@@ -266,10 +268,12 @@ func TestCopyPublishableManuscriptDirExcludesRawBrowserSniffCaptures(t *testing.
 	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "traffic-analysis.json"), []byte(`{"auth_stripped":true}`+"\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "browser-sniff-report.md"), []byte("# Report"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "research", "brief.md"), []byte("our synthesis"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "proofs", "shipcheck.md.pre-pii-scrub"), []byte("customer@gmail.com"), 0o644))
 
 	require.NoError(t, CopyPublishableManuscriptDir(src, dst))
 
 	assert.NoFileExists(t, filepath.Join(dst, "discovery", "probe-001.json"))
+	assert.NoFileExists(t, filepath.Join(dst, "discovery", "probe_users_show.json"))
 	assert.NoFileExists(t, filepath.Join(dst, "discovery", "batch-01", "probe-002.json"))
 	assert.NoFileExists(t, filepath.Join(dst, "discovery", "capture.har"))
 	assert.NoDirExists(t, filepath.Join(dst, "discovery", "bundles"))
@@ -278,6 +282,7 @@ func TestCopyPublishableManuscriptDirExcludesRawBrowserSniffCaptures(t *testing.
 	assert.FileExists(t, filepath.Join(dst, "discovery", "traffic-analysis.json"))
 	assert.FileExists(t, filepath.Join(dst, "discovery", "browser-sniff-report.md"))
 	assert.FileExists(t, filepath.Join(dst, "research", "brief.md"))
+	assert.NoFileExists(t, filepath.Join(dst, "proofs", "shipcheck.md.pre-pii-scrub"))
 }
 
 func TestCopyPublishableManuscriptDirCanIncludeRawBrowserSniffCaptures(t *testing.T) {
@@ -292,6 +297,7 @@ func TestCopyPublishableManuscriptDirCanIncludeRawBrowserSniffCaptures(t *testin
 	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "bundles", "app.js"), []byte("console.log('sample')"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "research", "squire-browser-sniff-spec-samples", "sample.json"), []byte(`{"status":"sample"}`+"\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "research", "sources", "thirdparty", "lib.py"), []byte("# third party"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "research", "brief.md.pre-pii-scrub"), []byte("customer@gmail.com"), 0o644))
 	largeFile, err := os.Create(filepath.Join(src, "large-authored-artifact.bin"))
 	require.NoError(t, err)
 	require.NoError(t, largeFile.Truncate(publishableManuscriptMaxCaptureBytes))
@@ -304,6 +310,7 @@ func TestCopyPublishableManuscriptDirCanIncludeRawBrowserSniffCaptures(t *testin
 	assert.FileExists(t, filepath.Join(dst, "discovery", "bundles", "app.js"))
 	assert.FileExists(t, filepath.Join(dst, "research", "squire-browser-sniff-spec-samples", "sample.json"))
 	assert.NoDirExists(t, filepath.Join(dst, "research", "sources"))
+	assert.NoFileExists(t, filepath.Join(dst, "research", "brief.md.pre-pii-scrub"))
 	assert.NoFileExists(t, filepath.Join(dst, "large-authored-artifact.bin"))
 }
 

--- a/internal/pipeline/publish_test.go
+++ b/internal/pipeline/publish_test.go
@@ -258,6 +258,7 @@ func TestCopyPublishableManuscriptDirExcludesRawBrowserSniffCaptures(t *testing.
 	require.NoError(t, os.MkdirAll(filepath.Join(src, "research", "squire-browser-sniff-spec-samples"), 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Join(src, "research"), 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Join(src, "proofs"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "proofs", "snapshot.pre-pii-scrub"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "probe-001.json"), []byte(`{"email":"customer@gmail.com"}`+"\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "probe_users_show.json"), []byte(`{"email":"customer@gmail.com"}`+"\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "batch-01", "probe-002.json"), []byte(`{"email":"customer@gmail.com"}`+"\n"), 0o644))
@@ -269,6 +270,7 @@ func TestCopyPublishableManuscriptDirExcludesRawBrowserSniffCaptures(t *testing.
 	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "browser-sniff-report.md"), []byte("# Report"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "research", "brief.md"), []byte("our synthesis"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "proofs", "shipcheck.md.pre-pii-scrub"), []byte("customer@gmail.com"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "proofs", "snapshot.pre-pii-scrub", "leak.json"), []byte(`{"email":"customer@gmail.com"}`), 0o644))
 
 	require.NoError(t, CopyPublishableManuscriptDir(src, dst))
 
@@ -283,6 +285,7 @@ func TestCopyPublishableManuscriptDirExcludesRawBrowserSniffCaptures(t *testing.
 	assert.FileExists(t, filepath.Join(dst, "discovery", "browser-sniff-report.md"))
 	assert.FileExists(t, filepath.Join(dst, "research", "brief.md"))
 	assert.NoFileExists(t, filepath.Join(dst, "proofs", "shipcheck.md.pre-pii-scrub"))
+	assert.NoDirExists(t, filepath.Join(dst, "proofs", "snapshot.pre-pii-scrub"))
 }
 
 func TestCopyPublishableManuscriptDirCanIncludeRawBrowserSniffCaptures(t *testing.T) {


### PR DESCRIPTION
## Summary

`publish package` now stages the manuscript run named by the CLI manifest instead of silently choosing a later amend run. If that run is unavailable, packaging uses the newest valid run, warns with both run IDs, and updates the staged manifest so its Phase 5 proof remains aligned. Package filtering also excludes pre-PII-scrub backups and both hyphenated and underscored discovery probes, including when raw captures are explicitly requested.

## Validation

- `go test ./internal/cli -run '^TestPublishPackage' -count=1`
- `go test ./internal/pipeline -run '^TestCopyPublishableManuscriptDir' -count=1`
- `golangci-lint run ./internal/cli ./internal/pipeline`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `scripts/golden.sh verify` (32 cases)
- `go test ./... -count=1 -timeout=20m` completed except for an unrelated flaky pipeline test; its isolated rerun passed

Closes #3576

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
