### PR TITLE
fix(cli): honor explicit quiet for teach JSON output

### DIFF
--- a/internal/generator/templates/teach.go.tmpl
+++ b/internal/generator/templates/teach.go.tmpl
@@ -334,7 +334,7 @@ Disabling: pass --no-learn or set ` + noLearnEnvVar + `=true.`,
 				writeTeachErrLog(fmt.Sprintf("teach: audit append: %v", auditErr))
 			}
 
-			if !quiet && flags.asJSON {
+			if flags.asJSON && !flags.quiet && !(quiet && cmd.Flags().Changed("quiet")) {
 				return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
 					"recorded":   true,
 					"query":      query,

--- a/internal/generator/templates/teach_test.go.tmpl
+++ b/internal/generator/templates/teach_test.go.tmpl
@@ -103,6 +103,60 @@ func TestTeachCommand_SilentOnSuccess(t *testing.T) {
 	}
 }
 
+func TestTeachCommand_JSONOutputRespectsExplicitQuiet(t *testing.T) {
+	tests := []struct {
+		name       string
+		quietArg   string
+		rootQuiet  bool
+		wantOutput bool
+	}{
+		{name: "default quiet", wantOutput: true},
+		{name: "explicit quiet", quietArg: "--quiet", wantOutput: false},
+		{name: "explicit quiet false", quietArg: "--quiet=false", wantOutput: true},
+		{name: "root explicit quiet", rootQuiet: true, wantOutput: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := withTempLearnHome(t)
+			dbPath := filepath.Join(home, "data.db")
+			args := []string{
+				"teach",
+				"--query", "find all widgets in inventory",
+				"--resource", "widget-42",
+				"--resource-type", "items",
+				"--db", dbPath,
+				"--json",
+			}
+			if tt.quietArg != "" {
+				args = append(args, tt.quietArg)
+			}
+			if tt.rootQuiet {
+				args = append([]string{"--quiet"}, args...)
+			}
+
+			stdout, stderr, err := runRootArgs(t, args...)
+			if err != nil {
+				t.Fatalf("teach: %v (stderr=%q)", err, stderr)
+			}
+			if !tt.wantOutput {
+				if stdout != "" {
+					t.Errorf("teach should be silent with explicit quiet; stdout=%q", stdout)
+				}
+				return
+			}
+
+			var response map[string]any
+			if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+				t.Fatalf("teach JSON: %v (stdout=%q)", err, stdout)
+			}
+			if recorded, _ := response["recorded"].(bool); !recorded {
+				t.Errorf("teach JSON recorded = %v, want true", response["recorded"])
+			}
+		})
+	}
+}
+
 func TestTeachCommand_MissingResourceTypeErrors(t *testing.T) {
 	home := withTempLearnHome(t)
 	dbPath := filepath.Join(home, "data.db")

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/teach.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/teach.go
@@ -334,7 +334,7 @@ Disabling: pass --no-learn or set ` + noLearnEnvVar + `=true.`,
 				writeTeachErrLog(fmt.Sprintf("teach: audit append: %v", auditErr))
 			}
 
-			if !quiet && flags.asJSON {
+			if flags.asJSON && !flags.quiet && !(quiet && cmd.Flags().Changed("quiet")) {
 				return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
 					"recorded":   true,
 					"query":      query,


### PR DESCRIPTION
## Summary

`teach --json` now emits its acknowledgement by default, even though the background-friendly local `--quiet` flag defaults to true. Output remains silent when `--quiet` is explicitly enabled, and the root persistent `--quiet` flag remains authoritative.

Closes #3541

## Verification

- Generated CLI runtime coverage for default JSON, local `--quiet`, local `--quiet=false`, root `--quiet`, and silent success.
- `go test ./internal/generator -run '^TestGenerateLearnCLICommandsCompileAndTest$' -count=1`
- `scripts/golden.sh verify` (32/32)
- `scripts/verify-generator-output.sh` (10 cases)
- `go test ./internal/generator -count=1`
- The full suite's unrelated `TestRunLiveDogfoodProcessPreservesLargeJSONUnderCap` failure passes when isolated.
