### PR TITLE
fix(cli): harden generated store file permissions

### DIFF
--- a/internal/generator/fleet_hardening_test.go
+++ b/internal/generator/fleet_hardening_test.go
@@ -63,15 +63,16 @@ func TestGeneratedFleetHardening(t *testing.T) {
 	require.NotContains(t, deliverGo, "os.MkdirAll(dir, 0o755)")
 
 	requireGeneratedCompiles(t, outputDir)
-	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "^TestOpen(HardensSQLiteFilePermissions|WithRelativePathDoesNotChmodWorkingDirectory)$")
+	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "^(TestOpen(HardensSQLiteFilePermissions|WithRelativePathDoesNotChmodWorkingDirectory)|TestHardenSQLiteFilesSkipsSymlinkSidecars)$")
 }
 
 // TestNoWorldReadableMkdirAllInTemplates is the fleet-wide regression guard for
-// gosec G301: no emitted template may create a directory world-readable
+// gosec G301: no emitted production template may create a directory world-readable
 // (`0o755`). Scoped to template source because the alternative — generating
 // every feature combination (store, deliver, share, session-handshake, ...) and
 // asserting on each emitted file — is impractical; this catches a future
-// template edit reintroducing the mode regardless of which feature emits it.
+// production template edit reintroducing the mode regardless of which feature
+// emits it. Generated test templates may deliberately create permissive fixtures.
 // The generator's own `MkdirAll` calls (build-time output dirs in *.go) are out
 // of scope — they don't ship in printed CLIs.
 func TestNoWorldReadableMkdirAllInTemplates(t *testing.T) {
@@ -82,7 +83,7 @@ func TestNoWorldReadableMkdirAllInTemplates(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() || !strings.HasSuffix(path, ".tmpl") {
+		if d.IsDir() || !strings.HasSuffix(path, ".tmpl") || strings.HasSuffix(path, "_test.go.tmpl") {
 			return nil
 		}
 		data, readErr := os.ReadFile(path)

--- a/internal/generator/fleet_hardening_test.go
+++ b/internal/generator/fleet_hardening_test.go
@@ -61,6 +61,9 @@ func TestGeneratedFleetHardening(t *testing.T) {
 	require.Contains(t, deliverGo, "os.MkdirAll(dir, 0o700)",
 		"the agent-deliver dir must be created mode 0700 (gosec G301)")
 	require.NotContains(t, deliverGo, "os.MkdirAll(dir, 0o755)")
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "^TestOpen(HardensSQLiteFilePermissions|WithRelativePathDoesNotChmodWorkingDirectory)$")
 }
 
 // TestNoWorldReadableMkdirAllInTemplates is the fleet-wide regression guard for
@@ -101,7 +104,7 @@ func generateForHardeningTest(t *testing.T, apiSpec *spec.APISpec) string {
 	t.Helper()
 	outputDir := strings.TrimSuffix(t.TempDir(), "/") + "/" + naming.CLI(apiSpec.Name)
 	gen := New(apiSpec, outputDir)
-	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, MCP: true}
 	gen.profile = &profiler.APIProfile{
 		SyncableResources: []profiler.SyncableResource{
 			{Name: "widgets", Path: "/widgets", Method: "GET"},

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -139,6 +139,8 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
 		return nil, fmt.Errorf("creating db directory: %w", err)
 	}
+	hardenSQLiteFiles(dbPath)
+	defer hardenSQLiteFiles(dbPath)
 
 	// Pragma order is load-bearing: busy_timeout must engage BEFORE
 	// journal_mode(WAL) so the delete→WAL conversion (an exclusive
@@ -171,6 +173,14 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	}
 
 	return s, nil
+}
+
+// hardenSQLiteFiles is best-effort so stores on filesystems without Unix modes
+// remain usable. The deferred call catches files the SQLite driver creates.
+func hardenSQLiteFiles(dbPath string) {
+	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		_ = os.Chmod(path, 0o600)
+	}
 }
 
 func ensureSQLiteDriverInitialized(ctx context.Context, dsn string) error {

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -179,7 +179,21 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 // remain usable. The deferred call catches files the SQLite driver creates.
 func hardenSQLiteFiles(dbPath string) {
 	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
-		_ = os.Chmod(path, 0o600)
+		info, err := os.Lstat(path)
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		openInfo, statErr := file.Stat()
+		pathInfo, lstatErr := os.Lstat(path)
+		if statErr == nil && lstatErr == nil && pathInfo.Mode().IsRegular() && os.SameFile(openInfo, pathInfo) {
+			_ = file.Chmod(0o600)
+		}
+		_ = file.Close()
 	}
 }
 

--- a/internal/generator/templates/store_schema_version_test.go.tmpl
+++ b/internal/generator/templates/store_schema_version_test.go.tmpl
@@ -8,7 +8,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -16,6 +18,80 @@ import (
 
 	_ "modernc.org/sqlite"
 )
+
+func TestOpenHardensSQLiteFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose Unix permission bits")
+	}
+
+	for _, tc := range []struct {
+		name       string
+		precreateDB bool
+		wantDirMode os.FileMode
+	}{
+		{name: "fresh store", wantDirMode: 0o700},
+		{name: "pre-existing permissive store", precreateDB: true, wantDirMode: 0o755},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dbPath := filepath.Join(t.TempDir(), "private", "data.db")
+			if tc.precreateDB {
+				if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+					t.Fatalf("create permissive store dir: %v", err)
+				}
+				if err := os.WriteFile(dbPath, nil, 0o644); err != nil {
+					t.Fatalf("create permissive store: %v", err)
+				}
+			}
+
+			s, err := Open(dbPath)
+			if err != nil {
+				t.Fatalf("open store: %v", err)
+			}
+			defer s.Close()
+
+			assertPrivateMode(t, filepath.Dir(dbPath), tc.wantDirMode)
+			assertPrivateMode(t, dbPath, 0o600)
+			assertPrivateMode(t, dbPath+"-wal", 0o600)
+			assertPrivateMode(t, dbPath+"-shm", 0o600)
+		})
+	}
+}
+
+func TestOpenWithRelativePathDoesNotChmodWorkingDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose Unix permission bits")
+	}
+
+	workingDir := t.TempDir()
+	info, err := os.Stat(workingDir)
+	if err != nil {
+		t.Fatalf("stat working directory: %v", err)
+	}
+	wantDirMode := info.Mode().Perm()
+	t.Chdir(workingDir)
+
+	s, err := Open("data.db")
+	if err != nil {
+		t.Fatalf("open relative store: %v", err)
+	}
+	defer s.Close()
+
+	assertPrivateMode(t, ".", wantDirMode)
+	assertPrivateMode(t, "data.db", 0o600)
+	assertPrivateMode(t, "data.db-wal", 0o600)
+	assertPrivateMode(t, "data.db-shm", 0o600)
+}
+
+func assertPrivateMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("%s mode = %04o, want %04o", path, got, want)
+	}
+}
 
 // TestSchemaVersion_StampedOnFreshDB verifies that opening a brand-new
 // database stamps the current schema version. This is the contract that

--- a/internal/generator/templates/store_schema_version_test.go.tmpl
+++ b/internal/generator/templates/store_schema_version_test.go.tmpl
@@ -82,6 +82,26 @@ func TestOpenWithRelativePathDoesNotChmodWorkingDirectory(t *testing.T) {
 	assertPrivateMode(t, "data.db-shm", 0o600)
 }
 
+func TestHardenSQLiteFilesSkipsSymlinkSidecars(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose Unix permission bits")
+	}
+
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "unrelated")
+	if err := os.WriteFile(targetPath, nil, 0o644); err != nil {
+		t.Fatalf("create unrelated file: %v", err)
+	}
+	dbPath := filepath.Join(dir, "data.db")
+	if err := os.Symlink(targetPath, dbPath+"-wal"); err != nil {
+		t.Fatalf("create WAL symlink: %v", err)
+	}
+
+	hardenSQLiteFiles(dbPath)
+
+	assertPrivateMode(t, targetPath, 0o644)
+}
+
 func assertPrivateMode(t *testing.T, path string, want os.FileMode) {
 	t.Helper()
 	info, err := os.Stat(path)

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -174,7 +174,21 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 // remain usable. The deferred call catches files the SQLite driver creates.
 func hardenSQLiteFiles(dbPath string) {
 	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
-		_ = os.Chmod(path, 0o600)
+		info, err := os.Lstat(path)
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		openInfo, statErr := file.Stat()
+		pathInfo, lstatErr := os.Lstat(path)
+		if statErr == nil && lstatErr == nil && pathInfo.Mode().IsRegular() && os.SameFile(openInfo, pathInfo) {
+			_ = file.Chmod(0o600)
+		}
+		_ = file.Close()
 	}
 }
 

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -134,6 +134,8 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
 		return nil, fmt.Errorf("creating db directory: %w", err)
 	}
+	hardenSQLiteFiles(dbPath)
+	defer hardenSQLiteFiles(dbPath)
 
 	// Pragma order is load-bearing: busy_timeout must engage BEFORE
 	// journal_mode(WAL) so the delete→WAL conversion (an exclusive
@@ -166,6 +168,14 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	}
 
 	return s, nil
+}
+
+// hardenSQLiteFiles is best-effort so stores on filesystems without Unix modes
+// remain usable. The deferred call catches files the SQLite driver creates.
+func hardenSQLiteFiles(dbPath string) {
+	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		_ = os.Chmod(path, 0o600)
+	}
 }
 
 func ensureSQLiteDriverInitialized(ctx context.Context, dsn string) error {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -138,6 +138,8 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
 		return nil, fmt.Errorf("creating db directory: %w", err)
 	}
+	hardenSQLiteFiles(dbPath)
+	defer hardenSQLiteFiles(dbPath)
 
 	// Pragma order is load-bearing: busy_timeout must engage BEFORE
 	// journal_mode(WAL) so the delete→WAL conversion (an exclusive
@@ -170,6 +172,14 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	}
 
 	return s, nil
+}
+
+// hardenSQLiteFiles is best-effort so stores on filesystems without Unix modes
+// remain usable. The deferred call catches files the SQLite driver creates.
+func hardenSQLiteFiles(dbPath string) {
+	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		_ = os.Chmod(path, 0o600)
+	}
 }
 
 func ensureSQLiteDriverInitialized(ctx context.Context, dsn string) error {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -178,7 +178,21 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 // remain usable. The deferred call catches files the SQLite driver creates.
 func hardenSQLiteFiles(dbPath string) {
 	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
-		_ = os.Chmod(path, 0o600)
+		info, err := os.Lstat(path)
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		openInfo, statErr := file.Stat()
+		pathInfo, lstatErr := os.Lstat(path)
+		if statErr == nil && lstatErr == nil && pathInfo.Mode().IsRegular() && os.SameFile(openInfo, pathInfo) {
+			_ = file.Chmod(0o600)
+		}
+		_ = file.Close()
 	}
 }
 

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -138,6 +138,8 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
 		return nil, fmt.Errorf("creating db directory: %w", err)
 	}
+	hardenSQLiteFiles(dbPath)
+	defer hardenSQLiteFiles(dbPath)
 
 	// Pragma order is load-bearing: busy_timeout must engage BEFORE
 	// journal_mode(WAL) so the delete→WAL conversion (an exclusive
@@ -170,6 +172,14 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	}
 
 	return s, nil
+}
+
+// hardenSQLiteFiles is best-effort so stores on filesystems without Unix modes
+// remain usable. The deferred call catches files the SQLite driver creates.
+func hardenSQLiteFiles(dbPath string) {
+	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		_ = os.Chmod(path, 0o600)
+	}
 }
 
 func ensureSQLiteDriverInitialized(ctx context.Context, dsn string) error {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -178,7 +178,21 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 // remain usable. The deferred call catches files the SQLite driver creates.
 func hardenSQLiteFiles(dbPath string) {
 	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
-		_ = os.Chmod(path, 0o600)
+		info, err := os.Lstat(path)
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		openInfo, statErr := file.Stat()
+		pathInfo, lstatErr := os.Lstat(path)
+		if statErr == nil && lstatErr == nil && pathInfo.Mode().IsRegular() && os.SameFile(openInfo, pathInfo) {
+			_ = file.Chmod(0o600)
+		}
+		_ = file.Close()
 	}
 }
 

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -138,6 +138,8 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
 		return nil, fmt.Errorf("creating db directory: %w", err)
 	}
+	hardenSQLiteFiles(dbPath)
+	defer hardenSQLiteFiles(dbPath)
 
 	// Pragma order is load-bearing: busy_timeout must engage BEFORE
 	// journal_mode(WAL) so the delete→WAL conversion (an exclusive
@@ -170,6 +172,14 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	}
 
 	return s, nil
+}
+
+// hardenSQLiteFiles is best-effort so stores on filesystems without Unix modes
+// remain usable. The deferred call catches files the SQLite driver creates.
+func hardenSQLiteFiles(dbPath string) {
+	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		_ = os.Chmod(path, 0o600)
+	}
 }
 
 func ensureSQLiteDriverInitialized(ctx context.Context, dsn string) error {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -178,7 +178,21 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 // remain usable. The deferred call catches files the SQLite driver creates.
 func hardenSQLiteFiles(dbPath string) {
 	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
-		_ = os.Chmod(path, 0o600)
+		info, err := os.Lstat(path)
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		openInfo, statErr := file.Stat()
+		pathInfo, lstatErr := os.Lstat(path)
+		if statErr == nil && lstatErr == nil && pathInfo.Mode().IsRegular() && os.SameFile(openInfo, pathInfo) {
+			_ = file.Chmod(0o600)
+		}
+		_ = file.Close()
 	}
 }
 


### PR DESCRIPTION
## Summary

Generated CLIs now keep SQLite store databases and their WAL/SHM sidecars owner-only on fresh and legacy opens. Permission tightening remains best-effort for unsupported filesystems, newly created store directories stay `0700`, and relative database paths do not change an existing parent directory's mode.

## Validation

- `go test ./internal/generator -run '^TestGeneratedFleetHardening$' -count=1`
- `scripts/golden.sh verify` (32 cases)
- `scripts/verify-generator-output.sh` (10 generated modules)
- `go test ./...` completed all reported packages except `internal/pipeline`, which hit its 10-minute timeout under concurrent batch load

Closes #3447
