### PR TITLE
fix(cli): parse protocol-relative server URLs

### DIFF
--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -584,8 +584,8 @@ func parseWithLocation(data []byte, lenient bool, strictRefs bool, location *url
 	// existing byte-compat goldens for single-host APIs don't churn.
 	var serverTemplatePlaceholders []string
 	var serverTemplateDefaults map[string]string
-	if len(doc.Servers) > 0 && doc.Servers[0] != nil {
-		baseURL, basePath, serverTemplatePlaceholders, serverTemplateDefaults = resolveServerURLTemplate(doc.Servers[0])
+	if server := preferredTopLevelServer(doc.Servers); server != nil {
+		baseURL, basePath, serverTemplatePlaceholders, serverTemplateDefaults = resolveServerURLTemplate(server)
 	}
 	if baseURL == "" && basePath == "" {
 		// No top-level servers — walk per-operation `servers:` blocks. Specs
@@ -3674,7 +3674,8 @@ func operationServerBaseURL(specBaseURL string, pathItem *openapi3.PathItem, op 
 	if len(servers) == 0 || servers[0] == nil {
 		return ""
 	}
-	baseURL, _ := resolveServerURL(servers[0])
+	baseURL, basePath := resolveServerURL(servers[0])
+	baseURL += basePath
 	if baseURL == "" || baseURL == strings.TrimRight(specBaseURL, "/") {
 		return ""
 	}
@@ -3776,6 +3777,9 @@ func resolveServerURLTemplate(server *openapi3.Server) (baseURL, basePath string
 		}
 		return ""
 	})
+	if baseURL, basePath, ok := resolveProtocolRelativeServerURL(serverURL); ok {
+		return baseURL, basePath, placeholders, defaults
+	}
 	serverURL = normalizeURLSlashes(serverURL)
 	serverURL = strings.TrimRight(serverURL, "/")
 	if serverURL == "" {
@@ -3820,6 +3824,48 @@ func normalizeURLSlashes(s string) string {
 	s = strings.Replace(s, "http:/", "http://", 1)
 	s = strings.Replace(s, "https:/", "https://", 1)
 	return s
+}
+
+func preferredTopLevelServer(servers openapi3.Servers) *openapi3.Server {
+	if len(servers) == 0 || servers[0] == nil {
+		return nil
+	}
+	protocolRelativeHost, ok := protocolRelativeServerHost(servers[0].URL)
+	if !ok {
+		return servers[0]
+	}
+	for _, server := range servers[1:] {
+		if server == nil {
+			continue
+		}
+		parsed, err := url.Parse(strings.TrimSpace(server.URL))
+		if err == nil && (parsed.Scheme == "http" || parsed.Scheme == "https") &&
+			strings.EqualFold(parsed.Host, protocolRelativeHost) {
+			return server
+		}
+	}
+	return servers[0]
+}
+
+func protocolRelativeServerHost(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if !strings.HasPrefix(raw, "//") || strings.HasPrefix(raw, "///") {
+		return "", false
+	}
+	host := strings.TrimPrefix(raw, "//")
+	if i := strings.IndexByte(host, '/'); i >= 0 {
+		host = host[:i]
+	}
+	return host, host != ""
+}
+
+func resolveProtocolRelativeServerURL(raw string) (baseURL, basePath string, ok bool) {
+	host, ok := protocolRelativeServerHost(raw)
+	if !ok {
+		return "", "", false
+	}
+	path := strings.TrimPrefix(strings.TrimSpace(raw), "//"+host)
+	return "https://" + host, strings.TrimRight(path, "/"), true
 }
 
 // mergeServerTemplatePlaceholders folds the placeholders the parser pulled
@@ -3888,6 +3934,9 @@ func resolveServerURL(server *openapi3.Server) (baseURL, basePath string) {
 		}
 		serverURL = serverURL[:start] + serverURL[end+1:]
 	}
+	if baseURL, basePath, ok := resolveProtocolRelativeServerURL(serverURL); ok {
+		return baseURL, basePath
+	}
 	serverURL = normalizeURLSlashes(serverURL)
 	serverURL = strings.TrimRight(serverURL, "/")
 	if serverURL == "" {
@@ -3910,13 +3959,17 @@ func mostCommonOperationServer(doc *openapi3.T) (baseURL, basePath string) {
 	if doc == nil || doc.Paths == nil {
 		return "", ""
 	}
-	urlCounts := map[string]int{}
+	type resolvedServer struct {
+		baseURL  string
+		basePath string
+	}
+	urlCounts := map[resolvedServer]int{}
 	pathCounts := map[string]int{}
 	tally := func(servers openapi3.Servers) {
 		for _, srv := range servers {
 			u, p := resolveServerURL(srv)
 			if u != "" {
-				urlCounts[u]++
+				urlCounts[resolvedServer{baseURL: u, basePath: p}]++
 			} else if p != "" {
 				pathCounts[p]++
 			}
@@ -3946,8 +3999,18 @@ func mostCommonOperationServer(doc *openapi3.T) (baseURL, basePath string) {
 		}
 		return best
 	}
-	if u := pickTopKey(urlCounts); u != "" {
-		return u, ""
+	var best resolvedServer
+	var bestCount int
+	for server, count := range urlCounts {
+		key := server.baseURL + server.basePath
+		bestKey := best.baseURL + best.basePath
+		if count > bestCount || (count == bestCount && key < bestKey) {
+			best = server
+			bestCount = count
+		}
+	}
+	if best.baseURL != "" {
+		return best.baseURL, best.basePath
 	}
 	if p := pickTopKey(pathCounts); p != "" {
 		warnf("no top-level servers; using most common per-operation relative path %q (generated CLI will need base_url in config)", p)

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -3677,6 +3677,12 @@ func operationServerBaseURL(specBaseURL string, pathItem *openapi3.PathItem, op 
 	baseURL, basePath := resolveServerURL(servers[0])
 	if baseURL != "" {
 		baseURL += basePath
+	} else if basePath != "" {
+		configuredBase, configuredErr := url.Parse(strings.TrimSpace(specBaseURL))
+		relativeBase, relativeErr := url.Parse(basePath)
+		if configuredErr == nil && relativeErr == nil && configuredBase.IsAbs() {
+			baseURL = configuredBase.ResolveReference(relativeBase).String()
+		}
 	}
 	if baseURL == "" || baseURL == strings.TrimRight(specBaseURL, "/") {
 		return ""

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -3675,7 +3675,9 @@ func operationServerBaseURL(specBaseURL string, pathItem *openapi3.PathItem, op 
 		return ""
 	}
 	baseURL, basePath := resolveServerURL(servers[0])
-	baseURL += basePath
+	if baseURL != "" {
+		baseURL += basePath
+	}
 	if baseURL == "" || baseURL == strings.TrimRight(specBaseURL, "/") {
 		return ""
 	}
@@ -3852,11 +3854,11 @@ func protocolRelativeServerHost(raw string) (string, bool) {
 	if !strings.HasPrefix(raw, "//") || strings.HasPrefix(raw, "///") {
 		return "", false
 	}
-	host := strings.TrimPrefix(raw, "//")
-	if i := strings.IndexByte(host, '/'); i >= 0 {
-		host = host[:i]
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" {
+		return "", false
 	}
-	return host, host != ""
+	return parsed.Host, true
 }
 
 func resolveProtocolRelativeServerURL(raw string) (baseURL, basePath string, ok bool) {
@@ -3864,7 +3866,11 @@ func resolveProtocolRelativeServerURL(raw string) (baseURL, basePath string, ok 
 	if !ok {
 		return "", "", false
 	}
-	path := strings.TrimPrefix(strings.TrimSpace(raw), "//"+host)
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", "", false
+	}
+	path := parsed.EscapedPath()
 	return "https://" + host, strings.TrimRight(path, "/"), true
 }
 

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -10711,7 +10711,28 @@ paths:
 		require.NoError(t, err)
 		assert.Equal(t, "https://api.real.com", parsed.BaseURL)
 		endpoint := findParsedEndpointByPath(t, parsed, "GET", "/resource")
-		assert.Empty(t, endpoint.BaseURL)
+		assert.Equal(t, "https://api.real.com/api/v2", endpoint.BaseURL)
+		assert.Equal(t, "/resource", endpoint.Path)
+	})
+
+	t.Run("relative operation server replaces configured base path", func(t *testing.T) {
+		parsed, err := Parse([]byte(`openapi: "3.0.3"
+info: {title: Relative Operation Replacement Test, version: "1.0"}
+servers:
+  - url: https://api.real.com/api/v1
+paths:
+  /resource:
+    get:
+      operationId: getResource
+      servers:
+        - url: /api/v2
+      responses:
+        '200': {description: OK}
+`))
+		require.NoError(t, err)
+		assert.Equal(t, "https://api.real.com/api/v1", parsed.BaseURL)
+		endpoint := findParsedEndpointByPath(t, parsed, "GET", "/resource")
+		assert.Equal(t, "https://api.real.com/api/v2", endpoint.BaseURL)
 		assert.Equal(t, "/resource", endpoint.Path)
 	})
 

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -10587,6 +10587,115 @@ paths:
 	})
 }
 
+func TestParseProtocolRelativeServer(t *testing.T) {
+	t.Parallel()
+
+	parse := func(t *testing.T, servers string) *spec.APISpec {
+		t.Helper()
+		parsed, err := Parse([]byte(fmt.Sprintf(`openapi: "3.0.3"
+info:
+  title: Protocol Relative Server Test
+  version: "1.0"
+servers:
+%s
+paths:
+  /resource:
+    get:
+      operationId: getResource
+      responses:
+        '200': {description: OK}
+`, servers)))
+		require.NoError(t, err)
+		return parsed
+	}
+
+	t.Run("defaults scheme and separates host from path", func(t *testing.T) {
+		parsed := parse(t, `  - url: //api.real.com/api/v2`)
+		assert.Equal(t, "https://api.real.com", parsed.BaseURL)
+		assert.Equal(t, "/api/v2", parsed.BasePath)
+
+		outputDir := filepath.Join(t.TempDir(), naming.CLI(parsed.Name))
+		require.NoError(t, generator.New(parsed, outputDir).Generate())
+
+		configData, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+		require.NoError(t, err)
+		assert.Contains(t, string(configData), `BaseURL:  "https://api.real.com"`)
+		assert.Contains(t, string(configData), `BasePath: "/api/v2"`)
+
+		clientData, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+		require.NoError(t, err)
+		assert.Contains(t, string(clientData), "return c.BaseURL + c.BasePath")
+		runtimeTest := `package client
+
+import (
+	"testing"
+	"time"
+
+	"protocol-relative-server-pp-cli/internal/config"
+)
+
+func TestProtocolRelativeRequestBaseURL(t *testing.T) {
+	c := New(&config.Config{BaseURL: "https://api.real.com", BasePath: "/api/v2"}, time.Second, 0)
+	if got := c.RequestBaseURL(); got != "https://api.real.com/api/v2" {
+		t.Fatalf("RequestBaseURL() = %q", got)
+	}
+}
+`
+		require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "protocol_relative_test.go"), []byte(runtimeTest), 0o600))
+		runGo(t, outputDir, "mod", "tidy")
+		runGo(t, outputDir, "test", "./internal/client")
+	})
+
+	t.Run("prefers an absolute sibling for the same host", func(t *testing.T) {
+		parsed := parse(t, `  - url: //api.real.com/api/v2
+  - url: http://api.real.com/api/v3`)
+		assert.Equal(t, "http://api.real.com/api/v3", parsed.BaseURL)
+		assert.Empty(t, parsed.BasePath)
+	})
+
+	t.Run("leaves an absolute server unchanged", func(t *testing.T) {
+		parsed := parse(t, `  - url: https://api.real.com/api/v2`)
+		assert.Equal(t, "https://api.real.com/api/v2", parsed.BaseURL)
+		assert.Empty(t, parsed.BasePath)
+	})
+
+	t.Run("preserves path for an operation-level server", func(t *testing.T) {
+		parsedWithOperationServer, err := Parse([]byte(`openapi: "3.0.3"
+info: {title: Operation Server Test, version: "1.0"}
+servers:
+  - url: https://api.real.com
+paths:
+  /resource:
+    get:
+      operationId: getResource
+      servers:
+        - url: //other.real.com/api/v2
+      responses:
+        '200': {description: OK}
+`))
+		require.NoError(t, err)
+		endpoint := findParsedEndpointByPath(t, parsedWithOperationServer, "GET", "/resource")
+		assert.Equal(t, "https://other.real.com/api/v2", endpoint.BaseURL)
+	})
+
+	t.Run("preserves path for operation-only fallback", func(t *testing.T) {
+		parsed, err := Parse([]byte(`openapi: "3.0.3"
+info: {title: Operation Only Server Test, version: "1.0"}
+paths:
+  /resource:
+    get:
+      operationId: getResource
+      servers:
+        - url: //api.real.com/api/v2
+      responses:
+        '200': {description: OK}
+`))
+		require.NoError(t, err)
+		assert.Equal(t, "https://api.real.com", parsed.BaseURL)
+		assert.Equal(t, "/api/v2", parsed.BasePath)
+	})
+}
+
 // TestAuthCompanionFromOpenAPI exercises the x-auth-companion extension at
 // both scheme level and info level, including the scheme-wins precedence
 // when both are set.

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -10592,7 +10592,7 @@ func TestParseProtocolRelativeServer(t *testing.T) {
 
 	parse := func(t *testing.T, servers string) *spec.APISpec {
 		t.Helper()
-		parsed, err := Parse([]byte(fmt.Sprintf(`openapi: "3.0.3"
+		parsed, err := Parse(fmt.Appendf(nil, `openapi: "3.0.3"
 info:
   title: Protocol Relative Server Test
   version: "1.0"
@@ -10604,7 +10604,7 @@ paths:
       operationId: getResource
       responses:
         '200': {description: OK}
-`, servers)))
+`, servers))
 		require.NoError(t, err)
 		return parsed
 	}
@@ -10659,6 +10659,22 @@ func TestProtocolRelativeRequestBaseURL(t *testing.T) {
 		assert.Empty(t, parsed.BasePath)
 	})
 
+	t.Run("keeps query outside host and before resource paths", func(t *testing.T) {
+		parsed := parse(t, `  - url: //api.real.com?version=2`)
+		assert.Equal(t, "https://api.real.com", parsed.BaseURL)
+		assert.Empty(t, parsed.BasePath)
+		endpoint := findParsedEndpointByPath(t, parsed, "GET", "/resource")
+		assert.Equal(t, "/resource", endpoint.Path)
+	})
+
+	t.Run("keeps fragment outside host and before resource paths", func(t *testing.T) {
+		parsed := parse(t, `  - url: //api.real.com#metadata`)
+		assert.Equal(t, "https://api.real.com", parsed.BaseURL)
+		assert.Empty(t, parsed.BasePath)
+		endpoint := findParsedEndpointByPath(t, parsed, "GET", "/resource")
+		assert.Equal(t, "/resource", endpoint.Path)
+	})
+
 	t.Run("preserves path for an operation-level server", func(t *testing.T) {
 		parsedWithOperationServer, err := Parse([]byte(`openapi: "3.0.3"
 info: {title: Operation Server Test, version: "1.0"}
@@ -10676,6 +10692,27 @@ paths:
 		require.NoError(t, err)
 		endpoint := findParsedEndpointByPath(t, parsedWithOperationServer, "GET", "/resource")
 		assert.Equal(t, "https://other.real.com/api/v2", endpoint.BaseURL)
+	})
+
+	t.Run("keeps relative operation server on configured origin", func(t *testing.T) {
+		parsed, err := Parse([]byte(`openapi: "3.0.3"
+info: {title: Relative Operation Server Test, version: "1.0"}
+servers:
+  - url: https://api.real.com
+paths:
+  /resource:
+    get:
+      operationId: getResource
+      servers:
+        - url: /api/v2
+      responses:
+        '200': {description: OK}
+`))
+		require.NoError(t, err)
+		assert.Equal(t, "https://api.real.com", parsed.BaseURL)
+		endpoint := findParsedEndpointByPath(t, parsed, "GET", "/resource")
+		assert.Empty(t, endpoint.BaseURL)
+		assert.Equal(t, "/resource", endpoint.Path)
 	})
 
 	t.Run("preserves path for operation-only fallback", func(t *testing.T) {


### PR DESCRIPTION
Protocol-relative OpenAPI server URLs now generate working clients instead of scheme-less requests. The parser defaults lone `//host/path` servers to HTTPS while preserving host and path boundaries, and prefers an explicit same-host HTTP(S) sibling when available. Operation-level servers retain their path as well, including operation-only fallback specs.

Validation: focused protocol-relative coverage executes the generated client's `RequestBaseURL()` and all 633 OpenAPI tests pass. The 32-case golden suite and 10-case generated-output compile suite pass. The full Go suite reported 6,778 passes plus the unrelated existing `TestHelpScanIndicatesSideEffect` failure in `internal/pipeline`.

Closes #3488
