### PR TITLE
fix(cli): stop doctor from reporting an unverifiable credential probe as ok

### DIFF
--- a/internal/generator/auth_status_test.go
+++ b/internal/generator/auth_status_test.go
@@ -51,8 +51,10 @@ func TestDoctorWithVerifyPathCanClaimCredentialsValid(t *testing.T) {
 	require.Contains(t, src, `verifyPath := "/account"`)
 	require.Contains(t, src, `report["credentials"] = "valid"`,
 		"doctor may report valid credentials after a configured authenticated verification probe succeeds")
-	require.Contains(t, src, "but auth was accepted",
-		"non-auth HTTP statuses only imply accepted auth when they come from the configured verification path")
+	require.Contains(t, src, "WARN not verified (HTTP %d from %s)",
+		"a non-401/403 status from the verification path cannot distinguish a valid token from a garbage one (a well-chosen verify_path 401s on bad creds), so the default branch must report an honest not-verified WARN, not claim auth was accepted")
+	require.NotContains(t, src, "but auth was accepted",
+		"the old copy that treated any non-auth status from the verify path as accepted auth must be gone")
 
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "build", "./...")

--- a/internal/generator/doctor_health_path.go
+++ b/internal/generator/doctor_health_path.go
@@ -84,18 +84,76 @@ func deriveAuthVerifyPath(s *spec.APISpec) string {
 }
 
 // findMeShapedEndpointPath walks the spec for the first GET endpoint whose
-// path matches one of meShapedPathTails (most-specific tail first). Returns
-// "" when no candidate qualifies — used as the shared heuristic step inside
-// the two derivation helpers above.
+// path matches one of meShapedPathTails (most-specific tail first) and whose
+// path still composes cleanly against base_url. Returns "" when no candidate
+// qualifies; used as the shared heuristic step inside the two derivation
+// helpers above.
+//
+// The composability filter matters because the derived path is emitted as
+// Auth.VerifyPath, which the runtime appends to base_url. A candidate whose
+// path re-enters the base_url path prefix (a host-root path masquerading as
+// base-relative) would double-prefix at probe time; skipping it here leaves
+// the doctor's honest "present, not verified" branch authoritative rather
+// than emitting a knowingly-404 probe path.
 func findMeShapedEndpointPath(s *spec.APISpec) string {
 	for _, tail := range meShapedPathTails {
 		if e, ok := findEndpointMatch(s, func(e spec.Endpoint) bool {
 			return isMeShapedEndpoint(e, tail)
 		}); ok {
-			return e.Path
+			if composableAgainstBase(s.BaseURL, e.Path) {
+				return e.Path
+			}
 		}
 	}
 	return ""
+}
+
+// composableAgainstBase reports whether path, appended to baseURL, reaches the
+// endpoint the spec author meant. Endpoint paths are base_url-relative by
+// contract (the runtime concatenates base_url + path), so a path that re-enters
+// the base_url's own leading path segment is a host-root path masquerading as
+// base-relative: appending it double-prefixes the shared segment (base
+// `/api/v1/workspaces/{slug}` + `/api/v1/users/me` -> `.../workspaces/{slug}/
+// api/v1/users/me`, a 404). When base_url carries no path prefix (the common
+// case where it equals the server root), every path composes cleanly.
+func composableAgainstBase(baseURL, path string) bool {
+	baseSeg := firstPathSegment(baseURLPathPrefix(baseURL))
+	if baseSeg == "" {
+		return true
+	}
+	return !strings.EqualFold(baseSeg, firstPathSegment(path))
+}
+
+// baseURLPathPrefix returns the path component of baseURL (everything from the
+// first "/" after the scheme+authority), or "" when baseURL is the server root.
+// Avoids url.Parse so template-var authorities like `https://{region}.host.com`
+// don't trip the parser; only the path portion is needed here.
+func baseURLPathPrefix(baseURL string) string {
+	b := baseURL
+	for _, scheme := range []string{"https://", "http://"} {
+		if len(b) >= len(scheme) && strings.EqualFold(b[:len(scheme)], scheme) {
+			rest := b[len(scheme):]
+			if i := strings.IndexByte(rest, '/'); i >= 0 {
+				return rest[i:]
+			}
+			return ""
+		}
+	}
+	// Scheme-less base (rare): a leading slash is itself the path prefix.
+	if strings.HasPrefix(b, "/") {
+		return b
+	}
+	return ""
+}
+
+// firstPathSegment returns the first non-empty "/"-delimited segment of p
+// (e.g. "/api/v1/users" -> "api"), or "" when p has no segment.
+func firstPathSegment(p string) string {
+	p = strings.TrimLeft(p, "/")
+	if i := strings.IndexByte(p, '/'); i >= 0 {
+		return p[:i]
+	}
+	return p
 }
 
 func isMeShapedEndpoint(e spec.Endpoint, tail string) bool {

--- a/internal/generator/doctor_health_path.go
+++ b/internal/generator/doctor_health_path.go
@@ -149,11 +149,8 @@ func baseURLPathPrefix(baseURL string) string {
 // firstPathSegment returns the first non-empty "/"-delimited segment of p
 // (e.g. "/api/v1/users" -> "api"), or "" when p has no segment.
 func firstPathSegment(p string) string {
-	p = strings.TrimLeft(p, "/")
-	if i := strings.IndexByte(p, '/'); i >= 0 {
-		return p[:i]
-	}
-	return p
+	seg, _, _ := strings.Cut(strings.TrimLeft(p, "/"), "/")
+	return seg
 }
 
 func isMeShapedEndpoint(e spec.Endpoint, tail string) bool {

--- a/internal/generator/doctor_health_path_test.go
+++ b/internal/generator/doctor_health_path_test.go
@@ -373,6 +373,135 @@ func TestDeriveAuthVerifyPath_NilSpec(t *testing.T) {
 	assert.Equal(t, "", deriveAuthVerifyPath(nil))
 }
 
+// TestDeriveAuthVerifyPath_SkipsHostRootPathAgainstPrefixedBase is the issue
+// #3701 repro. base_url carries a path prefix (`/api/v1/workspaces/{slug}`) and
+// the only me-shaped endpoint is stored host-root-relative (`/api/v1/users/me/`).
+// Appending that to base_url double-prefixes the shared `/api/v1` segment and
+// 404s, so the derivation must skip it and leave the honest "not verified"
+// branch authoritative rather than emit a knowingly-broken probe path.
+func TestDeriveAuthVerifyPath_SkipsHostRootPathAgainstPrefixedBase(t *testing.T) {
+	t.Parallel()
+
+	s := &spec.APISpec{
+		Name:    "prefixed-base",
+		BaseURL: "https://plane.example.com/api/v1/workspaces/{slug}",
+		Resources: map[string]spec.Resource{
+			"users": {Endpoints: map[string]spec.Endpoint{
+				"me": {Method: "GET", Path: "/api/v1/users/me/"},
+			}},
+		},
+	}
+	assert.Equal(t, "", deriveAuthVerifyPath(s),
+		"a host-root me path that re-enters the base_url prefix segment must not be emitted")
+	assert.Equal(t, "", deriveHealthCheckPath(s),
+		"the same un-composable candidate must not leak into the reachability probe")
+}
+
+// TestDeriveAuthVerifyPath_KeepsBaseRelativePathAgainstPrefixedBase is the
+// companion: a genuinely base-relative me endpoint under the same prefixed
+// base_url composes cleanly and must still be derived. The filter is narrow:
+// it only rejects paths that re-enter the base_url's leading path segment.
+func TestDeriveAuthVerifyPath_KeepsBaseRelativePathAgainstPrefixedBase(t *testing.T) {
+	t.Parallel()
+
+	s := &spec.APISpec{
+		Name:    "prefixed-base-ok",
+		BaseURL: "https://plane.example.com/api/v1/workspaces/{slug}",
+		Resources: map[string]spec.Resource{
+			"users": {Endpoints: map[string]spec.Endpoint{
+				"me": {Method: "GET", Path: "/users/me"},
+			}},
+		},
+	}
+	assert.Equal(t, "/users/me", deriveAuthVerifyPath(s),
+		"a base-relative me path composes cleanly and must still be derived")
+}
+
+func TestComposableAgainstBase(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		baseURL string
+		path    string
+		want    bool
+	}{
+		{"root base composes anything", "https://api.example.com", "/api/v1/users/me", true},
+		{"empty base composes anything", "", "/api/v1/users/me", true},
+		{"prefixed base, re-enters segment", "https://h.example.com/api/v1/workspaces/{slug}", "/api/v1/users/me/", false},
+		{"prefixed base, distinct segment", "https://h.example.com/api/v1/workspaces/{slug}", "/users/me", true},
+		{"single-segment base, re-enters", "https://h.example.com/v2", "/v2/user", false},
+		{"single-segment base, distinct", "https://h.example.com/v2", "/user", true},
+		{"segment boundary not substring", "https://h.example.com/api", "/apiary/me", true},
+		{"case-insensitive segment match", "https://h.example.com/API/v1", "/api/users/me", false},
+		{"http scheme prefix path", "http://h.example.com/gw", "/gw/me", false},
+		{"scheme-less base with path", "/api/v1", "/api/v1/me", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, composableAgainstBase(tc.baseURL, tc.path))
+		})
+	}
+}
+
+// TestGeneratedDoctor_SkipsHostRootVerifyPathAgainstPrefixedBase wires the
+// composability filter through Generate(): the emitted doctor.go must fall back
+// to the "present, not verified" branch instead of probing a double-prefixed
+// path that always 404s.
+func TestGeneratedDoctor_SkipsHostRootVerifyPathAgainstPrefixedBase(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("prefixed-skip")
+	apiSpec.BaseURL = "https://plane.example.com/api/v1/workspaces/{slug}"
+	apiSpec.Resources["users"] = spec.Resource{
+		Description: "Users",
+		Endpoints: map[string]spec.Endpoint{
+			"me": {Method: "GET", Path: "/api/v1/users/me/", Description: "Get current user"},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "prefixed-skip-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	doctorGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "doctor.go"))
+	require.NoError(t, err)
+	content := string(doctorGo)
+
+	assert.NotContains(t, content, `verifyPath := "/api/v1/users/me/"`,
+		"a host-root me path under a prefixed base_url must not be emitted as verifyPath")
+	assert.Equal(t, "", apiSpec.Auth.VerifyPath,
+		"derivation must leave Auth.VerifyPath empty for an un-composable candidate")
+}
+
+// TestGeneratedDoctor_UnverifiableProbeReportsWarnNotOk pins issue #3701's
+// defect 2: a probe that returns neither 2xx nor 401/403 (e.g. 404) must be
+// reported as not-verified at WARN, never `ok` at OK severity. Asserted on the
+// emitted doctor.go for a spec that does derive a verify path.
+func TestGeneratedDoctor_UnverifiableProbeReportsWarnNotOk(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("warn-probe")
+	apiSpec.Resources["users"] = spec.Resource{
+		Description: "Users",
+		Endpoints: map[string]spec.Endpoint{
+			"me": {Method: "GET", Path: "/users/me", Description: "Get current user"},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "warn-probe-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	doctorGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "doctor.go"))
+	require.NoError(t, err)
+	content := string(doctorGo)
+
+	assert.Contains(t, content, `"WARN not verified (HTTP %d from %s)`,
+		"the non-auth-status branch must report WARN not-verified, not ok")
+	assert.NotContains(t, content, `"ok (HTTP %d from %s, but auth was accepted)"`,
+		"the old false-positive ok verdict must be gone")
+}
+
 // TestGeneratedDoctor_DerivesAuthVerifyPathFromMeEndpoint wires the helper
 // through Generate(): a spec with a me-shaped GET and no explicit
 // Auth.VerifyPath must emit a doctor.go that actually probes that endpoint

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -631,8 +631,13 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 							case authAPIErr.StatusCode == 403:
 								report["credentials"] = fmt.Sprintf("scope-limited (HTTP %d) — credentials are valid but lack permission for this endpoint. Check your dashboard's API key scope.", authAPIErr.StatusCode)
 							default:
-								// Non-auth HTTP error (404, 500, etc.) — don't blame credentials
-								report["credentials"] = fmt.Sprintf("ok (HTTP %d from %s, but auth was accepted)", authAPIErr.StatusCode, verifyPath)
+								// Non-auth HTTP status (404, 500, etc.): the probe never
+								// reached an authenticated resource, so auth was neither
+								// accepted nor rejected. "Don't blame the credentials" and
+								// "the credentials are ok" are different claims; only the
+								// first is supported here. Report not-verified at WARN so the
+								// verdict is honest and --fail-on warn can trip on it.
+								report["credentials"] = fmt.Sprintf("WARN not verified (HTTP %d from %s) — probe reached a non-auth endpoint; set auth.verify_path to a known-good authenticated GET", authAPIErr.StatusCode, verifyPath)
 							}
 						default:
 							report["credentials"] = fmt.Sprintf("error: %s", authErr)
@@ -664,7 +669,11 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 							case gqlAPIErr.StatusCode == 403:
 								report["credentials"] = fmt.Sprintf("scope-limited (HTTP %d) — credentials are valid but lack permission for this endpoint. Check your dashboard's API key scope.", gqlAPIErr.StatusCode)
 							default:
-								report["credentials"] = fmt.Sprintf("ok (HTTP %d from GraphQL probe, but auth was accepted)", gqlAPIErr.StatusCode)
+								// Non-auth HTTP status: the probe never reached the
+								// authenticated GraphQL surface, so auth was neither
+								// accepted nor rejected. Report not-verified at WARN
+								// (honest verdict; --fail-on warn can trip on it).
+								report["credentials"] = fmt.Sprintf("WARN not verified (HTTP %d from GraphQL probe) — auth was neither accepted nor rejected; set auth.verify_query to a known-good viewer query", gqlAPIErr.StatusCode)
 							}
 						default:
 							report["credentials"] = fmt.Sprintf("error: %s", gqlErr)


### PR DESCRIPTION
## Intent

The generated `doctor`'s credentials probe reported `ok` at OK severity for a valid **and** an invalid token on any API whose `base_url` carries a path prefix — the exact false positive the probe exists to prevent.

Issue: Closes #3701

## Approach

Two compounding defects, fixed together:

**Defect 2 — unverifiable probe labelled `ok`.** The probe's `default` branch treated every non-401/403 status (e.g. a 404) as `ok (HTTP %d ..., but auth was accepted)` at OK severity. A 404 means the probe never reached an authenticated resource, so auth was neither accepted nor rejected. Both the REST and GraphQL default branches now emit `WARN not verified (HTTP %d ...)`, which renders yellow WARN and trips `--fail-on warn` (the issue's open question — decided: yes, an unverifiable probe is a warning worth failing an opt-in gate on).

**Defect 1 — host-root `verify_path` composed against a prefixed base.** The auto-derived me-shaped `verify_path` was emitted as the spec endpoint's raw path, but the runtime appends `verify_path` to `base_url`. When `base_url` has a path prefix (`/api/v1/workspaces/{slug}`) and the me endpoint is host-root-relative (`/api/v1/users/me`), the composition double-prefixes the shared `/api/v1` segment and 404s. Derivation now skips any candidate whose leading path segment collides with `base_url`'s prefix segment, leaving the honest "present, not verified" branch authoritative instead of emitting a knowingly-404 probe path. The filter is deliberately narrow — genuinely base-relative me endpoints under a prefixed base are still derived.

Defect 2 was masking defect 1: with an honest verdict, the broken composition is now visible.

## Scope

Primary area: generator + `doctor.go.tmpl` (machine change; affects every future printed CLI).

Why this belongs in this repo: the derivation and the probe verdict are generated by the machine. A per-CLI `auth.verify_path` override cannot fix the prefixed-base case (the me endpoint lives at host root and isn't expressible as a suffix of the prefixed base), so the generator has to reconcile it.

## Risk

Low. The verdict-string change swaps two `fmt.Sprintf` calls with identical arg lists (no format/arg mismatch possible). The derivation filter only ever *removes* an un-composable candidate, falling back to the pre-existing honest branch; it never invents a path. `--fail-on warn` now trips on a previously-silent state — intended, and opt-in only (default `doctor` still exits 0 with a yellow WARN).

## Output Contract

Generated output shape: the credentials probe's default-branch verdict and the derived `verify_path` for prefixed-base specs.

Evidence:
- Golden unchanged — no golden spec derives a `verify_path` or renders the probe default branch (verified: zero `doctor.go` in `scripts/golden.sh verify` output).
- New emitted-code assertions: `TestGeneratedDoctor_UnverifiableProbeReportsWarnNotOk` (WARN verdict emitted, old `ok` gone), `TestGeneratedDoctor_SkipsHostRootVerifyPathAgainstPrefixedBase` (un-composable candidate not emitted).
- New unit coverage: `TestComposableAgainstBase` (table), `TestDeriveAuthVerifyPath_{Skips,Keeps}...PrefixedBase`.
- `scripts/verify-generator-output.sh`: generated modules compile with the template change (the one unrelated `things_list.go` failure reproduces on clean `main`).

## Verification

- `go build ./...`
- `go test ./internal/generator/ -run 'Doctor|DeriveAuthVerifyPath|DeriveHealthCheckPath|ComposableAgainstBase'` — pass
- `scripts/golden.sh verify` — no `doctor.go` diff (remaining diffs are the known local Windows baseline, reproduce on clean `main`)
- `scripts/verify-generator-output.sh` — doctor.go compiles in every generated module

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
