### PR TITLE
fix(cli): emit sync since-filter in UTC (Z), not a local offset

### DIFF
--- a/internal/generator/sync_pagination_maximum_test.go
+++ b/internal/generator/sync_pagination_maximum_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Anthropic, PBC. Licensed under Apache-2.0.
+
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// paginationMaximumSpec builds a spec whose list endpoint declares a page_size
+// param with an inclusive maximum below the 100 default. It exercises the
+// full profiler -> template path so the assertion is on the *generated* CLI's
+// behavior, not on a hand-constructed profile.
+func paginationMaximumSpec(name string, maximum float64) *spec.APISpec {
+	apiSpec := minimalSpec(name)
+	apiSpec.Resources = map[string]spec.Resource{
+		"widgets": {
+			Description: "Widgets",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method: "GET",
+					Path:   "/widgets",
+					Params: []spec.Param{
+						{Name: "cursor", Type: "string"},
+						{Name: "page_size", Type: "int", Maximum: &maximum},
+					},
+					Response:   spec.ResponseDef{Type: "array"},
+					Pagination: &spec.Pagination{Type: "cursor", LimitParam: "page_size", CursorParam: "cursor"},
+				},
+			},
+		},
+	}
+	return apiSpec
+}
+
+// TestGeneratedSyncPaginationCapsAtSpecMaximum proves the emitted
+// determinePaginationDefaults caps the page size at the spec's declared
+// page_size maximum instead of the 100 default. Without the clamp, sync sends
+// limit=100 and APIs that cap page_size below 100 reject the request (e.g.
+// HTTP 400 "Number must be less than or equal to 30"). The assertion is
+// compile-level: it runs the generated helper and reads its return value,
+// so it survives gofmt spacing and struct-literal reordering.
+func TestGeneratedSyncPaginationCapsAtSpecMaximum(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := paginationMaximumSpec("pagcap", 30)
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	runtimeTest := `package cli
+
+import "testing"
+
+func TestDeterminePaginationDefaultsCapsAtSpecMaximum(t *testing.T) {
+	// resourceSupportsPagination must be true, otherwise the capped limit is
+	// never actually sent and the cap would be vacuously "correct".
+	if !resourceSupportsPagination("widgets") {
+		t.Fatal("resourceSupportsPagination(\"widgets\") = false, want true so the capped limit is sent")
+	}
+	got := determinePaginationDefaults("widgets")
+	if got.limitParam != "page_size" {
+		t.Fatalf("limitParam = %q, want \"page_size\"", got.limitParam)
+	}
+	if got.limit != 30 {
+		t.Fatalf("limit = %d, want 30 (the spec's page_size maximum, not the 100 default)", got.limit)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "cli", "sync_pagination_cap_test.go"),
+		[]byte(runtimeTest), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestDeterminePaginationDefaultsCapsAtSpecMaximum")
+}
+
+// TestGeneratedSyncSinceRendersUTC pins the incremental-sync temporal filter to
+// UTC. A local-zone RFC3339 renders a numeric offset like "-04:00", which some
+// APIs reject as an invalid date; ".UTC().Format" renders the zone as "Z".
+func TestGeneratedSyncSinceRendersUTC(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := paginationMaximumSpec("sinceutc", 30)
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+
+	// Both since-formatting sites (explicit --since and last_synced_at
+	// incremental) must render in UTC.
+	assert.Contains(t, syncSrc, "ts.UTC().Format(time.RFC3339)",
+		"explicit --since must be formatted in UTC")
+	assert.Contains(t, syncSrc, "lastSynced.UTC().Format(time.RFC3339)",
+		"incremental last_synced_at must be formatted in UTC")
+
+	// The bare local-zone forms must be gone.
+	assert.NotContains(t, syncSrc, "ts.Format(time.RFC3339)",
+		"explicit --since must not use the bare local-zone Format")
+	assert.NotContains(t, syncSrc, "lastSynced.Format(time.RFC3339)",
+		"incremental since must not use the bare local-zone Format")
+}

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -319,14 +319,16 @@ Resource scoping:
 			// safety limit, which is a real anomaly worth surfacing.
 			effectiveLatestOnly := latestOnly && since == ""
 
-			// Resolve --since into an RFC3339 timestamp
+			// Resolve --since into an RFC3339 timestamp. Render in UTC so the
+			// zone is "Z" rather than a numeric offset like "-04:00"; some APIs
+			// reject the offset form of the temporal filter as an invalid date.
 			sinceTS := ""
 			if since != "" {
 				ts, err := parseSinceDuration(since)
 				if err != nil {
 					return fmt.Errorf("invalid --since value %q: %w", since, err)
 				}
-				sinceTS = ts.Format(time.RFC3339)
+				sinceTS = ts.UTC().Format(time.RFC3339)
 			}
 
 {{- if .Pagination.DateRangeParam}}
@@ -665,7 +667,8 @@ func syncResource(ctx context.Context, c interface {
 	sinceParam := syncResourceSinceParam(resource)
 	effectiveSince := sinceTS
 	if effectiveSince == "" && !lastSynced.IsZero() && !full {
-		effectiveSince = lastSynced.Format(time.RFC3339)
+		// UTC so the zone renders as "Z"; see the --since resolution above.
+		effectiveSince = lastSynced.UTC().Format(time.RFC3339)
 	}
 	// Resources whose list endpoint declares no temporal-filter parameter
 	// fall back to plain pagination — sending a synthetic since=... would

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -196,14 +196,16 @@ Resource scoping:
 			// safety limit, which is a real anomaly worth surfacing.
 			effectiveLatestOnly := latestOnly && since == ""
 
-			// Resolve --since into an RFC3339 timestamp
+			// Resolve --since into an RFC3339 timestamp. Render in UTC so the
+			// zone is "Z" rather than a numeric offset like "-04:00"; some APIs
+			// reject the offset form of the temporal filter as an invalid date.
 			sinceTS := ""
 			if since != "" {
 				ts, err := parseSinceDuration(since)
 				if err != nil {
 					return fmt.Errorf("invalid --since value %q: %w", since, err)
 				}
-				sinceTS = ts.Format(time.RFC3339)
+				sinceTS = ts.UTC().Format(time.RFC3339)
 			}
 
 			// Worker pool: produce resources, N workers consume
@@ -481,7 +483,8 @@ func syncResource(ctx context.Context, c interface {
 	sinceParam := syncResourceSinceParam(resource)
 	effectiveSince := sinceTS
 	if effectiveSince == "" && !lastSynced.IsZero() && !full {
-		effectiveSince = lastSynced.Format(time.RFC3339)
+		// UTC so the zone renders as "Z"; see the --since resolution above.
+		effectiveSince = lastSynced.UTC().Format(time.RFC3339)
 	}
 	// Resources whose list endpoint declares no temporal-filter parameter
 	// fall back to plain pagination — sending a synthetic since=... would

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -190,14 +190,16 @@ Resource scoping:
 			// safety limit, which is a real anomaly worth surfacing.
 			effectiveLatestOnly := latestOnly && since == ""
 
-			// Resolve --since into an RFC3339 timestamp
+			// Resolve --since into an RFC3339 timestamp. Render in UTC so the
+			// zone is "Z" rather than a numeric offset like "-04:00"; some APIs
+			// reject the offset form of the temporal filter as an invalid date.
 			sinceTS := ""
 			if since != "" {
 				ts, err := parseSinceDuration(since)
 				if err != nil {
 					return fmt.Errorf("invalid --since value %q: %w", since, err)
 				}
-				sinceTS = ts.Format(time.RFC3339)
+				sinceTS = ts.UTC().Format(time.RFC3339)
 			}
 
 			// Worker pool: produce resources, N workers consume
@@ -442,7 +444,8 @@ func syncResource(ctx context.Context, c interface {
 	sinceParam := syncResourceSinceParam(resource)
 	effectiveSince := sinceTS
 	if effectiveSince == "" && !lastSynced.IsZero() && !full {
-		effectiveSince = lastSynced.Format(time.RFC3339)
+		// UTC so the zone renders as "Z"; see the --since resolution above.
+		effectiveSince = lastSynced.UTC().Format(time.RFC3339)
 	}
 	// Resources whose list endpoint declares no temporal-filter parameter
 	// fall back to plain pagination — sending a synthetic since=... would

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -196,14 +196,16 @@ Resource scoping:
 			// safety limit, which is a real anomaly worth surfacing.
 			effectiveLatestOnly := latestOnly && since == ""
 
-			// Resolve --since into an RFC3339 timestamp
+			// Resolve --since into an RFC3339 timestamp. Render in UTC so the
+			// zone is "Z" rather than a numeric offset like "-04:00"; some APIs
+			// reject the offset form of the temporal filter as an invalid date.
 			sinceTS := ""
 			if since != "" {
 				ts, err := parseSinceDuration(since)
 				if err != nil {
 					return fmt.Errorf("invalid --since value %q: %w", since, err)
 				}
-				sinceTS = ts.Format(time.RFC3339)
+				sinceTS = ts.UTC().Format(time.RFC3339)
 			}
 
 			// Worker pool: produce resources, N workers consume
@@ -481,7 +483,8 @@ func syncResource(ctx context.Context, c interface {
 	sinceParam := syncResourceSinceParam(resource)
 	effectiveSince := sinceTS
 	if effectiveSince == "" && !lastSynced.IsZero() && !full {
-		effectiveSince = lastSynced.Format(time.RFC3339)
+		// UTC so the zone renders as "Z"; see the --since resolution above.
+		effectiveSince = lastSynced.UTC().Format(time.RFC3339)
 	}
 	// Resources whose list endpoint declares no temporal-filter parameter
 	// fall back to plain pagination — sending a synthetic since=... would

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -190,14 +190,16 @@ Resource scoping:
 			// safety limit, which is a real anomaly worth surfacing.
 			effectiveLatestOnly := latestOnly && since == ""
 
-			// Resolve --since into an RFC3339 timestamp
+			// Resolve --since into an RFC3339 timestamp. Render in UTC so the
+			// zone is "Z" rather than a numeric offset like "-04:00"; some APIs
+			// reject the offset form of the temporal filter as an invalid date.
 			sinceTS := ""
 			if since != "" {
 				ts, err := parseSinceDuration(since)
 				if err != nil {
 					return fmt.Errorf("invalid --since value %q: %w", since, err)
 				}
-				sinceTS = ts.Format(time.RFC3339)
+				sinceTS = ts.UTC().Format(time.RFC3339)
 			}
 
 			// Worker pool: produce resources, N workers consume
@@ -442,7 +444,8 @@ func syncResource(ctx context.Context, c interface {
 	sinceParam := syncResourceSinceParam(resource)
 	effectiveSince := sinceTS
 	if effectiveSince == "" && !lastSynced.IsZero() && !full {
-		effectiveSince = lastSynced.Format(time.RFC3339)
+		// UTC so the zone renders as "Z"; see the --since resolution above.
+		effectiveSince = lastSynced.UTC().Format(time.RFC3339)
 	}
 	// Resources whose list endpoint declares no temporal-filter parameter
 	// fall back to plain pagination — sending a synthetic since=... would


### PR DESCRIPTION
## What & why
Fixes https://github.com/mvanhorn/cli-printing-press/issues/3671. The generated `sync` formats the incremental `since` value with `.Format(time.RFC3339)` on a possibly-local time → numeric offset (`-04:00`). Strict temporal-filter APIs (Granola's `updated_after`, verified live) reject that with HTTP 400 `Invalid date`, breaking incremental sync. Now emits `.UTC().Format(time.RFC3339)` (→ `Z`) at both `--since` sites in `sync.go.tmpl`. Date-only params unaffected (route through `formatSyncSinceValue`).

Also adds a **generated-output** regression test for the pagination-maximum clamp (#3441) — the prior suite only unit-tested it at the profiler, never on emitted CLI behavior.

## Testing
- `go test ./...` — PASS (full suite)
- `scripts/golden.sh verify` — PASS (4 sync.go fixtures refreshed: diff is only the UTC change + comments; no golden spec declares a page_size maximum so no pagination golden change)
- `scripts/verify-generator-output.sh` — PASS (10 cases compile)
- No API break: the clamp falls back to the current default when no `maximum` is declared; UTC change only affects zone rendering of an already-RFC3339 value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)