### PR TITLE
fix(cli): handle HAL pagination envelopes and size page parameters

### DIFF
--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -476,6 +476,32 @@ func TestPaginatedGetExtractsHALEmbeddedItems(t *testing.T) {
 }
 
 func TestPaginatedGetSelectsHALEmbeddedCollectionMatchingPath(t *testing.T) {
+	for _, requestPath := range []string{"/discovery/v2/events.json", "/events/search"} {
+		t.Run(requestPath, func(t *testing.T) {
+			client := &paginatedTestClient{responses: []json.RawMessage{
+				json.RawMessage(` + "`" + `{
+					"_embedded": {
+						"events": [{"id":"event-one"}],
+						"items": [{"id":"unrelated-item"}]
+					}
+				}` + "`" + `),
+			}}
+			data, err := paginatedGet(context.Background(), client, requestPath, map[string]string{"size":"2"}, nil, true, "page", "page", "size", 2, "", "")
+			if err != nil {
+				t.Fatalf("paginatedGet returned error: %v", err)
+			}
+			var got []map[string]string
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("unmarshal data: %v", err)
+			}
+			if len(got) != 1 || got[0]["id"] != "event-one" {
+				t.Fatalf("got items %#v, want only the events collection", got)
+			}
+		})
+	}
+}
+
+func TestPaginatedGetKeepsUnmatchedHALEmbeddedCollectionsAmbiguous(t *testing.T) {
 	client := &paginatedTestClient{responses: []json.RawMessage{
 		json.RawMessage(` + "`" + `{
 			"_embedded": {
@@ -484,7 +510,7 @@ func TestPaginatedGetSelectsHALEmbeddedCollectionMatchingPath(t *testing.T) {
 			}
 		}` + "`" + `),
 	}}
-	data, err := paginatedGet(context.Background(), client, "/discovery/v2/events.json", map[string]string{"size":"2"}, nil, true, "page", "page", "size", 2, "", "")
+	data, err := paginatedGet(context.Background(), client, "/discovery/v2/catalog.json", map[string]string{"size":"2"}, nil, true, "page", "page", "size", 2, "", "")
 	if err != nil {
 		t.Fatalf("paginatedGet returned error: %v", err)
 	}
@@ -492,8 +518,8 @@ func TestPaginatedGetSelectsHALEmbeddedCollectionMatchingPath(t *testing.T) {
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("unmarshal data: %v", err)
 	}
-	if len(got) != 1 || got[0]["id"] != "event-one" {
-		t.Fatalf("got items %#v, want only the events collection", got)
+	if len(got) != 0 {
+		t.Fatalf("got items %#v, want ambiguous HAL collections left unselected", got)
 	}
 }
 

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -475,6 +475,28 @@ func TestPaginatedGetExtractsHALEmbeddedItems(t *testing.T) {
 	}
 }
 
+func TestPaginatedGetSelectsHALEmbeddedCollectionMatchingPath(t *testing.T) {
+	client := &paginatedTestClient{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `{
+			"_embedded": {
+				"events": [{"id":"event-one"}],
+				"items": [{"id":"unrelated-item"}]
+			}
+		}` + "`" + `),
+	}}
+	data, err := paginatedGet(context.Background(), client, "/discovery/v2/events.json", map[string]string{"size":"2"}, nil, true, "page", "page", "size", 2, "", "")
+	if err != nil {
+		t.Fatalf("paginatedGet returned error: %v", err)
+	}
+	var got []map[string]string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if len(got) != 1 || got[0]["id"] != "event-one" {
+		t.Fatalf("got items %#v, want only the events collection", got)
+	}
+}
+
 func TestPaginatedGetFallsBackToCursorParamResponseField(t *testing.T) {
 	client := &paginatedTestClient{responses: []json.RawMessage{
 		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"cursor":"page-2"}` + "`" + `),

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -442,6 +442,39 @@ func TestPaginatedGetAcceptsNumericNextCursor(t *testing.T) {
 	}
 }
 
+func TestPaginatedGetExtractsHALEmbeddedItems(t *testing.T) {
+	client := &paginatedTestClient{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `{"_embedded":{"events":[{"id":"one"}]}}` + "`" + `),
+		json.RawMessage(` + "`" + `{"_embedded":{"events":[{"id":"two"}]}}` + "`" + `),
+		json.RawMessage(` + "`" + `{"_embedded":{"events":[]}}` + "`" + `),
+	}}
+	data, err := paginatedGet(context.Background(), client, "/events", map[string]string{"page":"1", "size":"0"}, nil, true, "page", "page", "size", 1, "", "")
+	if err != nil {
+		t.Fatalf("paginatedGet returned error: %v", err)
+	}
+	var got []map[string]string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d items, want 2; data=%s", len(got), data)
+	}
+	if got[0]["id"] != "one" || got[1]["id"] != "two" {
+		t.Fatalf("got items %#v, want one followed by two", got)
+	}
+	if len(client.params) != 3 {
+		t.Fatalf("got %d requests, want 3", len(client.params))
+	}
+	for i, wantPage := range []string{"1", "2", "3"} {
+		if client.params[i]["page"] != wantPage {
+			t.Fatalf("request %d page = %q, want %s", i+1, client.params[i]["page"], wantPage)
+		}
+		if client.params[i]["size"] != "1" {
+			t.Fatalf("request %d size = %q, want 1", i+1, client.params[i]["size"])
+		}
+	}
+}
+
 func TestPaginatedGetFallsBackToCursorParamResponseField(t *testing.T) {
 	client := &paginatedTestClient{responses: []json.RawMessage{
 		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"cursor":"page-2"}` + "`" + `),

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1385,11 +1385,26 @@ func paginationCursorToken(raw json.RawMessage) string {
 }
 
 func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	return extractPaginatedItemsFromObject(obj, true)
+}
+
+func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, allowEmbedded bool) ([]json.RawMessage, bool) {
 	for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
 		if arr, ok := obj[field]; ok {
 			var nested []json.RawMessage
 			if json.Unmarshal(arr, &nested) == nil {
 				return nested, true
+			}
+		}
+	}
+
+	if allowEmbedded {
+		if raw, ok := obj["_embedded"]; ok {
+			var embedded map[string]json.RawMessage
+			if json.Unmarshal(raw, &embedded) == nil {
+				if nested, ok := extractPaginatedItemsFromObject(embedded, false); ok {
+					return nested, true
+				}
 			}
 		}
 	}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1395,16 +1395,16 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath
 		}
 	}
 
-	for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
-		if arr, ok := obj[field]; ok {
-			var nested []json.RawMessage
-			if json.Unmarshal(arr, &nested) == nil {
-				return nested, true
+	if allowEmbedded {
+		for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
+			if arr, ok := obj[field]; ok {
+				var nested []json.RawMessage
+				if json.Unmarshal(arr, &nested) == nil {
+					return nested, true
+				}
 			}
 		}
-	}
 
-	if allowEmbedded {
 		if raw, ok := obj["_embedded"]; ok {
 			var embedded map[string]json.RawMessage
 			if json.Unmarshal(raw, &embedded) == nil {
@@ -1435,34 +1435,31 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath
 func extractPaginatedItemsMatchingPath(obj map[string]json.RawMessage, requestPath string) ([]json.RawMessage, bool) {
 	pathWithoutQuery := strings.SplitN(requestPath, "?", 2)[0]
 	segments := strings.Split(strings.Trim(pathWithoutQuery, "/"), "/")
-	collectionKey := ""
 	for i := len(segments) - 1; i >= 0; i-- {
-		segment := strings.TrimSpace(segments[i])
+		segment := strings.TrimSuffix(strings.TrimSpace(segments[i]), ".json")
 		if segment == "" || (strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}")) {
 			continue
 		}
-		collectionKey = strings.TrimSuffix(segment, ".json")
-		break
-	}
-	if collectionKey == "" {
-		return nil, false
-	}
 
-	var matched []json.RawMessage
-	matches := 0
-	for key, raw := range obj {
-		if !strings.EqualFold(key, collectionKey) {
-			continue
+		var matched []json.RawMessage
+		matches := 0
+		for key, raw := range obj {
+			if !strings.EqualFold(key, segment) {
+				continue
+			}
+			var items []json.RawMessage
+			if json.Unmarshal(raw, &items) != nil {
+				continue
+			}
+			matched = items
+			matches++
 		}
-		var items []json.RawMessage
-		if json.Unmarshal(raw, &items) != nil {
-			continue
+		if matches == 1 {
+			return matched, true
 		}
-		matched = items
-		matches++
-	}
-	if matches == 1 {
-		return matched, true
+		if matches > 1 {
+			return nil, false
+		}
 	}
 	return nil, false
 }

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1174,7 +1174,7 @@ func paginatedGet(ctx context.Context, c interface {
 			var obj map[string]json.RawMessage
 			if json.Unmarshal(data, &obj) == nil {
 				itemCount := 0
-				if nested, ok := extractPaginatedItems(obj); ok {
+				if nested, ok := extractPaginatedItems(obj, path); ok {
 					allItems = append(allItems, nested...)
 					itemCount = len(nested)
 				}
@@ -1384,11 +1384,17 @@ func paginationCursorToken(raw json.RawMessage) string {
 	return ""
 }
 
-func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, bool) {
-	return extractPaginatedItemsFromObject(obj, true)
+func extractPaginatedItems(obj map[string]json.RawMessage, requestPath string) ([]json.RawMessage, bool) {
+	return extractPaginatedItemsFromObject(obj, requestPath, true)
 }
 
-func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, allowEmbedded bool) ([]json.RawMessage, bool) {
+func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath string, allowEmbedded bool) ([]json.RawMessage, bool) {
+	if !allowEmbedded {
+		if nested, ok := extractPaginatedItemsMatchingPath(obj, requestPath); ok {
+			return nested, true
+		}
+	}
+
 	for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
 		if arr, ok := obj[field]; ok {
 			var nested []json.RawMessage
@@ -1402,7 +1408,7 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, allowEmbedd
 		if raw, ok := obj["_embedded"]; ok {
 			var embedded map[string]json.RawMessage
 			if json.Unmarshal(raw, &embedded) == nil {
-				if nested, ok := extractPaginatedItemsFromObject(embedded, false); ok {
+				if nested, ok := extractPaginatedItemsFromObject(embedded, requestPath, false); ok {
 					return nested, true
 				}
 			}
@@ -1422,6 +1428,41 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, allowEmbedd
 	}
 	if arrayCount == 1 {
 		return onlyArray, true
+	}
+	return nil, false
+}
+
+func extractPaginatedItemsMatchingPath(obj map[string]json.RawMessage, requestPath string) ([]json.RawMessage, bool) {
+	pathWithoutQuery := strings.SplitN(requestPath, "?", 2)[0]
+	segments := strings.Split(strings.Trim(pathWithoutQuery, "/"), "/")
+	collectionKey := ""
+	for i := len(segments) - 1; i >= 0; i-- {
+		segment := strings.TrimSpace(segments[i])
+		if segment == "" || (strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}")) {
+			continue
+		}
+		collectionKey = strings.TrimSuffix(segment, ".json")
+		break
+	}
+	if collectionKey == "" {
+		return nil, false
+	}
+
+	var matched []json.RawMessage
+	matches := 0
+	for key, raw := range obj {
+		if !strings.EqualFold(key, collectionKey) {
+			continue
+		}
+		var items []json.RawMessage
+		if json.Unmarshal(raw, &items) != nil {
+			continue
+		}
+		matched = items
+		matches++
+	}
+	if matches == 1 {
+		return matched, true
 	}
 	return nil, false
 }
@@ -1500,7 +1541,7 @@ func fetchEmbeddedPagedSubresource(ctx context.Context, c interface {
 		if err := json.Unmarshal(data, &obj); err != nil {
 			return nil, fmt.Errorf("paginating embedded sub-resource %q page %d: unexpected response shape: %w", childPath, page+1, err)
 		}
-		if items, ok := extractPaginatedItems(obj); ok {
+		if items, ok := extractPaginatedItems(obj, childPath); ok {
 			all = append(all, items...)
 		}
 		if !nextIsURL {

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -8245,6 +8245,14 @@ func detectPagination(params []spec.Param, op *openapi3.Operation) *spec.Paginat
 			}
 		}
 	}
+	// A standalone size parameter is ambiguous and cannot advance pages by
+	// itself. Treat it as a page-size parameter only when an advance parameter
+	// was detected as well.
+	if pag.LimitParam == "" && pag.CursorParam != "" {
+		if orig, ok := originalCase["size"]; ok {
+			pag.LimitParam = orig
+		}
+	}
 
 	// Also check for has_more in response schemas
 	if op != nil && op.Responses != nil {

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -8191,8 +8191,11 @@ func detectPagination(params []spec.Param, op *openapi3.Operation) *spec.Paginat
 	// the detected LimitParam/CursorParam preserves whatever the API
 	// expects (e.g. Google APIs reject `pagesize` but accept `pageSize`).
 	originalCase := map[string]string{}
+	paramsByLowerName := map[string]spec.Param{}
 	for _, p := range params {
-		originalCase[strings.ToLower(p.Name)] = p.Name
+		lowerName := strings.ToLower(p.Name)
+		originalCase[lowerName] = p.Name
+		paramsByLowerName[lowerName] = p
 	}
 
 	var pag spec.Pagination
@@ -8245,12 +8248,11 @@ func detectPagination(params []spec.Param, op *openapi3.Operation) *spec.Paginat
 			}
 		}
 	}
-	// A standalone size parameter is ambiguous and cannot advance pages by
-	// itself. Treat it as a page-size parameter only when an advance parameter
-	// was detected as well.
+	// `size` is also a common domain filter, so require pagination wording in
+	// its description before treating it as the page length.
 	if pag.LimitParam == "" && pag.CursorParam != "" {
-		if orig, ok := originalCase["size"]; ok {
-			pag.LimitParam = orig
+		if sizeParam, ok := paramsByLowerName["size"]; ok && describesPageSize(sizeParam.Description) {
+			pag.LimitParam = sizeParam.Name
 		}
 	}
 
@@ -8366,6 +8368,25 @@ func successResponseSchema(op *openapi3.Operation) *openapi3.Schema {
 		return nil
 	}
 	return schemaRef.Value
+}
+
+func describesPageSize(description string) bool {
+	description = strings.ToLower(description)
+	if strings.Contains(description, "page size") ||
+		strings.Contains(description, "page-size") ||
+		strings.Contains(description, "size of the page") ||
+		strings.Contains(description, "size of a page") {
+		return true
+	}
+	if !strings.Contains(description, "per page") {
+		return false
+	}
+	for _, noun := range []string{"item", "result", "record", "entry", "object", "element", "resource", "row", "value"} {
+		if strings.Contains(description, noun) {
+			return true
+		}
+	}
+	return false
 }
 
 func detectPaginationResponseFields(schema *openapi3.Schema, prefix string, pag *spec.Pagination) {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -11999,6 +11999,22 @@ func TestDetectPaginationPreservesParameterCase(t *testing.T) {
 	}
 }
 
+func TestDetectPaginationRecognizesSizeWithAdvanceParam(t *testing.T) {
+	t.Parallel()
+
+	pag := detectPagination([]spec.Param{{Name: "page"}, {Name: "size"}}, nil)
+	require.NotNil(t, pag)
+	assert.Equal(t, "page", pag.CursorParam)
+	assert.Equal(t, "page", pag.Type)
+	assert.Equal(t, "size", pag.LimitParam)
+}
+
+func TestDetectPaginationDoesNotClassifySizeOnly(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, detectPagination([]spec.Param{{Name: "size"}}, nil))
+}
+
 func TestDetectPaginationPreservesCursorParamCase(t *testing.T) {
 	t.Parallel()
 

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -11999,14 +11999,43 @@ func TestDetectPaginationPreservesParameterCase(t *testing.T) {
 	}
 }
 
-func TestDetectPaginationRecognizesSizeWithAdvanceParam(t *testing.T) {
+func TestDetectPaginationRecognizesDescribedPageSizeWithAdvanceParam(t *testing.T) {
 	t.Parallel()
 
-	pag := detectPagination([]spec.Param{{Name: "page"}, {Name: "size"}}, nil)
+	cases := []struct {
+		name        string
+		paramName   string
+		description string
+	}{
+		{name: "page size", paramName: "SiZe", description: "Page size for the response."},
+		{name: "items per page", paramName: "SIZE", description: "Number of items per page."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pag := detectPagination([]spec.Param{
+				{Name: "page"},
+				{Name: tc.paramName, Description: tc.description},
+			}, nil)
+			require.NotNil(t, pag)
+			assert.Equal(t, "page", pag.CursorParam)
+			assert.Equal(t, "page", pag.Type)
+			assert.Equal(t, tc.paramName, pag.LimitParam)
+		})
+	}
+}
+
+func TestDetectPaginationDoesNotClassifyUnrelatedSizeWithAdvanceParam(t *testing.T) {
+	t.Parallel()
+
+	pag := detectPagination([]spec.Param{
+		{Name: "page"},
+		{Name: "SiZe", Description: "Minimum file size in bytes."},
+	}, nil)
 	require.NotNil(t, pag)
 	assert.Equal(t, "page", pag.CursorParam)
 	assert.Equal(t, "page", pag.Type)
-	assert.Equal(t, "size", pag.LimitParam)
+	assert.Empty(t, pag.LimitParam)
 }
 
 func TestDetectPaginationDoesNotClassifySizeOnly(t *testing.T) {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -864,16 +864,16 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath
 		}
 	}
 
-	for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
-		if arr, ok := obj[field]; ok {
-			var nested []json.RawMessage
-			if json.Unmarshal(arr, &nested) == nil {
-				return nested, true
+	if allowEmbedded {
+		for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
+			if arr, ok := obj[field]; ok {
+				var nested []json.RawMessage
+				if json.Unmarshal(arr, &nested) == nil {
+					return nested, true
+				}
 			}
 		}
-	}
 
-	if allowEmbedded {
 		if raw, ok := obj["_embedded"]; ok {
 			var embedded map[string]json.RawMessage
 			if json.Unmarshal(raw, &embedded) == nil {
@@ -904,34 +904,31 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath
 func extractPaginatedItemsMatchingPath(obj map[string]json.RawMessage, requestPath string) ([]json.RawMessage, bool) {
 	pathWithoutQuery := strings.SplitN(requestPath, "?", 2)[0]
 	segments := strings.Split(strings.Trim(pathWithoutQuery, "/"), "/")
-	collectionKey := ""
 	for i := len(segments) - 1; i >= 0; i-- {
-		segment := strings.TrimSpace(segments[i])
+		segment := strings.TrimSuffix(strings.TrimSpace(segments[i]), ".json")
 		if segment == "" || (strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}")) {
 			continue
 		}
-		collectionKey = strings.TrimSuffix(segment, ".json")
-		break
-	}
-	if collectionKey == "" {
-		return nil, false
-	}
 
-	var matched []json.RawMessage
-	matches := 0
-	for key, raw := range obj {
-		if !strings.EqualFold(key, collectionKey) {
-			continue
+		var matched []json.RawMessage
+		matches := 0
+		for key, raw := range obj {
+			if !strings.EqualFold(key, segment) {
+				continue
+			}
+			var items []json.RawMessage
+			if json.Unmarshal(raw, &items) != nil {
+				continue
+			}
+			matched = items
+			matches++
 		}
-		var items []json.RawMessage
-		if json.Unmarshal(raw, &items) != nil {
-			continue
+		if matches == 1 {
+			return matched, true
 		}
-		matched = items
-		matches++
-	}
-	if matches == 1 {
-		return matched, true
+		if matches > 1 {
+			return nil, false
+		}
 	}
 	return nil, false
 }

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -643,7 +643,7 @@ func paginatedGet(ctx context.Context, c interface {
 			var obj map[string]json.RawMessage
 			if json.Unmarshal(data, &obj) == nil {
 				itemCount := 0
-				if nested, ok := extractPaginatedItems(obj); ok {
+				if nested, ok := extractPaginatedItems(obj, path); ok {
 					allItems = append(allItems, nested...)
 					itemCount = len(nested)
 				}
@@ -853,11 +853,17 @@ func paginationCursorToken(raw json.RawMessage) string {
 	return ""
 }
 
-func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, bool) {
-	return extractPaginatedItemsFromObject(obj, true)
+func extractPaginatedItems(obj map[string]json.RawMessage, requestPath string) ([]json.RawMessage, bool) {
+	return extractPaginatedItemsFromObject(obj, requestPath, true)
 }
 
-func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, allowEmbedded bool) ([]json.RawMessage, bool) {
+func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath string, allowEmbedded bool) ([]json.RawMessage, bool) {
+	if !allowEmbedded {
+		if nested, ok := extractPaginatedItemsMatchingPath(obj, requestPath); ok {
+			return nested, true
+		}
+	}
+
 	for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
 		if arr, ok := obj[field]; ok {
 			var nested []json.RawMessage
@@ -871,7 +877,7 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, allowEmbedd
 		if raw, ok := obj["_embedded"]; ok {
 			var embedded map[string]json.RawMessage
 			if json.Unmarshal(raw, &embedded) == nil {
-				if nested, ok := extractPaginatedItemsFromObject(embedded, false); ok {
+				if nested, ok := extractPaginatedItemsFromObject(embedded, requestPath, false); ok {
 					return nested, true
 				}
 			}
@@ -891,6 +897,41 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, allowEmbedd
 	}
 	if arrayCount == 1 {
 		return onlyArray, true
+	}
+	return nil, false
+}
+
+func extractPaginatedItemsMatchingPath(obj map[string]json.RawMessage, requestPath string) ([]json.RawMessage, bool) {
+	pathWithoutQuery := strings.SplitN(requestPath, "?", 2)[0]
+	segments := strings.Split(strings.Trim(pathWithoutQuery, "/"), "/")
+	collectionKey := ""
+	for i := len(segments) - 1; i >= 0; i-- {
+		segment := strings.TrimSpace(segments[i])
+		if segment == "" || (strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}")) {
+			continue
+		}
+		collectionKey = strings.TrimSuffix(segment, ".json")
+		break
+	}
+	if collectionKey == "" {
+		return nil, false
+	}
+
+	var matched []json.RawMessage
+	matches := 0
+	for key, raw := range obj {
+		if !strings.EqualFold(key, collectionKey) {
+			continue
+		}
+		var items []json.RawMessage
+		if json.Unmarshal(raw, &items) != nil {
+			continue
+		}
+		matched = items
+		matches++
+	}
+	if matches == 1 {
+		return matched, true
 	}
 	return nil, false
 }
@@ -967,7 +1008,7 @@ func fetchEmbeddedPagedSubresource(ctx context.Context, c interface {
 		if err := json.Unmarshal(data, &obj); err != nil {
 			return nil, fmt.Errorf("paginating embedded sub-resource %q page %d: unexpected response shape: %w", childPath, page+1, err)
 		}
-		if items, ok := extractPaginatedItems(obj); ok {
+		if items, ok := extractPaginatedItems(obj, childPath); ok {
 			all = append(all, items...)
 		}
 		if !nextIsURL {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -854,11 +854,26 @@ func paginationCursorToken(raw json.RawMessage) string {
 }
 
 func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	return extractPaginatedItemsFromObject(obj, true)
+}
+
+func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, allowEmbedded bool) ([]json.RawMessage, bool) {
 	for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
 		if arr, ok := obj[field]; ok {
 			var nested []json.RawMessage
 			if json.Unmarshal(arr, &nested) == nil {
 				return nested, true
+			}
+		}
+	}
+
+	if allowEmbedded {
+		if raw, ok := obj["_embedded"]; ok {
+			var embedded map[string]json.RawMessage
+			if json.Unmarshal(raw, &embedded) == nil {
+				if nested, ok := extractPaginatedItemsFromObject(embedded, false); ok {
+					return nested, true
+				}
 			}
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -847,11 +847,26 @@ func paginationCursorToken(raw json.RawMessage) string {
 }
 
 func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	return extractPaginatedItemsFromObject(obj, true)
+}
+
+func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, allowEmbedded bool) ([]json.RawMessage, bool) {
 	for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
 		if arr, ok := obj[field]; ok {
 			var nested []json.RawMessage
 			if json.Unmarshal(arr, &nested) == nil {
 				return nested, true
+			}
+		}
+	}
+
+	if allowEmbedded {
+		if raw, ok := obj["_embedded"]; ok {
+			var embedded map[string]json.RawMessage
+			if json.Unmarshal(raw, &embedded) == nil {
+				if nested, ok := extractPaginatedItemsFromObject(embedded, false); ok {
+					return nested, true
+				}
 			}
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -857,16 +857,16 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath
 		}
 	}
 
-	for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
-		if arr, ok := obj[field]; ok {
-			var nested []json.RawMessage
-			if json.Unmarshal(arr, &nested) == nil {
-				return nested, true
+	if allowEmbedded {
+		for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
+			if arr, ok := obj[field]; ok {
+				var nested []json.RawMessage
+				if json.Unmarshal(arr, &nested) == nil {
+					return nested, true
+				}
 			}
 		}
-	}
 
-	if allowEmbedded {
 		if raw, ok := obj["_embedded"]; ok {
 			var embedded map[string]json.RawMessage
 			if json.Unmarshal(raw, &embedded) == nil {
@@ -897,34 +897,31 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath
 func extractPaginatedItemsMatchingPath(obj map[string]json.RawMessage, requestPath string) ([]json.RawMessage, bool) {
 	pathWithoutQuery := strings.SplitN(requestPath, "?", 2)[0]
 	segments := strings.Split(strings.Trim(pathWithoutQuery, "/"), "/")
-	collectionKey := ""
 	for i := len(segments) - 1; i >= 0; i-- {
-		segment := strings.TrimSpace(segments[i])
+		segment := strings.TrimSuffix(strings.TrimSpace(segments[i]), ".json")
 		if segment == "" || (strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}")) {
 			continue
 		}
-		collectionKey = strings.TrimSuffix(segment, ".json")
-		break
-	}
-	if collectionKey == "" {
-		return nil, false
-	}
 
-	var matched []json.RawMessage
-	matches := 0
-	for key, raw := range obj {
-		if !strings.EqualFold(key, collectionKey) {
-			continue
+		var matched []json.RawMessage
+		matches := 0
+		for key, raw := range obj {
+			if !strings.EqualFold(key, segment) {
+				continue
+			}
+			var items []json.RawMessage
+			if json.Unmarshal(raw, &items) != nil {
+				continue
+			}
+			matched = items
+			matches++
 		}
-		var items []json.RawMessage
-		if json.Unmarshal(raw, &items) != nil {
-			continue
+		if matches == 1 {
+			return matched, true
 		}
-		matched = items
-		matches++
-	}
-	if matches == 1 {
-		return matched, true
+		if matches > 1 {
+			return nil, false
+		}
 	}
 	return nil, false
 }

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -636,7 +636,7 @@ func paginatedGet(ctx context.Context, c interface {
 			var obj map[string]json.RawMessage
 			if json.Unmarshal(data, &obj) == nil {
 				itemCount := 0
-				if nested, ok := extractPaginatedItems(obj); ok {
+				if nested, ok := extractPaginatedItems(obj, path); ok {
 					allItems = append(allItems, nested...)
 					itemCount = len(nested)
 				}
@@ -846,11 +846,17 @@ func paginationCursorToken(raw json.RawMessage) string {
 	return ""
 }
 
-func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, bool) {
-	return extractPaginatedItemsFromObject(obj, true)
+func extractPaginatedItems(obj map[string]json.RawMessage, requestPath string) ([]json.RawMessage, bool) {
+	return extractPaginatedItemsFromObject(obj, requestPath, true)
 }
 
-func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, allowEmbedded bool) ([]json.RawMessage, bool) {
+func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath string, allowEmbedded bool) ([]json.RawMessage, bool) {
+	if !allowEmbedded {
+		if nested, ok := extractPaginatedItemsMatchingPath(obj, requestPath); ok {
+			return nested, true
+		}
+	}
+
 	for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
 		if arr, ok := obj[field]; ok {
 			var nested []json.RawMessage
@@ -864,7 +870,7 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, allowEmbedd
 		if raw, ok := obj["_embedded"]; ok {
 			var embedded map[string]json.RawMessage
 			if json.Unmarshal(raw, &embedded) == nil {
-				if nested, ok := extractPaginatedItemsFromObject(embedded, false); ok {
+				if nested, ok := extractPaginatedItemsFromObject(embedded, requestPath, false); ok {
 					return nested, true
 				}
 			}
@@ -884,6 +890,41 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, allowEmbedd
 	}
 	if arrayCount == 1 {
 		return onlyArray, true
+	}
+	return nil, false
+}
+
+func extractPaginatedItemsMatchingPath(obj map[string]json.RawMessage, requestPath string) ([]json.RawMessage, bool) {
+	pathWithoutQuery := strings.SplitN(requestPath, "?", 2)[0]
+	segments := strings.Split(strings.Trim(pathWithoutQuery, "/"), "/")
+	collectionKey := ""
+	for i := len(segments) - 1; i >= 0; i-- {
+		segment := strings.TrimSpace(segments[i])
+		if segment == "" || (strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}")) {
+			continue
+		}
+		collectionKey = strings.TrimSuffix(segment, ".json")
+		break
+	}
+	if collectionKey == "" {
+		return nil, false
+	}
+
+	var matched []json.RawMessage
+	matches := 0
+	for key, raw := range obj {
+		if !strings.EqualFold(key, collectionKey) {
+			continue
+		}
+		var items []json.RawMessage
+		if json.Unmarshal(raw, &items) != nil {
+			continue
+		}
+		matched = items
+		matches++
+	}
+	if matches == 1 {
+		return matched, true
 	}
 	return nil, false
 }

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 73
+    "total": 75
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -932,11 +932,26 @@ func paginationCursorToken(raw json.RawMessage) string {
 }
 
 func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	return extractPaginatedItemsFromObject(obj, true)
+}
+
+func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, allowEmbedded bool) ([]json.RawMessage, bool) {
 	for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
 		if arr, ok := obj[field]; ok {
 			var nested []json.RawMessage
 			if json.Unmarshal(arr, &nested) == nil {
 				return nested, true
+			}
+		}
+	}
+
+	if allowEmbedded {
+		if raw, ok := obj["_embedded"]; ok {
+			var embedded map[string]json.RawMessage
+			if json.Unmarshal(raw, &embedded) == nil {
+				if nested, ok := extractPaginatedItemsFromObject(embedded, false); ok {
+					return nested, true
+				}
 			}
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -942,16 +942,16 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath
 		}
 	}
 
-	for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
-		if arr, ok := obj[field]; ok {
-			var nested []json.RawMessage
-			if json.Unmarshal(arr, &nested) == nil {
-				return nested, true
+	if allowEmbedded {
+		for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
+			if arr, ok := obj[field]; ok {
+				var nested []json.RawMessage
+				if json.Unmarshal(arr, &nested) == nil {
+					return nested, true
+				}
 			}
 		}
-	}
 
-	if allowEmbedded {
 		if raw, ok := obj["_embedded"]; ok {
 			var embedded map[string]json.RawMessage
 			if json.Unmarshal(raw, &embedded) == nil {
@@ -982,34 +982,31 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath
 func extractPaginatedItemsMatchingPath(obj map[string]json.RawMessage, requestPath string) ([]json.RawMessage, bool) {
 	pathWithoutQuery := strings.SplitN(requestPath, "?", 2)[0]
 	segments := strings.Split(strings.Trim(pathWithoutQuery, "/"), "/")
-	collectionKey := ""
 	for i := len(segments) - 1; i >= 0; i-- {
-		segment := strings.TrimSpace(segments[i])
+		segment := strings.TrimSuffix(strings.TrimSpace(segments[i]), ".json")
 		if segment == "" || (strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}")) {
 			continue
 		}
-		collectionKey = strings.TrimSuffix(segment, ".json")
-		break
-	}
-	if collectionKey == "" {
-		return nil, false
-	}
 
-	var matched []json.RawMessage
-	matches := 0
-	for key, raw := range obj {
-		if !strings.EqualFold(key, collectionKey) {
-			continue
+		var matched []json.RawMessage
+		matches := 0
+		for key, raw := range obj {
+			if !strings.EqualFold(key, segment) {
+				continue
+			}
+			var items []json.RawMessage
+			if json.Unmarshal(raw, &items) != nil {
+				continue
+			}
+			matched = items
+			matches++
 		}
-		var items []json.RawMessage
-		if json.Unmarshal(raw, &items) != nil {
-			continue
+		if matches == 1 {
+			return matched, true
 		}
-		matched = items
-		matches++
-	}
-	if matches == 1 {
-		return matched, true
+		if matches > 1 {
+			return nil, false
+		}
 	}
 	return nil, false
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -721,7 +721,7 @@ func paginatedGet(ctx context.Context, c interface {
 			var obj map[string]json.RawMessage
 			if json.Unmarshal(data, &obj) == nil {
 				itemCount := 0
-				if nested, ok := extractPaginatedItems(obj); ok {
+				if nested, ok := extractPaginatedItems(obj, path); ok {
 					allItems = append(allItems, nested...)
 					itemCount = len(nested)
 				}
@@ -931,11 +931,17 @@ func paginationCursorToken(raw json.RawMessage) string {
 	return ""
 }
 
-func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, bool) {
-	return extractPaginatedItemsFromObject(obj, true)
+func extractPaginatedItems(obj map[string]json.RawMessage, requestPath string) ([]json.RawMessage, bool) {
+	return extractPaginatedItemsFromObject(obj, requestPath, true)
 }
 
-func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, allowEmbedded bool) ([]json.RawMessage, bool) {
+func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath string, allowEmbedded bool) ([]json.RawMessage, bool) {
+	if !allowEmbedded {
+		if nested, ok := extractPaginatedItemsMatchingPath(obj, requestPath); ok {
+			return nested, true
+		}
+	}
+
 	for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
 		if arr, ok := obj[field]; ok {
 			var nested []json.RawMessage
@@ -949,7 +955,7 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, allowEmbedd
 		if raw, ok := obj["_embedded"]; ok {
 			var embedded map[string]json.RawMessage
 			if json.Unmarshal(raw, &embedded) == nil {
-				if nested, ok := extractPaginatedItemsFromObject(embedded, false); ok {
+				if nested, ok := extractPaginatedItemsFromObject(embedded, requestPath, false); ok {
 					return nested, true
 				}
 			}
@@ -969,6 +975,41 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, allowEmbedd
 	}
 	if arrayCount == 1 {
 		return onlyArray, true
+	}
+	return nil, false
+}
+
+func extractPaginatedItemsMatchingPath(obj map[string]json.RawMessage, requestPath string) ([]json.RawMessage, bool) {
+	pathWithoutQuery := strings.SplitN(requestPath, "?", 2)[0]
+	segments := strings.Split(strings.Trim(pathWithoutQuery, "/"), "/")
+	collectionKey := ""
+	for i := len(segments) - 1; i >= 0; i-- {
+		segment := strings.TrimSpace(segments[i])
+		if segment == "" || (strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}")) {
+			continue
+		}
+		collectionKey = strings.TrimSuffix(segment, ".json")
+		break
+	}
+	if collectionKey == "" {
+		return nil, false
+	}
+
+	var matched []json.RawMessage
+	matches := 0
+	for key, raw := range obj {
+		if !strings.EqualFold(key, collectionKey) {
+			continue
+		}
+		var items []json.RawMessage
+		if json.Unmarshal(raw, &items) != nil {
+			continue
+		}
+		matched = items
+		matches++
+	}
+	if matches == 1 {
+		return matched, true
 	}
 	return nil, false
 }


### PR DESCRIPTION
## Summary

Fix generated `list --all` pagination for HAL-style responses and APIs that use `size` for page length, without reinterpreting unrelated `size` filters.

## Approach

Within one HAL `_embedded` object, pagination now prefers the collection relation that matches the requested path before falling back to known wrapper names or a single unambiguous array. This keeps the primary collection selectable when sibling domain arrays are present.

OpenAPI pagination detection recognizes `size` only when an advance parameter such as `page`, `offset`, or a cursor is present and the parameter description explicitly identifies page-length semantics. Size-only endpoints and unrelated size filters remain unclassified.

## Scope

This belongs in the Printing Press because the behavior is emitted into every affected printed CLI, rather than being specific to one API.

## Risk

The HAL fallback remains bounded to one embedded object and preserves ambiguity when the request path does not identify a collection. Focused regressions cover a requested `events` collection beside an `items` relation, accepted page-size descriptions, and an unrelated file-size filter.

## Output Contract

Updated the three affected helper golden fixtures and the deterministic generated dead-function count (`73` to `75`). Generated-output verification compiled 10 generated cases successfully.

## Verification

- `go test ./...` — 6,759 tests passed across 44 packages
- `go test ./internal/generator -run '^TestPaginatedGetHandlesNumericCursorAndMissingAllSignal$' -v -count=1`
- `go test ./internal/openapi -run '^TestDetectPagination(RecognizesDescribedPageSizeWithAdvanceParam|DoesNotClassifyUnrelatedSizeWithAdvanceParam)$' -v -count=1`
- `scripts/verify-generator-output.sh` — 10 generated cases compiled
- `scripts/golden.sh verify` — 32 cases passed

Closes #3566
