### PR TITLE
fix(cli): require patched Go generator release

### DIFF
--- a/supported-versions.txt
+++ b/supported-versions.txt
@@ -10,5 +10,5 @@
 # latest published release, so a typo above the newest version cannot brick
 # every install. Below the skill's frozen `min-binary-version` (the hard
 # compatibility floor) it has no effect — that floor always wins.
-min_supported=4.27.1
+min_supported=4.28.0
 reason=Releases below this version generate CLIs with since-fixed bugs; upgrade to regenerate cleanly.


### PR DESCRIPTION
Generation skills now reject v4.27.1 and older, ensuring fresh CLIs use v4.28.0's patched Go 1.26.5 toolchain instead of emitting vulnerable 1.26.4 directives. This uses the existing out-of-band currency gate so older standalone installations upgrade before regenerating.

Closes #3531.

Validation: `go test ./internal/pipeline -run '^TestSkillsEnforceCurrencyFloor$'`, `python3 scripts/verify-go-floor.py`, and `git diff --check`.
