### PR TITLE
fix(dogfood): support JSON fixtures over stdin

### DIFF
--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -1290,6 +1290,18 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 	successCodes := liveDogfoodSuccessExitCodes(command)
 	mutating := liveDogfoodCommandMutates(command)
 	useDryRun := mutating && commandSupportsDryRun(command.Help)
+	happyStdinJSON, stdinFixturePresent, stdinFixtureErr := liveDogfoodHappyStdinJSON(command)
+	if stdinFixtureErr != nil {
+		results = append(results,
+			failedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, command.Path, stdinFixtureErr.Error()),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, stdinFixtureErr.Error()),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestError, stdinFixtureErr.Error()),
+		)
+		if useDryRun {
+			results = append(results, skippedLiveDogfoodResult(commandName, LiveDogfoodTestErrorReal, stdinFixtureErr.Error()))
+		}
+		return results
+	}
 
 	if annotationIsTrueValue(command.Annotations[interactiveAnnotation]) {
 		results = append(results,
@@ -1364,7 +1376,7 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 			runArgs = appendDryRunArg(happyArgs)
 		}
 
-		happyRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, runArgs, ctx.timeout)
+		happyRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, runArgs, ctx.timeout, optionalStdinFixture(happyStdinJSON, stdinFixturePresent)...)
 		happyResult := liveDogfoodResult(commandName, LiveDogfoodTestHappy, runArgs, happyRun)
 		happyResult.FixtureSource = fixtureSource
 		if successCodes[happyRun.exitCode] {
@@ -1391,7 +1403,7 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 			results = append(results, jsonResult)
 		} else if commandSupportsJSON(command.Help) {
 			jsonArgs := appendJSONArg(runArgs)
-			jsonRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, jsonArgs, ctx.timeout)
+			jsonRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, jsonArgs, ctx.timeout, optionalStdinFixture(happyStdinJSON, stdinFixturePresent)...)
 			jsonResult := liveDogfoodResult(commandName, LiveDogfoodTestJSON, jsonArgs, jsonRun)
 			jsonResult.FixtureSource = fixtureSource
 			if jsonRun.exitCode == 0 {
@@ -1548,9 +1560,9 @@ func extractFlagsSection(help string) string {
 	return strings.Join(out, "\n")
 }
 
-func runLiveDogfoodProcess(binaryPath, cliDir string, args []string, timeout time.Duration) liveDogfoodRun {
+func runLiveDogfoodProcess(binaryPath, cliDir string, args []string, timeout time.Duration, stdinJSON ...string) liveDogfoodRun {
 	deadline := time.Now().Add(timeout)
-	run := runLiveDogfoodProcessOnce(binaryPath, cliDir, args, timeout)
+	run := runLiveDogfoodProcessOnce(binaryPath, cliDir, args, timeout, stdinJSON...)
 	if !liveDogfoodRetryableAuth401(run) || time.Until(deadline) <= liveDogfoodAuthRetryDelay {
 		return run
 	}
@@ -1559,10 +1571,10 @@ func runLiveDogfoodProcess(binaryPath, cliDir string, args []string, timeout tim
 	if remaining <= 0 {
 		return run
 	}
-	return runLiveDogfoodProcessOnce(binaryPath, cliDir, args, remaining)
+	return runLiveDogfoodProcessOnce(binaryPath, cliDir, args, remaining, stdinJSON...)
 }
 
-func runLiveDogfoodProcessOnce(binaryPath, cliDir string, args []string, timeout time.Duration) liveDogfoodRun {
+func runLiveDogfoodProcessOnce(binaryPath, cliDir string, args []string, timeout time.Duration, stdinJSON ...string) liveDogfoodRun {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -1575,6 +1587,9 @@ func runLiveDogfoodProcessOnce(binaryPath, cliDir string, args []string, timeout
 	// The transport-layer short-circuit is for verify mock-mode only.
 	cmd.Env = filterVerifyEnv(cmd.Env)
 	cmd.Env = append(cmd.Env, dogfoodEnvVar+"=1")
+	if len(stdinJSON) > 0 {
+		cmd.Stdin = strings.NewReader(stdinJSON[0])
+	}
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	stdoutCap := &limitedWriter{w: stdout, remaining: liveDogfoodMaxOutputBytes}
@@ -1604,6 +1619,25 @@ func runLiveDogfoodProcessOnce(binaryPath, cliDir string, args []string, timeout
 		}
 	}
 	return result
+}
+
+func liveDogfoodHappyStdinJSON(command liveDogfoodCommand) (string, bool, error) {
+	raw := strings.TrimSpace(command.Annotations[happyStdinJSONAnnotation])
+	if raw == "" {
+		return "", false, nil
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &object); err != nil || object == nil {
+		return "", true, fmt.Errorf("invalid %s annotation: expected a JSON object", happyStdinJSONAnnotation)
+	}
+	return raw, true, nil
+}
+
+func optionalStdinFixture(value string, present bool) []string {
+	if !present {
+		return nil
+	}
+	return []string{value}
 }
 
 func liveDogfoodRetryableAuth401(run liveDogfoodRun) bool {

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -277,6 +277,150 @@ func TestRunLiveDogfoodProcessSetsDogfoodEnvVar(t *testing.T) {
 	assert.Equal(t, "1", run.stdout, "live-dogfood subprocess should see PRINTING_PRESS_DOGFOOD=1")
 }
 
+func TestRunLiveDogfoodUsesHappyStdinJSONForHappyAndJSONProbes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir := t.TempDir()
+	stdinLog := filepath.Join(dir, "stdin.log")
+	t.Setenv("PRINTING_PRESS_TEST_STDIN_LOG", stdinLog)
+	binPath := filepath.Join(dir, "fixture-pp-cli")
+	script := `#!/bin/sh
+set -eu
+if [ "${1:-}" = "widgets" ] && [ "${2:-}" = "list" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'EOF'
+Usage:
+  fixture-pp-cli widgets list [flags]
+
+Examples:
+  fixture-pp-cli widgets list --stdin
+
+Flags:
+      --json    emit JSON
+      --stdin   read request JSON from stdin
+EOF
+  exit 0
+fi
+input=$(cat)
+printf '%s\n' "$input" >> "$PRINTING_PRESS_TEST_STDIN_LOG"
+printf '{"ok":true}'
+`
+	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o700))
+
+	fixture := `{"input":{"patient_ref":"patient_synthetic"}}`
+	results := runLiveDogfoodCommand(liveDogfoodCommand{
+		Path: []string{"widgets", "list"},
+		Annotations: map[string]string{
+			happyStdinJSONAnnotation: fixture,
+		},
+	}, resolveCtx{
+		binaryPath: binPath,
+		cliDir:     dir,
+		cache:      newCompanionCache(),
+		timeout:    5 * time.Second,
+	})
+
+	var happy, jsonResult *LiveDogfoodTestResult
+	for i := range results {
+		switch results[i].Kind {
+		case LiveDogfoodTestHappy:
+			happy = &results[i]
+		case LiveDogfoodTestJSON:
+			jsonResult = &results[i]
+		}
+	}
+	require.NotNil(t, happy)
+	require.NotNil(t, jsonResult)
+	assert.Equal(t, LiveDogfoodStatusPass, happy.Status, happy.Reason)
+	assert.Equal(t, LiveDogfoodStatusPass, jsonResult.Status, jsonResult.Reason)
+
+	logged, err := os.ReadFile(stdinLog)
+	require.NoError(t, err)
+	assert.Equal(t, fixture+"\n"+fixture+"\n", string(logged), "happy and JSON probes must receive the same stdin fixture")
+	for _, result := range results {
+		assert.NotContains(t, strings.Join(result.Args, " "), fixture, "stdin fixture must never be exposed in argv")
+		assert.NotContains(t, result.OutputSample, fixture, "runner must not add the fixture to captured output")
+	}
+}
+
+func TestRunLiveDogfoodRejectsInvalidHappyStdinJSONBeforeDomainProbe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir := t.TempDir()
+	invocationLog := filepath.Join(dir, "invocations.log")
+	t.Setenv("PRINTING_PRESS_TEST_INVOCATION_LOG", invocationLog)
+	binPath := filepath.Join(dir, "fixture-pp-cli")
+	script := `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$PRINTING_PRESS_TEST_INVOCATION_LOG"
+if [ "${3:-}" = "--help" ]; then
+  cat <<'EOF'
+Usage:
+  fixture-pp-cli widgets list [flags]
+
+Examples:
+  fixture-pp-cli widgets list --stdin
+
+Flags:
+      --json    emit JSON
+      --stdin   read request JSON from stdin
+EOF
+  exit 0
+fi
+exit 99
+`
+	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o700))
+
+	results := runLiveDogfoodCommand(liveDogfoodCommand{
+		Path: []string{"widgets", "list"},
+		Annotations: map[string]string{
+			happyStdinJSONAnnotation: `["not-an-object"]`,
+		},
+	}, resolveCtx{
+		binaryPath: binPath,
+		cliDir:     dir,
+		cache:      newCompanionCache(),
+		timeout:    5 * time.Second,
+	})
+
+	var happy *LiveDogfoodTestResult
+	for i := range results {
+		if results[i].Kind == LiveDogfoodTestHappy {
+			happy = &results[i]
+			break
+		}
+	}
+	require.NotNil(t, happy)
+	assert.Equal(t, LiveDogfoodStatusFail, happy.Status)
+	assert.Equal(t, "invalid pp:happy-stdin-json annotation: expected a JSON object", happy.Reason)
+	assert.NotContains(t, happy.Reason, "not-an-object")
+
+	logged, err := os.ReadFile(invocationLog)
+	require.NoError(t, err)
+	assert.Equal(t, "widgets list --help\n", string(logged), "invalid fixture must stop before a domain command invocation")
+}
+
+func TestLiveDogfoodHappyStdinJSONRequiresObject(t *testing.T) {
+	valid, present, err := liveDogfoodHappyStdinJSON(liveDogfoodCommand{Annotations: map[string]string{
+		happyStdinJSONAnnotation: `{}`,
+	}})
+	require.NoError(t, err)
+	assert.True(t, present)
+	assert.Equal(t, `{}`, valid)
+
+	for _, invalid := range []string{`null`, `[]`, `"string"`, `{broken`} {
+		_, present, err = liveDogfoodHappyStdinJSON(liveDogfoodCommand{Annotations: map[string]string{
+			happyStdinJSONAnnotation: invalid,
+		}})
+		assert.True(t, present)
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), invalid)
+	}
+}
+
 func TestRunLiveDogfoodLocalDatastoreManifestPreservesOperatorHome(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")
@@ -810,7 +954,10 @@ func TestRunLiveDogfoodProcessRetriesTransientAuth401(t *testing.T) {
 
 	dir := t.TempDir()
 	countPath := filepath.Join(dir, "count")
+	stdinPath := filepath.Join(dir, "stdin.log")
 	binPath := writeStubBinary(t, dir, "flaky-auth", `count_file="count"
+input=$(cat)
+printf '%s\n' "$input" >> "stdin.log"
 count=0
 if [ -f "$count_file" ]; then
   count=$(cat "$count_file")
@@ -824,7 +971,8 @@ fi
 printf '{"ok":true}'
 `)
 
-	run := runLiveDogfoodProcess(binPath, dir, nil, 5*time.Second)
+	fixture := `{"input":{"patient_ref":"patient_synthetic"}}`
+	run := runLiveDogfoodProcess(binPath, dir, nil, 5*time.Second, fixture)
 	require.NoError(t, run.err, "fixture: %s", run.stderr)
 	assert.Equal(t, 0, run.exitCode)
 	assert.Equal(t, `{"ok":true}`, run.stdout)
@@ -832,6 +980,10 @@ printf '{"ok":true}'
 	count, err := os.ReadFile(countPath)
 	require.NoError(t, err)
 	assert.Equal(t, "2", string(count), "auth-shaped 401 should be retried once")
+
+	stdin, err := os.ReadFile(stdinPath)
+	require.NoError(t, err)
+	assert.Equal(t, fixture+"\n"+fixture+"\n", string(stdin), "auth retry must reuse the same stdin fixture")
 }
 
 func TestRunLiveDogfoodSkipsPersistentAuth401AsRunnerCredentialUnavailable(t *testing.T) {

--- a/internal/pipeline/runtime_annotations.go
+++ b/internal/pipeline/runtime_annotations.go
@@ -41,7 +41,9 @@ func sourceCommandAnnotations(dir string) map[string]map[string]string {
 	out := map[string]map[string]string{}
 	for _, path := range files {
 		data, err := os.ReadFile(path)
-		if err != nil || (!bytes.Contains(data, []byte(typedExitCodesAnnotation)) && !bytes.Contains(data, []byte(happyArgsAnnotation))) {
+		if err != nil || (!bytes.Contains(data, []byte(typedExitCodesAnnotation)) &&
+			!bytes.Contains(data, []byte(happyArgsAnnotation)) &&
+			!bytes.Contains(data, []byte(happyStdinJSONAnnotation))) {
 			continue
 		}
 		file, err := parser.ParseFile(fset, path, data, parser.SkipObjectResolution)

--- a/internal/pipeline/runtime_commands.go
+++ b/internal/pipeline/runtime_commands.go
@@ -114,7 +114,10 @@ type discoveredCommand struct {
 	Annotations map[string]string
 }
 
-const happyArgsAnnotation = "pp:happy-args"
+const (
+	happyArgsAnnotation      = "pp:happy-args"
+	happyStdinJSONAnnotation = "pp:happy-stdin-json"
+)
 
 type happyArgs struct {
 	positionals []string

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -1684,6 +1684,26 @@ func newWhereaboutsCmd() *cobra.Command {
 	assert.Equal(t, "<person>=Alice;--query=sunset", commands[0].Annotations[happyArgsAnnotation])
 }
 
+func TestEnrichCommandAnnotationsFromSourceReadsHappyStdinJSONOnly(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "cli"), 0o755))
+	writeTestFile(t, filepath.Join(dir, "internal", "cli", "patient.go"), `package cli
+
+import "github.com/spf13/cobra"
+
+func newPatientCmd() *cobra.Command {
+	return &cobra.Command{
+		Use: "patient",
+		Annotations: map[string]string{"pp:happy-stdin-json": "{\"input\":{\"patient_ref\":\"patient_synthetic\"}}"},
+	}
+}
+`)
+
+	commands := enrichCommandAnnotationsFromSource(dir, []discoveredCommand{{Name: "patient"}})
+	require.Len(t, commands, 1)
+	assert.JSONEq(t, `{"input":{"patient_ref":"patient_synthetic"}}`, commands[0].Annotations[happyStdinJSONAnnotation])
+}
+
 func TestEnrichCommandAnnotationsFromSourceReadsAssignmentForm(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "cli"), 0o755))


### PR DESCRIPTION
## Summary
- add validated `pp:happy-stdin-json` runtime metadata
- deliver fixtures only through subprocess stdin for happy/JSON/retry probes
- keep fixtures out of argv and reports and preserve no-stdin behavior

## Verification
- focused retry and argv-isolation tests
- full pipeline and CLI suites
- go vet

Bead: `ronanrx-core-3wgm.9.5`