### PR TITLE
fix(verify-skill): honor private module install paths

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -359,7 +359,7 @@ func newPublishPackageCmd() *cobra.Command {
 				cleanupOnFailure()
 				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("backfilling printer attribution: %w", err)}
 			}
-			if err := normalizePackagedPublishMetadata(outCLIDir, category); err != nil {
+			if err := normalizePackagedPublishMetadata(outCLIDir, category, modulePath); err != nil {
 				cleanupOnFailure()
 				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("normalizing publish metadata: %w", err)}
 			}
@@ -1085,7 +1085,7 @@ func backfillPackagedManifestAttribution(dir string) error {
 	return os.WriteFile(manifestPath, updated, info.Mode())
 }
 
-func normalizePackagedPublishMetadata(dir, category string) error {
+func normalizePackagedPublishMetadata(dir, category, modulePath string) error {
 	manifestPath := filepath.Join(dir, pipeline.CLIManifestFilename)
 	data, err := os.ReadFile(manifestPath)
 	if err != nil {
@@ -1100,12 +1100,24 @@ func normalizePackagedPublishMetadata(dir, category string) error {
 		return err
 	}
 
+	changed := false
 	if strings.TrimSpace(manifest.Category) != category {
 		encoded, err := json.Marshal(category)
 		if err != nil {
 			return err
 		}
 		raw["category"] = encoded
+		changed = true
+	}
+	if strings.TrimSpace(modulePath) != "" && strings.TrimSpace(manifest.ModulePath) != strings.TrimSpace(modulePath) {
+		encoded, err := json.Marshal(strings.TrimSpace(modulePath))
+		if err != nil {
+			return err
+		}
+		raw["module_path"] = encoded
+		changed = true
+	}
+	if changed {
 		updated, err := json.MarshalIndent(raw, "", "  ")
 		if err != nil {
 			return err

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -930,6 +930,19 @@ func TestPublishPackageNormalizesManifestCategoryToPublishCategory(t *testing.T)
 	assert.Equal(t, "productivity", source.Category, "publish package should normalize only the staged copy")
 }
 
+func TestNormalizePackagedPublishMetadataRecordsCustomModulePath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, pipeline.CLIManifestFilename)
+	require.NoError(t, os.WriteFile(manifestPath, []byte(`{"schema_version":2,"api_name":"ronanrx","cli_name":"ronanrx-pp-cli","category":"health"}`), 0o644))
+	modulePath := "github.com/RonanRx/printing-press-library/library/health/ronanrx"
+	require.NoError(t, normalizePackagedPublishMetadata(dir, "health", modulePath))
+
+	manifest, err := pipeline.ReadCLIManifest(dir)
+	require.NoError(t, err)
+	require.Equal(t, modulePath, manifest.ModulePath)
+}
+
 func TestPublishPackageFailsWhenSkillReferencesUnknownCommand(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")

--- a/internal/cli/verify_skill.go
+++ b/internal/cli/verify_skill.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/generator"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline"
 	"github.com/spf13/cobra"
+	"golang.org/x/mod/modfile"
 )
 
 // verifySkillScript is the full text of scripts/verify-skill/verify_skill.py
@@ -144,8 +145,17 @@ func runCanonicalSectionsCheck(dir string) (finding canonicalFinding, hasFinding
 		return canonicalFinding{}, false, true, nil
 	}
 
-	if _, gErr := os.Stat(filepath.Join(dir, "go.mod")); gErr != nil {
+	goModBytes, gErr := os.ReadFile(filepath.Join(dir, "go.mod"))
+	if gErr != nil {
 		return canonicalFinding{}, false, true, nil
+	}
+	declaredModulePath := modfile.ModulePath(goModBytes)
+	modulePath := strings.TrimSpace(manifest.ModulePath)
+	if modulePath != "" && modulePath != declaredModulePath {
+		return canonicalFinding{
+			Check: canonicalSectionsCheckName, Severity: "error", Command: "(file: .printing-press.json)",
+			Detail: fmt.Sprintf("manifest module_path %q does not match go.mod module %q", modulePath, declaredModulePath),
+		}, true, false, nil
 	}
 
 	skillBytes, sErr := os.ReadFile(filepath.Join(dir, "SKILL.md"))
@@ -154,7 +164,7 @@ func runCanonicalSectionsCheck(dir string) (finding canonicalFinding, hasFinding
 	}
 	skill := string(skillBytes)
 
-	expected := generator.CanonicalSkillInstallSection(name, manifest.Category)
+	expected := generator.CanonicalSkillInstallSectionForModule(name, manifest.Category, modulePath)
 	got, ok := ExtractInstallSectionForTest(skill)
 	if !ok {
 		return canonicalFinding{

--- a/internal/cli/verify_skill_test.go
+++ b/internal/cli/verify_skill_test.go
@@ -731,6 +731,16 @@ func TestVerifySkill_CanonicalSectionsPassesOnFreshFixture(t *testing.T) {
 	require.Contains(t, string(out), "canonical-sections passed")
 }
 
+func TestVerifySkill_CanonicalSectionsPassesForPrivateModule(t *testing.T) {
+	t.Parallel()
+	bin := buildPrintingPressBinary(t)
+	modulePath := "github.com/RonanRx/printing-press-library/library/health/ronanrx"
+	dir := writeCanonicalFixture(t, "ronanrx", "health", "", modulePath)
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir, "--only", "canonical-sections").CombinedOutput()
+	require.NoError(t, err, "private module fixture must pass canonical-sections: %s", string(out))
+	require.Contains(t, string(out), "canonical-sections passed")
+}
+
 // TestVerifySkill_CanonicalSectionsNormalizesCRLF guards against Windows
 // checkouts rewriting SKILL.md line endings and producing false drift in the
 // generator-owned install section.
@@ -804,7 +814,7 @@ func Execute() error { return (&cobra.Command{Use: "fixture-pp-cli"}).Execute() 
 // for exercising the canonical-sections check end-to-end. When skillBody is
 // "", the canonical install section is used verbatim; pass a tampered body
 // to simulate hand-editing of the install section.
-func writeCanonicalFixture(t *testing.T, name, category, skillBody string) string {
+func writeCanonicalFixture(t *testing.T, name, category, skillBody string, modulePaths ...string) string {
 	t.Helper()
 	dir := t.TempDir()
 	cliDir := filepath.Join(dir, "internal", "cli")
@@ -814,15 +824,23 @@ import "github.com/spf13/cobra"
 func Execute() error { return (&cobra.Command{Use: "`+name+`-pp-cli"}).Execute() }
 `), 0o644))
 
+	modulePath := "github.com/mvanhorn/printing-press-library/library/" + category + "/" + name
+	if len(modulePaths) > 0 {
+		modulePath = modulePaths[0]
+	}
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
-		[]byte("module github.com/example/"+name+"-pp-cli\n\ngo 1.26.5\n"), 0o644))
+		[]byte("module "+modulePath+"\n\ngo 1.26.5\n"), 0o644))
 
 	manifest := fmt.Sprintf(`{"api_name":%q,"cli_name":%q,"category":%q}`,
 		name, name+"-pp-cli", category)
+	if len(modulePaths) > 0 {
+		manifest = fmt.Sprintf(`{"api_name":%q,"cli_name":%q,"category":%q,"module_path":%q}`,
+			name, name+"-pp-cli", category, modulePath)
+	}
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".printing-press.json"), []byte(manifest), 0o644))
 
 	if skillBody == "" {
-		skillBody = generator.CanonicalSkillInstallSection(name, category)
+		skillBody = generator.CanonicalSkillInstallSectionForModule(name, category, modulePath)
 	}
 	skill := "---\nname: pp-" + name + "\ndescription: \"fixture\"\n---\n\n# " + name + "\n\n" + skillBody + "\nFixture body.\n"
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skill), 0o644))

--- a/internal/generator/install_section.go
+++ b/internal/generator/install_section.go
@@ -45,6 +45,13 @@ const canonicalSkillInstallSectionGoFallbackFormat = "If the `npx` install fails
 	"```\n" +
 	"\n"
 
+const canonicalSkillInstallSectionModuleFallbackFormat = "If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.5 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:\n" +
+	"\n" +
+	"```bash\n" +
+	"go install %[2]s/cmd/%[1]s-pp-cli@latest\n" +
+	"```\n" +
+	"\n"
+
 const canonicalSkillInstallSectionPrepublishFallback = "If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.\n" +
 	"\n"
 
@@ -61,14 +68,30 @@ const canonicalSkillInstallSectionEnd = "If `--version` reports \"command not fo
 // authoritative source post-generation; the template stays in sync via
 // TestCanonicalSkillInstallSectionMatchesTemplate.
 func CanonicalSkillInstallSection(name, category string) string {
+	return CanonicalSkillInstallSectionForModule(name, category, "")
+}
+
+// CanonicalSkillInstallSectionForModule returns the canonical install section
+// for an already-published module. Qualified custom module paths are honored
+// so publish --module-path packages do not fail canonical verification after
+// RewriteModulePath updates their direct-install instructions. Bare standalone
+// generation modules keep the public-library default.
+func CanonicalSkillInstallSectionForModule(name, category, modulePath string) string {
 	section := fmt.Sprintf(canonicalSkillInstallSectionStartFormat, name)
-	if category != "" {
+	if isQualifiedModulePath(modulePath) {
+		section += fmt.Sprintf(canonicalSkillInstallSectionModuleFallbackFormat, name, strings.TrimSuffix(modulePath, "/"))
+	} else if category != "" {
 		section += fmt.Sprintf(canonicalSkillInstallSectionGoFallbackFormat, name, category)
 	} else {
 		section += canonicalSkillInstallSectionPrepublishFallback
 	}
 	section += canonicalSkillInstallSectionEnd
 	return section
+}
+
+func isQualifiedModulePath(modulePath string) bool {
+	host, _, ok := strings.Cut(strings.TrimSpace(modulePath), "/")
+	return ok && strings.Contains(host, ".")
 }
 
 // ExtractSkillInstallSection slices the install/prerequisites block out of

--- a/internal/generator/install_section_test.go
+++ b/internal/generator/install_section_test.go
@@ -87,6 +87,20 @@ func TestCategorylessInstallSectionsAvoidOtherLibraryPath(t *testing.T) {
 	}
 }
 
+func TestCanonicalSkillInstallSectionHonorsQualifiedModulePath(t *testing.T) {
+	t.Parallel()
+	modulePath := "github.com/RonanRx/printing-press-library/library/health/ronanrx"
+	section := CanonicalSkillInstallSectionForModule("ronanrx", "health", modulePath)
+	require.Contains(t, section, "go install "+modulePath+"/cmd/ronanrx-pp-cli@latest")
+	require.NotContains(t, section, "github.com/mvanhorn/printing-press-library/library/health/ronanrx")
+
+	require.Equal(t,
+		CanonicalSkillInstallSection("ronanrx", "health"),
+		CanonicalSkillInstallSectionForModule("ronanrx", "health", "ronanrx-pp-cli"),
+		"bare generation modules must retain the public default",
+	)
+}
+
 // TestExtractSkillInstallSectionMissingStart confirms the extractor
 // reports ok=false when the canonical heading is missing — the case
 // where an agent has rewritten the section into something unrecognizable.

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -93,6 +93,10 @@ type CLIManifest struct {
 	// CLIName is the executable/binary name (for example "espn-pp-cli").
 	// It does not track the slug-keyed library directory.
 	CLIName string `json:"cli_name"`
+	// ModulePath records a qualified custom publication target supplied via
+	// publish package --module-path. It keeps canonical install verification
+	// aligned with private and forked library distributions.
+	ModulePath string `json:"module_path,omitempty"`
 	// Creator is the permanent original author (handle + display name),
 	// preserved across regens regardless of who runs the generator. Source
 	// of truth for every attribution surface.


### PR DESCRIPTION
## Summary
- resolve canonical Go install paths from a printed CLI's private module metadata
- keep public module behavior unchanged
- add focused regression coverage for private-library layouts

## Verification
- focused verifier tests
- complete relevant generator suite

Bead: `ronanrx-core-3wgm.9.4`