### PR TITLE
fix(cli): honor paginated HTML responses

### DIFF
--- a/internal/generator/html_paginated_read_test.go
+++ b/internal/generator/html_paginated_read_test.go
@@ -1,0 +1,155 @@
+package generator
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedPaginatedReadHonorsResponseFormat(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(`<html><body><a href="/posts/one">One</a></body></html>`))
+	}))
+	t.Cleanup(server.Close)
+
+	apiSpec := minimalSpec("html-paginated-read")
+	apiSpec.BaseURL = server.URL
+	apiSpec.Resources = map[string]spec.Resource{
+		"html_posts": {
+			Description: "HTML posts",
+			Endpoints: map[string]spec.Endpoint{
+				"list": paginatedReadEndpoint(spec.ResponseFormatHTML),
+				"page": {
+					Method:         "GET",
+					Path:           "/posts",
+					Description:    "Read an HTML page",
+					ResponseFormat: spec.ResponseFormatHTML,
+					HTMLExtract:    &spec.HTMLExtract{Mode: spec.HTMLExtractModePage},
+				},
+			},
+		},
+		"promoted_html_posts": {
+			Description: "Promoted HTML posts",
+			Endpoints: map[string]spec.Endpoint{
+				"list": paginatedReadEndpoint(spec.ResponseFormatHTML),
+			},
+		},
+		"json_posts": {
+			Description: "JSON posts",
+			Endpoints: map[string]spec.Endpoint{
+				"list": paginatedReadEndpoint(spec.ResponseFormatJSON),
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, Search: true, MCP: true}
+	require.NoError(t, gen.Generate())
+	requireGeneratedCompiles(t, outputDir)
+
+	binaryPath := filepath.Join(outputDir, naming.CLI(apiSpec.Name))
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/"+naming.CLI(apiSpec.Name))
+
+	baseEnv := append(os.Environ(), strings.ToUpper(strings.ReplaceAll(apiSpec.Name, "-", "_"))+"_BASE_URL="+server.URL)
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "nested live", args: []string{"html-posts", "list", "--json", "--data-source", "live"}},
+		{name: "nested auto", args: []string{"html-posts", "list", "--json"}},
+		{name: "promoted live", args: []string{"promoted-html-posts", "--json", "--data-source", "live"}},
+		{name: "promoted auto", args: []string{"promoted-html-posts", "--json"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command(binaryPath, tc.args...)
+			cmd.Env = baseEnv
+			out, err := cmd.CombinedOutput()
+			require.NoError(t, err, string(out))
+			var envelope struct {
+				Results []map[string]any `json:"results"`
+			}
+			require.NoError(t, json.Unmarshal(out, &envelope), string(out))
+			require.Len(t, envelope.Results, 1)
+			require.Equal(t, "One", envelope.Results[0]["name"])
+		})
+	}
+
+	for _, strategyArgs := range [][]string{{"--data-source", "live"}, nil} {
+		args := append([]string{"json-posts", "--json"}, strategyArgs...)
+		cmd := exec.Command(binaryPath, args...)
+		cmd.Env = baseEnv
+		out, err := cmd.CombinedOutput()
+		require.Error(t, err, string(out))
+		require.Contains(t, string(out), "returned HTML instead of JSON")
+	}
+
+	cmd := exec.Command(binaryPath, "html-posts", "list", "--json", "--all")
+	cmd.Env = baseEnv
+	out, err := cmd.CombinedOutput()
+	require.Error(t, err, string(out))
+	require.Contains(t, string(out), "--all is not supported for live HTML responses")
+
+	cmd = exec.Command(binaryPath, "html-posts", "list", "--json", "--all", "--data-source", "local")
+	cmd.Env = baseEnv
+	out, err = cmd.CombinedOutput()
+	require.Error(t, err, string(out))
+	require.NotContains(t, string(out), "--all is not supported for live HTML responses")
+	require.Contains(t, string(out), "no local data")
+
+	storelessSpec := *apiSpec
+	storelessSpec.Learn.Disabled = true
+	storelessDir := filepath.Join(t.TempDir(), naming.CLI(storelessSpec.Name))
+	storelessGen := New(&storelessSpec, storelessDir)
+	storelessGen.VisionSet = VisionTemplateSet{MCP: true}
+	require.NoError(t, storelessGen.Generate())
+	requireGeneratedCompiles(t, storelessDir)
+	storelessBinary := filepath.Join(storelessDir, naming.CLI(storelessSpec.Name))
+	runGoCommand(t, storelessDir, "build", "-o", storelessBinary, "./cmd/"+naming.CLI(storelessSpec.Name))
+	for _, args := range [][]string{
+		{"html-posts", "list", "--json", "--all"},
+		{"promoted-html-posts", "--json", "--all"},
+	} {
+		cmd = exec.Command(storelessBinary, args...)
+		cmd.Env = baseEnv
+		out, err = cmd.CombinedOutput()
+		require.Error(t, err, string(out))
+		require.Contains(t, string(out), "--all is not supported for live HTML responses")
+	}
+}
+
+func paginatedReadEndpoint(responseFormat string) spec.Endpoint {
+	endpoint := spec.Endpoint{
+		Method:         "GET",
+		Path:           "/posts",
+		Description:    "List posts",
+		ResponseFormat: responseFormat,
+		Response:       spec.ResponseDef{Type: "array", Item: "html_link"},
+		Params: []spec.Param{
+			{Name: "limit", Type: "integer", Default: 10},
+			{Name: "offset", Type: "integer"},
+		},
+		Pagination: &spec.Pagination{
+			Type:        "offset",
+			CursorParam: "offset",
+			LimitParam:  "limit",
+		},
+	}
+	if responseFormat == spec.ResponseFormatHTML {
+		endpoint.HTMLExtract = &spec.HTMLExtract{
+			Mode:         spec.HTMLExtractModeLinks,
+			LinkPrefixes: []string{"/posts"},
+		}
+	}
+	return endpoint
+}

--- a/internal/generator/html_paginated_read_test.go
+++ b/internal/generator/html_paginated_read_test.go
@@ -126,6 +126,29 @@ func TestGeneratedPaginatedReadHonorsResponseFormat(t *testing.T) {
 		require.Error(t, err, string(out))
 		require.Contains(t, string(out), "--all is not supported for live HTML responses")
 	}
+
+	cacheServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(`<html><body><a href="/posts/one">One</a></body></html>`))
+	}))
+	cacheEnv := append(os.Environ(), strings.ToUpper(strings.ReplaceAll(apiSpec.Name, "-", "_"))+"_BASE_URL="+cacheServer.URL)
+	cacheArgs := []string{"html-posts", "list", "--json", "--home", t.TempDir()}
+	cacheCmd := exec.Command(binaryPath, cacheArgs...)
+	cacheCmd.Env = cacheEnv
+	out, err = cacheCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	cacheServer.Close()
+
+	cacheCmd = exec.Command(binaryPath, cacheArgs...)
+	cacheCmd.Env = cacheEnv
+	out, err = cacheCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	var cachedEnvelope struct {
+		Results []map[string]any `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(out, &cachedEnvelope), string(out))
+	require.Len(t, cachedEnvelope.Results, 1)
+	require.Equal(t, "One", cachedEnvelope.Results[0]["name"])
 }
 
 func paginatedReadEndpoint(responseFormat string) spec.Endpoint {

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -324,8 +324,13 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			}
 {{- end}}
 {{- else if $supportsAllPagination}}
+{{- if and (eq .Endpoint.ResponseFormat "html") (not .HasStore)}}
+			if flagAll {
+				return fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
+			}
+{{- end}}
 {{- if .HasStore}}
-			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", path, map[string]string{
+			{{if eq .Endpoint.ResponseFormat "html"}}data, prov, err := resolvePaginatedReadWithStrategyAndJSONGuard{{else}}data, prov, err := resolvePaginatedReadWithStrategy{{end}}(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", path, map[string]string{
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
@@ -334,7 +339,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", cmd.ErrOrStderr())
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{if eq .Endpoint.ResponseFormat "html"}}false, {{end}}cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -198,8 +198,13 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 
 {{- if $supportsAllPagination}}
+{{- if and (eq .Endpoint.ResponseFormat "html") (not .HasStore)}}
+			if flagAll {
+				return fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
+			}
+{{- end}}
 {{- if .HasStore}}
-			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", path, map[string]string{
+			{{if eq .Endpoint.ResponseFormat "html"}}data, prov, err := resolvePaginatedReadWithStrategyAndJSONGuard{{else}}data, prov, err := resolvePaginatedReadWithStrategy{{end}}(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", path, map[string]string{
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
@@ -208,7 +213,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", cmd.ErrOrStderr())
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{if eq .Endpoint.ResponseFormat "html"}}false, {{end}}cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -219,6 +219,10 @@ func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlag
 }
 
 func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+	return resolvePaginatedReadWithStrategyAndJSONGuard(ctx, c, flags, strategy, resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, true, hintWriter)
+}
+
+func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string, guardLiveJSON bool, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
 	if err := validateDataSourceStrategy(flags, strategy); err != nil {
 		return nil, DataProvenance{}, err
 	}
@@ -227,12 +231,17 @@ func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, fla
 		return data, attachFreshness(prov, flags), err
 	}
 	if strategy == "live" {
+		if !guardLiveJSON && fetchAll {
+			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
+		}
 		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
-		if err := assertLiveJSONBody(data); err != nil {
-			return nil, DataProvenance{}, err
+		if guardLiveJSON {
+			if err := assertLiveJSONBody(data); err != nil {
+				return nil, DataProvenance{}, err
+			}
 		}
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 	}
@@ -242,22 +251,32 @@ func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, fla
 		return data, attachFreshness(prov, flags), err
 
 	case "live":
+		if !guardLiveJSON && fetchAll {
+			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
+		}
 		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
-		if err := assertLiveJSONBody(data); err != nil {
-			return nil, DataProvenance{}, err
+		if guardLiveJSON {
+			if err := assertLiveJSONBody(data); err != nil {
+				return nil, DataProvenance{}, err
+			}
 		}
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 
 	default: // "auto"
+		if !guardLiveJSON && fetchAll {
+			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all or use --data-source local")
+		}
 		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
 		if err == nil {
-			if err := assertLiveJSONBody(data); err != nil {
-				return nil, DataProvenance{}, err
+			if guardLiveJSON {
+				if err := assertLiveJSONBody(data); err != nil {
+					return nil, DataProvenance{}, err
+				}
+				writeThroughCache(ctx, resourceType, data)
 			}
-			writeThroughCache(ctx, resourceType, data)
 			return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 		}
 		if !isNetworkError(err) {

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -275,8 +275,8 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 				if err := assertLiveJSONBody(data); err != nil {
 					return nil, DataProvenance{}, err
 				}
-				writeThroughCache(ctx, resourceType, data)
 			}
+			writeThroughCache(ctx, resourceType, data)
 			return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 		}
 		if !isNetworkError(err) {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -219,6 +219,10 @@ func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlag
 }
 
 func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+	return resolvePaginatedReadWithStrategyAndJSONGuard(ctx, c, flags, strategy, resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, true, hintWriter)
+}
+
+func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string, guardLiveJSON bool, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
 	if err := validateDataSourceStrategy(flags, strategy); err != nil {
 		return nil, DataProvenance{}, err
 	}
@@ -227,12 +231,17 @@ func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, fla
 		return data, attachFreshness(prov, flags), err
 	}
 	if strategy == "live" {
+		if !guardLiveJSON && fetchAll {
+			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
+		}
 		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
-		if err := assertLiveJSONBody(data); err != nil {
-			return nil, DataProvenance{}, err
+		if guardLiveJSON {
+			if err := assertLiveJSONBody(data); err != nil {
+				return nil, DataProvenance{}, err
+			}
 		}
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 	}
@@ -242,22 +251,32 @@ func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, fla
 		return data, attachFreshness(prov, flags), err
 
 	case "live":
+		if !guardLiveJSON && fetchAll {
+			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
+		}
 		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
-		if err := assertLiveJSONBody(data); err != nil {
-			return nil, DataProvenance{}, err
+		if guardLiveJSON {
+			if err := assertLiveJSONBody(data); err != nil {
+				return nil, DataProvenance{}, err
+			}
 		}
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 
 	default: // "auto"
+		if !guardLiveJSON && fetchAll {
+			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all or use --data-source local")
+		}
 		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
 		if err == nil {
-			if err := assertLiveJSONBody(data); err != nil {
-				return nil, DataProvenance{}, err
+			if guardLiveJSON {
+				if err := assertLiveJSONBody(data); err != nil {
+					return nil, DataProvenance{}, err
+				}
+				writeThroughCache(ctx, resourceType, data)
 			}
-			writeThroughCache(ctx, resourceType, data)
 			return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 		}
 		if !isNetworkError(err) {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -275,8 +275,8 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 				if err := assertLiveJSONBody(data); err != nil {
 					return nil, DataProvenance{}, err
 				}
-				writeThroughCache(ctx, resourceType, data)
 			}
+			writeThroughCache(ctx, resourceType, data)
 			return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 		}
 		if !isNetworkError(err) {


### PR DESCRIPTION
## Summary

Paginated HTML endpoint commands now reach their declared HTML extractor instead of failing the JSON-body guard first. JSON endpoints continue to reject HTML responses, while unsupported live HTML `--all` requests fail explicitly instead of returning a misleading empty result. The behavior is covered for nested and promoted commands, store-backed and storeless prints, and `live`, `auto`, and explicit local routing.

## Validation

- `go test ./...`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`

Closes #3458
