### PR TITLE
fix(cli): warn on unknown --select fields

### DIFF
--- a/internal/generator/filter_fields_envelope_test.go
+++ b/internal/generator/filter_fields_envelope_test.go
@@ -108,18 +108,7 @@ func TestFilterFieldsEnvelopeDescent(t *testing.T) {
 
 func TestFilterFieldsEnvelopeDescent_UnknownSelector(t *testing.T) {
 	input := "{\"items\":[{\"id\":\"a\",\"name\":\"Alpha\"},{\"id\":\"b\",\"name\":\"Beta\"}]}"
-
-	oldStderr := os.Stderr
-	read, write, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe() error: %v", err)
-	}
-	os.Stderr = write
-	got := filterFields(json.RawMessage(input), "missing")
-	_ = write.Close()
-	os.Stderr = oldStderr
-	warning, _ := io.ReadAll(read)
-	_ = read.Close()
+	got, warning := filterFieldsWithWarning(t, input, "missing")
 
 	var gotV, wantV interface{}
 	if err := json.Unmarshal(got, &gotV); err != nil {
@@ -140,7 +129,74 @@ func TestFilterFieldsEnvelopeDescent_UnknownSelector(t *testing.T) {
 		t.Fatalf("warning = %q, want valid top-level fields", warning)
 	}
 }
+
+func TestFilterFieldsEnvelopeDescent_EmptyCollectionsDoNotWarn(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		fields string
+		want   string
+	}{
+		{"top-level array", `+"`"+`[]`+"`"+`, "id", `+"`"+`[]`+"`"+`},
+		{"list envelope", `+"`"+`{"items":[]}`+"`"+`, "id", `+"`"+`{"items":[]}`+"`"+`},
+		{"known dotted head", `+"`"+`{"events":[],"other":1}`+"`"+`, "events.name", `+"`"+`{"events":[]}`+"`"+`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, warning := filterFieldsWithWarning(t, tc.input, tc.fields)
+			if string(warning) != "" {
+				t.Fatalf("warning = %q, want no warning for an empty collection", warning)
+			}
+			assertJSONEqual(t, got, tc.want)
+		})
+	}
+}
+
+func TestFilterFieldsEnvelopeDescent_PartiallyInvalidSelectorWarns(t *testing.T) {
+	input := `+"`"+`[{"id":"a","name":"Alpha"}]`+"`"+`
+	got, warning := filterFieldsWithWarning(t, input, "id,naem")
+
+	assertJSONEqual(t, got, `+"`"+`[{"id":"a"}]`+"`"+`)
+	if !strings.Contains(string(warning), "--select \"naem\" matched no fields") {
+		t.Fatalf("warning = %q, want warning naming the unmatched selector", warning)
+	}
+	if strings.Contains(string(warning), "--select \"id\" matched no fields") {
+		t.Fatalf("warning = %q, valid selector id must not be reported", warning)
+	}
+}
+
+func filterFieldsWithWarning(t *testing.T, input, fields string) (json.RawMessage, []byte) {
+	t.Helper()
+	oldStderr := os.Stderr
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error: %v", err)
+	}
+	os.Stderr = write
+	got := filterFields(json.RawMessage(input), fields)
+	_ = write.Close()
+	os.Stderr = oldStderr
+	warning, _ := io.ReadAll(read)
+	_ = read.Close()
+	return got, warning
+}
+
+func assertJSONEqual(t *testing.T, got json.RawMessage, want string) {
+	t.Helper()
+	var gotV, wantV interface{}
+	if err := json.Unmarshal(got, &gotV); err != nil {
+		t.Fatalf("invalid json output: %v (raw=%s)", err, string(got))
+	}
+	if err := json.Unmarshal([]byte(want), &wantV); err != nil {
+		t.Fatalf("invalid want json: %v (raw=%s)", err, want)
+	}
+	gotBytes, _ := json.Marshal(gotV)
+	wantBytes, _ := json.Marshal(wantV)
+	if string(gotBytes) != string(wantBytes) {
+		t.Fatalf("filterFields output = %s, want %s", gotBytes, wantBytes)
+	}
+}
 `), 0o644))
 
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestFilterFieldsEnvelopeDescent", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "^(TestFilterFieldsEnvelopeDescent|TestFilterFieldsEnvelopeDescent_UnknownSelector|TestFilterFieldsEnvelopeDescent_EmptyCollectionsDoNotWarn|TestFilterFieldsEnvelopeDescent_PartiallyInvalidSelectorWarns)$", "-count=1")
 }

--- a/internal/generator/filter_fields_envelope_test.go
+++ b/internal/generator/filter_fields_envelope_test.go
@@ -165,6 +165,44 @@ func TestFilterFieldsEnvelopeDescent_PartiallyInvalidSelectorWarns(t *testing.T)
 	}
 }
 
+func TestFilterFieldsEnvelopeDescent_EmptyEnvelopeSelectorWarnings(t *testing.T) {
+	input := `+"`"+`{"items":[]}`+"`"+`
+	cases := []struct {
+		name           string
+		fields         string
+		wantWarnings   []string
+		forbidWarnings []string
+	}{
+		{
+			name:           "known prefix and unrelated typo",
+			fields:         "items.id,naem",
+			wantWarnings:   []string{"naem"},
+			forbidWarnings: []string{"items.id"},
+		},
+		{
+			name:         "multiple unrelated selectors",
+			fields:       "naem,missing",
+			wantWarnings: []string{"naem", "missing"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, warning := filterFieldsWithWarning(t, input, tc.fields)
+			assertJSONEqual(t, got, input)
+			for _, field := range tc.wantWarnings {
+				if !strings.Contains(string(warning), "--select \""+field+"\" matched no fields") {
+					t.Fatalf("warning = %q, want warning naming %q", warning, field)
+				}
+			}
+			for _, field := range tc.forbidWarnings {
+				if strings.Contains(string(warning), "--select \""+field+"\" matched no fields") {
+					t.Fatalf("warning = %q, indeterminate selector %q must not be reported", warning, field)
+				}
+			}
+		})
+	}
+}
+
 func filterFieldsWithWarning(t *testing.T, input, fields string) (json.RawMessage, []byte) {
 	t.Helper()
 	oldStderr := os.Stderr
@@ -198,5 +236,5 @@ func assertJSONEqual(t *testing.T, got json.RawMessage, want string) {
 }
 `), 0o644))
 
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "^(TestFilterFieldsEnvelopeDescent|TestFilterFieldsEnvelopeDescent_UnknownSelector|TestFilterFieldsEnvelopeDescent_EmptyCollectionsDoNotWarn|TestFilterFieldsEnvelopeDescent_PartiallyInvalidSelectorWarns)$", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "^(TestFilterFieldsEnvelopeDescent|TestFilterFieldsEnvelopeDescent_UnknownSelector|TestFilterFieldsEnvelopeDescent_EmptyCollectionsDoNotWarn|TestFilterFieldsEnvelopeDescent_PartiallyInvalidSelectorWarns|TestFilterFieldsEnvelopeDescent_EmptyEnvelopeSelectorWarnings)$", "-count=1")
 }

--- a/internal/generator/filter_fields_envelope_test.go
+++ b/internal/generator/filter_fields_envelope_test.go
@@ -31,6 +31,9 @@ func TestFilterFieldsEnvelopeDescent_EmittedHelper(t *testing.T) {
 
 import (
 	"encoding/json"
+	"io"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -70,10 +73,10 @@ func TestFilterFieldsEnvelopeDescent(t *testing.T) {
 			`+"`"+`{"items":[{"id":"a"}],"next_cursor":null}`+"`"+`,
 		},
 		{
-			"flat object no match returns empty",
+			"flat object no match preserves input",
 			`+"`"+`{"a":1,"b":2}`+"`"+`,
 			"c",
-			`+"`"+`{}`+"`"+`,
+			`+"`"+`{"a":1,"b":2}`+"`"+`,
 		},
 		{
 			"selector matches envelope key suppresses descent",
@@ -100,6 +103,41 @@ func TestFilterFieldsEnvelopeDescent(t *testing.T) {
 					tc.input, tc.fields, string(gotBytes), string(wantBytes))
 			}
 		})
+	}
+}
+
+func TestFilterFieldsEnvelopeDescent_UnknownSelector(t *testing.T) {
+	input := "{\"items\":[{\"id\":\"a\",\"name\":\"Alpha\"},{\"id\":\"b\",\"name\":\"Beta\"}]}"
+
+	oldStderr := os.Stderr
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error: %v", err)
+	}
+	os.Stderr = write
+	got := filterFields(json.RawMessage(input), "missing")
+	_ = write.Close()
+	os.Stderr = oldStderr
+	warning, _ := io.ReadAll(read)
+	_ = read.Close()
+
+	var gotV, wantV interface{}
+	if err := json.Unmarshal(got, &gotV); err != nil {
+		t.Fatalf("invalid json output: %v (raw=%s)", err, string(got))
+	}
+	if err := json.Unmarshal([]byte(input), &wantV); err != nil {
+		t.Fatalf("invalid input json: %v", err)
+	}
+	gotBytes, _ := json.Marshal(gotV)
+	wantBytes, _ := json.Marshal(wantV)
+	if string(gotBytes) != string(wantBytes) {
+		t.Fatalf("unknown selector changed the payload: got %s, want %s", gotBytes, wantBytes)
+	}
+	if !strings.Contains(string(warning), "--select \"missing\" matched no fields") {
+		t.Fatalf("warning = %q, want unknown-selector warning", warning)
+	}
+	if !strings.Contains(string(warning), "valid fields: items") {
+		t.Fatalf("warning = %q, want valid top-level fields", warning)
 	}
 }
 `), 0o644))

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1722,11 +1722,12 @@ func filterFields(data json.RawMessage, fields string) json.RawMessage {
 	if len(paths) == 0 {
 		return data
 	}
-	filtered, matched, indeterminate := filterFieldsRec(data, paths)
+	filtered, state := filterFieldsRec(data, paths, true)
 	valid := ""
 	for i, path := range paths {
-		_, pathMatched, pathIndeterminate := filterFieldsRec(data, [][]string{path})
-		if pathMatched || pathIndeterminate {
+		_, pathState := filterFieldsRec(data, [][]string{path}, true)
+		pathIndeterminate := pathState.anchoredIndeterminate || (len(paths) == 1 && pathState.fallbackIndeterminate)
+		if pathState.matched || pathIndeterminate {
 			continue
 		}
 		if valid == "" {
@@ -1737,7 +1738,7 @@ func filterFields(data json.RawMessage, fields string) json.RawMessage {
 		}
 		fmt.Fprintf(os.Stderr, "warning: --select %q matched no fields; valid fields: %s\n", requestedPaths[i], valid)
 	}
-	if !matched && !indeterminate {
+	if !state.matched && !state.anchoredIndeterminate && !state.fallbackIndeterminate {
 		return data
 	}
 	return filtered
@@ -1771,25 +1772,37 @@ func selectFieldKeys(data json.RawMessage) []string {
 	return result
 }
 
+type selectMatchState struct {
+	matched               bool
+	anchoredIndeterminate bool
+	fallbackIndeterminate bool
+}
+
+func (s *selectMatchState) merge(other selectMatchState) {
+	s.matched = s.matched || other.matched
+	s.anchoredIndeterminate = s.anchoredIndeterminate || other.anchoredIndeterminate
+	s.fallbackIndeterminate = s.fallbackIndeterminate || other.fallbackIndeterminate
+}
+
 // filterFieldsRec applies path filters to a JSON value. Each path is a list of
-// lowercase segments; arrays descend element-wise. The final return value is
-// true when an empty array makes the requested path indeterminate rather than
-// definitively unmatched.
-func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool) {
+// lowercase segments; arrays descend element-wise. pathAnchored distinguishes
+// empty arrays reached through a known selector prefix from empty arrays found
+// only by the list-envelope fallback.
+func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) (json.RawMessage, selectMatchState) {
 	var arr []json.RawMessage
 	if err := json.Unmarshal(data, &arr); err == nil {
 		out := make([]json.RawMessage, len(arr))
-		matchedAny := false
-		indeterminateAny := len(arr) == 0
+		state := selectMatchState{
+			anchoredIndeterminate: len(arr) == 0 && pathAnchored,
+			fallbackIndeterminate: len(arr) == 0 && !pathAnchored,
+		}
 		for i, el := range arr {
-			var matched bool
-			var indeterminate bool
-			out[i], matched, indeterminate = filterFieldsRec(el, paths)
-			matchedAny = matchedAny || matched
-			indeterminateAny = indeterminateAny || indeterminate
+			var childState selectMatchState
+			out[i], childState = filterFieldsRec(el, paths, pathAnchored)
+			state.merge(childState)
 		}
 		result, _ := json.Marshal(out)
-		return result, matchedAny, indeterminateAny
+		return result, state
 	}
 
 	var obj map[string]json.RawMessage
@@ -1809,8 +1822,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 		}
 		filtered := map[string]json.RawMessage{}
 		headMatched := false
-		pathMatched := false
-		pathIndeterminate := false
+		state := selectMatchState{}
 		for k, v := range obj {
 			matched := matchSelectSegment(k, keepWhole, subPaths)
 			if matched == "" {
@@ -1819,15 +1831,13 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 			headMatched = true
 			if keepWhole[matched] {
 				filtered[k] = v
-				pathMatched = true
+				state.matched = true
 				continue
 			}
 			if subs := subPaths[matched]; subs != nil {
-				var childMatched bool
-				var childIndeterminate bool
-				filtered[k], childMatched, childIndeterminate = filterFieldsRec(v, subs)
-				pathMatched = pathMatched || childMatched
-				pathIndeterminate = pathIndeterminate || childIndeterminate
+				var childState selectMatchState
+				filtered[k], childState = filterFieldsRec(v, subs, true)
+				state.merge(childState)
 			}
 		}
 		// Envelope fallback: when no top-level keys matched but at least one
@@ -1841,24 +1851,22 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 		// which json.Unmarshal otherwise accepts into a []json.RawMessage
 		// as a nil slice and would coerce to `[]`.
 		if !headMatched {
-			if pending, foundArray, nestedMatched, nestedIndeterminate := filterListEnvelopeFields(obj, paths); foundArray {
+			if pending, foundArray, nestedState := filterListEnvelopeFields(obj, paths); foundArray {
 				filtered = pending
-				pathMatched = pathMatched || nestedMatched
-				pathIndeterminate = pathIndeterminate || nestedIndeterminate
+				state.merge(nestedState)
 			}
 		}
 		result, _ := json.Marshal(filtered)
-		return result, pathMatched, pathIndeterminate
+		return result, state
 	}
 
-	return data, false, false
+	return data, selectMatchState{}
 }
 
-func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, bool, bool) {
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, selectMatchState) {
 	pending := map[string]json.RawMessage{}
 	foundArray := false
-	matchedAny := false
-	indeterminateAny := false
+	state := selectMatchState{}
 	for k, v := range obj {
 		if envelopeMetadataArrayKeys[k] {
 			pending[k] = v
@@ -1867,38 +1875,35 @@ func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) 
 		var arr []json.RawMessage
 		if json.Unmarshal(v, &arr) == nil && arr != nil {
 			foundArray = true
-			var matched bool
-			var indeterminate bool
-			pending[k], matched, indeterminate = filterFieldsRec(v, paths)
-			matchedAny = matchedAny || matched
-			indeterminateAny = indeterminateAny || indeterminate
+			var childState selectMatchState
+			pending[k], childState = filterFieldsRec(v, paths, false)
+			state.merge(childState)
 			continue
 		}
 		if k == "_embedded" {
-			if nested, ok, matched, indeterminate := filterNestedListEnvelopeFields(v, paths); ok {
+			if nested, ok, nestedState := filterNestedListEnvelopeFields(v, paths); ok {
 				foundArray = true
 				pending[k] = nested
-				matchedAny = matchedAny || matched
-				indeterminateAny = indeterminateAny || indeterminate
+				state.merge(nestedState)
 				continue
 			}
 		}
 		pending[k] = v
 	}
-	return pending, foundArray, matchedAny, indeterminateAny
+	return pending, foundArray, state
 }
 
-func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool, bool) {
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, selectMatchState) {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, false, false, false
+		return nil, false, selectMatchState{}
 	}
-	filtered, found, matched, indeterminate := filterListEnvelopeFields(obj, paths)
+	filtered, found, state := filterListEnvelopeFields(obj, paths)
 	if !found {
-		return nil, false, false, false
+		return nil, false, selectMatchState{}
 	}
 	result, _ := json.Marshal(filtered)
-	return result, true, matched, indeterminate
+	return result, true, state
 }
 
 // matchSelectSegment returns the matching lowercase segment, or "" if no match.

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1720,20 +1720,60 @@ func filterFields(data json.RawMessage, fields string) json.RawMessage {
 	if len(paths) == 0 {
 		return data
 	}
-	return filterFieldsRec(data, paths)
+	filtered, matched := filterFieldsRec(data, paths)
+	if !matched {
+		valid := strings.Join(selectFieldKeys(data), ", ")
+		if valid == "" {
+			valid = "none"
+		}
+		fmt.Fprintf(os.Stderr, "warning: --select %q matched no fields; valid fields: %s\n", fields, valid)
+		return data
+	}
+	return filtered
+}
+
+func selectFieldKeys(data json.RawMessage) []string {
+	keys := map[string]bool{}
+	var collect func(json.RawMessage)
+	collect = func(value json.RawMessage) {
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(value, &obj); err == nil && obj != nil {
+			for key := range obj {
+				keys[key] = true
+			}
+			return
+		}
+		var arr []json.RawMessage
+		if err := json.Unmarshal(value, &arr); err == nil {
+			for _, element := range arr {
+				collect(element)
+			}
+		}
+	}
+	collect(data)
+
+	result := make([]string, 0, len(keys))
+	for key := range keys {
+		result = append(result, key)
+	}
+	sort.Strings(result)
+	return result
 }
 
 // filterFieldsRec applies path filters to a JSON value. Each path is a list of
 // lowercase segments; arrays descend element-wise.
-func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
+func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, bool) {
 	var arr []json.RawMessage
 	if err := json.Unmarshal(data, &arr); err == nil {
 		out := make([]json.RawMessage, len(arr))
+		matchedAny := false
 		for i, el := range arr {
-			out[i] = filterFieldsRec(el, paths)
+			var matched bool
+			out[i], matched = filterFieldsRec(el, paths)
+			matchedAny = matchedAny || matched
 		}
 		result, _ := json.Marshal(out)
-		return result
+		return result, matchedAny
 	}
 
 	var obj map[string]json.RawMessage
@@ -1752,19 +1792,23 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 			}
 		}
 		filtered := map[string]json.RawMessage{}
-		matchedAny := false
+		headMatched := false
+		pathMatched := false
 		for k, v := range obj {
 			matched := matchSelectSegment(k, keepWhole, subPaths)
 			if matched == "" {
 				continue
 			}
-			matchedAny = true
+			headMatched = true
 			if keepWhole[matched] {
 				filtered[k] = v
+				pathMatched = true
 				continue
 			}
 			if subs := subPaths[matched]; subs != nil {
-				filtered[k] = filterFieldsRec(v, subs)
+				var childMatched bool
+				filtered[k], childMatched = filterFieldsRec(v, subs)
+				pathMatched = pathMatched || childMatched
 			}
 		}
 		// Envelope fallback: when no top-level keys matched but at least one
@@ -1772,26 +1816,28 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 		// (`{"items":[...]}`, `{"data":[...]}`, `{"total_count":N,"items":[...]}`)
 		// and apply the selector inside the array(s). Non-array siblings pass
 		// through verbatim so envelope metadata (counts, null pagination
-		// cursors) stays visible. The foundArray guard preserves the prior
-		// empty-object result for flat objects where no key matches and no
-		// array exists. The `arr != nil` check rejects JSON null, which
-		// json.Unmarshal otherwise accepts into a []json.RawMessage as a
-		// nil slice and would coerce to `[]`.
-		if !matchedAny {
-			if pending, foundArray := filterListEnvelopeFields(obj, paths); foundArray {
+		// cursors) stays visible. The foundArray guard keeps flat objects
+		// without matching keys as an all-miss result for the caller to
+		// diagnose and preserve. The `arr != nil` check rejects JSON null,
+		// which json.Unmarshal otherwise accepts into a []json.RawMessage
+		// as a nil slice and would coerce to `[]`.
+		if !headMatched {
+			if pending, foundArray, nestedMatched := filterListEnvelopeFields(obj, paths); foundArray {
 				filtered = pending
+				pathMatched = pathMatched || nestedMatched
 			}
 		}
 		result, _ := json.Marshal(filtered)
-		return result
+		return result, pathMatched
 	}
 
-	return data
+	return data, false
 }
 
-func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool) {
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, bool) {
 	pending := map[string]json.RawMessage{}
 	foundArray := false
+	matchedAny := false
 	for k, v := range obj {
 		if envelopeMetadataArrayKeys[k] {
 			pending[k] = v
@@ -1800,32 +1846,35 @@ func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) 
 		var arr []json.RawMessage
 		if json.Unmarshal(v, &arr) == nil && arr != nil {
 			foundArray = true
-			pending[k] = filterFieldsRec(v, paths)
+			var matched bool
+			pending[k], matched = filterFieldsRec(v, paths)
+			matchedAny = matchedAny || matched
 			continue
 		}
 		if k == "_embedded" {
-			if nested, ok := filterNestedListEnvelopeFields(v, paths); ok {
+			if nested, ok, matched := filterNestedListEnvelopeFields(v, paths); ok {
 				foundArray = true
 				pending[k] = nested
+				matchedAny = matchedAny || matched
 				continue
 			}
 		}
 		pending[k] = v
 	}
-	return pending, foundArray
+	return pending, foundArray, matchedAny
 }
 
-func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool) {
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool) {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, false
+		return nil, false, false
 	}
-	filtered, found := filterListEnvelopeFields(obj, paths)
+	filtered, found, matched := filterListEnvelopeFields(obj, paths)
 	if !found {
-		return nil, false
+		return nil, false, false
 	}
 	result, _ := json.Marshal(filtered)
-	return result, true
+	return result, true, matched
 }
 
 // matchSelectSegment returns the matching lowercase segment, or "" if no match.

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1706,11 +1706,13 @@ func unwrapSingleKeyArray(data json.RawMessage) json.RawMessage {
 // Arrays are traversed element-wise: "events.shortName" keeps shortName on each event.
 func filterFields(data json.RawMessage, fields string) json.RawMessage {
 	var paths [][]string
+	var requestedPaths []string
 	for _, f := range strings.Split(fields, ",") {
 		f = strings.TrimSpace(f)
 		if f == "" {
 			continue
 		}
+		requestedPaths = append(requestedPaths, f)
 		parts := strings.Split(f, ".")
 		for i := range parts {
 			parts[i] = strings.ToLower(parts[i])
@@ -1720,13 +1722,22 @@ func filterFields(data json.RawMessage, fields string) json.RawMessage {
 	if len(paths) == 0 {
 		return data
 	}
-	filtered, matched := filterFieldsRec(data, paths)
-	if !matched {
-		valid := strings.Join(selectFieldKeys(data), ", ")
-		if valid == "" {
-			valid = "none"
+	filtered, matched, indeterminate := filterFieldsRec(data, paths)
+	valid := ""
+	for i, path := range paths {
+		_, pathMatched, pathIndeterminate := filterFieldsRec(data, [][]string{path})
+		if pathMatched || pathIndeterminate {
+			continue
 		}
-		fmt.Fprintf(os.Stderr, "warning: --select %q matched no fields; valid fields: %s\n", fields, valid)
+		if valid == "" {
+			valid = strings.Join(selectFieldKeys(data), ", ")
+			if valid == "" {
+				valid = "none"
+			}
+		}
+		fmt.Fprintf(os.Stderr, "warning: --select %q matched no fields; valid fields: %s\n", requestedPaths[i], valid)
+	}
+	if !matched && !indeterminate {
 		return data
 	}
 	return filtered
@@ -1761,19 +1772,24 @@ func selectFieldKeys(data json.RawMessage) []string {
 }
 
 // filterFieldsRec applies path filters to a JSON value. Each path is a list of
-// lowercase segments; arrays descend element-wise.
-func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, bool) {
+// lowercase segments; arrays descend element-wise. The final return value is
+// true when an empty array makes the requested path indeterminate rather than
+// definitively unmatched.
+func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool) {
 	var arr []json.RawMessage
 	if err := json.Unmarshal(data, &arr); err == nil {
 		out := make([]json.RawMessage, len(arr))
 		matchedAny := false
+		indeterminateAny := len(arr) == 0
 		for i, el := range arr {
 			var matched bool
-			out[i], matched = filterFieldsRec(el, paths)
+			var indeterminate bool
+			out[i], matched, indeterminate = filterFieldsRec(el, paths)
 			matchedAny = matchedAny || matched
+			indeterminateAny = indeterminateAny || indeterminate
 		}
 		result, _ := json.Marshal(out)
-		return result, matchedAny
+		return result, matchedAny, indeterminateAny
 	}
 
 	var obj map[string]json.RawMessage
@@ -1794,6 +1810,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 		filtered := map[string]json.RawMessage{}
 		headMatched := false
 		pathMatched := false
+		pathIndeterminate := false
 		for k, v := range obj {
 			matched := matchSelectSegment(k, keepWhole, subPaths)
 			if matched == "" {
@@ -1807,8 +1824,10 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 			}
 			if subs := subPaths[matched]; subs != nil {
 				var childMatched bool
-				filtered[k], childMatched = filterFieldsRec(v, subs)
+				var childIndeterminate bool
+				filtered[k], childMatched, childIndeterminate = filterFieldsRec(v, subs)
 				pathMatched = pathMatched || childMatched
+				pathIndeterminate = pathIndeterminate || childIndeterminate
 			}
 		}
 		// Envelope fallback: when no top-level keys matched but at least one
@@ -1822,22 +1841,24 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 		// which json.Unmarshal otherwise accepts into a []json.RawMessage
 		// as a nil slice and would coerce to `[]`.
 		if !headMatched {
-			if pending, foundArray, nestedMatched := filterListEnvelopeFields(obj, paths); foundArray {
+			if pending, foundArray, nestedMatched, nestedIndeterminate := filterListEnvelopeFields(obj, paths); foundArray {
 				filtered = pending
 				pathMatched = pathMatched || nestedMatched
+				pathIndeterminate = pathIndeterminate || nestedIndeterminate
 			}
 		}
 		result, _ := json.Marshal(filtered)
-		return result, pathMatched
+		return result, pathMatched, pathIndeterminate
 	}
 
-	return data, false
+	return data, false, false
 }
 
-func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, bool) {
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, bool, bool) {
 	pending := map[string]json.RawMessage{}
 	foundArray := false
 	matchedAny := false
+	indeterminateAny := false
 	for k, v := range obj {
 		if envelopeMetadataArrayKeys[k] {
 			pending[k] = v
@@ -1847,34 +1868,37 @@ func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) 
 		if json.Unmarshal(v, &arr) == nil && arr != nil {
 			foundArray = true
 			var matched bool
-			pending[k], matched = filterFieldsRec(v, paths)
+			var indeterminate bool
+			pending[k], matched, indeterminate = filterFieldsRec(v, paths)
 			matchedAny = matchedAny || matched
+			indeterminateAny = indeterminateAny || indeterminate
 			continue
 		}
 		if k == "_embedded" {
-			if nested, ok, matched := filterNestedListEnvelopeFields(v, paths); ok {
+			if nested, ok, matched, indeterminate := filterNestedListEnvelopeFields(v, paths); ok {
 				foundArray = true
 				pending[k] = nested
 				matchedAny = matchedAny || matched
+				indeterminateAny = indeterminateAny || indeterminate
 				continue
 			}
 		}
 		pending[k] = v
 	}
-	return pending, foundArray, matchedAny
+	return pending, foundArray, matchedAny, indeterminateAny
 }
 
-func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool) {
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool, bool) {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, false, false
+		return nil, false, false, false
 	}
-	filtered, found, matched := filterListEnvelopeFields(obj, paths)
+	filtered, found, matched, indeterminate := filterListEnvelopeFields(obj, paths)
 	if !found {
-		return nil, false, false
+		return nil, false, false, false
 	}
 	result, _ := json.Marshal(filtered)
-	return result, true, matched
+	return result, true, matched, indeterminate
 }
 
 // matchSelectSegment returns the matching lowercase segment, or "" if no match.

--- a/internal/generator/templates/root_test.go.tmpl
+++ b/internal/generator/templates/root_test.go.tmpl
@@ -135,10 +135,16 @@ func TestFilterFields(t *testing.T) {
 			want:   `{"projects":[{"id":"a"}]}`,
 		},
 		{
-			name:   "flat object no match returns empty (no array fallback)",
+			name:   "flat object no match preserves input",
 			input:  `{"a":1,"b":2}`,
 			fields: "c",
-			want:   `{}`,
+			want:   `{"a":1,"b":2}`,
+		},
+		{
+			name:   "unknown selector preserves nested array objects",
+			input:  `{"items":[{"id":"a","name":"Alpha"},{"id":"b","name":"Beta"}]}`,
+			fields: "missing",
+			want:   `{"items":[{"id":"a","name":"Alpha"},{"id":"b","name":"Beta"}]}`,
 		},
 		{
 			// Null pagination cursors are common envelope metadata.
@@ -152,12 +158,11 @@ func TestFilterFields(t *testing.T) {
 		},
 		{
 			// Without a real array sibling the envelope fallback does not
-			// fire, so a flat object whose only "extra" key is null still
-			// returns {} for a non-matching selector.
-			name:   "flat object with null sibling no match returns empty",
+			// fire, but an invalid selector still preserves the input.
+			name:   "flat object with null sibling no match preserves input",
 			input:  `{"a":1,"b":null}`,
 			fields: "c",
-			want:   `{}`,
+			want:   `{"a":1,"b":null}`,
 		},
 		{
 			// Multiple array siblings at the same level each receive the
@@ -172,13 +177,11 @@ func TestFilterFields(t *testing.T) {
 			// Envelope fallback is intentionally one level deep. A nested
 			// object envelope like {"data":{"items":[...]}} surfaces no
 			// array at the outer level, so the fallback does not fire and
-			// the result is the empty-object that flat-no-match would
-			// produce. Pins the boundary so a future deeper-walk change
-			// is an explicit decision, not an accident.
-			name:   "nested object envelope returns empty (one-level only)",
+			// an invalid selector preserves the input.
+			name:   "nested object envelope preserves input (one-level only)",
 			input:  `{"data":{"items":[{"id":"a","other":"y"}]}}`,
 			fields: "id",
-			want:   `{}`,
+			want:   `{"data":{"items":[{"id":"a","other":"y"}]}}`,
 		},
 	}
 	for _, tc := range cases {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -1186,20 +1186,60 @@ func filterFields(data json.RawMessage, fields string) json.RawMessage {
 	if len(paths) == 0 {
 		return data
 	}
-	return filterFieldsRec(data, paths)
+	filtered, matched := filterFieldsRec(data, paths)
+	if !matched {
+		valid := strings.Join(selectFieldKeys(data), ", ")
+		if valid == "" {
+			valid = "none"
+		}
+		fmt.Fprintf(os.Stderr, "warning: --select %q matched no fields; valid fields: %s\n", fields, valid)
+		return data
+	}
+	return filtered
+}
+
+func selectFieldKeys(data json.RawMessage) []string {
+	keys := map[string]bool{}
+	var collect func(json.RawMessage)
+	collect = func(value json.RawMessage) {
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(value, &obj); err == nil && obj != nil {
+			for key := range obj {
+				keys[key] = true
+			}
+			return
+		}
+		var arr []json.RawMessage
+		if err := json.Unmarshal(value, &arr); err == nil {
+			for _, element := range arr {
+				collect(element)
+			}
+		}
+	}
+	collect(data)
+
+	result := make([]string, 0, len(keys))
+	for key := range keys {
+		result = append(result, key)
+	}
+	sort.Strings(result)
+	return result
 }
 
 // filterFieldsRec applies path filters to a JSON value. Each path is a list of
 // lowercase segments; arrays descend element-wise.
-func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
+func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, bool) {
 	var arr []json.RawMessage
 	if err := json.Unmarshal(data, &arr); err == nil {
 		out := make([]json.RawMessage, len(arr))
+		matchedAny := false
 		for i, el := range arr {
-			out[i] = filterFieldsRec(el, paths)
+			var matched bool
+			out[i], matched = filterFieldsRec(el, paths)
+			matchedAny = matchedAny || matched
 		}
 		result, _ := json.Marshal(out)
-		return result
+		return result, matchedAny
 	}
 
 	var obj map[string]json.RawMessage
@@ -1218,19 +1258,23 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 			}
 		}
 		filtered := map[string]json.RawMessage{}
-		matchedAny := false
+		headMatched := false
+		pathMatched := false
 		for k, v := range obj {
 			matched := matchSelectSegment(k, keepWhole, subPaths)
 			if matched == "" {
 				continue
 			}
-			matchedAny = true
+			headMatched = true
 			if keepWhole[matched] {
 				filtered[k] = v
+				pathMatched = true
 				continue
 			}
 			if subs := subPaths[matched]; subs != nil {
-				filtered[k] = filterFieldsRec(v, subs)
+				var childMatched bool
+				filtered[k], childMatched = filterFieldsRec(v, subs)
+				pathMatched = pathMatched || childMatched
 			}
 		}
 		// Envelope fallback: when no top-level keys matched but at least one
@@ -1238,26 +1282,28 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 		// (`{"items":[...]}`, `{"data":[...]}`, `{"total_count":N,"items":[...]}`)
 		// and apply the selector inside the array(s). Non-array siblings pass
 		// through verbatim so envelope metadata (counts, null pagination
-		// cursors) stays visible. The foundArray guard preserves the prior
-		// empty-object result for flat objects where no key matches and no
-		// array exists. The `arr != nil` check rejects JSON null, which
-		// json.Unmarshal otherwise accepts into a []json.RawMessage as a
-		// nil slice and would coerce to `[]`.
-		if !matchedAny {
-			if pending, foundArray := filterListEnvelopeFields(obj, paths); foundArray {
+		// cursors) stays visible. The foundArray guard keeps flat objects
+		// without matching keys as an all-miss result for the caller to
+		// diagnose and preserve. The `arr != nil` check rejects JSON null,
+		// which json.Unmarshal otherwise accepts into a []json.RawMessage
+		// as a nil slice and would coerce to `[]`.
+		if !headMatched {
+			if pending, foundArray, nestedMatched := filterListEnvelopeFields(obj, paths); foundArray {
 				filtered = pending
+				pathMatched = pathMatched || nestedMatched
 			}
 		}
 		result, _ := json.Marshal(filtered)
-		return result
+		return result, pathMatched
 	}
 
-	return data
+	return data, false
 }
 
-func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool) {
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, bool) {
 	pending := map[string]json.RawMessage{}
 	foundArray := false
+	matchedAny := false
 	for k, v := range obj {
 		if envelopeMetadataArrayKeys[k] {
 			pending[k] = v
@@ -1266,32 +1312,35 @@ func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) 
 		var arr []json.RawMessage
 		if json.Unmarshal(v, &arr) == nil && arr != nil {
 			foundArray = true
-			pending[k] = filterFieldsRec(v, paths)
+			var matched bool
+			pending[k], matched = filterFieldsRec(v, paths)
+			matchedAny = matchedAny || matched
 			continue
 		}
 		if k == "_embedded" {
-			if nested, ok := filterNestedListEnvelopeFields(v, paths); ok {
+			if nested, ok, matched := filterNestedListEnvelopeFields(v, paths); ok {
 				foundArray = true
 				pending[k] = nested
+				matchedAny = matchedAny || matched
 				continue
 			}
 		}
 		pending[k] = v
 	}
-	return pending, foundArray
+	return pending, foundArray, matchedAny
 }
 
-func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool) {
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool) {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, false
+		return nil, false, false
 	}
-	filtered, found := filterListEnvelopeFields(obj, paths)
+	filtered, found, matched := filterListEnvelopeFields(obj, paths)
 	if !found {
-		return nil, false
+		return nil, false, false
 	}
 	result, _ := json.Marshal(filtered)
-	return result, true
+	return result, true, matched
 }
 
 // matchSelectSegment returns the matching lowercase segment, or "" if no match.

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -1172,11 +1172,13 @@ func unwrapSingleKeyArray(data json.RawMessage) json.RawMessage {
 // Arrays are traversed element-wise: "events.shortName" keeps shortName on each event.
 func filterFields(data json.RawMessage, fields string) json.RawMessage {
 	var paths [][]string
+	var requestedPaths []string
 	for _, f := range strings.Split(fields, ",") {
 		f = strings.TrimSpace(f)
 		if f == "" {
 			continue
 		}
+		requestedPaths = append(requestedPaths, f)
 		parts := strings.Split(f, ".")
 		for i := range parts {
 			parts[i] = strings.ToLower(parts[i])
@@ -1186,13 +1188,22 @@ func filterFields(data json.RawMessage, fields string) json.RawMessage {
 	if len(paths) == 0 {
 		return data
 	}
-	filtered, matched := filterFieldsRec(data, paths)
-	if !matched {
-		valid := strings.Join(selectFieldKeys(data), ", ")
-		if valid == "" {
-			valid = "none"
+	filtered, matched, indeterminate := filterFieldsRec(data, paths)
+	valid := ""
+	for i, path := range paths {
+		_, pathMatched, pathIndeterminate := filterFieldsRec(data, [][]string{path})
+		if pathMatched || pathIndeterminate {
+			continue
 		}
-		fmt.Fprintf(os.Stderr, "warning: --select %q matched no fields; valid fields: %s\n", fields, valid)
+		if valid == "" {
+			valid = strings.Join(selectFieldKeys(data), ", ")
+			if valid == "" {
+				valid = "none"
+			}
+		}
+		fmt.Fprintf(os.Stderr, "warning: --select %q matched no fields; valid fields: %s\n", requestedPaths[i], valid)
+	}
+	if !matched && !indeterminate {
 		return data
 	}
 	return filtered
@@ -1227,19 +1238,24 @@ func selectFieldKeys(data json.RawMessage) []string {
 }
 
 // filterFieldsRec applies path filters to a JSON value. Each path is a list of
-// lowercase segments; arrays descend element-wise.
-func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, bool) {
+// lowercase segments; arrays descend element-wise. The final return value is
+// true when an empty array makes the requested path indeterminate rather than
+// definitively unmatched.
+func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool) {
 	var arr []json.RawMessage
 	if err := json.Unmarshal(data, &arr); err == nil {
 		out := make([]json.RawMessage, len(arr))
 		matchedAny := false
+		indeterminateAny := len(arr) == 0
 		for i, el := range arr {
 			var matched bool
-			out[i], matched = filterFieldsRec(el, paths)
+			var indeterminate bool
+			out[i], matched, indeterminate = filterFieldsRec(el, paths)
 			matchedAny = matchedAny || matched
+			indeterminateAny = indeterminateAny || indeterminate
 		}
 		result, _ := json.Marshal(out)
-		return result, matchedAny
+		return result, matchedAny, indeterminateAny
 	}
 
 	var obj map[string]json.RawMessage
@@ -1260,6 +1276,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 		filtered := map[string]json.RawMessage{}
 		headMatched := false
 		pathMatched := false
+		pathIndeterminate := false
 		for k, v := range obj {
 			matched := matchSelectSegment(k, keepWhole, subPaths)
 			if matched == "" {
@@ -1273,8 +1290,10 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 			}
 			if subs := subPaths[matched]; subs != nil {
 				var childMatched bool
-				filtered[k], childMatched = filterFieldsRec(v, subs)
+				var childIndeterminate bool
+				filtered[k], childMatched, childIndeterminate = filterFieldsRec(v, subs)
 				pathMatched = pathMatched || childMatched
+				pathIndeterminate = pathIndeterminate || childIndeterminate
 			}
 		}
 		// Envelope fallback: when no top-level keys matched but at least one
@@ -1288,22 +1307,24 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 		// which json.Unmarshal otherwise accepts into a []json.RawMessage
 		// as a nil slice and would coerce to `[]`.
 		if !headMatched {
-			if pending, foundArray, nestedMatched := filterListEnvelopeFields(obj, paths); foundArray {
+			if pending, foundArray, nestedMatched, nestedIndeterminate := filterListEnvelopeFields(obj, paths); foundArray {
 				filtered = pending
 				pathMatched = pathMatched || nestedMatched
+				pathIndeterminate = pathIndeterminate || nestedIndeterminate
 			}
 		}
 		result, _ := json.Marshal(filtered)
-		return result, pathMatched
+		return result, pathMatched, pathIndeterminate
 	}
 
-	return data, false
+	return data, false, false
 }
 
-func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, bool) {
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, bool, bool) {
 	pending := map[string]json.RawMessage{}
 	foundArray := false
 	matchedAny := false
+	indeterminateAny := false
 	for k, v := range obj {
 		if envelopeMetadataArrayKeys[k] {
 			pending[k] = v
@@ -1313,34 +1334,37 @@ func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) 
 		if json.Unmarshal(v, &arr) == nil && arr != nil {
 			foundArray = true
 			var matched bool
-			pending[k], matched = filterFieldsRec(v, paths)
+			var indeterminate bool
+			pending[k], matched, indeterminate = filterFieldsRec(v, paths)
 			matchedAny = matchedAny || matched
+			indeterminateAny = indeterminateAny || indeterminate
 			continue
 		}
 		if k == "_embedded" {
-			if nested, ok, matched := filterNestedListEnvelopeFields(v, paths); ok {
+			if nested, ok, matched, indeterminate := filterNestedListEnvelopeFields(v, paths); ok {
 				foundArray = true
 				pending[k] = nested
 				matchedAny = matchedAny || matched
+				indeterminateAny = indeterminateAny || indeterminate
 				continue
 			}
 		}
 		pending[k] = v
 	}
-	return pending, foundArray, matchedAny
+	return pending, foundArray, matchedAny, indeterminateAny
 }
 
-func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool) {
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool, bool) {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, false, false
+		return nil, false, false, false
 	}
-	filtered, found, matched := filterListEnvelopeFields(obj, paths)
+	filtered, found, matched, indeterminate := filterListEnvelopeFields(obj, paths)
 	if !found {
-		return nil, false, false
+		return nil, false, false, false
 	}
 	result, _ := json.Marshal(filtered)
-	return result, true, matched
+	return result, true, matched, indeterminate
 }
 
 // matchSelectSegment returns the matching lowercase segment, or "" if no match.

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -1188,11 +1188,12 @@ func filterFields(data json.RawMessage, fields string) json.RawMessage {
 	if len(paths) == 0 {
 		return data
 	}
-	filtered, matched, indeterminate := filterFieldsRec(data, paths)
+	filtered, state := filterFieldsRec(data, paths, true)
 	valid := ""
 	for i, path := range paths {
-		_, pathMatched, pathIndeterminate := filterFieldsRec(data, [][]string{path})
-		if pathMatched || pathIndeterminate {
+		_, pathState := filterFieldsRec(data, [][]string{path}, true)
+		pathIndeterminate := pathState.anchoredIndeterminate || (len(paths) == 1 && pathState.fallbackIndeterminate)
+		if pathState.matched || pathIndeterminate {
 			continue
 		}
 		if valid == "" {
@@ -1203,7 +1204,7 @@ func filterFields(data json.RawMessage, fields string) json.RawMessage {
 		}
 		fmt.Fprintf(os.Stderr, "warning: --select %q matched no fields; valid fields: %s\n", requestedPaths[i], valid)
 	}
-	if !matched && !indeterminate {
+	if !state.matched && !state.anchoredIndeterminate && !state.fallbackIndeterminate {
 		return data
 	}
 	return filtered
@@ -1237,25 +1238,37 @@ func selectFieldKeys(data json.RawMessage) []string {
 	return result
 }
 
+type selectMatchState struct {
+	matched               bool
+	anchoredIndeterminate bool
+	fallbackIndeterminate bool
+}
+
+func (s *selectMatchState) merge(other selectMatchState) {
+	s.matched = s.matched || other.matched
+	s.anchoredIndeterminate = s.anchoredIndeterminate || other.anchoredIndeterminate
+	s.fallbackIndeterminate = s.fallbackIndeterminate || other.fallbackIndeterminate
+}
+
 // filterFieldsRec applies path filters to a JSON value. Each path is a list of
-// lowercase segments; arrays descend element-wise. The final return value is
-// true when an empty array makes the requested path indeterminate rather than
-// definitively unmatched.
-func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool) {
+// lowercase segments; arrays descend element-wise. pathAnchored distinguishes
+// empty arrays reached through a known selector prefix from empty arrays found
+// only by the list-envelope fallback.
+func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) (json.RawMessage, selectMatchState) {
 	var arr []json.RawMessage
 	if err := json.Unmarshal(data, &arr); err == nil {
 		out := make([]json.RawMessage, len(arr))
-		matchedAny := false
-		indeterminateAny := len(arr) == 0
+		state := selectMatchState{
+			anchoredIndeterminate: len(arr) == 0 && pathAnchored,
+			fallbackIndeterminate: len(arr) == 0 && !pathAnchored,
+		}
 		for i, el := range arr {
-			var matched bool
-			var indeterminate bool
-			out[i], matched, indeterminate = filterFieldsRec(el, paths)
-			matchedAny = matchedAny || matched
-			indeterminateAny = indeterminateAny || indeterminate
+			var childState selectMatchState
+			out[i], childState = filterFieldsRec(el, paths, pathAnchored)
+			state.merge(childState)
 		}
 		result, _ := json.Marshal(out)
-		return result, matchedAny, indeterminateAny
+		return result, state
 	}
 
 	var obj map[string]json.RawMessage
@@ -1275,8 +1288,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 		}
 		filtered := map[string]json.RawMessage{}
 		headMatched := false
-		pathMatched := false
-		pathIndeterminate := false
+		state := selectMatchState{}
 		for k, v := range obj {
 			matched := matchSelectSegment(k, keepWhole, subPaths)
 			if matched == "" {
@@ -1285,15 +1297,13 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 			headMatched = true
 			if keepWhole[matched] {
 				filtered[k] = v
-				pathMatched = true
+				state.matched = true
 				continue
 			}
 			if subs := subPaths[matched]; subs != nil {
-				var childMatched bool
-				var childIndeterminate bool
-				filtered[k], childMatched, childIndeterminate = filterFieldsRec(v, subs)
-				pathMatched = pathMatched || childMatched
-				pathIndeterminate = pathIndeterminate || childIndeterminate
+				var childState selectMatchState
+				filtered[k], childState = filterFieldsRec(v, subs, true)
+				state.merge(childState)
 			}
 		}
 		// Envelope fallback: when no top-level keys matched but at least one
@@ -1307,24 +1317,22 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 		// which json.Unmarshal otherwise accepts into a []json.RawMessage
 		// as a nil slice and would coerce to `[]`.
 		if !headMatched {
-			if pending, foundArray, nestedMatched, nestedIndeterminate := filterListEnvelopeFields(obj, paths); foundArray {
+			if pending, foundArray, nestedState := filterListEnvelopeFields(obj, paths); foundArray {
 				filtered = pending
-				pathMatched = pathMatched || nestedMatched
-				pathIndeterminate = pathIndeterminate || nestedIndeterminate
+				state.merge(nestedState)
 			}
 		}
 		result, _ := json.Marshal(filtered)
-		return result, pathMatched, pathIndeterminate
+		return result, state
 	}
 
-	return data, false, false
+	return data, selectMatchState{}
 }
 
-func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, bool, bool) {
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, selectMatchState) {
 	pending := map[string]json.RawMessage{}
 	foundArray := false
-	matchedAny := false
-	indeterminateAny := false
+	state := selectMatchState{}
 	for k, v := range obj {
 		if envelopeMetadataArrayKeys[k] {
 			pending[k] = v
@@ -1333,38 +1341,35 @@ func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) 
 		var arr []json.RawMessage
 		if json.Unmarshal(v, &arr) == nil && arr != nil {
 			foundArray = true
-			var matched bool
-			var indeterminate bool
-			pending[k], matched, indeterminate = filterFieldsRec(v, paths)
-			matchedAny = matchedAny || matched
-			indeterminateAny = indeterminateAny || indeterminate
+			var childState selectMatchState
+			pending[k], childState = filterFieldsRec(v, paths, false)
+			state.merge(childState)
 			continue
 		}
 		if k == "_embedded" {
-			if nested, ok, matched, indeterminate := filterNestedListEnvelopeFields(v, paths); ok {
+			if nested, ok, nestedState := filterNestedListEnvelopeFields(v, paths); ok {
 				foundArray = true
 				pending[k] = nested
-				matchedAny = matchedAny || matched
-				indeterminateAny = indeterminateAny || indeterminate
+				state.merge(nestedState)
 				continue
 			}
 		}
 		pending[k] = v
 	}
-	return pending, foundArray, matchedAny, indeterminateAny
+	return pending, foundArray, state
 }
 
-func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool, bool) {
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, selectMatchState) {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, false, false, false
+		return nil, false, selectMatchState{}
 	}
-	filtered, found, matched, indeterminate := filterListEnvelopeFields(obj, paths)
+	filtered, found, state := filterListEnvelopeFields(obj, paths)
 	if !found {
-		return nil, false, false, false
+		return nil, false, selectMatchState{}
 	}
 	result, _ := json.Marshal(filtered)
-	return result, true, matched, indeterminate
+	return result, true, state
 }
 
 // matchSelectSegment returns the matching lowercase segment, or "" if no match.

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -1055,11 +1055,12 @@ func filterFields(data json.RawMessage, fields string) json.RawMessage {
 	if len(paths) == 0 {
 		return data
 	}
-	filtered, matched, indeterminate := filterFieldsRec(data, paths)
+	filtered, state := filterFieldsRec(data, paths, true)
 	valid := ""
 	for i, path := range paths {
-		_, pathMatched, pathIndeterminate := filterFieldsRec(data, [][]string{path})
-		if pathMatched || pathIndeterminate {
+		_, pathState := filterFieldsRec(data, [][]string{path}, true)
+		pathIndeterminate := pathState.anchoredIndeterminate || (len(paths) == 1 && pathState.fallbackIndeterminate)
+		if pathState.matched || pathIndeterminate {
 			continue
 		}
 		if valid == "" {
@@ -1070,7 +1071,7 @@ func filterFields(data json.RawMessage, fields string) json.RawMessage {
 		}
 		fmt.Fprintf(os.Stderr, "warning: --select %q matched no fields; valid fields: %s\n", requestedPaths[i], valid)
 	}
-	if !matched && !indeterminate {
+	if !state.matched && !state.anchoredIndeterminate && !state.fallbackIndeterminate {
 		return data
 	}
 	return filtered
@@ -1104,25 +1105,37 @@ func selectFieldKeys(data json.RawMessage) []string {
 	return result
 }
 
+type selectMatchState struct {
+	matched               bool
+	anchoredIndeterminate bool
+	fallbackIndeterminate bool
+}
+
+func (s *selectMatchState) merge(other selectMatchState) {
+	s.matched = s.matched || other.matched
+	s.anchoredIndeterminate = s.anchoredIndeterminate || other.anchoredIndeterminate
+	s.fallbackIndeterminate = s.fallbackIndeterminate || other.fallbackIndeterminate
+}
+
 // filterFieldsRec applies path filters to a JSON value. Each path is a list of
-// lowercase segments; arrays descend element-wise. The final return value is
-// true when an empty array makes the requested path indeterminate rather than
-// definitively unmatched.
-func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool) {
+// lowercase segments; arrays descend element-wise. pathAnchored distinguishes
+// empty arrays reached through a known selector prefix from empty arrays found
+// only by the list-envelope fallback.
+func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) (json.RawMessage, selectMatchState) {
 	var arr []json.RawMessage
 	if err := json.Unmarshal(data, &arr); err == nil {
 		out := make([]json.RawMessage, len(arr))
-		matchedAny := false
-		indeterminateAny := len(arr) == 0
+		state := selectMatchState{
+			anchoredIndeterminate: len(arr) == 0 && pathAnchored,
+			fallbackIndeterminate: len(arr) == 0 && !pathAnchored,
+		}
 		for i, el := range arr {
-			var matched bool
-			var indeterminate bool
-			out[i], matched, indeterminate = filterFieldsRec(el, paths)
-			matchedAny = matchedAny || matched
-			indeterminateAny = indeterminateAny || indeterminate
+			var childState selectMatchState
+			out[i], childState = filterFieldsRec(el, paths, pathAnchored)
+			state.merge(childState)
 		}
 		result, _ := json.Marshal(out)
-		return result, matchedAny, indeterminateAny
+		return result, state
 	}
 
 	var obj map[string]json.RawMessage
@@ -1142,8 +1155,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 		}
 		filtered := map[string]json.RawMessage{}
 		headMatched := false
-		pathMatched := false
-		pathIndeterminate := false
+		state := selectMatchState{}
 		for k, v := range obj {
 			matched := matchSelectSegment(k, keepWhole, subPaths)
 			if matched == "" {
@@ -1152,15 +1164,13 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 			headMatched = true
 			if keepWhole[matched] {
 				filtered[k] = v
-				pathMatched = true
+				state.matched = true
 				continue
 			}
 			if subs := subPaths[matched]; subs != nil {
-				var childMatched bool
-				var childIndeterminate bool
-				filtered[k], childMatched, childIndeterminate = filterFieldsRec(v, subs)
-				pathMatched = pathMatched || childMatched
-				pathIndeterminate = pathIndeterminate || childIndeterminate
+				var childState selectMatchState
+				filtered[k], childState = filterFieldsRec(v, subs, true)
+				state.merge(childState)
 			}
 		}
 		// Envelope fallback: when no top-level keys matched but at least one
@@ -1174,24 +1184,22 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 		// which json.Unmarshal otherwise accepts into a []json.RawMessage
 		// as a nil slice and would coerce to `[]`.
 		if !headMatched {
-			if pending, foundArray, nestedMatched, nestedIndeterminate := filterListEnvelopeFields(obj, paths); foundArray {
+			if pending, foundArray, nestedState := filterListEnvelopeFields(obj, paths); foundArray {
 				filtered = pending
-				pathMatched = pathMatched || nestedMatched
-				pathIndeterminate = pathIndeterminate || nestedIndeterminate
+				state.merge(nestedState)
 			}
 		}
 		result, _ := json.Marshal(filtered)
-		return result, pathMatched, pathIndeterminate
+		return result, state
 	}
 
-	return data, false, false
+	return data, selectMatchState{}
 }
 
-func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, bool, bool) {
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, selectMatchState) {
 	pending := map[string]json.RawMessage{}
 	foundArray := false
-	matchedAny := false
-	indeterminateAny := false
+	state := selectMatchState{}
 	for k, v := range obj {
 		if envelopeMetadataArrayKeys[k] {
 			pending[k] = v
@@ -1200,38 +1208,35 @@ func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) 
 		var arr []json.RawMessage
 		if json.Unmarshal(v, &arr) == nil && arr != nil {
 			foundArray = true
-			var matched bool
-			var indeterminate bool
-			pending[k], matched, indeterminate = filterFieldsRec(v, paths)
-			matchedAny = matchedAny || matched
-			indeterminateAny = indeterminateAny || indeterminate
+			var childState selectMatchState
+			pending[k], childState = filterFieldsRec(v, paths, false)
+			state.merge(childState)
 			continue
 		}
 		if k == "_embedded" {
-			if nested, ok, matched, indeterminate := filterNestedListEnvelopeFields(v, paths); ok {
+			if nested, ok, nestedState := filterNestedListEnvelopeFields(v, paths); ok {
 				foundArray = true
 				pending[k] = nested
-				matchedAny = matchedAny || matched
-				indeterminateAny = indeterminateAny || indeterminate
+				state.merge(nestedState)
 				continue
 			}
 		}
 		pending[k] = v
 	}
-	return pending, foundArray, matchedAny, indeterminateAny
+	return pending, foundArray, state
 }
 
-func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool, bool) {
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, selectMatchState) {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, false, false, false
+		return nil, false, selectMatchState{}
 	}
-	filtered, found, matched, indeterminate := filterListEnvelopeFields(obj, paths)
+	filtered, found, state := filterListEnvelopeFields(obj, paths)
 	if !found {
-		return nil, false, false, false
+		return nil, false, selectMatchState{}
 	}
 	result, _ := json.Marshal(filtered)
-	return result, true, matched, indeterminate
+	return result, true, state
 }
 
 // matchSelectSegment returns the matching lowercase segment, or "" if no match.

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -1053,20 +1053,60 @@ func filterFields(data json.RawMessage, fields string) json.RawMessage {
 	if len(paths) == 0 {
 		return data
 	}
-	return filterFieldsRec(data, paths)
+	filtered, matched := filterFieldsRec(data, paths)
+	if !matched {
+		valid := strings.Join(selectFieldKeys(data), ", ")
+		if valid == "" {
+			valid = "none"
+		}
+		fmt.Fprintf(os.Stderr, "warning: --select %q matched no fields; valid fields: %s\n", fields, valid)
+		return data
+	}
+	return filtered
+}
+
+func selectFieldKeys(data json.RawMessage) []string {
+	keys := map[string]bool{}
+	var collect func(json.RawMessage)
+	collect = func(value json.RawMessage) {
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(value, &obj); err == nil && obj != nil {
+			for key := range obj {
+				keys[key] = true
+			}
+			return
+		}
+		var arr []json.RawMessage
+		if err := json.Unmarshal(value, &arr); err == nil {
+			for _, element := range arr {
+				collect(element)
+			}
+		}
+	}
+	collect(data)
+
+	result := make([]string, 0, len(keys))
+	for key := range keys {
+		result = append(result, key)
+	}
+	sort.Strings(result)
+	return result
 }
 
 // filterFieldsRec applies path filters to a JSON value. Each path is a list of
 // lowercase segments; arrays descend element-wise.
-func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
+func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, bool) {
 	var arr []json.RawMessage
 	if err := json.Unmarshal(data, &arr); err == nil {
 		out := make([]json.RawMessage, len(arr))
+		matchedAny := false
 		for i, el := range arr {
-			out[i] = filterFieldsRec(el, paths)
+			var matched bool
+			out[i], matched = filterFieldsRec(el, paths)
+			matchedAny = matchedAny || matched
 		}
 		result, _ := json.Marshal(out)
-		return result
+		return result, matchedAny
 	}
 
 	var obj map[string]json.RawMessage
@@ -1085,19 +1125,23 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 			}
 		}
 		filtered := map[string]json.RawMessage{}
-		matchedAny := false
+		headMatched := false
+		pathMatched := false
 		for k, v := range obj {
 			matched := matchSelectSegment(k, keepWhole, subPaths)
 			if matched == "" {
 				continue
 			}
-			matchedAny = true
+			headMatched = true
 			if keepWhole[matched] {
 				filtered[k] = v
+				pathMatched = true
 				continue
 			}
 			if subs := subPaths[matched]; subs != nil {
-				filtered[k] = filterFieldsRec(v, subs)
+				var childMatched bool
+				filtered[k], childMatched = filterFieldsRec(v, subs)
+				pathMatched = pathMatched || childMatched
 			}
 		}
 		// Envelope fallback: when no top-level keys matched but at least one
@@ -1105,26 +1149,28 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 		// (`{"items":[...]}`, `{"data":[...]}`, `{"total_count":N,"items":[...]}`)
 		// and apply the selector inside the array(s). Non-array siblings pass
 		// through verbatim so envelope metadata (counts, null pagination
-		// cursors) stays visible. The foundArray guard preserves the prior
-		// empty-object result for flat objects where no key matches and no
-		// array exists. The `arr != nil` check rejects JSON null, which
-		// json.Unmarshal otherwise accepts into a []json.RawMessage as a
-		// nil slice and would coerce to `[]`.
-		if !matchedAny {
-			if pending, foundArray := filterListEnvelopeFields(obj, paths); foundArray {
+		// cursors) stays visible. The foundArray guard keeps flat objects
+		// without matching keys as an all-miss result for the caller to
+		// diagnose and preserve. The `arr != nil` check rejects JSON null,
+		// which json.Unmarshal otherwise accepts into a []json.RawMessage
+		// as a nil slice and would coerce to `[]`.
+		if !headMatched {
+			if pending, foundArray, nestedMatched := filterListEnvelopeFields(obj, paths); foundArray {
 				filtered = pending
+				pathMatched = pathMatched || nestedMatched
 			}
 		}
 		result, _ := json.Marshal(filtered)
-		return result
+		return result, pathMatched
 	}
 
-	return data
+	return data, false
 }
 
-func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool) {
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, bool) {
 	pending := map[string]json.RawMessage{}
 	foundArray := false
+	matchedAny := false
 	for k, v := range obj {
 		if envelopeMetadataArrayKeys[k] {
 			pending[k] = v
@@ -1133,32 +1179,35 @@ func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) 
 		var arr []json.RawMessage
 		if json.Unmarshal(v, &arr) == nil && arr != nil {
 			foundArray = true
-			pending[k] = filterFieldsRec(v, paths)
+			var matched bool
+			pending[k], matched = filterFieldsRec(v, paths)
+			matchedAny = matchedAny || matched
 			continue
 		}
 		if k == "_embedded" {
-			if nested, ok := filterNestedListEnvelopeFields(v, paths); ok {
+			if nested, ok, matched := filterNestedListEnvelopeFields(v, paths); ok {
 				foundArray = true
 				pending[k] = nested
+				matchedAny = matchedAny || matched
 				continue
 			}
 		}
 		pending[k] = v
 	}
-	return pending, foundArray
+	return pending, foundArray, matchedAny
 }
 
-func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool) {
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool) {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, false
+		return nil, false, false
 	}
-	filtered, found := filterListEnvelopeFields(obj, paths)
+	filtered, found, matched := filterListEnvelopeFields(obj, paths)
 	if !found {
-		return nil, false
+		return nil, false, false
 	}
 	result, _ := json.Marshal(filtered)
-	return result, true
+	return result, true, matched
 }
 
 // matchSelectSegment returns the matching lowercase segment, or "" if no match.

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -1039,11 +1039,13 @@ func unwrapSingleKeyArray(data json.RawMessage) json.RawMessage {
 // Arrays are traversed element-wise: "events.shortName" keeps shortName on each event.
 func filterFields(data json.RawMessage, fields string) json.RawMessage {
 	var paths [][]string
+	var requestedPaths []string
 	for _, f := range strings.Split(fields, ",") {
 		f = strings.TrimSpace(f)
 		if f == "" {
 			continue
 		}
+		requestedPaths = append(requestedPaths, f)
 		parts := strings.Split(f, ".")
 		for i := range parts {
 			parts[i] = strings.ToLower(parts[i])
@@ -1053,13 +1055,22 @@ func filterFields(data json.RawMessage, fields string) json.RawMessage {
 	if len(paths) == 0 {
 		return data
 	}
-	filtered, matched := filterFieldsRec(data, paths)
-	if !matched {
-		valid := strings.Join(selectFieldKeys(data), ", ")
-		if valid == "" {
-			valid = "none"
+	filtered, matched, indeterminate := filterFieldsRec(data, paths)
+	valid := ""
+	for i, path := range paths {
+		_, pathMatched, pathIndeterminate := filterFieldsRec(data, [][]string{path})
+		if pathMatched || pathIndeterminate {
+			continue
 		}
-		fmt.Fprintf(os.Stderr, "warning: --select %q matched no fields; valid fields: %s\n", fields, valid)
+		if valid == "" {
+			valid = strings.Join(selectFieldKeys(data), ", ")
+			if valid == "" {
+				valid = "none"
+			}
+		}
+		fmt.Fprintf(os.Stderr, "warning: --select %q matched no fields; valid fields: %s\n", requestedPaths[i], valid)
+	}
+	if !matched && !indeterminate {
 		return data
 	}
 	return filtered
@@ -1094,19 +1105,24 @@ func selectFieldKeys(data json.RawMessage) []string {
 }
 
 // filterFieldsRec applies path filters to a JSON value. Each path is a list of
-// lowercase segments; arrays descend element-wise.
-func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, bool) {
+// lowercase segments; arrays descend element-wise. The final return value is
+// true when an empty array makes the requested path indeterminate rather than
+// definitively unmatched.
+func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool) {
 	var arr []json.RawMessage
 	if err := json.Unmarshal(data, &arr); err == nil {
 		out := make([]json.RawMessage, len(arr))
 		matchedAny := false
+		indeterminateAny := len(arr) == 0
 		for i, el := range arr {
 			var matched bool
-			out[i], matched = filterFieldsRec(el, paths)
+			var indeterminate bool
+			out[i], matched, indeterminate = filterFieldsRec(el, paths)
 			matchedAny = matchedAny || matched
+			indeterminateAny = indeterminateAny || indeterminate
 		}
 		result, _ := json.Marshal(out)
-		return result, matchedAny
+		return result, matchedAny, indeterminateAny
 	}
 
 	var obj map[string]json.RawMessage
@@ -1127,6 +1143,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 		filtered := map[string]json.RawMessage{}
 		headMatched := false
 		pathMatched := false
+		pathIndeterminate := false
 		for k, v := range obj {
 			matched := matchSelectSegment(k, keepWhole, subPaths)
 			if matched == "" {
@@ -1140,8 +1157,10 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 			}
 			if subs := subPaths[matched]; subs != nil {
 				var childMatched bool
-				filtered[k], childMatched = filterFieldsRec(v, subs)
+				var childIndeterminate bool
+				filtered[k], childMatched, childIndeterminate = filterFieldsRec(v, subs)
 				pathMatched = pathMatched || childMatched
+				pathIndeterminate = pathIndeterminate || childIndeterminate
 			}
 		}
 		// Envelope fallback: when no top-level keys matched but at least one
@@ -1155,22 +1174,24 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 		// which json.Unmarshal otherwise accepts into a []json.RawMessage
 		// as a nil slice and would coerce to `[]`.
 		if !headMatched {
-			if pending, foundArray, nestedMatched := filterListEnvelopeFields(obj, paths); foundArray {
+			if pending, foundArray, nestedMatched, nestedIndeterminate := filterListEnvelopeFields(obj, paths); foundArray {
 				filtered = pending
 				pathMatched = pathMatched || nestedMatched
+				pathIndeterminate = pathIndeterminate || nestedIndeterminate
 			}
 		}
 		result, _ := json.Marshal(filtered)
-		return result, pathMatched
+		return result, pathMatched, pathIndeterminate
 	}
 
-	return data, false
+	return data, false, false
 }
 
-func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, bool) {
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, bool, bool) {
 	pending := map[string]json.RawMessage{}
 	foundArray := false
 	matchedAny := false
+	indeterminateAny := false
 	for k, v := range obj {
 		if envelopeMetadataArrayKeys[k] {
 			pending[k] = v
@@ -1180,34 +1201,37 @@ func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) 
 		if json.Unmarshal(v, &arr) == nil && arr != nil {
 			foundArray = true
 			var matched bool
-			pending[k], matched = filterFieldsRec(v, paths)
+			var indeterminate bool
+			pending[k], matched, indeterminate = filterFieldsRec(v, paths)
 			matchedAny = matchedAny || matched
+			indeterminateAny = indeterminateAny || indeterminate
 			continue
 		}
 		if k == "_embedded" {
-			if nested, ok, matched := filterNestedListEnvelopeFields(v, paths); ok {
+			if nested, ok, matched, indeterminate := filterNestedListEnvelopeFields(v, paths); ok {
 				foundArray = true
 				pending[k] = nested
 				matchedAny = matchedAny || matched
+				indeterminateAny = indeterminateAny || indeterminate
 				continue
 			}
 		}
 		pending[k] = v
 	}
-	return pending, foundArray, matchedAny
+	return pending, foundArray, matchedAny, indeterminateAny
 }
 
-func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool) {
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool, bool) {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, false, false
+		return nil, false, false, false
 	}
-	filtered, found, matched := filterListEnvelopeFields(obj, paths)
+	filtered, found, matched, indeterminate := filterListEnvelopeFields(obj, paths)
 	if !found {
-		return nil, false, false
+		return nil, false, false, false
 	}
 	result, _ := json.Marshal(filtered)
-	return result, true, matched
+	return result, true, matched, indeterminate
 }
 
 // matchSelectSegment returns the matching lowercase segment, or "" if no match.

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/root_test.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/root_test.go
@@ -135,10 +135,16 @@ func TestFilterFields(t *testing.T) {
 			want:   `{"projects":[{"id":"a"}]}`,
 		},
 		{
-			name:   "flat object no match returns empty (no array fallback)",
+			name:   "flat object no match preserves input",
 			input:  `{"a":1,"b":2}`,
 			fields: "c",
-			want:   `{}`,
+			want:   `{"a":1,"b":2}`,
+		},
+		{
+			name:   "unknown selector preserves nested array objects",
+			input:  `{"items":[{"id":"a","name":"Alpha"},{"id":"b","name":"Beta"}]}`,
+			fields: "missing",
+			want:   `{"items":[{"id":"a","name":"Alpha"},{"id":"b","name":"Beta"}]}`,
 		},
 		{
 			// Null pagination cursors are common envelope metadata.
@@ -152,12 +158,11 @@ func TestFilterFields(t *testing.T) {
 		},
 		{
 			// Without a real array sibling the envelope fallback does not
-			// fire, so a flat object whose only "extra" key is null still
-			// returns {} for a non-matching selector.
-			name:   "flat object with null sibling no match returns empty",
+			// fire, but an invalid selector still preserves the input.
+			name:   "flat object with null sibling no match preserves input",
 			input:  `{"a":1,"b":null}`,
 			fields: "c",
-			want:   `{}`,
+			want:   `{"a":1,"b":null}`,
 		},
 		{
 			// Multiple array siblings at the same level each receive the
@@ -172,13 +177,11 @@ func TestFilterFields(t *testing.T) {
 			// Envelope fallback is intentionally one level deep. A nested
 			// object envelope like {"data":{"items":[...]}} surfaces no
 			// array at the outer level, so the fallback does not fire and
-			// the result is the empty-object that flat-no-match would
-			// produce. Pins the boundary so a future deeper-walk change
-			// is an explicit decision, not an accident.
-			name:   "nested object envelope returns empty (one-level only)",
+			// an invalid selector preserves the input.
+			name:   "nested object envelope preserves input (one-level only)",
 			input:  `{"data":{"items":[{"id":"a","other":"y"}]}}`,
 			fields: "id",
-			want:   `{}`,
+			want:   `{"data":{"items":[{"id":"a","other":"y"}]}}`,
 		},
 	}
 	for _, tc := range cases {

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 73
+    "total": 74
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -1138,20 +1138,60 @@ func filterFields(data json.RawMessage, fields string) json.RawMessage {
 	if len(paths) == 0 {
 		return data
 	}
-	return filterFieldsRec(data, paths)
+	filtered, matched := filterFieldsRec(data, paths)
+	if !matched {
+		valid := strings.Join(selectFieldKeys(data), ", ")
+		if valid == "" {
+			valid = "none"
+		}
+		fmt.Fprintf(os.Stderr, "warning: --select %q matched no fields; valid fields: %s\n", fields, valid)
+		return data
+	}
+	return filtered
+}
+
+func selectFieldKeys(data json.RawMessage) []string {
+	keys := map[string]bool{}
+	var collect func(json.RawMessage)
+	collect = func(value json.RawMessage) {
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(value, &obj); err == nil && obj != nil {
+			for key := range obj {
+				keys[key] = true
+			}
+			return
+		}
+		var arr []json.RawMessage
+		if err := json.Unmarshal(value, &arr); err == nil {
+			for _, element := range arr {
+				collect(element)
+			}
+		}
+	}
+	collect(data)
+
+	result := make([]string, 0, len(keys))
+	for key := range keys {
+		result = append(result, key)
+	}
+	sort.Strings(result)
+	return result
 }
 
 // filterFieldsRec applies path filters to a JSON value. Each path is a list of
 // lowercase segments; arrays descend element-wise.
-func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
+func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, bool) {
 	var arr []json.RawMessage
 	if err := json.Unmarshal(data, &arr); err == nil {
 		out := make([]json.RawMessage, len(arr))
+		matchedAny := false
 		for i, el := range arr {
-			out[i] = filterFieldsRec(el, paths)
+			var matched bool
+			out[i], matched = filterFieldsRec(el, paths)
+			matchedAny = matchedAny || matched
 		}
 		result, _ := json.Marshal(out)
-		return result
+		return result, matchedAny
 	}
 
 	var obj map[string]json.RawMessage
@@ -1170,19 +1210,23 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 			}
 		}
 		filtered := map[string]json.RawMessage{}
-		matchedAny := false
+		headMatched := false
+		pathMatched := false
 		for k, v := range obj {
 			matched := matchSelectSegment(k, keepWhole, subPaths)
 			if matched == "" {
 				continue
 			}
-			matchedAny = true
+			headMatched = true
 			if keepWhole[matched] {
 				filtered[k] = v
+				pathMatched = true
 				continue
 			}
 			if subs := subPaths[matched]; subs != nil {
-				filtered[k] = filterFieldsRec(v, subs)
+				var childMatched bool
+				filtered[k], childMatched = filterFieldsRec(v, subs)
+				pathMatched = pathMatched || childMatched
 			}
 		}
 		// Envelope fallback: when no top-level keys matched but at least one
@@ -1190,26 +1234,28 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 		// (`{"items":[...]}`, `{"data":[...]}`, `{"total_count":N,"items":[...]}`)
 		// and apply the selector inside the array(s). Non-array siblings pass
 		// through verbatim so envelope metadata (counts, null pagination
-		// cursors) stays visible. The foundArray guard preserves the prior
-		// empty-object result for flat objects where no key matches and no
-		// array exists. The `arr != nil` check rejects JSON null, which
-		// json.Unmarshal otherwise accepts into a []json.RawMessage as a
-		// nil slice and would coerce to `[]`.
-		if !matchedAny {
-			if pending, foundArray := filterListEnvelopeFields(obj, paths); foundArray {
+		// cursors) stays visible. The foundArray guard keeps flat objects
+		// without matching keys as an all-miss result for the caller to
+		// diagnose and preserve. The `arr != nil` check rejects JSON null,
+		// which json.Unmarshal otherwise accepts into a []json.RawMessage
+		// as a nil slice and would coerce to `[]`.
+		if !headMatched {
+			if pending, foundArray, nestedMatched := filterListEnvelopeFields(obj, paths); foundArray {
 				filtered = pending
+				pathMatched = pathMatched || nestedMatched
 			}
 		}
 		result, _ := json.Marshal(filtered)
-		return result
+		return result, pathMatched
 	}
 
-	return data
+	return data, false
 }
 
-func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool) {
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, bool) {
 	pending := map[string]json.RawMessage{}
 	foundArray := false
+	matchedAny := false
 	for k, v := range obj {
 		if envelopeMetadataArrayKeys[k] {
 			pending[k] = v
@@ -1218,32 +1264,35 @@ func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) 
 		var arr []json.RawMessage
 		if json.Unmarshal(v, &arr) == nil && arr != nil {
 			foundArray = true
-			pending[k] = filterFieldsRec(v, paths)
+			var matched bool
+			pending[k], matched = filterFieldsRec(v, paths)
+			matchedAny = matchedAny || matched
 			continue
 		}
 		if k == "_embedded" {
-			if nested, ok := filterNestedListEnvelopeFields(v, paths); ok {
+			if nested, ok, matched := filterNestedListEnvelopeFields(v, paths); ok {
 				foundArray = true
 				pending[k] = nested
+				matchedAny = matchedAny || matched
 				continue
 			}
 		}
 		pending[k] = v
 	}
-	return pending, foundArray
+	return pending, foundArray, matchedAny
 }
 
-func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool) {
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool) {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, false
+		return nil, false, false
 	}
-	filtered, found := filterListEnvelopeFields(obj, paths)
+	filtered, found, matched := filterListEnvelopeFields(obj, paths)
 	if !found {
-		return nil, false
+		return nil, false, false
 	}
 	result, _ := json.Marshal(filtered)
-	return result, true
+	return result, true, matched
 }
 
 // matchSelectSegment returns the matching lowercase segment, or "" if no match.

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -1124,11 +1124,13 @@ func unwrapSingleKeyArray(data json.RawMessage) json.RawMessage {
 // Arrays are traversed element-wise: "events.shortName" keeps shortName on each event.
 func filterFields(data json.RawMessage, fields string) json.RawMessage {
 	var paths [][]string
+	var requestedPaths []string
 	for _, f := range strings.Split(fields, ",") {
 		f = strings.TrimSpace(f)
 		if f == "" {
 			continue
 		}
+		requestedPaths = append(requestedPaths, f)
 		parts := strings.Split(f, ".")
 		for i := range parts {
 			parts[i] = strings.ToLower(parts[i])
@@ -1138,13 +1140,22 @@ func filterFields(data json.RawMessage, fields string) json.RawMessage {
 	if len(paths) == 0 {
 		return data
 	}
-	filtered, matched := filterFieldsRec(data, paths)
-	if !matched {
-		valid := strings.Join(selectFieldKeys(data), ", ")
-		if valid == "" {
-			valid = "none"
+	filtered, matched, indeterminate := filterFieldsRec(data, paths)
+	valid := ""
+	for i, path := range paths {
+		_, pathMatched, pathIndeterminate := filterFieldsRec(data, [][]string{path})
+		if pathMatched || pathIndeterminate {
+			continue
 		}
-		fmt.Fprintf(os.Stderr, "warning: --select %q matched no fields; valid fields: %s\n", fields, valid)
+		if valid == "" {
+			valid = strings.Join(selectFieldKeys(data), ", ")
+			if valid == "" {
+				valid = "none"
+			}
+		}
+		fmt.Fprintf(os.Stderr, "warning: --select %q matched no fields; valid fields: %s\n", requestedPaths[i], valid)
+	}
+	if !matched && !indeterminate {
 		return data
 	}
 	return filtered
@@ -1179,19 +1190,24 @@ func selectFieldKeys(data json.RawMessage) []string {
 }
 
 // filterFieldsRec applies path filters to a JSON value. Each path is a list of
-// lowercase segments; arrays descend element-wise.
-func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, bool) {
+// lowercase segments; arrays descend element-wise. The final return value is
+// true when an empty array makes the requested path indeterminate rather than
+// definitively unmatched.
+func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool) {
 	var arr []json.RawMessage
 	if err := json.Unmarshal(data, &arr); err == nil {
 		out := make([]json.RawMessage, len(arr))
 		matchedAny := false
+		indeterminateAny := len(arr) == 0
 		for i, el := range arr {
 			var matched bool
-			out[i], matched = filterFieldsRec(el, paths)
+			var indeterminate bool
+			out[i], matched, indeterminate = filterFieldsRec(el, paths)
 			matchedAny = matchedAny || matched
+			indeterminateAny = indeterminateAny || indeterminate
 		}
 		result, _ := json.Marshal(out)
-		return result, matchedAny
+		return result, matchedAny, indeterminateAny
 	}
 
 	var obj map[string]json.RawMessage
@@ -1212,6 +1228,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 		filtered := map[string]json.RawMessage{}
 		headMatched := false
 		pathMatched := false
+		pathIndeterminate := false
 		for k, v := range obj {
 			matched := matchSelectSegment(k, keepWhole, subPaths)
 			if matched == "" {
@@ -1225,8 +1242,10 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 			}
 			if subs := subPaths[matched]; subs != nil {
 				var childMatched bool
-				filtered[k], childMatched = filterFieldsRec(v, subs)
+				var childIndeterminate bool
+				filtered[k], childMatched, childIndeterminate = filterFieldsRec(v, subs)
 				pathMatched = pathMatched || childMatched
+				pathIndeterminate = pathIndeterminate || childIndeterminate
 			}
 		}
 		// Envelope fallback: when no top-level keys matched but at least one
@@ -1240,22 +1259,24 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 		// which json.Unmarshal otherwise accepts into a []json.RawMessage
 		// as a nil slice and would coerce to `[]`.
 		if !headMatched {
-			if pending, foundArray, nestedMatched := filterListEnvelopeFields(obj, paths); foundArray {
+			if pending, foundArray, nestedMatched, nestedIndeterminate := filterListEnvelopeFields(obj, paths); foundArray {
 				filtered = pending
 				pathMatched = pathMatched || nestedMatched
+				pathIndeterminate = pathIndeterminate || nestedIndeterminate
 			}
 		}
 		result, _ := json.Marshal(filtered)
-		return result, pathMatched
+		return result, pathMatched, pathIndeterminate
 	}
 
-	return data, false
+	return data, false, false
 }
 
-func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, bool) {
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, bool, bool) {
 	pending := map[string]json.RawMessage{}
 	foundArray := false
 	matchedAny := false
+	indeterminateAny := false
 	for k, v := range obj {
 		if envelopeMetadataArrayKeys[k] {
 			pending[k] = v
@@ -1265,34 +1286,37 @@ func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) 
 		if json.Unmarshal(v, &arr) == nil && arr != nil {
 			foundArray = true
 			var matched bool
-			pending[k], matched = filterFieldsRec(v, paths)
+			var indeterminate bool
+			pending[k], matched, indeterminate = filterFieldsRec(v, paths)
 			matchedAny = matchedAny || matched
+			indeterminateAny = indeterminateAny || indeterminate
 			continue
 		}
 		if k == "_embedded" {
-			if nested, ok, matched := filterNestedListEnvelopeFields(v, paths); ok {
+			if nested, ok, matched, indeterminate := filterNestedListEnvelopeFields(v, paths); ok {
 				foundArray = true
 				pending[k] = nested
 				matchedAny = matchedAny || matched
+				indeterminateAny = indeterminateAny || indeterminate
 				continue
 			}
 		}
 		pending[k] = v
 	}
-	return pending, foundArray, matchedAny
+	return pending, foundArray, matchedAny, indeterminateAny
 }
 
-func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool) {
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool, bool) {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, false, false
+		return nil, false, false, false
 	}
-	filtered, found, matched := filterListEnvelopeFields(obj, paths)
+	filtered, found, matched, indeterminate := filterListEnvelopeFields(obj, paths)
 	if !found {
-		return nil, false, false
+		return nil, false, false, false
 	}
 	result, _ := json.Marshal(filtered)
-	return result, true, matched
+	return result, true, matched, indeterminate
 }
 
 // matchSelectSegment returns the matching lowercase segment, or "" if no match.

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -1140,11 +1140,12 @@ func filterFields(data json.RawMessage, fields string) json.RawMessage {
 	if len(paths) == 0 {
 		return data
 	}
-	filtered, matched, indeterminate := filterFieldsRec(data, paths)
+	filtered, state := filterFieldsRec(data, paths, true)
 	valid := ""
 	for i, path := range paths {
-		_, pathMatched, pathIndeterminate := filterFieldsRec(data, [][]string{path})
-		if pathMatched || pathIndeterminate {
+		_, pathState := filterFieldsRec(data, [][]string{path}, true)
+		pathIndeterminate := pathState.anchoredIndeterminate || (len(paths) == 1 && pathState.fallbackIndeterminate)
+		if pathState.matched || pathIndeterminate {
 			continue
 		}
 		if valid == "" {
@@ -1155,7 +1156,7 @@ func filterFields(data json.RawMessage, fields string) json.RawMessage {
 		}
 		fmt.Fprintf(os.Stderr, "warning: --select %q matched no fields; valid fields: %s\n", requestedPaths[i], valid)
 	}
-	if !matched && !indeterminate {
+	if !state.matched && !state.anchoredIndeterminate && !state.fallbackIndeterminate {
 		return data
 	}
 	return filtered
@@ -1189,25 +1190,37 @@ func selectFieldKeys(data json.RawMessage) []string {
 	return result
 }
 
+type selectMatchState struct {
+	matched               bool
+	anchoredIndeterminate bool
+	fallbackIndeterminate bool
+}
+
+func (s *selectMatchState) merge(other selectMatchState) {
+	s.matched = s.matched || other.matched
+	s.anchoredIndeterminate = s.anchoredIndeterminate || other.anchoredIndeterminate
+	s.fallbackIndeterminate = s.fallbackIndeterminate || other.fallbackIndeterminate
+}
+
 // filterFieldsRec applies path filters to a JSON value. Each path is a list of
-// lowercase segments; arrays descend element-wise. The final return value is
-// true when an empty array makes the requested path indeterminate rather than
-// definitively unmatched.
-func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool) {
+// lowercase segments; arrays descend element-wise. pathAnchored distinguishes
+// empty arrays reached through a known selector prefix from empty arrays found
+// only by the list-envelope fallback.
+func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) (json.RawMessage, selectMatchState) {
 	var arr []json.RawMessage
 	if err := json.Unmarshal(data, &arr); err == nil {
 		out := make([]json.RawMessage, len(arr))
-		matchedAny := false
-		indeterminateAny := len(arr) == 0
+		state := selectMatchState{
+			anchoredIndeterminate: len(arr) == 0 && pathAnchored,
+			fallbackIndeterminate: len(arr) == 0 && !pathAnchored,
+		}
 		for i, el := range arr {
-			var matched bool
-			var indeterminate bool
-			out[i], matched, indeterminate = filterFieldsRec(el, paths)
-			matchedAny = matchedAny || matched
-			indeterminateAny = indeterminateAny || indeterminate
+			var childState selectMatchState
+			out[i], childState = filterFieldsRec(el, paths, pathAnchored)
+			state.merge(childState)
 		}
 		result, _ := json.Marshal(out)
-		return result, matchedAny, indeterminateAny
+		return result, state
 	}
 
 	var obj map[string]json.RawMessage
@@ -1227,8 +1240,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 		}
 		filtered := map[string]json.RawMessage{}
 		headMatched := false
-		pathMatched := false
-		pathIndeterminate := false
+		state := selectMatchState{}
 		for k, v := range obj {
 			matched := matchSelectSegment(k, keepWhole, subPaths)
 			if matched == "" {
@@ -1237,15 +1249,13 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 			headMatched = true
 			if keepWhole[matched] {
 				filtered[k] = v
-				pathMatched = true
+				state.matched = true
 				continue
 			}
 			if subs := subPaths[matched]; subs != nil {
-				var childMatched bool
-				var childIndeterminate bool
-				filtered[k], childMatched, childIndeterminate = filterFieldsRec(v, subs)
-				pathMatched = pathMatched || childMatched
-				pathIndeterminate = pathIndeterminate || childIndeterminate
+				var childState selectMatchState
+				filtered[k], childState = filterFieldsRec(v, subs, true)
+				state.merge(childState)
 			}
 		}
 		// Envelope fallback: when no top-level keys matched but at least one
@@ -1259,24 +1269,22 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) (json.RawMessage, b
 		// which json.Unmarshal otherwise accepts into a []json.RawMessage
 		// as a nil slice and would coerce to `[]`.
 		if !headMatched {
-			if pending, foundArray, nestedMatched, nestedIndeterminate := filterListEnvelopeFields(obj, paths); foundArray {
+			if pending, foundArray, nestedState := filterListEnvelopeFields(obj, paths); foundArray {
 				filtered = pending
-				pathMatched = pathMatched || nestedMatched
-				pathIndeterminate = pathIndeterminate || nestedIndeterminate
+				state.merge(nestedState)
 			}
 		}
 		result, _ := json.Marshal(filtered)
-		return result, pathMatched, pathIndeterminate
+		return result, state
 	}
 
-	return data, false, false
+	return data, selectMatchState{}
 }
 
-func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, bool, bool) {
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, selectMatchState) {
 	pending := map[string]json.RawMessage{}
 	foundArray := false
-	matchedAny := false
-	indeterminateAny := false
+	state := selectMatchState{}
 	for k, v := range obj {
 		if envelopeMetadataArrayKeys[k] {
 			pending[k] = v
@@ -1285,38 +1293,35 @@ func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) 
 		var arr []json.RawMessage
 		if json.Unmarshal(v, &arr) == nil && arr != nil {
 			foundArray = true
-			var matched bool
-			var indeterminate bool
-			pending[k], matched, indeterminate = filterFieldsRec(v, paths)
-			matchedAny = matchedAny || matched
-			indeterminateAny = indeterminateAny || indeterminate
+			var childState selectMatchState
+			pending[k], childState = filterFieldsRec(v, paths, false)
+			state.merge(childState)
 			continue
 		}
 		if k == "_embedded" {
-			if nested, ok, matched, indeterminate := filterNestedListEnvelopeFields(v, paths); ok {
+			if nested, ok, nestedState := filterNestedListEnvelopeFields(v, paths); ok {
 				foundArray = true
 				pending[k] = nested
-				matchedAny = matchedAny || matched
-				indeterminateAny = indeterminateAny || indeterminate
+				state.merge(nestedState)
 				continue
 			}
 		}
 		pending[k] = v
 	}
-	return pending, foundArray, matchedAny, indeterminateAny
+	return pending, foundArray, state
 }
 
-func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, bool, bool) {
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, selectMatchState) {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, false, false, false
+		return nil, false, selectMatchState{}
 	}
-	filtered, found, matched, indeterminate := filterListEnvelopeFields(obj, paths)
+	filtered, found, state := filterListEnvelopeFields(obj, paths)
 	if !found {
-		return nil, false, false, false
+		return nil, false, selectMatchState{}
 	}
 	result, _ := json.Marshal(filtered)
-	return result, true, matched, indeterminate
+	return result, true, state
 }
 
 // matchSelectSegment returns the matching lowercase segment, or "" if no match.

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root_test.go
@@ -135,10 +135,16 @@ func TestFilterFields(t *testing.T) {
 			want:   `{"projects":[{"id":"a"}]}`,
 		},
 		{
-			name:   "flat object no match returns empty (no array fallback)",
+			name:   "flat object no match preserves input",
 			input:  `{"a":1,"b":2}`,
 			fields: "c",
-			want:   `{}`,
+			want:   `{"a":1,"b":2}`,
+		},
+		{
+			name:   "unknown selector preserves nested array objects",
+			input:  `{"items":[{"id":"a","name":"Alpha"},{"id":"b","name":"Beta"}]}`,
+			fields: "missing",
+			want:   `{"items":[{"id":"a","name":"Alpha"},{"id":"b","name":"Beta"}]}`,
 		},
 		{
 			// Null pagination cursors are common envelope metadata.
@@ -152,12 +158,11 @@ func TestFilterFields(t *testing.T) {
 		},
 		{
 			// Without a real array sibling the envelope fallback does not
-			// fire, so a flat object whose only "extra" key is null still
-			// returns {} for a non-matching selector.
-			name:   "flat object with null sibling no match returns empty",
+			// fire, but an invalid selector still preserves the input.
+			name:   "flat object with null sibling no match preserves input",
 			input:  `{"a":1,"b":null}`,
 			fields: "c",
-			want:   `{}`,
+			want:   `{"a":1,"b":null}`,
 		},
 		{
 			// Multiple array siblings at the same level each receive the
@@ -172,13 +177,11 @@ func TestFilterFields(t *testing.T) {
 			// Envelope fallback is intentionally one level deep. A nested
 			// object envelope like {"data":{"items":[...]}} surfaces no
 			// array at the outer level, so the fallback does not fire and
-			// the result is the empty-object that flat-no-match would
-			// produce. Pins the boundary so a future deeper-walk change
-			// is an explicit decision, not an accident.
-			name:   "nested object envelope returns empty (one-level only)",
+			// an invalid selector preserves the input.
+			name:   "nested object envelope preserves input (one-level only)",
 			input:  `{"data":{"items":[{"id":"a","other":"y"}]}}`,
 			fields: "id",
-			want:   `{}`,
+			want:   `{"data":{"items":[{"id":"a","other":"y"}]}}`,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Unknown `--select` fields now emit a warning naming valid top-level fields and preserve the original JSON, instead of returning arrays of `{}`. Match state propagates through nested arrays and list envelopes, while valid selectors and dotted paths keep their existing behavior. Regression coverage exercises the generated helper and golden output.

Verification:
- `go test ./internal/generator -run 'FilterFields|WrappedArrayProjection' -count=1`
- `go test ./...` (changed packages passed; one unrelated flaky `TestLiveDogfoodHappyArgsHonorsPPHappyArgs` failure was isolated and passed on rerun)
- `go test ./internal/pipeline -run '^TestLiveDogfoodHappyArgsHonorsPPHappyArgs$' -count=1`
- `bash scripts/golden.sh verify`
- `bash scripts/verify-generator-output.sh`
- `golangci-lint run ./...`

Closes #3553
