### PR TITLE
fix(cli): gate nested required fields by parent

### DIFF
--- a/internal/generator/body_map_test.go
+++ b/internal/generator/body_map_test.go
@@ -280,7 +280,7 @@ func TestBodyMap_NestedObject_BooleanLeaf(t *testing.T) {
 	}
 }
 
-func TestBodyMap_NestedObject_BooleanDefaultIsEmitted(t *testing.T) {
+func TestBodyMap_NestedObject_DefaultTrueBooleanRequiresChangedFlag(t *testing.T) {
 	t.Parallel()
 	got := bodyMap([]spec.Param{{
 		Name: "settings",
@@ -290,8 +290,8 @@ func TestBodyMap_NestedObject_BooleanDefaultIsEmitted(t *testing.T) {
 		},
 	}}, "\t")
 
-	require.Contains(t, got, `if cmd.Flags().Changed("settings-enabled") || bodySettingsEnabled != false {`)
-	require.Contains(t, got, `nestedSettings["enabled"] = bodySettingsEnabled`)
+	require.Contains(t, got, `if cmd.Flags().Changed("settings-enabled") {`)
+	require.NotContains(t, got, `bodySettingsEnabled != false`)
 }
 
 // TestBodyMap_NestedObject_PreservesScalarSiblings verifies that

--- a/internal/generator/body_map_test.go
+++ b/internal/generator/body_map_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
 )
 
 // TestBodyMap pins the rendered Go code for each of the three body-param
@@ -507,10 +508,10 @@ func TestBodyFlagRegs_NonJSONStaysFlat(t *testing.T) {
 	}
 }
 
-// TestBodyRequiredChecks_NestedField uses parent-prefixed flag in the
-// emitted `cmd.Flags().Changed(...)` call so the validator agrees with
-// the flag name registered in bodyFlagRegs.
-func TestBodyRequiredChecks_NestedField(t *testing.T) {
+// TestBodyRequiredChecks_OptionalNestedObject gates required child fields on
+// the optional parent being populated. JSON Schema's child `required` list
+// applies only when the parent object is present.
+func TestBodyRequiredChecks_OptionalNestedObject(t *testing.T) {
 	t.Parallel()
 	got := bodyRequiredChecks(spec.Endpoint{
 		Body: []spec.Param{{
@@ -518,14 +519,97 @@ func TestBodyRequiredChecks_NestedField(t *testing.T) {
 			Type: "object",
 			Fields: []spec.Param{
 				{Name: "dateTime", Type: "string", Required: true},
+				{Name: "timeZone", Type: "string"},
 			},
 		}},
 	}, "\t\t\t")
-	if !strings.Contains(got, `cmd.Flags().Changed("start-date-time")`) {
-		t.Errorf("expected parent-prefixed Changed() call for nested required field, got:\n%s", got)
+	require.Contains(t, got, `if bodyStartDateTime != "" || bodyStartTimeZone != "" {`)
+	require.Contains(t, got, `if !cmd.Flags().Changed("start-date-time") && !flags.dryRun {`)
+	require.Contains(t, got, `"required flag \"%s\" not set", "start-date-time"`)
+}
+
+func TestBodyRequiredChecks_OptionalNestedObjectDefaultActivatesParent(t *testing.T) {
+	t.Parallel()
+	got := bodyRequiredChecks(spec.Endpoint{
+		Body: []spec.Param{{
+			Name: "start",
+			Type: "object",
+			Fields: []spec.Param{
+				{Name: "dateTime", Type: "string", Required: true},
+				{Name: "timeZone", Type: "string", Default: "UTC"},
+			},
+		}},
+	}, "\t\t\t")
+	require.Contains(t, got, `if bodyStartDateTime != "" || bodyStartTimeZone != "" {`)
+	require.Contains(t, got, `if !cmd.Flags().Changed("start-date-time") && !flags.dryRun {`)
+}
+
+func TestBodyRequiredChecks_RecursiveOptionalObjects(t *testing.T) {
+	t.Parallel()
+	got := bodyRequiredChecks(spec.Endpoint{
+		Body: []spec.Param{{
+			Name: "outer",
+			Type: "object",
+			Fields: []spec.Param{
+				{Name: "label", Type: "string"},
+				{
+					Name: "config",
+					Type: "object",
+					Fields: []spec.Param{
+						{Name: "mode", Type: "string", Required: true},
+						{Name: "note", Type: "string"},
+					},
+				},
+			},
+		}},
+	}, "\t\t\t")
+	require.Contains(t, got, `if bodyOuterLabel != "" || bodyOuterConfigMode != "" || bodyOuterConfigNote != "" {`)
+	require.Contains(t, got, `if bodyOuterConfigMode != "" || bodyOuterConfigNote != "" {`)
+	require.Contains(t, got, `if !cmd.Flags().Changed("outer-config-mode") && !flags.dryRun {`)
+}
+
+func TestBodyRequiredChecks_RequiredNestedObjectRemainsUnconditional(t *testing.T) {
+	t.Parallel()
+	got := bodyRequiredChecks(spec.Endpoint{
+		Body: []spec.Param{{
+			Name:     "start",
+			Type:     "object",
+			Required: true,
+			Fields: []spec.Param{
+				{Name: "dateTime", Type: "string", Required: true},
+				{Name: "timeZone", Type: "string"},
+			},
+		}},
+	}, "\t\t\t")
+	require.NotContains(t, got, `cmd.Flags().Changed("start-time-zone")`)
+	require.Contains(t, got, `if !cmd.Flags().Changed("start-date-time") && !flags.dryRun {`)
+}
+
+func TestMCPBodyInputParams_NestedRequiredFollowsParent(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		parentRequired bool
+		wantRequired   bool
+	}{
+		{name: "optional parent", parentRequired: false, wantRequired: false},
+		{name: "required parent", parentRequired: true, wantRequired: true},
 	}
-	if !strings.Contains(got, `"required flag \"%s\" not set", "start-date-time"`) {
-		t.Errorf("expected parent-prefixed flag name in error message, got:\n%s", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := mcpBodyInputParams(spec.Endpoint{Body: []spec.Param{{
+				Name:     "start",
+				Type:     "object",
+				Required: tt.parentRequired,
+				Fields: []spec.Param{{
+					Name: "dateTime", Type: "string", Required: true,
+				}},
+			}}})
+			require.Len(t, got, 1)
+			require.Equal(t, tt.wantRequired, got[0].Required)
+			require.Equal(t, "start-date-time", got[0].FlagName)
+		})
 	}
 }
 

--- a/internal/generator/body_map_test.go
+++ b/internal/generator/body_map_test.go
@@ -280,6 +280,20 @@ func TestBodyMap_NestedObject_BooleanLeaf(t *testing.T) {
 	}
 }
 
+func TestBodyMap_NestedObject_BooleanDefaultIsEmitted(t *testing.T) {
+	t.Parallel()
+	got := bodyMap([]spec.Param{{
+		Name: "settings",
+		Type: "object",
+		Fields: []spec.Param{
+			{Name: "enabled", Type: "boolean", Default: true},
+		},
+	}}, "\t")
+
+	require.Contains(t, got, `if cmd.Flags().Changed("settings-enabled") || bodySettingsEnabled != false {`)
+	require.Contains(t, got, `nestedSettings["enabled"] = bodySettingsEnabled`)
+}
+
 // TestBodyMap_NestedObject_PreservesScalarSiblings verifies that
 // nested and flat body params can coexist: nested produces a block,
 // scalars keep their existing if-then-set form.

--- a/internal/generator/body_nested_object_test.go
+++ b/internal/generator/body_nested_object_test.go
@@ -92,8 +92,10 @@ func TestGenerateNestedObjectBodyEmitsFieldFlags(t *testing.T) {
 		require.Containsf(t, got, want, "expected flag registration %q", want)
 	}
 
-	// Required-flag validation: parent-prefixed flag in the error message
-	// matches the registered flag name.
+	// Required-flag validation: the nested requirement applies only when the
+	// optional start object is populated, and the parent-prefixed flag in the
+	// error message matches the registered flag name.
+	require.Contains(t, got, `if bodyStartDateTime != "" || bodyStartTimeZone != "" {`)
 	require.Contains(t, got, `cmd.Flags().Changed("start-date-time")`, "required check must use parent-prefixed flag")
 	require.Contains(t, got, `"required flag \"%s\" not set", "start-date-time"`)
 
@@ -120,6 +122,65 @@ func TestGenerateNestedObjectBodyEmitsFieldFlags(t *testing.T) {
 	fset := token.NewFileSet()
 	_, parseErr := parser.ParseFile(fset, "events_create.go", got, parser.AllErrors)
 	require.NoError(t, parseErr, "generated file with nested-object body must parse as Go")
+
+	mcpGot := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
+	require.Contains(t, mcpGot, `mcplib.WithString("start-date-time", mcplib.Description("RFC3339 timestamp"))`)
+	require.NotContains(t, mcpGot, `mcplib.WithString("start-date-time", mcplib.Required()`)
+
+	runtimeTest := `package cli
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func runNestedRequiredCommand(t *testing.T, args ...string) error {
+	t.Helper()
+	var flags rootFlags
+	cmd := newRootCmd(&flags)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+func TestOptionalNestedRequiredRuntime(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{}"))
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MYAPI_TOKEN", "test-token")
+	t.Setenv("NESTED_BODY_BASE_URL", server.URL)
+
+	if err := runNestedRequiredCommand(t, "events", "create", "--subject", "Planning"); err != nil {
+		t.Fatalf("optional parent omitted: %v", err)
+	}
+	err := runNestedRequiredCommand(t, "events", "create", "--subject", "Planning", "--start-time-zone", "UTC")
+	if err == nil || !strings.Contains(err.Error(), "required flag \"start-date-time\" not set") {
+		t.Fatalf("partially populated parent error = %v", err)
+	}
+	if err := runNestedRequiredCommand(t, "events", "create", "--subject", "Planning", "--start-time-zone", "UTC", "--start-date-time", "2026-07-13T12:00:00Z"); err != nil {
+		t.Fatalf("complete optional parent: %v", err)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "nested_required_runtime_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestOptionalNestedRequiredRuntime", "-count=1")
+	requireGeneratedCompiles(t, outputDir)
+
+	promotedSpec := apiSpec
+	delete(promotedSpec.Resources["events"].Endpoints, "get")
+	promotedOutputDir := filepath.Join(t.TempDir(), "nested-body-promoted-pp-cli")
+	require.NoError(t, New(promotedSpec, promotedOutputDir).Generate())
+	promoted := readGeneratedFile(t, promotedOutputDir, "internal", "cli", "promoted_events.go")
+	require.Contains(t, promoted, `if bodyStartDateTime != "" || bodyStartTimeZone != "" {`)
+	require.Contains(t, promoted, `if !cmd.Flags().Changed("start-date-time") && !flags.dryRun {`)
+	requireGeneratedCompiles(t, promotedOutputDir)
 }
 
 func TestGenerateInternalYAMLBodyObjectSchema(t *testing.T) {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -6332,7 +6332,7 @@ func renderBodyMap(b *strings.Builder, body []spec.Param, depth int, indent, map
 			// false" from "user did not touch the flag" and is correct
 			// for POST, PUT, and PATCH. Internal YAML specs use "boolean";
 			// the OpenAPI parser normalizes to "bool".
-			fmt.Fprintf(b, "%sif cmd.Flags().Changed(%q) {\n", indent, flag)
+			fmt.Fprintf(b, "%sif %s {\n", indent, bodyLeafPresenceExpr(p, ident, flag))
 			fmt.Fprintf(b, "%s\t%s[%q] = body%s\n", indent, mapVar, p.BodyWireName(), ident)
 			fmt.Fprintf(b, "%s}\n", indent)
 			continue
@@ -6353,6 +6353,9 @@ func renderBodyMap(b *strings.Builder, body []spec.Param, depth int, indent, map
 
 func bodyLeafPresenceExpr(p spec.Param, ident, flag string) string {
 	if (p.Type == "boolean" || p.Type == "bool") && (!p.Required || p.Default != nil) {
+		if p.Default != nil {
+			return fmt.Sprintf("cmd.Flags().Changed(%q) || body%s != %s", flag, ident, zeroValForParamRequired(p.Name, p.Type, p.Required, true))
+		}
 		return fmt.Sprintf("cmd.Flags().Changed(%q)", flag)
 	}
 	return fmt.Sprintf("body%s != %s", ident, zeroValForParamRequired(p.Name, p.Type, p.Required, paramHasDefault(p)))

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -5786,19 +5786,20 @@ func mcpBodyInputParams(endpoint spec.Endpoint) []spec.Param {
 	}
 	body := flattenCollidingBodyFields(endpoint.Body)
 	params := make([]spec.Param, 0, len(body))
-	collectMCPBodyInputParams(&params, body, 0, "")
+	collectMCPBodyInputParams(&params, body, 0, "", true)
 	return params
 }
 
-func collectMCPBodyInputParams(params *[]spec.Param, body []spec.Param, depth int, flagPrefix string) {
+func collectMCPBodyInputParams(params *[]spec.Param, body []spec.Param, depth int, flagPrefix string, ancestorsRequired bool) {
 	for _, p := range body {
 		if p.Type == "object" && len(p.Fields) > 0 {
 			if depth+1 >= maxBodyFlagDepth {
 				continue
 			}
-			collectMCPBodyInputParams(params, p.Fields, depth+1, joinFlag(flagPrefix, publicFlagName(p)))
+			collectMCPBodyInputParams(params, p.Fields, depth+1, joinFlag(flagPrefix, publicFlagName(p)), ancestorsRequired && p.Required)
 			continue
 		}
+		p.Required = p.Required && ancestorsRequired
 		if flagPrefix != "" {
 			p.FlagName = joinFlag(flagPrefix, publicFlagName(p))
 			p.Aliases = nil
@@ -6276,7 +6277,7 @@ func renderBodyMap(b *strings.Builder, body []spec.Param, depth int, indent, map
 			continue
 		}
 		if isStringCSVArrayParam(p) {
-			fmt.Fprintf(b, "%sif body%s != \"\" {\n", indent, ident)
+			fmt.Fprintf(b, "%sif %s {\n", indent, bodyLeafPresenceExpr(p, ident, flag))
 			if strings.EqualFold(strings.TrimSpace(p.ItemType), "object") {
 				fmt.Fprintf(b, "%s\t%s[%q] = %s\n", indent, mapVar, p.BodyWireName(), csvArrayValueExpr(p, "body"+ident))
 			} else {
@@ -6290,7 +6291,7 @@ func renderBodyMap(b *strings.Builder, body []spec.Param, depth int, indent, map
 			continue
 		}
 		if isJSONOrScalarParam(p) {
-			fmt.Fprintf(b, "%sif body%s != \"\" {\n", indent, ident)
+			fmt.Fprintf(b, "%sif %s {\n", indent, bodyLeafPresenceExpr(p, ident, flag))
 			fmt.Fprintf(b, "%s\tif looksLikeJSONComposite(body%s) {\n", indent, ident)
 			fmt.Fprintf(b, "%s\t\tvar parsed%s any\n", indent, ident)
 			fmt.Fprintf(b, "%s\t\tif err := json.Unmarshal([]byte(body%s), &parsed%s); err != nil {\n", indent, ident, ident)
@@ -6312,7 +6313,7 @@ func renderBodyMap(b *strings.Builder, body []spec.Param, depth int, indent, map
 			if isComplex {
 				rhs = "parsed" + ident
 			}
-			fmt.Fprintf(b, "%sif body%s != \"\" {\n", indent, ident)
+			fmt.Fprintf(b, "%sif %s {\n", indent, bodyLeafPresenceExpr(p, ident, flag))
 			fmt.Fprintf(b, "%s\tvar parsed%s any\n", indent, ident)
 			fmt.Fprintf(b, "%s\tif err := json.Unmarshal([]byte(body%s), &parsed%s); err != nil {\n", indent, ident, ident)
 			fmt.Fprintf(b, "%s\t\treturn fmt.Errorf(\"parsing --%s JSON: %%w\", err)\n", indent, flag)
@@ -6336,7 +6337,7 @@ func renderBodyMap(b *strings.Builder, body []spec.Param, depth int, indent, map
 			fmt.Fprintf(b, "%s}\n", indent)
 			continue
 		}
-		fmt.Fprintf(b, "%sif body%s != %s {\n", indent, ident, zeroValForParamRequired(p.Name, p.Type, p.Required, paramHasDefault(p)))
+		fmt.Fprintf(b, "%sif %s {\n", indent, bodyLeafPresenceExpr(p, ident, flag))
 		if isStringBackedBoolParam(p) {
 			fmt.Fprintf(b, "%s\tparsed%s, err := strconv.ParseBool(body%s)\n", indent, ident, ident)
 			fmt.Fprintf(b, "%s\tif err != nil {\n", indent)
@@ -6348,6 +6349,13 @@ func renderBodyMap(b *strings.Builder, body []spec.Param, depth int, indent, map
 		}
 		fmt.Fprintf(b, "%s}\n", indent)
 	}
+}
+
+func bodyLeafPresenceExpr(p spec.Param, ident, flag string) string {
+	if (p.Type == "boolean" || p.Type == "bool") && (!p.Required || p.Default != nil) {
+		return fmt.Sprintf("cmd.Flags().Changed(%q)", flag)
+	}
+	return fmt.Sprintf("body%s != %s", ident, zeroValForParamRequired(p.Name, p.Type, p.Required, paramHasDefault(p)))
 }
 
 func bodyHasStringBackedBool(endpoint spec.Endpoint) bool {
@@ -6501,6 +6509,9 @@ func renderFlatBodyFlagReg(b *strings.Builder, p spec.Param, identPrefix, flagPr
 // behavior. For non-multipart, top-level params use flagChangedExpr
 // (lifts aliases); nested fields use a single Changed() check on the
 // parent-prefixed flag because aliases are not propagated to children.
+// Required fields below an optional object are checked only when any flag
+// in that object was supplied, matching JSON Schema's conditional presence
+// semantics for nested required lists.
 func bodyRequiredChecks(endpoint spec.Endpoint, indent string) string {
 	var b strings.Builder
 	if endpoint.BodyJSONFallback {
@@ -6517,22 +6528,57 @@ func bodyRequiredChecks(endpoint spec.Endpoint, indent string) string {
 		}
 		return b.String()
 	}
-	renderBodyRequiredChecks(&b, flattenCollidingBodyFields(endpoint.Body), 0, indent, "", true)
+	renderBodyRequiredChecks(&b, flattenCollidingBodyFields(endpoint.Body), 0, indent, "", "", true)
 	return b.String()
 }
 
-func renderBodyRequiredChecks(b *strings.Builder, body []spec.Param, depth int, indent, flagPrefix string, topLevel bool) {
+func renderBodyRequiredChecks(b *strings.Builder, body []spec.Param, depth int, indent, flagPrefix, identPrefix string, topLevel bool) {
 	for _, p := range body {
 		if p.Type == "object" && len(p.Fields) > 0 {
 			if depth+1 >= maxBodyFlagDepth {
 				continue
 			}
 			flag := joinFlag(flagPrefix, publicFlagName(p))
-			renderBodyRequiredChecks(b, p.Fields, depth+1, indent, flag, false)
+			ident := identPrefix + toCamel(paramIdent(p))
+			if p.Required {
+				renderBodyRequiredChecks(b, p.Fields, depth+1, indent, flag, ident, false)
+				continue
+			}
+			var nested strings.Builder
+			renderBodyRequiredChecks(&nested, p.Fields, depth+1, indent+"\t", flag, ident, false)
+			if nested.Len() == 0 {
+				continue
+			}
+			changedExpr := bodyFieldsChangedExpr(p.Fields, depth+1, flag, ident)
+			if changedExpr == "" {
+				continue
+			}
+			fmt.Fprintf(b, "\n%sif %s {", indent, changedExpr)
+			b.WriteString(nested.String())
+			fmt.Fprintf(b, "\n%s}", indent)
 			continue
 		}
 		renderFlatBodyRequiredCheck(b, p, indent, flagPrefix, topLevel)
 	}
+}
+
+func bodyFieldsChangedExpr(body []spec.Param, depth int, flagPrefix, identPrefix string) string {
+	var expressions []string
+	for _, p := range body {
+		flag := joinFlag(flagPrefix, publicFlagName(p))
+		ident := identPrefix + toCamel(paramIdent(p))
+		if p.Type == "object" && len(p.Fields) > 0 {
+			if depth+1 >= maxBodyFlagDepth {
+				continue
+			}
+			if nested := bodyFieldsChangedExpr(p.Fields, depth+1, flag, ident); nested != "" {
+				expressions = append(expressions, nested)
+			}
+			continue
+		}
+		expressions = append(expressions, bodyLeafPresenceExpr(p, ident, flag))
+	}
+	return strings.Join(expressions, " || ")
 }
 
 // bodyExceedsFlagDepth reports whether emitting per-field body flags for

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -6277,7 +6277,7 @@ func renderBodyMap(b *strings.Builder, body []spec.Param, depth int, indent, map
 			continue
 		}
 		if isStringCSVArrayParam(p) {
-			fmt.Fprintf(b, "%sif %s {\n", indent, bodyLeafPresenceExpr(p, ident, flag))
+			fmt.Fprintf(b, "%sif cmd.Flags().Changed(%q) {\n", indent, flag)
 			if strings.EqualFold(strings.TrimSpace(p.ItemType), "object") {
 				fmt.Fprintf(b, "%s\t%s[%q] = %s\n", indent, mapVar, p.BodyWireName(), csvArrayValueExpr(p, "body"+ident))
 			} else {
@@ -6353,9 +6353,6 @@ func renderBodyMap(b *strings.Builder, body []spec.Param, depth int, indent, map
 
 func bodyLeafPresenceExpr(p spec.Param, ident, flag string) string {
 	if (p.Type == "boolean" || p.Type == "bool") && (!p.Required || p.Default != nil) {
-		if p.Default != nil {
-			return fmt.Sprintf("cmd.Flags().Changed(%q) || body%s != %s", flag, ident, zeroValForParamRequired(p.Name, p.Type, p.Required, true))
-		}
 		return fmt.Sprintf("cmd.Flags().Changed(%q)", flag)
 	}
 	return fmt.Sprintf("body%s != %s", ident, zeroValForParamRequired(p.Name, p.Type, p.Required, paramHasDefault(p)))


### PR DESCRIPTION
## Summary

Generated commands no longer require nested body fields when their optional parent object is omitted. When any sibling populates that parent, its required children are still validated before the request; required parent objects remain unconditional, defaults use the same presence rules as serialization, and typed MCP inputs no longer hoist conditional child requirements to the top level.

Generated runtime coverage proves omitted, partial, and complete optional-object cases on endpoint and promoted command shapes. The full Go suite, all 32 golden cases, and all 10 generated-output compile cases pass.

Closes #2895

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
