### PR TITLE
fix(cli): avoid reserved store schema collisions

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -477,9 +477,8 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		// dead tables (created but never written to) leak in for resources whose
 		// names hit the framework-cobra rename. JSONOnlyFallback intentionally
 		// keeps a writable per-resource table while dropping extracted columns.
-		"emitsDomainTable": func(t TableDef) bool {
-			return (len(t.Columns) > 3 || t.JSONOnlyFallback) && t.Name != "sync_state" && domainUpsertMethodName(t.Name) != "UpsertBatch"
-		},
+		"emitsDomainTable":           emitsDomainTable,
+		"reconcileTypedTableEntries": reconcileTypedTableEntries,
 		"pathContainsParam": func(path, name string) bool {
 			return strings.Contains(path, "{"+name+"}")
 		},
@@ -3716,6 +3715,10 @@ func (g *Generator) renderVisionAndRootFiles(promotedCommands []PromotedCommand,
 // user-visible API.
 func (g *Generator) schemaWithDependentParents() []TableDef {
 	schema := BuildSchema(g.Spec)
+	// BuildSchema always appends the framework sync_state definition after API
+	// domain tables. Dependent enrichment and reserved-name routing apply only
+	// to the domain portion, including an API resource also named sync_state.
+	domainSchema := schema[:len(schema)-1]
 
 	// Add parent_id column to tables for dependent (parent-child) sync resources
 	if g.profile != nil {
@@ -3723,7 +3726,7 @@ func (g *Generator) schemaWithDependentParents() []TableDef {
 		for _, dep := range g.profile.DependentSyncResources {
 			depSet[dep.Name] = true
 		}
-		for i, table := range schema {
+		for i, table := range domainSchema {
 			if depSet[table.Name] {
 				if table.JSONOnlyFallback {
 					continue
@@ -3765,7 +3768,7 @@ func (g *Generator) schemaWithDependentParents() []TableDef {
 
 	// Reapply after dependent enrichment so parent_id cannot restore a reserved
 	// domain table routed through generic storage by BuildSchema.
-	routeReservedStoreTablesToGenericOnly(schema, reservedStoreObjectNames(g.Spec))
+	routeReservedStoreTablesToGenericOnly(domainSchema, reservedStoreObjectNames(g.Spec))
 
 	return schema
 }
@@ -5191,6 +5194,47 @@ func toPascal(s string) string {
 
 func domainUpsertMethodName(tableName string) string {
 	return "Upsert" + toPascal(tableName)
+}
+
+func emitsDomainTable(t TableDef) bool {
+	return (len(t.Columns) > 3 || t.JSONOnlyFallback) && t.Name != "sync_state" && domainUpsertMethodName(t.Name) != "UpsertBatch"
+}
+
+type reconcileTypedTableEntry struct {
+	Resource string
+	Table    string
+}
+
+func reconcileTypedTableEntries(tables []TableDef) []reconcileTypedTableEntry {
+	byResource := make(map[string]string)
+	ambiguous := make(map[string]struct{})
+	for _, table := range tables {
+		if !emitsDomainTable(table) {
+			continue
+		}
+		resource := strings.ToLower(table.Resource)
+		if _, skip := ambiguous[resource]; skip {
+			continue
+		}
+		if existing, ok := byResource[resource]; ok && existing != table.Name {
+			delete(byResource, resource)
+			ambiguous[resource] = struct{}{}
+			continue
+		}
+		byResource[resource] = table.Name
+	}
+
+	resources := make([]string, 0, len(byResource))
+	for resource := range byResource {
+		resources = append(resources, resource)
+	}
+	sort.Strings(resources)
+
+	entries := make([]reconcileTypedTableEntry, 0, len(resources))
+	for _, resource := range resources {
+		entries = append(entries, reconcileTypedTableEntry{Resource: resource, Table: byResource[resource]})
+	}
+	return entries
 }
 
 // isIDParam returns true if the parameter name suggests it's an identifier

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3763,6 +3763,10 @@ func (g *Generator) schemaWithDependentParents() []TableDef {
 		}
 	}
 
+	// Reapply after dependent enrichment so parent_id cannot restore a reserved
+	// domain table routed through generic storage by BuildSchema.
+	routeReservedStoreTablesToGenericOnly(schema, reservedStoreObjectNames(g.Spec))
+
 	return schema
 }
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -12411,7 +12411,7 @@ func TestGenerateReservedStoreTableCollisionUsesGenericStore(t *testing.T) {
 		{Name: "created_at", Type: "string", Format: "date-time"},
 	}
 	apiSpec := &spec.APISpec{
-		Name:    "store-collision",
+		Name:    "CollisionAPI",
 		Version: "0.1.0",
 		BaseURL: "https://api.example.com",
 		Auth:    spec.AuthConfig{Type: "none"},
@@ -12420,23 +12420,52 @@ func TestGenerateReservedStoreTableCollisionUsesGenericStore(t *testing.T) {
 			Path:   "~/.config/store-collision-pp-cli/config.toml",
 		},
 		Resources: map[string]spec.Resource{
-			"resources":          resource("/resources", "Resource"),
-			"bookings":           resource("/bookings", "Booking"),
-			"idx_resources_type": resource("/indexed-resources", "IndexedResource"),
+			"resources":                     resource("/resources", "Resource"),
+			"sync_state":                    resource("/sync-state", "SyncState"),
+			"bookings":                      resource("/bookings", "Booking"),
+			"Reports":                       resource("/reports", "Report"),
+			"reportData":                    resource("/report-data", "ReportData"),
+			"reportdata":                    resource("/reportdata", "Reportdata"),
+			"idx_resources_type":            resource("/indexed-resources", "IndexedResource"),
+			"search_learnings":              resource("/search-learnings", "SearchLearning"),
+			"collision_a_p_i_stream_frames": resource("/stream-frames", "StreamFrame"),
 		},
 		Types: map[string]spec.TypeDef{
 			"Resource":        {Fields: fields},
+			"SyncState":       {Fields: fields},
 			"Booking":         {Fields: fields},
+			"Report":          {Fields: fields},
+			"ReportData":      {Fields: fields},
+			"Reportdata":      {Fields: fields},
 			"IndexedResource": {Fields: fields},
+			"SearchLearning":  {Fields: fields},
+			"StreamFrame":     {Fields: fields},
 		},
 	}
+	apiSpec.Learn.Disabled = true
+	resources := apiSpec.Resources["resources"]
+	resourcesList := resources.Endpoints["list"]
+	resourcesList.Path = "/accounts/{accountId}/resources"
+	resourcesList.Params = []spec.Param{{Name: "accountId", Type: "string", Required: true, Positional: true}}
+	resources.Endpoints["list"] = resourcesList
+	apiSpec.Resources["resources"] = resources
+	syncStateResource := apiSpec.Resources["sync_state"]
+	syncStateList := syncStateResource.Endpoints["list"]
+	syncStateList.Path = "/accounts/{accountId}/sync-state"
+	syncStateList.Params = []spec.Param{{Name: "accountId", Type: "string", Required: true, Positional: true}}
+	syncStateResource.Endpoints["list"] = syncStateList
+	apiSpec.Resources["sync_state"] = syncStateResource
 
 	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
 	gen := New(apiSpec, outputDir)
-	gen.VisionSet = VisionTemplateSet{Store: true, MCP: true}
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, MCP: true}
 	gen.profile = &profiler.APIProfile{
+		SyncableResources: []profiler.SyncableResource{
+			{Name: "idx_resources_type", Path: "/indexed-resources", Method: "GET", ReconcileMode: "flat", TenantScopeColumn: "account_id"},
+		},
 		DependentSyncResources: []profiler.DependentResource{
-			{Name: "resources", ParentResource: "accounts", ParentIDParam: "accountId", Path: "/accounts/{accountId}/resources", Method: "GET"},
+			{Name: "resources", ParentResource: "accounts", ParentIDParam: "accountId", Path: "/accounts/{accountId}/resources", Method: "GET", ReconcileMode: "per_parent"},
+			{Name: "sync_state", ParentResource: "accounts", ParentIDParam: "accountId", Path: "/accounts/{accountId}/sync-state", Method: "GET", ReconcileMode: "per_parent"},
 		},
 	}
 	require.NoError(t, gen.Generate())
@@ -12447,12 +12476,24 @@ func TestGenerateReservedStoreTableCollisionUsesGenericStore(t *testing.T) {
 	assert.NotContains(t, store, `CREATE TRIGGER IF NOT EXISTS "resources_ai"`)
 	assert.NotContains(t, store, "func (s *Store) upsertResourcesTx(")
 	assert.NotContains(t, store, "func (s *Store) SearchResources(")
-	assert.Contains(t, store, `"resources": "parent_id"`)
+	assert.NotContains(t, store, "func (s *Store) upsertSearchLearningsTx(",
+		"learn table names must stay reserved while learn is disabled")
+	assert.NotContains(t, store, "func (s *Store) upsertCollisionAPIStreamFramesTx(",
+		"stream table names must stay reserved while streaming is disabled")
+	assert.Regexp(t, `"resources":\s+"parent_id"`, store)
 	assert.NotContains(t, store, `CREATE TABLE IF NOT EXISTS "resources" (
 		id TEXT PRIMARY KEY,
 		data TEXT NOT NULL,
 		synced_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 		parent_id TEXT`, "dependent-resource enrichment must not restore the reserved domain table")
+
+	syncSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	syncContent := string(syncSrc)
+	assert.Contains(t, syncContent, `seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),`,
+		"flat reconcile must resolve its typed deletion target from the generated schema")
+	assert.Contains(t, syncContent, `seenIDs, reconcileTypedTable(dep.Name), store.CascadeJunctionsFor(dep.Name),`,
+		"dependent reconcile must resolve its typed deletion target from the generated schema")
 
 	runtimeTest := `package store
 
@@ -12473,6 +12514,8 @@ func TestReservedResourceNameDoesNotBreakStoreWrites(t *testing.T) {
 	resourceB := json.RawMessage(` + "`" + `{"id":"resource-1","parent_id":"account-2","name":"Meeting room","notes":"Window floor"}` + "`" + `)
 	booking := json.RawMessage(` + "`" + `{"id":"booking-1","name":"Planning session","notes":"Meeting room"}` + "`" + `)
 	indexed := json.RawMessage(` + "`" + `{"id":"indexed-1","name":"Indexed room","notes":"Meeting room"}` + "`" + `)
+	learning := json.RawMessage(` + "`" + `{"id":"learning-1","name":"Learned room","notes":"Meeting room"}` + "`" + `)
+	frame := json.RawMessage(` + "`" + `{"id":"frame-1","name":"Streamed room","notes":"Meeting room"}` + "`" + `)
 	if stored, failed, err := s.UpsertBatch("resources", []json.RawMessage{resourceA, resourceB}); err != nil {
 		t.Fatalf("upsert resources: %v", err)
 	} else if stored != 2 || failed != 0 {
@@ -12488,9 +12531,26 @@ func TestReservedResourceNameDoesNotBreakStoreWrites(t *testing.T) {
 	} else if stored != 1 || failed != 0 {
 		t.Fatalf("upsert indexed resources stored=%d failed=%d, want 1,0", stored, failed)
 	}
+	if stored, failed, err := s.UpsertBatch("search_learnings", []json.RawMessage{learning}); err != nil {
+		t.Fatalf("upsert search learnings: %v", err)
+	} else if stored != 1 || failed != 0 {
+		t.Fatalf("upsert search learnings stored=%d failed=%d, want 1,0", stored, failed)
+	}
+	if stored, failed, err := s.UpsertBatch("collision_a_p_i_stream_frames", []json.RawMessage{frame}); err != nil {
+		t.Fatalf("upsert stream frames: %v", err)
+	} else if stored != 1 || failed != 0 {
+		t.Fatalf("upsert stream frames stored=%d failed=%d, want 1,0", stored, failed)
+	}
 
-	wantRows := map[string]int{"resources": 2, "bookings": 1, "idx_resources_type": 1}
-	for _, resourceType := range []string{"resources", "bookings", "idx_resources_type"} {
+	wantRows := map[string]int{
+		"resources": 2, "bookings": 1, "idx_resources_type": 1,
+		"search_learnings": 1, "collision_a_p_i_stream_frames": 1,
+	}
+	resourceTypes := []string{
+		"resources", "bookings", "idx_resources_type",
+		"search_learnings", "collision_a_p_i_stream_frames",
+	}
+	for _, resourceType := range resourceTypes {
 		rows, err := s.List(resourceType, 10)
 		if err != nil {
 			t.Fatalf("list %s: %v", resourceType, err)
@@ -12500,7 +12560,7 @@ func TestReservedResourceNameDoesNotBreakStoreWrites(t *testing.T) {
 		}
 	}
 
-	for _, resourceType := range []string{"resources", "bookings", "idx_resources_type"} {
+	for _, resourceType := range resourceTypes {
 		hits, err := s.Search("Meeting room", 10, resourceType)
 		if err != nil {
 			t.Fatalf("search %s: %v", resourceType, err)
@@ -12513,8 +12573,73 @@ func TestReservedResourceNameDoesNotBreakStoreWrites(t *testing.T) {
 `
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "store", "reserved_table_collision_test.go"), []byte(runtimeTest), 0o644))
 
+	reconcileRuntimeTest := `package cli
+
+import "testing"
+
+func TestReservedReconcileUsesGenericOnlyStorage(t *testing.T) {
+	for _, resource := range []string{"resources", "idx_resources_type", "search_learnings", "collision_a_p_i_stream_frames"} {
+		if got := reconcileTypedTable(resource); got != "" {
+			t.Fatalf("reconcileTypedTable(%q) = %q, want empty generic-only target", resource, got)
+		}
+	}
+	if got := reconcileTypedTable("bookings"); got != "bookings" {
+		t.Fatalf("reconcileTypedTable(bookings) = %q, want bookings", got)
+	}
+	if got := reconcileTypedTable("reports"); got != "reports" {
+		t.Fatalf("reconcileTypedTable(reports) = %q, want reports", got)
+	}
+	if got := reconcileTypedTable("reportdata"); got != "" {
+		t.Fatalf("reconcileTypedTable(reportdata) = %q, want empty ambiguous target", got)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "reserved_reconcile_collision_test.go"), []byte(reconcileRuntimeTest), 0o644))
+
 	requireGeneratedCompiles(t, outputDir)
 	runGoCommandRequired(t, outputDir, "test", "./internal/store", "-run", "TestReservedResourceNameDoesNotBreakStoreWrites", "-count=1")
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "TestReservedReconcileUsesGenericOnlyStorage", "-count=1")
+}
+
+func TestSchemaWithDependentParentsPreservesFrameworkSyncState(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("dependent-framework-schema")
+	apiSpec.Resources = map[string]spec.Resource{
+		"sync_state": {
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:   "GET",
+					Path:     "/accounts/{accountId}/resources",
+					Response: spec.ResponseDef{Type: "array"},
+				},
+			},
+		},
+	}
+	gen := New(apiSpec, t.TempDir())
+	gen.profile = &profiler.APIProfile{
+		DependentSyncResources: []profiler.DependentResource{{Name: "sync_state"}},
+	}
+
+	schema := gen.schemaWithDependentParents()
+	require.Len(t, schema, 2, "domain and framework sync_state definitions must remain distinct")
+	domainSyncState := schema[0]
+	assert.Equal(t, "sync_state", domainSyncState.Name)
+	assert.Equal(t, baseTableColumns, domainSyncState.Columns,
+		"colliding dependent API resource must remain generic-only after parent enrichment")
+	assert.Equal(t, "parent_id", domainSyncState.ParentKeyColumn,
+		"generic dependent resource must retain its parent identity mapping")
+
+	frameworkSyncState := schema[1]
+	assert.Equal(t, "sync_state", frameworkSyncState.Name)
+	assert.Equal(t, []ColumnDef{
+		{Name: "resource_type", Type: "TEXT", PrimaryKey: true},
+		{Name: "last_cursor", Type: "TEXT"},
+		{Name: "last_synced_at", Type: "DATETIME"},
+		{Name: "total_count", Type: "INTEGER DEFAULT 0"},
+	}, frameworkSyncState.Columns, "framework sync_state must keep its cursor/state schema")
+	assert.Empty(t, frameworkSyncState.ParentKeyColumn,
+		"framework sync_state must not be enriched as a dependent API table")
 }
 
 func TestGeneratedSyncTreatsAccessDeniedAsWarning(t *testing.T) {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -12389,6 +12389,134 @@ func TestGenerateReservedWordResourceTableNamesCompileAndMigrate(t *testing.T) {
 	runGoCommand(t, outputDir, "test", "./internal/store")
 }
 
+func TestGenerateReservedStoreTableCollisionUsesGenericStore(t *testing.T) {
+	t.Parallel()
+
+	resource := func(path, item string) spec.Resource {
+		return spec.Resource{
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        path,
+					Description: "List items",
+					Response:    spec.ResponseDef{Type: "array", Item: item},
+				},
+			},
+		}
+	}
+	fields := []spec.TypeField{
+		{Name: "id", Type: "string"},
+		{Name: "name", Type: "string"},
+		{Name: "notes", Type: "string"},
+		{Name: "created_at", Type: "string", Format: "date-time"},
+	}
+	apiSpec := &spec.APISpec{
+		Name:    "store-collision",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/store-collision-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"resources":          resource("/resources", "Resource"),
+			"bookings":           resource("/bookings", "Booking"),
+			"idx_resources_type": resource("/indexed-resources", "IndexedResource"),
+		},
+		Types: map[string]spec.TypeDef{
+			"Resource":        {Fields: fields},
+			"Booking":         {Fields: fields},
+			"IndexedResource": {Fields: fields},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, MCP: true}
+	gen.profile = &profiler.APIProfile{
+		DependentSyncResources: []profiler.DependentResource{
+			{Name: "resources", ParentResource: "accounts", ParentIDParam: "accountId", Path: "/accounts/{accountId}/resources", Method: "GET"},
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	storeSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	store := string(storeSrc)
+	assert.NotContains(t, store, `CREATE TRIGGER IF NOT EXISTS "resources_ai"`)
+	assert.NotContains(t, store, "func (s *Store) upsertResourcesTx(")
+	assert.NotContains(t, store, "func (s *Store) SearchResources(")
+	assert.Contains(t, store, `"resources": "parent_id"`)
+	assert.NotContains(t, store, `CREATE TABLE IF NOT EXISTS "resources" (
+		id TEXT PRIMARY KEY,
+		data TEXT NOT NULL,
+		synced_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		parent_id TEXT`, "dependent-resource enrichment must not restore the reserved domain table")
+
+	runtimeTest := `package store
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+func TestReservedResourceNameDoesNotBreakStoreWrites(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	resourceA := json.RawMessage(` + "`" + `{"id":"resource-1","parent_id":"account-1","name":"Meeting room","notes":"Quiet floor"}` + "`" + `)
+	resourceB := json.RawMessage(` + "`" + `{"id":"resource-1","parent_id":"account-2","name":"Meeting room","notes":"Window floor"}` + "`" + `)
+	booking := json.RawMessage(` + "`" + `{"id":"booking-1","name":"Planning session","notes":"Meeting room"}` + "`" + `)
+	indexed := json.RawMessage(` + "`" + `{"id":"indexed-1","name":"Indexed room","notes":"Meeting room"}` + "`" + `)
+	if stored, failed, err := s.UpsertBatch("resources", []json.RawMessage{resourceA, resourceB}); err != nil {
+		t.Fatalf("upsert resources: %v", err)
+	} else if stored != 2 || failed != 0 {
+		t.Fatalf("upsert resources stored=%d failed=%d, want 2,0", stored, failed)
+	}
+	if stored, failed, err := s.UpsertBatch("bookings", []json.RawMessage{booking}); err != nil {
+		t.Fatalf("upsert bookings: %v", err)
+	} else if stored != 1 || failed != 0 {
+		t.Fatalf("upsert bookings stored=%d failed=%d, want 1,0", stored, failed)
+	}
+	if stored, failed, err := s.UpsertBatch("idx_resources_type", []json.RawMessage{indexed}); err != nil {
+		t.Fatalf("upsert indexed resources: %v", err)
+	} else if stored != 1 || failed != 0 {
+		t.Fatalf("upsert indexed resources stored=%d failed=%d, want 1,0", stored, failed)
+	}
+
+	wantRows := map[string]int{"resources": 2, "bookings": 1, "idx_resources_type": 1}
+	for _, resourceType := range []string{"resources", "bookings", "idx_resources_type"} {
+		rows, err := s.List(resourceType, 10)
+		if err != nil {
+			t.Fatalf("list %s: %v", resourceType, err)
+		}
+		if len(rows) != wantRows[resourceType] {
+			t.Fatalf("list %s returned %d rows, want %d", resourceType, len(rows), wantRows[resourceType])
+		}
+	}
+
+	for _, resourceType := range []string{"resources", "bookings", "idx_resources_type"} {
+		hits, err := s.Search("Meeting room", 10, resourceType)
+		if err != nil {
+			t.Fatalf("search %s: %v", resourceType, err)
+		}
+		if len(hits) != wantRows[resourceType] {
+			t.Fatalf("search %s returned %d rows, want %d", resourceType, len(hits), wantRows[resourceType])
+		}
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "store", "reserved_table_collision_test.go"), []byte(runtimeTest), 0o644))
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommandRequired(t, outputDir, "test", "./internal/store", "-run", "TestReservedResourceNameDoesNotBreakStoreWrites", "-count=1")
+}
+
 func TestGeneratedSyncTreatsAccessDeniedAsWarning(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/schema_builder.go
+++ b/internal/generator/schema_builder.go
@@ -243,22 +243,18 @@ func reservedStoreObjectNames(s *spec.APISpec) map[string]struct{} {
 	for name := range frameworkStoreObjectNames {
 		names[name] = struct{}{}
 	}
-	if s.Learn.Enabled {
-		for name := range learnStoreObjectNames {
-			names[name] = struct{}{}
-		}
+	for name := range learnStoreObjectNames {
+		names[name] = struct{}{}
 	}
-	if s.Streaming.Enabled() {
-		prefix := naming.Snake(s.Name)
-		for _, suffix := range []string{
-			"_stream_frames",
-			"_stream_metadata",
-			"_rebase_log",
-			"_stream_metadata_status",
-			"_rebase_log_created",
-		} {
-			names[prefix+suffix] = struct{}{}
-		}
+	prefix := naming.Snake(s.Name)
+	for _, suffix := range []string{
+		"_stream_frames",
+		"_stream_metadata",
+		"_rebase_log",
+		"_stream_metadata_status",
+		"_rebase_log_created",
+	} {
+		names[prefix+suffix] = struct{}{}
 	}
 	return names
 }

--- a/internal/generator/schema_builder.go
+++ b/internal/generator/schema_builder.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 )
 
@@ -54,6 +55,45 @@ var baseTableColumns = []ColumnDef{
 // SQLite defaults to SQLITE_MAX_COLUMN=2000. Keep typed domain tables below
 // that hard limit with room for generator-added columns and future schema drift.
 const maxStoreDomainTableColumns = 1500
+
+// frameworkStoreObjectNames owns SQLite schema names that domain projections
+// must not reuse. A collision is routed through the generic resources table so
+// the API resource remains syncable without colliding with framework tables or
+// indexes.
+var frameworkStoreObjectNames = map[string]struct{}{
+	"resources":             {},
+	"resources_fts":         {},
+	"resources_fts_data":    {},
+	"resources_fts_idx":     {},
+	"resources_fts_content": {},
+	"resources_fts_docsize": {},
+	"resources_fts_config":  {},
+	"resources_v2":          {},
+	"sync_state":            {},
+	"idx_resources_type":    {},
+	"idx_resources_synced":  {},
+}
+
+var learnStoreObjectNames = map[string]struct{}{
+	"search_learnings":               {},
+	"entity_lookups":                 {},
+	"search_patterns":                {},
+	"learning_playbooks":             {},
+	"learn_candidates":               {},
+	"learn_events":                   {},
+	"learn_recall_misses":            {},
+	"idx_learn_query":                {},
+	"idx_learn_unique":               {},
+	"idx_entity_lookup_canonical":    {},
+	"idx_entity_lookup_kind":         {},
+	"idx_patterns_query_template":    {},
+	"idx_patterns_unique":            {},
+	"idx_playbooks_source":           {},
+	"idx_playbooks_last_observed_at": {},
+	"idx_learn_candidates_status":    {},
+	"idx_learn_candidates_family":    {},
+	"idx_learn_events_event_ts":      {},
+}
 
 // BuildSchema generates domain-specific table definitions from the API spec.
 // High-gravity entities (many endpoints, text fields, temporal fields) get
@@ -182,6 +222,7 @@ func BuildSchema(s *spec.APISpec) []TableDef {
 		}
 	}
 	tables = deduped
+	routeReservedStoreTablesToGenericOnly(tables, reservedStoreObjectNames(s))
 
 	tables = append(tables, TableDef{
 		Name:     "sync_state",
@@ -195,6 +236,46 @@ func BuildSchema(s *spec.APISpec) []TableDef {
 	})
 
 	return tables
+}
+
+func reservedStoreObjectNames(s *spec.APISpec) map[string]struct{} {
+	names := make(map[string]struct{}, len(frameworkStoreObjectNames)+len(learnStoreObjectNames)+5)
+	for name := range frameworkStoreObjectNames {
+		names[name] = struct{}{}
+	}
+	if s.Learn.Enabled {
+		for name := range learnStoreObjectNames {
+			names[name] = struct{}{}
+		}
+	}
+	if s.Streaming.Enabled() {
+		prefix := naming.Snake(s.Name)
+		for _, suffix := range []string{
+			"_stream_frames",
+			"_stream_metadata",
+			"_rebase_log",
+			"_stream_metadata_status",
+			"_rebase_log_created",
+		} {
+			names[prefix+suffix] = struct{}{}
+		}
+	}
+	return names
+}
+
+func routeReservedStoreTablesToGenericOnly(tables []TableDef, reserved map[string]struct{}) {
+	for i := range tables {
+		if _, collision := reserved[tables[i].Name]; !collision {
+			continue
+		}
+		tables[i].Columns = append([]ColumnDef(nil), baseTableColumns...)
+		tables[i].Indexes = nil
+		tables[i].FTS5 = false
+		tables[i].FTS5Fields = nil
+		tables[i].FTS5Triggers = false
+		tables[i].JSONOnlyFallback = false
+		tables[i].OriginalColumnCount = 0
+	}
 }
 
 // computeDataGravity scores 0-12 based on endpoint count, response field

--- a/internal/generator/schema_builder_test.go
+++ b/internal/generator/schema_builder_test.go
@@ -65,18 +65,18 @@ func TestBuildSchemaRoutesReservedStoreTablesToGenericOnly(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		resource   string
-		streaming  bool
-		learn      bool
-		wantDomain bool
+		name      string
+		resource  string
+		streaming bool
+		learn     bool
 	}{
 		{name: "generic resources table", resource: "resources"},
 		{name: "fts shadow table", resource: "resources_fts_data"},
 		{name: "lazy learn table", resource: "learn_recall_misses", learn: true},
-		{name: "disabled learn table", resource: "search_learnings", wantDomain: true},
+		{name: "disabled learn table remains reserved", resource: "search_learnings"},
 		{name: "framework index", resource: "idx_resources_type"},
 		{name: "stream frames table", resource: "collision_a_p_i_stream_frames", streaming: true},
+		{name: "disabled stream table remains reserved", resource: "collision_a_p_i_stream_frames"},
 		{name: "stream metadata table", resource: "collision_a_p_i_stream_metadata", streaming: true},
 		{name: "stream rebase table", resource: "collision_a_p_i_rebase_log", streaming: true},
 		{name: "stream metadata index", resource: "collision_a_p_i_stream_metadata_status", streaming: true},
@@ -116,10 +116,6 @@ func TestBuildSchemaRoutesReservedStoreTablesToGenericOnly(t *testing.T) {
 
 			table := findTable(BuildSchema(apiSpec), tt.resource)
 			if !assert.NotNil(t, table) {
-				return
-			}
-			if tt.wantDomain {
-				assert.Greater(t, len(table.Columns), len(baseTableColumns))
 				return
 			}
 			assert.Equal(t, baseTableColumns, table.Columns)

--- a/internal/generator/schema_builder_test.go
+++ b/internal/generator/schema_builder_test.go
@@ -61,6 +61,76 @@ func TestSafeSQLNameAlwaysQuotes(t *testing.T) {
 	}
 }
 
+func TestBuildSchemaRoutesReservedStoreTablesToGenericOnly(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		resource   string
+		streaming  bool
+		learn      bool
+		wantDomain bool
+	}{
+		{name: "generic resources table", resource: "resources"},
+		{name: "fts shadow table", resource: "resources_fts_data"},
+		{name: "lazy learn table", resource: "learn_recall_misses", learn: true},
+		{name: "disabled learn table", resource: "search_learnings", wantDomain: true},
+		{name: "framework index", resource: "idx_resources_type"},
+		{name: "stream frames table", resource: "collision_a_p_i_stream_frames", streaming: true},
+		{name: "stream metadata table", resource: "collision_a_p_i_stream_metadata", streaming: true},
+		{name: "stream rebase table", resource: "collision_a_p_i_rebase_log", streaming: true},
+		{name: "stream metadata index", resource: "collision_a_p_i_stream_metadata_status", streaming: true},
+		{name: "stream rebase index", resource: "collision_a_p_i_rebase_log_created", streaming: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apiSpec := &spec.APISpec{
+				Name: "CollisionAPI",
+				Resources: map[string]spec.Resource{
+					tt.resource: {
+						Endpoints: map[string]spec.Endpoint{
+							"list": {
+								Method:   "GET",
+								Path:     "/items",
+								Response: spec.ResponseDef{Type: "array", Item: "Resource"},
+							},
+						},
+					},
+				},
+				Types: map[string]spec.TypeDef{
+					"Resource": {
+						Fields: []spec.TypeField{
+							{Name: "id", Type: "string"},
+							{Name: "name", Type: "string"},
+							{Name: "notes", Type: "string"},
+							{Name: "created_at", Type: "string", Format: "date-time"},
+						},
+					},
+				},
+			}
+			if tt.streaming {
+				apiSpec.Streaming = spec.StreamingConfig{Transport: "websocket"}
+			}
+			apiSpec.Learn.Enabled = tt.learn
+
+			table := findTable(BuildSchema(apiSpec), tt.resource)
+			if !assert.NotNil(t, table) {
+				return
+			}
+			if tt.wantDomain {
+				assert.Greater(t, len(table.Columns), len(baseTableColumns))
+				return
+			}
+			assert.Equal(t, baseTableColumns, table.Columns)
+			assert.Empty(t, table.Indexes)
+			assert.False(t, table.FTS5)
+			assert.Empty(t, table.FTS5Fields)
+			assert.False(t, table.FTS5Triggers)
+		})
+	}
+}
+
 func TestCollectTextFieldNames(t *testing.T) {
 	// Fields like tag/label/category/metadata should be picked up for FTS5
 	// alongside the core text fields. Motivated by the ESPN retro where

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1457,7 +1457,7 @@ var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", 
 // child's bare id and silently keep only the last synced parent.
 var resourceParentKeyColumns = map[string]string{
 {{- range .Tables}}
-{{- if and (emitsDomainTable .) .ParentKeyColumn}}
+{{- if .ParentKeyColumn}}
 	{{printf "%q" .Resource}}: {{printf "%q" .ParentKeyColumn}},
 {{- end}}
 {{- end}}

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1168,7 +1168,7 @@ func syncResource(ctx context.Context, c interface {
 		} else if outcome.complete {
 			deleted, rerr := db.ReconcilePartition(
 				resource, "$."+def.BodyField, tenantUUID,
-				seenIDs, resource, store.CascadeJunctionsFor(resource),
+				seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
 			)
 			if rerr != nil {
 				fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", resource, tenantUUID, rerr.Error())
@@ -3272,7 +3272,7 @@ func syncOneParent(
 	if prune && outcome.complete && dep.ReconcileMode == "per_parent" {
 		deleted, rerr := db.ReconcilePartition(
 			dep.Name, dep.GenericScopeJSONPath, outcome.scopeVal,
-			seenIDs, dep.Name, store.CascadeJunctionsFor(dep.Name),
+			seenIDs, reconcileTypedTable(dep.Name), store.CascadeJunctionsFor(dep.Name),
 		)
 		if rerr != nil {
 			fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", dep.Name, outcome.scopeVal, rerr.Error())
@@ -3650,6 +3650,19 @@ var flatReconcileDefs = map[string]flatReconcileDefT{
 // value when absent; the call site only reaches it for flatReconcilable resources).
 func flatReconcileDef(resource string) flatReconcileDefT {
 	return flatReconcileDefs[resource]
+}
+
+// reconcileTypedTables maps runtime resource keys to typed tables that are
+// actually emitted. Generic-only resources are absent and resolve to "" so
+// ReconcilePartition deletes only from the shared resources table.
+var reconcileTypedTables = map[string]string{
+{{- range reconcileTypedTableEntries .Tables}}
+	{{printf "%q" .Resource}}: {{printf "%q" .Table}},
+{{- end}}
+}
+
+func reconcileTypedTable(resource string) string {
+	return reconcileTypedTables[resource]
 }
 
 // resolveTenantID returns the active tenant's stable ID for tenant-scoped

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -828,7 +828,7 @@ func syncResource(ctx context.Context, c interface {
 		} else if outcome.complete {
 			deleted, rerr := db.ReconcilePartition(
 				resource, "$."+def.BodyField, tenantUUID,
-				seenIDs, resource, store.CascadeJunctionsFor(resource),
+				seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
 			)
 			if rerr != nil {
 				fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", resource, tenantUUID, rerr.Error())
@@ -2205,7 +2205,7 @@ func syncOneParent(
 	if prune && outcome.complete && dep.ReconcileMode == "per_parent" {
 		deleted, rerr := db.ReconcilePartition(
 			dep.Name, dep.GenericScopeJSONPath, outcome.scopeVal,
-			seenIDs, dep.Name, store.CascadeJunctionsFor(dep.Name),
+			seenIDs, reconcileTypedTable(dep.Name), store.CascadeJunctionsFor(dep.Name),
 		)
 		if rerr != nil {
 			fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", dep.Name, outcome.scopeVal, rerr.Error())
@@ -2544,6 +2544,21 @@ var flatReconcileDefs = map[string]flatReconcileDefT{}
 // value when absent; the call site only reaches it for flatReconcilable resources).
 func flatReconcileDef(resource string) flatReconcileDefT {
 	return flatReconcileDefs[resource]
+}
+
+// reconcileTypedTables maps runtime resource keys to typed tables that are
+// actually emitted. Generic-only resources are absent and resolve to "" so
+// ReconcilePartition deletes only from the shared resources table.
+var reconcileTypedTables = map[string]string{
+	"avatar":   "avatar",
+	"export":   "export",
+	"projects": "projects",
+	"summary":  "summary",
+	"tasks":    "tasks",
+}
+
+func reconcileTypedTable(resource string) string {
+	return reconcileTypedTables[resource]
 }
 
 // resolveTenantID returns the active tenant's stable ID for tenant-scoped

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -848,7 +848,7 @@ func syncResource(ctx context.Context, c interface {
 		} else if outcome.complete {
 			deleted, rerr := db.ReconcilePartition(
 				resource, "$."+def.BodyField, tenantUUID,
-				seenIDs, resource, store.CascadeJunctionsFor(resource),
+				seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
 			)
 			if rerr != nil {
 				fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", resource, tenantUUID, rerr.Error())
@@ -1879,6 +1879,18 @@ var flatReconcileDefs = map[string]flatReconcileDefT{}
 // value when absent; the call site only reaches it for flatReconcilable resources).
 func flatReconcileDef(resource string) flatReconcileDefT {
 	return flatReconcileDefs[resource]
+}
+
+// reconcileTypedTables maps runtime resource keys to typed tables that are
+// actually emitted. Generic-only resources are absent and resolve to "" so
+// ReconcilePartition deletes only from the shared resources table.
+var reconcileTypedTables = map[string]string{
+	"gadgets": "gadgets",
+	"widgets": "widgets",
+}
+
+func reconcileTypedTable(resource string) string {
+	return reconcileTypedTables[resource]
 }
 
 // resolveTenantID returns the active tenant's stable ID for tenant-scoped

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -828,7 +828,7 @@ func syncResource(ctx context.Context, c interface {
 		} else if outcome.complete {
 			deleted, rerr := db.ReconcilePartition(
 				resource, "$."+def.BodyField, tenantUUID,
-				seenIDs, resource, store.CascadeJunctionsFor(resource),
+				seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
 			)
 			if rerr != nil {
 				fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", resource, tenantUUID, rerr.Error())
@@ -2176,7 +2176,7 @@ func syncOneParent(
 	if prune && outcome.complete && dep.ReconcileMode == "per_parent" {
 		deleted, rerr := db.ReconcilePartition(
 			dep.Name, dep.GenericScopeJSONPath, outcome.scopeVal,
-			seenIDs, dep.Name, store.CascadeJunctionsFor(dep.Name),
+			seenIDs, reconcileTypedTable(dep.Name), store.CascadeJunctionsFor(dep.Name),
 		)
 		if rerr != nil {
 			fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", dep.Name, outcome.scopeVal, rerr.Error())
@@ -2514,6 +2514,17 @@ var flatReconcileDefs = map[string]flatReconcileDefT{}
 // value when absent; the call site only reaches it for flatReconcilable resources).
 func flatReconcileDef(resource string) flatReconcileDefT {
 	return flatReconcileDefs[resource]
+}
+
+// reconcileTypedTables maps runtime resource keys to typed tables that are
+// actually emitted. Generic-only resources are absent and resolve to "" so
+// ReconcilePartition deletes only from the shared resources table.
+var reconcileTypedTables = map[string]string{
+	"leagues": "leagues",
+}
+
+func reconcileTypedTable(resource string) string {
+	return reconcileTypedTables[resource]
 }
 
 // resolveTenantID returns the active tenant's stable ID for tenant-scoped

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -789,7 +789,7 @@ func syncResource(ctx context.Context, c interface {
 		} else if outcome.complete {
 			deleted, rerr := db.ReconcilePartition(
 				resource, "$."+def.BodyField, tenantUUID,
-				seenIDs, resource, store.CascadeJunctionsFor(resource),
+				seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
 			)
 			if rerr != nil {
 				fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", resource, tenantUUID, rerr.Error())
@@ -1833,6 +1833,15 @@ var flatReconcileDefs = map[string]flatReconcileDefT{}
 // value when absent; the call site only reaches it for flatReconcilable resources).
 func flatReconcileDef(resource string) flatReconcileDefT {
 	return flatReconcileDefs[resource]
+}
+
+// reconcileTypedTables maps runtime resource keys to typed tables that are
+// actually emitted. Generic-only resources are absent and resolve to "" so
+// ReconcilePartition deletes only from the shared resources table.
+var reconcileTypedTables = map[string]string{}
+
+func reconcileTypedTable(resource string) string {
+	return reconcileTypedTables[resource]
 }
 
 // resolveTenantID returns the active tenant's stable ID for tenant-scoped


### PR DESCRIPTION
## Summary

Printed CLIs whose API resource names match framework-owned SQLite tables or indexes now sync and search without store migration collisions. Colliding resources stay on the generic resource path, while ordinary resources continue receiving typed tables. The policy also preserves parent-scoped identity for dependent resources and only reserves learn-owned names when learning is enabled.

Generated runtime coverage proves migration, persistence, listing, and search for table-name, index-name, and dependent-resource collisions.

## Validation

- `go test ./...`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `golangci-lint run ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`

Closes #3393
