### PR TITLE
fix(cli): normalize brand-named auth env vars

### DIFF
--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -1296,9 +1296,9 @@ func mapAuthWithDescriptionInference(doc *openapi3.T, name string, allowDescript
 	envPrefix := naming.EnvPrefix(name)
 	switch auth.Type {
 	case "api_key":
-		auth.EnvVars = defaultAuthEnvVars(auth.Type, auth.Format, schemeName, envPrefix)
+		auth.EnvVars = defaultAuthEnvVars(auth.Type, auth.Format, schemeName, envPrefix, auth.In)
 	case "bearer_token":
-		auth.EnvVars = defaultAuthEnvVars(auth.Type, auth.Format, schemeName, envPrefix)
+		auth.EnvVars = defaultAuthEnvVars(auth.Type, auth.Format, schemeName, envPrefix, "")
 	}
 	applyAuthOverrideExtensions(&auth, scheme.Extensions)
 	applyAuthEnvVarDefaults(&auth, envPrefix)
@@ -1554,14 +1554,14 @@ func derivedAdditionalHeaderEnvVar(schemeName, headerName, envPrefix string, fal
 		}
 		return envPrefix + "_" + strings.ToUpper(headerSuffix)
 	}
-	envVars := defaultAuthEnvVars("api_key", "", schemeName, envPrefix)
+	envVars := defaultAuthEnvVars("api_key", "", schemeName, envPrefix, "")
 	if len(envVars) == 0 {
 		return ""
 	}
 	return envVars[0]
 }
 
-func defaultAuthEnvVars(authType, format, schemeName, envPrefix string) []string {
+func defaultAuthEnvVars(authType, format, schemeName, envPrefix, placement string) []string {
 	switch authType {
 	case "api_key":
 		if authFormatIsBasic(format) {
@@ -1571,7 +1571,10 @@ func defaultAuthEnvVars(authType, format, schemeName, envPrefix string) []string
 			return []string{envPrefix + "_USERNAME", envPrefix + "_PASSWORD"}
 		}
 		// Use scheme name for more specific env var (e.g. BotToken -> DISCORD_BOT_TOKEN).
-		schemeEnvSuffix := stripLeadingEnvPrefix(toSnakeCase(schemeName), envPrefix)
+		schemeEnvSuffix := toSnakeCase(schemeName)
+		if !strings.EqualFold(strings.TrimSpace(placement), "cookie") {
+			schemeEnvSuffix = stripLeadingEnvPrefix(schemeEnvSuffix, envPrefix)
+		}
 		if schemeEnvSuffix != "" && !isGenericAPIKeySchemeSuffix(schemeEnvSuffix) {
 			return []string{envPrefix + "_" + strings.ToUpper(schemeEnvSuffix)}
 		}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -1571,13 +1571,13 @@ func defaultAuthEnvVars(authType, format, schemeName, envPrefix string) []string
 			return []string{envPrefix + "_USERNAME", envPrefix + "_PASSWORD"}
 		}
 		// Use scheme name for more specific env var (e.g. BotToken -> DISCORD_BOT_TOKEN).
-		schemeEnvSuffix := toSnakeCase(schemeName)
+		schemeEnvSuffix := stripLeadingEnvPrefix(toSnakeCase(schemeName), envPrefix)
 		if schemeEnvSuffix != "" && !isGenericAPIKeySchemeSuffix(schemeEnvSuffix) {
 			return []string{envPrefix + "_" + strings.ToUpper(schemeEnvSuffix)}
 		}
 		return []string{envPrefix + "_API_KEY"}
 	case "bearer_token":
-		schemeEnvSuffix := toSnakeCase(schemeName)
+		schemeEnvSuffix := stripLeadingEnvPrefix(toSnakeCase(schemeName), envPrefix)
 		switch schemeEnvSuffix {
 		case "", "bearer", "bearer_token", "token":
 			return []string{envPrefix + "_TOKEN"}
@@ -1587,6 +1587,47 @@ func defaultAuthEnvVars(authType, format, schemeName, envPrefix string) []string
 	default:
 		return nil
 	}
+}
+
+func stripLeadingEnvPrefix(schemeEnvSuffix, envPrefix string) string {
+	prefix := strings.ToLower(strings.TrimSpace(envPrefix))
+	if prefix == "" || prefix == "api" {
+		return schemeEnvSuffix
+	}
+	prefixes := []string{prefix}
+	if numericPrefix, ok := strings.CutPrefix(prefix, "api_"); ok && numericPrefix != "" && numericPrefix[0] >= '0' && numericPrefix[0] <= '9' {
+		prefixes = append(prefixes, numericPrefix)
+	}
+	for _, candidate := range prefixes {
+		if stripped, ok := stripNormalizedEnvPrefix(schemeEnvSuffix, candidate); ok {
+			return stripped
+		}
+	}
+	return schemeEnvSuffix
+}
+
+func stripNormalizedEnvPrefix(schemeEnvSuffix, prefix string) (string, bool) {
+	normalizedPrefix := strings.ReplaceAll(strings.ToLower(prefix), "_", "")
+	if normalizedPrefix == "" {
+		return "", false
+	}
+	index := 0
+	for prefixIndex := 0; prefixIndex < len(normalizedPrefix); prefixIndex++ {
+		for index < len(schemeEnvSuffix) && schemeEnvSuffix[index] == '_' {
+			index++
+		}
+		if index == len(schemeEnvSuffix) || strings.ToLower(schemeEnvSuffix[index:index+1]) != normalizedPrefix[prefixIndex:prefixIndex+1] {
+			return "", false
+		}
+		index++
+	}
+	if index == len(schemeEnvSuffix) || schemeEnvSuffix[index] != '_' {
+		return "", false
+	}
+	for index < len(schemeEnvSuffix) && schemeEnvSuffix[index] == '_' {
+		index++
+	}
+	return schemeEnvSuffix[index:], true
 }
 
 func requirementAllSupportedAPIKeys(doc *openapi3.T, req openapi3.SecurityRequirement) bool {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -4566,6 +4566,157 @@ paths:
 	}
 }
 
+func TestBrandNamedSecuritySchemesDoNotDuplicateEnvPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		title      string
+		schemeName string
+		scheme     string
+		want       string
+	}{
+		{
+			name:       "api key",
+			title:      "Clay",
+			schemeName: "ClayApiKey",
+			scheme: `type: apiKey
+      in: header
+      name: X-API-Key`,
+			want: "CLAY_API_KEY",
+		},
+		{
+			name:       "api key with multiword brand",
+			title:      "FooBar",
+			schemeName: "FooBarApiKey",
+			scheme: `type: apiKey
+      in: header
+      name: X-API-Key`,
+			want: "FOOBAR_API_KEY",
+		},
+		{
+			name:       "api key with numeric brand",
+			title:      "1Password",
+			schemeName: "1PasswordApiKey",
+			scheme: `type: apiKey
+      in: header
+      name: X-API-Key`,
+			want: "API_1PASSWORD_API_KEY",
+		},
+		{
+			name:       "specific api key",
+			title:      "Stripe",
+			schemeName: "StripeSecretKey",
+			scheme: `type: apiKey
+      in: header
+      name: X-API-Key`,
+			want: "STRIPE_SECRET_KEY",
+		},
+		{
+			name:       "generic api key",
+			title:      "Foo",
+			schemeName: "ApiKey",
+			scheme: `type: apiKey
+      in: header
+      name: X-API-Key`,
+			want: "FOO_API_KEY",
+		},
+		{
+			name:       "generic api key with fallback prefix",
+			title:      "API",
+			schemeName: "ApiKey",
+			scheme: `type: apiKey
+      in: header
+      name: X-API-Key`,
+			want: "API_API_KEY",
+		},
+		{
+			name:       "bearer token",
+			title:      "Clay",
+			schemeName: "ClayToken",
+			scheme: `type: http
+      scheme: bearer`,
+			want: "CLAY_TOKEN",
+		},
+		{
+			name:       "unprefixed scheme name",
+			title:      "Clay",
+			schemeName: "BotToken",
+			scheme: `type: http
+      scheme: bearer`,
+			want: "CLAY_BOT_TOKEN",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			yamlSpec := fmt.Appendf(nil, `openapi: "3.0.3"
+info:
+  title: %s
+  version: "1.0.0"
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    %s:
+      %s
+security:
+  - %s: []
+paths:
+  /items:
+    get:
+      responses:
+        "200":
+          description: OK
+`, tt.title, tt.schemeName, tt.scheme, tt.schemeName)
+			parsed, err := Parse(yamlSpec)
+			require.NoError(t, err)
+
+			assert.Equal(t, []string{tt.want}, parsed.Auth.EnvVars)
+		})
+	}
+}
+
+func TestBrandNamedSecuritySchemeEmitsCanonicalAuthEnvVar(t *testing.T) {
+	parsed, err := Parse([]byte(`openapi: "3.0.3"
+info:
+  title: Clay
+  version: "1.0.0"
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    ClayApiKey:
+      type: apiKey
+      in: header
+      name: X-API-Key
+security:
+  - ClayApiKey: []
+paths:
+  /items:
+    get:
+      responses:
+        "200":
+          description: OK
+`))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(parsed.Name))
+	require.NoError(t, generator.New(parsed, outputDir).Generate())
+
+	for _, path := range []string{"internal/config/config.go", "README.md", "SKILL.md"} {
+		content, err := os.ReadFile(filepath.Join(outputDir, path))
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "CLAY_API_KEY", path)
+		assert.NotContains(t, string(content), "CLAY_CLAY_API_KEY", path)
+	}
+
+	runGo(t, outputDir, "mod", "tidy")
+	runGo(t, outputDir, "build", "./...")
+}
+
 func TestParseGoogleDiscoveryOriginInjectsAPIKeyAuth(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Intent

Issue: Fixes #3570

## Approach

Normalize a leading API-name token from inferred security-scheme suffixes before constructing the environment variable. The match tolerates casing and word-boundary differences, handles the numeric-name `API_` guard, and preserves generic `API` fallback behavior.

## Scope

Primary area: OpenAPI auth environment-variable inference.

Why this belongs in this repo: the parser supplies the auth environment variable to every newly generated CLI; a printed-CLI patch would leave future generated config, doctor, README, SKILL, and MCP metadata incorrect.

## Risk

Only inferred names change, and only when the scheme begins with the normalized API prefix followed by a boundary. Explicit auth environment-variable overrides still apply after the inference step. Coverage includes brand-prefixed API-key and bearer schemes, multiword and numeric names, generic schemes, and a near-fallback `API` case.

## Output Contract

Generated config, README, and SKILL now use the canonical inferred variable such as `CLAY_API_KEY` instead of `CLAY_CLAY_API_KEY`. The regression test parses a spec, generates a CLI, checks all three emitted surfaces, and builds the generated module. No golden fixtures changed; `scripts/golden.sh verify` passes.

## Verification

- [x] `go test ./internal/openapi -run '^(TestBrandNamedSecuritySchemesDoNotDuplicateEnvPrefix|TestBrandNamedSecuritySchemeEmitsCanonicalAuthEnvVar)$' -count=1`
- [x] `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- [x] `go vet ./internal/openapi`
- [x] `scripts/golden.sh verify`

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change
