### PR TITLE
fix(cli): exit non-zero on missing positional and unknown subcommand

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -7588,7 +7588,7 @@ func TestPipedJsonGateRespectsExplicitFormatFlags(t *testing.T) {
 func TestRequiredFlagCommands_HelpFallbackOnEmptyInvocation(t *testing.T) {
 	t.Parallel()
 
-	guard := "if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {"
+	guard := "if !hasChangedLocalFlags(cmd) && len(args) == 0 && !flags.dryRun {"
 
 	for _, path := range []string{
 		filepath.Join("templates", "command_endpoint.go.tmpl"),
@@ -7658,7 +7658,7 @@ func TestRequiredFlagCommands_HelpFallbackGatedToRequiredInput(t *testing.T) {
 	gen := New(apiSpec, outputDir)
 	require.NoError(t, gen.Generate())
 
-	guard := "if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {"
+	guard := "if !hasChangedLocalFlags(cmd) && len(args) == 0 && !flags.dryRun {"
 
 	listBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "items_list.go"))
 	require.NoError(t, err)

--- a/internal/generator/help_exit_test.go
+++ b/internal/generator/help_exit_test.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -34,13 +35,39 @@ func TestGeneratedNestedHelpExitsZeroAndUsageErrorsExitTwo(t *testing.T) {
 	require.NoError(t, New(apiSpec, outputDir).Generate())
 	requireGeneratedCompiles(t, outputDir)
 
-	binPath := filepath.Join(outputDir, "help-exit-pp-cli")
-	runGoCommandRequired(t, outputDir, "build", "-o", "./help-exit-pp-cli", "./cmd/help-exit-pp-cli")
+	exe := ""
+	if runtime.GOOS == "windows" {
+		exe = ".exe"
+	}
+	binPath := filepath.Join(outputDir, "help-exit-pp-cli"+exe)
+	runGoCommandRequired(t, outputDir, "build", "-o", "./help-exit-pp-cli"+exe, "./cmd/help-exit-pp-cli")
 
 	assertExitCode(t, 0, binPath, "items", "list", "--help")
 	assertExitCode(t, 0, binPath, "auth", "status", "--help")
 	assertExitCode(t, 2, binPath, "--bogus-flag")
 	assertExitCode(t, 2, binPath, "items", "compare", "left-only", "--json")
+
+	// A missing required positional is a usage error (exit 2) in every output
+	// mode, human included — not exit-0 help. Before the fix a bare leaf
+	// invocation fell through to cobra help and exited 0, so agents read a
+	// usage error as a binary bug (#3632). --json adds a structured envelope on
+	// stdout; the exit code is 2 either way.
+	humanMissing := assertExitCode(t, 2, binPath, "items", "compare")
+	require.Contains(t, humanMissing, "missing required argument")
+	jsonMissing := assertExitCode(t, 2, binPath, "items", "compare", "--json")
+	require.Contains(t, jsonMissing, `"missing required argument"`)
+
+	// An unknown/misspelled subcommand on a parent group is a usage error in
+	// every output mode. Before the fix human mode fell through to exit-0 help
+	// (#2955); machine mode already exited 2.
+	humanUnknown := assertExitCode(t, 2, binPath, "items", "bogus")
+	require.Contains(t, humanUnknown, `unknown subcommand "bogus"`)
+	jsonUnknown := assertExitCode(t, 2, binPath, "items", "bogus", "--json")
+	require.Contains(t, jsonUnknown, `"unknown subcommand"`)
+
+	// A genuine bare parent invocation still prints help and exits 0 for humans
+	// (only a leftover/typo'd token is an error), preserving the friendly UX.
+	assertExitCode(t, 0, binPath, "items")
 }
 
 func TestGeneratedRootTreatsPflagHelpSentinelAsSuccess(t *testing.T) {
@@ -63,16 +90,17 @@ func TestGeneratedRootTreatsPflagHelpSentinelAsSuccess(t *testing.T) {
 	)
 }
 
-func assertExitCode(t *testing.T, want int, binaryPath string, args ...string) {
+func assertExitCode(t *testing.T, want int, binaryPath string, args ...string) string {
 	t.Helper()
 
 	cmd := exec.Command(binaryPath, args...)
 	output, err := cmd.CombinedOutput()
 	if want == 0 {
 		require.NoError(t, err, "args %v output:\n%s", args, string(output))
-		return
+		return string(output)
 	}
 	var exitErr *exec.ExitError
 	require.ErrorAs(t, err, &exitErr, "args %v output:\n%s", args, string(output))
 	require.Equal(t, want, exitErr.ExitCode(), "args %v output:\n%s", args, string(output))
+	return string(output)
 }

--- a/internal/generator/help_exit_test.go
+++ b/internal/generator/help_exit_test.go
@@ -19,6 +19,14 @@ func TestGeneratedNestedHelpExitsZeroAndUsageErrorsExitTwo(t *testing.T) {
 		Description: "Manage items",
 		Endpoints: map[string]spec.Endpoint{
 			"list": {Method: "GET", Path: "/items", Description: "List items"},
+			"find": {
+				Method:      "GET",
+				Path:        "/items/find",
+				Description: "Find an item",
+				Params: []spec.Param{
+					{Name: "query", Type: "string", Required: true},
+				},
+			},
 			"compare": {
 				Method:      "GET",
 				Path:        "/items/{left_id}/compare/{right_id}",
@@ -26,6 +34,19 @@ func TestGeneratedNestedHelpExitsZeroAndUsageErrorsExitTwo(t *testing.T) {
 				Params: []spec.Param{
 					{Name: "left_id", Type: "string", Required: true, Positional: true, PathParam: true},
 					{Name: "right_id", Type: "string", Required: true, Positional: true, PathParam: true},
+				},
+			},
+		},
+	}
+	apiSpec.Resources["subscribe"] = spec.Resource{
+		Description: "Manage subscriptions",
+		Endpoints: map[string]spec.Endpoint{
+			"create": {
+				Method:      "POST",
+				Path:        "/subscribe",
+				Description: "Create a subscription",
+				Body: []spec.Param{
+					{Name: "email", Type: "string", Required: true},
 				},
 			},
 		},
@@ -56,6 +77,16 @@ func TestGeneratedNestedHelpExitsZeroAndUsageErrorsExitTwo(t *testing.T) {
 	require.Contains(t, humanMissing, "missing required argument")
 	jsonMissing := assertExitCode(t, 2, binPath, "items", "compare", "--json")
 	require.Contains(t, jsonMissing, `"missing required argument"`)
+
+	for _, args := range [][]string{
+		{"items", "find", "--json"},
+		{"items", "find", "--agent"},
+		{"subscribe", "--json"},
+		{"subscribe", "--agent"},
+	} {
+		missingInput := assertExitCode(t, 2, binPath, args...)
+		require.Contains(t, missingInput, `"requires input"`, "args %v output:\n%s", args, missingInput)
+	}
 
 	// An unknown/misspelled subcommand on a parent group is a usage error in
 	// every output mode. Before the fix human mode fell through to exit-0 help

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -80,13 +80,31 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			// Bare invocation of a command with required input prints help
 			// instead of pflag's terse "required flag not set" error. Optional-
 			// only read commands fall through so a bare call still executes.
+			// Machine callers (--json/--agent, which sets asJSON) get a usage
+			// error + exit 2 instead of silent exit-0 help, so an incomplete
+			// invocation is never mistaken for success.
 			if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {
+				if flags.asJSON {
+					return usageErr(fmt.Errorf("%q requires input; run %q for usage", cmd.CommandPath(), cmd.CommandPath()+" --help"))
+				}
 				return cmd.Help()
 			}
 {{- end}}
 {{- if positionalArgs .Endpoint}}
 			if len(args) == 0 {
-				return cmd.Help()
+				// A missing required positional is a usage error in every output
+				// mode (matches command_promoted.go.tmpl). Machine callers
+				// (--json/--agent) also get a JSON error envelope on stdout;
+				// usageErr sets exit 2.
+				if flags.asJSON {
+					if printErr := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+						"error": "missing required argument",
+						"usage": fmt.Sprintf("%s%s", cmd.CommandPath(), "{{positionalArgs .Endpoint}}"),
+					}, flags); printErr != nil {
+						return printErr
+					}
+				}
+				return usageErr(fmt.Errorf("missing required argument\nUsage: %s%s", cmd.CommandPath(), "{{positionalArgs .Endpoint}}"))
 			}
 {{- end}}
 {{- range .Endpoint.Params}}

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -83,8 +83,14 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			// Machine callers (--json/--agent, which sets asJSON) get a usage
 			// error + exit 2 instead of silent exit-0 help, so an incomplete
 			// invocation is never mistaken for success.
-			if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {
+			if !hasChangedLocalFlags(cmd) && len(args) == 0 && !flags.dryRun {
 				if flags.asJSON {
+					if printErr := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+						"error": "requires input",
+						"usage": cmd.CommandPath() + " --help",
+					}, flags); printErr != nil {
+						return printErr
+					}
 					return usageErr(fmt.Errorf("%q requires input; run %q for usage", cmd.CommandPath(), cmd.CommandPath()+" --help"))
 				}
 				return cmd.Help()

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -67,7 +67,12 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			// instead of pflag's terse "required flag not set" error. Optional-
 			// only reads fall through so a bare call still executes; positional
 			// commands keep their existing usageErr (exit 2 + JSON envelope).
+			// Machine callers (--json/--agent, which sets asJSON) get a usage
+			// error + exit 2 instead of silent exit-0 help.
 			if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {
+				if flags.asJSON {
+					return usageErr(fmt.Errorf("%q requires input; run %q for usage", cmd.CommandPath(), cmd.CommandPath()+" --help"))
+				}
 				return cmd.Help()
 			}
 {{- end}}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -69,8 +69,14 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			// commands keep their existing usageErr (exit 2 + JSON envelope).
 			// Machine callers (--json/--agent, which sets asJSON) get a usage
 			// error + exit 2 instead of silent exit-0 help.
-			if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {
+			if !hasChangedLocalFlags(cmd) && len(args) == 0 && !flags.dryRun {
 				if flags.asJSON {
+					if printErr := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+						"error": "requires input",
+						"usage": cmd.CommandPath() + " --help",
+					}, flags); printErr != nil {
+						return printErr
+					}
 					return usageErr(fmt.Errorf("%q requires input; run %q for usage", cmd.CommandPath(), cmd.CommandPath()+" --help"))
 				}
 				return cmd.Help()

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -483,6 +483,18 @@ func boundCtx(parent context.Context, flags *rootFlags) (context.Context, contex
 	return context.WithTimeout(parent, flags.timeout)
 }
 
+// hasChangedLocalFlags checks Flag.Changed because Cobra's derived local flag
+// set does not populate the internal bookkeeping used by FlagSet.NFlag.
+func hasChangedLocalFlags(cmd *cobra.Command) bool {
+	changed := false
+	cmd.LocalNonPersistentFlags().VisitAll(func(flag *pflag.Flag) {
+		if flag.Changed {
+			changed = true
+		}
+	})
+	return changed
+}
+
 // parentNoSubcommandRunE returns a RunE that handles parents invoked without a
 // subcommand. A leftover positional means the user typed a token where a
 // subcommand was expected (a typo, an underscore instead of a hyphen, or a

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -484,21 +484,34 @@ func boundCtx(parent context.Context, flags *rootFlags) (context.Context, contex
 }
 
 // parentNoSubcommandRunE returns a RunE that handles parents invoked without a
-// subcommand. In machine output (--json/--agent) the parent emits a structured
-// error to stdout listing valid subcommands and exits 2; otherwise cobra's
-// default help text is printed. Without this, agents driving the CLI in
-// --agent mode received only human-readable help on stdout and exit 0, with no
-// signal that the invocation was incomplete.
+// subcommand. A leftover positional means the user typed a token where a
+// subcommand was expected (a typo, an underscore instead of a hyphen, or a
+// bogus name); cobra routes it here because non-root parents don't reject
+// unknown subcommands. That case is a usage error in every output mode, so it
+// never masquerades as exit-0 help. A genuine bare parent invocation (no
+// leftover args) still emits a structured "subcommand required" error and exits
+// 2 in machine output (--json/--agent) but prints cobra's help for humans.
 func parentNoSubcommandRunE(flags *rootFlags) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		if flags != nil && flags.asJSON {
-			subs := make([]string, 0, len(cmd.Commands()))
-			for _, c := range cmd.Commands() {
-				if c.IsAvailableCommand() && c.Name() != "help" {
-					subs = append(subs, c.Name())
-				}
+		machine := flags != nil && flags.asJSON
+		subs := make([]string, 0, len(cmd.Commands()))
+		for _, c := range cmd.Commands() {
+			if c.IsAvailableCommand() && c.Name() != "help" {
+				subs = append(subs, c.Name())
 			}
-			sort.Strings(subs)
+		}
+		sort.Strings(subs)
+		if len(args) > 0 {
+			if machine {
+				_ = json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
+					"error":             "unknown subcommand",
+					"unknown":           args[0],
+					"valid_subcommands": subs,
+				})
+			}
+			return usageErr(fmt.Errorf("unknown subcommand %q for %q\nRun '%s --help' for available subcommands", args[0], cmd.CommandPath(), cmd.CommandPath()))
+		}
+		if machine {
 			_ = json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
 				"error":             "subcommand required",
 				"valid_subcommands": subs,

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
@@ -22,7 +22,19 @@ func newCustomersGetCmd(flags *rootFlags) *cobra.Command {
 		Annotations: map[string]string{"pp:endpoint": "customers.get", "pp:method": "GET", "pp:path": "/customers/{id}", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return cmd.Help()
+				// A missing required positional is a usage error in every output
+				// mode (matches command_promoted.go.tmpl). Machine callers
+				// (--json/--agent) also get a JSON error envelope on stdout;
+				// usageErr sets exit 2.
+				if flags.asJSON {
+					if printErr := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+						"error": "missing required argument",
+						"usage": fmt.Sprintf("%s%s", cmd.CommandPath(), " <id>"),
+					}, flags); printErr != nil {
+						return printErr
+					}
+				}
+				return usageErr(fmt.Errorf("missing required argument\nUsage: %s%s", cmd.CommandPath(), " <id>"))
 			}
 			path := "/customers/{id}"
 			if len(args) < 1 || args[0] == "" {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -146,22 +146,47 @@ func boundCtx(parent context.Context, flags *rootFlags) (context.Context, contex
 	return context.WithTimeout(parent, flags.timeout)
 }
 
+// hasChangedLocalFlags checks Flag.Changed because Cobra's derived local flag
+// set does not populate the internal bookkeeping used by FlagSet.NFlag.
+func hasChangedLocalFlags(cmd *cobra.Command) bool {
+	changed := false
+	cmd.LocalNonPersistentFlags().VisitAll(func(flag *pflag.Flag) {
+		if flag.Changed {
+			changed = true
+		}
+	})
+	return changed
+}
+
 // parentNoSubcommandRunE returns a RunE that handles parents invoked without a
-// subcommand. In machine output (--json/--agent) the parent emits a structured
-// error to stdout listing valid subcommands and exits 2; otherwise cobra's
-// default help text is printed. Without this, agents driving the CLI in
-// --agent mode received only human-readable help on stdout and exit 0, with no
-// signal that the invocation was incomplete.
+// subcommand. A leftover positional means the user typed a token where a
+// subcommand was expected (a typo, an underscore instead of a hyphen, or a
+// bogus name); cobra routes it here because non-root parents don't reject
+// unknown subcommands. That case is a usage error in every output mode, so it
+// never masquerades as exit-0 help. A genuine bare parent invocation (no
+// leftover args) still emits a structured "subcommand required" error and exits
+// 2 in machine output (--json/--agent) but prints cobra's help for humans.
 func parentNoSubcommandRunE(flags *rootFlags) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		if flags != nil && flags.asJSON {
-			subs := make([]string, 0, len(cmd.Commands()))
-			for _, c := range cmd.Commands() {
-				if c.IsAvailableCommand() && c.Name() != "help" {
-					subs = append(subs, c.Name())
-				}
+		machine := flags != nil && flags.asJSON
+		subs := make([]string, 0, len(cmd.Commands()))
+		for _, c := range cmd.Commands() {
+			if c.IsAvailableCommand() && c.Name() != "help" {
+				subs = append(subs, c.Name())
 			}
-			sort.Strings(subs)
+		}
+		sort.Strings(subs)
+		if len(args) > 0 {
+			if machine {
+				_ = json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
+					"error":             "unknown subcommand",
+					"unknown":           args[0],
+					"valid_subcommands": subs,
+				})
+			}
+			return usageErr(fmt.Errorf("unknown subcommand %q for %q\nRun '%s --help' for available subcommands", args[0], cmd.CommandPath(), cmd.CommandPath()))
+		}
+		if machine {
 			_ = json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
 				"error":             "subcommand required",
 				"valid_subcommands": subs,

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
@@ -22,7 +22,19 @@ func newPagesGetCmd(flags *rootFlags) *cobra.Command {
 		Annotations: map[string]string{"pp:endpoint": "pages.get", "pp:method": "GET", "pp:path": "/pages/{id}", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return cmd.Help()
+				// A missing required positional is a usage error in every output
+				// mode (matches command_promoted.go.tmpl). Machine callers
+				// (--json/--agent) also get a JSON error envelope on stdout;
+				// usageErr sets exit 2.
+				if flags.asJSON {
+					if printErr := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+						"error": "missing required argument",
+						"usage": fmt.Sprintf("%s%s", cmd.CommandPath(), " <id>"),
+					}, flags); printErr != nil {
+						return printErr
+					}
+				}
+				return usageErr(fmt.Errorf("missing required argument\nUsage: %s%s", cmd.CommandPath(), " <id>"))
 			}
 			path := "/pages/{id}"
 			if len(args) < 1 || args[0] == "" {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
@@ -22,7 +22,19 @@ func newPlaylistsGetCmd(flags *rootFlags) *cobra.Command {
 		Annotations: map[string]string{"pp:endpoint": "playlists.get", "pp:method": "GET", "pp:path": "/playlists/{id}", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return cmd.Help()
+				// A missing required positional is a usage error in every output
+				// mode (matches command_promoted.go.tmpl). Machine callers
+				// (--json/--agent) also get a JSON error envelope on stdout;
+				// usageErr sets exit 2.
+				if flags.asJSON {
+					if printErr := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+						"error": "missing required argument",
+						"usage": fmt.Sprintf("%s%s", cmd.CommandPath(), " <id>"),
+					}, flags); printErr != nil {
+						return printErr
+					}
+				}
+				return usageErr(fmt.Errorf("missing required argument\nUsage: %s%s", cmd.CommandPath(), " <id>"))
 			}
 			path := "/playlists/{id}"
 			if len(args) < 1 || args[0] == "" {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_delete.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_delete.go
@@ -20,7 +20,19 @@ func newQuotesDeleteCmd(flags *rootFlags) *cobra.Command {
 		Annotations: map[string]string{"pp:endpoint": "quotes.delete", "pp:method": "DELETE", "pp:path": "/api/quotes/{quote_id}"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return cmd.Help()
+				// A missing required positional is a usage error in every output
+				// mode (matches command_promoted.go.tmpl). Machine callers
+				// (--json/--agent) also get a JSON error envelope on stdout;
+				// usageErr sets exit 2.
+				if flags.asJSON {
+					if printErr := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+						"error": "missing required argument",
+						"usage": fmt.Sprintf("%s%s", cmd.CommandPath(), " <quote_id>"),
+					}, flags); printErr != nil {
+						return printErr
+					}
+				}
+				return usageErr(fmt.Errorf("missing required argument\nUsage: %s%s", cmd.CommandPath(), " <quote_id>"))
 			}
 			path := "/api/quotes/{quote_id}"
 			if len(args) < 1 || args[0] == "" {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_get.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_get.go
@@ -20,7 +20,19 @@ func newQuotesGetCmd(flags *rootFlags) *cobra.Command {
 		Annotations: map[string]string{"pp:endpoint": "quotes.get", "pp:method": "GET", "pp:path": "/api/quotes/{quote_id}", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return cmd.Help()
+				// A missing required positional is a usage error in every output
+				// mode (matches command_promoted.go.tmpl). Machine callers
+				// (--json/--agent) also get a JSON error envelope on stdout;
+				// usageErr sets exit 2.
+				if flags.asJSON {
+					if printErr := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+						"error": "missing required argument",
+						"usage": fmt.Sprintf("%s%s", cmd.CommandPath(), " <quote_id>"),
+					}, flags); printErr != nil {
+						return printErr
+					}
+				}
+				return usageErr(fmt.Errorf("missing required argument\nUsage: %s%s", cmd.CommandPath(), " <quote_id>"))
 			}
 			path := "/api/quotes/{quote_id}"
 			if len(args) < 1 || args[0] == "" {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update-status.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update-status.go
@@ -22,7 +22,19 @@ func newQuotesUpdateStatusCmd(flags *rootFlags) *cobra.Command {
 		Annotations: map[string]string{"pp:endpoint": "quotes.update-status", "pp:method": "POST", "pp:path": "/api/quotes/{quote_id}"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return cmd.Help()
+				// A missing required positional is a usage error in every output
+				// mode (matches command_promoted.go.tmpl). Machine callers
+				// (--json/--agent) also get a JSON error envelope on stdout;
+				// usageErr sets exit 2.
+				if flags.asJSON {
+					if printErr := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+						"error": "missing required argument",
+						"usage": fmt.Sprintf("%s%s", cmd.CommandPath(), " <quote_id>"),
+					}, flags); printErr != nil {
+						return printErr
+					}
+				}
+				return usageErr(fmt.Errorf("missing required argument\nUsage: %s%s", cmd.CommandPath(), " <quote_id>"))
 			}
 			if !stdinBody {
 			}

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update.go
@@ -22,7 +22,19 @@ func newQuotesUpdateCmd(flags *rootFlags) *cobra.Command {
 		Annotations: map[string]string{"pp:endpoint": "quotes.update", "pp:method": "PATCH", "pp:path": "/api/quotes/{quote_id}"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return cmd.Help()
+				// A missing required positional is a usage error in every output
+				// mode (matches command_promoted.go.tmpl). Machine callers
+				// (--json/--agent) also get a JSON error envelope on stdout;
+				// usageErr sets exit 2.
+				if flags.asJSON {
+					if printErr := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+						"error": "missing required argument",
+						"usage": fmt.Sprintf("%s%s", cmd.CommandPath(), " <quote_id>"),
+					}, flags); printErr != nil {
+						return printErr
+					}
+				}
+				return usageErr(fmt.Errorf("missing required argument\nUsage: %s%s", cmd.CommandPath(), " <quote_id>"))
 			}
 			if !stdinBody {
 			}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -145,22 +145,47 @@ func boundCtx(parent context.Context, flags *rootFlags) (context.Context, contex
 	return context.WithTimeout(parent, flags.timeout)
 }
 
+// hasChangedLocalFlags checks Flag.Changed because Cobra's derived local flag
+// set does not populate the internal bookkeeping used by FlagSet.NFlag.
+func hasChangedLocalFlags(cmd *cobra.Command) bool {
+	changed := false
+	cmd.LocalNonPersistentFlags().VisitAll(func(flag *pflag.Flag) {
+		if flag.Changed {
+			changed = true
+		}
+	})
+	return changed
+}
+
 // parentNoSubcommandRunE returns a RunE that handles parents invoked without a
-// subcommand. In machine output (--json/--agent) the parent emits a structured
-// error to stdout listing valid subcommands and exits 2; otherwise cobra's
-// default help text is printed. Without this, agents driving the CLI in
-// --agent mode received only human-readable help on stdout and exit 0, with no
-// signal that the invocation was incomplete.
+// subcommand. A leftover positional means the user typed a token where a
+// subcommand was expected (a typo, an underscore instead of a hyphen, or a
+// bogus name); cobra routes it here because non-root parents don't reject
+// unknown subcommands. That case is a usage error in every output mode, so it
+// never masquerades as exit-0 help. A genuine bare parent invocation (no
+// leftover args) still emits a structured "subcommand required" error and exits
+// 2 in machine output (--json/--agent) but prints cobra's help for humans.
 func parentNoSubcommandRunE(flags *rootFlags) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		if flags != nil && flags.asJSON {
-			subs := make([]string, 0, len(cmd.Commands()))
-			for _, c := range cmd.Commands() {
-				if c.IsAvailableCommand() && c.Name() != "help" {
-					subs = append(subs, c.Name())
-				}
+		machine := flags != nil && flags.asJSON
+		subs := make([]string, 0, len(cmd.Commands()))
+		for _, c := range cmd.Commands() {
+			if c.IsAvailableCommand() && c.Name() != "help" {
+				subs = append(subs, c.Name())
 			}
-			sort.Strings(subs)
+		}
+		sort.Strings(subs)
+		if len(args) > 0 {
+			if machine {
+				_ = json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
+					"error":             "unknown subcommand",
+					"unknown":           args[0],
+					"valid_subcommands": subs,
+				})
+			}
+			return usageErr(fmt.Errorf("unknown subcommand %q for %q\nRun '%s --help' for available subcommands", args[0], cmd.CommandPath(), cmd.CommandPath()))
+		}
+		if machine {
 			_ = json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
 				"error":             "subcommand required",
 				"valid_subcommands": subs,

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 72
+    "total": 73
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -221,22 +221,47 @@ func boundCtx(parent context.Context, flags *rootFlags) (context.Context, contex
 	return context.WithTimeout(parent, flags.timeout)
 }
 
+// hasChangedLocalFlags checks Flag.Changed because Cobra's derived local flag
+// set does not populate the internal bookkeeping used by FlagSet.NFlag.
+func hasChangedLocalFlags(cmd *cobra.Command) bool {
+	changed := false
+	cmd.LocalNonPersistentFlags().VisitAll(func(flag *pflag.Flag) {
+		if flag.Changed {
+			changed = true
+		}
+	})
+	return changed
+}
+
 // parentNoSubcommandRunE returns a RunE that handles parents invoked without a
-// subcommand. In machine output (--json/--agent) the parent emits a structured
-// error to stdout listing valid subcommands and exits 2; otherwise cobra's
-// default help text is printed. Without this, agents driving the CLI in
-// --agent mode received only human-readable help on stdout and exit 0, with no
-// signal that the invocation was incomplete.
+// subcommand. A leftover positional means the user typed a token where a
+// subcommand was expected (a typo, an underscore instead of a hyphen, or a
+// bogus name); cobra routes it here because non-root parents don't reject
+// unknown subcommands. That case is a usage error in every output mode, so it
+// never masquerades as exit-0 help. A genuine bare parent invocation (no
+// leftover args) still emits a structured "subcommand required" error and exits
+// 2 in machine output (--json/--agent) but prints cobra's help for humans.
 func parentNoSubcommandRunE(flags *rootFlags) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		if flags != nil && flags.asJSON {
-			subs := make([]string, 0, len(cmd.Commands()))
-			for _, c := range cmd.Commands() {
-				if c.IsAvailableCommand() && c.Name() != "help" {
-					subs = append(subs, c.Name())
-				}
+		machine := flags != nil && flags.asJSON
+		subs := make([]string, 0, len(cmd.Commands()))
+		for _, c := range cmd.Commands() {
+			if c.IsAvailableCommand() && c.Name() != "help" {
+				subs = append(subs, c.Name())
 			}
-			sort.Strings(subs)
+		}
+		sort.Strings(subs)
+		if len(args) > 0 {
+			if machine {
+				_ = json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
+					"error":             "unknown subcommand",
+					"unknown":           args[0],
+					"valid_subcommands": subs,
+				})
+			}
+			return usageErr(fmt.Errorf("unknown subcommand %q for %q\nRun '%s --help' for available subcommands", args[0], cmd.CommandPath(), cmd.CommandPath()))
+		}
+		if machine {
 			_ = json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
 				"error":             "subcommand required",
 				"valid_subcommands": subs,

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
@@ -24,7 +24,19 @@ func newProjectsAvatarUploadProjectCmd(flags *rootFlags) *cobra.Command {
 		Annotations: map[string]string{"pp:endpoint": "avatar.upload-project", "pp:method": "PUT", "pp:path": "/projects/{projectId}/avatar"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return cmd.Help()
+				// A missing required positional is a usage error in every output
+				// mode (matches command_promoted.go.tmpl). Machine callers
+				// (--json/--agent) also get a JSON error envelope on stdout;
+				// usageErr sets exit 2.
+				if flags.asJSON {
+					if printErr := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+						"error": "missing required argument",
+						"usage": fmt.Sprintf("%s%s", cmd.CommandPath(), " <projectId>"),
+					}, flags); printErr != nil {
+						return printErr
+					}
+				}
+				return usageErr(fmt.Errorf("missing required argument\nUsage: %s%s", cmd.CommandPath(), " <projectId>"))
 			}
 			path := "/projects/{projectId}/avatar"
 			if len(args) < 1 || args[0] == "" {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
@@ -27,7 +27,19 @@ func newProjectsCreateCmd(flags *rootFlags) *cobra.Command {
 			// Bare invocation of a command with required input prints help
 			// instead of pflag's terse "required flag not set" error. Optional-
 			// only read commands fall through so a bare call still executes.
-			if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {
+			// Machine callers (--json/--agent, which sets asJSON) get a usage
+			// error + exit 2 instead of silent exit-0 help, so an incomplete
+			// invocation is never mistaken for success.
+			if !hasChangedLocalFlags(cmd) && len(args) == 0 && !flags.dryRun {
+				if flags.asJSON {
+					if printErr := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+						"error": "requires input",
+						"usage": cmd.CommandPath() + " --help",
+					}, flags); printErr != nil {
+						return printErr
+					}
+					return usageErr(fmt.Errorf("%q requires input; run %q for usage", cmd.CommandPath(), cmd.CommandPath()+" --help"))
+				}
 				return cmd.Help()
 			}
 			if !stdinBody {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
@@ -25,7 +25,19 @@ func newProjectsTasksListProjectCmd(flags *rootFlags) *cobra.Command {
 		Annotations: map[string]string{"pp:endpoint": "tasks.list-project", "pp:method": "GET", "pp:path": "/projects/{projectId}/tasks", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return cmd.Help()
+				// A missing required positional is a usage error in every output
+				// mode (matches command_promoted.go.tmpl). Machine callers
+				// (--json/--agent) also get a JSON error envelope on stdout;
+				// usageErr sets exit 2.
+				if flags.asJSON {
+					if printErr := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+						"error": "missing required argument",
+						"usage": fmt.Sprintf("%s%s", cmd.CommandPath(), " <projectId>"),
+					}, flags); printErr != nil {
+						return printErr
+					}
+				}
+				return usageErr(fmt.Errorf("missing required argument\nUsage: %s%s", cmd.CommandPath(), " <projectId>"))
 			}
 			if cmd.Flags().Changed("priority") {
 				allowedPriority := []string{"low", "normal", "high"}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
@@ -27,7 +27,19 @@ func newProjectsTasksUpdateProjectCmd(flags *rootFlags) *cobra.Command {
 		Annotations: map[string]string{"pp:endpoint": "tasks.update-project", "pp:method": "PATCH", "pp:path": "/projects/{projectId}/tasks/{taskId}"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return cmd.Help()
+				// A missing required positional is a usage error in every output
+				// mode (matches command_promoted.go.tmpl). Machine callers
+				// (--json/--agent) also get a JSON error envelope on stdout;
+				// usageErr sets exit 2.
+				if flags.asJSON {
+					if printErr := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+						"error": "missing required argument",
+						"usage": fmt.Sprintf("%s%s", cmd.CommandPath(), " <projectId> <taskId>"),
+					}, flags); printErr != nil {
+						return printErr
+					}
+				}
+				return usageErr(fmt.Errorf("missing required argument\nUsage: %s%s", cmd.CommandPath(), " <projectId> <taskId>"))
 			}
 			if !stdinBody {
 			}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
@@ -24,7 +24,19 @@ func newReportsExportReportYearCmd(flags *rootFlags) *cobra.Command {
 			// Bare invocation of a command with required input prints help
 			// instead of pflag's terse "required flag not set" error. Optional-
 			// only read commands fall through so a bare call still executes.
-			if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {
+			// Machine callers (--json/--agent, which sets asJSON) get a usage
+			// error + exit 2 instead of silent exit-0 help, so an incomplete
+			// invocation is never mistaken for success.
+			if !hasChangedLocalFlags(cmd) && len(args) == 0 && !flags.dryRun {
+				if flags.asJSON {
+					if printErr := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+						"error": "requires input",
+						"usage": cmd.CommandPath() + " --help",
+					}, flags); printErr != nil {
+						return printErr
+					}
+					return usageErr(fmt.Errorf("%q requires input; run %q for usage", cmd.CommandPath(), cmd.CommandPath()+" --help"))
+				}
 				return cmd.Help()
 			}
 			if !cmd.Flags().Changed("year") && !flags.dryRun {

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
@@ -27,7 +27,19 @@ func newStoresCreateCmd(flags *rootFlags) *cobra.Command {
 			// Bare invocation of a command with required input prints help
 			// instead of pflag's terse "required flag not set" error. Optional-
 			// only read commands fall through so a bare call still executes.
-			if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {
+			// Machine callers (--json/--agent, which sets asJSON) get a usage
+			// error + exit 2 instead of silent exit-0 help, so an incomplete
+			// invocation is never mistaken for success.
+			if !hasChangedLocalFlags(cmd) && len(args) == 0 && !flags.dryRun {
+				if flags.asJSON {
+					if printErr := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+						"error": "requires input",
+						"usage": cmd.CommandPath() + " --help",
+					}, flags); printErr != nil {
+						return printErr
+					}
+					return usageErr(fmt.Errorf("%q requires input; run %q for usage", cmd.CommandPath(), cmd.CommandPath()+" --help"))
+				}
 				return cmd.Help()
 			}
 			if !stdinBody {

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
@@ -26,7 +26,19 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 			// Bare invocation of a command with required input prints help
 			// instead of pflag's terse "required flag not set" error. Optional-
 			// only read commands fall through so a bare call still executes.
-			if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {
+			// Machine callers (--json/--agent, which sets asJSON) get a usage
+			// error + exit 2 instead of silent exit-0 help, so an incomplete
+			// invocation is never mistaken for success.
+			if !hasChangedLocalFlags(cmd) && len(args) == 0 && !flags.dryRun {
+				if flags.asJSON {
+					if printErr := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+						"error": "requires input",
+						"usage": cmd.CommandPath() + " --help",
+					}, flags); printErr != nil {
+						return printErr
+					}
+					return usageErr(fmt.Errorf("%q requires input; run %q for usage", cmd.CommandPath(), cmd.CommandPath()+" --help"))
+				}
 				return cmd.Help()
 			}
 			if !(cmd.Flags().Changed("address") || cmd.Flags().Changed("s")) && !flags.dryRun {


### PR DESCRIPTION
## Intent

Generated CLIs silently printed help and exited **0** when a leaf command was missing its required positional, or a parent group received an unknown/misspelled subcommand. Agents driving the CLI read those usage errors as binary bugs ("the positional won't bind") and misdiagnosed them.

Issue: Closes #2955, Closes #3632

## Approach

Three emission points, split by the kind of missing input so the deliberate #1289 "bare invocation prints help" UX is preserved for humans:

- **Unknown subcommand** (`parentNoSubcommandRunE` in `helpers.go.tmpl`): a leftover positional means a token was typed where a subcommand was expected. Cobra routes it to the parent's `RunE` because non-root parents don't reject unknown subcommands. It now returns `usageErr` (exit 2) in **every** output mode, with a JSON envelope (`unknown`, `valid_subcommands`) under `--json`/`--agent`. A genuine bare parent invocation (no leftover args) is unchanged: help + exit 0 for humans, structured error + exit 2 for machines.
- **Missing required positional** (`command_endpoint.go.tmpl`): now exits 2 in **every** mode with a JSON error envelope under `--json`/`--agent`, matching the existing `command_promoted.go.tmpl` positional guard (they were inconsistent — endpoint fell through to `cmd.Help()`).
- **Missing required flag/body** (`command_endpoint.go.tmpl` + `command_promoted.go.tmpl`): stays **machine-mode-only** — exit 2 under `--json`/`--agent`, help + exit 0 for humans — preserving #1289. `--agent` sets `asJSON`, so a single `flags.asJSON` check covers both machine modes.

## Scope

Primary area: generator templates (CLI/MCP exit-code contract).

Why this belongs in this repo: this is a machine change. Every printed CLI inherits the same silent exit-0-on-usage-error behavior from these shared templates; fixing one printed CLI would not compound. Verified against a freshly regenerated real-world CLI (the `plane` spec): `issues frobnicate`, `issues get_by_identifier VER 26`, and `issues get --json` went 0 → 2, while bare human `issues get` correctly stays 0 (it is a required-flag command → #1289 rule).

## Risk

- Changes an emitted **exit-code contract**: commands that previously exited 0 on missing/unknown input now exit 2 (except bare human invocation of required-flag/body commands, unchanged). Verifier interaction was considered: the runtime error-path probe passes a bogus positional (`len(args)==1`), so the `len(args)==0` guard does not disturb it; `endpointHasRequiredInput` is false for positional-only GETs.
- No change to auth, publish flow, scorer, or the MCP tool surface.
- `parentNoSubcommandRunE` already carried `pp:typed-exit-codes: "0,2"`; leaf endpoint commands exit 2 only on invocations the verifier does not perform (it uses happy-args).

## Output Contract

Emitted Go changes for `internal/cli/helpers.go` (`parentNoSubcommandRunE`) and endpoint/promoted command files that have a positional or required input. Files without those shapes (GET-list, promoted list) are byte-identical.

Generated-output evidence:
- Extended `TestGeneratedNestedHelpExitsZeroAndUsageErrorsExitTwo` (`internal/generator/help_exit_test.go`) — **compiles, builds, and execs a generated CLI**, asserting exit 2 + error text for missing positional (human and `--json`) and unknown subcommand (human and `--json`), and exit 0 for a bare parent. Made GOOS-safe (`.exe` suffix on Windows).
- `scripts/verify-generator-output.sh` — 10/10 emitted-code cases compile.
- `go test ./...` — no regressions (see Verification).

**Golden fixtures were NOT regenerated in this PR** and need a `scripts/golden.sh update` on Linux/CI. The development environment is Windows, where the golden harness's normalization emits CRLF and contaminates every fixture (an untouched `client.go` is byte-identical after stripping `\r`), so a Windows update would bake CRLF + platform drift into the fixtures. On Linux the diff is exactly `helpers.go` + positional/required-input command files. The `helpers.go` delta was hand-verified (CR-stripped) to equal the intended change.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:
- `go test ./...` — only environmental failures unrelated to this change (two Windows-specific `internal/pipeline/regenmerge` tests: Unix file-mode `0640` vs `0666`, and a `..`-path assertion on backslash paths — both reproduce identically in isolation and reference nothing this PR touches; one concurrency-starvation timeout in `internal/pipeline`).
- `go test ./internal/generator/ -run TestGeneratedNestedHelpExitsZeroAndUsageErrorsExitTwo` — PASS.
- `scripts/verify-generator-output.sh` — PASS (10 cases).
- Behavioral: generated + built a CLI from the `golden-api` fixture and from the real `plane` spec; confirmed the full exit-code matrix by hand.
- `scripts/golden.sh update` — **Not run** (Windows CRLF contamination; must run on Linux/CI, see Output Contract).

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
