### PR TITLE
fix(cli): allow credential-free OAuth login probes

### DIFF
--- a/internal/generator/auth_oauth_login_test.go
+++ b/internal/generator/auth_oauth_login_test.go
@@ -70,6 +70,15 @@ func TestOAuthLoginTopLevelCommandAndCredentialFallback(t *testing.T) {
 	require.NoError(t, err, "top-level login --dry-run should not require credentials: %s", string(dryRunOut))
 	require.JSONEq(t, `{"status":"dry_run","action":"auth login","would":"start OAuth2 authorization-code flow (PKCE without client secret), open browser, capture loopback callback"}`, string(dryRunOut))
 
+	require.NoError(t, os.WriteFile(configPath, []byte("client_id = \"saved-id\"\n"), 0o600))
+	configuredProbe := exec.Command(binPath, "--config", configPath, "--no-input", "--dry-run", "login")
+	configuredProbe.Env = append(os.Environ(), "PRINTING_PRESS_VERIFY=1")
+	configuredProbeOut, err := configuredProbe.CombinedOutput()
+	require.NoError(t, err, "configured OAuth login probe failed: %s", string(configuredProbeOut))
+	require.Contains(t, string(configuredProbeOut), "would launch: https://accounts.example.com/oauth/authorize?")
+	require.Contains(t, string(configuredProbeOut), "client_id=saved-id")
+	require.Contains(t, string(configuredProbeOut), "code_challenge_method=S256")
+
 	const runtimeTest = `package cli
 
 import (

--- a/internal/generator/auth_oauth_login_test.go
+++ b/internal/generator/auth_oauth_login_test.go
@@ -66,6 +66,10 @@ func TestOAuthLoginTopLevelCommandAndCredentialFallback(t *testing.T) {
 	require.Error(t, err, "top-level login --no-input should fail when no credentials are available")
 	require.Contains(t, string(noInputOut), "OAUTH_LOGIN_PROMPTS_CLIENT_ID")
 
+	dryRunOut, err := exec.Command(binPath, "--config", configPath, "--no-input", "--dry-run", "login").CombinedOutput()
+	require.NoError(t, err, "top-level login --dry-run should not require credentials: %s", string(dryRunOut))
+	require.JSONEq(t, `{"status":"dry_run","action":"auth login","would":"start OAuth2 authorization-code flow (PKCE without client secret), open browser, capture loopback callback"}`, string(dryRunOut))
+
 	const runtimeTest = `package cli
 
 import (

--- a/internal/generator/templates/auth.go.tmpl
+++ b/internal/generator/templates/auth.go.tmpl
@@ -140,6 +140,12 @@ func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 
 func runOAuthLogin(cmd *cobra.Command, flags *rootFlags, clientID, clientSecret string, port int) error {
 	w := cmd.OutOrStdout()
+	// Credential-free probes cannot construct an authorize URL. Keep supplied
+	// client IDs on the detailed verify path below so it still emits PKCE params.
+	if (dryRunOK(flags) || cliutil.IsVerifyEnv()) && clientID == "" {
+		fmt.Fprintln(w, `{"status":"dry_run","action":"auth login","would":"start OAuth2 authorization-code flow (PKCE without client secret), open browser, capture loopback callback"}`)
+		return nil
+	}
 	cfg, err := config.Load(flags.configPath)
 	if err != nil {
 		return err

--- a/internal/generator/templates/auth.go.tmpl
+++ b/internal/generator/templates/auth.go.tmpl
@@ -140,15 +140,16 @@ func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 
 func runOAuthLogin(cmd *cobra.Command, flags *rootFlags, clientID, clientSecret string, port int) error {
 	w := cmd.OutOrStdout()
-	// Credential-free probes cannot construct an authorize URL. Keep supplied
-	// client IDs on the detailed verify path below so it still emits PKCE params.
-	if (dryRunOK(flags) || cliutil.IsVerifyEnv()) && clientID == "" {
-		fmt.Fprintln(w, `{"status":"dry_run","action":"auth login","would":"start OAuth2 authorization-code flow (PKCE without client secret), open browser, capture loopback callback"}`)
-		return nil
-	}
 	cfg, err := config.Load(flags.configPath)
 	if err != nil {
 		return err
+	}
+	// Credential-free probes cannot construct an authorize URL. Keep supplied
+	// or configured client IDs on the detailed verify path below so it still
+	// emits PKCE params.
+	if (dryRunOK(flags) || cliutil.IsVerifyEnv()) && clientID == "" && cfg.ClientID == "" {
+		fmt.Fprintln(w, `{"status":"dry_run","action":"auth login","would":"start OAuth2 authorization-code flow (PKCE without client secret), open browser, capture loopback callback"}`)
+		return nil
 	}
 	clientID, clientSecret, err = resolveOAuthCredentials(cmd, flags, cfg, clientID, clientSecret)
 	if err != nil {

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/cli/auth.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/cli/auth.go
@@ -93,6 +93,12 @@ func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 
 func runOAuthLogin(cmd *cobra.Command, flags *rootFlags, clientID, clientSecret string, port int) error {
 	w := cmd.OutOrStdout()
+	// Credential-free probes cannot construct an authorize URL. Keep supplied
+	// client IDs on the detailed verify path below so it still emits PKCE params.
+	if (dryRunOK(flags) || cliutil.IsVerifyEnv()) && clientID == "" {
+		fmt.Fprintln(w, `{"status":"dry_run","action":"auth login","would":"start OAuth2 authorization-code flow (PKCE without client secret), open browser, capture loopback callback"}`)
+		return nil
+	}
 	cfg, err := config.Load(flags.configPath)
 	if err != nil {
 		return err

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/cli/auth.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/cli/auth.go
@@ -93,15 +93,16 @@ func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 
 func runOAuthLogin(cmd *cobra.Command, flags *rootFlags, clientID, clientSecret string, port int) error {
 	w := cmd.OutOrStdout()
-	// Credential-free probes cannot construct an authorize URL. Keep supplied
-	// client IDs on the detailed verify path below so it still emits PKCE params.
-	if (dryRunOK(flags) || cliutil.IsVerifyEnv()) && clientID == "" {
-		fmt.Fprintln(w, `{"status":"dry_run","action":"auth login","would":"start OAuth2 authorization-code flow (PKCE without client secret), open browser, capture loopback callback"}`)
-		return nil
-	}
 	cfg, err := config.Load(flags.configPath)
 	if err != nil {
 		return err
+	}
+	// Credential-free probes cannot construct an authorize URL. Keep supplied
+	// or configured client IDs on the detailed verify path below so it still
+	// emits PKCE params.
+	if (dryRunOK(flags) || cliutil.IsVerifyEnv()) && clientID == "" && cfg.ClientID == "" {
+		fmt.Fprintln(w, `{"status":"dry_run","action":"auth login","would":"start OAuth2 authorization-code flow (PKCE without client secret), open browser, capture loopback callback"}`)
+		return nil
 	}
 	clientID, clientSecret, err = resolveOAuthCredentials(cmd, flags, cfg, clientID, clientSecret)
 	if err != nil {


### PR DESCRIPTION
Credential-free OAuth authorization-code CLIs now let sterile verify and `--dry-run` probes exit successfully instead of failing on a missing client ID. Probes without credentials emit a structured dry-run envelope, while credential-bearing verify runs retain the detailed PKCE authorize URL.

Generated-runtime coverage reproduces the no-config, no-credential path and the OAuth authorization-code golden records the emitted behavior. `go test ./...` passed 6,818 tests across 44 packages, and generated-output verification passed for `generate-golden-api-oauth2-authcode`. The full golden run passed the affected case but still reports the unrelated existing `verify-runtime-matrix` missing artifact `structural-fail.json`; lint likewise reports only the pre-existing `modernize` finding in `internal/googlediscovery/parser.go`.

Closes #3491
