### PR TITLE
fix(cli): emit runnable command examples

### DIFF
--- a/internal/generator/learn_emission_test.go
+++ b/internal/generator/learn_emission_test.go
@@ -182,6 +182,25 @@ func TestGenerateLearnCLICommandsCompileAndTest(t *testing.T) {
 	runGoCommand(t, outputDir, "test", "-run", "^(TestTeach|TestRecall|TestLearnings|TestSkipLearnHook|TestNewLearnConfig|TestInitLearn|TestPlaybook)", "./internal/cli/...")
 }
 
+func TestGenerateLearnCommandExamplesAreRunnableOnFirstLine(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("learn-examples")
+	apiSpec.Learn.Enabled = true
+	outputDir := filepath.Join(t.TempDir(), "learn-examples-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	teachSrc := readEmitted(t, outputDir, "internal", "cli", "teach.go")
+	require.Contains(t, teachSrc, "Example: `  learn-examples-pp-cli teach --query \"<question>\" --resource-type <type> --resource <id> --resource <id> &`,")
+	require.Contains(t, teachSrc, "Example: `  learn-examples-pp-cli teach-pattern --query-template \"items in {entity}\" --resource-template \"GROUP-{entity:category}\" --resource-type \"items\" --entity-kind \"category\" --strategy substitute`,")
+
+	playbookSrc := readEmitted(t, outputDir, "internal", "cli", "teach_playbook.go")
+	require.Contains(t, playbookSrc, "Example: `  learn-examples-pp-cli teach-playbook --query \"<question that anchors the family>\" --playbook-file ~/playbooks/recipe.json --notes-file ~/playbooks/recipe-notes.md`,")
+	require.Contains(t, playbookSrc, "Example: `  learn-examples-pp-cli playbook amend --query \"<exact recall query>\" --add-note \"summary endpoint envelope: data lives at .results.header, not .header\"`,")
+}
+
 // TestGenerateLearnInitWiresSpec verifies that the emitted learn_init.go
 // translates a populated spec.Learn block (ticker patterns + stopwords +
 // entity-lookup seeds) into the corresponding Go literals at the right

--- a/internal/generator/novel_feature_stubs.go
+++ b/internal/generator/novel_feature_stubs.go
@@ -542,10 +542,9 @@ func novelFeatureFlags(feature NovelFeature, commandPath []string, apiName strin
 	return flags
 }
 
-// novelFeatureExample returns the prefix-stripped runnable form of the
-// feature's research example, suitable for a Cobra Example field. Empty when
-// the feature has no example or the example yields no tokens after stripping
-// the binary/command-path prefix.
+// novelFeatureExample returns a complete invocation suitable for a Cobra
+// Example field. Empty when the feature has no example or the example yields
+// no arguments after stripping an existing binary/command-path prefix.
 func novelFeatureExample(feature NovelFeature, commandPath []string, apiName string) string {
 	if strings.TrimSpace(feature.Example) == "" {
 		return ""
@@ -555,7 +554,14 @@ func novelFeatureExample(feature NovelFeature, commandPath []string, apiName str
 		return ""
 	}
 	tokens = dropNovelFeatureExamplePrefix(tokens, commandPath, apiName)
-	return strings.Join(tokens, " ")
+	if len(tokens) == 0 {
+		return ""
+	}
+	invocation := make([]string, 0, 1+len(commandPath)+len(tokens))
+	invocation = append(invocation, naming.CLI(apiName))
+	invocation = append(invocation, commandPath...)
+	invocation = append(invocation, tokens...)
+	return "  " + shellargs.Join(invocation)
 }
 
 func dropNovelFeatureExamplePrefix(tokens []string, commandPath []string, apiName string) []string {

--- a/internal/generator/novel_feature_stubs_test.go
+++ b/internal/generator/novel_feature_stubs_test.go
@@ -47,9 +47,7 @@ func TestGeneratorEmitsNovelFeatureCommandStubs(t *testing.T) {
 	assert.Contains(t, call, "// pp:data-source auto")
 	assert.Contains(t, call, "auto, local, live, or computed")
 	assert.Contains(t, call, `Use:         "call"`)
-	// The Cobra Example field carries the prefix-stripped runnable form of the
-	// research example (binary + command path dropped).
-	assert.Contains(t, call, `Example:     "apify/web-scraper --tag skill=reddit-digest --dedupe-key daily --ttl 24h --wait --agent"`)
+	assert.Contains(t, call, `Example:     "  apify-pp-cli call apify/web-scraper --tag skill=reddit-digest --dedupe-key daily --ttl 24h --wait --agent"`)
 	assert.Contains(t, call, `Annotations: map[string]string{"mcp:read-only": "false"}`)
 	assert.Contains(t, call, `StringSliceVar(&flagTag, "tag", nil`)
 	assert.Contains(t, call, `StringVar(&flagDedupeKey, "dedupe-key", ""`)
@@ -66,9 +64,7 @@ func TestGeneratorEmitsNovelFeatureCommandStubs(t *testing.T) {
 	classify := readGeneratedFile(t, outputDir, "internal", "cli", "runs_classify.go")
 	assert.Contains(t, classify, "// pp:data-source auto")
 	assert.Contains(t, classify, `Use:         "classify"`)
-	// Multi-segment command path: dropNovelFeatureExamplePrefix strips the
-	// binary AND both path segments ("runs classify"), leaving only the args.
-	assert.Contains(t, classify, `Example:     "run-123 --limit 10"`)
+	assert.Contains(t, classify, `Example:     "  apify-pp-cli runs classify run-123 --limit 10"`)
 	assert.Contains(t, classify, `Annotations: map[string]string{"mcp:read-only": "true"}`)
 	assert.Contains(t, classify, `StringVar(&flagLimit, "limit", ""`)
 	assert.Contains(t, classify, `TODO: implement novel feature %q", "runs classify"`)
@@ -111,6 +107,49 @@ func TestNovelFeatureStubsResolveAtRuntime(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "novel_stub_runtime_test.go"), []byte(runtimeTest.String()), 0o644))
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "test", "./internal/cli")
+}
+
+func TestGeneratorNormalizesBareFlagNovelFeatureExample(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("bareflag")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.NovelFeatures = []NovelFeature{
+		{
+			Name:        "Inspect state",
+			Command:     "inspect",
+			Description: "Inspect current state.",
+			Example:     "--json",
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	inspect := readGeneratedFile(t, outputDir, "internal", "cli", "inspect.go")
+	assert.Contains(t, inspect, `Example:     "  bareflag-pp-cli inspect --json"`)
+	assert.NotContains(t, inspect, `Example:     "--json"`)
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestGeneratorPreservesQuotedNovelFeatureExampleArguments(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("quoted")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.NovelFeatures = []NovelFeature{
+		{
+			Name:        "Inspect state",
+			Command:     "inspect",
+			Description: "Inspect current state.",
+			Example:     `quoted-pp-cli inspect --query "weekly digest" --json`,
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	inspect := readGeneratedFile(t, outputDir, "internal", "cli", "inspect.go")
+	assert.Contains(t, inspect, `Example:     "  quoted-pp-cli inspect --query 'weekly digest' --json"`)
+	requireGeneratedCompiles(t, outputDir)
 }
 
 func TestGeneratorSanitizesNovelFeatureCommandStubFilenames(t *testing.T) {

--- a/internal/generator/templates/teach.go.tmpl
+++ b/internal/generator/templates/teach.go.tmpl
@@ -185,8 +185,7 @@ emits the user-facing response: silent on success, errors only to
 the CLI state directory's teach.log, safe to fire-and-forget.
 
 Disabling: pass --no-learn or set ` + noLearnEnvVar + `=true.`,
-		Example: `  {{.Name}}-pp-cli teach --query "<question>" --resource-type <type> \
-    --resource <id> --resource <id> &`,
+		Example: `  {{.Name}}-pp-cli teach --query "<question>" --resource-type <type> --resource <id> --resource <id> &`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
@@ -895,12 +894,7 @@ substitute live query entities into a resource template, so a pattern
 with query_template="items in {entity}" and
 resource_template="GROUP-{entity:category}" generalizes one teach into
 a whole family.`,
-		Example: `  {{.Name}}-pp-cli teach-pattern \
-    --query-template "items in {entity}" \
-    --resource-template "GROUP-{entity:category}" \
-    --resource-type "items" \
-    --entity-kind "category" \
-    --strategy substitute`,
+		Example: `  {{.Name}}-pp-cli teach-pattern --query-template "items in {entity}" --resource-template "GROUP-{entity:category}" --resource-type "items" --entity-kind "category" --strategy substitute`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if dryRunOK(flags) {
 				return nil

--- a/internal/generator/templates/teach_playbook.go.tmpl
+++ b/internal/generator/templates/teach_playbook.go.tmpl
@@ -59,10 +59,7 @@ notes verbatim.
 At least one of --playbook-json/--playbook-file and --notes/--notes-file
 must be set. --playbook-json takes the playbook body inline so MCP-only
 agents can record playbooks without a file on disk.`,
-		Example: `  {{.Name}}-pp-cli teach-playbook \
-    --query "<question that anchors the family>" \
-    --playbook-file ~/playbooks/recipe.json \
-    --notes-file ~/playbooks/recipe-notes.md`,
+		Example: `  {{.Name}}-pp-cli teach-playbook --query "<question that anchors the family>" --playbook-file ~/playbooks/recipe.json --notes-file ~/playbooks/recipe-notes.md`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
@@ -199,9 +196,7 @@ drift). Same fire-and-forget posture as teach: silent on success,
 errors to teach.log, safe to background with &.
 
 Disabling: pass --no-learn or set ` + noLearnEnvVar + `=true.`,
-		Example: `  {{.Name}}-pp-cli playbook amend \
-    --query "<exact recall query>" \
-    --add-note "summary endpoint envelope: data lives at .results.header, not .header"`,
+		Example: `  {{.Name}}-pp-cli playbook amend --query "<exact recall query>" --add-note "summary endpoint envelope: data lives at .results.header, not .header"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -570,6 +570,9 @@ func liveDogfoodCommandMutates(command liveDogfoodCommand) bool {
 	if annotationIsTrueValue(command.Annotations[mcpReadOnlyAnnotation]) {
 		return false
 	}
+	if annotationIsTrueValue(command.Annotations[mcpLocalWriteAnnotation]) {
+		return true
+	}
 	if method := strings.ToUpper(strings.TrimSpace(command.Annotations[endpointMethodAnnotation])); method != "" {
 		return method == "POST" || method == "PUT" || method == "PATCH" || method == "DELETE"
 	}
@@ -1662,6 +1665,7 @@ const (
 	endpointMethodAnnotation   = "pp:method"
 	endpointPathAnnotation     = "pp:path"
 	mcpReadOnlyAnnotation      = "mcp:read-only"
+	mcpLocalWriteAnnotation    = "mcp:local-write"
 	destructiveAuthAnnotation  = "pp:destructive-auth"
 	noErrorPathProbeAnnotation = "pp:no-error-path-probe"
 	requiresTierAnnotation     = "pp:requires-tier"

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -1598,6 +1598,25 @@ func TestLiveDogfoodCommandMutatesPrefersEndpointMethod(t *testing.T) {
 	}))
 }
 
+func TestLiveDogfoodCommandMutatesHonorsLocalWrite(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, liveDogfoodCommandMutates(liveDogfoodCommand{
+		Path: []string{"teach"},
+		Annotations: map[string]string{
+			"pp:method":       "GET",
+			"mcp:local-write": "true",
+		},
+	}))
+	assert.False(t, liveDogfoodCommandMutates(liveDogfoodCommand{
+		Path: []string{"teach"},
+		Annotations: map[string]string{
+			"mcp:read-only":   "true",
+			"mcp:local-write": "true",
+		},
+	}))
+}
+
 func TestHappyPathFileFixtureSkip(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -3,19 +3,163 @@ package pipeline
 import (
 	"encoding/json"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/generator"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestLiveDogfoodParsesGeneratedRunnableExamples(t *testing.T) {
+	apiSpec := &spec.APISpec{
+		Name:      "runnable",
+		Version:   "0.1.0",
+		BaseURL:   "https://api.example.com",
+		Owner:     "test-owner",
+		OwnerName: "Test Author",
+		Auth: spec.AuthConfig{
+			Type:    "api_key",
+			Header:  "Authorization",
+			Format:  "Bearer {token}",
+			EnvVars: []string{"RUNNABLE_TOKEN"},
+		},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/runnable-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Description: "Manage items",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/items", Description: "List items"},
+				},
+			},
+		},
+	}
+	apiSpec.Learn.Enabled = true
+	outputDir := filepath.Join(t.TempDir(), "runnable-pp-cli")
+	gen := generator.New(apiSpec, outputDir)
+	gen.VisionSet = generator.VisionTemplateSet{Store: true}
+	gen.NovelFeatures = []generator.NovelFeature{
+		{
+			Name:        "Inspect state",
+			Command:     "inspect",
+			Description: "Inspect current state.",
+			Example:     `runnable-pp-cli inspect --query "weekly digest" --json`,
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	tests := []struct {
+		name        string
+		file        string
+		use         string
+		commandPath []string
+		want        []string
+	}{
+		{
+			name:        "teach",
+			file:        "teach.go",
+			use:         "teach",
+			commandPath: []string{"teach"},
+			want:        []string{"teach", "--query", "<question>", "--resource-type", "<type>", "--resource", "<id>", "--resource", "<id>", "&"},
+		},
+		{
+			name:        "teach pattern",
+			file:        "teach.go",
+			use:         "teach-pattern",
+			commandPath: []string{"teach-pattern"},
+			want:        []string{"teach-pattern", "--query-template", "items in {entity}", "--resource-template", "GROUP-{entity:category}", "--resource-type", "items", "--entity-kind", "category", "--strategy", "substitute"},
+		},
+		{
+			name:        "teach playbook",
+			file:        "teach_playbook.go",
+			use:         "teach-playbook",
+			commandPath: []string{"teach-playbook"},
+			want:        []string{"teach-playbook", "--query", "<question that anchors the family>", "--playbook-file", "~/playbooks/recipe.json", "--notes-file", "~/playbooks/recipe-notes.md"},
+		},
+		{
+			name:        "playbook amend",
+			file:        "teach_playbook.go",
+			use:         "amend",
+			commandPath: []string{"playbook", "amend"},
+			want:        []string{"playbook", "amend", "--query", "<exact recall query>", "--add-note", "summary endpoint envelope: data lives at .results.header, not .header"},
+		},
+		{
+			name:        "quoted novel feature",
+			file:        "inspect.go",
+			use:         "inspect",
+			commandPath: []string{"inspect"},
+			want:        []string{"inspect", "--query", "weekly digest", "--json"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			example := generatedCobraExample(t, filepath.Join(outputDir, "internal", "cli", tc.file), tc.use)
+			require.NotContains(t, example, "\n")
+
+			got, ok := liveDogfoodExampleArgs(liveDogfoodCommand{
+				Path: tc.commandPath,
+				Help: "Examples:\n" + example,
+			})
+			require.True(t, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func generatedCobraExample(t *testing.T, filename, use string) string {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, nil, 0)
+	require.NoError(t, err)
+
+	var found string
+	ast.Inspect(file, func(node ast.Node) bool {
+		literal, ok := node.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		fields := make(map[string]string)
+		for _, element := range literal.Elts {
+			keyValue, ok := element.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, ok := keyValue.Key.(*ast.Ident)
+			if !ok || (key.Name != "Use" && key.Name != "Example") {
+				continue
+			}
+			value, ok := keyValue.Value.(*ast.BasicLit)
+			if !ok || value.Kind != token.STRING {
+				continue
+			}
+			unquoted, unquoteErr := strconv.Unquote(value.Value)
+			require.NoError(t, unquoteErr)
+			fields[key.Name] = unquoted
+		}
+		if fields["Use"] == use {
+			found = fields["Example"]
+			return false
+		}
+		return true
+	})
+	require.NotEmpty(t, found, "generated command %q has no Example", use)
+	return found
+}
 
 func TestRunLiveDogfoodDetectsJSONParseFailure(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/internal/shellargs/shellargs.go
+++ b/internal/shellargs/shellargs.go
@@ -3,6 +3,7 @@ package shellargs
 import (
 	"fmt"
 	"strings"
+	"unicode"
 )
 
 // Split tokenizes the simple command examples the Printing Press emits in
@@ -202,4 +203,23 @@ func ArgsAfterBinary(example string) ([]string, error) {
 		return nil, fmt.Errorf("example has no subcommand: %q", example)
 	}
 	return tokens[1:], nil
+}
+
+// Join renders tokens as one POSIX-shell-safe command line that Split can
+// recover without losing token boundaries.
+func Join(tokens []string) string {
+	quoted := make([]string, len(tokens))
+	for i, token := range tokens {
+		quoted[i] = quote(token)
+	}
+	return strings.Join(quoted, " ")
+}
+
+func quote(token string) string {
+	if token != "" && strings.IndexFunc(token, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r) && !strings.ContainsRune("_@%+=:,./-", r)
+	}) == -1 {
+		return token
+	}
+	return "'" + strings.ReplaceAll(token, "'", `'\''`) + "'"
 }

--- a/internal/shellargs/shellargs_test.go
+++ b/internal/shellargs/shellargs_test.go
@@ -135,3 +135,26 @@ func TestArgsAfterBinary(t *testing.T) {
 		t.Fatal("expected missing subcommand error")
 	}
 }
+
+func TestJoinRoundTripsTokens(t *testing.T) {
+	tokens := []string{
+		"cli",
+		"inspect",
+		"--query",
+		"weekly digest",
+		"--literal",
+		"it's ready",
+		"",
+		"#tag",
+		"<id>",
+	}
+
+	joined := Join(tokens)
+	got, err := Split(joined)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, tokens) {
+		t.Fatalf("Split(Join()) = %#v, want %#v; joined = %q", got, tokens, joined)
+	}
+}

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/teach.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/teach.go
@@ -185,8 +185,7 @@ emits the user-facing response: silent on success, errors only to
 the CLI state directory's teach.log, safe to fire-and-forget.
 
 Disabling: pass --no-learn or set ` + noLearnEnvVar + `=true.`,
-		Example: `  learn-loop-example-pp-cli teach --query "<question>" --resource-type <type> \
-    --resource <id> --resource <id> &`,
+		Example: `  learn-loop-example-pp-cli teach --query "<question>" --resource-type <type> --resource <id> --resource <id> &`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
@@ -895,12 +894,7 @@ substitute live query entities into a resource template, so a pattern
 with query_template="items in {entity}" and
 resource_template="GROUP-{entity:category}" generalizes one teach into
 a whole family.`,
-		Example: `  learn-loop-example-pp-cli teach-pattern \
-    --query-template "items in {entity}" \
-    --resource-template "GROUP-{entity:category}" \
-    --resource-type "items" \
-    --entity-kind "category" \
-    --strategy substitute`,
+		Example: `  learn-loop-example-pp-cli teach-pattern --query-template "items in {entity}" --resource-template "GROUP-{entity:category}" --resource-type "items" --entity-kind "category" --strategy substitute`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if dryRunOK(flags) {
 				return nil


### PR DESCRIPTION
## Summary

Generated learn-loop and novel-feature examples are now directly runnable by full live dogfood instead of being rejected as prefix-only or truncated continuation lines. Novel examples retain quoted argument boundaries when normalized, so multiword values reach the generated command as one argument.

## Validation

- `go test ./... -timeout 20m`
- `scripts/golden.sh verify` (32/32 cases)
- `scripts/verify-generator-output.sh` (10 generated modules)
- `golangci-lint run --new-from-rev=origin/main ./...` (0 issues)

Closes #3665
