### PR TITLE
fix(cli): follow generated pagination cursors safely

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -5769,9 +5769,14 @@ func mcpPageConfig(endpoint spec.Endpoint) string {
 	if !mcpEndpointPageable(endpoint) {
 		return "mcpPageConfig{}"
 	}
+	nextCursorPath := endpoint.Pagination.NextCursorPath
+	paginationType := strings.ToLower(strings.TrimSpace(endpoint.Pagination.Type))
+	if strings.TrimSpace(nextCursorPath) == "" && paginationType != "offset" && paginationType != "page" {
+		nextCursorPath = endpoint.Pagination.CursorParam
+	}
 	return fmt.Sprintf("mcpPageConfig{CursorParam: %q, NextCursorPath: %q}",
 		endpoint.Pagination.CursorParam,
-		endpoint.Pagination.NextCursorPath,
+		nextCursorPath,
 	)
 }
 

--- a/internal/generator/mcp_bound_package_test.go
+++ b/internal/generator/mcp_bound_package_test.go
@@ -153,10 +153,9 @@ func TestGenerateMCPToolsUseOpaqueCursorForResumableListEndpoints(t *testing.T) 
 						{Name: "after", Type: "string"},
 					},
 					Pagination: &spec.Pagination{
-						Type:           "cursor",
-						LimitParam:     "limit",
-						CursorParam:    "after",
-						NextCursorPath: "next_cursor",
+						Type:        "cursor",
+						LimitParam:  "limit",
+						CursorParam: "after",
 					},
 					Response: spec.ResponseDef{Type: "array", Item: "Group"},
 				},
@@ -184,10 +183,25 @@ func TestGenerateMCPToolsUseOpaqueCursorForResumableListEndpoints(t *testing.T) 
 		"resumable MCP list tools should expose a canonical opaque cursor input")
 	assert.NotContains(t, toolsCode, `mcplib.WithString("after"`,
 		"resumable MCP list tools should not expose the raw upstream cursor parameter")
-	assert.Contains(t, toolsCode, `mcpPageConfig{CursorParam: "after", NextCursorPath: "next_cursor"}`,
-		"generated handler should receive the upstream cursor metadata needed to continue safely")
+	assert.Contains(t, toolsCode, `mcpPageConfig{CursorParam: "after", NextCursorPath: "after"}`,
+		"generated handler should fall back to the cursor parameter as the response lookup path")
 	assert.Contains(t, toolsCode, `bound.EndpointPageResponse(method, data, bound.PageOptions{`,
 		"typed MCP responses should route resumable endpoints through the cursor-aware bound path")
 
 	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestMCPPageConfigDoesNotTreatNumericCursorAsResponsePath(t *testing.T) {
+	for _, paginationType := range []string{"offset", "page"} {
+		t.Run(paginationType, func(t *testing.T) {
+			endpoint := spec.Endpoint{
+				Method: "GET",
+				Pagination: &spec.Pagination{
+					Type:        paginationType,
+					CursorParam: paginationType,
+				},
+			}
+			assert.Equal(t, `mcpPageConfig{CursorParam: "`+paginationType+`", NextCursorPath: ""}`, mcpPageConfig(endpoint))
+		})
+	}
 }

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -203,25 +203,34 @@ func TestPaginatedGetWarnsForCursorParamFallbackWithoutAll(t *testing.T) {
 	}
 }
 
-func TestPaginatedGetTreatsEmptyFallbackCursorAsLastPage(t *testing.T) {
-	client := &paginatedTestClient{responses: []json.RawMessage{
-		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"cursor":""}` + "`" + `),
-	}}
-	stderr := capturePaginatedStderr(t, func() {
-		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "cursor", "cursor", "limit", 100, "", "")
-		if err != nil {
-			t.Fatalf("paginatedGet returned error: %v", err)
-		}
-		var got []map[string]string
-		if err := json.Unmarshal(data, &got); err != nil {
-			t.Fatalf("unmarshal data: %v", err)
-		}
-		if len(got) != 1 {
-			t.Fatalf("got %d items, want 1", len(got))
-		}
-	})
-	if strings.Contains(stderr, ` + "`" + `"reason":"pagination_signal_missing"` + "`" + `) {
-		t.Fatalf("stderr should not warn when the fallback cursor field is present and empty: %s", stderr)
+func TestPaginatedGetWarnsForUnusableFallbackCursor(t *testing.T) {
+	for name, cursor := range map[string]string{
+		"empty": ` + "`" + `""` + "`" + `,
+		"null":  "null",
+		"zero":  "0",
+		"object": ` + "`" + `{"value":"next"}` + "`" + `,
+	} {
+		t.Run(name, func(t *testing.T) {
+			client := &paginatedTestClient{responses: []json.RawMessage{
+				json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"cursor":` + "`" + ` + cursor + ` + "`" + `}` + "`" + `),
+			}}
+			stderr := capturePaginatedStderr(t, func() {
+				data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "cursor", "cursor", "limit", 100, "", "")
+				if err != nil {
+					t.Fatalf("paginatedGet returned error: %v", err)
+				}
+				var got []map[string]string
+				if err := json.Unmarshal(data, &got); err != nil {
+					t.Fatalf("unmarshal data: %v", err)
+				}
+				if len(got) != 1 {
+					t.Fatalf("got %d items, want 1", len(got))
+				}
+			})
+			if !strings.Contains(stderr, ` + "`" + `"reason":"pagination_signal_missing"` + "`" + `) {
+				t.Fatalf("stderr missing pagination signal warning for unusable cursor: %s", stderr)
+			}
+		})
 	}
 }
 

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -65,11 +65,14 @@ func TestPaginatedGetHandlesNumericCursorAndMissingAllSignal(t *testing.T) {
 					Method:      "GET",
 					Path:        "/orders",
 					Description: "List orders",
+					Params: []spec.Param{
+						{Name: "limit", Type: "integer"},
+						{Name: "cursor", Type: "string"},
+					},
 					Pagination: &spec.Pagination{
-						Type:           "page",
-						CursorParam:    "page",
-						LimitParam:     "limit",
-						NextCursorPath: "meta.nextPage",
+						Type:        "cursor",
+						CursorParam: "cursor",
+						LimitParam:  "limit",
 					},
 					Response: spec.ResponseDef{Type: "array", Item: "Order"},
 				},
@@ -79,12 +82,16 @@ func TestPaginatedGetHandlesNumericCursorAndMissingAllSignal(t *testing.T) {
 
 	outputDir := filepath.Join(t.TempDir(), "paginate-edge-pp-cli")
 	require.NoError(t, New(apiSpec, outputDir).Generate())
+	endpointSrc := readGeneratedCLIFileContaining(t, outputDir, `flagAll, "cursor", "cursor", "limit"`)
+	require.Contains(t, endpointSrc, `flagAll, "cursor", "cursor", "limit", 100, "", ""`,
+		"generated list command must preserve an empty next-cursor path for the runtime fallback")
 
 	behaviorTest := `package cli
 
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -154,6 +161,137 @@ func TestPaginatedGetAcceptsNumericNextCursor(t *testing.T) {
 	}
 	if client.params[1]["page"] != "2" {
 		t.Fatalf("second request page = %q, want 2", client.params[1]["page"])
+	}
+}
+
+func TestPaginatedGetFallsBackToCursorParamResponseField(t *testing.T) {
+	client := &paginatedTestClient{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"cursor":"page-2"}` + "`" + `),
+		json.RawMessage(` + "`" + `{"items":[{"id":"two"}],"cursor":""}` + "`" + `),
+	}}
+	data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "cursor", "cursor", "limit", 100, "", "")
+	if err != nil {
+		t.Fatalf("paginatedGet returned error: %v", err)
+	}
+	var got []map[string]string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d items, want 2; data=%s", len(got), data)
+	}
+	if len(client.params) != 2 {
+		t.Fatalf("got %d requests, want 2", len(client.params))
+	}
+	if client.params[1]["cursor"] != "page-2" {
+		t.Fatalf("second request cursor = %q, want page-2", client.params[1]["cursor"])
+	}
+}
+
+func TestPaginatedGetWarnsForCursorParamFallbackWithoutAll(t *testing.T) {
+	client := &paginatedTestClient{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"cursor":"page-2"}` + "`" + `),
+	}}
+	stderr := capturePaginatedStderr(t, func() {
+		_, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, false, "cursor", "cursor", "limit", 100, "", "")
+		if err != nil {
+			t.Fatalf("paginatedGet returned error: %v", err)
+		}
+	})
+	if !containsAll(stderr, ` + "`" + `"event":"truncated"` + "`" + `, ` + "`" + `"hint":"pass --all to fetch every page"` + "`" + `) {
+		t.Fatalf("stderr missing cursor fallback truncation warning: %s", stderr)
+	}
+}
+
+func TestPaginatedGetTreatsEmptyFallbackCursorAsLastPage(t *testing.T) {
+	client := &paginatedTestClient{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"cursor":""}` + "`" + `),
+	}}
+	stderr := capturePaginatedStderr(t, func() {
+		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "cursor", "cursor", "limit", 100, "", "")
+		if err != nil {
+			t.Fatalf("paginatedGet returned error: %v", err)
+		}
+		var got []map[string]string
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal data: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("got %d items, want 1", len(got))
+		}
+	})
+	if strings.Contains(stderr, ` + "`" + `"reason":"pagination_signal_missing"` + "`" + `) {
+		t.Fatalf("stderr should not warn when the fallback cursor field is present and empty: %s", stderr)
+	}
+}
+
+func TestPaginatedGetWarnsWhenFallbackCursorFieldIsMissing(t *testing.T) {
+	client := &paginatedTestClient{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `{"items":[{"id":"one"}]}` + "`" + `),
+	}}
+	stderr := capturePaginatedStderr(t, func() {
+		_, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "cursor", "cursor", "limit", 100, "", "")
+		if err != nil {
+			t.Fatalf("paginatedGet returned error: %v", err)
+		}
+	})
+	if !strings.Contains(stderr, ` + "`" + `"reason":"pagination_signal_missing"` + "`" + `) {
+		t.Fatalf("stderr missing pagination signal warning: %s", stderr)
+	}
+}
+
+func TestPaginatedGetStopsWhenResponseRepeatsSentCursor(t *testing.T) {
+	client := &paginatedTestClient{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"cursor":"page-2"}` + "`" + `),
+		json.RawMessage(` + "`" + `{"items":[{"id":"two"}],"cursor":"page-2"}` + "`" + `),
+		json.RawMessage(` + "`" + `{"items":[{"id":"unexpected"}],"cursor":""}` + "`" + `),
+	}}
+	stderr := capturePaginatedStderr(t, func() {
+		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "cursor", "cursor", "limit", 100, "", "")
+		if err != nil {
+			t.Fatalf("paginatedGet returned error: %v", err)
+		}
+		var got []map[string]string
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal data: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("got %d items, want 2; data=%s", len(got), data)
+		}
+	})
+	if len(client.params) != 2 {
+		t.Fatalf("got %d requests, want 2", len(client.params))
+	}
+	if !containsAll(stderr, ` + "`" + `"event":"truncated"` + "`" + `, ` + "`" + `"reason":"pagination_cursor_repeated"` + "`" + `) {
+		t.Fatalf("stderr missing repeated-cursor warning: %s", stderr)
+	}
+}
+
+func TestPaginatedGetStopsWhenResponseCyclesToEarlierCursor(t *testing.T) {
+	client := &paginatedTestClient{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"cursor":"page-2"}` + "`" + `),
+		json.RawMessage(` + "`" + `{"items":[{"id":"two"}],"cursor":"page-3"}` + "`" + `),
+		json.RawMessage(` + "`" + `{"items":[{"id":"three"}],"cursor":"page-2"}` + "`" + `),
+		json.RawMessage(` + "`" + `{"items":[{"id":"unexpected"}],"cursor":""}` + "`" + `),
+	}}
+	stderr := capturePaginatedStderr(t, func() {
+		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "cursor", "cursor", "limit", 100, "", "")
+		if err != nil {
+			t.Fatalf("paginatedGet returned error: %v", err)
+		}
+		var got []map[string]string
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal data: %v", err)
+		}
+		if len(got) != 3 {
+			t.Fatalf("got %d items, want 3; data=%s", len(got), data)
+		}
+	})
+	if len(client.params) != 3 {
+		t.Fatalf("got %d requests, want 3", len(client.params))
+	}
+	if !containsAll(stderr, ` + "`" + `"event":"truncated"` + "`" + `, ` + "`" + `"reason":"pagination_cursor_repeated"` + "`" + `) {
+		t.Fatalf("stderr missing repeated-cursor warning: %s", stderr)
 	}
 }
 
@@ -494,7 +632,7 @@ func TestPaginatedGetStopsAtMaxPageSafetyLimit(t *testing.T) {
 func TestPaginatedGetStopsAtMaxPageSafetyLimitForBodyCursor(t *testing.T) {
 	responses := make([]json.RawMessage, paginatedGetMaxPages+1)
 	for i := range responses {
-		responses[i] = json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"meta":{"next":"next-token"}}` + "`" + `)
+		responses[i] = json.RawMessage(fmt.Sprintf(` + "`" + `{"items":[{"id":"one"}],"meta":{"next":"next-token-%d"}}` + "`" + `, i+1))
 	}
 	client := &paginatedTestClient{responses: responses}
 	stderr := capturePaginatedStderr(t, func() {
@@ -513,8 +651,8 @@ func TestPaginatedGetStopsAtMaxPageSafetyLimitForBodyCursor(t *testing.T) {
 	if len(client.params) != paginatedGetMaxPages {
 		t.Fatalf("got %d requests, want %d", len(client.params), paginatedGetMaxPages)
 	}
-	if client.params[1]["cursor"] != "next-token" {
-		t.Fatalf("second request cursor = %q, want next-token", client.params[1]["cursor"])
+	if client.params[1]["cursor"] != "next-token-1" {
+		t.Fatalf("second request cursor = %q, want next-token-1", client.params[1]["cursor"])
 	}
 	if !containsAll(stderr, ` + "`" + `"event":"truncated"` + "`" + `, ` + "`" + `"reason":"max_pages_cap_hit"` + "`" + `) {
 		t.Fatalf("stderr missing max-pages body-cursor truncation warning: %s", stderr)
@@ -571,6 +709,7 @@ func containsAll(s string, needles ...string) bool {
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "paginated_get_issue1688_test.go"), []byte(behaviorTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "TestPaginatedGet")
+	requireGeneratedCompiles(t, outputDir)
 }
 
 func TestIssue3497BareAllOffsetUsesEndpointPageSize(t *testing.T) {

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -47,7 +47,7 @@ func TestPaginatedGetEmitsTruncationWarning(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(helpersSrc), "func emitTruncationWarning(",
 		"generated helpers.go should define emitTruncationWarning")
-	require.Contains(t, string(helpersSrc), "emitTruncationWarning(data, nextCursorPath, hasMoreField, paginationType)",
+	require.Contains(t, string(helpersSrc), "emitTruncationWarning(data, cursorLookupPath, hasMoreField, paginationType)",
 		"paginatedGet should call emitTruncationWarning on the single-page path")
 
 	runGoCommand(t, outputDir, "build", "./internal/cli")

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1157,8 +1157,8 @@ func paginatedGet(ctx context.Context, c interface {
 				// Check for next cursor
 				if cursorLookupPath != "" {
 					if tokenRaw, ok := rawAtPath(obj, cursorLookupPath); ok {
-						foundCursorField = true
 						if token := paginationCursorToken(tokenRaw); token != "" {
+							foundCursorField = true
 							if _, seen := seenCursorTokens[token]; seen {
 								if humanFriendly {
 									fmt.Fprintf(os.Stderr, "warning: --all received the same pagination cursor twice; returning fetched pages only.\n")

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1080,12 +1080,16 @@ func paginatedGet(ctx context.Context, c interface {
 			clean[k] = v
 		}
 	}
+	cursorLookupPath := nextCursorPath
+	if cursorLookupPath == "" && paginationType != "offset" && paginationType != "page" {
+		cursorLookupPath = cursorParam
+	}
 	if !fetchAll {
 		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
 			return nil, err
 		}
-		emitTruncationWarning(data, nextCursorPath, hasMoreField, paginationType)
+		emitTruncationWarning(data, cursorLookupPath, hasMoreField, paginationType)
 		return data, nil
 	}
 
@@ -1109,6 +1113,11 @@ func paginatedGet(ctx context.Context, c interface {
 
 	// Fetch all pages
 	allItems := make([]json.RawMessage, 0)
+	seenCursorTokens := map[string]struct{}{}
+	if sentCursor := clean[cursorParam]; sentCursor != "" {
+		seenCursorTokens[sentCursor] = struct{}{}
+	}
+	foundCursorField := false
 	page := 0
 	for {
 		page++
@@ -1146,9 +1155,19 @@ func paginatedGet(ctx context.Context, c interface {
 				}
 
 				// Check for next cursor
-				if nextCursorPath != "" {
-					if tokenRaw, ok := rawAtPath(obj, nextCursorPath); ok {
+				if cursorLookupPath != "" {
+					if tokenRaw, ok := rawAtPath(obj, cursorLookupPath); ok {
+						foundCursorField = true
 						if token := paginationCursorToken(tokenRaw); token != "" {
+							if _, seen := seenCursorTokens[token]; seen {
+								if humanFriendly {
+									fmt.Fprintf(os.Stderr, "warning: --all received the same pagination cursor twice; returning fetched pages only.\n")
+								} else {
+									fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_cursor_repeated","next_cursor_path":%q,"message":"--all received the same pagination cursor twice; returning fetched pages only"}`+"\n", cursorLookupPath)
+								}
+								break
+							}
+							seenCursorTokens[token] = struct{}{}
 							if page >= paginatedGetMaxPages {
 								emitPaginatedGetMaxPagesWarning()
 								break
@@ -1175,7 +1194,7 @@ func paginatedGet(ctx context.Context, c interface {
 									clean[cursorParam] = next
 									continue
 								}
-								emitMissingPaginationCursorWarning(nextCursorPath)
+							emitMissingPaginationCursorWarning(cursorLookupPath)
 								break
 							}
 							hasExplicitNoMore = true
@@ -1201,7 +1220,7 @@ func paginatedGet(ctx context.Context, c interface {
 		break
 	}
 
-	if fetchAll && page == 1 && nextCursorPath == "" && hasMoreField == "" && paginationType != "offset" && paginationType != "page" {
+	if fetchAll && page == 1 && nextCursorPath == "" && !foundCursorField && hasMoreField == "" && paginationType != "offset" && paginationType != "page" {
 		emitMissingPaginationSignalWarning()
 	}
 	if humanFriendly {

--- a/internal/generator/templates/mcp_bound.go.tmpl
+++ b/internal/generator/templates/mcp_bound.go.tmpl
@@ -226,6 +226,11 @@ func boundedSingleArrayPageObject(data json.RawMessage, opts PageOptions) ([]byt
 		return nil, false
 	}
 	nextUpstream := extractStringPath(data, opts.NextCursorPath)
+	if nextUpstream != "" {
+		if state, err := decodeEndpointCursor(opts.Cursor); err == nil && nextUpstream == state.UpstreamCursor {
+			nextUpstream = ""
+		}
+	}
 	return boundedPageListEnvelope(arrayField, items, data, endpointListNote, opts, obj, nextUpstream), true
 }
 

--- a/internal/generator/templates/mcp_bound_test.go.tmpl
+++ b/internal/generator/templates/mcp_bound_test.go.tmpl
@@ -172,6 +172,34 @@ func TestEndpointPageResponseWrapsUpstreamCursorOpaquely(t *testing.T) {
 	}
 }
 
+func TestEndpointPageResponseDoesNotContinueWithEchoedUpstreamCursor(t *testing.T) {
+	cursor := encodeEndpointCursor(endpointCursor{Version: 1, UpstreamCursor: "server-token"})
+	data, err := json.Marshal(map[string]any{
+		"items": []map[string]string{
+			{"id": "item-0"},
+		},
+		"after": "server-token",
+	})
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+
+	text := EndpointPageResponse("GET", data, PageOptions{
+		Cursor:         cursor,
+		CursorParam:    "after",
+		NextCursorPath: "after",
+	})
+	var envelope struct {
+		NextCursor string `json:"next_cursor"`
+	}
+	if err := json.Unmarshal([]byte(text), &envelope); err != nil {
+		t.Fatalf("page result must remain valid JSON: %v\n%s", err, text)
+	}
+	if envelope.NextCursor != "" {
+		t.Fatalf("echoed upstream cursor produced another continuation: %q", envelope.NextCursor)
+	}
+}
+
 func TestEndpointPageResponseOversizedFirstItemReturnsPreviewAndAdvances(t *testing.T) {
 	items := []map[string]string{
 		{"id": "too-large", "payload": strings.Repeat("x", MaxBytes+10000)},

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -626,8 +626,8 @@ func paginatedGet(ctx context.Context, c interface {
 				// Check for next cursor
 				if cursorLookupPath != "" {
 					if tokenRaw, ok := rawAtPath(obj, cursorLookupPath); ok {
-						foundCursorField = true
 						if token := paginationCursorToken(tokenRaw); token != "" {
+							foundCursorField = true
 							if _, seen := seenCursorTokens[token]; seen {
 								if humanFriendly {
 									fmt.Fprintf(os.Stderr, "warning: --all received the same pagination cursor twice; returning fetched pages only.\n")

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -549,12 +549,16 @@ func paginatedGet(ctx context.Context, c interface {
 			clean[k] = v
 		}
 	}
+	cursorLookupPath := nextCursorPath
+	if cursorLookupPath == "" && paginationType != "offset" && paginationType != "page" {
+		cursorLookupPath = cursorParam
+	}
 	if !fetchAll {
 		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
 			return nil, err
 		}
-		emitTruncationWarning(data, nextCursorPath, hasMoreField, paginationType)
+		emitTruncationWarning(data, cursorLookupPath, hasMoreField, paginationType)
 		return data, nil
 	}
 
@@ -578,6 +582,11 @@ func paginatedGet(ctx context.Context, c interface {
 
 	// Fetch all pages
 	allItems := make([]json.RawMessage, 0)
+	seenCursorTokens := map[string]struct{}{}
+	if sentCursor := clean[cursorParam]; sentCursor != "" {
+		seenCursorTokens[sentCursor] = struct{}{}
+	}
+	foundCursorField := false
 	page := 0
 	for {
 		page++
@@ -615,9 +624,19 @@ func paginatedGet(ctx context.Context, c interface {
 				}
 
 				// Check for next cursor
-				if nextCursorPath != "" {
-					if tokenRaw, ok := rawAtPath(obj, nextCursorPath); ok {
+				if cursorLookupPath != "" {
+					if tokenRaw, ok := rawAtPath(obj, cursorLookupPath); ok {
+						foundCursorField = true
 						if token := paginationCursorToken(tokenRaw); token != "" {
+							if _, seen := seenCursorTokens[token]; seen {
+								if humanFriendly {
+									fmt.Fprintf(os.Stderr, "warning: --all received the same pagination cursor twice; returning fetched pages only.\n")
+								} else {
+									fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_cursor_repeated","next_cursor_path":%q,"message":"--all received the same pagination cursor twice; returning fetched pages only"}`+"\n", cursorLookupPath)
+								}
+								break
+							}
+							seenCursorTokens[token] = struct{}{}
 							if page >= paginatedGetMaxPages {
 								emitPaginatedGetMaxPagesWarning()
 								break
@@ -644,7 +663,7 @@ func paginatedGet(ctx context.Context, c interface {
 									clean[cursorParam] = next
 									continue
 								}
-								emitMissingPaginationCursorWarning(nextCursorPath)
+								emitMissingPaginationCursorWarning(cursorLookupPath)
 								break
 							}
 							hasExplicitNoMore = true
@@ -670,7 +689,7 @@ func paginatedGet(ctx context.Context, c interface {
 		break
 	}
 
-	if fetchAll && page == 1 && nextCursorPath == "" && hasMoreField == "" && paginationType != "offset" && paginationType != "page" {
+	if fetchAll && page == 1 && nextCursorPath == "" && !foundCursorField && hasMoreField == "" && paginationType != "offset" && paginationType != "page" {
 		emitMissingPaginationSignalWarning()
 	}
 	if humanFriendly {

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -542,12 +542,16 @@ func paginatedGet(ctx context.Context, c interface {
 			clean[k] = v
 		}
 	}
+	cursorLookupPath := nextCursorPath
+	if cursorLookupPath == "" && paginationType != "offset" && paginationType != "page" {
+		cursorLookupPath = cursorParam
+	}
 	if !fetchAll {
 		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
 			return nil, err
 		}
-		emitTruncationWarning(data, nextCursorPath, hasMoreField, paginationType)
+		emitTruncationWarning(data, cursorLookupPath, hasMoreField, paginationType)
 		return data, nil
 	}
 
@@ -571,6 +575,11 @@ func paginatedGet(ctx context.Context, c interface {
 
 	// Fetch all pages
 	allItems := make([]json.RawMessage, 0)
+	seenCursorTokens := map[string]struct{}{}
+	if sentCursor := clean[cursorParam]; sentCursor != "" {
+		seenCursorTokens[sentCursor] = struct{}{}
+	}
+	foundCursorField := false
 	page := 0
 	for {
 		page++
@@ -608,9 +617,19 @@ func paginatedGet(ctx context.Context, c interface {
 				}
 
 				// Check for next cursor
-				if nextCursorPath != "" {
-					if tokenRaw, ok := rawAtPath(obj, nextCursorPath); ok {
+				if cursorLookupPath != "" {
+					if tokenRaw, ok := rawAtPath(obj, cursorLookupPath); ok {
+						foundCursorField = true
 						if token := paginationCursorToken(tokenRaw); token != "" {
+							if _, seen := seenCursorTokens[token]; seen {
+								if humanFriendly {
+									fmt.Fprintf(os.Stderr, "warning: --all received the same pagination cursor twice; returning fetched pages only.\n")
+								} else {
+									fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_cursor_repeated","next_cursor_path":%q,"message":"--all received the same pagination cursor twice; returning fetched pages only"}`+"\n", cursorLookupPath)
+								}
+								break
+							}
+							seenCursorTokens[token] = struct{}{}
 							if page >= paginatedGetMaxPages {
 								emitPaginatedGetMaxPagesWarning()
 								break
@@ -637,7 +656,7 @@ func paginatedGet(ctx context.Context, c interface {
 									clean[cursorParam] = next
 									continue
 								}
-								emitMissingPaginationCursorWarning(nextCursorPath)
+								emitMissingPaginationCursorWarning(cursorLookupPath)
 								break
 							}
 							hasExplicitNoMore = true
@@ -663,7 +682,7 @@ func paginatedGet(ctx context.Context, c interface {
 		break
 	}
 
-	if fetchAll && page == 1 && nextCursorPath == "" && hasMoreField == "" && paginationType != "offset" && paginationType != "page" {
+	if fetchAll && page == 1 && nextCursorPath == "" && !foundCursorField && hasMoreField == "" && paginationType != "offset" && paginationType != "page" {
 		emitMissingPaginationSignalWarning()
 	}
 	if humanFriendly {

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -619,8 +619,8 @@ func paginatedGet(ctx context.Context, c interface {
 				// Check for next cursor
 				if cursorLookupPath != "" {
 					if tokenRaw, ok := rawAtPath(obj, cursorLookupPath); ok {
-						foundCursorField = true
 						if token := paginationCursorToken(tokenRaw); token != "" {
+							foundCursorField = true
 							if _, seen := seenCursorTokens[token]; seen {
 								if humanFriendly {
 									fmt.Fprintf(os.Stderr, "warning: --all received the same pagination cursor twice; returning fetched pages only.\n")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -704,8 +704,8 @@ func paginatedGet(ctx context.Context, c interface {
 				// Check for next cursor
 				if cursorLookupPath != "" {
 					if tokenRaw, ok := rawAtPath(obj, cursorLookupPath); ok {
-						foundCursorField = true
 						if token := paginationCursorToken(tokenRaw); token != "" {
+							foundCursorField = true
 							if _, seen := seenCursorTokens[token]; seen {
 								if humanFriendly {
 									fmt.Fprintf(os.Stderr, "warning: --all received the same pagination cursor twice; returning fetched pages only.\n")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -627,12 +627,16 @@ func paginatedGet(ctx context.Context, c interface {
 			clean[k] = v
 		}
 	}
+	cursorLookupPath := nextCursorPath
+	if cursorLookupPath == "" && paginationType != "offset" && paginationType != "page" {
+		cursorLookupPath = cursorParam
+	}
 	if !fetchAll {
 		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
 			return nil, err
 		}
-		emitTruncationWarning(data, nextCursorPath, hasMoreField, paginationType)
+		emitTruncationWarning(data, cursorLookupPath, hasMoreField, paginationType)
 		return data, nil
 	}
 
@@ -656,6 +660,11 @@ func paginatedGet(ctx context.Context, c interface {
 
 	// Fetch all pages
 	allItems := make([]json.RawMessage, 0)
+	seenCursorTokens := map[string]struct{}{}
+	if sentCursor := clean[cursorParam]; sentCursor != "" {
+		seenCursorTokens[sentCursor] = struct{}{}
+	}
+	foundCursorField := false
 	page := 0
 	for {
 		page++
@@ -693,9 +702,19 @@ func paginatedGet(ctx context.Context, c interface {
 				}
 
 				// Check for next cursor
-				if nextCursorPath != "" {
-					if tokenRaw, ok := rawAtPath(obj, nextCursorPath); ok {
+				if cursorLookupPath != "" {
+					if tokenRaw, ok := rawAtPath(obj, cursorLookupPath); ok {
+						foundCursorField = true
 						if token := paginationCursorToken(tokenRaw); token != "" {
+							if _, seen := seenCursorTokens[token]; seen {
+								if humanFriendly {
+									fmt.Fprintf(os.Stderr, "warning: --all received the same pagination cursor twice; returning fetched pages only.\n")
+								} else {
+									fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_cursor_repeated","next_cursor_path":%q,"message":"--all received the same pagination cursor twice; returning fetched pages only"}`+"\n", cursorLookupPath)
+								}
+								break
+							}
+							seenCursorTokens[token] = struct{}{}
 							if page >= paginatedGetMaxPages {
 								emitPaginatedGetMaxPagesWarning()
 								break
@@ -722,7 +741,7 @@ func paginatedGet(ctx context.Context, c interface {
 									clean[cursorParam] = next
 									continue
 								}
-								emitMissingPaginationCursorWarning(nextCursorPath)
+								emitMissingPaginationCursorWarning(cursorLookupPath)
 								break
 							}
 							hasExplicitNoMore = true
@@ -748,7 +767,7 @@ func paginatedGet(ctx context.Context, c interface {
 		break
 	}
 
-	if fetchAll && page == 1 && nextCursorPath == "" && hasMoreField == "" && paginationType != "offset" && paginationType != "page" {
+	if fetchAll && page == 1 && nextCursorPath == "" && !foundCursorField && hasMoreField == "" && paginationType != "offset" && paginationType != "page" {
 		emitMissingPaginationSignalWarning()
 	}
 	if humanFriendly {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
@@ -77,7 +77,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/projects", true, false, nil, mcpPageConfig{CursorParam: "cursor", NextCursorPath: ""}, []mcpParamBinding{{PublicName: "status", WireName: "status", Location: "query"}, {PublicName: "limit", WireName: "limit", Location: "query", Default: "25"}}, []string{}),
+		makeAPIHandler("GET", "/projects", true, false, nil, mcpPageConfig{CursorParam: "cursor", NextCursorPath: "cursor"}, []mcpParamBinding{{PublicName: "status", WireName: "status", Location: "query"}, {PublicName: "limit", WireName: "limit", Location: "query", Default: "25"}}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_avatar_upload-project",
@@ -101,7 +101,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/projects/{projectId}/tasks", true, false, nil, mcpPageConfig{CursorParam: "cursor", NextCursorPath: ""}, []mcpParamBinding{{PublicName: "projectId", WireName: "projectId", Location: "path"}, {PublicName: "priority", WireName: "priority", Location: "query"}, {PublicName: "limit", WireName: "limit", Location: "query", Default: "50"}}, []string{"projectId"}),
+		makeAPIHandler("GET", "/projects/{projectId}/tasks", true, false, nil, mcpPageConfig{CursorParam: "cursor", NextCursorPath: "cursor"}, []mcpParamBinding{{PublicName: "projectId", WireName: "projectId", Location: "path"}, {PublicName: "priority", WireName: "priority", Location: "query"}, {PublicName: "limit", WireName: "limit", Location: "query", Default: "50"}}, []string{"projectId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_tasks_update-project",

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
@@ -54,7 +54,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/items", "free", true, false, nil, mcpPageConfig{CursorParam: "cursor", NextCursorPath: ""}, []mcpParamBinding{}, []string{}),
+		makeAPIHandler("GET", "/items", "free", true, false, nil, mcpPageConfig{CursorParam: "cursor", NextCursorPath: "cursor"}, []mcpParamBinding{}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("items_premium",


### PR DESCRIPTION
## Summary

Generated cursor-paginated commands now follow every page when an API returns its continuation token under the same name as the request cursor, even when OpenAPI provides no explicit response cursor path. The same fallback now reaches typed MCP pagination, while offset and page-number pagination remain unchanged. Repeated or cyclic cursor tokens stop safely with a structured truncation warning instead of looping.

## Validation

- `scripts/golden.sh verify` (32 cases passed)
- `scripts/verify-generator-output.sh` (10 generated modules compiled)
- focused generated behavior and MCP pagination tests passed
- `go vet ./...`, `go build -o ./cli-printing-press ./cmd/cli-printing-press`, and `golangci-lint run ./...` passed
- `go test ./...` reached an intermittent parallel `govulncheck` subprocess failure in `TestGenerateWithNoAuth`; that exact test passes in isolation

Closes #3436

## Not included

Issue #3513 requires a separate TLS client, configuration, and compatibility review.
