### PR TITLE
docs(cli): require a field proof for emitted home-touching code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,19 +92,28 @@ If the "obvious" fix violates a parser, verifier, scorer, or printed-CLI invaria
 
 #### Emitted code that touches the developer's home requires a field proof
 
-CI proves the emitted code compiles and passes on a clean Linux runner. It does not prove the code leaves a populated home directory alone. When the change touches emitted code that resolves user paths or credentials (`HOME` / `USERPROFILE` lookups, `internal/cliutil` path and credential helpers, emitted `*_test.go` helpers), prove it against a real print before handoff:
+CI proves the emitted code compiles and passes on a clean Linux runner. It does not prove the code leaves a populated home directory alone. When the change touches emitted code that resolves user paths or credentials (`HOME` / `USERPROFILE` lookups, `internal/cliutil` path and credential helpers, emitted `*_test.go` helpers), prove it against a real print before handoff.
+
+Point the proof at a **decoy profile, never your own home**. The snapshot below detects an escape after it lands, so a run against live credentials destroys them and only then reports it.
 
 ```bash
+DECOY=$(mktemp -d)
+mkdir -p "$DECOY"/.config "$DECOY"/.local/share "$DECOY"/.local/state
+echo sentinel > "$DECOY"/.config/sentinel   # an escape needs something to clobber
+export HOME="$DECOY" USERPROFILE="$DECOY" \
+       XDG_CONFIG_HOME="$DECOY/.config" XDG_DATA_HOME="$DECOY/.local/share" \
+       XDG_STATE_HOME="$DECOY/.local/state" XDG_CACHE_HOME="$DECOY/.cache"
+
 go build -o ./cli-printing-press ./cmd/cli-printing-press
-./cli-printing-press generate --spec ./testdata/stytch.yaml --output <scratch>/stytch-pp-cli
-find ~/.config ~/.local/share -type f | sort | xargs md5sum > before.txt
-(cd <scratch>/stytch-pp-cli && go test ./...)
-find ~/.config ~/.local/share -type f | sort | xargs md5sum | diff before.txt -
+./cli-printing-press generate --spec ./testdata/stytch.yaml --output "$DECOY/print/stytch-pp-cli"
+find "$DECOY"/.config "$DECOY"/.local -type f | sort | xargs md5sum > "$DECOY/before.txt"
+(cd "$DECOY/print/stytch-pp-cli" && go test ./...)
+find "$DECOY"/.config "$DECOY"/.local -type f | sort | xargs md5sum | diff "$DECOY/before.txt" -
 ```
 
-A byte-identical snapshot is the pass condition. Back up live credentials first; a regression here overwrites them.
+A byte-identical snapshot is the pass condition.
 
-Never run the suite of a CLI printed by an older generator without overriding **both** `HOME` and `USERPROFILE`. On Windows the production resolver reads `USERPROFILE`, so a suite that sets only `HOME` escapes its sandbox and writes to the real profile.
+Redirect **both** `HOME` and `USERPROFILE`, plus the `XDG_*` variables. On Windows the production resolver reads `USERPROFILE`, so redirecting only `HOME` leaves the real profile exposed, which is the exact shape of the escape this proof exists to catch.
 
 ## Cross-repo dependency: published-library sweep tool
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,22 @@ Required before handoff:
 
 If the "obvious" fix violates a parser, verifier, scorer, or printed-CLI invariant, stop and resolve the invariant conflict rather than shipping a narrow band-aid.
 
+#### Emitted code that touches the developer's home requires a field proof
+
+CI proves the emitted code compiles and passes on a clean Linux runner. It does not prove the code leaves a populated home directory alone. When the change touches emitted code that resolves user paths or credentials (`HOME` / `USERPROFILE` lookups, `internal/cliutil` path and credential helpers, emitted `*_test.go` helpers), prove it against a real print before handoff:
+
+```bash
+go build -o ./cli-printing-press ./cmd/cli-printing-press
+./cli-printing-press generate --spec ./testdata/stytch.yaml --output <scratch>/stytch-pp-cli
+find ~/.config ~/.local/share -type f | sort | xargs md5sum > before.txt
+(cd <scratch>/stytch-pp-cli && go test ./...)
+find ~/.config ~/.local/share -type f | sort | xargs md5sum | diff before.txt -
+```
+
+A byte-identical snapshot is the pass condition. Back up live credentials first; a regression here overwrites them.
+
+Never run the suite of a CLI printed by an older generator without overriding **both** `HOME` and `USERPROFILE`. On Windows the production resolver reads `USERPROFILE`, so a suite that sets only `HOME` escapes its sandbox and writes to the real profile.
+
 ## Cross-repo dependency: published-library sweep tool
 
 When a change to `internal/generator/templates/readme.md.tmpl` or `skill.md.tmpl` shifts canonical published-library shape — install-block structure, top-of-README section ordering, presence/removal of `## ` sections, frontmatter top-level field set, install command syntax — also update `tools/sweep-canonical/main.go` in [`mvanhorn/printing-press-library`](https://github.com/mvanhorn/printing-press-library) so already-published CLIs can be retrofitted to match. Fresh prints get the new shape automatically; existing entries drift until the sweep runs.


### PR DESCRIPTION
## Intent

The "Generator fixes require generated-output proof" checklist proves emitted code compiles and passes on a clean runner. Nothing in it proves emitted code leaves a *populated* home directory alone. #3690 fell through exactly that gap: emitted test helpers set `HOME`, the production resolver read `USERPROFILE` on Windows, and running a printed CLI's suite destroyed a live API token while passing every listed check.

Issue: Closes #3703

## Approach

One `####` subsection appended to the existing generated-output-proof section, kept command-shaped per the "Editing AGENTS.md" rule: trigger, required action, concrete commands, pass condition.

Two deliberate choices:

**The trigger is narrow.** It fires only for emitted code that resolves user paths or credentials (`HOME` / `USERPROFILE` lookups, `internal/cliutil` path and credential helpers, emitted `*_test.go` helpers). Requiring a full print for every generator change would turn the rule into noise and get it skipped, including on the changes that need it.

**The pass condition is mechanical.** A byte-identical hash snapshot of the decoy profile, not a visual once-over. The original incident was silent; an eyeball check would not have caught it.

The closing paragraph records the platform trap itself, so the next contributor does not rediscover it while fixing something unrelated: redirecting only `HOME` leaves the real profile exposed, because the production resolver reads `USERPROFILE` on Windows.


Greptile flagged a P1 on the first revision: the snapshot detects an escape only after it has landed, so pointing the proof at a live home destroys credentials and then reports it. The procedure now redirects `HOME`, `USERPROFILE` and the `XDG_*` variables at a populated decoy profile, keeping the detection while taking the real profile out of the blast radius.

## Scope

Primary area: `AGENTS.md`, docs only. No code, template, or generated output changes.

Why this belongs in this repo: it is a contributor-workflow rule for changes to `internal/generator/**`, and `AGENTS.md` is the file loaded into agent context on every turn. A printed CLI cannot carry it.

## Risk

Low. Docs only, no behavior change.

The one real consideration is sequencing, called out in #3703 and repeated here: **this should merge after #3692.** On current `main` the prescribed check fails by construction, because printed CLIs still escape their sandbox. Merging this first would mandate a check the repository cannot pass.

## Output Contract

N/A. No templates, generated files, manifests, command output, MCP schemas, scorecard output, or pipeline artifacts are touched.

## Verification

The procedure written into the rule was run end to end on Windows 11, in both directions. A proof that cannot fail is worthless, so the failure case matters as much as the pass case.

**Pass case**, generator built from #3692:

```
=== diff ===
PASS: snapshot byte-identical
```

**Failure case**, identical procedure, generator built from current `main`:

```
> $DECOY/.config/stytch-pp-cli/config.toml
> $DECOY/.local/share/stytch-pp-cli/credentials.toml
> $DECOY/.local/share/stytch-pp-cli/data.db
< $DECOY/.local/state/stytch-pp-cli/learn/journal.offset      (overwritten)
> $DECOY/.local/state/stytch-pp-cli/learn/journal-20260102.jsonl
> ...
```

The escape writes `credentials.toml` straight into the profile, which is the shape of the original incident. Against a real home that write is the token loss; against the decoy it is a red diff.

Generator/template checkboxes are not applicable to a docs-only change, so they are left unchecked rather than ticked:

- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
