### PR TITLE
fix(cli): serialize OpenAPI array query params

### DIFF
--- a/internal/generator/array_query_param_test.go
+++ b/internal/generator/array_query_param_test.go
@@ -1,0 +1,190 @@
+package generator
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedArrayQueryParamUsesRepeatedKeysByDefault(t *testing.T) {
+	t.Parallel()
+
+	requests := make(chan []string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.URL.Query()["fdcIds"]
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	apiSpec := minimalSpec("array-query-param")
+	apiSpec.BaseURL = server.URL
+	apiSpec.Resources = map[string]spec.Resource{
+		"foods": {
+			Description: "Foods",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/foods",
+					Description: "Get foods",
+					Params: []spec.Param{
+						{Name: "fdcIds", Type: "array", ItemType: "integer", Description: "Food IDs"},
+					},
+					Response: spec.ResponseDef{Type: "array", Item: "Food"},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Food": {Fields: []spec.TypeField{{Name: "id", Type: "integer"}}},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "array-query-param-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	promotedSrc := readPromotedCommandFile(t, outputDir)
+	require.Contains(t, promotedSrc, `path = appendArrayQueryParam(path, "fdcIds", flagFdcIds, "form", true)`)
+	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
+	require.Contains(t, mcpSrc, `QueryArray: true, QueryStyle: "form", QueryExplode: true`)
+	require.Contains(t, mcpSrc, `appendMCPArrayQueryParam(path, binding.WireName, v, binding.QueryStyle, binding.QueryExplode)`)
+	requireGeneratedCompiles(t, outputDir)
+
+	binaryPath := filepath.Join(outputDir, "array-query-param-pp-cli")
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/array-query-param-pp-cli")
+	runGeneratedBinary(t, binaryPath, "foods", "get", "--fdc-ids", "534358,373052")
+	require.Equal(t, []string{"534358", "373052"}, <-requests)
+}
+
+func TestGeneratedArrayQueryParamRuntimeHandlesNativeAndDefaultValues(t *testing.T) {
+	t.Parallel()
+
+	requests := make(chan []string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.URL.Query()["fdcIds"]
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	apiSpec := minimalSpec("array-query-mcp")
+	apiSpec.BaseURL = server.URL
+	apiSpec.MCP = spec.MCPConfig{Orchestration: "code"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"foods": {
+			Description: "Foods",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/foods",
+					Description: "Get foods",
+					Params: []spec.Param{{
+						Name: "fdcIds", Type: "array", ItemType: "integer", Default: []any{534358, 373052},
+					}},
+					Response: spec.ResponseDef{Type: "array", Item: "Food"},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Food": {Fields: []spec.TypeField{{Name: "id", Type: "integer"}}},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "array-query-mcp-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	codeOrchSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "code_orch.go")
+	require.Contains(t, codeOrchSrc, `QueryArray: true, QueryStyle: "form", QueryExplode: true`)
+	runtimeTest := `package mcp
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestArrayQuerySerialization(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		want  []string
+	}{
+		{name: "native MCP array", value: []any{float64(534358), float64(373052)}, want: []string{"534358", "373052"}},
+		{name: "JSON encoded default", value: "[534358,373052]", want: []string{"534358", "373052"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := appendMCPArrayQueryParam("/foods", "fdcIds", tt.value, "form", true)
+			parsed, err := url.Parse(path)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, parsed.Query()["fdcIds"])
+		})
+	}
+
+	params := map[string]any{"fdcIds": []any{float64(534358), float64(373052)}}
+	path := codeOrchSplitQuery("/foods", []codeOrchParamBinding{{
+		PublicName: "fdcIds", WireName: "fdcIds", QueryArray: true, QueryStyle: "form", QueryExplode: true,
+	}}, params)
+	parsed, err := url.Parse(path)
+	require.NoError(t, err)
+	require.Equal(t, []string{"534358", "373052"}, parsed.Query()["fdcIds"])
+	require.Empty(t, params)
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "mcp", "array_query_test.go"), []byte(runtimeTest), 0o600))
+	runGoCommand(t, outputDir, "test", "./internal/mcp", "-run", "^TestArrayQuerySerialization$")
+
+	binaryPath := filepath.Join(outputDir, "array-query-mcp-pp-cli")
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/array-query-mcp-pp-cli")
+	runGeneratedBinary(t, binaryPath, "foods", "get")
+	require.Equal(t, []string{"534358", "373052"}, <-requests)
+}
+
+func TestGeneratedArrayQueryParamHonorsFormExplodeFalse(t *testing.T) {
+	t.Parallel()
+
+	requestURIs := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestURIs <- r.RequestURI
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	explode := false
+	apiSpec := minimalSpec("compact-array-query-param")
+	apiSpec.BaseURL = server.URL
+	apiSpec.Resources = map[string]spec.Resource{
+		"foods": {
+			Description: "Foods",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/foods",
+					Description: "Get foods",
+					Params: []spec.Param{{
+						Name: "fdcIds", Type: "array", ItemType: "integer", Description: "Food IDs",
+						QueryStyle: "form", QueryExplode: &explode,
+					}},
+					Response: spec.ResponseDef{Type: "array", Item: "Food"},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Food": {Fields: []spec.TypeField{{Name: "id", Type: "integer"}}},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "compact-array-query-param-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	requireGeneratedCompiles(t, outputDir)
+
+	binaryPath := filepath.Join(outputDir, "compact-array-query-param-pp-cli")
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/compact-array-query-param-pp-cli")
+	runGeneratedBinary(t, binaryPath, "foods", "get", "--fdc-ids", "534358,373052")
+
+	require.Contains(t, <-requestURIs, "fdcIds=534358%2C373052")
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -314,6 +314,10 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"flagName":                            flagName,
 		"paramIdent":                          paramIdent,
 		"paramWireName":                       paramWireName,
+		"isArrayQueryParam":                   isArrayQueryParam,
+		"queryParamStyle":                     queryParamStyle,
+		"queryParamExplodes":                  queryParamExplodes,
+		"hasArrayQueryParams":                 hasArrayQueryParams,
 		"typeFieldIdent":                      typeFieldIdent,
 		"typeFieldJSONTagComment":             typeFieldJSONTagComment,
 		"safeTypeName":                        safeTypeName,
@@ -5627,6 +5631,9 @@ type mcpParamBinding struct {
 	Location           string
 	BodyPath           []string
 	Format             string
+	QueryArray         bool
+	QueryStyle         string
+	QueryExplode       bool
 	RequestContentType string
 	Default            string
 }
@@ -5672,6 +5679,11 @@ func mcpParamBindings(endpoint spec.Endpoint, pathTemplate string) []mcpParamBin
 		// must match the cobra default rendering for CLI/MCP wire parity; keep in
 		// sync with that path (and cf. pipeline.stringifyParamDefault).
 		if loc == "query" {
+			if isArrayQueryParam(p) {
+				binding.QueryArray = true
+				binding.QueryStyle = queryParamStyle(p)
+				binding.QueryExplode = queryParamExplodes(p)
+			}
 			if def, ok := mcpParamDefaultValue(p); ok {
 				binding.Default = def
 			}
@@ -7150,6 +7162,27 @@ func isStringCSVArrayParam(p spec.Param) bool {
 		return true
 	}
 	return primitiveKind(p.Type) == "array" && strings.EqualFold(strings.TrimSpace(p.ItemType), "string") && len(p.Fields) == 0
+}
+
+func isArrayQueryParam(p spec.Param) bool {
+	return !p.Positional && !p.PathParam && primitiveKind(p.Type) == "array"
+}
+
+func queryParamStyle(p spec.Param) string {
+	if style := strings.TrimSpace(p.QueryStyle); style != "" {
+		return style
+	}
+	return "form"
+}
+
+func queryParamExplodes(p spec.Param) bool {
+	return p.QueryExplode == nil || *p.QueryExplode
+}
+
+func hasArrayQueryParams(apiSpec *spec.APISpec) bool {
+	return anyEndpointMatches(apiSpec, func(endpoint spec.Endpoint) bool {
+		return slices.ContainsFunc(endpoint.Params, isArrayQueryParam)
+	})
 }
 
 func csvArrayValueExpr(p spec.Param, inputExpr string) string {

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -187,6 +187,13 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			path = replacePathParam(path, "{{.Name}}", formatCLIParamValue(flag{{camel (paramIdent .)}}))
 {{- end}}
 {{- end}}
+{{- range .Endpoint.Params}}
+{{- if isArrayQueryParam .}}
+			if flag{{camel (paramIdent .)}} != "" {
+				path = appendArrayQueryParam(path, "{{paramWireName .}}", flag{{camel (paramIdent .)}}, "{{queryParamStyle .}}", {{queryParamExplodes .}})
+			}
+{{- end}}
+{{- end}}
 {{- if $isGraphQLEndpoint}}
 			_ = path
 {{- end}}
@@ -197,7 +204,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			htmlRequestParams["{{.Name}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam)}}
+{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
 				htmlRequestParams["{{.Name}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
@@ -323,7 +330,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
-{{- if and (not .Positional) (not .PathParam)}}
+{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
@@ -341,7 +348,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
-{{- if and (not .Positional) (not .PathParam)}}
+{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
@@ -353,7 +360,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam)}}
+{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
@@ -386,7 +393,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam)}}
+{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
@@ -466,7 +473,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam)}}
+{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
@@ -527,7 +534,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam)}}
+{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
@@ -590,7 +597,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam)}}
+{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -164,6 +164,13 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			path = replacePathParam(path, "{{.Name}}", formatCLIParamValue(flag{{camel (paramIdent .)}}))
 {{- end}}
 {{- end}}
+{{- range .Endpoint.Params}}
+{{- if isArrayQueryParam .}}
+			if flag{{camel (paramIdent .)}} != "" {
+				path = appendArrayQueryParam(path, "{{paramWireName .}}", flag{{camel (paramIdent .)}}, "{{queryParamStyle .}}", {{queryParamExplodes .}})
+			}
+{{- end}}
+{{- end}}
 
 {{- if .Endpoint.UsesHTMLResponse}}
 			htmlRequestParams := map[string]string{}
@@ -171,7 +178,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			htmlRequestParams["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam)}}
+{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
 				htmlRequestParams["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
@@ -197,7 +204,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
-{{- if and (not .Positional) (not .PathParam)}}
+{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
@@ -215,7 +222,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
-{{- if and (not .Positional) (not .PathParam)}}
+{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
@@ -228,7 +235,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam)}}
+{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-{{- if or .HasEmbeddedPaged .HasPathParams}}
+{{- if or .HasEmbeddedPaged .HasPathParams (hasArrayQueryParams .APISpec)}}
 	"net/url"
 {{- end}}
 	"os"
@@ -53,6 +53,53 @@ func formatCLIParamValue(v any) string {
 	}
 	return fmt.Sprintf("%v", v)
 }
+
+{{- if hasArrayQueryParams .APISpec}}
+func appendArrayQueryParam(path, name, raw, style string, explode bool) string {
+	values := make([]string, 0)
+	var decoded []any
+	if json.Unmarshal([]byte(raw), &decoded) == nil {
+		for _, value := range decoded {
+			values = append(values, formatCLIParamValue(value))
+		}
+	} else {
+		for _, value := range strings.Split(raw, ",") {
+			if value = strings.TrimSpace(value); value != "" {
+				values = append(values, value)
+			}
+		}
+	}
+	if len(values) == 0 {
+		return path
+	}
+
+	query := url.Values{}
+	switch style {
+	case "spaceDelimited":
+		query.Set(name, strings.Join(values, " "))
+	case "pipeDelimited":
+		query.Set(name, strings.Join(values, "|"))
+	case "form":
+		if explode {
+			for _, value := range values {
+				query.Add(name, value)
+			}
+		} else {
+			query.Set(name, strings.Join(values, ","))
+		}
+	default:
+		query.Set(name, raw)
+	}
+
+	encoded := query.Encode()
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return path + separator + encoded
+}
+
+{{- end}}
 
 {{- if hasMCPJSONOrScalarBody .APISpec}}
 func looksLikeJSONComposite(input string) bool {

--- a/internal/generator/templates/mcp_code_orch.go.tmpl
+++ b/internal/generator/templates/mcp_code_orch.go.tmpl
@@ -93,6 +93,11 @@ type codeOrchEndpoint struct {
 type codeOrchParamBinding struct {
 	PublicName string
 	WireName   string
+{{- if hasArrayQueryParams .APISpec}}
+	QueryArray bool
+	QueryStyle string
+	QueryExplode bool
+{{- end}}
 }
 
 // codeOrchEndpoints is the generator-populated registry covering every
@@ -115,7 +120,7 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 		Summary: {{printf "%q" (oneline $endpoint.Description)}},
 		Positional: []string{ {{- range $endpoint.Params}}{{if .Positional}}"{{.Name}}",{{end}}{{end}} },
 		TemplateParams: []codeOrchParamBinding{ {{- range mcpGlobalTemplateBindings $endpoint $path $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}},{{end}} },
-		QueryParams: []codeOrchParamBinding{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "query"}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}},{{end}}{{end}} },
+		QueryParams: []codeOrchParamBinding{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "query"}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}},{{end}}{{end}} },
 {{- if $endpoint.BodyIsArray}}
 		BodyIsArray: true,
 {{- end}}
@@ -141,7 +146,7 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 		Summary: {{printf "%q" (oneline $endpoint.Description)}},
 		Positional: []string{ {{- range $endpoint.Params}}{{if .Positional}}"{{.Name}}",{{end}}{{end}} },
 		TemplateParams: []codeOrchParamBinding{ {{- range mcpGlobalTemplateBindings $endpoint $path $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}},{{end}} },
-		QueryParams: []codeOrchParamBinding{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "query"}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}},{{end}}{{end}} },
+		QueryParams: []codeOrchParamBinding{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "query"}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}},{{end}}{{end}} },
 {{- if $endpoint.BodyIsArray}}
 		BodyIsArray: true,
 {{- end}}
@@ -318,6 +323,9 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 	// remaining params used as the request body below.
 	query := map[string]string{}
 	if ep.Method == "GET" || ep.Method == "DELETE" {
+{{- if hasArrayQueryParams .APISpec}}
+		path = codeOrchSplitQuery(path, ep.QueryParams, params)
+{{- end}}
 		for k, v := range params {
 			query[codeOrchWireQueryName(ep.QueryParams, k)] = formatMCPParamValue(v)
 		}
@@ -327,6 +335,9 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 		// PUT /ledger/voucher/{id}) wrongly lands in the JSON body and the
 		// API silently ignores it or rejects the request. The remaining
 		// params stay in the map for codeOrchWriteBody (the JSON body).
+{{- if hasArrayQueryParams .APISpec}}
+		path = codeOrchSplitQuery(path, ep.QueryParams, params)
+{{- else}}
 		if enc := codeOrchSplitQuery(ep.QueryParams, params); enc != "" {
 			sep := "?"
 			if strings.Contains(path, "?") {
@@ -334,6 +345,7 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 			}
 			path += sep + enc
 		}
+{{- end}}
 	}
 
 	hdrs := ep.HeaderOverrides
@@ -419,11 +431,15 @@ func codeOrchArrayBody(params map[string]any) any {
 }
 
 // codeOrchSplitQuery removes spec-declared in:query params from params and
+{{- if hasArrayQueryParams .APISpec}}
+// appends them URL-encoded to the request path. The remaining
+{{- else}}
 // returns them URL-encoded for appending to the request path. The remaining
+{{- end}}
 // entries stay in the map for codeOrchWriteBody (the JSON body), so a write
 // method's query parameters never get buried in the body. Mutates params by
 // design (deletes the consumed query keys).
-func codeOrchSplitQuery(queryParams []codeOrchParamBinding, params map[string]any) string {
+func codeOrchSplitQuery({{if hasArrayQueryParams .APISpec}}path string, {{end}}queryParams []codeOrchParamBinding, params map[string]any) string {
 	uv := neturl.Values{}
 	for _, q := range queryParams {
 		for _, key := range []string{q.PublicName, q.WireName} {
@@ -431,13 +447,32 @@ func codeOrchSplitQuery(queryParams []codeOrchParamBinding, params map[string]an
 				continue
 			}
 			if v, ok := params[key]; ok {
+{{- if hasArrayQueryParams .APISpec}}
+				if q.QueryArray {
+					path = appendMCPArrayQueryParam(path, q.WireName, v, q.QueryStyle, q.QueryExplode)
+				} else {
+					uv.Set(q.WireName, formatMCPParamValue(v))
+				}
+{{- else}}
 				uv.Set(q.WireName, formatMCPParamValue(v))
+{{- end}}
 				delete(params, key)
 				break
 			}
 		}
 	}
+{{- if hasArrayQueryParams .APISpec}}
+	if enc := uv.Encode(); enc != "" {
+		sep := "?"
+		if strings.Contains(path, "?") {
+			sep = "&"
+		}
+		path += sep + enc
+	}
+	return path
+{{- else}}
 	return uv.Encode()
+{{- end}}
 }
 
 func codeOrchWireQueryName(queryParams []codeOrchParamBinding, name string) string {

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -6,7 +6,7 @@
 {{- $hasBodyJSONFallback := hasBodyJSONFallback .APISpec}}
 {{- $hasNestedBodyPath := hasMCPNestedBodyPath .APISpec}}
 {{- $hasMCPJSONOrScalar := hasMCPJSONOrScalarBody .APISpec}}
-{{- $hasMCPBindingFormat := or $hasMultipartRequest $hasFormRequest $hasMCPJSONOrScalar}}
+{{- $hasMCPBindingFormat := or $hasMultipartRequest $hasFormRequest $hasMCPJSONOrScalar (hasArrayQueryParams .APISpec)}}
 {{- $hasMCPRequestContentType := or $hasMultipartRequest $hasFormRequest}}
 {{- $hasMCPParamDefault := hasMCPParamDefault .APISpec}}
 
@@ -95,9 +95,9 @@ func RegisterTools(s *server.MCPServer) {
 {{- end}}
 		),
 {{- if $.HasTierRouting}}
-		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveEndpointPath $resource $endpoint)}}, {{printf "%q" (effectiveTier $.APISpec $resource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveEndpointPath $resource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if and $hasMCPRequestContentType .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveEndpointPath $resource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
+		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveEndpointPath $resource $endpoint)}}, {{printf "%q" (effectiveTier $.APISpec $resource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveEndpointPath $resource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}{{if and $hasMCPRequestContentType .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveEndpointPath $resource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
 {{- else}}
-		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveEndpointPath $resource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveEndpointPath $resource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if and $hasMCPRequestContentType .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveEndpointPath $resource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
+		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveEndpointPath $resource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveEndpointPath $resource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}{{if and $hasMCPRequestContentType .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveEndpointPath $resource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
 {{- end}}
 	)
 {{- end}}
@@ -134,9 +134,9 @@ func RegisterTools(s *server.MCPServer) {
 {{- end}}
 		),
 {{- if $.HasTierRouting}}
-		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveSubEndpointPath $resource $subResource $endpoint)}}, {{printf "%q" (effectiveSubTier $.APISpec $resource $subResource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if and $hasMCPRequestContentType .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
+		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveSubEndpointPath $resource $subResource $endpoint)}}, {{printf "%q" (effectiveSubTier $.APISpec $resource $subResource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}{{if and $hasMCPRequestContentType .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
 {{- else}}
-		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveSubEndpointPath $resource $subResource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if and $hasMCPRequestContentType .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
+		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveSubEndpointPath $resource $subResource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}{{if and $hasMCPRequestContentType .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
 {{- end}}
 	)
 {{- end}}
@@ -202,6 +202,11 @@ type mcpParamBinding struct {
 {{- if $hasMCPBindingFormat}}
 	Format string
 {{- end}}
+{{- if hasArrayQueryParams .APISpec}}
+	QueryArray   bool
+	QueryStyle   string
+	QueryExplode bool
+{{- end}}
 {{- if $hasMCPRequestContentType}}
 	RequestContentType string
 {{- end}}
@@ -254,6 +259,63 @@ func formatMCPParamValue(v any) string {
 func mcpPathValue(v any) string {
 	return url.PathEscape(formatMCPParamValue(v))
 }
+
+{{- if hasArrayQueryParams .APISpec}}
+func appendMCPArrayQueryParam(path, name string, value any, style string, explode bool) string {
+	var values []string
+	switch typed := value.(type) {
+	case []any:
+		values = make([]string, 0, len(typed))
+		for _, item := range typed {
+			values = append(values, formatMCPParamValue(item))
+		}
+	case []string:
+		values = typed
+	default:
+		raw := formatMCPParamValue(value)
+		var decoded []any
+		if json.Unmarshal([]byte(raw), &decoded) == nil {
+			for _, item := range decoded {
+				values = append(values, formatMCPParamValue(item))
+			}
+		} else {
+			for _, item := range strings.Split(raw, ",") {
+				if item = strings.TrimSpace(item); item != "" {
+					values = append(values, item)
+				}
+			}
+		}
+	}
+	if len(values) == 0 {
+		return path
+	}
+
+	query := url.Values{}
+	switch style {
+	case "spaceDelimited":
+		query.Set(name, strings.Join(values, " "))
+	case "pipeDelimited":
+		query.Set(name, strings.Join(values, "|"))
+	case "form":
+		if explode {
+			for _, item := range values {
+				query.Add(name, item)
+			}
+		} else {
+			query.Set(name, strings.Join(values, ","))
+		}
+	default:
+		query.Set(name, formatMCPParamValue(value))
+	}
+
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return path + separator + query.Encode()
+}
+
+{{- end}}
 
 {{- if $hasMultipartRequest}}
 func mcpMultipartFieldValue(v any) string {
@@ -500,7 +562,15 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 				}
 {{- end}}
 			default:
+{{- if hasArrayQueryParams .APISpec}}
+				if binding.QueryArray {
+					path = appendMCPArrayQueryParam(path, binding.WireName, v, binding.QueryStyle, binding.QueryExplode)
+				} else {
+					params[binding.WireName] = formatMCPParamValue(v)
+				}
+{{- else}}
 				params[binding.WireName] = formatMCPParamValue(v)
+{{- end}}
 			}
 		}
 		for _, p := range positionalParams {

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -4464,10 +4464,13 @@ func mapParameters(pathItem *openapi3.PathItem, op *openapi3.Operation) []spec.P
 		}
 		param.Example = parameterExample(parameter, schema)
 		if parameter.In == openapi3.ParameterInQuery {
-			if serialization, err := parameter.SerializationMethod(); err == nil {
-				param.QueryStyle = serialization.Style
-				param.QueryExplode = &serialization.Explode
+			serialization, err := parameter.SerializationMethod()
+			if err != nil {
+				warnf("skipping query parameter %q with invalid serialization: %v", paramName, err)
+				continue
 			}
+			param.QueryStyle = serialization.Style
+			param.QueryExplode = &serialization.Explode
 			if !urlNameOverridesRead {
 				urlNameOverrides = readParamURLNameOverrides(pathItem, op)
 				urlNameOverridesRead = true

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -3489,7 +3489,10 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) error {
 				descriptionSynthesized = true
 			}
 
-			params := mapParameters(pathItem, op)
+			params, err := mapParameters(pathItem, op)
+			if err != nil {
+				return fmt.Errorf("map parameters for %s %q: %w", strings.ToUpper(method), path, err)
+			}
 			body, requestContentType, bodyJSONFallback, bodyRequired, bodyIsArray := mapRequestBody(op.RequestBody, method, path)
 
 			endpoint := spec.Endpoint{
@@ -4424,7 +4427,7 @@ func hasPathParams(path string) bool {
 	return strings.Contains(path, "{") && strings.Contains(path, "}")
 }
 
-func mapParameters(pathItem *openapi3.PathItem, op *openapi3.Operation) []spec.Param {
+func mapParameters(pathItem *openapi3.PathItem, op *openapi3.Operation) ([]spec.Param, error) {
 	merged := mergeParameters(pathItem, op)
 	var urlNameOverrides map[string]string
 	urlNameOverridesRead := false
@@ -4466,8 +4469,10 @@ func mapParameters(pathItem *openapi3.PathItem, op *openapi3.Operation) []spec.P
 		if parameter.In == openapi3.ParameterInQuery {
 			serialization, err := parameter.SerializationMethod()
 			if err != nil {
-				warnf("skipping query parameter %q with invalid serialization: %v", paramName, err)
-				continue
+				return nil, fmt.Errorf("query parameter %q has invalid serialization: %w", paramName, err)
+			}
+			if !supportedQuerySerialization(serialization) {
+				return nil, fmt.Errorf("query parameter %q has invalid serialization: style=%q explode=%t", paramName, serialization.Style, serialization.Explode)
 			}
 			param.QueryStyle = serialization.Style
 			param.QueryExplode = &serialization.Explode
@@ -4499,7 +4504,21 @@ func mapParameters(pathItem *openapi3.PathItem, op *openapi3.Operation) []spec.P
 	// instead of required positional args.
 	reclassifyPathParamModifiers(params)
 
-	return params
+	return params, nil
+}
+
+func supportedQuerySerialization(method *openapi3.SerializationMethod) bool {
+	if method == nil {
+		return false
+	}
+	switch method.Style {
+	case openapi3.SerializationForm, openapi3.SerializationSpaceDelimited, openapi3.SerializationPipeDelimited:
+		return true
+	case openapi3.SerializationDeepObject:
+		return method.Explode
+	default:
+		return false
+	}
 }
 
 // setParamMaximum records a numeric upper-bound constraint from the schema onto

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -4464,6 +4464,10 @@ func mapParameters(pathItem *openapi3.PathItem, op *openapi3.Operation) []spec.P
 		}
 		param.Example = parameterExample(parameter, schema)
 		if parameter.In == openapi3.ParameterInQuery {
+			if serialization, err := parameter.SerializationMethod(); err == nil {
+				param.QueryStyle = serialization.Style
+				param.QueryExplode = &serialization.Explode
+			}
 			if !urlNameOverridesRead {
 				urlNameOverrides = readParamURLNameOverrides(pathItem, op)
 				urlNameOverridesRead = true

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -523,6 +523,38 @@ func TestMapParametersOnlyMarksQueryFieldSelectors(t *testing.T) {
 	assert.Equal(t, spec.ParamPurposeFieldSelector, byName["opt_fields"].Purpose)
 }
 
+func TestMapParametersPreservesEffectiveQuerySerialization(t *testing.T) {
+	t.Parallel()
+
+	explodeFalse := false
+	op := &openapi3.Operation{
+		Parameters: openapi3.Parameters{
+			{Value: &openapi3.Parameter{
+				Name:   "default_ids",
+				In:     openapi3.ParameterInQuery,
+				Schema: openapi3.NewArraySchema().WithItems(openapi3.NewIntegerSchema()).NewRef(),
+			}},
+			{Value: &openapi3.Parameter{
+				Name:    "compact_ids",
+				In:      openapi3.ParameterInQuery,
+				Style:   openapi3.SerializationForm,
+				Explode: &explodeFalse,
+				Schema:  openapi3.NewArraySchema().WithItems(openapi3.NewIntegerSchema()).NewRef(),
+			}},
+		},
+	}
+
+	params := mapParameters(&openapi3.PathItem{}, op)
+	require.Len(t, params, 2)
+
+	assert.Equal(t, "form", params[0].QueryStyle)
+	require.NotNil(t, params[0].QueryExplode)
+	assert.True(t, *params[0].QueryExplode, "query parameters default to explode=true")
+	assert.Equal(t, "form", params[1].QueryStyle)
+	require.NotNil(t, params[1].QueryExplode)
+	assert.False(t, *params[1].QueryExplode)
+}
+
 // TestMapParametersDropsPhantomBracketName verifies that phantom parameter
 // names are dropped (issue #1670). A spec parameter literally named "[]" (or
 // empty) is not a usable MCP/CLI argument and would emit "?[]=value" on the

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -511,7 +511,8 @@ func TestMapParametersOnlyMarksQueryFieldSelectors(t *testing.T) {
 		},
 	}
 
-	params := mapParameters(pathItem, op)
+	params, err := mapParameters(pathItem, op)
+	require.NoError(t, err)
 	require.Len(t, params, 2)
 
 	byName := make(map[string]spec.Param, len(params))
@@ -544,7 +545,8 @@ func TestMapParametersPreservesEffectiveQuerySerialization(t *testing.T) {
 		},
 	}
 
-	params := mapParameters(&openapi3.PathItem{}, op)
+	params, err := mapParameters(&openapi3.PathItem{}, op)
+	require.NoError(t, err)
 	require.Len(t, params, 2)
 
 	assert.Equal(t, "form", params[0].QueryStyle)
@@ -575,7 +577,9 @@ func TestMapParametersDropsPhantomBracketName(t *testing.T) {
 	}
 
 	byName := make(map[string]bool)
-	for _, p := range mapParameters(pathItem, op) {
+	params, err := mapParameters(pathItem, op)
+	require.NoError(t, err)
+	for _, p := range params {
 		byName[p.Name] = true
 	}
 
@@ -583,6 +587,20 @@ func TestMapParametersDropsPhantomBracketName(t *testing.T) {
 	assert.False(t, byName["  "], "whitespace-only param name must be dropped")
 	assert.True(t, byName["tags[]"], "legitimate array-style param must be kept")
 	assert.True(t, byName["limit"], "normal param must be kept")
+}
+
+func TestMapParametersRejectsInvalidQuerySerialization(t *testing.T) {
+	t.Parallel()
+
+	op := &openapi3.Operation{Parameters: openapi3.Parameters{{Value: &openapi3.Parameter{
+		Name:   "ids",
+		In:     openapi3.ParameterInQuery,
+		Style:  openapi3.SerializationMatrix,
+		Schema: openapi3.NewArraySchema().WithItems(openapi3.NewIntegerSchema()).NewRef(),
+	}}}}
+
+	_, err := mapParameters(&openapi3.PathItem{}, op)
+	require.ErrorContains(t, err, `query parameter "ids" has invalid serialization`)
 }
 
 func readAICLargeSpec(tb testing.TB) []byte {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -2323,22 +2323,24 @@ func (h *HTMLExtract) EffectiveScriptSelector() string {
 }
 
 type Param struct {
-	Name        string   `yaml:"name" json:"name"`
-	FlagName    string   `yaml:"flag_name,omitempty" json:"flag_name,omitempty"`
-	URLName     string   `yaml:"url_name,omitempty" json:"url_name,omitempty"`   // optional override for URL query-key emission (e.g., "$limit" for Socrata while keeping --limit flag)
-	BodyName    string   `yaml:"body_name,omitempty" json:"body_name,omitempty"` // optional override for request-body field emission while keeping the public name
-	Aliases     []string `yaml:"aliases,omitempty" json:"aliases,omitempty"`
-	Type        string   `yaml:"type" json:"type"`
-	Required    bool     `yaml:"required" json:"required"`
-	Positional  bool     `yaml:"positional" json:"positional"`
-	PathParam   bool     `yaml:"path_param,omitempty" json:"path_param,omitempty"` // true for path params rendered as flags (e.g., pagination)
-	GlobalScope bool     `yaml:"global_scope,omitempty" json:"global_scope,omitempty"`
-	Default     any      `yaml:"default" json:"default"`
-	Example     any      `yaml:"example,omitempty" json:"example,omitempty"`
-	Description string   `yaml:"description" json:"description"`
-	Fields      []Param  `yaml:"fields" json:"fields"`                     // for nested objects
-	Enum        []string `yaml:"enum,omitempty" json:"enum,omitempty"`     // enum constraints for the parameter
-	Format      string   `yaml:"format,omitempty" json:"format,omitempty"` // OpenAPI format hints (date-time, email, uri, etc.)
+	Name         string   `yaml:"name" json:"name"`
+	FlagName     string   `yaml:"flag_name,omitempty" json:"flag_name,omitempty"`
+	URLName      string   `yaml:"url_name,omitempty" json:"url_name,omitempty"`   // optional override for URL query-key emission (e.g., "$limit" for Socrata while keeping --limit flag)
+	BodyName     string   `yaml:"body_name,omitempty" json:"body_name,omitempty"` // optional override for request-body field emission while keeping the public name
+	Aliases      []string `yaml:"aliases,omitempty" json:"aliases,omitempty"`
+	Type         string   `yaml:"type" json:"type"`
+	Required     bool     `yaml:"required" json:"required"`
+	Positional   bool     `yaml:"positional" json:"positional"`
+	PathParam    bool     `yaml:"path_param,omitempty" json:"path_param,omitempty"` // true for path params rendered as flags (e.g., pagination)
+	GlobalScope  bool     `yaml:"global_scope,omitempty" json:"global_scope,omitempty"`
+	Default      any      `yaml:"default" json:"default"`
+	Example      any      `yaml:"example,omitempty" json:"example,omitempty"`
+	Description  string   `yaml:"description" json:"description"`
+	Fields       []Param  `yaml:"fields" json:"fields"`                     // for nested objects
+	Enum         []string `yaml:"enum,omitempty" json:"enum,omitempty"`     // enum constraints for the parameter
+	Format       string   `yaml:"format,omitempty" json:"format,omitempty"` // OpenAPI format hints (date-time, email, uri, etc.)
+	QueryStyle   string   `yaml:"query_style,omitempty" json:"query_style,omitempty"`
+	QueryExplode *bool    `yaml:"query_explode,omitempty" json:"query_explode,omitempty"`
 	// Maximum captures an inclusive numeric `maximum` schema constraint on the
 	// parameter. Sync uses it to clamp the page size it requests so a generated
 	// CLI never sends a page size the API rejects (e.g. a page_size param with


### PR DESCRIPTION
## Summary

OpenAPI array query parameters now preserve their effective style and explode semantics instead of collapsing into one comma-containing value. Generated CLI commands, typed MCP endpoint tools, and code-orchestration execute all emit repeated keys by default while retaining compact serialization for `explode: false`; omitted array defaults follow the same path.

## Validation

- `go test ./... -timeout 20m`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`
- `golangci-lint run ./...`

Closes #3437
