### PR TITLE
fix(cli): preserve hierarchical path parameter slashes

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -17243,6 +17243,8 @@ func TestGenerateMCPCodeOrchestrationEmitsSearchExecute(t *testing.T) {
 	} {
 		assert.Contains(t, body, want, "code_orch.go missing expected snippet %q", want)
 	}
+	assert.Contains(t, body, `path = strings.ReplaceAll(path, "{"+p+"}", mcpPathValue(v))`,
+		"code orchestration path params must use the shared MCP path-value helper")
 
 	toolsPath := filepath.Join(outputDir, "internal", "mcp", "tools.go")
 	toolsData, err := os.ReadFile(toolsPath)
@@ -17689,7 +17691,7 @@ func TestGenerateMCPHandlerFormatsNumericPathAndQueryScalars(t *testing.T) {
 	tools := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
 	assert.Contains(t, tools, "func formatMCPParamValue(v any) string",
 		"generated MCP handler must emit a scalar formatter shared by path and query binding")
-	assert.Contains(t, tools, `return url.PathEscape(formatMCPParamValue(v))`,
+	assert.Contains(t, tools, `return cliutil.EscapePathParam(formatMCPParamValue(v))`,
 		"path params must use scalar formatting before percent-encoding")
 	assert.Contains(t, tools, `path = strings.Replace(path, placeholder, mcpPathValue(v), 1)`,
 		"path params must use plain-decimal formatting and percent-encoding")
@@ -18145,6 +18147,8 @@ func TestGenerateMCPIntentsEmittedWhenDeclared(t *testing.T) {
 	} {
 		assert.Contains(t, body, want, "intents.go missing expected snippet %q", want)
 	}
+	assert.Contains(t, body, `path = strings.ReplaceAll(path, placeholder, mcpPathValue(v))`,
+		"intent path params must use the shared MCP path-value helper")
 
 	toolsPath := filepath.Join(outputDir, "internal", "mcp", "tools.go")
 	toolsData, err := os.ReadFile(toolsPath)

--- a/internal/generator/numeric_param_format_test.go
+++ b/internal/generator/numeric_param_format_test.go
@@ -43,7 +43,7 @@ func TestGeneratedNumericPathAndQueryParamsUsePlainDecimalFormatting(t *testing.
 
 	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
 	require.Contains(t, mcpSrc, "func formatMCPParamValue(v any) string")
-	require.Contains(t, mcpSrc, `return url.PathEscape(formatMCPParamValue(v))`)
+	require.Contains(t, mcpSrc, `return cliutil.EscapePathParam(formatMCPParamValue(v))`)
 	require.Contains(t, mcpSrc, `path = strings.Replace(path, placeholder, mcpPathValue(v), 1)`)
 	require.Contains(t, mcpSrc, `params[binding.WireName] = formatMCPParamValue(v)`)
 	require.NotContains(t, mcpSrc, `params[binding.WireName] = fmt.Sprintf("%v", v)`)

--- a/internal/generator/path_param_encoding_test.go
+++ b/internal/generator/path_param_encoding_test.go
@@ -14,15 +14,15 @@ import (
 )
 
 // TestReplacePathParamPercentEncodesValue pins the helpers.go template so the
-// emitted replacePathParam routes the user-supplied value through
-// url.PathEscape before substituting it into the URL path. Without the escape,
-// values that contain path-reserved characters (e.g. "src/main.go" for the
-// GitHub Contents API or "https://example.com/" for Search Console's siteUrl)
-// silently produce malformed request URLs that 404 against the live API.
+// emitted replacePathParam routes the user-supplied value through the shared
+// segment-aware cliutil escaper before substituting it into the URL path. Without
+// the escape, values that contain path-reserved characters silently produce
+// malformed request URLs; escaping the whole value instead breaks hierarchical
+// identifiers such as "allenai/c4".
 //
-// We assert at the template-output level (helpers.go contains the escape call
-// and imports net/url) so the contract is checked once and every printed CLI
-// inherits the fix.
+// We assert at the template-output level (helpers.go calls cliutil and
+// cliutil/text.go contains the implementation) so every printed CLI inherits
+// the fix.
 func TestReplacePathParamPercentEncodesValue(t *testing.T) {
 	t.Parallel()
 
@@ -60,20 +60,74 @@ func TestReplacePathParamPercentEncodesValue(t *testing.T) {
 	require.NoError(t, err)
 	src := string(helpersGo)
 
-	assert.Contains(t, src, `"net/url"`,
-		"helpers.go must import net/url when replacePathParam is emitted")
+	// The shared implementation is emitted in cliutil/text.go below.
+	assert.Contains(t, src, "/internal/cliutil",
+		"helpers.go must import cliutil when replacePathParam is emitted")
 	assert.Contains(t, src,
-		`return strings.ReplaceAll(path, "{"+name+"}", url.PathEscape(value))`,
-		"replacePathParam must percent-encode the value via url.PathEscape so "+
-			"path-reserved characters (/, :, ?, #, space, %) don't produce a malformed URL")
+		`return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(value))`,
+		"replacePathParam must use the shared segment-aware escaper")
+
+	cliutilPath := filepath.Join(outputDir, "internal", "cliutil", "text.go")
+	cliutilGo, err := os.ReadFile(cliutilPath)
+	require.NoError(t, err)
+	cliutilSrc := string(cliutilGo)
+	assert.Contains(t, cliutilSrc, "func EscapePathParam(value string) string",
+		"cliutil must emit the shared path-param escaper")
+	assert.Contains(t, cliutilSrc, "segments := strings.Split(value, \"/\")",
+		"path-param escaping must preserve slash separators in hierarchical identifiers")
+	assert.Contains(t, cliutilSrc, "segments[i] = url.PathEscape(segment)",
+		"each path segment must be percent-encoded independently")
 
 	mcpPath := filepath.Join(outputDir, "internal", "mcp", "tools.go")
 	mcpGo, err := os.ReadFile(mcpPath)
 	require.NoError(t, err)
 	mcpSrc := string(mcpGo)
-	assert.Contains(t, mcpSrc, `return url.PathEscape(formatMCPParamValue(v))`)
+	assert.Contains(t, mcpSrc, `return cliutil.EscapePathParam(formatMCPParamValue(v))`,
+		"MCP path params must use the same generated helper as the CLI")
 	assert.Equal(t, 2, strings.Count(mcpSrc, `strings.Replace(path, placeholder, mcpPathValue(v), 1)`),
 		"both MCP path-binding loops must percent-encode path values")
+
+	cliTest := `package cli
+
+import "testing"
+
+func TestReplacePathParamPreservesHierarchicalIdentifiers(t *testing.T) {
+	tests := map[string]string{
+		"opaque-id": "opaque-id",
+		"allenai/c4": "allenai/c4",
+		"src/main file.go": "src/main%20file.go",
+		"a b?c#d": "a%20b%3Fc%23d",
+	}
+	for input, want := range tests {
+		if got := replacePathParam("/datasets/{id}", "id", input); got != "/datasets/"+want {
+			t.Fatalf("replacePathParam(%q) = %q, want %q", input, got, "/datasets/"+want)
+		}
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "path_param_test.go"), []byte(cliTest), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "TestReplacePathParamPreservesHierarchicalIdentifiers")
+
+	cliutilTest := `package cliutil
+
+import "testing"
+
+func TestEscapePathParamPreservesHierarchicalIdentifiers(t *testing.T) {
+	tests := map[string]string{
+		"opaque-id": "opaque-id",
+		"allenai/c4": "allenai/c4",
+		"src/main file.go": "src/main%20file.go",
+		"a b?c#d": "a%20b%3Fc%23d",
+	}
+	for input, want := range tests {
+		if got := EscapePathParam(input); got != want {
+			t.Fatalf("EscapePathParam(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cliutil", "path_param_test.go"), []byte(cliutilTest), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/cliutil", "-run", "TestEscapePathParamPreservesHierarchicalIdentifiers")
 
 	mcpTest := `package mcp
 
@@ -82,8 +136,8 @@ import "testing"
 func TestMCPPathValuePercentEncodesReservedCharacters(t *testing.T) {
 	tests := map[string]string{
 		"opaque-id": "opaque-id",
-		"src/main.go": "src%2Fmain.go",
-		"../secret": "..%2Fsecret",
+		"allenai/c4": "allenai/c4",
+		"src/main file.go": "src/main%20file.go",
 		"a b?c#d": "a%20b%3Fc%23d",
 	}
 	for input, want := range tests {
@@ -156,11 +210,10 @@ func TestDependentPathParamStripsCompositeStorageID(t *testing.T) {
 			"parent (composite id) never leaks a %00 into the request URL (nginx 400)")
 }
 
-// TestURLPathEscapeBehaviorPinsContract is a stdlib-behavior pin: if Go ever
-// changed url.PathEscape's encoding shape, every printed CLI's request URLs
-// would change too. We document the inputs the issue cited (opaque IDs round-
-// trip; slashes/colons encode) so a future stdlib regression is caught here
-// rather than in a live-API 404.
+// TestURLPathEscapeBehaviorPinsContract is a stdlib-behavior pin for each
+// segment of a path-param value. The shared helper deliberately preserves
+// slash separators while retaining url.PathEscape's reserved-character
+// behavior within each segment.
 func TestURLPathEscapeBehaviorPinsContract(t *testing.T) {
 	t.Parallel()
 
@@ -169,14 +222,18 @@ func TestURLPathEscapeBehaviorPinsContract(t *testing.T) {
 	}{
 		{"abc-123-def", "abc-123-def"},
 		{"2026-01-15", "2026-01-15"},
-		{"src/cli/main.go", "src%2Fcli%2Fmain.go"},
-		{"https://example.com/", "https:%2F%2Fexample.com%2F"},
+		{"src/cli/main.go", "src/cli/main.go"},
+		{"https://example.com/", "https://example.com/"},
 		{"sc-domain:example.com", "sc-domain:example.com"},
 	}
 	for _, c := range cases {
 		t.Run(c.in, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, c.want, url.PathEscape(c.in))
+			parts := strings.Split(c.in, "/")
+			for i, part := range parts {
+				parts[i] = url.PathEscape(part)
+			}
+			assert.Equal(t, c.want, strings.Join(parts, "/"))
 		})
 	}
 }

--- a/internal/generator/path_param_encoding_test.go
+++ b/internal/generator/path_param_encoding_test.go
@@ -96,6 +96,8 @@ func TestReplacePathParamPreservesHierarchicalIdentifiers(t *testing.T) {
 		"opaque-id": "opaque-id",
 		"allenai/c4": "allenai/c4",
 		"src/main file.go": "src/main%20file.go",
+		"../secret": "%2E%2E/secret",
+		"./file": "%2E/file",
 		"a b?c#d": "a%20b%3Fc%23d",
 	}
 	for input, want := range tests {
@@ -117,6 +119,8 @@ func TestEscapePathParamPreservesHierarchicalIdentifiers(t *testing.T) {
 		"opaque-id": "opaque-id",
 		"allenai/c4": "allenai/c4",
 		"src/main file.go": "src/main%20file.go",
+		"../secret": "%2E%2E/secret",
+		"./file": "%2E/file",
 		"a b?c#d": "a%20b%3Fc%23d",
 	}
 	for input, want := range tests {
@@ -138,6 +142,8 @@ func TestMCPPathValuePercentEncodesReservedCharacters(t *testing.T) {
 		"opaque-id": "opaque-id",
 		"allenai/c4": "allenai/c4",
 		"src/main file.go": "src/main%20file.go",
+		"../secret": "%2E%2E/secret",
+		"./file": "%2E/file",
 		"a b?c#d": "a%20b%3Fc%23d",
 	}
 	for input, want := range tests {
@@ -223,6 +229,8 @@ func TestURLPathEscapeBehaviorPinsContract(t *testing.T) {
 		{"abc-123-def", "abc-123-def"},
 		{"2026-01-15", "2026-01-15"},
 		{"src/cli/main.go", "src/cli/main.go"},
+		{"../secret", "%2E%2E/secret"},
+		{"./file", "%2E/file"},
 		{"https://example.com/", "https://example.com/"},
 		{"sc-domain:example.com", "sc-domain:example.com"},
 	}
@@ -231,6 +239,10 @@ func TestURLPathEscapeBehaviorPinsContract(t *testing.T) {
 			t.Parallel()
 			parts := strings.Split(c.in, "/")
 			for i, part := range parts {
+				if part == "." || part == ".." {
+					parts[i] = strings.Repeat("%2E", len(part))
+					continue
+				}
 				parts[i] = url.PathEscape(part)
 			}
 			assert.Equal(t, c.want, strings.Join(parts, "/"))

--- a/internal/generator/templates/cliutil_text.go.tmpl
+++ b/internal/generator/templates/cliutil_text.go.tmpl
@@ -45,6 +45,10 @@ func ScrubTerminal(s string) string {
 func EscapePathParam(value string) string {
 	segments := strings.Split(value, "/")
 	for i, segment := range segments {
+		if segment == "." || segment == ".." {
+			segments[i] = strings.Repeat("%2E", len(segment))
+			continue
+		}
 		segments[i] = url.PathEscape(segment)
 	}
 	return strings.Join(segments, "/")

--- a/internal/generator/templates/cliutil_text.go.tmpl
+++ b/internal/generator/templates/cliutil_text.go.tmpl
@@ -5,6 +5,7 @@ package cliutil
 
 import (
 	"html"
+	"net/url"
 {{- if and .Auth.Type (ne .Auth.Type "none")}}
 	"regexp"
 {{- end}}
@@ -37,6 +38,16 @@ func ScrubTerminal(s string) string {
 		}
 		return r
 	}, s)
+}
+
+// EscapePathParam preserves slash separators in hierarchical IDs so reserved
+// characters within each segment remain safe in the request URL.
+func EscapePathParam(value string) string {
+	segments := strings.Split(value, "/")
+	for i, segment := range segments {
+		segments[i] = url.PathEscape(segment)
+	}
+	return strings.Join(segments, "/")
 }
 
 // ParseStoredTime parses timestamps read back from SQLite-backed generated

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-{{- if or .HasEmbeddedPaged .HasPathParams (hasArrayQueryParams .APISpec)}}
+{{- if or .HasEmbeddedPaged (hasArrayQueryParams .APISpec)}}
 	"net/url"
 {{- end}}
 	"os"
@@ -30,7 +30,7 @@ import (
 {{- end}}
 	"unicode"
 
-{{- if or (and .Auth.Type (ne .Auth.Type "none")) .HasDataLayer}}
+{{- if or .HasPathParams (and .Auth.Type (ne .Auth.Type "none")) .HasDataLayer}}
 	"{{modulePath}}/internal/cliutil"
 {{- end}}
 {{- if .HasRequiredRoles}}
@@ -1080,10 +1080,10 @@ func newTabWriter(w io.Writer) *tabwriter.Writer {
 }
 
 {{- if .HasPathParams}}
-// replacePathParam percent-encodes value so path-reserved characters in
-// user input do not collapse into extra path segments.
+// replacePathParam escapes path-param values before substituting them so
+// reserved characters within each segment remain safe in the request URL.
 func replacePathParam(path, name, value string) string {
-	return strings.ReplaceAll(path, "{"+name+"}", url.PathEscape(value))
+	return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(value))
 }
 {{- end}}
 

--- a/internal/generator/templates/mcp_code_orch.go.tmpl
+++ b/internal/generator/templates/mcp_code_orch.go.tmpl
@@ -313,7 +313,7 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 	path := ep.Path
 	for _, p := range ep.Positional {
 		if v, ok := params[p]; ok {
-			path = strings.ReplaceAll(path, "{"+p+"}", formatMCPParamValue(v))
+			path = strings.ReplaceAll(path, "{"+p+"}", mcpPathValue(v))
 			delete(params, p)
 		}
 	}

--- a/internal/generator/templates/mcp_intents.go.tmpl
+++ b/internal/generator/templates/mcp_intents.go.tmpl
@@ -221,7 +221,7 @@ func callIntentEndpoint(ctx context.Context, c *client.Client, {{if .HasRequired
 	for k, v := range params {
 		placeholder := "{" + k + "}"
 		if strings.Contains(path, placeholder) {
-			path = strings.ReplaceAll(path, placeholder, formatMCPParamValue(v))
+			path = strings.ReplaceAll(path, placeholder, mcpPathValue(v))
 			continue
 		}
 		query[k] = formatMCPParamValue(v)

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -22,7 +22,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	{{- if or (hasArrayQueryParams .APISpec) $hasFormRequest}}
 	"net/url"
+	{{- end}}
 {{- if or .VisionSet.Search .VisionSet.Store}}
 	"os"
 {{- end}}
@@ -257,7 +259,7 @@ func formatMCPParamValue(v any) string {
 }
 
 func mcpPathValue(v any) string {
-	return url.PathEscape(formatMCPParamValue(v))
+	return cliutil.EscapePathParam(formatMCPParamValue(v))
 }
 
 {{- if hasArrayQueryParams .APISpec}}

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -2611,7 +2611,7 @@ func hydratedItemPath(config itemHydrationConfig, id string) string {
 	if param == "" {
 		param = "id"
 	}
-	return strings.ReplaceAll(config.path, "{"+param+"}", url.PathEscape(id))
+	return strings.ReplaceAll(config.path, "{"+param+"}", cliutil.EscapePathParam(id))
 }
 
 func scalarItemID(item json.RawMessage) string {

--- a/internal/pipeline/mcpsync/sync_test.go
+++ b/internal/pipeline/mcpsync/sync_test.go
@@ -355,6 +355,8 @@ func RegisterNovelFeatureTools() { shellOutToCLI("items list") }
 	require.NoError(t, err)
 	src := string(regenerated)
 	assert.Contains(t, src, "SanitizeErrorBody", "cliutil/text.go should be regenerated with SanitizeErrorBody")
+	assert.Contains(t, src, "func EscapePathParam(value string) string",
+		"cliutil/text.go should regenerate the shared path-param escaper")
 	assert.NotContains(t, src, "// CleanText is the only helper this older template emitted.", "stale stub content should be replaced")
 }
 

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -550,10 +550,10 @@ func newTabWriter(w io.Writer) *tabwriter.Writer {
 	return tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
 }
 
-// replacePathParam percent-encodes value so path-reserved characters in
-// user input do not collapse into extra path segments.
+// replacePathParam escapes path-param values before substituting them so
+// reserved characters within each segment remain safe in the request URL.
 func replacePathParam(path, name, value string) string {
-	return strings.ReplaceAll(path, "{"+name+"}", url.PathEscape(value))
+	return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(value))
 }
 
 // paginatedGet fetches pages and concatenates array results. The headers

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -194,7 +193,7 @@ func formatMCPParamValue(v any) string {
 }
 
 func mcpPathValue(v any) string {
-	return url.PathEscape(formatMCPParamValue(v))
+	return cliutil.EscapePathParam(formatMCPParamValue(v))
 }
 
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -132,7 +131,7 @@ func formatMCPParamValue(v any) string {
 }
 
 func mcpPathValue(v any) string {
-	return url.PathEscape(formatMCPParamValue(v))
+	return cliutil.EscapePathParam(formatMCPParamValue(v))
 }
 
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"io"
-	"net/url"
 	"os"
 	"path/filepath"
 	"printing-press-golden-pp-cli/internal/client"
@@ -628,10 +627,10 @@ func newTabWriter(w io.Writer) *tabwriter.Writer {
 	return tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
 }
 
-// replacePathParam percent-encodes value so path-reserved characters in
-// user input do not collapse into extra path segments.
+// replacePathParam escapes path-param values before substituting them so
+// reserved characters within each segment remain safe in the request URL.
 func replacePathParam(path, name, value string) string {
-	return strings.ReplaceAll(path, "{"+name+"}", url.PathEscape(value))
+	return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(value))
 }
 
 // paginatedGet fetches pages and concatenates array results. The headers

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -1802,7 +1802,7 @@ func hydratedItemPath(config itemHydrationConfig, id string) string {
 	if param == "" {
 		param = "id"
 	}
-	return strings.ReplaceAll(config.path, "{"+param+"}", url.PathEscape(id))
+	return strings.ReplaceAll(config.path, "{"+param+"}", cliutil.EscapePathParam(id))
 }
 
 func scalarItemID(item json.RawMessage) string {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/text.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/text.go
@@ -43,6 +43,10 @@ func ScrubTerminal(s string) string {
 func EscapePathParam(value string) string {
 	segments := strings.Split(value, "/")
 	for i, segment := range segments {
+		if segment == "." || segment == ".." {
+			segments[i] = strings.Repeat("%2E", len(segment))
+			continue
+		}
 		segments[i] = url.PathEscape(segment)
 	}
 	return strings.Join(segments, "/")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/text.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/text.go
@@ -5,6 +5,7 @@ package cliutil
 
 import (
 	"html"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -35,6 +36,16 @@ func ScrubTerminal(s string) string {
 		}
 		return r
 	}, s)
+}
+
+// EscapePathParam preserves slash separators in hierarchical IDs so reserved
+// characters within each segment remain safe in the request URL.
+func EscapePathParam(value string) string {
+	segments := strings.Split(value, "/")
+	for i, segment := range segments {
+		segments[i] = url.PathEscape(segment)
+	}
+	return strings.Join(segments, "/")
 }
 
 // ParseStoredTime parses timestamps read back from SQLite-backed generated

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -234,7 +233,7 @@ func formatMCPParamValue(v any) string {
 }
 
 func mcpPathValue(v any) string {
-	return url.PathEscape(formatMCPParamValue(v))
+	return cliutil.EscapePathParam(formatMCPParamValue(v))
 }
 func mcpMultipartFieldValue(v any) string {
 	if s, ok := v.(string); ok {

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/code_orch.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/code_orch.go
@@ -229,7 +229,7 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 	path := ep.Path
 	for _, p := range ep.Positional {
 		if v, ok := params[p]; ok {
-			path = strings.ReplaceAll(path, "{"+p+"}", formatMCPParamValue(v))
+			path = strings.ReplaceAll(path, "{"+p+"}", mcpPathValue(v))
 			delete(params, p)
 		}
 	}

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -126,7 +125,7 @@ func formatMCPParamValue(v any) string {
 }
 
 func mcpPathValue(v any) string {
-	return url.PathEscape(formatMCPParamValue(v))
+	return cliutil.EscapePathParam(formatMCPParamValue(v))
 }
 
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -145,7 +144,7 @@ func formatMCPParamValue(v any) string {
 }
 
 func mcpPathValue(v any) string {
-	return url.PathEscape(formatMCPParamValue(v))
+	return cliutil.EscapePathParam(formatMCPParamValue(v))
 }
 
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -1795,7 +1795,7 @@ func hydratedItemPath(config itemHydrationConfig, id string) string {
 	if param == "" {
 		param = "id"
 	}
-	return strings.ReplaceAll(config.path, "{"+param+"}", url.PathEscape(id))
+	return strings.ReplaceAll(config.path, "{"+param+"}", cliutil.EscapePathParam(id))
 }
 
 func scalarItemID(item json.RawMessage) string {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -1773,7 +1773,7 @@ func hydratedItemPath(config itemHydrationConfig, id string) string {
 	if param == "" {
 		param = "id"
 	}
-	return strings.ReplaceAll(config.path, "{"+param+"}", url.PathEscape(id))
+	return strings.ReplaceAll(config.path, "{"+param+"}", cliutil.EscapePathParam(id))
 }
 
 func scalarItemID(item json.RawMessage) string {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -1738,7 +1738,7 @@ func hydratedItemPath(config itemHydrationConfig, id string) string {
 	if param == "" {
 		param = "id"
 	}
-	return strings.ReplaceAll(config.path, "{"+param+"}", url.PathEscape(id))
+	return strings.ReplaceAll(config.path, "{"+param+"}", cliutil.EscapePathParam(id))
 }
 
 func scalarItemID(item json.RawMessage) string {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -151,7 +150,7 @@ func formatMCPParamValue(v any) string {
 }
 
 func mcpPathValue(v any) string {
-	return url.PathEscape(formatMCPParamValue(v))
+	return cliutil.EscapePathParam(formatMCPParamValue(v))
 }
 
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.


### PR DESCRIPTION
## Intent

Issue: Closes #3540

CLI and MCP generated paths must agree when an identifier contains slash-separated hierarchy, such as `allenai/c4`.

## Approach

The generated cliutil package now owns one segment-aware path escaper. It preserves slash separators and percent-encodes reserved characters within each segment, including exact `.` and `..` segments so they cannot remain structural. Generated CLI replacement, MCP endpoint mirrors, intents, code orchestration, and sync hydration all use it. MCP sync regeneration refreshes cliutil, keeping older printed CLIs buildable.

## Scope

Primary area: generator templates and generated-output contracts

Why this belongs in this repo: the behavior is emitted by the Printing Press across printed CLI and MCP surfaces.

## Risk

Generated URL paths change for raw slash-bearing values. This PR intentionally treats raw `/` as hierarchy to satisfy #3540; because current parameter metadata does not distinguish hierarchical identifiers from opaque IDs containing a slash, those opaque IDs are a known compatibility risk accepted for follow-up. Reserved characters and exact dot segments within preserved segments remain encoded. The golden suite covers the intentional output changes.

## Output Contract

Updated emitted-code assertions, generated runtime tests, compiled generated CLI cases, MCP sync compatibility coverage, and affected golden fixtures.

## Verification

- `go test ./...` (all other packages passed; the generator package reached the default 10-minute timeout)
- `go test ./internal/generator -timeout 20m -count=1`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`
