### PR TITLE
fix(workflow): deliver structured fixtures over stdin

### DIFF
--- a/internal/pipeline/workflow_manifest.go
+++ b/internal/pipeline/workflow_manifest.go
@@ -27,6 +27,7 @@ type WorkflowStep struct {
 	Command      string            `yaml:"command" json:"command"`
 	Args         map[string]string `yaml:"args,omitempty" json:"args,omitempty"`
 	ArgsStdin    bool              `yaml:"args_stdin,omitempty" json:"args_stdin,omitempty"`
+	StdinJSON    map[string]any    `yaml:"stdin_json,omitempty" json:"stdin_json,omitempty"`
 	Extract      map[string]string `yaml:"extract,omitempty" json:"extract,omitempty"`
 	Mode         StepMode          `yaml:"mode" json:"mode"`
 	ExpectFields []string          `yaml:"expect_fields,omitempty" json:"expect_fields,omitempty"`

--- a/internal/pipeline/workflow_manifest_test.go
+++ b/internal/pipeline/workflow_manifest_test.go
@@ -34,6 +34,9 @@ const testManifestYAML = `workflows:
         mode: local
       - command: "orders price_order"
         args_stdin: true
+        stdin_json:
+          input:
+            patient_ref: "patient_synthetic"
         mode: mock
         expect_fields:
           - "Order.Amounts.Customer"
@@ -87,6 +90,7 @@ func TestLoadWorkflowManifest_Valid(t *testing.T) {
 	assert.Equal(t, "orders price_order", s4.Command)
 	assert.Equal(t, StepModeMock, s4.Mode)
 	assert.True(t, s4.ArgsStdin)
+	assert.Equal(t, "patient_synthetic", s4.StdinJSON["input"].(map[string]any)["patient_ref"])
 	assert.Equal(t, []string{"Order.Amounts.Customer", "Order.Products"}, s4.ExpectFields)
 }
 

--- a/internal/pipeline/workflow_verify.go
+++ b/internal/pipeline/workflow_verify.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -106,7 +107,21 @@ func runWorkflow(binary string, wf Workflow, dir string) WorkflowResult {
 			continue
 		}
 
-		sr = executeStep(binary, step, cmdExpanded, dir)
+		stdinJSON, unresolvedStdin, stdinErr := workflowStepStdinJSON(step, vars)
+		if unresolvedStdin {
+			sr.Status = StepStatusSkippedNoInput
+			sr.Error = "missing variable from prior step in stdin_json"
+			result.Steps = append(result.Steps, sr)
+			continue
+		}
+		if stdinErr != nil {
+			sr.Status = StepStatusFailCLIBug
+			sr.Error = "invalid workflow stdin_json fixture"
+			result.Steps = append(result.Steps, sr)
+			continue
+		}
+
+		sr = executeStep(binary, step, cmdExpanded, dir, stdinJSON)
 
 		// Extract values on success.
 		if sr.Status == StepStatusPass && len(step.Extract) > 0 {
@@ -132,7 +147,7 @@ func runWorkflow(binary string, wf Workflow, dir string) WorkflowResult {
 }
 
 // executeStep runs a single workflow step and classifies the result.
-func executeStep(binary string, step WorkflowStep, cmdExpanded string, dir string) StepResult {
+func executeStep(binary string, step WorkflowStep, cmdExpanded string, dir string, stdinJSON []byte) StepResult {
 	sr := StepResult{
 		Command: step.Command,
 	}
@@ -152,6 +167,9 @@ func executeStep(binary string, step WorkflowStep, cmdExpanded string, dir strin
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		cmd := exec.CommandContext(ctx, binary, args...)
 		cmd.Dir = dir
+		if step.ArgsStdin {
+			cmd.Stdin = bytes.NewReader(stdinJSON)
+		}
 		applyDefaultSubprocessEnv(cmd)
 		// Strip verify-mode env from the subprocess so an inherited
 		// PRINTING_PRESS_VERIFY=1 cannot short-circuit the live workflow
@@ -217,6 +235,64 @@ func executeStep(binary string, step WorkflowStep, cmdExpanded string, dir strin
 
 	sr.Status = StepStatusPass
 	return sr
+}
+
+func workflowStepStdinJSON(step WorkflowStep, vars map[string]string) ([]byte, bool, error) {
+	if !step.ArgsStdin {
+		if step.StdinJSON != nil {
+			return nil, false, fmt.Errorf("stdin_json requires args_stdin")
+		}
+		return nil, false, nil
+	}
+
+	payload := any(step.StdinJSON)
+	if step.StdinJSON == nil {
+		fallback := make(map[string]any, len(step.Args))
+		for key, value := range step.Args {
+			fallback[key] = value
+		}
+		payload = fallback
+	}
+
+	resolved, unresolved := substituteWorkflowJSONVars(payload, vars)
+	if unresolved {
+		return nil, true, nil
+	}
+	data, err := json.Marshal(resolved)
+	if err != nil {
+		return nil, false, err
+	}
+	return data, false, nil
+}
+
+func substituteWorkflowJSONVars(value any, vars map[string]string) (any, bool) {
+	switch typed := value.(type) {
+	case string:
+		resolved := substituteVars(typed, vars)
+		return resolved, strings.Contains(resolved, "${")
+	case map[string]any:
+		resolved := make(map[string]any, len(typed))
+		for key, child := range typed {
+			candidate, unresolved := substituteWorkflowJSONVars(child, vars)
+			if unresolved {
+				return nil, true
+			}
+			resolved[key] = candidate
+		}
+		return resolved, false
+	case []any:
+		resolved := make([]any, len(typed))
+		for index, child := range typed {
+			candidate, unresolved := substituteWorkflowJSONVars(child, vars)
+			if unresolved {
+				return nil, true
+			}
+			resolved[index] = candidate
+		}
+		return resolved, false
+	default:
+		return value, false
+	}
 }
 
 // classifyError determines the step status from a command failure.

--- a/internal/pipeline/workflow_verify_test.go
+++ b/internal/pipeline/workflow_verify_test.go
@@ -2,8 +2,11 @@ package pipeline
 
 import (
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,6 +28,108 @@ func TestRunWorkflowVerification_NoManifest(t *testing.T) {
 	loaded, err := LoadWorkflowVerifyReport(dir)
 	require.NoError(t, err)
 	assert.Equal(t, report.Verdict, loaded.Verdict)
+}
+
+func TestRunWorkflowDeliversStructuredStdinJSONWithoutArgvExposure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir := t.TempDir()
+	stdinLog := filepath.Join(dir, "stdin.log")
+	argvLog := filepath.Join(dir, "argv.log")
+	t.Setenv("PRINTING_PRESS_WORKFLOW_STDIN_LOG", stdinLog)
+	t.Setenv("PRINTING_PRESS_WORKFLOW_ARGV_LOG", argvLog)
+	binary := filepath.Join(dir, "fixture-pp-cli")
+	script := `#!/bin/sh
+set -eu
+if [ "${1:-}" = "seed" ]; then
+  printf '{"patient_ref":"patient_synthetic"}'
+  exit 0
+fi
+printf '%s\n' "$*" >> "$PRINTING_PRESS_WORKFLOW_ARGV_LOG"
+input=$(cat)
+printf '%s\n' "$input" >> "$PRINTING_PRESS_WORKFLOW_STDIN_LOG"
+printf '{"ok":true,"command":"patient.diagnose"}'
+`
+	require.NoError(t, os.WriteFile(binary, []byte(script), 0o700))
+
+	result := runWorkflow(binary, Workflow{
+		Name:    "stdin workflow",
+		Primary: true,
+		Steps: []WorkflowStep{
+			{
+				Command: "seed",
+				Mode:    StepModeLocal,
+				Extract: map[string]string{"patient_ref": "$.patient_ref"},
+			},
+			{
+				Command:   "patient diagnose --stdin --dry-run",
+				ArgsStdin: true,
+				StdinJSON: map[string]any{"input": map[string]any{"patient_ref": "${patient_ref}"}},
+				Mode:      StepModeLocal,
+				ExpectFields: []string{
+					"ok",
+					"command",
+				},
+			},
+		},
+	}, dir)
+
+	assert.Equal(t, WorkflowVerdictPass, result.Verdict)
+	require.Len(t, result.Steps, 2)
+	assert.Equal(t, StepStatusPass, result.Steps[1].Status, result.Steps[1].Error)
+
+	stdin, err := os.ReadFile(stdinLog)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"input":{"patient_ref":"patient_synthetic"}}`, strings.TrimSpace(string(stdin)))
+	argv, err := os.ReadFile(argvLog)
+	require.NoError(t, err)
+	assert.Equal(t, "patient diagnose --stdin --dry-run --json\n", string(argv))
+	assert.NotContains(t, string(argv), "patient_synthetic")
+	assert.NotContains(t, result.Steps[1].Command, "patient_synthetic")
+	assert.NotContains(t, result.Steps[1].Output, "patient_synthetic")
+}
+
+func TestRunWorkflowSkipsUnresolvedStdinJSONWithoutExecuting(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir := t.TempDir()
+	invoked := filepath.Join(dir, "invoked")
+	t.Setenv("PRINTING_PRESS_WORKFLOW_INVOKED", invoked)
+	binary := filepath.Join(dir, "fixture-pp-cli")
+	require.NoError(t, os.WriteFile(binary, []byte("#!/bin/sh\ntouch \"$PRINTING_PRESS_WORKFLOW_INVOKED\"\n"), 0o700))
+
+	result := runWorkflow(binary, Workflow{Steps: []WorkflowStep{{
+		Command:   "patient diagnose --stdin",
+		ArgsStdin: true,
+		StdinJSON: map[string]any{"input": map[string]any{"patient_ref": "${missing_patient_ref}"}},
+		Mode:      StepModeLocal,
+	}}}, dir)
+
+	require.Len(t, result.Steps, 1)
+	assert.Equal(t, StepStatusSkippedNoInput, result.Steps[0].Status)
+	assert.Equal(t, "missing variable from prior step in stdin_json", result.Steps[0].Error)
+	_, err := os.Stat(invoked)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestWorkflowStepStdinJSONRejectsMisconfigurationAndInvalidValues(t *testing.T) {
+	_, unresolved, err := workflowStepStdinJSON(WorkflowStep{
+		StdinJSON: map[string]any{"input": map[string]any{}},
+	}, nil)
+	assert.False(t, unresolved)
+	require.EqualError(t, err, "stdin_json requires args_stdin")
+
+	_, unresolved, err = workflowStepStdinJSON(WorkflowStep{
+		ArgsStdin: true,
+		StdinJSON: map[string]any{"invalid": math.Inf(1)},
+	}, nil)
+	assert.False(t, unresolved)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "invalid")
 }
 
 func TestRunWorkflowVerification_NoCliName(t *testing.T) {


### PR DESCRIPTION
## Summary
- make workflow verification execute stdin-only CLIs instead of silently skipping them
- recursively substitute prior-step variables in structured objects
- reject unresolved or invalid fixtures before execution and keep sensitive values out of argv/output

## Verification
- focused stdin, substitution, retry, and leak tests
- complete pipeline and CLI suites
- go vet

Bead: `ronanrx-core-3wgm.9.6`