### PR TITLE
fix(cli): scrub generated terminal output

### DIFF
--- a/internal/generator/output_flags_contract_test.go
+++ b/internal/generator/output_flags_contract_test.go
@@ -89,9 +89,70 @@ func TestHumanFriendlyForcesTableAndNoColorStripsANSI(t *testing.T) {
 		t.Fatalf("--no-color should strip ANSI styling, got %q", plain.String())
 	}
 }
+
+func TestTerminalControlCharactersAreScrubbedFromHumanOutput(t *testing.T) {
+	rows := []map[string]any{{
+		"id":          "one",
+		"name\x1b[31m": "Alpha\x1b[0m\u009b31m",
+	}}
+
+	var table bytes.Buffer
+	if err := printAutoTable(&table, rows); err != nil {
+		t.Fatalf("printAutoTable returned error: %v", err)
+	}
+	if strings.ContainsAny(table.String(), "\x1b\u009b") {
+		t.Fatalf("table output retained terminal controls: %q", table.String())
+	}
+	if !strings.Contains(table.String(), "Alpha[0m31m") {
+		t.Fatalf("table output should preserve printable text, got %q", table.String())
+	}
+
+	cardRows := []map[string]any{{
+		"name\x1b[31m": "Alpha\u009b31m",
+		"flag":          true,
+	}}
+	var cards bytes.Buffer
+	if err := printAutoCards(&cards, cardRows); err != nil {
+		t.Fatalf("printAutoCards returned error: %v", err)
+	}
+	remainingFieldRows := []map[string]any{{
+		"id":              "one",
+		"status":          "active",
+		"details\x1b[31m": []any{"Beta\x1b[0m"},
+	}}
+	if err := printAutoCards(&cards, remainingFieldRows); err != nil {
+		t.Fatalf("printAutoCards returned error: %v", err)
+	}
+	if strings.ContainsAny(cards.String(), "\x1b\u009b") {
+		t.Fatalf("card output retained terminal controls: %q", cards.String())
+	}
+	if !strings.Contains(cards.String(), "NAME[31M Alpha31m") || !strings.Contains(cards.String(), "details[31m:") || !strings.Contains(cards.String(), "Beta[0m") {
+		t.Fatalf("card output should scrub title, remaining header, and array values while preserving printable text, got %q", cards.String())
+	}
+}
+
+func TestTerminalControlCharactersRemainInJSONOutput(t *testing.T) {
+	const rawValue = "Alpha\x1b[31m\u009b31m"
+	data, err := json.Marshal([]map[string]any{{"name": rawValue}})
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := printOutputWithFlags(&out, data, &rootFlags{asJSON: true}); err != nil {
+		t.Fatalf("printOutputWithFlags returned error: %v", err)
+	}
+	var decoded []map[string]any
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("JSON output is invalid: %v", err)
+	}
+	if got := decoded[0]["name"]; got != rawValue {
+		t.Fatalf("JSON value = %q, want byte-exact %q", got, rawValue)
+	}
+}
 `), 0o644))
 
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPrintOutputWithFlagsPlainRendersTSV|TestPrintOutputWithFlagsPlainEmptyArrayIsEmpty|TestHumanFriendlyForcesTableAndNoColorStripsANSI", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPrintOutputWithFlagsPlainRendersTSV|TestPrintOutputWithFlagsPlainEmptyArrayIsEmpty|TestHumanFriendlyForcesTableAndNoColorStripsANSI|TestTerminalControl", "-count=1")
 }
 
 func TestLocalAnalysisTemplatesRouteMachineFormatsThroughSharedGate(t *testing.T) {

--- a/internal/generator/templates/cliutil_test.go.tmpl
+++ b/internal/generator/templates/cliutil_test.go.tmpl
@@ -44,6 +44,14 @@ func TestCleanText(t *testing.T) {
 	}
 }
 
+func TestScrubTerminal(t *testing.T) {
+	input := "keep\tcolumns\nlines\x00\x07\x1b[31m\x7f\u0085\u009b31m"
+	want := "keep\tcolumns\nlines[31m31m"
+	if got := ScrubTerminal(input); got != want {
+		t.Fatalf("ScrubTerminal(%q) = %q, want %q", input, got, want)
+	}
+}
+
 func TestParseStoredTime(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/generator/templates/cliutil_test.go.tmpl
+++ b/internal/generator/templates/cliutil_test.go.tmpl
@@ -46,7 +46,7 @@ func TestCleanText(t *testing.T) {
 
 func TestScrubTerminal(t *testing.T) {
 	input := "keep\tcolumns\nlines\x00\x07\x1b[31m\x7f\u0085\u009b31m"
-	want := "keep\tcolumns\nlines[31m31m"
+	want := "keep columns lines[31m31m"
 	if got := ScrubTerminal(input); got != want {
 		t.Fatalf("ScrubTerminal(%q) = %q, want %q", input, got, want)
 	}

--- a/internal/generator/templates/cliutil_text.go.tmpl
+++ b/internal/generator/templates/cliutil_text.go.tmpl
@@ -25,12 +25,12 @@ func CleanText(s string) string {
 	return html.UnescapeString(strings.TrimSpace(s))
 }
 
-// ScrubTerminal removes control characters that can alter terminal behavior
-// while preserving tabs and newlines used by human-readable layouts.
+// ScrubTerminal prevents untrusted scalar values from altering terminal output.
+// Tabs and newlines become spaces; other control characters are removed.
 func ScrubTerminal(s string) string {
 	return strings.Map(func(r rune) rune {
 		if r == '\t' || r == '\n' {
-			return r
+			return ' '
 		}
 		if r < 0x20 || (r >= 0x7f && r <= 0x9f) {
 			return -1

--- a/internal/generator/templates/cliutil_text.go.tmpl
+++ b/internal/generator/templates/cliutil_text.go.tmpl
@@ -25,6 +25,20 @@ func CleanText(s string) string {
 	return html.UnescapeString(strings.TrimSpace(s))
 }
 
+// ScrubTerminal removes control characters that can alter terminal behavior
+// while preserving tabs and newlines used by human-readable layouts.
+func ScrubTerminal(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' {
+			return r
+		}
+		if r < 0x20 || (r >= 0x7f && r <= 0x9f) {
+			return -1
+		}
+		return r
+	}, s)
+}
+
 // ParseStoredTime parses timestamps read back from SQLite-backed generated
 // stores. modernc.org/sqlite can serialize time.Time using Go's native
 // time.String format, while hand-written sync code often stores RFC3339.

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -2363,7 +2363,7 @@ func printAutoTable(w io.Writer, items []map[string]any) error {
 	tw := newTabWriter(w)
 	upperHeaders := make([]string, len(headers))
 	for i, h := range headers {
-		upperHeaders[i] = bold(strings.ToUpper(h))
+		upperHeaders[i] = bold(strings.ToUpper(cliutil.ScrubTerminal(h)))
 	}
 
 	fmt.Fprintln(tw, strings.Join(upperHeaders, "\t"))
@@ -2525,8 +2525,9 @@ func printAutoCards(w io.Writer, items []map[string]any) error {
 	// Find the longest header for alignment (from fields we'll actually show)
 	maxLen := 0
 	for _, h := range headers {
-		if len(h) > maxLen {
-			maxLen = len(h)
+		displayHeader := cliutil.ScrubTerminal(h)
+		if len(displayHeader) > maxLen {
+			maxLen = len(displayHeader)
 		}
 	}
 
@@ -2537,15 +2538,16 @@ func printAutoCards(w io.Writer, items []map[string]any) error {
 
 		// Card header: use first priority field as the card title
 		titleVal := formatCellValue(item[headers[0]])
+		titleHeader := cliutil.ScrubTerminal(headers[0])
 		if len(headers) > 1 {
 			secondVal := formatCellValue(item[headers[1]])
 			if secondVal != "" {
-				fmt.Fprintf(w, "%s %s — %s\n", bold(strings.ToUpper(headers[0])), titleVal, secondVal)
+				fmt.Fprintf(w, "%s %s — %s\n", bold(strings.ToUpper(titleHeader)), titleVal, secondVal)
 			} else {
-				fmt.Fprintf(w, "%s %s\n", bold(strings.ToUpper(headers[0])), titleVal)
+				fmt.Fprintf(w, "%s %s\n", bold(strings.ToUpper(titleHeader)), titleVal)
 			}
 		} else {
-			fmt.Fprintf(w, "%s %s\n", bold(strings.ToUpper(headers[0])), titleVal)
+			fmt.Fprintf(w, "%s %s\n", bold(strings.ToUpper(titleHeader)), titleVal)
 		}
 
 		// Remaining fields indented — skip empty, zero, and false values
@@ -2555,10 +2557,11 @@ func printAutoCards(w io.Writer, items []map[string]any) error {
 				continue
 			}
 			// Multi-line values (nested arrays) start with \n
+			displayHeader := cliutil.ScrubTerminal(h)
 			if strings.HasPrefix(v, "\n") {
-				fmt.Fprintf(w, "  %s:%s\n", h, v)
+				fmt.Fprintf(w, "  %s:%s\n", displayHeader, v)
 			} else {
-				fmt.Fprintf(w, "  %-*s  %s\n", maxLen, h+":", v)
+				fmt.Fprintf(w, "  %-*s  %s\n", maxLen, displayHeader+":", v)
 			}
 		}
 	}
@@ -2568,6 +2571,7 @@ func printAutoCards(w io.Writer, items []map[string]any) error {
 func formatCellValue(v any) string {
 	switch val := v.(type) {
 	case string:
+		val = cliutil.ScrubTerminal(val)
 		// Format ISO dates as just the date portion
 		if len(val) >= 19 && val[4] == '-' && val[7] == '-' && val[10] == 'T' {
 			return val[:10]
@@ -2595,7 +2599,7 @@ func formatCellValue(v any) string {
 		parts := make([]string, 0, len(val))
 		for _, item := range val {
 			if s, ok := item.(string); ok {
-				parts = append(parts, s)
+				parts = append(parts, cliutil.ScrubTerminal(s))
 			} else {
 				b, _ := json.Marshal(item)
 				parts = append(parts, string(b))

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -1799,7 +1799,7 @@ func printAutoTable(w io.Writer, items []map[string]any) error {
 	tw := newTabWriter(w)
 	upperHeaders := make([]string, len(headers))
 	for i, h := range headers {
-		upperHeaders[i] = bold(strings.ToUpper(h))
+		upperHeaders[i] = bold(strings.ToUpper(cliutil.ScrubTerminal(h)))
 	}
 
 	fmt.Fprintln(tw, strings.Join(upperHeaders, "\t"))
@@ -1961,8 +1961,9 @@ func printAutoCards(w io.Writer, items []map[string]any) error {
 	// Find the longest header for alignment (from fields we'll actually show)
 	maxLen := 0
 	for _, h := range headers {
-		if len(h) > maxLen {
-			maxLen = len(h)
+		displayHeader := cliutil.ScrubTerminal(h)
+		if len(displayHeader) > maxLen {
+			maxLen = len(displayHeader)
 		}
 	}
 
@@ -1973,15 +1974,16 @@ func printAutoCards(w io.Writer, items []map[string]any) error {
 
 		// Card header: use first priority field as the card title
 		titleVal := formatCellValue(item[headers[0]])
+		titleHeader := cliutil.ScrubTerminal(headers[0])
 		if len(headers) > 1 {
 			secondVal := formatCellValue(item[headers[1]])
 			if secondVal != "" {
-				fmt.Fprintf(w, "%s %s — %s\n", bold(strings.ToUpper(headers[0])), titleVal, secondVal)
+				fmt.Fprintf(w, "%s %s — %s\n", bold(strings.ToUpper(titleHeader)), titleVal, secondVal)
 			} else {
-				fmt.Fprintf(w, "%s %s\n", bold(strings.ToUpper(headers[0])), titleVal)
+				fmt.Fprintf(w, "%s %s\n", bold(strings.ToUpper(titleHeader)), titleVal)
 			}
 		} else {
-			fmt.Fprintf(w, "%s %s\n", bold(strings.ToUpper(headers[0])), titleVal)
+			fmt.Fprintf(w, "%s %s\n", bold(strings.ToUpper(titleHeader)), titleVal)
 		}
 
 		// Remaining fields indented — skip empty, zero, and false values
@@ -1991,10 +1993,11 @@ func printAutoCards(w io.Writer, items []map[string]any) error {
 				continue
 			}
 			// Multi-line values (nested arrays) start with \n
+			displayHeader := cliutil.ScrubTerminal(h)
 			if strings.HasPrefix(v, "\n") {
-				fmt.Fprintf(w, "  %s:%s\n", h, v)
+				fmt.Fprintf(w, "  %s:%s\n", displayHeader, v)
 			} else {
-				fmt.Fprintf(w, "  %-*s  %s\n", maxLen, h+":", v)
+				fmt.Fprintf(w, "  %-*s  %s\n", maxLen, displayHeader+":", v)
 			}
 		}
 	}
@@ -2004,6 +2007,7 @@ func printAutoCards(w io.Writer, items []map[string]any) error {
 func formatCellValue(v any) string {
 	switch val := v.(type) {
 	case string:
+		val = cliutil.ScrubTerminal(val)
 		// Format ISO dates as just the date portion
 		if len(val) >= 19 && val[4] == '-' && val[7] == '-' && val[10] == 'T' {
 			return val[:10]
@@ -2031,7 +2035,7 @@ func formatCellValue(v any) string {
 		parts := make([]string, 0, len(val))
 		for _, item := range val {
 			if s, ok := item.(string); ok {
-				parts = append(parts, s)
+				parts = append(parts, cliutil.ScrubTerminal(s))
 			} else {
 				b, _ := json.Marshal(item)
 				parts = append(parts, string(b))

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -1666,7 +1666,7 @@ func printAutoTable(w io.Writer, items []map[string]any) error {
 	tw := newTabWriter(w)
 	upperHeaders := make([]string, len(headers))
 	for i, h := range headers {
-		upperHeaders[i] = bold(strings.ToUpper(h))
+		upperHeaders[i] = bold(strings.ToUpper(cliutil.ScrubTerminal(h)))
 	}
 
 	fmt.Fprintln(tw, strings.Join(upperHeaders, "\t"))
@@ -1828,8 +1828,9 @@ func printAutoCards(w io.Writer, items []map[string]any) error {
 	// Find the longest header for alignment (from fields we'll actually show)
 	maxLen := 0
 	for _, h := range headers {
-		if len(h) > maxLen {
-			maxLen = len(h)
+		displayHeader := cliutil.ScrubTerminal(h)
+		if len(displayHeader) > maxLen {
+			maxLen = len(displayHeader)
 		}
 	}
 
@@ -1840,15 +1841,16 @@ func printAutoCards(w io.Writer, items []map[string]any) error {
 
 		// Card header: use first priority field as the card title
 		titleVal := formatCellValue(item[headers[0]])
+		titleHeader := cliutil.ScrubTerminal(headers[0])
 		if len(headers) > 1 {
 			secondVal := formatCellValue(item[headers[1]])
 			if secondVal != "" {
-				fmt.Fprintf(w, "%s %s — %s\n", bold(strings.ToUpper(headers[0])), titleVal, secondVal)
+				fmt.Fprintf(w, "%s %s — %s\n", bold(strings.ToUpper(titleHeader)), titleVal, secondVal)
 			} else {
-				fmt.Fprintf(w, "%s %s\n", bold(strings.ToUpper(headers[0])), titleVal)
+				fmt.Fprintf(w, "%s %s\n", bold(strings.ToUpper(titleHeader)), titleVal)
 			}
 		} else {
-			fmt.Fprintf(w, "%s %s\n", bold(strings.ToUpper(headers[0])), titleVal)
+			fmt.Fprintf(w, "%s %s\n", bold(strings.ToUpper(titleHeader)), titleVal)
 		}
 
 		// Remaining fields indented — skip empty, zero, and false values
@@ -1858,10 +1860,11 @@ func printAutoCards(w io.Writer, items []map[string]any) error {
 				continue
 			}
 			// Multi-line values (nested arrays) start with \n
+			displayHeader := cliutil.ScrubTerminal(h)
 			if strings.HasPrefix(v, "\n") {
-				fmt.Fprintf(w, "  %s:%s\n", h, v)
+				fmt.Fprintf(w, "  %s:%s\n", displayHeader, v)
 			} else {
-				fmt.Fprintf(w, "  %-*s  %s\n", maxLen, h+":", v)
+				fmt.Fprintf(w, "  %-*s  %s\n", maxLen, displayHeader+":", v)
 			}
 		}
 	}
@@ -1871,6 +1874,7 @@ func printAutoCards(w io.Writer, items []map[string]any) error {
 func formatCellValue(v any) string {
 	switch val := v.(type) {
 	case string:
+		val = cliutil.ScrubTerminal(val)
 		// Format ISO dates as just the date portion
 		if len(val) >= 19 && val[4] == '-' && val[7] == '-' && val[10] == 'T' {
 			return val[:10]
@@ -1898,7 +1902,7 @@ func formatCellValue(v any) string {
 		parts := make([]string, 0, len(val))
 		for _, item := range val {
 			if s, ok := item.(string); ok {
-				parts = append(parts, s)
+				parts = append(parts, cliutil.ScrubTerminal(s))
 			} else {
 				b, _ := json.Marshal(item)
 				parts = append(parts, string(b))

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -1751,7 +1751,7 @@ func printAutoTable(w io.Writer, items []map[string]any) error {
 	tw := newTabWriter(w)
 	upperHeaders := make([]string, len(headers))
 	for i, h := range headers {
-		upperHeaders[i] = bold(strings.ToUpper(h))
+		upperHeaders[i] = bold(strings.ToUpper(cliutil.ScrubTerminal(h)))
 	}
 
 	fmt.Fprintln(tw, strings.Join(upperHeaders, "\t"))
@@ -1913,8 +1913,9 @@ func printAutoCards(w io.Writer, items []map[string]any) error {
 	// Find the longest header for alignment (from fields we'll actually show)
 	maxLen := 0
 	for _, h := range headers {
-		if len(h) > maxLen {
-			maxLen = len(h)
+		displayHeader := cliutil.ScrubTerminal(h)
+		if len(displayHeader) > maxLen {
+			maxLen = len(displayHeader)
 		}
 	}
 
@@ -1925,15 +1926,16 @@ func printAutoCards(w io.Writer, items []map[string]any) error {
 
 		// Card header: use first priority field as the card title
 		titleVal := formatCellValue(item[headers[0]])
+		titleHeader := cliutil.ScrubTerminal(headers[0])
 		if len(headers) > 1 {
 			secondVal := formatCellValue(item[headers[1]])
 			if secondVal != "" {
-				fmt.Fprintf(w, "%s %s — %s\n", bold(strings.ToUpper(headers[0])), titleVal, secondVal)
+				fmt.Fprintf(w, "%s %s — %s\n", bold(strings.ToUpper(titleHeader)), titleVal, secondVal)
 			} else {
-				fmt.Fprintf(w, "%s %s\n", bold(strings.ToUpper(headers[0])), titleVal)
+				fmt.Fprintf(w, "%s %s\n", bold(strings.ToUpper(titleHeader)), titleVal)
 			}
 		} else {
-			fmt.Fprintf(w, "%s %s\n", bold(strings.ToUpper(headers[0])), titleVal)
+			fmt.Fprintf(w, "%s %s\n", bold(strings.ToUpper(titleHeader)), titleVal)
 		}
 
 		// Remaining fields indented — skip empty, zero, and false values
@@ -1943,10 +1945,11 @@ func printAutoCards(w io.Writer, items []map[string]any) error {
 				continue
 			}
 			// Multi-line values (nested arrays) start with \n
+			displayHeader := cliutil.ScrubTerminal(h)
 			if strings.HasPrefix(v, "\n") {
-				fmt.Fprintf(w, "  %s:%s\n", h, v)
+				fmt.Fprintf(w, "  %s:%s\n", displayHeader, v)
 			} else {
-				fmt.Fprintf(w, "  %-*s  %s\n", maxLen, h+":", v)
+				fmt.Fprintf(w, "  %-*s  %s\n", maxLen, displayHeader+":", v)
 			}
 		}
 	}
@@ -1956,6 +1959,7 @@ func printAutoCards(w io.Writer, items []map[string]any) error {
 func formatCellValue(v any) string {
 	switch val := v.(type) {
 	case string:
+		val = cliutil.ScrubTerminal(val)
 		// Format ISO dates as just the date portion
 		if len(val) >= 19 && val[4] == '-' && val[7] == '-' && val[10] == 'T' {
 			return val[:10]
@@ -1983,7 +1987,7 @@ func formatCellValue(v any) string {
 		parts := make([]string, 0, len(val))
 		for _, item := range val {
 			if s, ok := item.(string); ok {
-				parts = append(parts, s)
+				parts = append(parts, cliutil.ScrubTerminal(s))
 			} else {
 				b, _ := json.Marshal(item)
 				parts = append(parts, string(b))

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/text.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/text.go
@@ -23,6 +23,20 @@ func CleanText(s string) string {
 	return html.UnescapeString(strings.TrimSpace(s))
 }
 
+// ScrubTerminal removes control characters that can alter terminal behavior
+// while preserving tabs and newlines used by human-readable layouts.
+func ScrubTerminal(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' {
+			return r
+		}
+		if r < 0x20 || (r >= 0x7f && r <= 0x9f) {
+			return -1
+		}
+		return r
+	}, s)
+}
+
 // ParseStoredTime parses timestamps read back from SQLite-backed generated
 // stores. modernc.org/sqlite can serialize time.Time using Go's native
 // time.String format, while hand-written sync code often stores RFC3339.

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/text.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/text.go
@@ -23,12 +23,12 @@ func CleanText(s string) string {
 	return html.UnescapeString(strings.TrimSpace(s))
 }
 
-// ScrubTerminal removes control characters that can alter terminal behavior
-// while preserving tabs and newlines used by human-readable layouts.
+// ScrubTerminal prevents untrusted scalar values from altering terminal output.
+// Tabs and newlines become spaces; other control characters are removed.
 func ScrubTerminal(s string) string {
 	return strings.Map(func(r rune) rune {
 		if r == '\t' || r == '\n' {
-			return r
+			return ' '
 		}
 		if r < 0x20 || (r >= 0x7f && r <= 0x9f) {
 			return -1


### PR DESCRIPTION
## Summary

Remote API strings can no longer inject terminal control sequences through generated human table or card output. The shared generated helper strips C0 controls except tabs and newlines, DEL, and C1 controls from displayed keys and values, while JSON output preserves the original data.

Generated runtime coverage exercises table values, card title and remaining-field keys, string arrays, and the untouched JSON path. Representative golden fixtures now lock the emitted helper and call sites.

## Validation

- `go test ./internal/generator -run '^TestGeneratedHelpersHonorPlainAndHumanFriendlyFlags$' -count=1`
- `scripts/golden.sh verify` (32 cases passed)
- `scripts/verify-generator-output.sh` (10 generated modules built)
- `go test ./...` completed twice with 6,807 passing tests; each run exposed a different unrelated `internal/pipeline` parallel-test flake, and every failing test passed immediately in isolation
- `golangci-lint run ./...` reported only the pre-existing `modernize` warning in `internal/googlediscovery/parser.go`

Closes #3442
