### PR TITLE
fix(cli): prevent unsafe request retries

### DIFF
--- a/internal/generator/client_retry_safety_test.go
+++ b/internal/generator/client_retry_safety_test.go
@@ -1,0 +1,212 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedClientRetrySafety(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("retry-safety")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const runtimeTest = `package client
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"retry-safety-pp-cli/internal/config"
+)
+
+type retryRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn retryRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func retryResponse(req *http.Request, status int) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(` + "`{}`" + `)),
+		Request:    req,
+	}
+}
+
+func newRetrySafetyClient(t *testing.T, transport http.RoundTripper) *Client {
+	t.Helper()
+	c := New(&config.Config{
+		BaseURL: "https://api.example.invalid",
+		Path:    filepath.Join(t.TempDir(), "config.toml"),
+	}, time.Second, 0)
+	c.NoCache = true
+	c.HTTPClient = &http.Client{Transport: transport}
+	return c
+}
+
+func TestRetrySafety_MutatingMethodsDoNotRetryServerError(t *testing.T) {
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			var calls int
+			c := newRetrySafetyClient(t, retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				return retryResponse(req, http.StatusInternalServerError), nil
+			}))
+
+			_, status, err := c.do(context.Background(), method, "/items", nil, map[string]string{"name": "one"}, nil)
+			if err == nil || status != http.StatusInternalServerError {
+				t.Fatalf("do(%s) = status %d, error %v; want HTTP 500 error", method, status, err)
+			}
+			if calls != 1 {
+				t.Fatalf("%s calls = %d, want 1", method, calls)
+			}
+		})
+	}
+}
+
+func TestRetrySafety_SafeMethodsRetryServerError(t *testing.T) {
+	for _, method := range []string{http.MethodGet, http.MethodHead, http.MethodOptions} {
+		t.Run(method, func(t *testing.T) {
+			var calls int
+			c := newRetrySafetyClient(t, retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				if calls == 1 {
+					return retryResponse(req, http.StatusBadGateway), nil
+				}
+				return retryResponse(req, http.StatusOK), nil
+			}))
+
+			_, status, err := c.do(context.Background(), method, "/items", nil, nil, nil)
+			if err != nil || status != http.StatusOK {
+				t.Fatalf("do(%s) = status %d, error %v; want HTTP 200", method, status, err)
+			}
+			if calls != 2 {
+				t.Fatalf("%s calls = %d, want 2", method, calls)
+			}
+		})
+	}
+}
+
+func TestRetrySafety_POSTRetriesRateLimit(t *testing.T) {
+	var calls int
+	c := newRetrySafetyClient(t, retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			resp := retryResponse(req, http.StatusTooManyRequests)
+			resp.Header.Set("Retry-After", "0")
+			return resp, nil
+		}
+		return retryResponse(req, http.StatusCreated), nil
+	}))
+
+	_, status, err := c.Post(context.Background(), "/items", map[string]string{"name": "one"})
+	if err != nil || status != http.StatusCreated {
+		t.Fatalf("Post() = status %d, error %v; want HTTP 201", status, err)
+	}
+	if calls != 2 {
+		t.Fatalf("POST calls = %d, want 2", calls)
+	}
+}
+
+func TestRetrySafety_TransportErrorsRespectMethodSafety(t *testing.T) {
+	for _, method := range []string{http.MethodGet, http.MethodHead, http.MethodOptions} {
+		t.Run(method+" retries with backoff", func(t *testing.T) {
+			var calls int
+			c := newRetrySafetyClient(t, retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				if calls == 1 {
+					return nil, errors.New("connection reset")
+				}
+				return retryResponse(req, http.StatusOK), nil
+			}))
+
+			started := time.Now()
+			_, status, err := c.do(context.Background(), method, "/items", nil, nil, nil)
+			if err != nil || status != http.StatusOK {
+				t.Fatalf("do(%s) = status %d, error %v; want HTTP 200", method, status, err)
+			}
+			if calls != 2 {
+				t.Fatalf("%s calls = %d, want 2", method, calls)
+			}
+			if elapsed := time.Since(started); elapsed < 900*time.Millisecond {
+				t.Fatalf("%s transport retry elapsed %s, want backoff near 1s", method, elapsed)
+			}
+		})
+	}
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		t.Run(method+" does not retry", func(t *testing.T) {
+			var calls int
+			c := newRetrySafetyClient(t, retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				return nil, errors.New("connection reset")
+			}))
+
+			_, _, err := c.do(context.Background(), method, "/items", nil, map[string]string{"name": "one"}, nil)
+			if err == nil {
+				t.Fatalf("do(%s) error = nil, want transport error", method)
+			}
+			if calls != 1 {
+				t.Fatalf("%s calls = %d, want 1", method, calls)
+			}
+		})
+	}
+}
+
+func TestRetrySafety_ReadOnlyPOSTRetriesAmbiguousFailures(t *testing.T) {
+	t.Run("server error", func(t *testing.T) {
+		var calls int
+		c := newRetrySafetyClient(t, retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return retryResponse(req, http.StatusBadGateway), nil
+			}
+			return retryResponse(req, http.StatusOK), nil
+		}))
+
+		_, status, err := c.doRead(context.Background(), http.MethodPost, "/search", nil, map[string]string{"query": "one"}, nil)
+		if err != nil || status != http.StatusOK {
+			t.Fatalf("doRead(POST) = status %d, error %v; want HTTP 200", status, err)
+		}
+		if calls != 2 {
+			t.Fatalf("read-only POST calls = %d, want 2", calls)
+		}
+	})
+
+	t.Run("transport error", func(t *testing.T) {
+		var calls int
+		c := newRetrySafetyClient(t, retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return nil, errors.New("connection reset")
+			}
+			return retryResponse(req, http.StatusOK), nil
+		}))
+
+		_, status, err := c.doRead(context.Background(), http.MethodPost, "/search", nil, map[string]string{"query": "one"}, nil)
+		if err != nil || status != http.StatusOK {
+			t.Fatalf("doRead(POST) = status %d, error %v; want HTTP 200", status, err)
+		}
+		if calls != 2 {
+			t.Fatalf("read-only POST calls = %d, want 2", calls)
+		}
+	})
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "retry_safety_test.go"), []byte(runtimeTest), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^TestRetrySafety_", "-count=1")
+}

--- a/internal/generator/client_retry_safety_test.go
+++ b/internal/generator/client_retry_safety_test.go
@@ -1,11 +1,14 @@
 package generator
 
 import (
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,6 +23,7 @@ func TestGeneratedClientRetrySafety(t *testing.T) {
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -166,47 +170,334 @@ func TestRetrySafety_TransportErrorsRespectMethodSafety(t *testing.T) {
 	}
 }
 
-func TestRetrySafety_ReadOnlyPOSTRetriesAmbiguousFailures(t *testing.T) {
-	t.Run("server error", func(t *testing.T) {
-		var calls int
-		c := newRetrySafetyClient(t, retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-			calls++
-			if calls == 1 {
-				return retryResponse(req, http.StatusBadGateway), nil
+func TestRetrySafety_ReadOnlyMutatingVerbHelpersRetryAmbiguousFailures(t *testing.T) {
+	requests := []struct {
+		name string
+		do   func(*Client) (json.RawMessage, int, error)
+	}{
+		{name: http.MethodPost, do: func(c *Client) (json.RawMessage, int, error) {
+			return c.PostQueryWithParams(context.Background(), "/search", nil, map[string]string{"query": "one"})
+		}},
+		{name: http.MethodPut, do: func(c *Client) (json.RawMessage, int, error) {
+			return c.PutQueryWithParams(context.Background(), "/search", nil, map[string]string{"query": "one"})
+		}},
+		{name: http.MethodPatch, do: func(c *Client) (json.RawMessage, int, error) {
+			return c.PatchQueryWithParams(context.Background(), "/search", nil, map[string]string{"query": "one"})
+		}},
+	}
+
+	for _, request := range requests {
+		t.Run(request.name+" server error", func(t *testing.T) {
+			var calls int
+			c := newRetrySafetyClient(t, retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				if calls == 1 {
+					return retryResponse(req, http.StatusBadGateway), nil
+				}
+				return retryResponse(req, http.StatusOK), nil
+			}))
+
+			_, status, err := request.do(c)
+			if err != nil || status != http.StatusOK {
+				t.Fatalf("read-only %s = status %d, error %v; want HTTP 200", request.name, status, err)
 			}
-			return retryResponse(req, http.StatusOK), nil
-		}))
-
-		_, status, err := c.doRead(context.Background(), http.MethodPost, "/search", nil, map[string]string{"query": "one"}, nil)
-		if err != nil || status != http.StatusOK {
-			t.Fatalf("doRead(POST) = status %d, error %v; want HTTP 200", status, err)
-		}
-		if calls != 2 {
-			t.Fatalf("read-only POST calls = %d, want 2", calls)
-		}
-	})
-
-	t.Run("transport error", func(t *testing.T) {
-		var calls int
-		c := newRetrySafetyClient(t, retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-			calls++
-			if calls == 1 {
-				return nil, errors.New("connection reset")
+			if calls != 2 {
+				t.Fatalf("read-only %s calls = %d, want 2", request.name, calls)
 			}
-			return retryResponse(req, http.StatusOK), nil
-		}))
+		})
 
-		_, status, err := c.doRead(context.Background(), http.MethodPost, "/search", nil, map[string]string{"query": "one"}, nil)
-		if err != nil || status != http.StatusOK {
-			t.Fatalf("doRead(POST) = status %d, error %v; want HTTP 200", status, err)
-		}
-		if calls != 2 {
-			t.Fatalf("read-only POST calls = %d, want 2", calls)
-		}
-	})
+		t.Run(request.name+" transport error", func(t *testing.T) {
+			var calls int
+			c := newRetrySafetyClient(t, retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				if calls == 1 {
+					return nil, errors.New("connection reset")
+				}
+				return retryResponse(req, http.StatusOK), nil
+			}))
+
+			_, status, err := request.do(c)
+			if err != nil || status != http.StatusOK {
+				t.Fatalf("read-only %s = status %d, error %v; want HTTP 200", request.name, status, err)
+			}
+			if calls != 2 {
+				t.Fatalf("read-only %s calls = %d, want 2", request.name, calls)
+			}
+		})
+	}
 }
 `
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "retry_safety_test.go"), []byte(runtimeTest), 0o644))
 
 	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^TestRetrySafety_", "-count=1")
+}
+
+func TestGeneratedReadOnlyPutPatchDispatchUsesQueryHelpers(t *testing.T) {
+	t.Parallel()
+
+	readOnlyEndpoint := func(method, contentType string, headers bool) spec.Endpoint {
+		endpoint := spec.Endpoint{
+			Method:             method,
+			Path:               "/query",
+			Description:        "Read query results",
+			RequestContentType: contentType,
+			Meta:               map[string]string{"mcp:read-only": "true"},
+			Body:               []spec.Param{{Name: "filter", Type: "string"}},
+		}
+		if contentType == "multipart/form-data" {
+			endpoint.Body = append(endpoint.Body, spec.Param{Name: "document", Type: "string", Format: "binary"})
+		}
+		if headers {
+			endpoint.HeaderOverrides = []spec.RequiredHeader{{Name: "Accept", Value: "application/json"}}
+		}
+		return endpoint
+	}
+
+	endpoints := map[string]spec.Endpoint{
+		"readPutJSON":        readOnlyEndpoint(http.MethodPut, "application/json", false),
+		"readPatchJSON":      readOnlyEndpoint(http.MethodPatch, "application/json", true),
+		"readPutForm":        readOnlyEndpoint(http.MethodPut, "application/x-www-form-urlencoded", true),
+		"readPatchForm":      readOnlyEndpoint(http.MethodPatch, "application/x-www-form-urlencoded", false),
+		"readPutMultipart":   readOnlyEndpoint(http.MethodPut, "multipart/form-data", false),
+		"readPatchMultipart": readOnlyEndpoint(http.MethodPatch, "multipart/form-data", true),
+		"updateWidget": {
+			Method: http.MethodPut, Path: "/widgets/{id}", Description: "Update a widget",
+			Body: []spec.Param{{Name: "name", Type: "string"}},
+		},
+		"patchWidget": {
+			Method: http.MethodPatch, Path: "/widgets/{id}", Description: "Patch a widget",
+			Body: []spec.Param{{Name: "name", Type: "string"}},
+		},
+	}
+
+	apiSpec := minimalSpec("readonly-put-patch")
+	apiSpec.Resources = map[string]spec.Resource{
+		"typed": {Description: "Typed endpoints", Endpoints: endpoints},
+	}
+	for name, endpoint := range endpoints {
+		if name == "updateWidget" || name == "patchWidget" {
+			continue
+		}
+		apiSpec.Resources["promoted"+name] = spec.Resource{
+			Description: "Promoted endpoint",
+			Endpoints:   map[string]spec.Endpoint{name: endpoint},
+		}
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
+	for _, want := range []string{
+		`func (c *Client) PutQueryWithParams(`,
+		`func (c *Client) PutQueryFormWithParams(`,
+		`func (c *Client) PutQueryMultipartWithParams(`,
+		`func (c *Client) PatchQueryWithParams(`,
+		`func (c *Client) PatchQueryFormWithParams(`,
+		`func (c *Client) PatchQueryMultipartWithParams(`,
+		`return c.doRead(ctx, "PUT"`,
+		`return c.doRead(ctx, "PATCH"`,
+	} {
+		require.Contains(t, clientSrc, want)
+	}
+
+	var typedSrc, promotedSrc strings.Builder
+	entries, err := os.ReadDir(filepath.Join(outputDir, "internal", "cli"))
+	require.NoError(t, err)
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".go" {
+			continue
+		}
+		src := readGeneratedFile(t, outputDir, "internal", "cli", entry.Name())
+		if strings.HasPrefix(entry.Name(), "promoted_") {
+			promotedSrc.WriteString(src)
+		} else if strings.Contains(src, `"pp:endpoint": "typed.`) {
+			typedSrc.WriteString(src)
+		}
+	}
+
+	for surface, src := range map[string]string{
+		"typed endpoint":   typedSrc.String(),
+		"promoted command": promotedSrc.String(),
+	} {
+		for _, want := range []string{
+			"c.PutQueryWithParams(",
+			"c.PatchQueryWithParamsAndHeaders(",
+			"c.PutQueryFormWithParamsAndHeaders(",
+			"c.PatchQueryFormWithParams(",
+			"c.PutQueryMultipartWithParams(",
+			"c.PatchQueryMultipartWithParamsAndHeaders(",
+		} {
+			require.Contains(t, src, want, "%s must route through %s", surface, want)
+		}
+	}
+	require.Contains(t, typedSrc.String(), "c.PutWithParams(")
+	require.Contains(t, typedSrc.String(), "c.PatchWithParams(")
+
+	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
+	for _, want := range []string{
+		"c.PutQueryWithParams(ctx, path, params, bodyArgs)",
+		"c.PatchQueryWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)",
+		"c.PutQueryFormWithParams(ctx, path, params, formFields)",
+		"c.PatchQueryFormWithParamsAndHeaders(ctx, path, params, formFields, headers)",
+		"c.PutQueryMultipartWithParams(ctx, path, params, multipartFields, multipartFileFields)",
+		"c.PatchQueryMultipartWithParamsAndHeaders(ctx, path, params, multipartFields, multipartFileFields, headers)",
+	} {
+		require.Contains(t, mcpSrc, want)
+	}
+	require.Contains(t, mcpSrc, "data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)")
+	require.Contains(t, mcpSrc, "data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)")
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestGeneratedSessionInvalidationRetrySafety(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := canonicalSessionHandshakeSpec()
+	apiSpec.Name = "retry-safety-session"
+	apiSpec.Auth.InvalidateOnStatus = []int{http.StatusUnauthorized, http.StatusInternalServerError}
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const runtimeTest = `package client
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"retry-safety-session-pp-cli/internal/config"
+)
+
+type sessionRetryRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn sessionRetryRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func sessionRetryResponse(req *http.Request, status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}
+}
+
+func newSessionRetrySafetyClient(t *testing.T, transport http.RoundTripper) (*Client, *int) {
+	t.Helper()
+	c := New(&config.Config{
+		BaseURL: "https://api.example.invalid",
+		Path:    filepath.Join(t.TempDir(), "config.toml"),
+	}, time.Second, 0)
+	c.NoCache = true
+	c.HTTPClient = &http.Client{Transport: transport}
+	c.Session.token = "token-one"
+
+	handshakeCalls := 0
+	c.Session.client = &http.Client{Transport: sessionRetryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		handshakeCalls++
+		return sessionRetryResponse(req, http.StatusOK, "token-two"), nil
+	})}
+	return c, &handshakeCalls
+}
+
+func TestSessionRetrySafety_MutatingMethodDoesNotInvalidateAndRetryServerError(t *testing.T) {
+	var calls int
+	c, handshakeCalls := newSessionRetrySafetyClient(t, sessionRetryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		return sessionRetryResponse(req, http.StatusInternalServerError, "{}"), nil
+	}))
+
+	_, status, err := c.do(context.Background(), http.MethodPost, "/items", nil, map[string]string{"name": "one"}, nil)
+	if err == nil || status != http.StatusInternalServerError {
+		t.Fatalf("do(POST) = status %d, error %v; want HTTP 500 error", status, err)
+	}
+	if calls != 1 {
+		t.Fatalf("POST calls = %d, want 1", calls)
+	}
+	if *handshakeCalls != 0 {
+		t.Fatalf("handshake calls = %d, want 0", *handshakeCalls)
+	}
+	if token := c.Session.Token(); token != "token-one" {
+		t.Fatalf("session token = %q, want original token", token)
+	}
+}
+
+func TestSessionRetrySafety_ReplaySafeRequestsInvalidateAndRetryServerError(t *testing.T) {
+	tests := []struct {
+		name string
+		do   func(*Client) (int, error)
+	}{
+		{
+			name: "GET",
+			do: func(c *Client) (int, error) {
+				_, status, err := c.do(context.Background(), http.MethodGet, "/items", nil, nil, nil)
+				return status, err
+			},
+		},
+		{
+			name: "read-only POST",
+			do: func(c *Client) (int, error) {
+				_, status, err := c.doRead(context.Background(), http.MethodPost, "/search", nil, map[string]string{"query": "one"}, nil)
+				return status, err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls int
+			c, handshakeCalls := newSessionRetrySafetyClient(t, sessionRetryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				if calls == 1 {
+					return sessionRetryResponse(req, http.StatusInternalServerError, "{}"), nil
+				}
+				return sessionRetryResponse(req, http.StatusOK, "{}"), nil
+			}))
+
+			status, err := tt.do(c)
+			if err != nil || status != http.StatusOK {
+				t.Fatalf("request = status %d, error %v; want HTTP 200", status, err)
+			}
+			if calls != 2 {
+				t.Fatalf("request calls = %d, want 2", calls)
+			}
+			if *handshakeCalls != 2 {
+				t.Fatalf("handshake calls = %d, want bootstrap and token fetch", *handshakeCalls)
+			}
+		})
+	}
+}
+
+func TestSessionRetrySafety_MutatingMethodRetriesAuthRejection(t *testing.T) {
+	var calls int
+	c, handshakeCalls := newSessionRetrySafetyClient(t, sessionRetryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return sessionRetryResponse(req, http.StatusUnauthorized, "{}"), nil
+		}
+		return sessionRetryResponse(req, http.StatusCreated, "{}"), nil
+	}))
+
+	_, status, err := c.do(context.Background(), http.MethodPost, "/items", nil, map[string]string{"name": "one"}, nil)
+	if err != nil || status != http.StatusCreated {
+		t.Fatalf("do(POST) = status %d, error %v; want HTTP 201", status, err)
+	}
+	if calls != 2 {
+		t.Fatalf("POST calls = %d, want 2", calls)
+	}
+	if *handshakeCalls != 2 {
+		t.Fatalf("handshake calls = %d, want bootstrap and token fetch", *handshakeCalls)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "session_retry_safety_test.go"), []byte(runtimeTest), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^TestSessionRetrySafety_", "-count=1")
 }

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -1023,6 +1023,14 @@ func (c *Client) PutWithParamsAndHeaders(ctx context.Context, path string, param
 	return c.do(ctx, "PUT", path, params, body, headers)
 }
 
+func (c *Client) PutQueryWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, body, nil)
+}
+
+func (c *Client) PutQueryWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, body, headers)
+}
+
 {{- if .HasMultipartRequest }}
 func (c *Client) PutMultipart(ctx context.Context, path string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
 	return c.do(ctx, "PUT", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
@@ -1038,6 +1046,14 @@ func (c *Client) PutMultipartWithHeaders(ctx context.Context, path string, field
 
 func (c *Client) PutMultipartWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
 	return c.do(ctx, "PUT", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
+}
+
+func (c *Client) PutQueryMultipartWithParams(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
+}
+
+func (c *Client) PutQueryMultipartWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
 }
 
 {{ end }}
@@ -1058,6 +1074,14 @@ func (c *Client) PutFormWithParamsAndHeaders(ctx context.Context, path string, p
 	return c.do(ctx, "PUT", path, params, formRequestBody{Fields: fields}, headers)
 }
 
+func (c *Client) PutQueryFormWithParams(ctx context.Context, path string, params map[string]string, fields url.Values) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, formRequestBody{Fields: fields}, nil)
+}
+
+func (c *Client) PutQueryFormWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields url.Values, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, formRequestBody{Fields: fields}, headers)
+}
+
 {{ end }}
 
 func (c *Client) Patch(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
@@ -1074,6 +1098,14 @@ func (c *Client) PatchWithHeaders(ctx context.Context, path string, body any, he
 
 func (c *Client) PatchWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
 	return c.do(ctx, "PATCH", path, params, body, headers)
+}
+
+func (c *Client) PatchQueryWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, body, nil)
+}
+
+func (c *Client) PatchQueryWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, body, headers)
 }
 
 {{- if .HasMultipartRequest }}
@@ -1093,6 +1125,14 @@ func (c *Client) PatchMultipartWithParamsAndHeaders(ctx context.Context, path st
 	return c.do(ctx, "PATCH", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
 }
 
+func (c *Client) PatchQueryMultipartWithParams(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
+}
+
+func (c *Client) PatchQueryMultipartWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
+}
+
 {{ end }}
 {{- if .HasFormRequest }}
 func (c *Client) PatchForm(ctx context.Context, path string, fields url.Values) (json.RawMessage, int, error) {
@@ -1109,6 +1149,14 @@ func (c *Client) PatchFormWithHeaders(ctx context.Context, path string, fields u
 
 func (c *Client) PatchFormWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields url.Values, headers map[string]string) (json.RawMessage, int, error) {
 	return c.do(ctx, "PATCH", path, params, formRequestBody{Fields: fields}, headers)
+}
+
+func (c *Client) PatchQueryFormWithParams(ctx context.Context, path string, params map[string]string, fields url.Values) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, formRequestBody{Fields: fields}, nil)
+}
+
+func (c *Client) PatchQueryFormWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields url.Values, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, formRequestBody{Fields: fields}, headers)
 }
 
 {{ end }}
@@ -1713,7 +1761,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		// Session-handshake invalidation: some status codes indicate the token
 		// was rejected. Clear the cache and retry once; EnsureToken() at the
 		// top of the next loop iteration will re-bootstrap.
-		if c.Session != nil && c.Session.ShouldInvalidate(resp.StatusCode) && attempt < maxRetries && authHeader != "" {
+		if c.Session != nil && c.Session.ShouldInvalidate(resp.StatusCode) && attempt < maxRetries && authHeader != "" && (resp.StatusCode < 500 || canRetryAmbiguousFailure) {
 			c.Session.Invalidate()
 			authHeader = "" // force re-fetch on next iteration
 {{- if .HasTierRouting}}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -1397,6 +1397,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	}
 
 	maxRetries := clientMaxRetries()
+	// Retry only methods that are safe to replay after an ambiguous transport
+	// failure or server error; a write may already have committed remotely.
+	canRetryAmbiguousFailure := readOnlyIntent || method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions
 	var lastErr error
 {{- if and .HasAuthCommand (ne .Auth.TokenURL "")}}
 	refreshedAfterUnauthorized := false
@@ -1599,14 +1602,15 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			// timeout). Back off before retrying — same exponential schedule as
 			// the 5xx path below — so a brief outage does not burn every attempt
 			// in a tight loop. ctx cancellation breaks out of the wait at once.
-			if attempt < maxRetries {
+			if attempt < maxRetries && canRetryAmbiguousFailure {
 				wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 				fmt.Fprintf(os.Stderr, "network error (%v), retrying in %s (attempt %d/%d)\n", c.maskError(err, authHeader), wait, attempt+1, maxRetries)
 				if serr := sleepContext(ctx, wait); serr != nil {
 					return nil, 0, serr
 				}
+				continue
 			}
-			continue
+			return nil, 0, lastErr
 		}
 
 		respBody, err := io.ReadAll(resp.Body)
@@ -1721,7 +1725,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 {{- end}}
 
 		// Server error - retry with backoff
-		if resp.StatusCode >= 500 && attempt < maxRetries {
+		if resp.StatusCode >= 500 && attempt < maxRetries && canRetryAmbiguousFailure {
 			wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 			fmt.Fprintf(os.Stderr, "server error %d, retrying in %s (attempt %d/%d)\n", resp.StatusCode, wait, attempt+1, maxRetries)
 			if err := sleepContext(ctx, wait); err != nil {

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -545,17 +545,33 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			fileFields := map[string]string{}
 {{multipartBodyMaps .Endpoint.Body "\t\t\t"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
+{{- if .IsReadOnly}}
+			data, statusCode, err := c.PutQueryMultipartWithParamsAndHeaders(cmd.Context(), path, params, fields, fileFields, headerOverrides)
+{{- else}}
 			data, statusCode, err := c.PutMultipartWithParamsAndHeaders(cmd.Context(), path, params, fields, fileFields, headerOverrides)
+{{- end}}
+{{- else}}
+{{- if .IsReadOnly}}
+			data, statusCode, err := c.PutQueryMultipartWithParams(cmd.Context(), path, params, fields, fileFields)
 {{- else}}
 			data, statusCode, err := c.PutMultipartWithParams(cmd.Context(), path, params, fields, fileFields)
+{{- end}}
 {{- end}}
 {{- else if $isForm}}
 			fields := url.Values{}
 {{formBodyMaps .Endpoint.Body "\t\t\t"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
+{{- if .IsReadOnly}}
+			data, statusCode, err := c.PutQueryFormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
+{{- else}}
 			data, statusCode, err := c.PutFormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
+{{- end}}
+{{- else}}
+{{- if .IsReadOnly}}
+			data, statusCode, err := c.PutQueryFormWithParams(cmd.Context(), path, params, fields)
 {{- else}}
 			data, statusCode, err := c.PutFormWithParams(cmd.Context(), path, params, fields)
+{{- end}}
 {{- end}}
 {{- else}}
 			var body any
@@ -586,9 +602,17 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				body = bodyMap
 {{bodyMapForEndpointVars .Endpoint "\t\t\t\t" "bodyMap" "body"}}{{- end}}			}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
+{{- if .IsReadOnly}}
+			data, statusCode, err := c.PutQueryWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
+{{- else}}
 			data, statusCode, err := c.PutWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
+{{- end}}
+{{- else}}
+{{- if .IsReadOnly}}
+			data, statusCode, err := c.PutQueryWithParams(cmd.Context(), path, params, body)
 {{- else}}
 			data, statusCode, err := c.PutWithParams(cmd.Context(), path, params, body)
+{{- end}}
 {{- end}}
 {{- end}}
 {{- else if eq .Endpoint.Method "PATCH"}}
@@ -608,17 +632,33 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			fileFields := map[string]string{}
 {{multipartBodyMaps .Endpoint.Body "\t\t\t"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
+{{- if .IsReadOnly}}
+			data, statusCode, err := c.PatchQueryMultipartWithParamsAndHeaders(cmd.Context(), path, params, fields, fileFields, headerOverrides)
+{{- else}}
 			data, statusCode, err := c.PatchMultipartWithParamsAndHeaders(cmd.Context(), path, params, fields, fileFields, headerOverrides)
+{{- end}}
+{{- else}}
+{{- if .IsReadOnly}}
+			data, statusCode, err := c.PatchQueryMultipartWithParams(cmd.Context(), path, params, fields, fileFields)
 {{- else}}
 			data, statusCode, err := c.PatchMultipartWithParams(cmd.Context(), path, params, fields, fileFields)
+{{- end}}
 {{- end}}
 {{- else if $isForm}}
 			fields := url.Values{}
 {{formBodyMaps .Endpoint.Body "\t\t\t"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
+{{- if .IsReadOnly}}
+			data, statusCode, err := c.PatchQueryFormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
+{{- else}}
 			data, statusCode, err := c.PatchFormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
+{{- end}}
+{{- else}}
+{{- if .IsReadOnly}}
+			data, statusCode, err := c.PatchQueryFormWithParams(cmd.Context(), path, params, fields)
 {{- else}}
 			data, statusCode, err := c.PatchFormWithParams(cmd.Context(), path, params, fields)
+{{- end}}
 {{- end}}
 {{- else}}
 			var body any
@@ -649,9 +689,17 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				body = bodyMap
 {{bodyMapForEndpointVars .Endpoint "\t\t\t\t" "bodyMap" "body"}}{{- end}}			}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
+{{- if .IsReadOnly}}
+			data, statusCode, err := c.PatchQueryWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
+{{- else}}
 			data, statusCode, err := c.PatchWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
+{{- end}}
+{{- else}}
+{{- if .IsReadOnly}}
+			data, statusCode, err := c.PatchQueryWithParams(cmd.Context(), path, params, body)
 {{- else}}
 			data, statusCode, err := c.PatchWithParams(cmd.Context(), path, params, body)
+{{- end}}
 {{- end}}
 {{- end}}
 {{- end}}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -286,9 +286,21 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			fileFields := map[string]string{}
 {{multipartBodyMaps .Endpoint.Body "\t\t\t"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
+{{- if and .IsReadOnly (eq (upper .Endpoint.Method) "PUT")}}
+			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.PutQueryMultipartWithParamsAndHeaders(cmd.Context(), path, params, fields, fileFields, headerOverrides)
+{{- else if and .IsReadOnly (eq (upper .Endpoint.Method) "PATCH")}}
+			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.PatchQueryMultipartWithParamsAndHeaders(cmd.Context(), path, params, fields, fileFields, headerOverrides)
+{{- else}}
 			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.{{pascal (lower .Endpoint.Method)}}MultipartWithParamsAndHeaders(cmd.Context(), path, params, fields, fileFields, headerOverrides)
+{{- end}}
+{{- else}}
+{{- if and .IsReadOnly (eq (upper .Endpoint.Method) "PUT")}}
+			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.PutQueryMultipartWithParams(cmd.Context(), path, params, fields, fileFields)
+{{- else if and .IsReadOnly (eq (upper .Endpoint.Method) "PATCH")}}
+			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.PatchQueryMultipartWithParams(cmd.Context(), path, params, fields, fileFields)
 {{- else}}
 			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.{{pascal (lower .Endpoint.Method)}}MultipartWithParams(cmd.Context(), path, params, fields, fileFields)
+{{- end}}
 {{- end}}
 {{- else if $isForm}}
 			fields := url.Values{}
@@ -296,12 +308,20 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
 {{- if and .IsReadOnly (eq (upper .Endpoint.Method) "POST")}}
 			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.PostQueryFormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
+{{- else if and .IsReadOnly (eq (upper .Endpoint.Method) "PUT")}}
+			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.PutQueryFormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
+{{- else if and .IsReadOnly (eq (upper .Endpoint.Method) "PATCH")}}
+			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.PatchQueryFormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
 {{- else}}
 			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.{{pascal (lower .Endpoint.Method)}}FormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
 {{- end}}
 {{- else}}
 {{- if and .IsReadOnly (eq (upper .Endpoint.Method) "POST")}}
 			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.PostQueryFormWithParams(cmd.Context(), path, params, fields)
+{{- else if and .IsReadOnly (eq (upper .Endpoint.Method) "PUT")}}
+			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.PutQueryFormWithParams(cmd.Context(), path, params, fields)
+{{- else if and .IsReadOnly (eq (upper .Endpoint.Method) "PATCH")}}
+			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.PatchQueryFormWithParams(cmd.Context(), path, params, fields)
 {{- else}}
 			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.{{pascal (lower .Endpoint.Method)}}FormWithParams(cmd.Context(), path, params, fields)
 {{- end}}
@@ -316,8 +336,8 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{bodyMapForEndpointVars .Endpoint "\t\t\t" "bodyMap" "body"}}{{else}}
 			bodyMap := map[string]any{}
 			var body any = bodyMap
-{{bodyMapForEndpointVars .Endpoint "\t\t\t" "bodyMap" "body"}}{{end}}{{if and .IsReadOnly (eq (upper .Endpoint.Method) "POST")}}{{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}			data, _, err := c.PostQueryWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
-{{else}}			data, _, err := c.PostQueryWithParams(cmd.Context(), path, params, body)
+{{bodyMapForEndpointVars .Endpoint "\t\t\t" "bodyMap" "body"}}{{end}}{{if .IsReadOnly}}{{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}			data, _, err := c.{{pascal (lower .Endpoint.Method)}}QueryWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
+{{else}}			data, _, err := c.{{pascal (lower .Endpoint.Method)}}QueryWithParams(cmd.Context(), path, params, body)
 {{end}}{{else}}{{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.{{pascal (lower .Endpoint.Method)}}WithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
 {{else}}			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.{{pascal (lower .Endpoint.Method)}}WithParams(cmd.Context(), path, params, body)
 {{end}}{{end}}

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -678,7 +678,15 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 {{- if $hasMultipartRequest}}
 			if multipart {
 				if len(headers) > 0 {
+					if readOnly {
+						data, _, err = c.PutQueryMultipartWithParamsAndHeaders(ctx, path, params, multipartFields, multipartFileFields, headers)
+						break
+					}
 					data, _, err = c.PutMultipartWithParamsAndHeaders(ctx, path, params, multipartFields, multipartFileFields, headers)
+					break
+				}
+				if readOnly {
+					data, _, err = c.PutQueryMultipartWithParams(ctx, path, params, multipartFields, multipartFileFields)
 					break
 				}
 				data, _, err = c.PutMultipartWithParams(ctx, path, params, multipartFields, multipartFileFields)
@@ -688,7 +696,15 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 {{- if $hasFormRequest}}
 			if formEncoded {
 				if len(headers) > 0 {
+					if readOnly {
+						data, _, err = c.PutQueryFormWithParamsAndHeaders(ctx, path, params, formFields, headers)
+						break
+					}
 					data, _, err = c.PutFormWithParamsAndHeaders(ctx, path, params, formFields, headers)
+					break
+				}
+				if readOnly {
+					data, _, err = c.PutQueryFormWithParams(ctx, path, params, formFields)
 					break
 				}
 				data, _, err = c.PutFormWithParams(ctx, path, params, formFields)
@@ -698,23 +714,47 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 {{- if $hasBodyJSONFallback}}
 			if len(bodyJSONOverride) > 0 {
 				if len(headers) > 0 {
-					data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyJSONOverride, headers)
+					if readOnly {
+						data, _, err = c.PutQueryWithParamsAndHeaders(ctx, path, params, bodyJSONOverride, headers)
+					} else {
+						data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyJSONOverride, headers)
+					}
 					break
 				}
-				data, _, err = c.PutWithParams(ctx, path, params, bodyJSONOverride)
+				if readOnly {
+					data, _, err = c.PutQueryWithParams(ctx, path, params, bodyJSONOverride)
+				} else {
+					data, _, err = c.PutWithParams(ctx, path, params, bodyJSONOverride)
+				}
 				break
 			}
 {{- end}}
 			if len(headers) > 0 {
-				data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				if readOnly {
+					data, _, err = c.PutQueryWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				} else {
+					data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				}
 				break
 			}
-			data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
+			if readOnly {
+				data, _, err = c.PutQueryWithParams(ctx, path, params, bodyArgs)
+			} else {
+				data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
+			}
 		case "PATCH":
 {{- if $hasMultipartRequest}}
 			if multipart {
 				if len(headers) > 0 {
+					if readOnly {
+						data, _, err = c.PatchQueryMultipartWithParamsAndHeaders(ctx, path, params, multipartFields, multipartFileFields, headers)
+						break
+					}
 					data, _, err = c.PatchMultipartWithParamsAndHeaders(ctx, path, params, multipartFields, multipartFileFields, headers)
+					break
+				}
+				if readOnly {
+					data, _, err = c.PatchQueryMultipartWithParams(ctx, path, params, multipartFields, multipartFileFields)
 					break
 				}
 				data, _, err = c.PatchMultipartWithParams(ctx, path, params, multipartFields, multipartFileFields)
@@ -724,7 +764,15 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 {{- if $hasFormRequest}}
 			if formEncoded {
 				if len(headers) > 0 {
+					if readOnly {
+						data, _, err = c.PatchQueryFormWithParamsAndHeaders(ctx, path, params, formFields, headers)
+						break
+					}
 					data, _, err = c.PatchFormWithParamsAndHeaders(ctx, path, params, formFields, headers)
+					break
+				}
+				if readOnly {
+					data, _, err = c.PatchQueryFormWithParams(ctx, path, params, formFields)
 					break
 				}
 				data, _, err = c.PatchFormWithParams(ctx, path, params, formFields)
@@ -734,18 +782,34 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 {{- if $hasBodyJSONFallback}}
 			if len(bodyJSONOverride) > 0 {
 				if len(headers) > 0 {
-					data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyJSONOverride, headers)
+					if readOnly {
+						data, _, err = c.PatchQueryWithParamsAndHeaders(ctx, path, params, bodyJSONOverride, headers)
+					} else {
+						data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyJSONOverride, headers)
+					}
 					break
 				}
-				data, _, err = c.PatchWithParams(ctx, path, params, bodyJSONOverride)
+				if readOnly {
+					data, _, err = c.PatchQueryWithParams(ctx, path, params, bodyJSONOverride)
+				} else {
+					data, _, err = c.PatchWithParams(ctx, path, params, bodyJSONOverride)
+				}
 				break
 			}
 {{- end}}
 			if len(headers) > 0 {
-				data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				if readOnly {
+					data, _, err = c.PatchQueryWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				} else {
+					data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				}
 				break
 			}
-			data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
+			if readOnly {
+				data, _, err = c.PatchQueryWithParams(ctx, path, params, bodyArgs)
+			} else {
+				data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
+			}
 		case "DELETE":
 			if len(headers) > 0 {
 				data, _, err = c.DeleteWithParamsAndHeaders(ctx, path, params, headers)

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
@@ -313,16 +313,32 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 		case "PUT":
 			if len(headers) > 0 {
-				data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				if readOnly {
+					data, _, err = c.PutQueryWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				} else {
+					data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				}
 				break
 			}
-			data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
+			if readOnly {
+				data, _, err = c.PutQueryWithParams(ctx, path, params, bodyArgs)
+			} else {
+				data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
+			}
 		case "PATCH":
 			if len(headers) > 0 {
-				data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				if readOnly {
+					data, _, err = c.PatchQueryWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				} else {
+					data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				}
 				break
 			}
-			data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
+			if readOnly {
+				data, _, err = c.PatchQueryWithParams(ctx, path, params, bodyArgs)
+			} else {
+				data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
+			}
 		case "DELETE":
 			if len(headers) > 0 {
 				data, _, err = c.DeleteWithParamsAndHeaders(ctx, path, params, headers)

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -570,6 +570,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	}
 
 	maxRetries := clientMaxRetries()
+	// Retry only methods that are safe to replay after an ambiguous transport
+	// failure or server error; a write may already have committed remotely.
+	canRetryAmbiguousFailure := readOnlyIntent || method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions
 	var lastErr error
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
@@ -662,14 +665,15 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			// timeout). Back off before retrying — same exponential schedule as
 			// the 5xx path below — so a brief outage does not burn every attempt
 			// in a tight loop. ctx cancellation breaks out of the wait at once.
-			if attempt < maxRetries {
+			if attempt < maxRetries && canRetryAmbiguousFailure {
 				wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 				fmt.Fprintf(os.Stderr, "network error (%v), retrying in %s (attempt %d/%d)\n", c.maskError(err, authHeader), wait, attempt+1, maxRetries)
 				if serr := sleepContext(ctx, wait); serr != nil {
 					return nil, 0, serr
 				}
+				continue
 			}
-			continue
+			return nil, 0, lastErr
 		}
 
 		respBody, err := io.ReadAll(resp.Body)
@@ -730,7 +734,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		}
 
 		// Server error - retry with backoff
-		if resp.StatusCode >= 500 && attempt < maxRetries {
+		if resp.StatusCode >= 500 && attempt < maxRetries && canRetryAmbiguousFailure {
 			wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 			fmt.Fprintf(os.Stderr, "server error %d, retrying in %s (attempt %d/%d)\n", resp.StatusCode, wait, attempt+1, maxRetries)
 			if err := sleepContext(ctx, wait); err != nil {

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -442,6 +442,14 @@ func (c *Client) PutWithParamsAndHeaders(ctx context.Context, path string, param
 	return c.do(ctx, "PUT", path, params, body, headers)
 }
 
+func (c *Client) PutQueryWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, body, nil)
+}
+
+func (c *Client) PutQueryWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, body, headers)
+}
+
 func (c *Client) Patch(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
 	return c.do(ctx, "PATCH", path, nil, body, nil)
 }
@@ -456,6 +464,14 @@ func (c *Client) PatchWithHeaders(ctx context.Context, path string, body any, he
 
 func (c *Client) PatchWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
 	return c.do(ctx, "PATCH", path, params, body, headers)
+}
+
+func (c *Client) PatchQueryWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, body, nil)
+}
+
+func (c *Client) PatchQueryWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, body, headers)
 }
 
 // isMutatingVerb reports whether the HTTP method writes server state.

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -445,6 +445,14 @@ func (c *Client) PutWithParamsAndHeaders(ctx context.Context, path string, param
 	return c.do(ctx, "PUT", path, params, body, headers)
 }
 
+func (c *Client) PutQueryWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, body, nil)
+}
+
+func (c *Client) PutQueryWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, body, headers)
+}
+
 func (c *Client) Patch(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
 	return c.do(ctx, "PATCH", path, nil, body, nil)
 }
@@ -459,6 +467,14 @@ func (c *Client) PatchWithHeaders(ctx context.Context, path string, body any, he
 
 func (c *Client) PatchWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
 	return c.do(ctx, "PATCH", path, params, body, headers)
+}
+
+func (c *Client) PatchQueryWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, body, nil)
+}
+
+func (c *Client) PatchQueryWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, body, headers)
 }
 
 // isMutatingVerb reports whether the HTTP method writes server state.

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -573,6 +573,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	}
 
 	maxRetries := clientMaxRetries()
+	// Retry only methods that are safe to replay after an ambiguous transport
+	// failure or server error; a write may already have committed remotely.
+	canRetryAmbiguousFailure := readOnlyIntent || method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions
 	var lastErr error
 	refreshedAfterUnauthorized := false
 
@@ -650,14 +653,15 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			// timeout). Back off before retrying — same exponential schedule as
 			// the 5xx path below — so a brief outage does not burn every attempt
 			// in a tight loop. ctx cancellation breaks out of the wait at once.
-			if attempt < maxRetries {
+			if attempt < maxRetries && canRetryAmbiguousFailure {
 				wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 				fmt.Fprintf(os.Stderr, "network error (%v), retrying in %s (attempt %d/%d)\n", c.maskError(err, authHeader), wait, attempt+1, maxRetries)
 				if serr := sleepContext(ctx, wait); serr != nil {
 					return nil, 0, serr
 				}
+				continue
 			}
-			continue
+			return nil, 0, lastErr
 		}
 
 		respBody, err := io.ReadAll(resp.Body)
@@ -735,7 +739,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		}
 
 		// Server error - retry with backoff
-		if resp.StatusCode >= 500 && attempt < maxRetries {
+		if resp.StatusCode >= 500 && attempt < maxRetries && canRetryAmbiguousFailure {
 			wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 			fmt.Fprintf(os.Stderr, "server error %d, retrying in %s (attempt %d/%d)\n", resp.StatusCode, wait, attempt+1, maxRetries)
 			if err := sleepContext(ctx, wait); err != nil {

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -455,6 +455,14 @@ func (c *Client) PutWithParamsAndHeaders(ctx context.Context, path string, param
 	return c.do(ctx, "PUT", path, params, body, headers)
 }
 
+func (c *Client) PutQueryWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, body, nil)
+}
+
+func (c *Client) PutQueryWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, body, headers)
+}
+
 func (c *Client) Patch(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
 	return c.do(ctx, "PATCH", path, nil, body, nil)
 }
@@ -469,6 +477,14 @@ func (c *Client) PatchWithHeaders(ctx context.Context, path string, body any, he
 
 func (c *Client) PatchWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
 	return c.do(ctx, "PATCH", path, params, body, headers)
+}
+
+func (c *Client) PatchQueryWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, body, nil)
+}
+
+func (c *Client) PatchQueryWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, body, headers)
 }
 
 // isMutatingVerb reports whether the HTTP method writes server state.

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -583,6 +583,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	}
 
 	maxRetries := clientMaxRetries()
+	// Retry only methods that are safe to replay after an ambiguous transport
+	// failure or server error; a write may already have committed remotely.
+	canRetryAmbiguousFailure := readOnlyIntent || method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions
 	var lastErr error
 	refreshedAfterUnauthorized := false
 
@@ -660,14 +663,15 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			// timeout). Back off before retrying — same exponential schedule as
 			// the 5xx path below — so a brief outage does not burn every attempt
 			// in a tight loop. ctx cancellation breaks out of the wait at once.
-			if attempt < maxRetries {
+			if attempt < maxRetries && canRetryAmbiguousFailure {
 				wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 				fmt.Fprintf(os.Stderr, "network error (%v), retrying in %s (attempt %d/%d)\n", c.maskError(err, authHeader), wait, attempt+1, maxRetries)
 				if serr := sleepContext(ctx, wait); serr != nil {
 					return nil, 0, serr
 				}
+				continue
 			}
-			continue
+			return nil, 0, lastErr
 		}
 
 		respBody, err := io.ReadAll(resp.Body)
@@ -745,7 +749,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		}
 
 		// Server error - retry with backoff
-		if resp.StatusCode >= 500 && attempt < maxRetries {
+		if resp.StatusCode >= 500 && attempt < maxRetries && canRetryAmbiguousFailure {
 			wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 			fmt.Fprintf(os.Stderr, "server error %d, retrying in %s (attempt %d/%d)\n", resp.StatusCode, wait, attempt+1, maxRetries)
 			if err := sleepContext(ctx, wait); err != nil {

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -445,6 +445,14 @@ func (c *Client) PutWithParamsAndHeaders(ctx context.Context, path string, param
 	return c.do(ctx, "PUT", path, params, body, headers)
 }
 
+func (c *Client) PutQueryWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, body, nil)
+}
+
+func (c *Client) PutQueryWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, body, headers)
+}
+
 func (c *Client) Patch(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
 	return c.do(ctx, "PATCH", path, nil, body, nil)
 }
@@ -459,6 +467,14 @@ func (c *Client) PatchWithHeaders(ctx context.Context, path string, body any, he
 
 func (c *Client) PatchWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
 	return c.do(ctx, "PATCH", path, params, body, headers)
+}
+
+func (c *Client) PatchQueryWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, body, nil)
+}
+
+func (c *Client) PatchQueryWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, body, headers)
 }
 
 // isMutatingVerb reports whether the HTTP method writes server state.

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -573,6 +573,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	}
 
 	maxRetries := clientMaxRetries()
+	// Retry only methods that are safe to replay after an ambiguous transport
+	// failure or server error; a write may already have committed remotely.
+	canRetryAmbiguousFailure := readOnlyIntent || method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions
 	var lastErr error
 	refreshedAfterUnauthorized := false
 
@@ -650,14 +653,15 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			// timeout). Back off before retrying — same exponential schedule as
 			// the 5xx path below — so a brief outage does not burn every attempt
 			// in a tight loop. ctx cancellation breaks out of the wait at once.
-			if attempt < maxRetries {
+			if attempt < maxRetries && canRetryAmbiguousFailure {
 				wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 				fmt.Fprintf(os.Stderr, "network error (%v), retrying in %s (attempt %d/%d)\n", c.maskError(err, authHeader), wait, attempt+1, maxRetries)
 				if serr := sleepContext(ctx, wait); serr != nil {
 					return nil, 0, serr
 				}
+				continue
 			}
-			continue
+			return nil, 0, lastErr
 		}
 
 		respBody, err := io.ReadAll(resp.Body)
@@ -735,7 +739,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		}
 
 		// Server error - retry with backoff
-		if resp.StatusCode >= 500 && attempt < maxRetries {
+		if resp.StatusCode >= 500 && attempt < maxRetries && canRetryAmbiguousFailure {
 			wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 			fmt.Fprintf(os.Stderr, "server error %d, retrying in %s (attempt %d/%d)\n", resp.StatusCode, wait, attempt+1, maxRetries)
 			if err := sleepContext(ctx, wait); err != nil {

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
@@ -251,16 +251,32 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 		case "PUT":
 			if len(headers) > 0 {
-				data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				if readOnly {
+					data, _, err = c.PutQueryWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				} else {
+					data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				}
 				break
 			}
-			data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
+			if readOnly {
+				data, _, err = c.PutQueryWithParams(ctx, path, params, bodyArgs)
+			} else {
+				data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
+			}
 		case "PATCH":
 			if len(headers) > 0 {
-				data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				if readOnly {
+					data, _, err = c.PatchQueryWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				} else {
+					data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				}
 				break
 			}
-			data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
+			if readOnly {
+				data, _, err = c.PatchQueryWithParams(ctx, path, params, bodyArgs)
+			} else {
+				data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
+			}
 		case "DELETE":
 			if len(headers) > 0 {
 				data, _, err = c.DeleteWithParamsAndHeaders(ctx, path, params, headers)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -460,6 +460,14 @@ func (c *Client) PutWithHeaders(ctx context.Context, path string, body any, head
 func (c *Client) PutWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
 	return c.do(ctx, "PUT", path, params, body, headers)
 }
+
+func (c *Client) PutQueryWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, body, nil)
+}
+
+func (c *Client) PutQueryWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, body, headers)
+}
 func (c *Client) PutMultipart(ctx context.Context, path string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
 	return c.do(ctx, "PUT", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
 }
@@ -474,6 +482,14 @@ func (c *Client) PutMultipartWithHeaders(ctx context.Context, path string, field
 
 func (c *Client) PutMultipartWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
 	return c.do(ctx, "PUT", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
+}
+
+func (c *Client) PutQueryMultipartWithParams(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
+}
+
+func (c *Client) PutQueryMultipartWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
 }
 
 func (c *Client) Patch(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
@@ -491,6 +507,14 @@ func (c *Client) PatchWithHeaders(ctx context.Context, path string, body any, he
 func (c *Client) PatchWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
 	return c.do(ctx, "PATCH", path, params, body, headers)
 }
+
+func (c *Client) PatchQueryWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, body, nil)
+}
+
+func (c *Client) PatchQueryWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, body, headers)
+}
 func (c *Client) PatchMultipart(ctx context.Context, path string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
 	return c.do(ctx, "PATCH", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
 }
@@ -505,6 +529,14 @@ func (c *Client) PatchMultipartWithHeaders(ctx context.Context, path string, fie
 
 func (c *Client) PatchMultipartWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
 	return c.do(ctx, "PATCH", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
+}
+
+func (c *Client) PatchQueryMultipartWithParams(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
+}
+
+func (c *Client) PatchQueryMultipartWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
 }
 
 type multipartRequestBody struct {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -672,6 +672,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	}
 
 	maxRetries := clientMaxRetries()
+	// Retry only methods that are safe to replay after an ambiguous transport
+	// failure or server error; a write may already have committed remotely.
+	canRetryAmbiguousFailure := readOnlyIntent || method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions
 	var lastErr error
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
@@ -749,14 +752,15 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			// timeout). Back off before retrying — same exponential schedule as
 			// the 5xx path below — so a brief outage does not burn every attempt
 			// in a tight loop. ctx cancellation breaks out of the wait at once.
-			if attempt < maxRetries {
+			if attempt < maxRetries && canRetryAmbiguousFailure {
 				wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 				fmt.Fprintf(os.Stderr, "network error (%v), retrying in %s (attempt %d/%d)\n", c.maskError(err, authHeader), wait, attempt+1, maxRetries)
 				if serr := sleepContext(ctx, wait); serr != nil {
 					return nil, 0, serr
 				}
+				continue
 			}
-			continue
+			return nil, 0, lastErr
 		}
 
 		respBody, err := io.ReadAll(resp.Body)
@@ -817,7 +821,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		}
 
 		// Server error - retry with backoff
-		if resp.StatusCode >= 500 && attempt < maxRetries {
+		if resp.StatusCode >= 500 && attempt < maxRetries && canRetryAmbiguousFailure {
 			wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 			fmt.Fprintf(os.Stderr, "server error %d, retrying in %s (attempt %d/%d)\n", resp.StatusCode, wait, attempt+1, maxRetries)
 			if err := sleepContext(ctx, wait); err != nil {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
@@ -391,31 +391,63 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 		case "PUT":
 			if multipart {
 				if len(headers) > 0 {
+					if readOnly {
+						data, _, err = c.PutQueryMultipartWithParamsAndHeaders(ctx, path, params, multipartFields, multipartFileFields, headers)
+						break
+					}
 					data, _, err = c.PutMultipartWithParamsAndHeaders(ctx, path, params, multipartFields, multipartFileFields, headers)
+					break
+				}
+				if readOnly {
+					data, _, err = c.PutQueryMultipartWithParams(ctx, path, params, multipartFields, multipartFileFields)
 					break
 				}
 				data, _, err = c.PutMultipartWithParams(ctx, path, params, multipartFields, multipartFileFields)
 				break
 			}
 			if len(headers) > 0 {
-				data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				if readOnly {
+					data, _, err = c.PutQueryWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				} else {
+					data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				}
 				break
 			}
-			data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
+			if readOnly {
+				data, _, err = c.PutQueryWithParams(ctx, path, params, bodyArgs)
+			} else {
+				data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
+			}
 		case "PATCH":
 			if multipart {
 				if len(headers) > 0 {
+					if readOnly {
+						data, _, err = c.PatchQueryMultipartWithParamsAndHeaders(ctx, path, params, multipartFields, multipartFileFields, headers)
+						break
+					}
 					data, _, err = c.PatchMultipartWithParamsAndHeaders(ctx, path, params, multipartFields, multipartFileFields, headers)
+					break
+				}
+				if readOnly {
+					data, _, err = c.PatchQueryMultipartWithParams(ctx, path, params, multipartFields, multipartFileFields)
 					break
 				}
 				data, _, err = c.PatchMultipartWithParams(ctx, path, params, multipartFields, multipartFileFields)
 				break
 			}
 			if len(headers) > 0 {
-				data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				if readOnly {
+					data, _, err = c.PatchQueryWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				} else {
+					data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				}
 				break
 			}
-			data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
+			if readOnly {
+				data, _, err = c.PatchQueryWithParams(ctx, path, params, bodyArgs)
+			} else {
+				data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
+			}
 		case "DELETE":
 			if len(headers) > 0 {
 				data, _, err = c.DeleteWithParamsAndHeaders(ctx, path, params, headers)

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
@@ -245,16 +245,32 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 		case "PUT":
 			if len(headers) > 0 {
-				data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				if readOnly {
+					data, _, err = c.PutQueryWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				} else {
+					data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				}
 				break
 			}
-			data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
+			if readOnly {
+				data, _, err = c.PutQueryWithParams(ctx, path, params, bodyArgs)
+			} else {
+				data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
+			}
 		case "PATCH":
 			if len(headers) > 0 {
-				data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				if readOnly {
+					data, _, err = c.PatchQueryWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				} else {
+					data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				}
 				break
 			}
-			data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
+			if readOnly {
+				data, _, err = c.PatchQueryWithParams(ctx, path, params, bodyArgs)
+			} else {
+				data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
+			}
 		case "DELETE":
 			if len(headers) > 0 {
 				data, _, err = c.DeleteWithParamsAndHeaders(ctx, path, params, headers)

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
@@ -264,16 +264,32 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 		case "PUT":
 			if len(headers) > 0 {
-				data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				if readOnly {
+					data, _, err = c.PutQueryWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				} else {
+					data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				}
 				break
 			}
-			data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
+			if readOnly {
+				data, _, err = c.PutQueryWithParams(ctx, path, params, bodyArgs)
+			} else {
+				data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
+			}
 		case "PATCH":
 			if len(headers) > 0 {
-				data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				if readOnly {
+					data, _, err = c.PatchQueryWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				} else {
+					data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				}
 				break
 			}
-			data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
+			if readOnly {
+				data, _, err = c.PatchQueryWithParams(ctx, path, params, bodyArgs)
+			} else {
+				data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
+			}
 		case "DELETE":
 			if len(headers) > 0 {
 				data, _, err = c.DeleteWithParamsAndHeaders(ctx, path, params, headers)

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -546,6 +546,14 @@ func (c *Client) PutWithParamsAndHeaders(ctx context.Context, path string, param
 	return c.do(ctx, "PUT", path, params, body, headers)
 }
 
+func (c *Client) PutQueryWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, body, nil)
+}
+
+func (c *Client) PutQueryWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PUT", path, params, body, headers)
+}
+
 func (c *Client) Patch(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
 	return c.do(ctx, "PATCH", path, nil, body, nil)
 }
@@ -560,6 +568,14 @@ func (c *Client) PatchWithHeaders(ctx context.Context, path string, body any, he
 
 func (c *Client) PatchWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
 	return c.do(ctx, "PATCH", path, params, body, headers)
+}
+
+func (c *Client) PatchQueryWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, body, nil)
+}
+
+func (c *Client) PatchQueryWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "PATCH", path, params, body, headers)
 }
 
 // isMutatingVerb reports whether the HTTP method writes server state.

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -676,6 +676,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	}
 
 	maxRetries := clientMaxRetries()
+	// Retry only methods that are safe to replay after an ambiguous transport
+	// failure or server error; a write may already have committed remotely.
+	canRetryAmbiguousFailure := readOnlyIntent || method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions
 	var lastErr error
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
@@ -758,14 +761,15 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			// timeout). Back off before retrying — same exponential schedule as
 			// the 5xx path below — so a brief outage does not burn every attempt
 			// in a tight loop. ctx cancellation breaks out of the wait at once.
-			if attempt < maxRetries {
+			if attempt < maxRetries && canRetryAmbiguousFailure {
 				wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 				fmt.Fprintf(os.Stderr, "network error (%v), retrying in %s (attempt %d/%d)\n", c.maskError(err, authHeader), wait, attempt+1, maxRetries)
 				if serr := sleepContext(ctx, wait); serr != nil {
 					return nil, 0, serr
 				}
+				continue
 			}
-			continue
+			return nil, 0, lastErr
 		}
 
 		respBody, err := io.ReadAll(resp.Body)
@@ -826,7 +830,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		}
 
 		// Server error - retry with backoff
-		if resp.StatusCode >= 500 && attempt < maxRetries {
+		if resp.StatusCode >= 500 && attempt < maxRetries && canRetryAmbiguousFailure {
 			wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 			fmt.Fprintf(os.Stderr, "server error %d, retrying in %s (attempt %d/%d)\n", resp.StatusCode, wait, attempt+1, maxRetries)
 			if err := sleepContext(ctx, wait); err != nil {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
@@ -271,16 +271,32 @@ func makeAPIHandler(method, pathTemplate, tier string, readOnly bool, binaryResp
 			}
 		case "PUT":
 			if len(headers) > 0 {
-				data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				if readOnly {
+					data, _, err = c.PutQueryWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				} else {
+					data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				}
 				break
 			}
-			data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
+			if readOnly {
+				data, _, err = c.PutQueryWithParams(ctx, path, params, bodyArgs)
+			} else {
+				data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
+			}
 		case "PATCH":
 			if len(headers) > 0 {
-				data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				if readOnly {
+					data, _, err = c.PatchQueryWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				} else {
+					data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
+				}
 				break
 			}
-			data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
+			if readOnly {
+				data, _, err = c.PatchQueryWithParams(ctx, path, params, bodyArgs)
+			} else {
+				data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
+			}
 		case "DELETE":
 			if len(headers) > 0 {
 				data, _, err = c.DeleteWithParamsAndHeaders(ctx, path, params, headers)


### PR DESCRIPTION
## Summary

Generated clients no longer replay mutation requests after ambiguous transport failures or 5xx responses, preventing duplicate side effects when a server may already have applied the first attempt. Safe HTTP methods and explicitly read-only POST-style operations retain bounded retries, while rate-limit handling remains unchanged.

Generated-runtime coverage exercises mutation, safe-method, read-only-intent, transport-error, 5xx, and 429 behavior. Affected golden clients were refreshed to lock the emitted contract.

## Validation

- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`

Closes #3492
