### PR TITLE
fix(cli): validate JSON body flag shapes

### DIFF
--- a/internal/generator/body_map_test.go
+++ b/internal/generator/body_map_test.go
@@ -69,7 +69,11 @@ func TestBodyMap(t *testing.T) {
 				"\t\t\t\tif err := json.Unmarshal([]byte(bodyMetadata), &parsedMetadata); err != nil {\n" +
 				"\t\t\t\t\treturn fmt.Errorf(\"parsing --metadata JSON: %w\", err)\n" +
 				"\t\t\t\t}\n" +
-				"\t\t\t\tbody[\"metadata\"] = parsedMetadata\n" +
+				"\t\t\t\tasMap, ok := parsedMetadata.(map[string]any)\n" +
+				"\t\t\t\tif !ok {\n" +
+				"\t\t\t\t\treturn fmt.Errorf(\"--metadata must be a JSON object, got JSON %T\", parsedMetadata)\n" +
+				"\t\t\t\t}\n" +
+				"\t\t\t\tbody[\"metadata\"] = asMap\n" +
 				"\t\t\t}\n",
 		},
 		{
@@ -81,7 +85,11 @@ func TestBodyMap(t *testing.T) {
 				"\t\t\t\tif err := json.Unmarshal([]byte(bodyTags), &parsedTags); err != nil {\n" +
 				"\t\t\t\t\treturn fmt.Errorf(\"parsing --tags JSON: %w\", err)\n" +
 				"\t\t\t\t}\n" +
-				"\t\t\t\tbody[\"tags\"] = parsedTags\n" +
+				"\t\t\t\tasArray, ok := parsedTags.([]any)\n" +
+				"\t\t\t\tif !ok {\n" +
+				"\t\t\t\t\treturn fmt.Errorf(\"--tags must be a JSON array, got JSON %T\", parsedTags)\n" +
+				"\t\t\t\t}\n" +
+				"\t\t\t\tbody[\"tags\"] = asArray\n" +
 				"\t\t\t}\n",
 		},
 		{
@@ -135,7 +143,11 @@ func TestBodyMap(t *testing.T) {
 				"\t\tif err := json.Unmarshal([]byte(bodyTags), &parsedTags); err != nil {\n" +
 				"\t\t\treturn fmt.Errorf(\"parsing --tags JSON: %w\", err)\n" +
 				"\t\t}\n" +
-				"\t\tbody[\"tags\"] = parsedTags\n" +
+				"\t\tasArray, ok := parsedTags.([]any)\n" +
+				"\t\tif !ok {\n" +
+				"\t\t\treturn fmt.Errorf(\"--tags must be a JSON array, got JSON %T\", parsedTags)\n" +
+				"\t\t}\n" +
+				"\t\tbody[\"tags\"] = asArray\n" +
 				"\t}\n",
 		},
 		{

--- a/internal/generator/body_map_test.go
+++ b/internal/generator/body_map_test.go
@@ -222,7 +222,7 @@ func TestBodyMap_BodyNameOverridesJSONKey(t *testing.T) {
 	if !strings.Contains(got, "bodyStartAfter") {
 		t.Errorf("expected public name to drive variable identity, got: %s", got)
 	}
-	if !strings.Contains(got, `body["searchAfter"] = parsedStartAfter`) {
+	if !strings.Contains(got, `body["searchAfter"] = asArray`) {
 		t.Errorf("expected body_name to drive JSON key, got: %s", got)
 	}
 	if strings.Contains(got, `body["startAfter"]`) {

--- a/internal/generator/body_shape_validation_test.go
+++ b/internal/generator/body_shape_validation_test.go
@@ -1,0 +1,136 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedBodyFlagsRejectWrongJSONShapesBeforeTransport(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("bodyshapeflag")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"items": {
+			Description: "Manage items",
+			Endpoints: map[string]spec.Endpoint{
+				"create": {
+					Method:             "POST",
+					Path:               "/items",
+					Description:        "Create item",
+					RequestContentType: "application/json",
+					Body: []spec.Param{
+						{Name: "metadata", Type: "object"},
+						{Name: "tags", Type: "array"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	runGoCommand(t, outputDir, "mod", "tidy")
+
+	behaviorTest := `package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBodyFlagsRejectWrongJSONShapesBeforeTransport(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "object rejects scalar",
+			args: []string{"--metadata", "207769210"},
+			want: "--metadata must be a JSON object",
+		},
+		{
+			name: "array rejects object",
+			args: []string{"--tags", "{}"},
+			want: "--tags must be a JSON array",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer server.Close()
+
+			t.Setenv("BODYSHAPEFLAG_BASE_URL", server.URL)
+			flags := &rootFlags{asJSON: true}
+			cmd := newRootCmd(flags)
+			cmd.SetArgs(append([]string{"items", "create"}, tc.args...))
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want substring %q", err, tc.want)
+			}
+			if calls != 0 {
+				t.Fatalf("server called %d time(s), want 0", calls)
+			}
+		})
+	}
+}
+
+func TestBodyFlagsAcceptMatchingJSONShapes(t *testing.T) {
+	var calls int
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"ok\":true}"))
+	}))
+	defer server.Close()
+
+	t.Setenv("BODYSHAPEFLAG_BASE_URL", server.URL)
+	flags := &rootFlags{asJSON: true}
+	cmd := newRootCmd(flags)
+	cmd.SetArgs([]string{
+		"items", "create",
+		"--metadata", "{\"source\":\"test\"}",
+		"--tags", "[\"blue\"]",
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("server called %d time(s), want 1", calls)
+	}
+	if metadata, ok := gotBody["metadata"].(map[string]any); !ok || metadata["source"] != "test" {
+		t.Fatalf("metadata body = %#v, want object with source=test", gotBody["metadata"])
+	}
+	if tags, ok := gotBody["tags"].([]any); !ok || len(tags) != 1 || tags[0] != "blue" {
+		t.Fatalf("tags body = %#v, want [blue]", gotBody["tags"])
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "body_shape_validation_test.go"), []byte(behaviorTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "^TestBodyFlags", "-count=1")
+}

--- a/internal/generator/delete_body_test.go
+++ b/internal/generator/delete_body_test.go
@@ -39,7 +39,7 @@ func TestGenerateDeleteEndpointWithJSONBodyUsesRequestBody(t *testing.T) {
 
 	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "assets_delete.go")
 	assert.Contains(t, endpointSrc, `bodyMap := map[string]any{}`)
-	assert.Contains(t, endpointSrc, `bodyMap["ids"] = parsed`)
+	assert.Contains(t, endpointSrc, `bodyMap["ids"] = asArray`)
 	assert.Contains(t, endpointSrc, `if cmd.Flags().Changed("force")`)
 	assert.Contains(t, endpointSrc, `bodyMap["force"] = bodyForce`)
 	assert.Contains(t, endpointSrc, `c.DeleteWithBody(cmd.Context(), path, body)`)
@@ -201,7 +201,7 @@ func TestGeneratePromotedDeleteEndpointWithJSONBodyUsesRequestBody(t *testing.T)
 
 	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_assets.go")
 	assert.Contains(t, endpointSrc, `bodyMap := map[string]any{}`)
-	assert.Contains(t, endpointSrc, `bodyMap["ids"] = parsed`)
+	assert.Contains(t, endpointSrc, `bodyMap["ids"] = asArray`)
 	assert.Contains(t, endpointSrc, `c.DeleteWithBody(cmd.Context(), path, body)`)
 	assert.NotContains(t, endpointSrc, `params["ids"]`)
 
@@ -238,7 +238,7 @@ func TestGeneratePromotedDeleteEndpointWithJSONBodyAndParamsUsesRequestBodyAndQu
 	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_assets.go")
 	assert.Contains(t, endpointSrc, `params["mode"] = formatCLIParamValue(flagMode)`)
 	assert.Contains(t, endpointSrc, `bodyMap := map[string]any{}`)
-	assert.Contains(t, endpointSrc, `bodyMap["ids"] = parsed`)
+	assert.Contains(t, endpointSrc, `bodyMap["ids"] = asArray`)
 	assert.Contains(t, endpointSrc, `c.DeleteWithParamsAndBody(cmd.Context(), path, params, body)`)
 	assert.NotContains(t, endpointSrc, `params["ids"]`)
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -6416,8 +6416,9 @@ func renderBodyMap(b *strings.Builder, body []spec.Param, depth int, indent, map
 		isComplex := p.Type == "object" || p.Type == "array"
 		if isComplex || isJSONStringParam(p) {
 			// object/array: store the parsed value (so the API receives
-			// real JSON). jsonStringParam: validate then store the raw
-			// string (the API expects a JSON-encoded string field).
+			// real JSON) after checking its top-level shape.
+			// jsonStringParam: validate then store the raw string (the API
+			// expects a JSON-encoded string field).
 			rhs := "body" + ident
 			if isComplex {
 				rhs = "parsed" + ident
@@ -6427,6 +6428,17 @@ func renderBodyMap(b *strings.Builder, body []spec.Param, depth int, indent, map
 			fmt.Fprintf(b, "%s\tif err := json.Unmarshal([]byte(body%s), &parsed%s); err != nil {\n", indent, ident, ident)
 			fmt.Fprintf(b, "%s\t\treturn fmt.Errorf(\"parsing --%s JSON: %%w\", err)\n", indent, flag)
 			fmt.Fprintf(b, "%s\t}\n", indent)
+			if isComplex {
+				shape, valueVar, valueType := "object", "asMap", "map[string]any"
+				if p.Type == "array" {
+					shape, valueVar, valueType = "array", "asArray", "[]any"
+				}
+				fmt.Fprintf(b, "%s\t%s, ok := parsed%s.(%s)\n", indent, valueVar, ident, valueType)
+				fmt.Fprintf(b, "%s\tif !ok {\n", indent)
+				fmt.Fprintf(b, "%s\t\treturn fmt.Errorf(\"--%s must be a JSON %s, got JSON %%T\", parsed%s)\n", indent, flag, shape, ident)
+				fmt.Fprintf(b, "%s\t}\n", indent)
+				rhs = valueVar
+			}
 			fmt.Fprintf(b, "%s\t%s[%q] = %s\n", indent, mapVar, p.BodyWireName(), rhs)
 			fmt.Fprintf(b, "%s}\n", indent)
 			continue

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -11628,9 +11628,9 @@ func TestGenerateObjectBodyDefaultsAreParsedAsJSON(t *testing.T) {
 	require.NotEmpty(t, content)
 	assert.Contains(t, content, `StringVar(&bodyVariables, "variables", "{\"date\":\"2026-04-22\"}"`)
 	assert.Contains(t, content, `json.Unmarshal([]byte(bodyVariables), &parsedVariables)`)
-	assert.Contains(t, content, `bodyMap["variables"] = parsedVariables`)
+	assert.Contains(t, content, `bodyMap["variables"] = asMap`)
 	assert.Contains(t, content, `json.Unmarshal([]byte(bodyExtensions), &parsedExtensions)`)
-	assert.Contains(t, content, `bodyMap["extensions"] = parsedExtensions`)
+	assert.Contains(t, content, `bodyMap["extensions"] = asMap`)
 	_, err = parser.ParseFile(token.NewFileSet(), "graphql_posts_today.go", content, parser.ParseComments)
 	require.NoError(t, err)
 
@@ -17855,8 +17855,8 @@ func TestGenerateBodyNameAcrossCLISurfaces(t *testing.T) {
 
 	searchSource := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_contacts.go")
 	assert.Contains(t, searchSource, `StringVar(&bodyStartAfter, "start-after", "", "Pagination cursor")`)
-	assert.Contains(t, searchSource, `bodyMap["searchAfter"] = parsedStartAfter`)
-	assert.NotContains(t, searchSource, `bodyMap["startAfter"] = parsedStartAfter`)
+	assert.Contains(t, searchSource, `bodyMap["searchAfter"] = asArray`)
+	assert.NotContains(t, searchSource, `bodyMap["startAfter"] = asArray`)
 
 	mcpSource := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
 	// CLI takes the array cursor as a JSON-string flag (StringVar + json.Unmarshal


### PR DESCRIPTION
## Summary

Object and array body flags now reject valid JSON with the wrong top-level shape before the CLI can send a malformed request. Previously, a scalar such as `207769210` was accepted for an object field and passed through as a bare JSON number, leaving providers to return opaque validation errors. The generator now validates decoded object and array types while preserving JSON-string fields and valid matching shapes.

Closes #3516

## Validation

- `go test ./internal/generator`
- `scripts/verify-generator-output.sh`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `go test ./...` reached the repository's 10-minute timeout in low-disk pipeline setup-contract subprocess tests.
- `scripts/golden.sh verify` reported 25 unrelated fixture and generated-artifact mismatches; no golden files were updated.
