### PR TITLE
fix(cli): prefer credential URLs in auth inference

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -823,12 +823,18 @@ Rules:
 - The parser does not validate the URL shape.
 
 When the extension is absent and the spec has any auth, the parser falls back
-through the following sources in order and uses the first plausible HTTPS URL:
+through the following sources in order:
 
 1. The selected security scheme's `description` (extracted via regex).
 2. `info.description`, but only when the surrounding text mentions
    credential-related cues (`token`, `api key`, `credential`, `register`,
    `sign up`, etc.) so an unrelated URL doesn't get picked.
+
+Within either description, generic protocol references such as MDN, RFC/IETF,
+HTTPWG, and Wikipedia links are ignored. A clear credential-management surface
+(`console`, `dashboard`, `api-keys`/`apikeys`, or `settings/integrations`) wins
+over an earlier neutral URL; otherwise the first accepted non-generic URL is
+kept as the fallback.
 
 `externalDocs.url` and `info.contact.url` are intentionally **not** fallbacks
 for `KeyURL`. Those almost always point at the API's docs landing page or the

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -1696,35 +1696,93 @@ func inferAuthKeyURL(doc *openapi3.T, schemeName string) string {
 	if schemeName != "" && doc.Components != nil {
 		if ref, ok := doc.Components.SecuritySchemes[schemeName]; ok {
 			if scheme := securitySchemeValue(ref); scheme != nil {
-				if u := firstHTTPSURL(scheme.Description); u != "" {
+				if u := authKeyURLFromText(scheme.Description); u != "" {
 					return u
 				}
 			}
 		}
 	}
 	if doc.Info != nil {
-		if u := firstAuthRelatedURL(doc.Info.Description); u != "" {
+		if u := authRelatedURLFromText(doc.Info.Description); u != "" {
 			return u
 		}
 	}
 	return ""
 }
 
-var httpsURLPattern = regexp.MustCompile(`https://[^\s)>\]"',]+`)
+var (
+	httpsURLPattern = regexp.MustCompile(`https://[^\s)>\]"',]+`)
 
-// firstHTTPSURL returns the first https:// substring found in s, with trailing
-// sentence punctuation trimmed.
-func firstHTTPSURL(s string) string {
+	genericAuthReferenceHosts = []string{
+		"developer.mozilla.org",
+		"datatracker.ietf.org",
+		"rfc-editor.org",
+		"tools.ietf.org",
+		"httpwg.org",
+		"en.wikipedia.org",
+	}
+)
+
+// Prefer clear credential-management surfaces because generated auth hints
+// label this URL as where users get a key; generic references would misdirect.
+func authKeyURLFromText(s string) string {
 	if s == "" {
 		return ""
 	}
-	m := httpsURLPattern.FindString(s)
-	m = strings.TrimRight(m, ".,;:!?)")
-	if m == "" || strings.ContainsAny(m, "<>{}[]") || isPlaceholderURL(m) {
-		// Reject templated placeholders (e.g. https://<your-dashboard>/...).
-		return ""
+	var best string
+	bestScore := -1
+	for _, match := range httpsURLPattern.FindAllString(s, -1) {
+		candidate := strings.TrimRight(match, ".,;:!?)")
+		if candidate == "" || strings.ContainsAny(candidate, "<>{}[]") || isPlaceholderURL(candidate) || isGenericAuthReferenceURL(candidate) {
+			continue
+		}
+		score := credentialSurfaceScore(candidate)
+		if best == "" || score > bestScore {
+			best = candidate
+			bestScore = score
+		}
 	}
-	return m
+	return best
+}
+
+func isGenericAuthReferenceURL(rawURL string) bool {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := strings.TrimSuffix(strings.ToLower(parsed.Hostname()), ".")
+	for _, genericHost := range genericAuthReferenceHosts {
+		if host == genericHost || strings.HasSuffix(host, "."+genericHost) {
+			return true
+		}
+	}
+	return false
+}
+
+func credentialSurfaceScore(rawURL string) int {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return 0
+	}
+	tokens := strings.FieldsFunc(strings.ToLower(parsed.Hostname()+parsed.EscapedPath()), func(r rune) bool {
+		return r == '.' || r == '/'
+	})
+	hasSettings := false
+	hasIntegrations := false
+	for _, token := range tokens {
+		switch token {
+		case "console", "dashboard", "api-keys", "apikeys":
+			return 2
+		case "settings":
+			hasSettings = true
+		case "integrations":
+			hasIntegrations = true
+		}
+	}
+	if hasSettings && hasIntegrations {
+		return 2
+	}
+	return 0
 }
 
 func isPlaceholderURL(u string) bool {
@@ -1737,10 +1795,7 @@ func isPlaceholderURL(u string) bool {
 	}
 }
 
-// firstAuthRelatedURL returns the first HTTPS URL in s, but only when s also
-// contains language indicating the URL is about credentials. Avoids picking a
-// URL that happens to appear in a description of an unrelated feature.
-func firstAuthRelatedURL(s string) string {
+func authRelatedURLFromText(s string) string {
 	if s == "" {
 		return ""
 	}
@@ -1760,7 +1815,7 @@ func firstAuthRelatedURL(s string) string {
 	if !matched {
 		return ""
 	}
-	return firstHTTPSURL(s)
+	return authKeyURLFromText(s)
 }
 
 func applyAuthOverrideExtensions(auth *spec.AuthConfig, extensions map[string]any) {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -5327,6 +5327,27 @@ paths:
 	})
 }
 
+const authKeyURLSelectionOpenAPISpec = `openapi: "3.0.3"
+info:
+  title: Apify
+  version: "1.0.0"
+servers:
+  - url: https://api.apify.com
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: http
+      scheme: bearer
+      description: |
+        Send the token in the Authorization header described at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization.
+        Create a token at https://console.apify.com/settings/integrations.
+paths:
+  /ping:
+    get:
+      responses:
+        "200": { description: OK }
+`
+
 func TestOpenAPIAuthKeyURLInference(t *testing.T) {
 	t.Parallel()
 
@@ -5385,6 +5406,33 @@ paths:
         "200": { description: OK }
 `,
 			expected: "https://example.com/account/api-keys",
+		},
+		{
+			name:     "vendor credential URL wins over generic auth reference",
+			yaml:     authKeyURLSelectionOpenAPISpec,
+			expected: "https://console.apify.com/settings/integrations",
+		},
+		{
+			name: "generic auth reference without vendor credential URL is omitted",
+			yaml: `openapi: "3.0.3"
+info:
+  title: Example
+  version: "1.0.0"
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: http
+      scheme: bearer
+      description: "See https://datatracker.ietf.org/doc/html/rfc6750 for bearer token syntax."
+paths:
+  /ping:
+    get:
+      responses:
+        "200": { description: OK }
+`,
+			expected: "",
 		},
 		{
 			name: "no inference when only externalDocs.url is set (docs URL is not a credentials page)",
@@ -5557,7 +5605,32 @@ paths:
 	}
 }
 
-func TestFirstHTTPSURLRejectsPlaceholders(t *testing.T) {
+func TestOpenAPIAuthKeyURLSelectionReachesGeneratedSurfaces(t *testing.T) {
+	parsed, err := Parse([]byte(authKeyURLSelectionOpenAPISpec))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(parsed.Name))
+	gen := generator.New(parsed, outputDir)
+	gen.VisionSet.MCP = true
+	require.NoError(t, gen.Generate())
+
+	for _, path := range []string{
+		"internal/cli/auth.go",
+		"internal/cli/doctor.go",
+		"internal/cli/helpers.go",
+		"internal/mcp/tools.go",
+	} {
+		content, err := os.ReadFile(filepath.Join(outputDir, path))
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "https://console.apify.com/settings/integrations", path)
+		assert.NotContains(t, string(content), "developer.mozilla.org", path)
+	}
+
+	runGo(t, outputDir, "mod", "tidy")
+	runGo(t, outputDir, "build", "./...")
+}
+
+func TestAuthKeyURLFromTextFiltersInvalidCandidates(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -5585,12 +5658,80 @@ func TestFirstHTTPSURLRejectsPlaceholders(t *testing.T) {
 			in:   "Get your key at https://en.wikipedia.org/wiki/HATEOAS",
 			want: "",
 		},
+		{
+			name: "generic Wikipedia reference",
+			in:   "See https://en.wikipedia.org/wiki/Basic_access_authentication",
+			want: "",
+		},
+		{
+			name: "generic RFC reference",
+			in:   "See https://www.rfc-editor.org/rfc/rfc6750 for bearer token syntax",
+			want: "",
+		},
+		{
+			name: "generic MDN reference",
+			in:   "See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization",
+			want: "",
+		},
+		{
+			name: "generic IETF tools reference",
+			in:   "See https://tools.ietf.org/html/rfc6750",
+			want: "",
+		},
+		{
+			name: "generic HTTP working group reference",
+			in:   "See https://httpwg.org/specs/rfc7235.html",
+			want: "",
+		},
+		{
+			name: "vendor credential surface preferred",
+			in:   "Read https://docs.example.com/auth then create a key at https://dashboard.example.com/account/api-keys",
+			want: "https://dashboard.example.com/account/api-keys",
+		},
+		{
+			name: "first accepted fallback is stable",
+			in:   "See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization then https://vendor.example.com/token-guide and https://vendor.example.com/auth-guide",
+			want: "https://vendor.example.com/token-guide",
+		},
+		{
+			name: "ambiguous developers URL does not displace fallback",
+			in:   "Create a token at https://portal.example.com/security/tokens then read https://developers.example.com/docs",
+			want: "https://portal.example.com/security/tokens",
+		},
+		{
+			name: "account substring does not displace fallback",
+			in:   "Create a token at https://portal.example.com/security/tokens then read https://docs.example.com/accounting",
+			want: "https://portal.example.com/security/tokens",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.want, firstHTTPSURL(tc.in))
+			assert.Equal(t, tc.want, authKeyURLFromText(tc.in))
+		})
+	}
+}
+
+func TestAuthKeyURLFromTextStrongCredentialCues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{name: "console host", url: "https://console.example.com/keys"},
+		{name: "dashboard host", url: "https://dashboard.example.com/keys"},
+		{name: "api keys path", url: "https://example.com/account/api-keys"},
+		{name: "apikeys path", url: "https://example.com/account/apikeys"},
+		{name: "settings integrations path", url: "https://example.com/settings/integrations"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			input := "Read https://docs.example.com/auth before opening " + tc.url
+			assert.Equal(t, tc.url, authKeyURLFromText(input))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Generated auth hints no longer send users to generic MDN, RFC/IETF, HTTPWG, or Wikipedia references when an OpenAPI description also links to a vendor credential page. Inference now prefers clear credential-management surfaces while preserving the first accepted non-generic URL as a conservative fallback. Regression coverage proves the selected URL reaches generated CLI and MCP auth surfaces; the issue's separate endpoint-parent delegation suggestion remains out of scope.

## Validation

- `go test ./...` (6770 tests passed in 44 packages)
- `go test ./internal/openapi -count=1` (655 tests passed)
- `scripts/golden.sh verify` (32 cases passed)
- `scripts/verify-generator-output.sh` (10 generated modules compiled)
- `golangci-lint run ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`

Closes #3387
