### PR TITLE
fix(cli): continue cursor sync across short pages

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -13657,7 +13657,7 @@ func TestGeneratedSyncAdvancesOffsetWhenHasMoreWithoutCursor(t *testing.T) {
 
 	assert.NotContains(t, syncContent, `if !hasMore || len(items) < pageSize.limit || nextCursor == ""`,
 		"sync loops must not require an API-returned next cursor for offset pagination")
-	assert.Contains(t, syncContent, `if !hasMore || fetchedThisPage < pageSize.limit {`,
+	assert.Contains(t, syncContent, `if !hasMore || shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit) {`,
 		"sync loops must break only on real done signals before handling cursor advancement")
 	assert.Contains(t, syncContent, `if pageSize.cursorType == "offset" {`,
 		"offset pagination must advance the cursor client-side when has_more is true")

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -51,6 +52,253 @@ func TestPaginatedGetEmitsTruncationWarning(t *testing.T) {
 		"paginatedGet should call emitTruncationWarning on the single-page path")
 
 	runGoCommand(t, outputDir, "build", "./internal/cli")
+}
+
+func TestGeneratedSyncShortPageTerminationRespectsPaginationType(t *testing.T) {
+	t.Parallel()
+
+	templateSrc, err := os.ReadFile(filepath.Join("templates", "sync.go.tmpl"))
+	require.NoError(t, err)
+	require.Equal(t, 11, strings.Count(string(templateSrc), "shortPageEndsPagination("),
+		"the helper definition and every termination and cap-classification variant must stay cursor-aware")
+	require.Equal(t, 3, strings.Count(string(templateSrc), "cursorPageHasContinuation("),
+		"the helper definition and both flat and dependent empty-page branches must preserve cursor continuation")
+
+	apiSpec := minimalSpec("sync-short-page")
+	apiSpec.Resources = map[string]spec.Resource{
+		"orders": {
+			Description: "Manage orders",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/orders",
+					Description: "List orders",
+					Pagination: &spec.Pagination{
+						Type:           "cursor",
+						CursorParam:    "after",
+						NextCursorPath: "next_cursor",
+						HasMoreField:   "has_more",
+					},
+					Response: spec.ResponseDef{Type: "array", Item: "Order"},
+				},
+			},
+		},
+		"tokens": {
+			Description: "Manage tokens",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/tokens",
+					Description: "List tokens",
+					Pagination: &spec.Pagination{
+						Type:           "page_token",
+						CursorParam:    "page_token",
+						NextCursorPath: "next_cursor",
+						HasMoreField:   "has_more",
+					},
+					Response: spec.ResponseDef{Type: "array", Item: "Token"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "sync-short-page-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	goMod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
+	require.NoError(t, err)
+	modulePath := strings.TrimPrefix(strings.SplitN(string(goMod), "\n", 2)[0], "module ")
+
+	behaviorTest := fmt.Sprintf(`package cli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"testing"
+
+	%q
+)
+
+type shortPageSyncClient struct {
+	responses []json.RawMessage
+	params    []map[string]string
+}
+
+func (c *shortPageSyncClient) Get(_ context.Context, _ string, params map[string]string) (json.RawMessage, error) {
+	copied := make(map[string]string, len(params))
+	for key, value := range params {
+		copied[key] = value
+	}
+	c.params = append(c.params, copied)
+	response := c.responses[0]
+	c.responses = c.responses[1:]
+	return response, nil
+}
+
+func (c *shortPageSyncClient) RateLimit() float64 { return 0 }
+
+func TestShortPageEndsPagination(t *testing.T) {
+	tests := []struct {
+		name       string
+		cursorType string
+		fetched    int
+		limit      int
+		want       bool
+	}{
+		{name: "cursor short page continues", cursorType: "cursor", fetched: 50, limit: 100, want: false},
+		{name: "page token short page continues", cursorType: "page_token", fetched: 50, limit: 100, want: false},
+		{name: "offset short page ends", cursorType: "offset", fetched: 50, limit: 100, want: true},
+		{name: "page short page ends", cursorType: "page", fetched: 50, limit: 100, want: true},
+		{name: "full cursor page continues", cursorType: "cursor", fetched: 100, limit: 100, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shortPageEndsPagination(tt.cursorType, tt.fetched, tt.limit); got != tt.want {
+				t.Fatalf("shortPageEndsPagination(%%q, %%d, %%d) = %%v, want %%v", tt.cursorType, tt.fetched, tt.limit, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCursorPageHasContinuation(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		cursorType string
+		hasMore    bool
+		nextCursor string
+		want       bool
+	}{
+		{name: "cursor continues", cursorType: "cursor", hasMore: true, nextCursor: "page-2", want: true},
+		{name: "page token continues", cursorType: "page_token", hasMore: true, nextCursor: "page-2", want: true},
+		{name: "missing cursor stops", cursorType: "cursor", hasMore: true, want: false},
+		{name: "has more false stops", cursorType: "cursor", nextCursor: "page-2", want: false},
+		{name: "offset empty page stops", cursorType: "offset", hasMore: true, nextCursor: "2", want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cursorPageHasContinuation(tt.cursorType, tt.hasMore, tt.nextCursor); got != tt.want {
+				t.Fatalf("cursorPageHasContinuation(%%q, %%v, %%q) = %%v, want %%v", tt.cursorType, tt.hasMore, tt.nextCursor, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSyncResourceFollowsShortCursorPages(t *testing.T) {
+	for _, tc := range []struct {
+		resource    string
+		cursorParam string
+	}{
+		{resource: "orders", cursorParam: "after"},
+		{resource: "tokens", cursorParam: "page_token"},
+	} {
+		t.Run(tc.resource, func(t *testing.T) {
+			db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+			if err != nil {
+				t.Fatalf("open store: %%v", err)
+			}
+			defer db.Close()
+
+			client := &shortPageSyncClient{responses: []json.RawMessage{
+				json.RawMessage("{\"items\":[{\"id\":\"one\"}],\"next_cursor\":\"page-2\",\"has_more\":true}"),
+				json.RawMessage("{\"items\":[{\"id\":\"two\"}],\"next_cursor\":\"\",\"has_more\":false}"),
+			}}
+			result := syncResource(context.Background(), client, db, tc.resource, "", true, 0, false, false, &syncUserParams{}, io.Discard)
+			if result.Err != nil || result.Warn != nil {
+				t.Fatalf("sync result error=%%v warning=%%v", result.Err, result.Warn)
+			}
+			if result.Count != 2 || len(client.params) != 2 {
+				t.Fatalf("sync count/calls = %%d/%%d, want 2/2", result.Count, len(client.params))
+			}
+			if got := client.params[1][tc.cursorParam]; got != "page-2" {
+				t.Fatalf("second request %%s = %%q, want page-2", tc.cursorParam, got)
+			}
+		})
+	}
+}
+
+func TestSyncResourceFollowsEmptyCursorPage(t *testing.T) {
+	for _, tc := range []struct {
+		resource    string
+		cursorParam string
+	}{
+		{resource: "orders", cursorParam: "after"},
+		{resource: "tokens", cursorParam: "page_token"},
+	} {
+		t.Run(tc.resource, func(t *testing.T) {
+			db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+			if err != nil {
+				t.Fatalf("open store: %%v", err)
+			}
+			defer db.Close()
+
+			client := &shortPageSyncClient{responses: []json.RawMessage{
+				json.RawMessage("{\"items\":[],\"next_cursor\":\"page-2\",\"has_more\":true}"),
+				json.RawMessage("{\"items\":[{\"id\":\"two\"}],\"next_cursor\":\"\",\"has_more\":false}"),
+			}}
+			result := syncResource(context.Background(), client, db, tc.resource, "", true, 0, false, false, &syncUserParams{}, io.Discard)
+			if result.Err != nil || result.Warn != nil {
+				t.Fatalf("sync result error=%%v warning=%%v", result.Err, result.Warn)
+			}
+			if result.Count != 1 || len(client.params) != 2 {
+				t.Fatalf("sync count/calls = %%d/%%d, want 1/2", result.Count, len(client.params))
+			}
+			if got := client.params[1][tc.cursorParam]; got != "page-2" {
+				t.Fatalf("second request %%s = %%q, want page-2", tc.cursorParam, got)
+			}
+		})
+	}
+}
+
+func TestSyncResourcePreservesCursorWhenCapHitsShortPage(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %%v", err)
+	}
+	defer db.Close()
+
+	client := &shortPageSyncClient{responses: []json.RawMessage{
+		json.RawMessage("{\"items\":[],\"next_cursor\":\"page-2\",\"has_more\":true}"),
+	}}
+	result := syncResource(context.Background(), client, db, "orders", "", true, 1, false, false, &syncUserParams{}, io.Discard)
+	if result.Err != nil || result.Warn != nil {
+		t.Fatalf("sync result error=%%v warning=%%v", result.Err, result.Warn)
+	}
+	cursor, _, _, err := db.GetSyncState("orders")
+	if err != nil {
+		t.Fatalf("get sync state: %%v", err)
+	}
+	if cursor != "page-2" {
+		t.Fatalf("saved cursor = %%q, want page-2", cursor)
+	}
+}
+
+func TestSyncResourceDoesNotAdvancePastNullItems(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %%v", err)
+	}
+	defer db.Close()
+
+	client := &shortPageSyncClient{responses: []json.RawMessage{
+		json.RawMessage("{\"items\":null,\"next_cursor\":\"page-2\",\"has_more\":true}"),
+	}}
+	_ = syncResource(context.Background(), client, db, "orders", "", true, 0, false, false, &syncUserParams{}, io.Discard)
+	if len(client.params) != 1 {
+		t.Fatalf("sync calls = %%d, want 1", len(client.params))
+	}
+	cursor, _, _, err := db.GetSyncState("orders")
+	if err != nil {
+		t.Fatalf("get sync state: %%v", err)
+	}
+	if cursor != "" {
+		t.Fatalf("saved cursor = %%q, want empty", cursor)
+	}
+}
+`, modulePath+"/internal/store")
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "sync_short_page_test.go"), []byte(behaviorTest), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "TestShortPageEndsPagination|TestCursorPageHasContinuation|TestSyncResource")
+	requireGeneratedCompiles(t, outputDir)
 }
 
 func TestPaginatedGetHandlesNumericCursorAndMissingAllSignal(t *testing.T) {

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -184,6 +184,17 @@ func TestCursorPageHasContinuation(t *testing.T) {
 	}
 }
 
+func TestExtractItemsByKnownKeysFallsThroughEmptyPreferredKey(t *testing.T) {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal([]byte("{\"items\":[],\"records\":[{\"id\":\"one\"}]}"), &envelope); err != nil {
+		t.Fatalf("unmarshal envelope: %%v", err)
+	}
+	items, ok := extractItemsByKnownKeys(envelope)
+	if !ok || len(items) != 1 {
+		t.Fatalf("extractItemsByKnownKeys() = %%d items, ok=%%v; want 1 item, ok=true", len(items), ok)
+	}
+}
+
 func TestSyncResourceFollowsShortCursorPages(t *testing.T) {
 	for _, tc := range []struct {
 		resource    string
@@ -250,6 +261,25 @@ func TestSyncResourceFollowsEmptyCursorPage(t *testing.T) {
 	}
 }
 
+func TestSyncResourceUsesPopulatedFallbackAfterEmptyItems(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %%v", err)
+	}
+	defer db.Close()
+
+	client := &shortPageSyncClient{responses: []json.RawMessage{
+		json.RawMessage("{\"items\":[],\"records\":[{\"id\":\"one\"}],\"next_cursor\":\"\",\"has_more\":false}"),
+	}}
+	result := syncResource(context.Background(), client, db, "orders", "", true, 0, false, false, &syncUserParams{}, io.Discard)
+	if result.Err != nil || result.Warn != nil {
+		t.Fatalf("sync result error=%%v warning=%%v", result.Err, result.Warn)
+	}
+	if result.Count != 1 {
+		t.Fatalf("sync count = %%d, want 1", result.Count)
+	}
+}
+
 func TestSyncResourcePreservesCursorWhenCapHitsShortPage(t *testing.T) {
 	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
 	if err != nil {
@@ -297,7 +327,7 @@ func TestSyncResourceDoesNotAdvancePastNullItems(t *testing.T) {
 }
 `, modulePath+"/internal/store")
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "sync_short_page_test.go"), []byte(behaviorTest), 0o644))
-	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "TestShortPageEndsPagination|TestCursorPageHasContinuation|TestSyncResource")
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "TestShortPageEndsPagination|TestCursorPageHasContinuation|TestExtractItemsByKnownKeys|TestSyncResource")
 	requireGeneratedCompiles(t, outputDir)
 }
 

--- a/internal/generator/read_search_extraction_test.go
+++ b/internal/generator/read_search_extraction_test.go
@@ -180,7 +180,7 @@ func TestGeneratedSyncHydratesScalarIDListItems(t *testing.T) {
 	require.Contains(t, syncSrc, `"updates": {path: "/item/{id}.json", idParam: "id"}`)
 	require.Contains(t, syncSrc, `fetchedThisPage := len(items)`)
 	require.Contains(t, syncSrc, `consumedTotal += fetchedThisPage`)
-	require.Contains(t, syncSrc, `truncatedByCap = truncatedByCap && fetchedThisPage >= pageSize.limit`)
+	require.Contains(t, syncSrc, `truncatedByCap = truncatedByCap && !shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit)`)
 
 	testPath := filepath.Join(outputDir, "internal", "cli", "sync_hydration_test.go")
 	require.NoError(t, os.WriteFile(testPath, []byte(`package cli

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1697,6 +1697,8 @@ func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMe
 }
 
 func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	var emptyItems []json.RawMessage
+	foundEmpty := false
 	for _, key := range pageItemKeys {
 		if raw, ok := envelope[key]; ok {
 			extract := extractObjectArray
@@ -1704,9 +1706,16 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 				extract = extractJSONItemsArray
 			}
 			if items, ok := extract(raw); ok {
-				return items, true
+				if len(items) > 0 {
+					return items, true
+				}
+				emptyItems = items
+				foundEmpty = true
 			}
 		}
+	}
+	if foundEmpty {
+		return emptyItems, true
 	}
 	return nil, false
 }

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -895,7 +895,7 @@ func syncResource(ctx context.Context, c interface {
 		break
 	}
 
-	if len(items) == 0 {
+	if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
 		if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 			// Natural end: the API legitimately returned an empty page.
 			outcome.complete = true
@@ -1028,19 +1028,19 @@ func syncResource(ctx context.Context, c interface {
 			truncatedByCap = hasMore && fetchedThisPage >= queryPageSize
 {{- if $hasIDWalk}}
 			} else {
-				truncatedByCap = truncatedByCap && fetchedThisPage >= activePageLimit
+				truncatedByCap = truncatedByCap && !shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, activePageLimit)
 			}
 {{- else}}
 			} else {
-				truncatedByCap = truncatedByCap && fetchedThisPage >= pageSize.limit
+				truncatedByCap = truncatedByCap && !shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit)
 			}
 {{- end}}
 {{- else}}
 			truncatedByCap := resourceSupportsPagination(resource) && hasMore
 {{- if $hasIDWalk}}
-			truncatedByCap = truncatedByCap && fetchedThisPage >= activePageLimit
+			truncatedByCap = truncatedByCap && !shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, activePageLimit)
 {{- else}}
-				truncatedByCap = truncatedByCap && fetchedThisPage >= pageSize.limit
+			truncatedByCap = truncatedByCap && !shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit)
 {{- end}}
 {{- end}}
 			if truncatedByCap {
@@ -1106,9 +1106,9 @@ func syncResource(ctx context.Context, c interface {
 			break
 	}
 {{- if $hasIDWalk}}
-		if path != queryPath && fetchedThisPage < activePageLimit {
+		if path != queryPath && shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, activePageLimit) {
 {{- else}}
-		if path != queryPath && fetchedThisPage < pageSize.limit {
+		if path != queryPath && shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit) {
 {{- end}}
 			outcome.complete = true
 			break
@@ -1119,9 +1119,9 @@ func syncResource(ctx context.Context, c interface {
 			break
 		}
 {{- if $hasIDWalk}}
-		if !hasMore || fetchedThisPage < activePageLimit {
+		if !hasMore || shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, activePageLimit) {
 {{- else}}
-		if !hasMore || fetchedThisPage < pageSize.limit {
+		if !hasMore || shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit) {
 {{- end}}
 			outcome.complete = true
 				break
@@ -1227,6 +1227,14 @@ type paginationDefaults struct {
 	cursorType  string // paginator class: "", "cursor", "page_token", "offset", "page"
 	limitParam  string
 	limit       int
+}
+
+func shortPageEndsPagination(cursorType string, fetched, limit int) bool {
+	return cursorType != "cursor" && cursorType != "page_token" && fetched < limit
+}
+
+func cursorPageHasContinuation(cursorType string, hasMore bool, nextCursor string) bool {
+	return (cursorType == "cursor" || cursorType == "page_token") && hasMore && nextCursor != ""
 }
 
 // determinePaginationDefaults returns the pagination parameter names to use.
@@ -1732,7 +1740,7 @@ func extractSingleObjectArraySibling(envelope map[string]json.RawMessage) ([]jso
 
 func extractJSONItemsArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	var items []json.RawMessage
-	if err := json.Unmarshal(raw, &items); err != nil || len(items) == 0 {
+	if err := json.Unmarshal(raw, &items); err != nil || isJSONNull(raw) {
 		return nil, false
 	}
 	return items, true
@@ -1740,7 +1748,7 @@ func extractJSONItemsArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 
 func extractObjectArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	items, ok := extractJSONItemsArray(raw)
-	if !ok {
+	if !ok || len(items) == 0 {
 		return nil, false
 	}
 	var obj map[string]json.RawMessage
@@ -3118,7 +3126,7 @@ func syncOneParent(
 			break
 		}
 
-		if len(items) == 0 {
+		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
 			if isEmptyPageResponse(data, responsePathForResource(dep.Name, path)...) {
 				outcome.complete = true // parent legitimately has zero children
 			} else {
@@ -3222,10 +3230,10 @@ func syncOneParent(
 			break
 		}
 {{- if $hasIDWalk}}
-		if !hasMore || len(items) < activePageLimit {
+		if !hasMore || shortPageEndsPagination(pageSize.cursorType, len(items), activePageLimit) {
 			outcome.complete = true
 {{- else}}
-		if !hasMore || len(items) < pageSize.limit {
+		if !hasMore || shortPageEndsPagination(pageSize.cursorType, len(items), pageSize.limit) {
 			outcome.complete = true
 {{- end}}
 			break

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -611,7 +611,7 @@ func syncResource(ctx context.Context, c interface {
 			break
 		}
 
-		if len(items) == 0 {
+		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
 			if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 				// Natural end: the API legitimately returned an empty page.
 				outcome.complete = true
@@ -730,7 +730,7 @@ func syncResource(ctx context.Context, c interface {
 		// sync_error output in the same stream.
 		if maxPages > 0 && pagesFetched >= maxPages {
 			truncatedByCap := resourceSupportsPagination(resource) && hasMore
-			truncatedByCap = truncatedByCap && fetchedThisPage >= pageSize.limit
+			truncatedByCap = truncatedByCap && !shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit)
 			if truncatedByCap {
 				capExitCursor = nextCursor
 			}
@@ -783,7 +783,7 @@ func syncResource(ctx context.Context, c interface {
 			outcome.complete = true // resource declares no pagination: one page is the whole set
 			break
 		}
-		if !hasMore || fetchedThisPage < pageSize.limit {
+		if !hasMore || shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit) {
 			outcome.complete = true
 			break
 		}
@@ -887,6 +887,14 @@ type paginationDefaults struct {
 	cursorType  string // paginator class: "", "cursor", "page_token", "offset", "page"
 	limitParam  string
 	limit       int
+}
+
+func shortPageEndsPagination(cursorType string, fetched, limit int) bool {
+	return cursorType != "cursor" && cursorType != "page_token" && fetched < limit
+}
+
+func cursorPageHasContinuation(cursorType string, hasMore bool, nextCursor string) bool {
+	return (cursorType == "cursor" || cursorType == "page_token") && hasMore && nextCursor != ""
 }
 
 // determinePaginationDefaults returns the pagination parameter names to use.
@@ -1108,7 +1116,7 @@ func extractSingleObjectArraySibling(envelope map[string]json.RawMessage) ([]jso
 
 func extractJSONItemsArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	var items []json.RawMessage
-	if err := json.Unmarshal(raw, &items); err != nil || len(items) == 0 {
+	if err := json.Unmarshal(raw, &items); err != nil || isJSONNull(raw) {
 		return nil, false
 	}
 	return items, true
@@ -1116,7 +1124,7 @@ func extractJSONItemsArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 
 func extractObjectArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	items, ok := extractJSONItemsArray(raw)
-	if !ok {
+	if !ok || len(items) == 0 {
 		return nil, false
 	}
 	var obj map[string]json.RawMessage
@@ -2062,7 +2070,7 @@ func syncOneParent(
 			break
 		}
 
-		if len(items) == 0 {
+		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
 			if isEmptyPageResponse(data, responsePathForResource(dep.Name, path)...) {
 				outcome.complete = true // parent legitimately has zero children
 			} else {
@@ -2159,7 +2167,7 @@ func syncOneParent(
 			outcome.complete = true
 			break
 		}
-		if !hasMore || len(items) < pageSize.limit {
+		if !hasMore || shortPageEndsPagination(pageSize.cursorType, len(items), pageSize.limit) {
 			outcome.complete = true
 			break
 		}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -1073,6 +1073,8 @@ func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMe
 }
 
 func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	var emptyItems []json.RawMessage
+	foundEmpty := false
 	for _, key := range pageItemKeys {
 		if raw, ok := envelope[key]; ok {
 			extract := extractObjectArray
@@ -1080,9 +1082,16 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 				extract = extractJSONItemsArray
 			}
 			if items, ok := extract(raw); ok {
-				return items, true
+				if len(items) > 0 {
+					return items, true
+				}
+				emptyItems = items
+				foundEmpty = true
 			}
 		}
+	}
+	if foundEmpty {
+		return emptyItems, true
 	}
 	return nil, false
 }

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -1076,6 +1076,8 @@ func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMe
 }
 
 func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	var emptyItems []json.RawMessage
+	foundEmpty := false
 	for _, key := range pageItemKeys {
 		if raw, ok := envelope[key]; ok {
 			extract := extractObjectArray
@@ -1083,9 +1085,16 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 				extract = extractJSONItemsArray
 			}
 			if items, ok := extract(raw); ok {
-				return items, true
+				if len(items) > 0 {
+					return items, true
+				}
+				emptyItems = items
+				foundEmpty = true
 			}
 		}
+	}
+	if foundEmpty {
+		return emptyItems, true
 	}
 	return nil, false
 }

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -616,7 +616,7 @@ func syncResource(ctx context.Context, c interface {
 			break
 		}
 
-		if len(items) == 0 {
+		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
 			if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 				// Natural end: the API legitimately returned an empty page.
 				outcome.complete = true
@@ -741,7 +741,7 @@ func syncResource(ctx context.Context, c interface {
 				// so the cap truncated and the STARTPOSITION resume cursor must persist.
 				truncatedByCap = hasMore && fetchedThisPage >= queryPageSize
 			} else {
-				truncatedByCap = truncatedByCap && fetchedThisPage >= pageSize.limit
+				truncatedByCap = truncatedByCap && !shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit)
 			}
 			if truncatedByCap {
 				capExitCursor = nextCursor
@@ -804,7 +804,7 @@ func syncResource(ctx context.Context, c interface {
 			outcome.complete = true
 			break
 		}
-		if path != queryPath && fetchedThisPage < pageSize.limit {
+		if path != queryPath && shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit) {
 			outcome.complete = true
 			break
 		}
@@ -908,6 +908,14 @@ type paginationDefaults struct {
 	cursorType  string // paginator class: "", "cursor", "page_token", "offset", "page"
 	limitParam  string
 	limit       int
+}
+
+func shortPageEndsPagination(cursorType string, fetched, limit int) bool {
+	return cursorType != "cursor" && cursorType != "page_token" && fetched < limit
+}
+
+func cursorPageHasContinuation(cursorType string, hasMore bool, nextCursor string) bool {
+	return (cursorType == "cursor" || cursorType == "page_token") && hasMore && nextCursor != ""
 }
 
 // determinePaginationDefaults returns the pagination parameter names to use.
@@ -1111,7 +1119,7 @@ func extractSingleObjectArraySibling(envelope map[string]json.RawMessage) ([]jso
 
 func extractJSONItemsArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	var items []json.RawMessage
-	if err := json.Unmarshal(raw, &items); err != nil || len(items) == 0 {
+	if err := json.Unmarshal(raw, &items); err != nil || isJSONNull(raw) {
 		return nil, false
 	}
 	return items, true
@@ -1119,7 +1127,7 @@ func extractJSONItemsArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 
 func extractObjectArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	items, ok := extractJSONItemsArray(raw)
-	if !ok {
+	if !ok || len(items) == 0 {
 		return nil, false
 	}
 	var obj map[string]json.RawMessage

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -611,7 +611,7 @@ func syncResource(ctx context.Context, c interface {
 			break
 		}
 
-		if len(items) == 0 {
+		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
 			if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 				// Natural end: the API legitimately returned an empty page.
 				outcome.complete = true
@@ -730,7 +730,7 @@ func syncResource(ctx context.Context, c interface {
 		// sync_error output in the same stream.
 		if maxPages > 0 && pagesFetched >= maxPages {
 			truncatedByCap := resourceSupportsPagination(resource) && hasMore
-			truncatedByCap = truncatedByCap && fetchedThisPage >= pageSize.limit
+			truncatedByCap = truncatedByCap && !shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit)
 			if truncatedByCap {
 				capExitCursor = nextCursor
 			}
@@ -783,7 +783,7 @@ func syncResource(ctx context.Context, c interface {
 			outcome.complete = true // resource declares no pagination: one page is the whole set
 			break
 		}
-		if !hasMore || fetchedThisPage < pageSize.limit {
+		if !hasMore || shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit) {
 			outcome.complete = true
 			break
 		}
@@ -887,6 +887,14 @@ type paginationDefaults struct {
 	cursorType  string // paginator class: "", "cursor", "page_token", "offset", "page"
 	limitParam  string
 	limit       int
+}
+
+func shortPageEndsPagination(cursorType string, fetched, limit int) bool {
+	return cursorType != "cursor" && cursorType != "page_token" && fetched < limit
+}
+
+func cursorPageHasContinuation(cursorType string, hasMore bool, nextCursor string) bool {
+	return (cursorType == "cursor" || cursorType == "page_token") && hasMore && nextCursor != ""
 }
 
 // determinePaginationDefaults returns the pagination parameter names to use.
@@ -1090,7 +1098,7 @@ func extractSingleObjectArraySibling(envelope map[string]json.RawMessage) ([]jso
 
 func extractJSONItemsArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	var items []json.RawMessage
-	if err := json.Unmarshal(raw, &items); err != nil || len(items) == 0 {
+	if err := json.Unmarshal(raw, &items); err != nil || isJSONNull(raw) {
 		return nil, false
 	}
 	return items, true
@@ -1098,7 +1106,7 @@ func extractJSONItemsArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 
 func extractObjectArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	items, ok := extractJSONItemsArray(raw)
-	if !ok {
+	if !ok || len(items) == 0 {
 		return nil, false
 	}
 	var obj map[string]json.RawMessage
@@ -2033,7 +2041,7 @@ func syncOneParent(
 			break
 		}
 
-		if len(items) == 0 {
+		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
 			if isEmptyPageResponse(data, responsePathForResource(dep.Name, path)...) {
 				outcome.complete = true // parent legitimately has zero children
 			} else {
@@ -2130,7 +2138,7 @@ func syncOneParent(
 			outcome.complete = true
 			break
 		}
-		if !hasMore || len(items) < pageSize.limit {
+		if !hasMore || shortPageEndsPagination(pageSize.cursorType, len(items), pageSize.limit) {
 			outcome.complete = true
 			break
 		}

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -1055,6 +1055,8 @@ func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMe
 }
 
 func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	var emptyItems []json.RawMessage
+	foundEmpty := false
 	for _, key := range pageItemKeys {
 		if raw, ok := envelope[key]; ok {
 			extract := extractObjectArray
@@ -1062,9 +1064,16 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 				extract = extractJSONItemsArray
 			}
 			if items, ok := extract(raw); ok {
-				return items, true
+				if len(items) > 0 {
+					return items, true
+				}
+				emptyItems = items
+				foundEmpty = true
 			}
 		}
+	}
+	if foundEmpty {
+		return emptyItems, true
 	}
 	return nil, false
 }

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -573,7 +573,7 @@ func syncResource(ctx context.Context, c interface {
 			break
 		}
 
-		if len(items) == 0 {
+		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
 			if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 				// Natural end: the API legitimately returned an empty page.
 				outcome.complete = true
@@ -692,7 +692,7 @@ func syncResource(ctx context.Context, c interface {
 		// sync_error output in the same stream.
 		if maxPages > 0 && pagesFetched >= maxPages {
 			truncatedByCap := resourceSupportsPagination(resource) && hasMore
-			truncatedByCap = truncatedByCap && fetchedThisPage >= pageSize.limit
+			truncatedByCap = truncatedByCap && !shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit)
 			if truncatedByCap {
 				capExitCursor = nextCursor
 			}
@@ -745,7 +745,7 @@ func syncResource(ctx context.Context, c interface {
 			outcome.complete = true // resource declares no pagination: one page is the whole set
 			break
 		}
-		if !hasMore || fetchedThisPage < pageSize.limit {
+		if !hasMore || shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit) {
 			outcome.complete = true
 			break
 		}
@@ -849,6 +849,14 @@ type paginationDefaults struct {
 	cursorType  string // paginator class: "", "cursor", "page_token", "offset", "page"
 	limitParam  string
 	limit       int
+}
+
+func shortPageEndsPagination(cursorType string, fetched, limit int) bool {
+	return cursorType != "cursor" && cursorType != "page_token" && fetched < limit
+}
+
+func cursorPageHasContinuation(cursorType string, hasMore bool, nextCursor string) bool {
+	return (cursorType == "cursor" || cursorType == "page_token") && hasMore && nextCursor != ""
 }
 
 // determinePaginationDefaults returns the pagination parameter names to use.
@@ -1061,7 +1069,7 @@ func extractSingleObjectArraySibling(envelope map[string]json.RawMessage) ([]jso
 
 func extractJSONItemsArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	var items []json.RawMessage
-	if err := json.Unmarshal(raw, &items); err != nil || len(items) == 0 {
+	if err := json.Unmarshal(raw, &items); err != nil || isJSONNull(raw) {
 		return nil, false
 	}
 	return items, true
@@ -1069,7 +1077,7 @@ func extractJSONItemsArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 
 func extractObjectArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	items, ok := extractJSONItemsArray(raw)
-	if !ok {
+	if !ok || len(items) == 0 {
 		return nil, false
 	}
 	var obj map[string]json.RawMessage

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -1026,6 +1026,8 @@ func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMe
 }
 
 func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	var emptyItems []json.RawMessage
+	foundEmpty := false
 	for _, key := range pageItemKeys {
 		if raw, ok := envelope[key]; ok {
 			extract := extractObjectArray
@@ -1033,9 +1035,16 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 				extract = extractJSONItemsArray
 			}
 			if items, ok := extract(raw); ok {
-				return items, true
+				if len(items) > 0 {
+					return items, true
+				}
+				emptyItems = items
+				foundEmpty = true
 			}
 		}
+	}
+	if foundEmpty {
+		return emptyItems, true
 	}
 	return nil, false
 }


### PR DESCRIPTION
Cursor and page-token syncs now follow server continuation signals even when a page is shorter than requested or legitimately empty, instead of treating page length as completion. When a page cap stops such a walk, the next cursor is persisted so a later sync resumes without skipping work. Offset and page-number pagination keep their existing short-page termination behavior. Generated runtime coverage verifies short, empty, null-item, and cap-resume cases, and the full repository and generated-output suites pass.

Closes #3557

Not included: #3393 requires a separate store-schema namespace policy and round-trip validation surface.
