### PR TITLE
fix(cli): refresh staged artifacts before promote

### DIFF
--- a/internal/cli/bundle.go
+++ b/internal/cli/bundle.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -267,15 +266,5 @@ func resolvePlatform(s string) (string, string, error) {
 // retaining the size-oriented ldflags Claude Desktop examples use. Users can
 // --skip-build and pass their own binary.
 func buildMCPBBinary(cliDir, mcpName, outputPath, goos, goarch string) error {
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
-		return fmt.Errorf("creating bin dir: %w", err)
-	}
-	pkg := "./cmd/" + mcpName
-	cmd := exec.Command("go", "build", "-trimpath", "-ldflags=-s -w -buildid=", "-o", outputPath, pkg)
-	cmd.Dir = cliDir
-	cmd.Env = append(os.Environ(), "GOOS="+goos, "GOARCH="+goarch)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("go build %s: %w\n%s", pkg, err, string(out))
-	}
-	return nil
+	return pipeline.BuildMCPBBinary(cliDir, mcpName, outputPath, goos, goarch)
 }

--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -371,6 +371,11 @@ func replaceLiveCheckBinary(src, dst string) error {
 	if runtime.GOOS != "windows" {
 		return os.Rename(src, dst)
 	}
+	if _, err := os.Stat(dst); os.IsNotExist(err) {
+		return os.Rename(src, dst)
+	} else if err != nil {
+		return err
+	}
 
 	backup, err := os.CreateTemp(filepath.Dir(dst), "."+filepath.Base(dst)+".old-*")
 	if err != nil {
@@ -460,7 +465,8 @@ func newestLiveCheckSourceUnder(root string) (time.Time, bool, error) {
 			}
 			return nil
 		}
-		if filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") {
+		isModuleInput := filepath.Dir(path) == root && (entry.Name() == "go.mod" || entry.Name() == "go.sum")
+		if !isModuleInput && (filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go")) {
 			return nil
 		}
 		info, err := entry.Info()

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -1089,7 +1089,8 @@ func TestLiveDogfoodBinaryPathKeepsFreshRootBinary(t *testing.T) {
 
 	dir := t.TempDir()
 	binaryName := "fixture-pp-cli"
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/live-dogfood-root-fresh-test\n\ngo 1.23\n"), 0o644))
+	modulePath := filepath.Join(dir, "go.mod")
+	require.NoError(t, os.WriteFile(modulePath, []byte("module example.com/live-dogfood-root-fresh-test\n\ngo 1.23\n"), 0o644))
 	cmdDir := filepath.Join(dir, "cmd", binaryName)
 	require.NoError(t, os.MkdirAll(cmdDir, 0o755))
 	mainPath := filepath.Join(cmdDir, "main.go")
@@ -1098,6 +1099,7 @@ func TestLiveDogfoodBinaryPathKeepsFreshRootBinary(t *testing.T) {
 	rootPath := writeStubBinary(t, dir, binaryName, `echo "fresh root"`)
 	oldTime := time.Now().Add(-2 * time.Hour)
 	freshTime := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(modulePath, oldTime, oldTime))
 	require.NoError(t, os.Chtimes(mainPath, oldTime, oldTime))
 	require.NoError(t, os.Chtimes(rootPath, freshTime, freshTime))
 

--- a/internal/pipeline/lock.go
+++ b/internal/pipeline/lock.go
@@ -234,6 +234,9 @@ func PromoteWorkingCLI(cliName, workingDir string, state *PipelineState) error {
 	if err := validatePIIGateForPromote(workingDir, state); err != nil {
 		return err
 	}
+	if _, err := refreshPromoteArtifacts(workingDir, cliName); err != nil {
+		return fmt.Errorf("refreshing staged artifacts: %w", err)
+	}
 
 	slug := naming.TrimCLISuffix(cliName)
 	libraryDir := filepath.Join(PublishedLibraryRoot(), slug)
@@ -296,6 +299,10 @@ func PromoteWorkingCLI(cliName, workingDir string, state *PipelineState) error {
 	if err := WriteMCPBManifest(stagingDir); err != nil {
 		_ = os.RemoveAll(stagingDir)
 		return fmt.Errorf("writing MCPB manifest to staging: %w", err)
+	}
+	if _, err := syncPromoteBundle(stagingDir, cliName); err != nil {
+		_ = os.RemoveAll(stagingDir)
+		return fmt.Errorf("syncing MCPB bundle in staging: %w", err)
 	}
 
 	// Remove any stale backup from a prior successful swap before we create a

--- a/internal/pipeline/mcpb_bundle.go
+++ b/internal/pipeline/mcpb_bundle.go
@@ -3,13 +3,16 @@ package pipeline
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"time"
 )
 
 // BundleParams describes one MCPB bundle build. CLIDir must contain a
@@ -212,4 +215,22 @@ func DefaultBundleOutputPath(cliDir, mcpBinary, goos, goarch string) string {
 // to construct the path themselves.
 func StagedMCPBinaryPath(cliDir, mcpBinary string) string {
 	return filepath.Join(cliDir, "build", "stage", "bin", mcpBinary)
+}
+
+// BuildMCPBBinary centralizes build flags so direct bundle builds and promote
+// refreshes produce interchangeable staged binaries.
+func BuildMCPBBinary(cliDir, name, outputPath, goos, goarch string) error {
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return fmt.Errorf("creating bin dir: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	pkg := "./cmd/" + name
+	cmd := exec.CommandContext(ctx, "go", "build", "-trimpath", "-ldflags=-s -w -buildid=", "-o", outputPath, pkg)
+	cmd.Dir = cliDir
+	cmd.Env = append(os.Environ(), "GOOS="+goos, "GOARCH="+goarch)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("go build %s: %w\n%s", pkg, err, string(out))
+	}
+	return nil
 }

--- a/internal/pipeline/mcpb_bundle.go
+++ b/internal/pipeline/mcpb_bundle.go
@@ -3,7 +3,6 @@ package pipeline
 import (
 	"archive/zip"
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,7 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"time"
 )
 
 // BundleParams describes one MCPB bundle build. CLIDir must contain a
@@ -223,10 +221,8 @@ func BuildMCPBBinary(cliDir, name, outputPath, goos, goarch string) error {
 	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
 		return fmt.Errorf("creating bin dir: %w", err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
 	pkg := "./cmd/" + name
-	cmd := exec.CommandContext(ctx, "go", "build", "-trimpath", "-ldflags=-s -w -buildid=", "-o", outputPath, pkg)
+	cmd := exec.Command("go", "build", "-trimpath", "-ldflags=-s -w -buildid=", "-o", outputPath, pkg)
 	cmd.Dir = cliDir
 	cmd.Env = append(os.Environ(), "GOOS="+goos, "GOARCH="+goarch)
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/internal/pipeline/promote_artifacts.go
+++ b/internal/pipeline/promote_artifacts.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"debug/buildinfo"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -58,11 +59,8 @@ func refreshPromoteArtifacts(cliDir, cliName string) (bool, error) {
 		if err := os.MkdirAll(filepath.Dir(cliBinary), 0o755); err != nil {
 			return false, fmt.Errorf("creating staged binary directory: %w", err)
 		}
-		if err := rebuildLiveCheckBinary(cliDir, cliBinary); err != nil {
-			return false, fmt.Errorf("rebuilding staged CLI binary: %w", err)
-		}
-		if err := rebuildPromoteMCPBinary(cliDir, manifest.Name, mcpBinary); err != nil {
-			return false, fmt.Errorf("rebuilding staged MCP binary: %w", err)
+		if err := rebuildPromoteBinaryPair(cliDir, manifest.Name, cliBinary, mcpBinary); err != nil {
+			return false, err
 		}
 		refreshed = true
 	}
@@ -142,26 +140,103 @@ func fileCurrentAt(path string, threshold time.Time, goos, goarch string) bool {
 	return settings["GOOS"] == goos && settings["GOARCH"] == goarch
 }
 
-func rebuildPromoteMCPBinary(cliDir, name, outputPath string) error {
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+func rebuildPromoteBinaryPair(cliDir, mcpName, cliOutputPath, mcpOutputPath string) error {
+	cliTmpPath, err := promoteRebuildTempPath(cliOutputPath)
+	if err != nil {
+		return fmt.Errorf("creating staged CLI rebuild path: %w", err)
+	}
+	defer func() { _ = os.Remove(cliTmpPath) }()
+	mcpTmpPath, err := promoteRebuildTempPath(mcpOutputPath)
+	if err != nil {
+		return fmt.Errorf("creating staged MCP rebuild path: %w", err)
+	}
+	defer func() { _ = os.Remove(mcpTmpPath) }()
+
+	if err := buildCLITo(cliDir, cliTmpPath); err != nil {
+		return fmt.Errorf("rebuilding staged CLI binary: %w", err)
+	}
+	if err := BuildMCPBBinary(cliDir, mcpName, mcpTmpPath, runtime.GOOS, runtime.GOARCH); err != nil {
+		return fmt.Errorf("rebuilding staged MCP binary: %w", err)
+	}
+	if err := replacePromoteBinaryPair(cliTmpPath, cliOutputPath, mcpTmpPath, mcpOutputPath, replaceLiveCheckBinary); err != nil {
 		return err
 	}
+	return nil
+}
+
+type promoteOriginalBackup struct {
+	destination string
+	backupPath  string
+	existed     bool
+}
+
+func replacePromoteBinaryPair(cliTmpPath, cliOutputPath, mcpTmpPath, mcpOutputPath string, replace func(string, string) error) error {
+	cliBackup, err := backupPromoteOriginal(cliOutputPath)
+	if err != nil {
+		return fmt.Errorf("backing up staged CLI binary: %w", err)
+	}
+	defer func() { _ = os.Remove(cliBackup.backupPath) }()
+	mcpBackup, err := backupPromoteOriginal(mcpOutputPath)
+	if err != nil {
+		return errors.Join(fmt.Errorf("backing up staged MCP binary: %w", err), restorePromoteOriginal(cliBackup))
+	}
+	defer func() { _ = os.Remove(mcpBackup.backupPath) }()
+
+	if err := replace(cliTmpPath, cliOutputPath); err != nil {
+		return errors.Join(fmt.Errorf("replacing staged CLI binary: %w", err), restorePromoteOriginal(cliBackup), restorePromoteOriginal(mcpBackup))
+	}
+	if err := replace(mcpTmpPath, mcpOutputPath); err != nil {
+		return errors.Join(fmt.Errorf("replacing staged MCP binary: %w", err), restorePromoteOriginal(cliBackup), restorePromoteOriginal(mcpBackup))
+	}
+	return nil
+}
+
+func backupPromoteOriginal(destination string) (promoteOriginalBackup, error) {
+	backup := promoteOriginalBackup{destination: destination}
+	if _, err := os.Stat(destination); os.IsNotExist(err) {
+		return backup, nil
+	} else if err != nil {
+		return backup, err
+	}
+	backupPath, err := promoteRebuildTempPath(destination + ".old")
+	if err != nil {
+		return backup, err
+	}
+	if err := os.Rename(destination, backupPath); err != nil {
+		return backup, err
+	}
+	backup.backupPath = backupPath
+	backup.existed = true
+	return backup, nil
+}
+
+func restorePromoteOriginal(backup promoteOriginalBackup) error {
+	if err := os.Remove(backup.destination); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing partial staged binary %s: %w", backup.destination, err)
+	}
+	if !backup.existed {
+		return nil
+	}
+	if err := os.Rename(backup.backupPath, backup.destination); err != nil {
+		return fmt.Errorf("restoring staged binary %s: %w", backup.destination, err)
+	}
+	return nil
+}
+
+func promoteRebuildTempPath(outputPath string) (string, error) {
 	tmp, err := os.CreateTemp(filepath.Dir(outputPath), "."+filepath.Base(outputPath)+".rebuild-*")
 	if err != nil {
-		return err
+		return "", err
 	}
 	tmpPath := tmp.Name()
 	if err := tmp.Close(); err != nil {
 		_ = os.Remove(tmpPath)
-		return err
+		return "", err
 	}
-	_ = os.Remove(tmpPath)
-	defer func() { _ = os.Remove(tmpPath) }()
-
-	if err := BuildMCPBBinary(cliDir, name, tmpPath, runtime.GOOS, runtime.GOARCH); err != nil {
-		return err
+	if err := os.Remove(tmpPath); err != nil {
+		return "", err
 	}
-	return replaceLiveCheckBinary(tmpPath, outputPath)
+	return tmpPath, nil
 }
 
 func promoteBundleMatches(bundlePath, cliDir, mcpArchiveName, mcpBinary, cliArchiveName, cliBinary string) (bool, error) {
@@ -203,7 +278,7 @@ func promoteBundleMatches(bundlePath, cliDir, mcpArchiveName, mcpBinary, cliArch
 	for _, entry := range zr.File {
 		want, ok := expected[entry.Name]
 		if !ok {
-			continue
+			return false, nil
 		}
 		r, err := entry.Open()
 		if err != nil {

--- a/internal/pipeline/promote_artifacts.go
+++ b/internal/pipeline/promote_artifacts.go
@@ -1,0 +1,220 @@
+package pipeline
+
+import (
+	"archive/zip"
+	"bytes"
+	"debug/buildinfo"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/platform"
+)
+
+// refreshPromoteArtifacts makes the host-platform staged binaries and MCPB
+// bundle match the printed CLI source before promotion. It returns false when
+// every artifact is already current so an unchanged promote remains a no-op.
+func refreshPromoteArtifacts(cliDir, cliName string) (bool, error) {
+	if err := WriteMCPBManifest(cliDir); err != nil {
+		return false, fmt.Errorf("refreshing MCPB manifest: %w", err)
+	}
+	manifest, ok, err := readPromoteMCPBManifest(cliDir)
+	if err != nil || !ok {
+		return false, err
+	}
+
+	cmdDir, err := findCLICommandDir(cliDir)
+	if err != nil {
+		return false, fmt.Errorf("finding CLI command directory: %w", err)
+	}
+	newestSource, found, err := newestLiveCheckSourceUnder(cliDir)
+	if err != nil {
+		return false, fmt.Errorf("checking source freshness: %w", err)
+	}
+	for _, buildDir := range []string{cmdDir, filepath.Join(cliDir, "cmd", manifest.Name)} {
+		graphNewest, graphFound, err := newestLiveCheckBuildGraphModTime(buildDir)
+		if err != nil {
+			return false, fmt.Errorf("checking %s build graph freshness: %w", filepath.Base(buildDir), err)
+		}
+		if graphFound && (!found || graphNewest.After(newestSource)) {
+			newestSource = graphNewest
+			found = true
+		}
+	}
+	if !found {
+		return false, nil
+	}
+
+	cliArchiveName := platform.ExecutablePathForGOOS(cliName, runtime.GOOS)
+	mcpArchiveName := platform.ExecutablePathForGOOS(manifest.Name, runtime.GOOS)
+	cliBinary := StagedMCPBinaryPath(cliDir, cliArchiveName)
+	mcpBinary := StagedMCPBinaryPath(cliDir, mcpArchiveName)
+	refreshed := false
+	if !fileCurrentAt(cliBinary, newestSource, runtime.GOOS, runtime.GOARCH) || !fileCurrentAt(mcpBinary, newestSource, runtime.GOOS, runtime.GOARCH) {
+		if err := os.MkdirAll(filepath.Dir(cliBinary), 0o755); err != nil {
+			return false, fmt.Errorf("creating staged binary directory: %w", err)
+		}
+		if err := rebuildLiveCheckBinary(cliDir, cliBinary); err != nil {
+			return false, fmt.Errorf("rebuilding staged CLI binary: %w", err)
+		}
+		if err := rebuildPromoteMCPBinary(cliDir, manifest.Name, mcpBinary); err != nil {
+			return false, fmt.Errorf("rebuilding staged MCP binary: %w", err)
+		}
+		refreshed = true
+	}
+
+	bundleRefreshed, err := syncPromoteBundle(cliDir, cliName)
+	if err != nil {
+		return false, err
+	}
+	return refreshed || bundleRefreshed, nil
+}
+
+// syncPromoteBundle repacks only when the host MCPB's manifest or binaries
+// differ from the files that promotion is about to publish.
+func syncPromoteBundle(cliDir, cliName string) (bool, error) {
+	manifest, ok, err := readPromoteMCPBManifest(cliDir)
+	if err != nil || !ok {
+		return false, err
+	}
+	cliArchiveName := platform.ExecutablePathForGOOS(cliName, runtime.GOOS)
+	mcpArchiveName := platform.ExecutablePathForGOOS(manifest.Name, runtime.GOOS)
+	cliBinary := StagedMCPBinaryPath(cliDir, cliArchiveName)
+	mcpBinary := StagedMCPBinaryPath(cliDir, mcpArchiveName)
+	bundlePath := DefaultBundleOutputPath(cliDir, manifest.Name, runtime.GOOS, runtime.GOARCH)
+
+	matches, err := promoteBundleMatches(bundlePath, cliDir, mcpArchiveName, mcpBinary, cliArchiveName, cliBinary)
+	if err != nil {
+		return false, err
+	}
+	if matches {
+		return false, nil
+	}
+	if err := BuildMCPBBundle(BundleParams{
+		CLIDir:        cliDir,
+		BinaryPath:    mcpBinary,
+		BinaryName:    mcpArchiveName,
+		CLIBinaryName: cliArchiveName,
+		CLIBinaryPath: cliBinary,
+		OutputPath:    bundlePath,
+	}); err != nil {
+		return false, fmt.Errorf("repacking MCPB bundle: %w", err)
+	}
+	return true, nil
+}
+
+func readPromoteMCPBManifest(cliDir string) (MCPBManifest, bool, error) {
+	data, err := os.ReadFile(filepath.Join(cliDir, MCPBManifestFilename))
+	if os.IsNotExist(err) {
+		return MCPBManifest{}, false, nil
+	}
+	if err != nil {
+		return MCPBManifest{}, false, fmt.Errorf("reading MCPB manifest: %w", err)
+	}
+	var manifest MCPBManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return MCPBManifest{}, false, fmt.Errorf("parsing MCPB manifest: %w", err)
+	}
+	if manifest.Name == "" {
+		return MCPBManifest{}, false, fmt.Errorf("MCPB manifest name is empty")
+	}
+	return manifest, true, nil
+}
+
+func fileCurrentAt(path string, threshold time.Time, goos, goarch string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Size() == 0 ||
+		!isLiveCheckExecutableForGOOS(path, info.Mode(), goos) || info.ModTime().Before(threshold) {
+		return false
+	}
+	build, err := buildinfo.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	settings := make(map[string]string, len(build.Settings))
+	for _, setting := range build.Settings {
+		settings[setting.Key] = setting.Value
+	}
+	return settings["GOOS"] == goos && settings["GOARCH"] == goarch
+}
+
+func rebuildPromoteMCPBinary(cliDir, name, outputPath string) error {
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(outputPath), "."+filepath.Base(outputPath)+".rebuild-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	_ = os.Remove(tmpPath)
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if err := BuildMCPBBinary(cliDir, name, tmpPath, runtime.GOOS, runtime.GOARCH); err != nil {
+		return err
+	}
+	return replaceLiveCheckBinary(tmpPath, outputPath)
+}
+
+func promoteBundleMatches(bundlePath, cliDir, mcpArchiveName, mcpBinary, cliArchiveName, cliBinary string) (bool, error) {
+	expectedManifest, err := os.ReadFile(filepath.Join(cliDir, MCPBManifestFilename))
+	if err != nil {
+		return false, err
+	}
+	var manifest MCPBManifest
+	if err := json.Unmarshal(expectedManifest, &manifest); err != nil {
+		return false, err
+	}
+	expectedEntryPoint := "bin/" + mcpArchiveName
+	if manifest.Server.EntryPoint != expectedEntryPoint {
+		expectedManifest, err = rewriteMCPBManifestLaunch(expectedManifest, expectedEntryPoint)
+		if err != nil {
+			return false, err
+		}
+	}
+	expected := map[string][]byte{MCPBManifestFilename: expectedManifest}
+	for name, path := range map[string]string{
+		"bin/" + mcpArchiveName: mcpBinary,
+		"bin/" + cliArchiveName: cliBinary,
+	} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return false, fmt.Errorf("reading staged artifact %s: %w", path, err)
+		}
+		expected[name] = data
+	}
+
+	zr, err := zip.OpenReader(bundlePath)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, nil
+	}
+	defer func() { _ = zr.Close() }()
+	for _, entry := range zr.File {
+		want, ok := expected[entry.Name]
+		if !ok {
+			continue
+		}
+		r, err := entry.Open()
+		if err != nil {
+			return false, nil
+		}
+		got, readErr := io.ReadAll(r)
+		_ = r.Close()
+		if readErr != nil || !bytes.Equal(got, want) {
+			return false, nil
+		}
+		delete(expected, entry.Name)
+	}
+	return len(expected) == 0, nil
+}

--- a/internal/pipeline/promote_artifacts_test.go
+++ b/internal/pipeline/promote_artifacts_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"crypto/sha256"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -127,6 +128,92 @@ func TestRefreshPromoteArtifacts_CreatesMissingStageDirectory(t *testing.T) {
 	assert.True(t, refreshed)
 }
 
+func TestRefreshPromoteArtifacts_FailedMCPBuildPreservesBothStagedBinaries(t *testing.T) {
+	cliDir := filepath.Join(t.TempDir(), "test-pp-cli")
+	require.NoError(t, os.MkdirAll(cliDir, 0o755))
+	cliName := "test-pp-cli"
+	mcpName := "test-pp-mcp"
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "go.mod"), []byte("module example.com/test\n\ngo 1.24\n"), 0o644))
+	writePromoteMain(t, cliDir, cliName, `println("fresh cli")`)
+	writePromoteMain(t, cliDir, mcpName, `this is not valid Go`)
+	require.NoError(t, WriteCLIManifest(cliDir, CLIManifest{
+		SchemaVersion: CurrentCLIManifestSchemaVersion,
+		APIName:       "test",
+		CLIName:       cliName,
+		MCPBinary:     mcpName,
+	}))
+
+	cliBinary := StagedMCPBinaryPath(cliDir, platform.ExecutablePathForGOOS(cliName, runtime.GOOS))
+	mcpBinary := StagedMCPBinaryPath(cliDir, platform.ExecutablePathForGOOS(mcpName, runtime.GOOS))
+	require.NoError(t, os.MkdirAll(filepath.Dir(cliBinary), 0o755))
+	require.NoError(t, os.WriteFile(cliBinary, []byte("original cli"), 0o755))
+	require.NoError(t, os.WriteFile(mcpBinary, []byte("original mcp"), 0o755))
+
+	refreshed, err := refreshPromoteArtifacts(cliDir, cliName)
+	require.Error(t, err)
+	assert.False(t, refreshed)
+	assert.Equal(t, "original cli", string(mustReadFile(t, cliBinary)))
+	assert.Equal(t, "original mcp", string(mustReadFile(t, mcpBinary)))
+}
+
+func TestReplacePromoteBinaryPair_SecondReplacementFailureRestoresBothOriginals(t *testing.T) {
+	dir := t.TempDir()
+	cliOutputPath := filepath.Join(dir, "cli")
+	mcpOutputPath := filepath.Join(dir, "mcp")
+	cliTmpPath := filepath.Join(dir, "new-cli")
+	mcpTmpPath := filepath.Join(dir, "new-mcp")
+	require.NoError(t, os.WriteFile(cliOutputPath, []byte("original cli"), 0o755))
+	require.NoError(t, os.WriteFile(mcpOutputPath, []byte("original mcp"), 0o755))
+	require.NoError(t, os.WriteFile(cliTmpPath, []byte("new cli"), 0o755))
+	require.NoError(t, os.WriteFile(mcpTmpPath, []byte("new mcp"), 0o755))
+
+	replacements := 0
+	err := replacePromoteBinaryPair(cliTmpPath, cliOutputPath, mcpTmpPath, mcpOutputPath, func(src, dst string) error {
+		replacements++
+		if replacements == 2 {
+			return errors.New("injected MCP replacement failure")
+		}
+		return replaceLiveCheckBinary(src, dst)
+	})
+	require.ErrorContains(t, err, "injected MCP replacement failure")
+	assert.Equal(t, "original cli", string(mustReadFile(t, cliOutputPath)))
+	assert.Equal(t, "original mcp", string(mustReadFile(t, mcpOutputPath)))
+}
+
+func TestPromoteBundleMatches_RequiresExactEntrySet(t *testing.T) {
+	cliDir := t.TempDir()
+	mcpArchiveName := "test-pp-mcp"
+	cliArchiveName := "test-pp-cli"
+	mcpBinary := filepath.Join(cliDir, "staged-mcp")
+	cliBinary := filepath.Join(cliDir, "staged-cli")
+	require.NoError(t, os.WriteFile(mcpBinary, []byte("mcp bytes"), 0o755))
+	require.NoError(t, os.WriteFile(cliBinary, []byte("cli bytes"), 0o755))
+	manifest := []byte(`{"name":"test-pp-mcp","server":{"entry_point":"bin/test-pp-mcp"}}`)
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, MCPBManifestFilename), manifest, 0o644))
+
+	expectedEntries := []zipTestEntry{
+		{name: MCPBManifestFilename, data: manifest},
+		{name: "bin/" + mcpArchiveName, data: []byte("mcp bytes")},
+		{name: "bin/" + cliArchiveName, data: []byte("cli bytes")},
+	}
+	tests := []struct {
+		name    string
+		entries []zipTestEntry
+	}{
+		{name: "unexpected entry", entries: append(append([]zipTestEntry{}, expectedEntries...), zipTestEntry{name: "extra.txt", data: []byte("extra")})},
+		{name: "duplicate expected entry", entries: append(append([]zipTestEntry{}, expectedEntries...), expectedEntries[1])},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bundlePath := filepath.Join(t.TempDir(), "bundle.mcpb")
+			writeTestZIP(t, bundlePath, tt.entries)
+			matches, err := promoteBundleMatches(bundlePath, cliDir, mcpArchiveName, mcpBinary, cliArchiveName, cliBinary)
+			require.NoError(t, err)
+			assert.False(t, matches)
+		})
+	}
+}
+
 func writePromoteMain(t *testing.T, cliDir, name, body string) {
 	t.Helper()
 	dir := filepath.Join(cliDir, "cmd", name)
@@ -164,4 +251,31 @@ func fileDigest(t *testing.T, path string) [sha256.Size]byte {
 	data, err := os.ReadFile(path)
 	require.NoError(t, err)
 	return sha256.Sum256(data)
+}
+
+type zipTestEntry struct {
+	name string
+	data []byte
+}
+
+func writeTestZIP(t *testing.T, path string, entries []zipTestEntry) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	zw := zip.NewWriter(f)
+	for _, entry := range entries {
+		w, err := zw.Create(entry.name)
+		require.NoError(t, err)
+		_, err = w.Write(entry.data)
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+	require.NoError(t, f.Close())
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return data
 }

--- a/internal/pipeline/promote_artifacts_test.go
+++ b/internal/pipeline/promote_artifacts_test.go
@@ -1,0 +1,167 @@
+package pipeline
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/platform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPromoteWorkingCLI_RebuildsStaleBinariesAndBundle(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	cliDir := filepath.Join(tmp, "working", "test-pp-cli")
+	require.NoError(t, os.MkdirAll(cliDir, 0o755))
+	cliName := "test-pp-cli"
+	mcpName := "test-pp-mcp"
+
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "go.mod"), []byte("module example.com/test\n\ngo 1.24\n"), 0o644))
+	writePromoteMain(t, cliDir, cliName, `println("fresh cli")`)
+	writePromoteMain(t, cliDir, mcpName, `println("fresh mcp")`)
+	require.NoError(t, WriteCLIManifest(cliDir, CLIManifest{
+		SchemaVersion: CurrentCLIManifestSchemaVersion,
+		APIName:       "test",
+		CLIName:       cliName,
+		MCPBinary:     mcpName,
+	}))
+	require.NoError(t, WriteMCPBManifest(cliDir))
+
+	cliBinary := StagedMCPBinaryPath(cliDir, platform.ExecutablePathForGOOS(cliName, runtime.GOOS))
+	mcpBinary := StagedMCPBinaryPath(cliDir, platform.ExecutablePathForGOOS(mcpName, runtime.GOOS))
+	require.NoError(t, os.MkdirAll(filepath.Dir(cliBinary), 0o755))
+	require.NoError(t, os.WriteFile(cliBinary, []byte("stale cli"), 0o755))
+	require.NoError(t, os.WriteFile(mcpBinary, []byte("stale mcp"), 0o755))
+	old := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(cliBinary, old, old))
+	require.NoError(t, os.Chtimes(mcpBinary, old, old))
+
+	state := NewMinimalState(cliName, cliDir)
+	require.NoError(t, PromoteWorkingCLI(cliName, cliDir, state))
+	workBundlePath := DefaultBundleOutputPath(cliDir, mcpName, runtime.GOOS, runtime.GOARCH)
+	before := fileDigest(t, workBundlePath)
+	infoBefore, err := os.Stat(workBundlePath)
+	require.NoError(t, err)
+
+	state.WorkingDir = cliDir
+	state.OutputDir = cliDir
+	writePhase5PassForState(t, state, "none")
+	require.NoError(t, PromoteWorkingCLI(cliName, cliDir, state))
+	assert.Equal(t, before, fileDigest(t, workBundlePath))
+	infoAfter, err := os.Stat(workBundlePath)
+	require.NoError(t, err)
+	assert.Equal(t, infoBefore.ModTime(), infoAfter.ModTime())
+
+	cliDir = filepath.Join(PublishedLibraryRoot(), "test")
+	cliBinary = StagedMCPBinaryPath(cliDir, platform.ExecutablePathForGOOS(cliName, runtime.GOOS))
+	mcpBinary = StagedMCPBinaryPath(cliDir, platform.ExecutablePathForGOOS(mcpName, runtime.GOOS))
+
+	output, err := exec.Command(cliBinary).CombinedOutput()
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "fresh cli")
+	output, err = exec.Command(mcpBinary).CombinedOutput()
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "fresh mcp")
+
+	bundlePath := DefaultBundleOutputPath(cliDir, mcpName, runtime.GOOS, runtime.GOARCH)
+	assertBundleEntryEqualsFile(t, bundlePath, MCPBManifestFilename, filepath.Join(cliDir, MCPBManifestFilename))
+	assertBundleEntryEqualsFile(t, bundlePath, "bin/"+platform.ExecutablePathForGOOS(cliName, runtime.GOOS), cliBinary)
+	assertBundleEntryEqualsFile(t, bundlePath, "bin/"+platform.ExecutablePathForGOOS(mcpName, runtime.GOOS), mcpBinary)
+}
+
+func TestRefreshPromoteArtifacts_CreatesMissingStageDirectory(t *testing.T) {
+	cliDir := filepath.Join(t.TempDir(), "test-pp-cli")
+	require.NoError(t, os.MkdirAll(cliDir, 0o755))
+	cliName := "test-pp-cli"
+	mcpName := "test-pp-mcp"
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "go.mod"), []byte("module example.com/test\n\ngo 1.24\n"), 0o644))
+	writePromoteMain(t, cliDir, cliName, `println("fresh cli")`)
+	writePromoteMain(t, cliDir, mcpName, `println("fresh mcp")`)
+	require.NoError(t, WriteCLIManifest(cliDir, CLIManifest{
+		SchemaVersion: CurrentCLIManifestSchemaVersion,
+		APIName:       "test",
+		CLIName:       cliName,
+		MCPBinary:     mcpName,
+	}))
+
+	refreshed, err := refreshPromoteArtifacts(cliDir, cliName)
+	require.NoError(t, err)
+	assert.True(t, refreshed)
+	cliBinary := StagedMCPBinaryPath(cliDir, platform.ExecutablePathForGOOS(cliName, runtime.GOOS))
+	assert.FileExists(t, cliBinary)
+	assert.FileExists(t, StagedMCPBinaryPath(cliDir, platform.ExecutablePathForGOOS(mcpName, runtime.GOOS)))
+
+	otherArch := "amd64"
+	if runtime.GOARCH == otherArch {
+		otherArch = "arm64"
+	}
+	require.NoError(t, BuildMCPBBinary(cliDir, cliName, cliBinary, runtime.GOOS, otherArch))
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(cliBinary, future, future))
+	refreshed, err = refreshPromoteArtifacts(cliDir, cliName)
+	require.NoError(t, err)
+	assert.True(t, refreshed)
+	assert.True(t, fileCurrentAt(cliBinary, time.Time{}, runtime.GOOS, runtime.GOARCH))
+
+	require.NoError(t, os.WriteFile(cliBinary, nil, 0o755))
+	require.NoError(t, os.Chtimes(cliBinary, future, future))
+	refreshed, err = refreshPromoteArtifacts(cliDir, cliName)
+	require.NoError(t, err)
+	assert.True(t, refreshed)
+	info, err := os.Stat(cliBinary)
+	require.NoError(t, err)
+	assert.Positive(t, info.Size())
+
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "go.mod"), []byte("module example.com/test\n\ngo 1.24\n\n// dependency input changed\n"), 0o644))
+	require.NoError(t, os.Chtimes(filepath.Join(cliDir, "go.mod"), future.Add(time.Hour), future.Add(time.Hour)))
+	refreshed, err = refreshPromoteArtifacts(cliDir, cliName)
+	require.NoError(t, err)
+	assert.True(t, refreshed)
+}
+
+func writePromoteMain(t *testing.T, cliDir, name, body string) {
+	t.Helper()
+	dir := filepath.Join(cliDir, "cmd", name)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	source := "package main\nfunc main() { " + body + " }\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte(source), 0o644))
+}
+
+func assertBundleEntryEqualsFile(t *testing.T, bundlePath, entryName, filePath string) {
+	t.Helper()
+	zr, err := zip.OpenReader(bundlePath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, zr.Close()) }()
+
+	want, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	for _, entry := range zr.File {
+		if entry.Name != entryName {
+			continue
+		}
+		r, err := entry.Open()
+		require.NoError(t, err)
+		var got bytes.Buffer
+		_, err = got.ReadFrom(r)
+		require.NoError(t, err)
+		require.NoError(t, r.Close())
+		assert.Equal(t, want, got.Bytes())
+		return
+	}
+	t.Fatalf("bundle entry %q not found", entryName)
+}
+
+func fileDigest(t *testing.T, path string) [sha256.Size]byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return sha256.Sum256(data)
+}

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -4642,7 +4642,7 @@ The override is forbidden unless the fresh tree contains the novels:
 "$PRINTING_PRESS_BIN" lock promote --cli <api>-pp-cli --dir "$CLI_WORK_DIR"
 ```
 
-The `promote` command handles the full sequence: stages the working directory, atomically swaps it into `$PRESS_LIBRARY/<api>` (slug-keyed), writes the `.printing-press.json` manifest, updates the `CurrentRunPointer`, and releases the lock — all in one step. The `--cli` flag accepts the CLI binary name; the Go code translates to the slug-keyed library path internally.
+The `promote` command handles the full sequence: refreshes stale host CLI/MCP binaries and their `.mcpb` bundle, stages the working directory, atomically swaps it into `$PRESS_LIBRARY/<api>` (slug-keyed), writes the `.printing-press.json` manifest, updates the `CurrentRunPointer`, and releases the lock — all in one step. When sources and bundle contents are unchanged, the refresh is a no-op. The `--cli` flag accepts the CLI binary name; the Go code translates to the slug-keyed library path internally.
 
 **Path B — reprint over a library with hand-authored content that the fresh tree did not fully rebuild (`-d "$LIB_TARGET"` AND `NOVEL_COUNT > 0` AND the guarded Path A override did not pass).** Use `regen-merge` to fold the fresh tree into the live library before promotion. `regen-merge` classifies every Go file under `internal/` and `cmd/` against the fresh tree, overwrites safely-templated files, re-injects `AddCommand` calls in `root.go` and resource-parents that the fresh tree lacks, and leaves files with hand-edited additions (`TEMPLATED-WITH-ADDITIONS`) untouched for human review. `--apply` writes via stage-and-swap-with-recovery, so partial failure can never lose data.
 


### PR DESCRIPTION
## Summary

Promotion now refreshes stale or invalid host CLI and MCP binaries after hand-authored Phase 3 changes, then republishes an `.mcpb` whose manifest and binaries match the staged tree. Unchanged artifacts remain a no-op, preserving repeat-promotion stability.

## Validation

- Focused promotion tests cover stale source, missing and corrupt binaries, dependency-only changes, cross-architecture artifacts, bundle contents, and unchanged repeat promotion.
- `go test ./internal/cli -run 'TestBundle|TestLockPromote' -count=1`
- `go vet ./internal/pipeline ./internal/cli`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...` was attempted; the aggregate run encountered generated-fixture `govulncheck` failures and the pipeline package's 10-minute timeout, while the affected focused tests pass.

Closes #3446
