### PR TITLE
fix(cli): report generated batch failures

### DIFF
--- a/internal/generator/import_failure_exit_test.go
+++ b/internal/generator/import_failure_exit_test.go
@@ -1,0 +1,210 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGeneratedImportFailureExitBehavior executes the emitted REST import
+// command against a local HTTP server. This protects the command's exit-code
+// contract rather than only asserting on template text.
+func TestGeneratedImportFailureExitBehavior(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("importfail")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources["items"].Endpoints["create"] = spec.Endpoint{
+		Method:      "POST",
+		Path:        "/items",
+		Description: "Create item",
+		Body:        []spec.Param{{Name: "name", Type: "string", Required: true}},
+		Response:    spec.ResponseDef{Type: "object"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Import: true, MCP: true}
+	require.NoError(t, gen.Generate())
+
+	behaviorTest := `package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runImportBatch(t *testing.T, statusForName func(string) int, records int, asJSON bool) (error, string, string, int) {
+	t.Helper()
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusForName(fmt.Sprint(body["name"])))
+		_, _ = w.Write([]byte(` + "`" + `{"ok":true}` + "`" + `))
+	}))
+	defer server.Close()
+	t.Setenv("IMPORTFAIL_BASE_URL", server.URL)
+
+	var input strings.Builder
+	for i := 0; i < records; i++ {
+		fmt.Fprintf(&input, ` + "`" + `{"name":"item-%d"}` + "`" + `+"\n", i)
+	}
+	inputPath := filepath.Join(t.TempDir(), "records.jsonl")
+	if err := os.WriteFile(inputPath, []byte(input.String()), 0o600); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	flags := &rootFlags{asJSON: asJSON}
+	cmd := newImportCmd(flags)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"items", "--input", inputPath})
+	stderrReader, stderrWriter, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatalf("capture stderr: %v", pipeErr)
+	}
+	originalStderr := os.Stderr
+	os.Stderr = stderrWriter
+	err := cmd.Execute()
+	os.Stderr = originalStderr
+	if closeErr := stderrWriter.Close(); closeErr != nil {
+		t.Fatalf("close stderr writer: %v", closeErr)
+	}
+	stderr, readErr := io.ReadAll(stderrReader)
+	if readErr != nil {
+		t.Fatalf("read stderr: %v", readErr)
+	}
+	if closeErr := stderrReader.Close(); closeErr != nil {
+		t.Fatalf("close stderr reader: %v", closeErr)
+	}
+	return err, out.String(), string(stderr), requests
+}
+
+func TestImportBatchAllFailuresReturnsNonZeroAfterEnvelope(t *testing.T) {
+	err, out, _, requests := runImportBatch(t, func(string) int { return http.StatusInternalServerError }, 2, true)
+	if err == nil {
+		t.Fatal("expected a typed import failure")
+	}
+	if code := ExitCode(err); code != 5 {
+		t.Fatalf("exit code = %d, want 5; err=%v", code, err)
+	}
+	if requests < 2 {
+		t.Fatalf("requests = %d, want both non-auth records attempted", requests)
+	}
+	for _, want := range []string{` + "`" + `"succeeded": 0` + "`" + `, ` + "`" + `"failed": 2` + "`" + `, ` + "`" + `"skipped": 0` + "`" + `} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %s: %s", want, out)
+		}
+	}
+}
+
+
+func TestImportBatchPartialFailureReportsCommittedCount(t *testing.T) {
+	err, out, _, _ := runImportBatch(t, func(name string) int {
+		if name == "item-0" {
+			return http.StatusCreated
+		}
+		return http.StatusInternalServerError
+	}, 2, true)
+	if err == nil || ExitCode(err) != 5 {
+		t.Fatalf("expected typed partial failure, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "1 succeeded") || !strings.Contains(err.Error(), "1 failed") {
+		t.Fatalf("partial failure error missing counts: %v", err)
+	}
+	for _, want := range []string{` + "`" + `"succeeded": 1` + "`" + `, ` + "`" + `"failed": 1` + "`" + `} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %s: %s", want, out)
+		}
+	}
+}
+
+func TestImportBatchAuthFailureAbortsAfterEnvelope(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(fmt.Sprint(status), func(t *testing.T) {
+			err, out, _, requests := runImportBatch(t, func(string) int { return status }, 3, true)
+			if err == nil {
+				t.Fatal("expected an auth failure")
+			}
+			if code := ExitCode(err); code != 4 {
+				t.Fatalf("exit code = %d, want 4; err=%v", code, err)
+			}
+			if requests != 1 {
+				t.Fatalf("requests = %d, want immediate abort after the first auth failure", requests)
+			}
+			if !strings.Contains(out, ` + "`" + `"failed": 1` + "`" + `) {
+				t.Fatalf("auth failure output missing failed count: %s", out)
+			}
+		})
+	}
+}
+
+func TestImportBatchMidstreamAuthFailurePreservesCommittedCount(t *testing.T) {
+	err, out, _, requests := runImportBatch(t, func(name string) int {
+		if name == "item-0" {
+			return http.StatusCreated
+		}
+		return http.StatusUnauthorized
+	}, 3, true)
+	if err == nil || ExitCode(err) != 4 {
+		t.Fatalf("expected typed auth failure, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "1 succeeded, 1 failed") {
+		t.Fatalf("auth failure error missing committed counts: %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want committed record plus auth failure only", requests)
+	}
+	for _, want := range []string{` + "`" + `"succeeded": 1` + "`" + `, ` + "`" + `"failed": 1` + "`" + `} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %s: %s", want, out)
+		}
+	}
+}
+
+func TestImportBatchHumanFailurePrintsSummary(t *testing.T) {
+	err, _, stderr, _ := runImportBatch(t, func(string) int { return http.StatusInternalServerError }, 1, false)
+	if err == nil || ExitCode(err) != 5 {
+		t.Fatalf("expected typed import failure, got %v", err)
+	}
+	if !strings.Contains(stderr, "Import complete: 0 succeeded, 1 failed, 0 skipped") {
+		t.Fatalf("stderr missing human summary: %s", stderr)
+	}
+}
+
+func TestImportBatchCleanRunKeepsZeroExit(t *testing.T) {
+	err, out, _, requests := runImportBatch(t, func(string) int { return http.StatusCreated }, 2, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+	if !strings.Contains(out, ` + "`" + `"succeeded": 2` + "`" + `) || !strings.Contains(out, ` + "`" + `"failed": 0` + "`" + `) {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+`
+
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "import_failure_exit_test.go"), []byte(behaviorTest), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "^TestImportBatch", "-count=1")
+	requireGeneratedCompiles(t, outputDir)
+}

--- a/internal/generator/import_failure_exit_test.go
+++ b/internal/generator/import_failure_exit_test.go
@@ -167,13 +167,13 @@ func TestImportBatchMidstreamAuthFailurePreservesCommittedCount(t *testing.T) {
 	if err == nil || ExitCode(err) != 4 {
 		t.Fatalf("expected typed auth failure, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "1 succeeded, 1 failed") {
+	if !strings.Contains(err.Error(), "1 succeeded, 1 failed, and 1 skipped") {
 		t.Fatalf("auth failure error missing committed counts: %v", err)
 	}
 	if requests != 2 {
 		t.Fatalf("requests = %d, want committed record plus auth failure only", requests)
 	}
-	for _, want := range []string{` + "`" + `"succeeded": 1` + "`" + `, ` + "`" + `"failed": 1` + "`" + `} {
+	for _, want := range []string{` + "`" + `"succeeded": 1` + "`" + `, ` + "`" + `"failed": 1` + "`" + `, ` + "`" + `"skipped": 1` + "`" + `} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("output missing %s: %s", want, out)
 		}

--- a/internal/generator/sync_dependent_fanout_race_test.go
+++ b/internal/generator/sync_dependent_fanout_race_test.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
@@ -85,6 +86,7 @@ func TestDependentFanoutWorkerPoolNoRace(t *testing.T) {
 	src := string(syncSrc)
 	require.Contains(t, src, "func syncOneParent(", "sync.go must emit the per-parent worker entry")
 	require.Contains(t, src, "lockedWriter", "sync.go must emit the mutex-guarded event writer for concurrent workers")
+	require.Equal(t, 4, strings.Count(src, "totalSynced += res.Count"), "warning and success results must both contribute stored rows")
 
 	// In-package test (package cli) for access to unexported syncDependentResource
 	// / dependentResourceDef. This minimal spec has no membership scope, no
@@ -102,6 +104,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"` + naming.CLI(apiSpec.Name) + `/internal/store"
 )
@@ -248,6 +251,100 @@ func TestSyncDependentResource_DryRunShortCircuitsUnderConcurrency(t *testing.T)
 	if cnt != 0 {
 		t.Errorf("stored modules rows = %d, want 0 (dry-run must not mutate)", cnt)
 	}
+}
+
+func installModuleUpsertFailure(t *testing.T, db *store.Store, when string) {
+	t.Helper()
+	stmt := ` + "`" + `CREATE TRIGGER fail_module_upsert
+		BEFORE INSERT ON resources
+		WHEN NEW.resource_type = 'modules'` + "`" + `
+	if when != "" {
+		stmt += " AND " + when
+	}
+	stmt += ` + "`" + ` BEGIN SELECT RAISE(ABORT, 'forced module upsert failure'); END` + "`" + `
+	if _, err := db.DB().Exec(stmt); err != nil {
+		t.Fatalf("install failure trigger: %v", err)
+	}
+}
+
+type moduleSyncState struct {
+	cursor   string
+	syncedAt time.Time
+	count    int
+}
+
+func seedModuleSyncState(t *testing.T, db *store.Store) moduleSyncState {
+	t.Helper()
+	if err := db.SaveSyncState("modules", "cursor-before", 7); err != nil {
+		t.Fatalf("seed sync state: %v", err)
+	}
+	return readModuleSyncState(t, db)
+}
+
+func readModuleSyncState(t *testing.T, db *store.Store) moduleSyncState {
+	t.Helper()
+	cursor, syncedAt, count, err := db.GetSyncState("modules")
+	if err != nil {
+		t.Fatalf("read sync state: %v", err)
+	}
+	return moduleSyncState{cursor: cursor, syncedAt: syncedAt, count: count}
+}
+
+func assertModuleSyncStateUnchanged(t *testing.T, db *store.Store, before moduleSyncState) {
+	t.Helper()
+	after := readModuleSyncState(t, db)
+	if after.cursor != before.cursor || !after.syncedAt.Equal(before.syncedAt) || after.count != before.count {
+		t.Fatalf("sync state changed after failed persistence: before=%+v after=%+v", before, after)
+	}
+}
+
+func TestSyncDependentResource_AllUpsertsFailReturnsError(t *testing.T) {
+	db := seedFanoutRaceProjects(t, 2)
+	defer db.Close()
+	before := seedModuleSyncState(t, db)
+	installModuleUpsertFailure(t, db, "")
+
+	fake := &fakeDependentGetter{respond: func(path string, _ map[string]string) (json.RawMessage, error) {
+		return json.RawMessage(fmt.Sprintf(` + "`" + `[{"id":"m-%s"}]` + "`" + `, sanitizeRacePath(path))), nil
+	}}
+	var events bytes.Buffer
+	res := syncDependentResource(context.Background(), fake, db, modulesDep(), "", true, 0, false, true, &syncUserParams{}, &events, 2)
+	if res.Err == nil {
+		t.Fatalf("expected all-parent upsert failure to return Err; result=%+v", res)
+	}
+	if res.Warn != nil {
+		t.Fatalf("all-parent failure returned Warn instead of Err: %v", res.Warn)
+	}
+	if n := strings.Count(events.String(), ` + "`" + `"event":"sync_error"` + "`" + `); n != 2 {
+		t.Fatalf("sync_error events = %d, want 2; events:\n%s", n, events.String())
+	}
+	assertModuleSyncStateUnchanged(t, db, before)
+}
+
+func TestSyncDependentResource_PartialUpsertFailureReturnsWarning(t *testing.T) {
+	db := seedFanoutRaceProjects(t, 2)
+	defer db.Close()
+	before := seedModuleSyncState(t, db)
+	installModuleUpsertFailure(t, db, ` + "`" + `json_extract(NEW.data, '$.parent_id') = 'p-0'` + "`" + `)
+
+	fake := &fakeDependentGetter{respond: func(path string, _ map[string]string) (json.RawMessage, error) {
+		return json.RawMessage(fmt.Sprintf(` + "`" + `[{"id":"m-%s"}]` + "`" + `, sanitizeRacePath(path))), nil
+	}}
+	var events bytes.Buffer
+	res := syncDependentResource(context.Background(), fake, db, modulesDep(), "", true, 0, false, true, &syncUserParams{}, &events, 2)
+	if res.Err != nil {
+		t.Fatalf("partial failure returned Err: %v", res.Err)
+	}
+	if res.Warn == nil {
+		t.Fatalf("expected partial upsert failure to return Warn; result=%+v", res)
+	}
+	if res.Count != 1 {
+		t.Fatalf("Count = %d, want one successfully stored parent", res.Count)
+	}
+	if n := strings.Count(events.String(), ` + "`" + `"event":"sync_error"` + "`" + `); n != 1 {
+		t.Fatalf("sync_error events = %d, want 1; events:\n%s", n, events.String())
+	}
+	assertModuleSyncStateUnchanged(t, db, before)
 }
 `
 	testPath := filepath.Join(outputDir, "internal", "cli", "fanout_race_test.go")

--- a/internal/generator/templates/import.go.tmpl
+++ b/internal/generator/templates/import.go.tmpl
@@ -61,6 +61,7 @@ but do not stop the import.`,
 			scanner.Buffer(make([]byte, 1024*1024), 1024*1024) // 1MB line buffer
 
 			var success, failed, skipped int
+			var terminalErr error
 			for scanner.Scan() {
 				line := strings.TrimSpace(scanner.Text())
 				if line == "" || line[0] == '#' {
@@ -75,10 +76,14 @@ but do not stop the import.`,
 					continue
 				}
 
-				_, _, err := c.Post(cmd.Context(), path, body)
+				_, status, err := c.Post(cmd.Context(), path, body)
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "warning: failed to import record: %v\n", err)
 					failed++
+					if status == 401 || status == 403 {
+						terminalErr = classifyAPIError(err, flags)
+						break
+					}
+					fmt.Fprintf(os.Stderr, "warning: failed to import record: %v\n", err)
 					continue
 				}
 				success++
@@ -90,13 +95,22 @@ but do not stop the import.`,
 
 			// JSON envelope: {succeeded, failed, skipped}.
 			if flags.asJSON {
-				return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+				if err := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
 					"succeeded": success,
 					"failed":    failed,
 					"skipped":   skipped,
-				}, flags)
+				}, flags); err != nil {
+					return err
+				}
+			} else {
+				fmt.Fprintf(os.Stderr, "Import complete: %d succeeded, %d failed, %d skipped\n", success, failed, skipped)
 			}
-			fmt.Fprintf(os.Stderr, "Import complete: %d succeeded, %d failed, %d skipped\n", success, failed, skipped)
+			if failed > 0 {
+				if terminalErr != nil {
+					return fmt.Errorf("import stopped after auth failure with %d succeeded, %d failed, and %d skipped: %w", success, failed, skipped, terminalErr)
+				}
+				return apiErr(fmt.Errorf("import completed with %d failed record(s), %d succeeded, and %d skipped", failed, success, skipped))
+			}
 			return nil
 		},
 	}

--- a/internal/generator/templates/import.go.tmpl
+++ b/internal/generator/templates/import.go.tmpl
@@ -63,6 +63,10 @@ but do not stop the import.`,
 			var success, failed, skipped int
 			var terminalErr error
 			for scanner.Scan() {
+				if terminalErr != nil {
+					skipped++
+					continue
+				}
 				line := strings.TrimSpace(scanner.Text())
 				if line == "" || line[0] == '#' {
 					skipped++
@@ -81,7 +85,7 @@ but do not stop the import.`,
 					failed++
 					if status == 401 || status == 403 {
 						terminalErr = classifyAPIError(err, flags)
-						break
+						continue
 					}
 					fmt.Fprintf(os.Stderr, "warning: failed to import record: %v\n", err)
 					continue

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -428,6 +428,7 @@ Resource scoping:
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "  %s: warning: %v\n", res.Resource, res.Warn)
 					}
+					totalSynced += res.Count
 					warnCount++
 				} else {
 					if humanFriendly {
@@ -464,6 +465,7 @@ Resource scoping:
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "  %s: warning: %v\n", res.Resource, res.Warn)
 					}
+					totalSynced += res.Count
 					warnCount++
 				} else {
 					if humanFriendly {
@@ -499,7 +501,7 @@ Resource scoping:
 			// The PersistentPreRunE learn hook skips `sync` via
 			// shouldSkipLearnHook, so this explicit post-sync call is the
 			// one wiring point for the staleness-heal loop.
-			if successCount > 0 && !c.DryRun && !noLearnActive(flags) && !cliutil.IsVerifyEnv() && !cliutil.IsDogfoodEnv() {
+			if totalSynced > 0 && !c.DryRun && !noLearnActive(flags) && !cliutil.IsVerifyEnv() && !cliutil.IsDogfoodEnv() {
 				refreshLookupsFromSyncedStore(cmd.Context(), db.DB(), syncEventWriter)
 			}
 {{- end}}
@@ -2891,6 +2893,7 @@ type parentReport struct {
 	stored          int
 	consumed        int
 	extractFailures int
+	failure         error          // non-nil when this parent's batch upsert failed
 	denied          bool
 	firstDenial     *accessWarning
 	anomaly         *parentAnomaly // nil unless this parent hit an extraction anomaly
@@ -3153,8 +3156,11 @@ func syncOneParent(
 		stored, extractFailures, err := upsertResourceBatch(db, dep.Name, items)
 		if err != nil {
 			outcome.reason = "upsert_error"
+			rep.failure = fmt.Errorf("upserting batch for %s parent %s: %w", dep.Name, parentID, err)
 			if humanFriendly {
 				fmt.Fprintf(os.Stderr, "\n  %s: upsert error for parent %s: %v\n", dep.Name, parentID, err)
+			} else {
+				fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, rep.failure))
 			}
 			break
 		}
@@ -3434,6 +3440,8 @@ func syncDependentResource(ctx context.Context, c interface {
 	// workers (first drained wins) — acceptable, both are diagnostic-only and
 	// "first parent" is inherently nondeterministic under concurrency.
 	dryRunHit := false
+	failedParents := 0
+	var firstFailure error
 	for rep := range reports {
 		if rep.dryRun {
 			dryRunHit = true
@@ -3442,6 +3450,12 @@ func syncDependentResource(ctx context.Context, c interface {
 		totalCount += rep.stored
 		depConsumedTotal += rep.consumed
 		depExtractFailureTotal += rep.extractFailures
+		if rep.failure != nil {
+			failedParents++
+			if firstFailure == nil {
+				firstFailure = rep.failure
+			}
+		}
 		if rep.denied {
 			deniedParents++
 			if firstDenial == nil {
@@ -3464,6 +3478,13 @@ func syncDependentResource(ctx context.Context, c interface {
 
 	if humanFriendly {
 		fmt.Fprintf(os.Stderr, "\n")
+	}
+	if failedParents > 0 {
+		failure := fmt.Errorf("%s failed to store data for %d of %d parents: %w", dep.Name, failedParents, len(parentRows), firstFailure)
+		if failedParents == len(parentRows) && totalCount == 0 {
+			return syncResult{Resource: dep.Name, Count: 0, Err: failure, Duration: time.Since(started)}
+		}
+		return syncResult{Resource: dep.Name, Count: totalCount, Warn: failure, Duration: time.Since(started)}
 	}
 
 	_ = db.SaveSyncState(dep.Name, "", totalCount)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/import.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/import.go
@@ -61,6 +61,7 @@ but do not stop the import.`,
 			scanner.Buffer(make([]byte, 1024*1024), 1024*1024) // 1MB line buffer
 
 			var success, failed, skipped int
+			var terminalErr error
 			for scanner.Scan() {
 				line := strings.TrimSpace(scanner.Text())
 				if line == "" || line[0] == '#' {
@@ -75,10 +76,14 @@ but do not stop the import.`,
 					continue
 				}
 
-				_, _, err := c.Post(cmd.Context(), path, body)
+				_, status, err := c.Post(cmd.Context(), path, body)
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "warning: failed to import record: %v\n", err)
 					failed++
+					if status == 401 || status == 403 {
+						terminalErr = classifyAPIError(err, flags)
+						break
+					}
+					fmt.Fprintf(os.Stderr, "warning: failed to import record: %v\n", err)
 					continue
 				}
 				success++
@@ -90,13 +95,22 @@ but do not stop the import.`,
 
 			// JSON envelope: {succeeded, failed, skipped}.
 			if flags.asJSON {
-				return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+				if err := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
 					"succeeded": success,
 					"failed":    failed,
 					"skipped":   skipped,
-				}, flags)
+				}, flags); err != nil {
+					return err
+				}
+			} else {
+				fmt.Fprintf(os.Stderr, "Import complete: %d succeeded, %d failed, %d skipped\n", success, failed, skipped)
 			}
-			fmt.Fprintf(os.Stderr, "Import complete: %d succeeded, %d failed, %d skipped\n", success, failed, skipped)
+			if failed > 0 {
+				if terminalErr != nil {
+					return fmt.Errorf("import stopped after auth failure with %d succeeded, %d failed, and %d skipped: %w", success, failed, skipped, terminalErr)
+				}
+				return apiErr(fmt.Errorf("import completed with %d failed record(s), %d succeeded, and %d skipped", failed, success, skipped))
+			}
 			return nil
 		},
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/import.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/import.go
@@ -63,6 +63,10 @@ but do not stop the import.`,
 			var success, failed, skipped int
 			var terminalErr error
 			for scanner.Scan() {
+				if terminalErr != nil {
+					skipped++
+					continue
+				}
 				line := strings.TrimSpace(scanner.Text())
 				if line == "" || line[0] == '#' {
 					skipped++
@@ -81,7 +85,7 @@ but do not stop the import.`,
 					failed++
 					if status == 401 || status == 403 {
 						terminalErr = classifyAPIError(err, flags)
-						break
+						continue
 					}
 					fmt.Fprintf(os.Stderr, "warning: failed to import record: %v\n", err)
 					continue

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -281,6 +281,7 @@ Resource scoping:
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "  %s: warning: %v\n", res.Resource, res.Warn)
 					}
+					totalSynced += res.Count
 					warnCount++
 				} else {
 					if humanFriendly {
@@ -313,6 +314,7 @@ Resource scoping:
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "  %s: warning: %v\n", res.Resource, res.Warn)
 					}
+					totalSynced += res.Count
 					warnCount++
 				} else {
 					if humanFriendly {
@@ -345,7 +347,7 @@ Resource scoping:
 			// The PersistentPreRunE learn hook skips `sync` via
 			// shouldSkipLearnHook, so this explicit post-sync call is the
 			// one wiring point for the staleness-heal loop.
-			if successCount > 0 && !c.DryRun && !noLearnActive(flags) && !cliutil.IsVerifyEnv() && !cliutil.IsDogfoodEnv() {
+			if totalSynced > 0 && !c.DryRun && !noLearnActive(flags) && !cliutil.IsVerifyEnv() && !cliutil.IsDogfoodEnv() {
 				refreshLookupsFromSyncedStore(cmd.Context(), db.DB(), syncEventWriter)
 			}
 
@@ -1898,6 +1900,7 @@ type parentReport struct {
 	stored          int
 	consumed        int
 	extractFailures int
+	failure         error // non-nil when this parent's batch upsert failed
 	denied          bool
 	firstDenial     *accessWarning
 	anomaly         *parentAnomaly // nil unless this parent hit an extraction anomaly
@@ -2097,8 +2100,11 @@ func syncOneParent(
 		stored, extractFailures, err := upsertResourceBatch(db, dep.Name, items)
 		if err != nil {
 			outcome.reason = "upsert_error"
+			rep.failure = fmt.Errorf("upserting batch for %s parent %s: %w", dep.Name, parentID, err)
 			if humanFriendly {
 				fmt.Fprintf(os.Stderr, "\n  %s: upsert error for parent %s: %v\n", dep.Name, parentID, err)
+			} else {
+				fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, rep.failure))
 			}
 			break
 		}
@@ -2342,6 +2348,8 @@ func syncDependentResource(ctx context.Context, c interface {
 	// workers (first drained wins) — acceptable, both are diagnostic-only and
 	// "first parent" is inherently nondeterministic under concurrency.
 	dryRunHit := false
+	failedParents := 0
+	var firstFailure error
 	for rep := range reports {
 		if rep.dryRun {
 			dryRunHit = true
@@ -2350,6 +2358,12 @@ func syncDependentResource(ctx context.Context, c interface {
 		totalCount += rep.stored
 		depConsumedTotal += rep.consumed
 		depExtractFailureTotal += rep.extractFailures
+		if rep.failure != nil {
+			failedParents++
+			if firstFailure == nil {
+				firstFailure = rep.failure
+			}
+		}
 		if rep.denied {
 			deniedParents++
 			if firstDenial == nil {
@@ -2372,6 +2386,13 @@ func syncDependentResource(ctx context.Context, c interface {
 
 	if humanFriendly {
 		fmt.Fprintf(os.Stderr, "\n")
+	}
+	if failedParents > 0 {
+		failure := fmt.Errorf("%s failed to store data for %d of %d parents: %w", dep.Name, failedParents, len(parentRows), firstFailure)
+		if failedParents == len(parentRows) && totalCount == 0 {
+			return syncResult{Resource: dep.Name, Count: 0, Err: failure, Duration: time.Since(started)}
+		}
+		return syncResult{Resource: dep.Name, Count: totalCount, Warn: failure, Duration: time.Since(started)}
 	}
 
 	_ = db.SaveSyncState(dep.Name, "", totalCount)

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -275,6 +275,7 @@ Resource scoping:
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "  %s: warning: %v\n", res.Resource, res.Warn)
 					}
+					totalSynced += res.Count
 					warnCount++
 				} else {
 					if humanFriendly {
@@ -307,7 +308,7 @@ Resource scoping:
 			// The PersistentPreRunE learn hook skips `sync` via
 			// shouldSkipLearnHook, so this explicit post-sync call is the
 			// one wiring point for the staleness-heal loop.
-			if successCount > 0 && !c.DryRun && !noLearnActive(flags) && !cliutil.IsVerifyEnv() && !cliutil.IsDogfoodEnv() {
+			if totalSynced > 0 && !c.DryRun && !noLearnActive(flags) && !cliutil.IsVerifyEnv() && !cliutil.IsDogfoodEnv() {
 				refreshLookupsFromSyncedStore(cmd.Context(), db.DB(), syncEventWriter)
 			}
 

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -281,6 +281,7 @@ Resource scoping:
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "  %s: warning: %v\n", res.Resource, res.Warn)
 					}
+					totalSynced += res.Count
 					warnCount++
 				} else {
 					if humanFriendly {
@@ -313,6 +314,7 @@ Resource scoping:
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "  %s: warning: %v\n", res.Resource, res.Warn)
 					}
+					totalSynced += res.Count
 					warnCount++
 				} else {
 					if humanFriendly {
@@ -345,7 +347,7 @@ Resource scoping:
 			// The PersistentPreRunE learn hook skips `sync` via
 			// shouldSkipLearnHook, so this explicit post-sync call is the
 			// one wiring point for the staleness-heal loop.
-			if successCount > 0 && !c.DryRun && !noLearnActive(flags) && !cliutil.IsVerifyEnv() && !cliutil.IsDogfoodEnv() {
+			if totalSynced > 0 && !c.DryRun && !noLearnActive(flags) && !cliutil.IsVerifyEnv() && !cliutil.IsDogfoodEnv() {
 				refreshLookupsFromSyncedStore(cmd.Context(), db.DB(), syncEventWriter)
 			}
 
@@ -1869,6 +1871,7 @@ type parentReport struct {
 	stored          int
 	consumed        int
 	extractFailures int
+	failure         error // non-nil when this parent's batch upsert failed
 	denied          bool
 	firstDenial     *accessWarning
 	anomaly         *parentAnomaly // nil unless this parent hit an extraction anomaly
@@ -2068,8 +2071,11 @@ func syncOneParent(
 		stored, extractFailures, err := upsertResourceBatch(db, dep.Name, items)
 		if err != nil {
 			outcome.reason = "upsert_error"
+			rep.failure = fmt.Errorf("upserting batch for %s parent %s: %w", dep.Name, parentID, err)
 			if humanFriendly {
 				fmt.Fprintf(os.Stderr, "\n  %s: upsert error for parent %s: %v\n", dep.Name, parentID, err)
+			} else {
+				fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, rep.failure))
 			}
 			break
 		}
@@ -2313,6 +2319,8 @@ func syncDependentResource(ctx context.Context, c interface {
 	// workers (first drained wins) — acceptable, both are diagnostic-only and
 	// "first parent" is inherently nondeterministic under concurrency.
 	dryRunHit := false
+	failedParents := 0
+	var firstFailure error
 	for rep := range reports {
 		if rep.dryRun {
 			dryRunHit = true
@@ -2321,6 +2329,12 @@ func syncDependentResource(ctx context.Context, c interface {
 		totalCount += rep.stored
 		depConsumedTotal += rep.consumed
 		depExtractFailureTotal += rep.extractFailures
+		if rep.failure != nil {
+			failedParents++
+			if firstFailure == nil {
+				firstFailure = rep.failure
+			}
+		}
 		if rep.denied {
 			deniedParents++
 			if firstDenial == nil {
@@ -2343,6 +2357,13 @@ func syncDependentResource(ctx context.Context, c interface {
 
 	if humanFriendly {
 		fmt.Fprintf(os.Stderr, "\n")
+	}
+	if failedParents > 0 {
+		failure := fmt.Errorf("%s failed to store data for %d of %d parents: %w", dep.Name, failedParents, len(parentRows), firstFailure)
+		if failedParents == len(parentRows) && totalCount == 0 {
+			return syncResult{Resource: dep.Name, Count: 0, Err: failure, Duration: time.Since(started)}
+		}
+		return syncResult{Resource: dep.Name, Count: totalCount, Warn: failure, Duration: time.Since(started)}
 	}
 
 	_ = db.SaveSyncState(dep.Name, "", totalCount)

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -275,6 +275,7 @@ Resource scoping:
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "  %s: warning: %v\n", res.Resource, res.Warn)
 					}
+					totalSynced += res.Count
 					warnCount++
 				} else {
 					if humanFriendly {
@@ -307,7 +308,7 @@ Resource scoping:
 			// The PersistentPreRunE learn hook skips `sync` via
 			// shouldSkipLearnHook, so this explicit post-sync call is the
 			// one wiring point for the staleness-heal loop.
-			if successCount > 0 && !c.DryRun && !noLearnActive(flags) && !cliutil.IsVerifyEnv() && !cliutil.IsDogfoodEnv() {
+			if totalSynced > 0 && !c.DryRun && !noLearnActive(flags) && !cliutil.IsVerifyEnv() && !cliutil.IsDogfoodEnv() {
 				refreshLookupsFromSyncedStore(cmd.Context(), db.DB(), syncEventWriter)
 			}
 


### PR DESCRIPTION
## Summary

Generated REST imports now emit final succeeded, failed, and skipped counts before returning a typed nonzero failure. Authentication failures stop further requests on HTTP 401 or 403 without hiding records committed earlier in the batch.

Dependent syncs now emit structured per-parent persistence errors, return an error when no parent stores data, return a warning for partial storage, count partially stored rows in summaries and lookup refreshes, and preserve the prior freshness checkpoint after any persistence failure.

Closes #3493

## Verification

- `go test ./...` (6,804 tests passed across 44 packages)
- `scripts/golden.sh verify` (32 cases passed)
- `scripts/verify-generator-output.sh` (10 generated modules compiled)
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./internal/generator/...`

Repository-wide lint still reports the pre-existing `modernize` finding in `internal/googlediscovery/parser.go`, which this branch does not modify.
