### PR TITLE
fix(cli): sandbox generated tests and verify the sandbox holds

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2278,6 +2278,7 @@ func (g *Generator) prepareOutput() error {
 		filepath.Join("internal", "cache"),
 		filepath.Join("internal", "client"),
 		filepath.Join("internal", "cliutil"),
+		filepath.Join("internal", "cliutil", "testenv"),
 		filepath.Join("internal", "config"),
 		filepath.Join("internal", "mcp", "bound"),
 		filepath.Join("internal", "mcp", "cobratree"),
@@ -2402,6 +2403,7 @@ func (g *Generator) renderSingleFiles() error {
 		"cliutil_verifyenv.go.tmpl":                filepath.Join("internal", "cliutil", "verifyenv.go"),
 		"cliutil_paths.go.tmpl":                    filepath.Join("internal", "cliutil", "paths.go"),
 		"cliutil_paths_test.go.tmpl":               filepath.Join("internal", "cliutil", "paths_test.go"),
+		"cliutil_testenv.go.tmpl":                  filepath.Join("internal", "cliutil", "testenv", "testenv.go"),
 		"cliutil_extractnumber.go.tmpl":            filepath.Join("internal", "cliutil", "extractnumber.go"),
 		"cliutil_extractnumber_test.go.tmpl":       filepath.Join("internal", "cliutil", "extractnumber_test.go"),
 		"cliutil_jwtshape.go.tmpl":                 filepath.Join("internal", "cliutil", "jwtshape.go"),
@@ -3181,6 +3183,7 @@ func (g *Generator) GenerateMCPSurface() error {
 		"cliutil_verifyenv.go.tmpl":          filepath.Join("internal", "cliutil", "verifyenv.go"),
 		"cliutil_paths.go.tmpl":              filepath.Join("internal", "cliutil", "paths.go"),
 		"cliutil_paths_test.go.tmpl":         filepath.Join("internal", "cliutil", "paths_test.go"),
+		"cliutil_testenv.go.tmpl":            filepath.Join("internal", "cliutil", "testenv", "testenv.go"),
 		"cliutil_extractnumber.go.tmpl":      filepath.Join("internal", "cliutil", "extractnumber.go"),
 		"cliutil_extractnumber_test.go.tmpl": filepath.Join("internal", "cliutil", "extractnumber_test.go"),
 		"cliutil_jwtshape.go.tmpl":           filepath.Join("internal", "cliutil", "jwtshape.go"),
@@ -3721,6 +3724,7 @@ func (g *Generator) renderMCPEntrypoint() error {
 			filepath.Join("cmd", naming.MCP(g.Spec.Name)),
 			filepath.Join("internal", "mcp"),
 			filepath.Join("internal", "mcp", "bound"),
+			filepath.Join("internal", "cliutil", "testenv"),
 		}
 		for _, d := range mcpDirs {
 			if err := os.MkdirAll(filepath.Join(g.OutputDir, d), 0755); err != nil {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -109,6 +109,7 @@ func TestGenerateProjectsCompile(t *testing.T) {
 		"internal/mcp/cobratree/shellout_test.go",
 		"internal/mcp/cobratree/cli_path.go",
 		"internal/mcp/cobratree/names.go",
+		"internal/cliutil/testenv/testenv.go",
 	}
 
 	tests := []struct {
@@ -136,9 +137,11 @@ func TestGenerateProjectsCompile(t *testing.T) {
 		// +2: MCP tenant-gate middleware and its single-gate conformance tests.
 		// +1: fail-closed endpoint-budget lookup conformance coverage.
 		// +2: command and MCP platform-window adoption plus conformance tests.
-		{name: "stytch", specPath: filepath.Join("..", "..", "testdata", "stytch.yaml"), expectedFiles: 166},
-		{name: "clerk", specPath: filepath.Join("..", "..", "testdata", "clerk.yaml"), expectedFiles: 170},
-		{name: "loops", specPath: filepath.Join("..", "..", "testdata", "loops.yaml"), expectedFiles: 168},
+		// +1: internal/cliutil/testenv, the sandbox helper every emitted test
+		// routes its HOME/USERPROFILE isolation through.
+		{name: "stytch", specPath: filepath.Join("..", "..", "testdata", "stytch.yaml"), expectedFiles: 167},
+		{name: "clerk", specPath: filepath.Join("..", "..", "testdata", "clerk.yaml"), expectedFiles: 171},
+		{name: "loops", specPath: filepath.Join("..", "..", "testdata", "loops.yaml"), expectedFiles: 169},
 	}
 
 	for _, tt := range tests {
@@ -2527,11 +2530,21 @@ func requireGeneratedCompiles(t *testing.T, dir string) {
 
 func runGoCommandRequired(t *testing.T, dir string, args ...string) {
 	t.Helper()
+	output, err := runGoCommandOutput(t, dir, args...)
+	require.NoError(t, err, output)
+}
+
+// runGoCommandOutput runs a go command in a generated module and hands
+// back its combined output and exit status. Callers that expect the
+// command to fail use this directly; runGoCommandRequired wraps it for
+// the usual must-succeed case.
+func runGoCommandOutput(t *testing.T, dir string, args ...string) (string, error) {
+	t.Helper()
 
 	// Generated-project compile tests exercise module resolution via -mod=mod;
 	// production Validate still owns the go mod tidy quality gate.
 	if len(args) >= 2 && args[0] == "mod" && args[1] == "tidy" {
-		return
+		return "", nil
 	}
 	if len(args) > 0 && (args[0] == "build" || args[0] == "test") {
 		args = append([]string{args[0], "-mod=mod"}, args[1:]...)
@@ -2542,8 +2555,36 @@ func runGoCommandRequired(t *testing.T, dir string, args ...string) {
 	cacheDir, err := goBuildCacheDir(dir)
 	require.NoError(t, err)
 	cmd.Env = append(os.Environ(), "GOCACHE="+cacheDir)
+	cmd.Env = append(cmd.Env, sandboxHomeEnv(t)...)
 	output, err := cmd.CombinedOutput()
-	require.NoError(t, err, string(output))
+	return string(output), err
+}
+
+// sandboxHomeEnv points a generated module's test run at a throwaway
+// home. Emitted tests resolve user directories from HOME on Unix and
+// USERPROFILE on Windows, so a run that inherits the real values reads
+// and writes the operator's own config, state, and data dirs. GOPATH
+// and GOMODCACHE stay on their real values: relocating them would
+// re-download the module cache on every case.
+func sandboxHomeEnv(t *testing.T) []string {
+	t.Helper()
+	home := t.TempDir()
+	env := []string{"HOME=" + home, "USERPROFILE=" + home}
+	for _, name := range []string{"GOPATH", "GOMODCACHE"} {
+		if value := goEnvValue(t, name); value != "" {
+			env = append(env, name+"="+value)
+		}
+	}
+	return env
+}
+
+func goEnvValue(t *testing.T, name string) string {
+	t.Helper()
+	out, err := exec.Command("go", "env", name).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func runGeneratedBinary(t *testing.T, binaryPath string, args ...string) (string, string) {

--- a/internal/generator/templates/cliutil_credentials_perms_test.go.tmpl
+++ b/internal/generator/templates/cliutil_credentials_perms_test.go.tmpl
@@ -18,6 +18,8 @@ import (
 	"os/exec"
 	"runtime"
 	"testing"
+
+	"{{modulePath}}/internal/cliutil/testenv"
 )
 
 // credsSampleReadPermsToken is an exposed on-disk token value written to the
@@ -28,19 +30,12 @@ const credsSampleReadPermsToken = "AT-LIVE-CREDS-FILE-DO-NOT-LEAK"
 // home so the test never reads or writes the developer's real credentials file.
 func isolateCredsHome(t *testing.T) {
 	t.Helper()
-	t.Setenv("HOME", t.TempDir())
-	for _, name := range []string{
-		"{{envName .Name}}_DATA_DIR",
-		"{{envName .Name}}_HOME",
-		"XDG_DATA_HOME",
-	} {
-		t.Setenv(name, "")
-	}
 	restore, err := SetHomeOverride("")
 	if err != nil {
 		t.Fatalf("reset home override: %v", err)
 	}
 	t.Cleanup(restore)
+	testenv.Isolate(t, DataDir)
 }
 
 func runCredsPermsCmd(t *testing.T, name string, args ...string) error {

--- a/internal/generator/templates/cliutil_credentials_test.go.tmpl
+++ b/internal/generator/templates/cliutil_credentials_test.go.tmpl
@@ -21,41 +21,35 @@ import (
 {{- end}}
 
 	"{{modulePath}}/internal/cliutil"
+	"{{modulePath}}/internal/cliutil/testenv"
 	"{{modulePath}}/internal/config"
 )
 
 func resetCredentialEnv(t *testing.T) (home, configPath string) {
 	t.Helper()
-	home = t.TempDir()
-	t.Setenv("HOME", home)
-	for _, name := range []string{
-		"{{envName .Name}}_CONFIG",
-		"{{envName .Name}}_CONFIG_DIR",
-		"{{envName .Name}}_DATA_DIR",
-		"{{envName .Name}}_STATE_DIR",
-		"{{envName .Name}}_CACHE_DIR",
-		"{{envName .Name}}_HOME",
-		"XDG_CONFIG_HOME",
-		"XDG_DATA_HOME",
-		"XDG_STATE_HOME",
-		"XDG_CACHE_HOME",
-{{- if .Auth.EnvVarSpecs}}
-{{- range .Auth.EnvVarSpecs}}
-		"{{.Name}}",
-{{- end}}
-{{- else if .Auth.EnvVars}}
-{{- range .Auth.EnvVars}}
-		"{{.}}",
-{{- end}}
-{{- end}}
-	} {
-		t.Setenv(name, "")
-	}
 	if restore, err := cliutil.SetHomeOverride(""); err == nil {
 		t.Cleanup(restore)
 	} else {
 		t.Fatalf("reset home override: %v", err)
 	}
+	home = testenv.Isolate(t, cliutil.ConfigDir, cliutil.DataDir, cliutil.StateDir, cliutil.CacheDir)
+{{- if .Auth.EnvVarSpecs}}
+	for _, name := range []string{
+{{- range .Auth.EnvVarSpecs}}
+		"{{.Name}}",
+{{- end}}
+	} {
+		t.Setenv(name, "")
+	}
+{{- else if .Auth.EnvVars}}
+	for _, name := range []string{
+{{- range .Auth.EnvVars}}
+		"{{.}}",
+{{- end}}
+	} {
+		t.Setenv(name, "")
+	}
+{{- end}}
 	return home, filepath.Join(home, ".config", "{{.Name}}-pp-cli", "config.{{or .Config.Format "json"}}")
 }
 

--- a/internal/generator/templates/cliutil_paths_test.go.tmpl
+++ b/internal/generator/templates/cliutil_paths_test.go.tmpl
@@ -10,31 +10,18 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"{{modulePath}}/internal/cliutil/testenv"
 )
 
 func resetPathEnv(t *testing.T) string {
 	t.Helper()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	for _, name := range []string{
-		envPrefix + "_CONFIG_DIR",
-		envPrefix + "_DATA_DIR",
-		envPrefix + "_STATE_DIR",
-		envPrefix + "_CACHE_DIR",
-		envPrefix + "_HOME",
-		"XDG_CONFIG_HOME",
-		"XDG_DATA_HOME",
-		"XDG_STATE_HOME",
-		"XDG_CACHE_HOME",
-	} {
-		t.Setenv(name, "")
-	}
 	restore, err := SetHomeOverride("")
 	if err != nil {
 		t.Fatalf("reset home override: %v", err)
 	}
 	t.Cleanup(restore)
-	return home
+	return testenv.Isolate(t, ConfigDir, DataDir, StateDir, CacheDir)
 }
 
 func TestKindDirDefaultsMatchLegacyLayout(t *testing.T) {

--- a/internal/generator/templates/cliutil_testenv.go.tmpl
+++ b/internal/generator/templates/cliutil_testenv.go.tmpl
@@ -1,0 +1,101 @@
+// Package testenv sandboxes a test's user directories and proves the
+// sandbox holds.
+//
+// Only test files import it, so it never reaches the CLI binary.
+package testenv
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// homeVars lists every variable os.UserHomeDir consults: HOME on Unix,
+// USERPROFILE on Windows. Redirecting one and not the other leaves the
+// other platform resolving the operator's real home directory.
+var homeVars = []string{"HOME", "USERPROFILE"}
+
+// clearedVars are the per-CLI and XDG overrides that would otherwise
+// point a lookup back out of the sandbox.
+var clearedVars = []string{
+	"{{envName .Name}}_CONFIG",
+	"{{envName .Name}}_CONFIG_DIR",
+	"{{envName .Name}}_DATA_DIR",
+	"{{envName .Name}}_STATE_DIR",
+	"{{envName .Name}}_CACHE_DIR",
+	"{{envName .Name}}_HOME",
+	"XDG_CONFIG_HOME",
+	"XDG_DATA_HOME",
+	"XDG_STATE_HOME",
+	"XDG_CACHE_HOME",
+}
+
+// Isolate redirects user-directory lookups into a throwaway home and
+// returns it. Each resolver passed in is called and its result must
+// land inside that home.
+//
+// Resolving is the load-bearing half. Environment setup that misses a
+// variable fails silently: the test reads and writes the operator's
+// real config, state, or data directory, and every assertion it makes
+// still passes. Routing the check through the same lookups the CLI
+// uses turns a missed variable into a failed test at the point of
+// setup, before anything is written.
+//
+// Callers that manipulate the --home override should reset it before
+// calling Isolate, so the resolvers see the state the test will run
+// under.
+func Isolate(t *testing.T, resolvers ...func() (string, error)) string {
+	t.Helper()
+	home := t.TempDir()
+	for _, name := range homeVars {
+		t.Setenv(name, home)
+	}
+	for _, name := range clearedVars {
+		t.Setenv(name, "")
+	}
+	for _, resolve := range resolvers {
+		requireWithin(t, home, resolve)
+	}
+	return home
+}
+
+func requireWithin(t *testing.T, home string, resolve func() (string, error)) {
+	t.Helper()
+	path, err := resolve()
+	if err != nil {
+		t.Fatalf("resolve sandboxed directory: %v", err)
+	}
+	if !within(home, path) {
+		t.Fatalf("test sandbox escaped: lookup resolved %q, want a path under %q\n"+
+			"Some user-directory lookup is still reading a real environment variable, "+
+			"so this test would read and write the operator's own files.", path, home)
+	}
+}
+
+func within(root, path string) bool {
+	rel, err := filepath.Rel(resolveExisting(root), resolveExisting(path))
+	if err != nil {
+		return false
+	}
+	return rel == "." || !strings.HasPrefix(rel, "..")
+}
+
+// resolveExisting walks up to the deepest existing ancestor, resolves
+// symlinks there, and reattaches the rest. Comparing an unresolved
+// path against a resolved one would read a macOS /var vs /private/var
+// mismatch as an escape.
+func resolveExisting(path string) string {
+	path = filepath.Clean(path)
+	remainder := ""
+	for {
+		if resolved, err := filepath.EvalSymlinks(path); err == nil {
+			return filepath.Join(resolved, remainder)
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return filepath.Join(path, remainder)
+		}
+		remainder = filepath.Join(filepath.Base(path), remainder)
+		path = parent
+	}
+}

--- a/internal/generator/templates/learn/journal_test.go.tmpl
+++ b/internal/generator/templates/learn/journal_test.go.tmpl
@@ -19,6 +19,7 @@ import (
 
 	"{{modulePath}}/internal/cli"
 	"{{modulePath}}/internal/cliutil"
+	"{{modulePath}}/internal/cliutil/testenv"
 	"{{modulePath}}/internal/learn"
 )
 
@@ -26,11 +27,7 @@ import (
 // switch cleared, so entries land in a fresh state dir.
 func withJournalHome(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
-	t.Setenv("{{envPrefix .Name}}_STATE_DIR", "")
-	t.Setenv("{{envPrefix .Name}}_HOME", "")
-	t.Setenv("XDG_STATE_HOME", "")
+	dir := testenv.Isolate(t, cliutil.StateDir)
 	t.Setenv("PRINTING_PRESS_VERIFY", "")
 	t.Setenv("PRINTING_PRESS_DOGFOOD", "")
 	t.Setenv("{{envPrefix .Name}}_NO_LEARN", "")

--- a/internal/generator/templates/learn/teach_log_test.go.tmpl
+++ b/internal/generator/templates/learn/teach_log_test.go.tmpl
@@ -12,16 +12,12 @@ import (
 	"testing"
 
 	"{{modulePath}}/internal/cliutil"
+	"{{modulePath}}/internal/cliutil/testenv"
 )
 
 func withTempHomeForLog(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
-	t.Setenv("{{envPrefix .Name}}_STATE_DIR", "")
-	t.Setenv("{{envPrefix .Name}}_HOME", "")
-	t.Setenv("XDG_STATE_HOME", "")
-	return dir
+	return testenv.Isolate(t, cliutil.StateDir)
 }
 
 func teachLogPathForTest(t *testing.T) string {

--- a/internal/generator/templates/mcp_tools_test.go.tmpl
+++ b/internal/generator/templates/mcp_tools_test.go.tmpl
@@ -18,6 +18,7 @@ import (
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"{{modulePath}}/internal/cliutil"
+	"{{modulePath}}/internal/cliutil/testenv"
 	"{{modulePath}}/internal/mcp/bound"
 {{- if or .VisionSet.Search .VisionSet.Store}}
 	"{{modulePath}}/internal/store"
@@ -76,28 +77,12 @@ func TestMCPPathResolutionMatchesCLIResolverWithPlatformDefaults(t *testing.T) {
 
 func resetMCPPathEnv(t *testing.T) string {
 	t.Helper()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	for _, name := range []string{
-		"{{envName .Name}}_CONFIG",
-		"{{envName .Name}}_CONFIG_DIR",
-		"{{envName .Name}}_DATA_DIR",
-		"{{envName .Name}}_STATE_DIR",
-		"{{envName .Name}}_CACHE_DIR",
-		"{{envName .Name}}_HOME",
-		"XDG_CONFIG_HOME",
-		"XDG_DATA_HOME",
-		"XDG_STATE_HOME",
-		"XDG_CACHE_HOME",
-	} {
-		t.Setenv(name, "")
-	}
 	restore, err := cliutil.SetHomeOverride("")
 	if err != nil {
 		t.Fatalf("reset home override: %v", err)
 	}
 	t.Cleanup(restore)
-	return home
+	return testenv.Isolate(t, cliutil.ConfigDir, cliutil.DataDir, cliutil.StateDir, cliutil.CacheDir)
 }
 
 func TestMCPRegisterToolsPreservesTypedSpecialTools(t *testing.T) {

--- a/internal/generator/templates/teach_test.go.tmpl
+++ b/internal/generator/templates/teach_test.go.tmpl
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"{{modulePath}}/internal/cliutil"
+	"{{modulePath}}/internal/cliutil/testenv"
 	"{{modulePath}}/internal/learn"
 	"{{modulePath}}/internal/learn/entities"
 	"{{modulePath}}/internal/store"
@@ -45,12 +46,8 @@ func unmarshalAgentResults(t *testing.T, stdout string, out any) {
 // per-cli state dir.
 func withTempLearnHome(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	dir := testenv.Isolate(t, cliutil.StateDir)
 	t.Setenv(noLearnEnvVar, "")
-	t.Setenv("{{envPrefix .Name}}_STATE_DIR", "")
-	t.Setenv("{{envPrefix .Name}}_HOME", "")
-	t.Setenv("XDG_STATE_HOME", "")
 	return dir
 }
 

--- a/internal/generator/test_sandbox_guard_test.go
+++ b/internal/generator/test_sandbox_guard_test.go
@@ -1,0 +1,85 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// emittedTestHelperFiles are the generated test files that sandbox a
+// test's user directories. Every one of them must isolate through
+// testenv, whose containment check is what turns a missed environment
+// variable into a failed test instead of a write into the operator's
+// real config.
+var emittedTestHelperFiles = []string{
+	filepath.Join("internal", "cliutil", "paths_test.go"),
+	filepath.Join("internal", "cliutil", "credentials_test.go"),
+	filepath.Join("internal", "cliutil", "credentials_perms_test.go"),
+	filepath.Join("internal", "mcp", "tools_test.go"),
+	filepath.Join("internal", "cli", "teach_test.go"),
+	filepath.Join("internal", "learn", "teach_log_test.go"),
+	filepath.Join("internal", "learn", "journal_test.go"),
+}
+
+// TestGeneratedTestsIsolateThroughTestenv fails if an emitted test
+// file goes back to redirecting HOME by hand. HOME alone is a silent
+// no-op on Windows, where os.UserHomeDir reads USERPROFILE.
+func TestGeneratedTestsIsolateThroughTestenv(t *testing.T) {
+	t.Parallel()
+
+	outputDir := generatePetstore(t)
+
+	for _, rel := range emittedTestHelperFiles {
+		data, err := os.ReadFile(filepath.Join(outputDir, rel))
+		require.NoError(t, err, rel)
+		source := string(data)
+
+		require.NotContains(t, source, `t.Setenv("HOME"`,
+			"%s redirects HOME by hand; isolate through testenv.Isolate so the redirect is verified", rel)
+		require.Contains(t, source, "testenv.Isolate(t",
+			"%s must sandbox its user directories through testenv.Isolate", rel)
+	}
+}
+
+// TestGeneratedTestEnvDetectsSandboxEscape is the load-bearing proof:
+// it drops a test into the generated module whose resolver reports a
+// path outside the sandbox, and requires the guard to fail the run.
+// An isolation helper that only sets environment variables would let
+// this pass, which is exactly the failure mode that let generated
+// tests overwrite a real credentials file.
+func TestGeneratedTestEnvDetectsSandboxEscape(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("generated-module test runs happen in the full generated-test CI lane")
+	}
+
+	outputDir := generatePetstore(t)
+
+	inlineTest := `package testenv_test
+
+import (
+	"os"
+	"testing"
+
+	"petstore-pp-cli/internal/cliutil/testenv"
+)
+
+// The resolver reports the parent of the sandbox, standing in for a
+// lookup that still reads a real environment variable.
+func TestSandboxEscapeIsCaught(t *testing.T) {
+	testenv.Isolate(t, func() (string, error) {
+		return os.TempDir(), nil
+	})
+}
+`
+	testPath := filepath.Join(outputDir, "internal", "cliutil", "testenv", "escape_probe_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
+
+	output, err := runGoCommandOutput(t, outputDir, "test", "./internal/cliutil/testenv", "-run", "TestSandboxEscapeIsCaught")
+	require.Error(t, err, "escaping the sandbox must fail the test run, got:\n%s", output)
+	require.True(t, strings.Contains(output, "test sandbox escaped"),
+		"guard should name the escape; got:\n%s", output)
+}

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/cliutil/credentials_test.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/cliutil/credentials_test.go
@@ -14,32 +14,22 @@ import (
 	"time"
 
 	"printing-press-oauth2-pp-cli/internal/cliutil"
+	"printing-press-oauth2-pp-cli/internal/cliutil/testenv"
 	"printing-press-oauth2-pp-cli/internal/config"
 )
 
 func resetCredentialEnv(t *testing.T) (home, configPath string) {
 	t.Helper()
-	home = t.TempDir()
-	t.Setenv("HOME", home)
-	for _, name := range []string{
-		"PRINTING_PRESS_OAUTH2_CONFIG",
-		"PRINTING_PRESS_OAUTH2_CONFIG_DIR",
-		"PRINTING_PRESS_OAUTH2_DATA_DIR",
-		"PRINTING_PRESS_OAUTH2_STATE_DIR",
-		"PRINTING_PRESS_OAUTH2_CACHE_DIR",
-		"PRINTING_PRESS_OAUTH2_HOME",
-		"XDG_CONFIG_HOME",
-		"XDG_DATA_HOME",
-		"XDG_STATE_HOME",
-		"XDG_CACHE_HOME",
-		"PRINTING_PRESS_OAUTH2_OAUTH2_AUTH_CODE",
-	} {
-		t.Setenv(name, "")
-	}
 	if restore, err := cliutil.SetHomeOverride(""); err == nil {
 		t.Cleanup(restore)
 	} else {
 		t.Fatalf("reset home override: %v", err)
+	}
+	home = testenv.Isolate(t, cliutil.ConfigDir, cliutil.DataDir, cliutil.StateDir, cliutil.CacheDir)
+	for _, name := range []string{
+		"PRINTING_PRESS_OAUTH2_OAUTH2_AUTH_CODE",
+	} {
+		t.Setenv(name, "")
 	}
 	return home, filepath.Join(home, ".config", "printing-press-oauth2-pp-cli", "config.toml")
 }


### PR DESCRIPTION
## Intent

Emitted test helpers sandboxed a test's user directories by setting `HOME` alone. Every path lookup resolves through `os.UserHomeDir`, which reads `USERPROFILE` on Windows, so the redirect was a no-op there — generated tests read and wrote the operator's real config, state, and data directories while every assertion still passed.

The silence is the dangerous part. A missed variable produces no failure: the write succeeds, just in the wrong place. This is not hypothetical — a generated CLI's own suite overwrote a live credentials file with the test fixture `agentcookie-secret` and stripped the credential out of the real `config.toml`, taking that CLI offline until the token was restored by hand. The same run left twelve stray golden-fixture directories in the operator's `~/.local/share/`.

Issue: Closes #3690

## Approach

Add a generated `internal/cliutil/testenv` package. Its `Isolate(t, resolvers...)` redirects both `HOME` and `USERPROFILE`, clears the per-CLI and XDG overrides, and then **calls each production path lookup and requires the result to land inside the sandbox**.

The verification is the load-bearing half, not the extra `USERPROFILE`. Setting one more variable fixes the one promise we know about; resolving through the same functions the CLI uses turns *any* future isolation miss into a failed test at the point of setup, before anything is written. Adding Windows to the CI matrix would not have caught this bug — on a clean runner the tests would have scribbled into an empty profile and passed.

`testenv` deliberately does not import `cliutil`: the in-package `cliutil` tests import `testenv`, and an import edge back would be a test-time import cycle. Resolvers are passed in as parameters instead.

Two supporting changes:
- All seven emitted helpers now isolate through `testenv` (`cliutil/paths_test`, `credentials_test`, `credentials_perms_test`, `mcp/tools_test`, `cli/teach_test`, `learn/teach_log_test`, `learn/journal_test`).
- Generator tests no longer hand their own environment to `go test` runs inside generated modules — that path is how the stray fixture directories reached a real profile. `GOPATH`/`GOMODCACHE` stay on their real values so the module cache is not re-downloaded per case.

## Scope

Primary area: generator templates + generator test harness.

Why this belongs in this repo: the defect is in the emitted test scaffolding every printed CLI inherits, so a per-CLI patch would fix one tree and leave every future print exposed.

## Risk

Every printed CLI gains a new package directory (`internal/cliutil/testenv`) on next regen, and the seven emitted test files change shape. `testenv` is imported only from `_test.go` files, so it never links into the CLI or MCP binary.

The guard can newly fail a test that was previously passing while writing outside its sandbox. That is the intended behavior, and it is worth stating plainly: this change can surface latent failures rather than only preventing new ones.

## Output Contract

Generated output changes: new emitted file `internal/cliutil/testenv/testenv.go`, plus reshaped isolation helpers in seven emitted test files.

Evidence:
- `TestGeneratedTestEnvDetectsSandboxEscape` compiles a generated module, drops in a test whose resolver reports a path outside the sandbox, runs `go test` against it, and requires the run to fail with the escape message. This exercises emitted behavior, not template text.
- `TestGeneratedTestsIsolateThroughTestenv` asserts no emitted helper redirects `HOME` by hand and that each isolates through `testenv.Isolate`.
- Golden fixture `generate-golden-api-oauth2-authcode/.../cliutil/credentials_test.go` updated for the new helper shape.

## Verification

- `go test ./...` — `internal/generator` green. `internal/pipeline` and `pipeline/regenmerge` fail on the Windows dev machine used here, but they fail more broadly on an unmodified `main` (20+ tests vs 3), all platform-specific: POSIX mode bits, backslash paths in a traversal assertion, CRLF in fence parsing. Untouched by this change.
- `scripts/verify-generator-output.sh generate-golden-api generate-learn-loop-api generate-mcp-api` — passes.
- `scripts/golden.sh verify` — same recognized set of local diffs as unmodified `main`, none introduced by this change. The pre-existing diffs are CRLF in `exit.txt`, `spec_checksum` (#3689), and a gofmt-version comment reflow.
- `golangci-lint` — not run; not installed on this machine. CI covers it.

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
