### PR TITLE
fix(cli): keep browser-http ALPN on HTTP/1.1

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2890,12 +2890,57 @@ func TestGenerateBrowserHTTPTransportDisablesHTTP2(t *testing.T) {
 	clientGo := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
 	assert.Contains(t, clientGo, `"crypto/tls"`)
 	assert.Contains(t, clientGo, `transport := http.DefaultTransport.(*http.Transport).Clone()`)
+	assert.Contains(t, clientGo, `transport.TLSClientConfig.NextProtos = []string{"http/1.1"}`)
 	assert.Contains(t, clientGo, `transport.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)`)
 	assert.NotContains(t, clientGo, `"github.com/enetx/surf"`)
 	assert.NotContains(t, clientGo, `Impersonate()`)
 
 	gomod := readGeneratedFile(t, outputDir, "go.mod")
 	assert.NotContains(t, gomod, "github.com/enetx/surf")
+	requireGeneratedCompiles(t, outputDir)
+
+	runtimeTest := `package client
+
+import (
+	"crypto/tls"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestBrowserHTTPTransportRejectsH2ALPN(t *testing.T) {
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+
+	defaultTransport := http.DefaultTransport.(*http.Transport)
+	originalTLSConfig := defaultTransport.TLSClientConfig
+	defaultTransport.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{"h2", "http/1.1"},
+	}
+	t.Cleanup(func() { defaultTransport.TLSClientConfig = originalTLSConfig })
+
+	client := newHTTPClient(time.Second, nil)
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("browser-http request failed after inherited h2 ALPN: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.ProtoMajor != 1 {
+		t.Fatalf("browser-http negotiated HTTP/%d, want HTTP/1.x", resp.ProtoMajor)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "client", "browser_http_runtime_test.go"),
+		[]byte(runtimeTest), 0o600))
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "TestBrowserHTTPTransportRejectsH2ALPN", "-count=1")
 }
 
 // TestGenerateCookieAuthEmitsSetTokenSubcommand verifies that the

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -381,6 +381,11 @@ const maxIdleConnsPerHost = 32
 func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 {{- if .UsesHTTP2DisabledTransport}}
 	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{}
+	}
+	// An initialized DefaultTransport can carry "h2" in ALPN even after its round tripper is removed.
+	transport.TLSClientConfig.NextProtos = []string{"http/1.1"}
 	transport.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
 	return &http.Client{Timeout: timeout, Jar: jar, Transport: transport}
 {{- else if .UsesBrowserHTTPTransport}}


### PR DESCRIPTION
## Summary

`browser-http` printed CLIs no longer negotiate HTTP/2 with CDN edges while their transport has only an HTTP/1.x round tripper, eliminating the malformed HTTP response that previously blocked every live request on affected hosts. The generator now constrains the cloned TLS configuration to advertise `http/1.1` while preserving the existing HTTP/2-disabled transport contract. An emitted runtime regression recreates the initialized-default-transport state, negotiates against an HTTP/2-capable TLS server, and verifies the generated client completes over HTTP/1.x.

## Validation

- `go test ./...` (6,809 tests across 44 packages)
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `scripts/golden.sh verify` (32 cases)
- `scripts/verify-generator-output.sh` (10 cases)

## New concepts

### ALPN must match the installed HTTP round tripper

ALPN selects the application protocol during the TLS handshake, before an HTTP request or response is parsed. A transport that advertises `h2` therefore also needs an HTTP/2 round tripper capable of consuming HTTP/2 frames.

Here, `browser-http` intentionally removes that round tripper, but cloning an already initialized `http.DefaultTransport` can retain `h2` in the TLS protocol list. Pinning ALPN to `http/1.1` keeps the advertised protocol aligned with the transport implementation. This pin should not be used for the standard or browser-Chrome modes, which intentionally support HTTP/2 or HTTP/3.

Closes #3548
