### PR TITLE
fix(cli): preserve generated credential aliases

### DIFF
--- a/internal/generator/credential_codegen_roundtrip_test.go
+++ b/internal/generator/credential_codegen_roundtrip_test.go
@@ -1,0 +1,187 @@
+package generator
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedMultiEnvAPIKeyCredentialsRoundTripAcrossConfigFormats(t *testing.T) {
+	t.Parallel()
+
+	for _, format := range []string{"json", "toml"} {
+		t.Run(format, func(t *testing.T) {
+			t.Parallel()
+
+			apiSpec := minimalSpec("credential-alias-" + format)
+			apiSpec.Auth = spec.AuthConfig{
+				Type:    "api_key",
+				Header:  "AccessKey",
+				EnvVars: []string{"BUNNY_API_KEY", "BUNNYNET_API_KEY"},
+				EnvVarSpecs: spec.NewORCaseEnvVarSpecs([]string{
+					"BUNNY_API_KEY",
+					"BUNNYNET_API_KEY",
+				}),
+			}
+			apiSpec.Config = spec.ConfigSpec{
+				Format: format,
+				Path:   "~/.config/credential-alias/config." + format,
+			}
+
+			outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+			require.NoError(t, New(apiSpec, outputDir).Generate())
+
+			credentialsSrc := readGeneratedFile(t, outputDir, "internal", "cliutil", "credentials.go")
+			require.Regexp(t, `BunnyApiKey\s+string\s+`+"`toml:\"api_key\"`", credentialsSrc)
+			require.Regexp(t, `BunnynetApiKey\s+string\s+`+"`toml:\"bunnynet_api_key\"`", credentialsSrc)
+
+			configSrc := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+			require.Regexp(t, `BunnyApiKey\s+string\s+`+"`"+format+":\"api_key\"`", configSrc)
+			require.Regexp(t, `BunnynetApiKey\s+string\s+`+"`"+format+":\"bunnynet_api_key\"`", configSrc)
+
+			authSrc := readGeneratedFile(t, outputDir, "internal", "cli", "auth.go")
+			require.Contains(t, authSrc, "cmd.AddCommand(newAuthSetTokenCmd(flags))")
+
+			const aliasRoundTripTest = `package cliutil
+
+import "testing"
+
+func TestCredentialAliasFieldsRoundTripIndependently(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", home)
+	if restore, err := SetHomeOverride(""); err == nil {
+		t.Cleanup(restore)
+	} else {
+		t.Fatalf("SetHomeOverride() error = %v", err)
+	}
+
+	cases := []struct {
+		name string
+		creds *Credentials
+		value func(*Credentials) string
+	}{
+		{"canonical", &Credentials{BunnyApiKey: "canonical-secret"}, func(c *Credentials) string { return c.BunnyApiKey }},
+		{"alias", &Credentials{BunnynetApiKey: "alias-secret"}, func(c *Credentials) string { return c.BunnynetApiKey }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := SaveCredentials(tc.creds); err != nil {
+				t.Fatalf("SaveCredentials() error = %v", err)
+			}
+			loaded, ok, err := LoadCredentials()
+			if err != nil || !ok {
+				t.Fatalf("LoadCredentials() = ok %v, err %v", ok, err)
+			}
+			if got := tc.value(loaded); got != tc.value(tc.creds) {
+				t.Fatalf("reloaded credential = %q, want %q", got, tc.value(tc.creds))
+			}
+		})
+	}
+}
+`
+			require.NoError(t, os.WriteFile(
+				filepath.Join(outputDir, "internal", "cliutil", "credential_alias_roundtrip_test.go"),
+				[]byte(aliasRoundTripTest), 0o600))
+
+			credentialTests := readGeneratedFile(t, outputDir, "internal", "cliutil", "credentials_test.go")
+			require.Contains(t, credentialTests, "go func()")
+			require.NotContains(t, credentialTests, "legacyCredentialTOML")
+			if format == "json" {
+				require.Contains(t, credentialTests, "json.Marshal")
+			} else {
+				require.NotContains(t, credentialTests, "json.Marshal")
+			}
+
+			requireGeneratedCompiles(t, outputDir)
+			runGoCommandRequired(t, outputDir, "test", "./internal/cliutil", "./internal/config", "./internal/cli")
+
+			binPath := filepath.Join(outputDir, naming.CLI(apiSpec.Name))
+			runGoCommandRequired(t, outputDir, "build", "-o", binPath, "./cmd/"+naming.CLI(apiSpec.Name))
+			home := t.TempDir()
+			dataHome := filepath.Join(home, "data")
+			cmd := exec.Command(binPath, "auth", "set-token", "set-token-secret")
+			cmd.Env = append(os.Environ(),
+				"HOME="+home,
+				"XDG_CONFIG_HOME="+filepath.Join(home, "config"),
+				"XDG_DATA_HOME="+dataHome,
+			)
+			out, err := cmd.CombinedOutput()
+			require.NoError(t, err, "auth set-token failed: %s", string(out))
+			persisted, err := os.ReadFile(filepath.Join(dataHome, naming.CLI(apiSpec.Name), "credentials.toml"))
+			require.NoError(t, err)
+			require.Contains(t, string(persisted), "api_key")
+			require.Contains(t, string(persisted), "set-token-secret")
+		})
+	}
+}
+
+func TestGeneratedCredentialStderrCaptureExercisesPipeCapacity(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("credential-stderr")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	credentialTests := readGeneratedFile(t, outputDir, "internal", "cliutil", "credentials_test.go")
+	require.Contains(t, credentialTests, `strings.Repeat("x", 128*1024)`)
+	require.True(t, strings.Index(credentialTests, "go func()") < strings.Index(credentialTests, "fn()"),
+		"stderr reader must start before the callback writes to the pipe")
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommandRequired(t, outputDir, "test", "./internal/cliutil", "-run", "TestCaptureCredentialStderrDrainsConcurrently")
+}
+
+func TestAuthSetTokenAvailabilityDistinguishesAliasesFromRequiredPairs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		auth spec.AuthConfig
+		want bool
+	}{
+		{
+			name: "optional aliases share one token",
+			auth: spec.AuthConfig{
+				Type:        "api_key",
+				EnvVarSpecs: spec.NewORCaseEnvVarSpecs([]string{"SERVICE_API_KEY", "SERVICE_TOKEN"}),
+			},
+			want: true,
+		},
+		{
+			name: "required pair needs separate credentials",
+			auth: spec.AuthConfig{
+				Type: "api_key",
+				EnvVarSpecs: []spec.AuthEnvVar{
+					{Name: "SERVICE_USER", Kind: spec.AuthEnvVarKindPerCall, Required: true},
+					{Name: "SERVICE_SECRET", Kind: spec.AuthEnvVarKindPerCall, Required: true},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "single required credential stays supported",
+			auth: spec.AuthConfig{
+				Type: "api_key",
+				EnvVarSpecs: []spec.AuthEnvVar{
+					{Name: "SERVICE_API_KEY", Kind: spec.AuthEnvVarKindPerCall, Required: true},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := authSetTokenAvailable(tt.auth); got != tt.want {
+				t.Fatalf("authSetTokenAvailable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1534,13 +1534,25 @@ func authAgentEnvVars(auth spec.AuthConfig) []spec.AuthEnvVar {
 
 func credentialFields(auth spec.AuthConfig) []credentialField {
 	var fields []credentialField
+	usedTags := make(map[string]struct{})
 	add := func(name string) {
 		if envVarIsBuiltinField(name) {
 			return
 		}
+		tag := naming.EnvVarPlaceholder(name)
+		if _, exists := usedTags[tag]; exists {
+			tag = strings.ToLower(name)
+			for suffix := 2; ; suffix++ {
+				if _, exists := usedTags[tag]; !exists {
+					break
+				}
+				tag = fmt.Sprintf("%s_%d", strings.ToLower(name), suffix)
+			}
+		}
+		usedTags[tag] = struct{}{}
 		fields = append(fields, credentialField{
 			GoField: envVarField(name),
-			Tag:     naming.EnvVarPlaceholder(name),
+			Tag:     tag,
 		})
 	}
 	if len(auth.EnvVarSpecs) > 0 {
@@ -1673,7 +1685,7 @@ func authSetTokenAvailableForRequiredCount(auth spec.AuthConfig, requiredCount i
 	}
 	switch auth.Type {
 	case "api_key", "bearer_token":
-		return requiredCount == 1
+		return requestAuthEnvVarCount(auth) > 0 && requiredCount <= 1
 	default:
 		return false
 	}

--- a/internal/generator/templates/cliutil_credentials_test.go.tmpl
+++ b/internal/generator/templates/cliutil_credentials_test.go.tmpl
@@ -5,6 +5,9 @@ package cliutil_test
 
 import (
 	"bytes"
+{{- if ne .Config.Format "toml"}}
+	"encoding/json"
+{{- end}}
 	"io"
 	"os"
 	"path/filepath"
@@ -61,7 +64,7 @@ func TestCredentialsFileWinsWhenLegacyConfigAlsoHasSecrets(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
 	}
-	if err := os.WriteFile(configPath, []byte("base_url = \"https://legacy.example\"\n"+legacyCredentialTOML("legacy-secret")), 0o600); err != nil {
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://legacy.example", "legacy-secret"), 0o600); err != nil {
 		t.Fatalf("write legacy config: %v", err)
 	}
 	if err := cliutil.SaveCredentials(testCredentials("data-secret")); err != nil {
@@ -83,7 +86,7 @@ func TestCorruptCredentialsFallsBackToLegacyConfig(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
 	}
-	if err := os.WriteFile(configPath, []byte("base_url = \"https://legacy.example\"\n"+legacyCredentialTOML("legacy-secret")), 0o600); err != nil {
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://legacy.example", "legacy-secret"), 0o600); err != nil {
 		t.Fatalf("write legacy config: %v", err)
 	}
 	credentialsPath := filepath.Join(home, ".local", "share", "{{$.Name}}-pp-cli", "credentials.toml")
@@ -149,7 +152,7 @@ func TestEmptyCredentialsFileDoesNotClearLegacyConfig(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
 	}
-	if err := os.WriteFile(configPath, []byte("base_url = \"https://legacy.example\"\n"+legacyCredentialTOML("legacy-secret")), 0o600); err != nil {
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://legacy.example", "legacy-secret"), 0o600); err != nil {
 		t.Fatalf("write legacy config: %v", err)
 	}
 	credentialsPath := filepath.Join(home, ".local", "share", "{{.Name}}-pp-cli", "credentials.toml")
@@ -175,7 +178,7 @@ func TestAuthWriteMigratesLegacyConfigToCredentialsOnly(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
 	}
-	if err := os.WriteFile(configPath, []byte("base_url = \"https://settings.example\"\n"+legacyCredentialTOML("legacy-secret")), 0o600); err != nil {
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://settings.example", "legacy-secret"), 0o600); err != nil {
 		t.Fatalf("write legacy config: %v", err)
 	}
 
@@ -211,7 +214,7 @@ func TestAuthWriteScrubsLegacyConfigWhenRelocated(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(defaultConfigPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
 	}
-	if err := os.WriteFile(defaultConfigPath, []byte("base_url = \"https://settings.example\"\n"+legacyCredentialTOML("legacy-secret")), 0o600); err != nil {
+	if err := os.WriteFile(defaultConfigPath, legacyConfigData(t, "https://settings.example", "legacy-secret"), 0o600); err != nil {
 		t.Fatalf("write legacy config: %v", err)
 	}
 
@@ -265,7 +268,7 @@ func TestClearTokensFromBothStateClearsCredentialsAndLegacy(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
 	}
-	if err := os.WriteFile(configPath, []byte("base_url = \"https://settings.example\"\n"+legacyCredentialTOML("legacy-secret")), 0o600); err != nil {
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://settings.example", "legacy-secret"), 0o600); err != nil {
 		t.Fatalf("write legacy config: %v", err)
 	}
 	if err := cliutil.SaveCredentials(testCredentials("data-secret")); err != nil {
@@ -363,8 +366,20 @@ func legacyCredentialKey() string {
 {{- end}}
 }
 
-func legacyCredentialTOML(token string) string {
-	return legacyCredentialKey() + " = \"" + token + "\"\n"
+func legacyConfigData(t *testing.T, baseURL, token string) []byte {
+	t.Helper()
+{{- if eq .Config.Format "toml"}}
+	return []byte("base_url = \"" + baseURL + "\"\n" + legacyCredentialKey() + " = \"" + token + "\"\n")
+{{- else}}
+	data, err := json.Marshal(map[string]string{
+		"base_url":             baseURL,
+		legacyCredentialKey(): token,
+	})
+	if err != nil {
+		t.Fatalf("marshal legacy config fixture: %v", err)
+	}
+	return data
+{{- end}}
 }
 
 func writeConfigCredential(t *testing.T, cfg *config.Config, token string) {
@@ -432,10 +447,36 @@ func captureCredentialStderr(t *testing.T, fn func()) string {
 		t.Fatalf("pipe: %v", err)
 	}
 	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	drained := false
+	defer func() {
+		os.Stderr = old
+		_ = w.Close()
+		if !drained {
+			<-done
+		}
+		_ = r.Close()
+	}()
 	fn()
 	_ = w.Close()
 	os.Stderr = old
-	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
-	return buf.String()
+	captured := <-done
+	drained = true
+	_ = r.Close()
+	return captured
+}
+
+func TestCaptureCredentialStderrDrainsConcurrently(t *testing.T) {
+	want := strings.Repeat("x", 128*1024)
+	got := captureCredentialStderr(t, func() {
+		_, _ = os.Stderr.Write([]byte(want))
+	})
+	if got != want {
+		t.Fatalf("captured stderr length = %d, want %d", len(got), len(want))
+	}
 }

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/cliutil/credentials_test.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/cliutil/credentials_test.go
@@ -49,7 +49,7 @@ func TestCredentialsFileWinsWhenLegacyConfigAlsoHasSecrets(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
 	}
-	if err := os.WriteFile(configPath, []byte("base_url = \"https://legacy.example\"\n"+legacyCredentialTOML("legacy-secret")), 0o600); err != nil {
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://legacy.example", "legacy-secret"), 0o600); err != nil {
 		t.Fatalf("write legacy config: %v", err)
 	}
 	if err := cliutil.SaveCredentials(testCredentials("data-secret")); err != nil {
@@ -71,7 +71,7 @@ func TestCorruptCredentialsFallsBackToLegacyConfig(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
 	}
-	if err := os.WriteFile(configPath, []byte("base_url = \"https://legacy.example\"\n"+legacyCredentialTOML("legacy-secret")), 0o600); err != nil {
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://legacy.example", "legacy-secret"), 0o600); err != nil {
 		t.Fatalf("write legacy config: %v", err)
 	}
 	credentialsPath := filepath.Join(home, ".local", "share", "printing-press-oauth2-pp-cli", "credentials.toml")
@@ -126,7 +126,7 @@ func TestEmptyCredentialsFileDoesNotClearLegacyConfig(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
 	}
-	if err := os.WriteFile(configPath, []byte("base_url = \"https://legacy.example\"\n"+legacyCredentialTOML("legacy-secret")), 0o600); err != nil {
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://legacy.example", "legacy-secret"), 0o600); err != nil {
 		t.Fatalf("write legacy config: %v", err)
 	}
 	credentialsPath := filepath.Join(home, ".local", "share", "printing-press-oauth2-pp-cli", "credentials.toml")
@@ -152,7 +152,7 @@ func TestAuthWriteMigratesLegacyConfigToCredentialsOnly(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
 	}
-	if err := os.WriteFile(configPath, []byte("base_url = \"https://settings.example\"\n"+legacyCredentialTOML("legacy-secret")), 0o600); err != nil {
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://settings.example", "legacy-secret"), 0o600); err != nil {
 		t.Fatalf("write legacy config: %v", err)
 	}
 
@@ -188,7 +188,7 @@ func TestAuthWriteScrubsLegacyConfigWhenRelocated(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(defaultConfigPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
 	}
-	if err := os.WriteFile(defaultConfigPath, []byte("base_url = \"https://settings.example\"\n"+legacyCredentialTOML("legacy-secret")), 0o600); err != nil {
+	if err := os.WriteFile(defaultConfigPath, legacyConfigData(t, "https://settings.example", "legacy-secret"), 0o600); err != nil {
 		t.Fatalf("write legacy config: %v", err)
 	}
 
@@ -242,7 +242,7 @@ func TestClearTokensFromBothStateClearsCredentialsAndLegacy(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
 	}
-	if err := os.WriteFile(configPath, []byte("base_url = \"https://settings.example\"\n"+legacyCredentialTOML("legacy-secret")), 0o600); err != nil {
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://settings.example", "legacy-secret"), 0o600); err != nil {
 		t.Fatalf("write legacy config: %v", err)
 	}
 	if err := cliutil.SaveCredentials(testCredentials("data-secret")); err != nil {
@@ -333,8 +333,9 @@ func legacyCredentialKey() string {
 	return "access_token"
 }
 
-func legacyCredentialTOML(token string) string {
-	return legacyCredentialKey() + " = \"" + token + "\"\n"
+func legacyConfigData(t *testing.T, baseURL, token string) []byte {
+	t.Helper()
+	return []byte("base_url = \"" + baseURL + "\"\n" + legacyCredentialKey() + " = \"" + token + "\"\n")
 }
 
 func writeConfigCredential(t *testing.T, cfg *config.Config, token string) {
@@ -382,10 +383,36 @@ func captureCredentialStderr(t *testing.T, fn func()) string {
 		t.Fatalf("pipe: %v", err)
 	}
 	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	drained := false
+	defer func() {
+		os.Stderr = old
+		_ = w.Close()
+		if !drained {
+			<-done
+		}
+		_ = r.Close()
+	}()
 	fn()
 	_ = w.Close()
 	os.Stderr = old
-	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
-	return buf.String()
+	captured := <-done
+	drained = true
+	_ = r.Close()
+	return captured
+}
+
+func TestCaptureCredentialStderrDrainsConcurrently(t *testing.T) {
+	want := strings.Repeat("x", 128*1024)
+	got := captureCredentialStderr(t, func() {
+		_, _ = os.Stderr.Write([]byte(want))
+	})
+	if got != want {
+		t.Fatalf("captured stderr length = %d, want %d", len(got), len(want))
+	}
 }


### PR DESCRIPTION
## Summary

Generated API-key CLIs now preserve each supported environment-variable alias under a unique credential key, and single-token alias auth registers `auth set-token` without enabling it for true multi-credential schemes. Generated credential tests now write fixtures in the configured JSON or TOML format and drain stderr concurrently, preventing pipe-capacity deadlocks.

Validation covered generated JSON and TOML modules, independent alias save/load round trips, executed `auth set-token` persistence, `go test ./...`, `scripts/golden.sh verify`, `scripts/verify-generator-output.sh`, and `golangci-lint run ./...`.

Closes #3455
Closes #3466
