### PR TITLE
fix(generator): reject malformed cookie imports

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -11253,6 +11253,9 @@ func TestGenerate_CookieAuthUsesBrowserTemplate(t *testing.T) {
 	assert.Contains(t, content, "--chrome")
 	assert.Contains(t, content, "detectCookieTool")
 	assert.Contains(t, content, "extractCookies")
+	assert.Contains(t, content, "validateExtractedCookieHeader(cookies)")
+	assert.Contains(t, content, "http.ParseCookie(header)")
+	assert.Contains(t, content, "refusing to save credentials")
 	assert.Contains(t, content, "cookieToolSupportsProfiles")
 	assert.Contains(t, content, `"pycookiecheat-cli"`)
 	assert.Contains(t, content, `exec.LookPath("pycookiecheat")`)
@@ -11301,6 +11304,21 @@ func TestGenerate_CookieAuthUsesBrowserTemplate(t *testing.T) {
 	assert.Contains(t, doctorContent, "browser_session_proof")
 
 	runGoCommand(t, outputDir, "mod", "tidy")
+	validationTest := `package cli
+
+import "testing"
+
+func TestGeneratedValidateExtractedCookieHeader(t *testing.T) {
+	if err := validateExtractedCookieHeader("session-id=abc; ubid-main=def"); err != nil {
+		t.Fatalf("valid Cookie header rejected: %v", err)
+	}
+	if err := validateExtractedCookieHeader("session-id=\x01\xffbinary"); err == nil {
+		t.Fatal("malformed Cookie header accepted")
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "auth_cookie_validation_test.go"), []byte(validationTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestGeneratedValidateExtractedCookieHeader")
 	runGoCommand(t, outputDir, "build", "./...")
 }
 

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -296,6 +296,14 @@ profile by name when the installed backend supports it.`,
 			}
 			} // end if !fromPressAuth
 
+			// Cookie extractors read Chrome's evolving on-disk schema. Refuse
+			// malformed output before it reaches TOML or net/http: stale tools can
+			// otherwise persist binary schema metadata as credentials and leave the
+			// CLI unable to parse its own config on the next invocation.
+			if err := validateExtractedCookieHeader(cookies); err != nil {
+				return authErr(err)
+			}
+
 
 {{- if eq .Auth.Type "composed"}}
 			// Step 4: Compose auth header from named cookies
@@ -994,6 +1002,9 @@ func refreshStoredBrowserCookies(cfg *config.Config, w io.Writer) error {
 	}
 	if cookies == "" {
 		return fmt.Errorf("no cookies found for %s", domain)
+	}
+	if err := validateExtractedCookieHeader(cookies); err != nil {
+		return err
 	}
 
 {{- if eq .Auth.Type "composed"}}
@@ -1881,6 +1892,18 @@ type cookieTool struct {
 	name   string
 	pyBin  string
 	pyArgs []string
+}
+
+// validateExtractedCookieHeader rejects malformed browser-extractor output
+// before it can be persisted or passed to net/http. In Chrome cookie database
+// schema 24+, stale extractors may leave the binary SHA-256(host_key) prefix
+// attached to each decrypted value. net/http rejects those bytes, and writing
+// invalid UTF-8 into TOML can make the CLI's config unreadable on its next run.
+func validateExtractedCookieHeader(header string) error {
+	if _, err := http.ParseCookie(header); err != nil {
+		return fmt.Errorf("cookie importer returned malformed Cookie header: %w; update the browser extractor (pycookiecheat 0.8.0 or newer) or use press-auth; refusing to save credentials", err)
+	}
+	return nil
 }
 
 // tryPressAuth shells out to `press-auth cookies <domain>` and returns the

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
@@ -230,6 +230,14 @@ profile by name when the installed backend supports it.`,
 					return authErr(fmt.Errorf("cookie tool returned no cookies for %s", domain))
 				}
 			} // end if !fromPressAuth
+
+			// Cookie extractors read Chrome's evolving on-disk schema. Refuse
+			// malformed output before it reaches TOML or net/http: stale tools can
+			// otherwise persist binary schema metadata as credentials and leave the
+			// CLI unable to parse its own config on the next invocation.
+			if err := validateExtractedCookieHeader(cookies); err != nil {
+				return authErr(err)
+			}
 			// Unfiltered, the persisted blob carries every cookie the target
 			// domain has set (CSRF, WAF, anti-bot fingerprints, etc.) into the
 			// Cookie header on every request, which routinely trips upstream
@@ -871,6 +879,18 @@ type cookieTool struct {
 	name   string
 	pyBin  string
 	pyArgs []string
+}
+
+// validateExtractedCookieHeader rejects malformed browser-extractor output
+// before it can be persisted or passed to net/http. In Chrome cookie database
+// schema 24+, stale extractors may leave the binary SHA-256(host_key) prefix
+// attached to each decrypted value. net/http rejects those bytes, and writing
+// invalid UTF-8 into TOML can make the CLI's config unreadable on its next run.
+func validateExtractedCookieHeader(header string) error {
+	if _, err := http.ParseCookie(header); err != nil {
+		return fmt.Errorf("cookie importer returned malformed Cookie header: %w; update the browser extractor (pycookiecheat 0.8.0 or newer) or use press-auth; refusing to save credentials", err)
+	}
+	return nil
 }
 
 // tryPressAuth shells out to `press-auth cookies <domain>` and returns the


### PR DESCRIPTION
## Intent

Prevent generated browser-cookie CLIs from persisting malformed extractor output that can both fail `net/http` header validation and make the saved TOML unreadable.

Issue: Fixes #3706

## Approach

Validate every completed cookie import with `net/http.ParseCookie` before parsing, persistence, or HTTP use. Apply the same guard to unattended browser-cookie refreshes. The error is deliberately generic: it identifies the extractor compatibility problem and recovery path without echoing credential material.

The generated-output test executes the emitted helper against valid and binary-contaminated headers, and the cookie-auth golden fixture records the intentional output-contract change.

## Scope

Primary area: `internal/generator/templates/auth_browser.go.tmpl`

Why this belongs in this repo: every generated cookie/composed-auth CLI inherits the extractor trust boundary. A printed-CLI-only fix would be lost on regeneration and leave other CLIs exposed to the same Chrome schema drift.

## Risk

The guard can reject non-RFC Cookie header material that an extractor previously returned. That material could not be sent reliably by Go's HTTP stack, so failing before persistence is the safer contract. Valid browser cookies, `press-auth` output, and cookie-file imports continue unchanged.

## Output Contract

Generated `internal/cli/auth.go` gains a validation helper plus login/refresh calls before credential persistence. Evidence:

- emitted-code assertions for the helper and call sites
- an executed test compiled into a generated cookie-auth CLI
- updated `generate-golden-api-cookie-auth` fixture
- `scripts/golden.sh verify` passes all 32 cases
- `scripts/verify-generator-output.sh` compiles all 10 verification cases

## Verification

- [x] `go test ./...`
- [x] `scripts/golden.sh verify`
- [x] `scripts/verify-generator-output.sh`
- [x] `git diff --check`
- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: the change was generated and submitted without human review for this specific change
