### PR TITLE
fix(cli): reject unusable auth declarations

### DIFF
--- a/internal/browsersniff/analysis_test.go
+++ b/internal/browsersniff/analysis_test.go
@@ -998,6 +998,13 @@ func TestApplyReachabilityDefaultsAddsBrowserClearanceCookieAuth(t *testing.T) {
 			Mode:       "browser_clearance_http",
 			Confidence: 0.9,
 		},
+		Auth: AuthAnalysis{
+			Candidates: []AuthCandidate{{
+				Type:        "cookie",
+				Confidence:  0.8,
+				CookieNames: []string{"ph_session", "csrf"},
+			}},
+		},
 	}
 
 	ApplyReachabilityDefaults(apiSpec, analysis)
@@ -1006,10 +1013,38 @@ func TestApplyReachabilityDefaultsAddsBrowserClearanceCookieAuth(t *testing.T) {
 	assert.Equal(t, "cookie", apiSpec.Auth.Type)
 	assert.Equal(t, "Cookie", apiSpec.Auth.Header)
 	assert.Equal(t, ".producthunt.com", apiSpec.Auth.CookieDomain)
+	assert.Equal(t, []string{"csrf", "ph_session"}, apiSpec.Auth.Cookies)
 	assert.Equal(t, []string{"PRODUCTHUNT_COOKIES"}, apiSpec.Auth.EnvVars)
 	assert.True(t, apiSpec.Auth.RequiresBrowserSession)
 	assert.Equal(t, "/posts", apiSpec.Auth.BrowserSessionValidationPath)
 	assert.Equal(t, "GET", apiSpec.Auth.BrowserSessionValidationMethod)
+	require.NoError(t, apiSpec.Validate())
+}
+
+func TestApplyReachabilityDefaultsDoesNotInventCookieAuthWithoutNames(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:      "producthunt",
+		BaseURL:   "https://www.producthunt.com",
+		Auth:      spec.AuthConfig{Type: "none"},
+		Resources: map[string]spec.Resource{"posts": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/posts"}}}},
+	}
+	analysis := &TrafficAnalysis{
+		Summary: TrafficAnalysisSummary{
+			TargetURL: "https://www.producthunt.com",
+		},
+		Reachability: &ReachabilityAnalysis{
+			Mode:       "browser_clearance_http",
+			Confidence: 0.9,
+		},
+	}
+
+	ApplyReachabilityDefaults(apiSpec, analysis)
+
+	assert.Equal(t, "none", apiSpec.Auth.Type)
+	assert.Empty(t, apiSpec.Auth.Cookies)
+	require.NoError(t, apiSpec.Validate())
 }
 
 func TestApplyReachabilityDefaultsDoesNotRequireProofWithoutValidationPath(t *testing.T) {
@@ -1033,6 +1068,13 @@ func TestApplyReachabilityDefaultsDoesNotRequireProofWithoutValidationPath(t *te
 		Reachability: &ReachabilityAnalysis{
 			Mode:       "browser_clearance_http",
 			Confidence: 0.9,
+		},
+		Auth: AuthAnalysis{
+			Candidates: []AuthCandidate{{
+				Type:        "cookie",
+				Confidence:  0.8,
+				CookieNames: []string{"ph_session"},
+			}},
 		},
 	}
 

--- a/internal/browsersniff/reachability.go
+++ b/internal/browsersniff/reachability.go
@@ -54,6 +54,10 @@ func ApplyReachabilityDefaults(apiSpec *spec.APISpec, analysis *TrafficAnalysis)
 	if domain == "" {
 		return
 	}
+	cookies := reachabilityCookieNames(analysis)
+	if len(cookies) == 0 {
+		return
+	}
 
 	validationPath := firstBrowserSessionValidationPath(apiSpec)
 	apiSpec.Auth = spec.AuthConfig{
@@ -61,6 +65,7 @@ func ApplyReachabilityDefaults(apiSpec *spec.APISpec, analysis *TrafficAnalysis)
 		Header:                       "Cookie",
 		In:                           "cookie",
 		CookieDomain:                 domain,
+		Cookies:                      cookies,
 		EnvVars:                      envVarsOrNil(strings.ToUpper(strings.ReplaceAll(apiSpec.Name, "-", "_")), "COOKIES"),
 		RequiresBrowserSession:       validationPath != "",
 		BrowserSessionReason:         "browser clearance is required to replay captured website traffic",
@@ -69,6 +74,16 @@ func ApplyReachabilityDefaults(apiSpec *spec.APISpec, analysis *TrafficAnalysis)
 	if validationPath != "" {
 		apiSpec.Auth.BrowserSessionValidationMethod = "GET"
 	}
+}
+
+func reachabilityCookieNames(analysis *TrafficAnalysis) []string {
+	var names []string
+	for _, candidate := range analysis.Auth.Candidates {
+		if candidate.Type == "cookie" || candidate.Type == "composed" {
+			names = append(names, candidate.CookieNames...)
+		}
+	}
+	return uniqueStrings(names)
 }
 
 func hasExplicitAuth(auth spec.AuthConfig) bool {

--- a/internal/browsersniff/specgen.go
+++ b/internal/browsersniff/specgen.go
@@ -1535,6 +1535,7 @@ func detectCapturedAuth(capture *AuthCapture, envPrefix string) spec.AuthConfig 
 				Header:       "Cookie",
 				In:           "cookie",
 				CookieDomain: capture.BoundDomain,
+				Cookies:      cookieNames(capture.Cookies),
 				EnvVars:      envVarsOrNil(envPrefix, "COOKIES"),
 			}
 		case "composed":
@@ -1556,6 +1557,7 @@ func detectCapturedAuth(capture *AuthCapture, envPrefix string) spec.AuthConfig 
 			Header:       "Cookie",
 			In:           "cookie",
 			CookieDomain: capture.BoundDomain,
+			Cookies:      cookieNames(capture.Cookies),
 			EnvVars:      envVarsOrNil(envPrefix, "COOKIES"),
 		}
 	}

--- a/internal/browsersniff/specgen_test.go
+++ b/internal/browsersniff/specgen_test.go
@@ -314,6 +314,7 @@ func TestAnalyzeCapture_UsesCapturedCookieAuth(t *testing.T) {
 	assert.Equal(t, "Cookie", apiSpec.Auth.Header)
 	assert.Equal(t, "cookie", apiSpec.Auth.In)
 	assert.Equal(t, "spotify.com", apiSpec.Auth.CookieDomain)
+	assert.Equal(t, []string{"_session"}, apiSpec.Auth.Cookies)
 	assert.Equal(t, []string{"SPOTIFY_COOKIES"}, apiSpec.Auth.EnvVars)
 }
 

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1176,6 +1176,15 @@ resources:
     "confidence": 0.9,
     "reasons": ["managed bot challenge observed"]
   },
+  "auth": {
+    "candidates": [
+      {
+        "type": "cookie",
+        "confidence": 0.8,
+        "cookie_names": ["ph_session"]
+      }
+    ]
+  },
   "generation_hints": ["browser_clearance_required", "graphql_persisted_query"]
 }`), 0o644))
 

--- a/internal/generator/auth_env_precedence_test.go
+++ b/internal/generator/auth_env_precedence_test.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,84 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestBearerAccessTokenFormatUsesPerCallEnvCredential(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		envVars       []string
+		envVarSpecs   []spec.AuthEnvVar
+		configFields  string
+		wantAuthValue string
+	}{
+		{
+			name: "single request credential",
+			envVarSpecs: []spec.AuthEnvVar{
+				{Name: "BEARER_ALIAS_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+			},
+			configFields:  `BearerAliasToken: "single-token"`,
+			wantAuthValue: "Bearer single-token",
+		},
+		{
+			name: "request credential aliases",
+			envVarSpecs: spec.NewORCaseEnvVarSpecs([]string{
+				"BEARER_ALIAS_PRIMARY",
+				"BEARER_ALIAS_SECONDARY",
+			}),
+			configFields:  `BearerAliasSecondary: "secondary-token"`,
+			wantAuthValue: "Bearer secondary-token",
+		},
+		{
+			name:          "legacy request credential",
+			envVars:       []string{"BEARER_ALIAS_LEGACY"},
+			configFields:  `BearerAliasLegacy: "legacy-token"`,
+			wantAuthValue: "Bearer legacy-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			apiSpec := minimalSpec("bearer-access-token-alias")
+			apiSpec.Auth = spec.AuthConfig{
+				Type:        "bearer_token",
+				Header:      "Authorization",
+				Format:      "Bearer {access_token}",
+				EnvVars:     tt.envVars,
+				EnvVarSpecs: tt.envVarSpecs,
+			}
+
+			outputDir := filepath.Join(t.TempDir(), "bearer-access-token-alias-pp-cli")
+			require.NoError(t, New(apiSpec, outputDir).Generate())
+
+			runtimeTest := fmt.Sprintf(`package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBearerAccessTokenAlias(t *testing.T) {
+	cfg := &Config{%s}
+	got := cfg.AuthHeader()
+	want := %q
+	if got != want {
+		t.Fatalf("AuthHeader() = %%q, want %%q", got, want)
+	}
+	if strings.Contains(got, "{access_token}") {
+		t.Fatalf("AuthHeader() left access_token placeholder unresolved: %%q", got)
+	}
+}
+`, tt.configFields, tt.wantAuthValue)
+			require.NoError(t, os.WriteFile(
+				filepath.Join(outputDir, "internal", "config", "bearer_access_token_alias_test.go"),
+				[]byte(runtimeTest), 0o644))
+			runGoCommand(t, outputDir, "test", "./internal/config", "-run", "^TestBearerAccessTokenAlias$")
+		})
+	}
+}
 
 // TestAuthHeader_ClientCredentialsDoesNotUseSetupEnvVars pins that under
 // OAuth2 client_credentials the setup inputs are never emitted as bearer

--- a/internal/generator/cookie_header_format_test.go
+++ b/internal/generator/cookie_header_format_test.go
@@ -1,8 +1,10 @@
 package generator
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
@@ -15,12 +17,13 @@ func TestHeaderCarriedCookieAuthAppliesFormat(t *testing.T) {
 	t.Run("canonical env and stored access token", func(t *testing.T) {
 		t.Parallel()
 
+		const hostileFormat = "Token \"quoted\" \\path\n{token}"
 		apiSpec := minimalSpec("cookie-format-canonical")
 		apiSpec.Auth = spec.AuthConfig{
 			Type:   "cookie",
 			Header: "Authorization",
 			In:     "header",
-			Format: "Token {token}",
+			Format: hostileFormat,
 			EnvVarSpecs: []spec.AuthEnvVar{{
 				Name:      "COOKIE_FORMAT_TOKEN",
 				Kind:      spec.AuthEnvVarKindPerCall,
@@ -32,24 +35,27 @@ func TestHeaderCarriedCookieAuthAppliesFormat(t *testing.T) {
 		outputDir := filepath.Join(t.TempDir(), "cookie-format-canonical-pp-cli")
 		require.NoError(t, New(apiSpec, outputDir).Generate())
 
-		const runtimeTest = `package config
+		runtimeTest := fmt.Sprintf(`package config
 
 import "testing"
 
 func TestCookieHeaderFormatCanonicalEnv(t *testing.T) {
 	cfg := &Config{CookieFormatToken: "env-token"}
-	if got, want := cfg.AuthHeader(), "Token env-token"; got != want {
-		t.Fatalf("AuthHeader() = %q, want %q", got, want)
+	if got, want := cfg.AuthHeader(), %q; got != want {
+		t.Fatalf("AuthHeader() = %%q, want %%q", got, want)
 	}
 }
 
 func TestCookieHeaderFormatStoredAccessToken(t *testing.T) {
 	cfg := &Config{AccessToken: "stored-token"}
-	if got, want := cfg.AuthHeader(), "Token stored-token"; got != want {
-		t.Fatalf("AuthHeader() = %q, want %q", got, want)
+	if got, want := cfg.AuthHeader(), %q; got != want {
+		t.Fatalf("AuthHeader() = %%q, want %%q", got, want)
 	}
 }
-`
+`,
+			strings.ReplaceAll(hostileFormat, "{token}", "env-token"),
+			strings.ReplaceAll(hostileFormat, "{token}", "stored-token"),
+		)
 		require.NoError(t, os.WriteFile(
 			filepath.Join(outputDir, "internal", "config", "cookie_header_format_test.go"),
 			[]byte(runtimeTest), 0o644))
@@ -59,12 +65,13 @@ func TestCookieHeaderFormatStoredAccessToken(t *testing.T) {
 	t.Run("OR-case env aliases", func(t *testing.T) {
 		t.Parallel()
 
+		const hostileFormat = "Token \"quoted\" \\path\n{token}:{access_token}:{format_secondary}:{COOKIE_FORMAT_SECONDARY}"
 		apiSpec := minimalSpec("cookie-format-aliases")
 		apiSpec.Auth = spec.AuthConfig{
 			Type:   "cookie",
 			Header: "Authorization",
 			In:     "header",
-			Format: "Token {token}:{access_token}:{format_secondary}:{COOKIE_FORMAT_SECONDARY}",
+			Format: hostileFormat,
 			EnvVarSpecs: spec.NewORCaseEnvVarSpecs([]string{
 				"COOKIE_FORMAT_PRIMARY",
 				"COOKIE_FORMAT_SECONDARY",
@@ -76,17 +83,26 @@ func TestCookieHeaderFormatStoredAccessToken(t *testing.T) {
 		configSource := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
 		require.Contains(t, authHeaderBody(t, configSource), `if c.CookieFormatSecondary != ""`)
 
-		const runtimeTest = `package config
+		expected := hostileFormat
+		for _, placeholder := range []string{
+			"{token}",
+			"{access_token}",
+			"{format_secondary}",
+			"{COOKIE_FORMAT_SECONDARY}",
+		} {
+			expected = strings.ReplaceAll(expected, placeholder, "secondary-token")
+		}
+		runtimeTest := fmt.Sprintf(`package config
 
 import "testing"
 
 func TestCookieHeaderFormatORCaseAliases(t *testing.T) {
 	cfg := &Config{CookieFormatSecondary: "secondary-token"}
-	if got, want := cfg.AuthHeader(), "Token secondary-token:secondary-token:secondary-token:secondary-token"; got != want {
-		t.Fatalf("AuthHeader() = %q, want %q", got, want)
+	if got, want := cfg.AuthHeader(), %q; got != want {
+		t.Fatalf("AuthHeader() = %%q, want %%q", got, want)
 	}
 }
-`
+`, expected)
 		require.NoError(t, os.WriteFile(
 			filepath.Join(outputDir, "internal", "config", "cookie_header_format_test.go"),
 			[]byte(runtimeTest), 0o644))

--- a/internal/generator/cookie_header_format_test.go
+++ b/internal/generator/cookie_header_format_test.go
@@ -1,0 +1,95 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeaderCarriedCookieAuthAppliesFormat(t *testing.T) {
+	t.Parallel()
+
+	t.Run("canonical env and stored access token", func(t *testing.T) {
+		t.Parallel()
+
+		apiSpec := minimalSpec("cookie-format-canonical")
+		apiSpec.Auth = spec.AuthConfig{
+			Type:   "cookie",
+			Header: "Authorization",
+			In:     "header",
+			Format: "Token {token}",
+			EnvVarSpecs: []spec.AuthEnvVar{{
+				Name:      "COOKIE_FORMAT_TOKEN",
+				Kind:      spec.AuthEnvVarKindPerCall,
+				Required:  true,
+				Sensitive: true,
+			}},
+		}
+
+		outputDir := filepath.Join(t.TempDir(), "cookie-format-canonical-pp-cli")
+		require.NoError(t, New(apiSpec, outputDir).Generate())
+
+		const runtimeTest = `package config
+
+import "testing"
+
+func TestCookieHeaderFormatCanonicalEnv(t *testing.T) {
+	cfg := &Config{CookieFormatToken: "env-token"}
+	if got, want := cfg.AuthHeader(), "Token env-token"; got != want {
+		t.Fatalf("AuthHeader() = %q, want %q", got, want)
+	}
+}
+
+func TestCookieHeaderFormatStoredAccessToken(t *testing.T) {
+	cfg := &Config{AccessToken: "stored-token"}
+	if got, want := cfg.AuthHeader(), "Token stored-token"; got != want {
+		t.Fatalf("AuthHeader() = %q, want %q", got, want)
+	}
+}
+`
+		require.NoError(t, os.WriteFile(
+			filepath.Join(outputDir, "internal", "config", "cookie_header_format_test.go"),
+			[]byte(runtimeTest), 0o644))
+		runGoCommand(t, outputDir, "test", "./internal/config", "-run", "^TestCookieHeaderFormat")
+	})
+
+	t.Run("OR-case env aliases", func(t *testing.T) {
+		t.Parallel()
+
+		apiSpec := minimalSpec("cookie-format-aliases")
+		apiSpec.Auth = spec.AuthConfig{
+			Type:   "cookie",
+			Header: "Authorization",
+			In:     "header",
+			Format: "Token {token}:{access_token}:{format_secondary}:{COOKIE_FORMAT_SECONDARY}",
+			EnvVarSpecs: spec.NewORCaseEnvVarSpecs([]string{
+				"COOKIE_FORMAT_PRIMARY",
+				"COOKIE_FORMAT_SECONDARY",
+			}),
+		}
+
+		outputDir := filepath.Join(t.TempDir(), "cookie-format-aliases-pp-cli")
+		require.NoError(t, New(apiSpec, outputDir).Generate())
+		configSource := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+		require.Contains(t, authHeaderBody(t, configSource), `if c.CookieFormatSecondary != ""`)
+
+		const runtimeTest = `package config
+
+import "testing"
+
+func TestCookieHeaderFormatORCaseAliases(t *testing.T) {
+	cfg := &Config{CookieFormatSecondary: "secondary-token"}
+	if got, want := cfg.AuthHeader(), "Token secondary-token:secondary-token:secondary-token:secondary-token"; got != want {
+		t.Fatalf("AuthHeader() = %q, want %q", got, want)
+	}
+}
+`
+		require.NoError(t, os.WriteFile(
+			filepath.Join(outputDir, "internal", "config", "cookie_header_format_test.go"),
+			[]byte(runtimeTest), 0o644))
+		runGoCommand(t, outputDir, "test", "./internal/config", "-run", "^TestCookieHeaderFormat")
+	})
+}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3082,6 +3082,7 @@ func TestGenerateCookieAuthDerivesCookieDomainFromBaseURL(t *testing.T) {
 		Type:    "cookie",
 		Header:  "Cookie",
 		In:      "cookie",
+		Cookies: []string{"session"},
 		EnvVars: []string{"COOKIEDOMAINDERIVE_COOKIES"},
 		// CookieDomain intentionally left empty — the generator must derive it.
 	}

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -527,7 +527,7 @@ func (c *Config) AuthHeader() string {
 {{- range .Auth.EnvVarSpecs}}
 	if c.{{resolveEnvVarField .Name}} != "" {
 		{{- if $.Auth.Format}}
-		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
+		return applyAuthFormat({{printf "%q" $.Auth.Format}}, map[string]string{
 			"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
 			"{{.Name}}": c.{{resolveEnvVarField .Name}},
 			{{- if ne (envVarPlaceholder .Name) "token"}}
@@ -593,7 +593,7 @@ func (c *Config) AuthHeader() string {
 	{{- end}}
 	{{- end}}
 	}
-	return applyAuthFormat("{{.Auth.Format}}", replacements)
+	return applyAuthFormat({{printf "%q" .Auth.Format}}, replacements)
 	{{- else if $canonicalEnvVar}}
 	{{- if .Auth.Prefix}}
 	return {{printf "%q" (printf "%s " .Auth.Prefix)}} + token
@@ -616,7 +616,7 @@ func (c *Config) AuthHeader() string {
 			c.AuthSource = "{{oauth2AuthSource .Auth}}"
 		}
 		{{- if .Auth.Format}}
-		return applyAuthFormat("{{.Auth.Format}}", map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
+		return applyAuthFormat({{printf "%q" .Auth.Format}}, map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
 		{{- else}}
 		return "{{.Auth.HeaderPrefix}} " + c.AccessToken
 		{{- end}}
@@ -629,7 +629,7 @@ func (c *Config) AuthHeader() string {
 	// this fallback: their env-var kind excludes them from emission here.
 	if c.{{resolveEnvVarField .Name}} != "" {
 		{{- if $.Auth.Format}}
-		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
+		return applyAuthFormat({{printf "%q" $.Auth.Format}}, map[string]string{
 			"access_token": c.{{resolveEnvVarField .Name}},
 			"token":        c.{{resolveEnvVarField .Name}},
 			{{- if and (ne (envVarPlaceholder .Name) "token") (ne (envVarPlaceholder .Name) "access_token")}}
@@ -650,7 +650,7 @@ func (c *Config) AuthHeader() string {
 	if c.AccessToken != "" {
 		c.AuthSource = "bearer_refresh"
 		{{- if .Auth.Format}}
-		return applyAuthFormat("{{.Auth.Format}}", map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
+		return applyAuthFormat({{printf "%q" .Auth.Format}}, map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
 		{{- else}}
 		return "{{.Auth.HeaderPrefix}} " + c.AccessToken
 		{{- end}}
@@ -665,7 +665,7 @@ func (c *Config) AuthHeader() string {
 			c.AuthSource = "{{oauth2AuthSource .Auth}}"
 		}
 		{{- if .Auth.Format}}
-		return applyAuthFormat("{{.Auth.Format}}", map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
+		return applyAuthFormat({{printf "%q" .Auth.Format}}, map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
 		{{- else}}
 		return "{{.Auth.HeaderPrefix}} " + c.AccessToken
 		{{- end}}
@@ -682,7 +682,7 @@ func (c *Config) AuthHeader() string {
 			c.AuthSource = "env:{{.Name}}"
 		}
 		{{- if $.Auth.Format}}
-		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
+		return applyAuthFormat({{printf "%q" $.Auth.Format}}, map[string]string{
 			"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
 			"{{.Name}}": c.{{resolveEnvVarField .Name}},
 			{{- if ne (envVarPlaceholder .Name) "token"}}
@@ -707,7 +707,7 @@ func (c *Config) AuthHeader() string {
 			c.AuthSource = "env:{{.Name}}"
 		}
 		{{- if $.Auth.Format}}
-		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
+		return applyAuthFormat({{printf "%q" $.Auth.Format}}, map[string]string{
 			"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
 			"{{.Name}}": c.{{resolveEnvVarField .Name}},
 			{{- if ne (envVarPlaceholder .Name) "token"}}
@@ -730,7 +730,7 @@ func (c *Config) AuthHeader() string {
 			c.AuthSource = "env:{{.Name}}"
 		}
 		{{- if $.Auth.Format}}
-		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
+		return applyAuthFormat({{printf "%q" $.Auth.Format}}, map[string]string{
 			"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
 			"{{.Name}}": c.{{resolveEnvVarField .Name}},
 			{{- if ne (envVarPlaceholder .Name) "token"}}
@@ -753,7 +753,7 @@ func (c *Config) AuthHeader() string {
 			c.AuthSource = "{{oauth2AuthSource .Auth}}"
 		}
 		{{- if .Auth.Format}}
-		return applyAuthFormat("{{.Auth.Format}}", map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
+		return applyAuthFormat({{printf "%q" .Auth.Format}}, map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
 		{{- else}}
 		return "{{.Auth.HeaderPrefix}} " + c.AccessToken
 		{{- end}}
@@ -770,7 +770,7 @@ func (c *Config) AuthHeader() string {
 			c.AuthSource = "env:{{.Name}}"
 		}
 		{{- if $.Auth.Format}}
-		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
+		return applyAuthFormat({{printf "%q" $.Auth.Format}}, map[string]string{
 			"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
 			"{{.Name}}": c.{{resolveEnvVarField .Name}},
 			{{- if ne (envVarPlaceholder .Name) "token"}}
@@ -792,7 +792,7 @@ func (c *Config) AuthHeader() string {
 			c.AuthSource = "env:{{.Name}}"
 		}
 		{{- if $.Auth.Format}}
-		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
+		return applyAuthFormat({{printf "%q" $.Auth.Format}}, map[string]string{
 			"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
 			"{{.Name}}": c.{{resolveEnvVarField .Name}},
 			{{- if ne (envVarPlaceholder .Name) "token"}}
@@ -813,7 +813,7 @@ func (c *Config) AuthHeader() string {
 			c.AuthSource = "browser"
 		}
 		{{- if .Auth.Format}}
-		return applyAuthFormat("{{.Auth.Format}}", map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
+		return applyAuthFormat({{printf "%q" .Auth.Format}}, map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
 		{{- else}}
 		return ensureAuthScheme("{{.Auth.HeaderPrefix}}", c.AccessToken)
 		{{- end}}

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -688,6 +688,9 @@ func (c *Config) AuthHeader() string {
 			{{- if ne (envVarPlaceholder .Name) "token"}}
 			"token": c.{{resolveEnvVarField .Name}},
 			{{- end}}
+			{{- if ne (envVarPlaceholder .Name) "access_token"}}
+			"access_token": c.{{resolveEnvVarField .Name}},
+			{{- end}}
 		})
 		{{- else}}
 		return "{{$.Auth.HeaderPrefix}} " + c.{{resolveEnvVarField .Name}}
@@ -710,6 +713,9 @@ func (c *Config) AuthHeader() string {
 			{{- if ne (envVarPlaceholder .Name) "token"}}
 			"token": c.{{resolveEnvVarField .Name}},
 			{{- end}}
+			{{- if ne (envVarPlaceholder .Name) "access_token"}}
+			"access_token": c.{{resolveEnvVarField .Name}},
+			{{- end}}
 		})
 		{{- else}}
 		return "{{$.Auth.HeaderPrefix}} " + c.{{resolveEnvVarField .Name}}
@@ -729,6 +735,9 @@ func (c *Config) AuthHeader() string {
 			"{{.Name}}": c.{{resolveEnvVarField .Name}},
 			{{- if ne (envVarPlaceholder .Name) "token"}}
 			"token": c.{{resolveEnvVarField .Name}},
+			{{- end}}
+			{{- if ne (envVarPlaceholder .Name) "access_token"}}
+			"access_token": c.{{resolveEnvVarField .Name}},
 			{{- end}}
 		})
 		{{- else}}

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -769,7 +769,20 @@ func (c *Config) AuthHeader() string {
 		if c.AuthSource == "" {
 			c.AuthSource = "env:{{.Name}}"
 		}
+		{{- if $.Auth.Format}}
+		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
+			"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
+			"{{.Name}}": c.{{resolveEnvVarField .Name}},
+			{{- if ne (envVarPlaceholder .Name) "token"}}
+			"token": c.{{resolveEnvVarField .Name}},
+			{{- end}}
+			{{- if ne (envVarPlaceholder .Name) "access_token"}}
+			"access_token": c.{{resolveEnvVarField .Name}},
+			{{- end}}
+		})
+		{{- else}}
 		return ensureAuthScheme("{{$.Auth.HeaderPrefix}}", c.{{resolveEnvVarField .Name}})
+		{{- end}}
 	}
 {{- end}}
 {{- else}}
@@ -778,7 +791,20 @@ func (c *Config) AuthHeader() string {
 		if c.AuthSource == "" {
 			c.AuthSource = "env:{{.Name}}"
 		}
+		{{- if $.Auth.Format}}
+		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
+			"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
+			"{{.Name}}": c.{{resolveEnvVarField .Name}},
+			{{- if ne (envVarPlaceholder .Name) "token"}}
+			"token": c.{{resolveEnvVarField .Name}},
+			{{- end}}
+			{{- if ne (envVarPlaceholder .Name) "access_token"}}
+			"access_token": c.{{resolveEnvVarField .Name}},
+			{{- end}}
+		})
+		{{- else}}
 		return ensureAuthScheme("{{$.Auth.HeaderPrefix}}", c.{{resolveEnvVarField .Name}})
+		{{- end}}
 	}
 	{{- end}}
 {{- end}}
@@ -786,7 +812,11 @@ func (c *Config) AuthHeader() string {
 		if c.AuthSource == "" {
 			c.AuthSource = "browser"
 		}
+		{{- if .Auth.Format}}
+		return applyAuthFormat("{{.Auth.Format}}", map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
+		{{- else}}
 		return ensureAuthScheme("{{.Auth.HeaderPrefix}}", c.AccessToken)
+		{{- end}}
 	}
 	return ""
 {{- else if eq .Auth.Type "composed"}}

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -3712,6 +3712,8 @@ base_url: https://api.example.com
 auth:
   type: cookie
   header: Cookie
+  cookies:
+    - session
   env_vars:
     - EXAMPLE_COOKIE
 resources:

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -7,6 +7,7 @@ import (
 	"net/netip"
 	"net/url"
 	"os"
+	"reflect"
 	"regexp"
 	"slices"
 	"strconv"
@@ -1551,7 +1552,12 @@ func (c AuthConfig) HasCompanionHints() bool {
 // auth.cookies when they need jar plumbing, and a composed-auth spec
 // without auth.cookies has nothing to persist.
 func (c AuthConfig) HasCookies() bool {
-	return len(c.Cookies) > 0
+	for _, name := range c.Cookies {
+		if strings.TrimSpace(name) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // HasNonCookieAuth reports whether the auth block exposes at least one
@@ -1681,6 +1687,116 @@ func validateAuthSubtype(c AuthConfig) error {
 		return fmt.Errorf("auth.subtype %q is not recognized (valid: %q)",
 			c.Subtype, AuthSubtypeAuth0SPAInMemory)
 	}
+}
+
+func validateAuthConfig(context string, auth AuthConfig) error {
+	switch strings.ToLower(strings.TrimSpace(auth.Type)) {
+	case "cookie", "composed":
+		if !auth.HasCookies() {
+			return fmt.Errorf("%s.type is %q but %s.cookies is empty; the generated client would never send cookies", context, auth.Type, context)
+		}
+		for _, name := range auth.Cookies {
+			if strings.TrimSpace(name) == "" {
+				return fmt.Errorf("%s.cookies contains an empty cookie name", context)
+			}
+		}
+	}
+	return validateAuthFormat(context, auth)
+}
+
+func validateAuthFormat(context string, auth AuthConfig) error {
+	if auth.Format == "" {
+		return nil
+	}
+	switch strings.ToLower(strings.TrimSpace(auth.Type)) {
+	case "api_key", "bearer_token", "oauth2", "oauth2_refresh":
+	default:
+		return nil
+	}
+
+	matches := authFormatPlaceholderRe.FindAllStringSubmatch(auth.Format, -1)
+	if len(matches) == 0 {
+		return fmt.Errorf("%s.format must contain a placeholder like {token} (got %q)", context, auth.Format)
+	}
+	if remaining := authFormatPlaceholderRe.ReplaceAllString(auth.Format, ""); strings.Contains(remaining, "{") {
+		return fmt.Errorf("%s.format contains invalid placeholder syntax (got %q)", context, auth.Format)
+	}
+
+	allowed := authFormatPlaceholderSet(auth)
+	if len(allowed) == 0 {
+		return fmt.Errorf("%s.format placeholder %q has no env_var mapping; declare an auth env-var credential", context, matches[0][0])
+	}
+	expected := make([]string, 0, len(allowed))
+	for placeholder := range allowed {
+		expected = append(expected, placeholder)
+	}
+	slices.Sort(expected)
+	for _, match := range matches {
+		if _, ok := allowed[match[1]]; !ok {
+			return fmt.Errorf("%s.format placeholder %q has no env_var mapping; expected one of: {%s}",
+				context, match[0], strings.Join(expected, ", "))
+		}
+	}
+	return nil
+}
+
+func authFormatPlaceholderSet(auth AuthConfig) map[string]struct{} {
+	allowed := make(map[string]struct{})
+	authType := strings.ToLower(strings.TrimSpace(auth.Type))
+
+	requestEnvVars := make([]AuthEnvVar, 0, len(auth.EnvVarSpecs))
+	for _, envVar := range auth.EnvVarSpecs {
+		if envVar.IsRequestCredential() {
+			requestEnvVars = append(requestEnvVars, envVar)
+		}
+	}
+	if len(requestEnvVars) == 0 && len(auth.EnvVarSpecs) == 0 {
+		for _, name := range auth.EnvVars {
+			requestEnvVars = append(requestEnvVars, AuthEnvVar{Name: name})
+		}
+	}
+
+	if authType != "api_key" || len(requestEnvVars) > 0 {
+		allowed["token"] = struct{}{}
+	}
+	basicAuth := authType == "api_key" && strings.Contains(strings.ToLower(auth.Format), "basic ")
+	if authType == "oauth2" || authType == "oauth2_refresh" || (authType == "bearer_token" && len(requestEnvVars) == 0) {
+		allowed["access_token"] = struct{}{}
+	}
+	if auth.IsAuthEnvVarORCase() && !basicAuth && len(requestEnvVars) > 1 {
+		return allowed
+	}
+	if authType == "bearer_token" && len(requestEnvVars) > 1 {
+		return allowed
+	}
+	if basicAuth {
+		if len(requestEnvVars) > 2 {
+			requestEnvVars = requestEnvVars[:2]
+		}
+		switch len(requestEnvVars) {
+		case 1:
+			allowed["access_token"] = struct{}{}
+		default:
+			if len(requestEnvVars) > 0 {
+				allowed["username"] = struct{}{}
+				allowed["user"] = struct{}{}
+			}
+			if len(requestEnvVars) > 1 {
+				allowed["password"] = struct{}{}
+				allowed["secret"] = struct{}{}
+				allowed["access_token"] = struct{}{}
+			}
+		}
+	}
+	for _, envVar := range requestEnvVars {
+		name := strings.TrimSpace(envVar.Name)
+		if name == "" {
+			continue
+		}
+		allowed[name] = struct{}{}
+		allowed[naming.EnvVarPlaceholder(name)] = struct{}{}
+	}
+	return allowed
 }
 
 // AuthConfig.Type is intentionally skipped: the field is ignored for
@@ -2922,6 +3038,16 @@ func validateRawSpecStructure(data []byte) error {
 		return fmt.Errorf("spec structural error: duplicate top-level key(s): %s", strings.Join(topLevelDuplicates, ", "))
 	}
 
+	if auth := mappingValue(root, "auth"); auth != nil {
+		unknown := unknownYAMLFields(auth, reflect.TypeFor[AuthConfig]())
+		if len(unknown) == 1 {
+			return fmt.Errorf("spec structural error: auth contains unknown field %q", unknown[0])
+		}
+		if len(unknown) > 1 {
+			return fmt.Errorf("spec structural error: auth contains unknown fields: %s", strings.Join(unknown, ", "))
+		}
+	}
+
 	types := mappingValue(root, "types")
 	if types == nil || types.Kind != yaml.MappingNode {
 		return nil
@@ -2939,6 +3065,47 @@ func validateRawSpecStructure(data []byte) error {
 		return fmt.Errorf("spec structural error: found resource-shaped entr%s under 'types:' (%s) - resources were likely appended at the wrong indentation level; move them under top-level 'resources:'", pluralSuffix(len(misplaced), "y", "ies"), strings.Join(misplaced, ", "))
 	}
 	return nil
+}
+
+func unknownYAMLFields(node *yaml.Node, structType reflect.Type) []string {
+	known := make(map[string]struct{}, structType.NumField())
+	for field := range structType.Fields() {
+		name := strings.Split(field.Tag.Get("yaml"), ",")[0]
+		if name != "" && name != "-" {
+			known[name] = struct{}{}
+		}
+	}
+	var unknown []string
+	collectUnknownYAMLFields(node, known, make(map[*yaml.Node]bool), &unknown)
+	slices.Sort(unknown)
+	return slices.Compact(unknown)
+}
+
+func collectUnknownYAMLFields(node *yaml.Node, known map[string]struct{}, visited map[*yaml.Node]bool, unknown *[]string) {
+	if node == nil || visited[node] {
+		return
+	}
+	visited[node] = true
+
+	switch node.Kind {
+	case yaml.AliasNode:
+		collectUnknownYAMLFields(node.Alias, known, visited, unknown)
+	case yaml.SequenceNode:
+		for _, child := range node.Content {
+			collectUnknownYAMLFields(child, known, visited, unknown)
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			name := node.Content[i].Value
+			if name == "<<" {
+				collectUnknownYAMLFields(node.Content[i+1], known, visited, unknown)
+				continue
+			}
+			if _, ok := known[name]; !ok {
+				*unknown = append(*unknown, name)
+			}
+		}
+	}
 }
 
 func yamlDocumentRoot(doc *yaml.Node) *yaml.Node {
@@ -3979,6 +4146,9 @@ func (s *APISpec) Validate() error {
 		return err
 	}
 	if err := validateAuthSubtype(s.Auth); err != nil {
+		return err
+	}
+	if err := validateAuthConfig("auth", s.Auth); err != nil {
 		return err
 	}
 	if err := validateSessionHandshake(s.Auth); err != nil {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1691,7 +1691,18 @@ func validateAuthSubtype(c AuthConfig) error {
 
 func validateAuthConfig(context string, auth AuthConfig) error {
 	switch strings.ToLower(strings.TrimSpace(auth.Type)) {
-	case "cookie", "composed":
+	case "cookie":
+		if !auth.HasCookies() {
+			if len(auth.Cookies) != 0 || !isHeaderCarriedCookieAuth(auth) {
+				return fmt.Errorf("%s.type is %q but %s.cookies is empty; the generated client would never send cookies", context, auth.Type, context)
+			}
+		}
+		for _, name := range auth.Cookies {
+			if strings.TrimSpace(name) == "" {
+				return fmt.Errorf("%s.cookies contains an empty cookie name", context)
+			}
+		}
+	case "composed":
 		if !auth.HasCookies() {
 			return fmt.Errorf("%s.type is %q but %s.cookies is empty; the generated client would never send cookies", context, auth.Type, context)
 		}
@@ -1702,6 +1713,30 @@ func validateAuthConfig(context string, auth AuthConfig) error {
 		}
 	}
 	return validateAuthFormat(context, auth)
+}
+
+func isHeaderCarriedCookieAuth(auth AuthConfig) bool {
+	header := strings.TrimSpace(auth.Header)
+	if !strings.EqualFold(strings.TrimSpace(auth.In), "header") ||
+		header == "" ||
+		strings.EqualFold(header, "Cookie") ||
+		strings.TrimSpace(auth.Format) == "" {
+		return false
+	}
+	for _, envVar := range auth.EnvVarSpecs {
+		if strings.TrimSpace(envVar.Name) != "" && envVar.IsRequestCredential() {
+			return true
+		}
+	}
+	if len(auth.EnvVarSpecs) != 0 {
+		return false
+	}
+	for _, envVar := range auth.EnvVars {
+		if strings.TrimSpace(envVar) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func validateAuthFormat(context string, auth AuthConfig) error {
@@ -1760,7 +1795,7 @@ func authFormatPlaceholderSet(auth AuthConfig) map[string]struct{} {
 		allowed["token"] = struct{}{}
 	}
 	basicAuth := authType == "api_key" && strings.Contains(strings.ToLower(auth.Format), "basic ")
-	if authType == "oauth2" || authType == "oauth2_refresh" || (authType == "bearer_token" && len(requestEnvVars) == 0) {
+	if authType == "oauth2" || authType == "oauth2_refresh" || authType == "bearer_token" {
 		allowed["access_token"] = struct{}{}
 	}
 	if auth.IsAuthEnvVarORCase() && !basicAuth && len(requestEnvVars) > 1 {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1745,6 +1745,10 @@ func validateAuthFormat(context string, auth AuthConfig) error {
 	}
 	switch strings.ToLower(strings.TrimSpace(auth.Type)) {
 	case "api_key", "bearer_token", "oauth2", "oauth2_refresh":
+	case "cookie":
+		if !isHeaderCarriedCookieAuth(auth) {
+			return nil
+		}
 	default:
 		return nil
 	}
@@ -1795,7 +1799,7 @@ func authFormatPlaceholderSet(auth AuthConfig) map[string]struct{} {
 		allowed["token"] = struct{}{}
 	}
 	basicAuth := authType == "api_key" && strings.Contains(strings.ToLower(auth.Format), "basic ")
-	if authType == "oauth2" || authType == "oauth2_refresh" || authType == "bearer_token" {
+	if authType == "oauth2" || authType == "oauth2_refresh" || authType == "bearer_token" || authType == "cookie" {
 		allowed["access_token"] = struct{}{}
 	}
 	if auth.IsAuthEnvVarORCase() && !basicAuth && len(requestEnvVars) > 1 {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -926,6 +926,76 @@ func TestValidateAuthConfigRejectsUnusableDeclarations(t *testing.T) {
 			wantErr: `auth.type is "cookie" but auth.cookies is empty`,
 		},
 		{
+			name: "header-carried cookie auth with request credential",
+			auth: AuthConfig{
+				Type:   "cookie",
+				Header: "Authorization",
+				In:     "header",
+				Format: "Bearer {token}",
+				EnvVarSpecs: []AuthEnvVar{{
+					Name:     "FOO_TOKEN",
+					Kind:     AuthEnvVarKindPerCall,
+					Required: true,
+				}},
+			},
+		},
+		{
+			name: "header-carried cookie auth with legacy env var",
+			auth: AuthConfig{
+				Type:    "cookie",
+				Header:  "X-API-Key",
+				In:      "header",
+				Format:  "{token}",
+				EnvVars: []string{"FOO_API_KEY"},
+			},
+		},
+		{
+			name: "cookie auth without cookies still rejects Cookie header",
+			auth: AuthConfig{
+				Type:    "cookie",
+				Header:  "Cookie",
+				In:      "header",
+				Format:  "{token}",
+				EnvVars: []string{"FOO_COOKIE"},
+			},
+			wantErr: `auth.type is "cookie" but auth.cookies is empty`,
+		},
+		{
+			name: "cookie auth without cookies rejects non-header placement",
+			auth: AuthConfig{
+				Type:    "cookie",
+				Header:  "Authorization",
+				In:      "cookie",
+				Format:  "Bearer {token}",
+				EnvVars: []string{"FOO_TOKEN"},
+			},
+			wantErr: `auth.type is "cookie" but auth.cookies is empty`,
+		},
+		{
+			name: "cookie auth without cookies rejects missing format",
+			auth: AuthConfig{
+				Type:    "cookie",
+				Header:  "Authorization",
+				In:      "header",
+				EnvVars: []string{"FOO_TOKEN"},
+			},
+			wantErr: `auth.type is "cookie" but auth.cookies is empty`,
+		},
+		{
+			name: "cookie auth without cookies rejects flow input",
+			auth: AuthConfig{
+				Type:   "cookie",
+				Header: "Authorization",
+				In:     "header",
+				Format: "Bearer {token}",
+				EnvVarSpecs: []AuthEnvVar{{
+					Name: "FOO_CLIENT_ID",
+					Kind: AuthEnvVarKindAuthFlowInput,
+				}},
+			},
+			wantErr: `auth.type is "cookie" but auth.cookies is empty`,
+		},
+		{
 			name:    "composed auth without cookies",
 			auth:    AuthConfig{Type: "composed"},
 			wantErr: `auth.type is "composed" but auth.cookies is empty`,
@@ -982,7 +1052,6 @@ func TestValidateAuthConfigRejectsUnusableDeclarations(t *testing.T) {
 					Required: true,
 				}},
 			},
-			wantErr: `auth.format placeholder "{access_token}" has no env_var mapping; expected one of: {FOO_TOKEN, token}`,
 		},
 		{
 			name: "canonical and raw env var placeholders",

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -950,6 +950,39 @@ func TestValidateAuthConfigRejectsUnusableDeclarations(t *testing.T) {
 			},
 		},
 		{
+			name: "header-carried cookie auth rejects format without placeholder",
+			auth: AuthConfig{
+				Type:    "cookie",
+				Header:  "Authorization",
+				In:      "header",
+				Format:  "Token ",
+				EnvVars: []string{"FOO_TOKEN"},
+			},
+			wantErr: `auth.format must contain a placeholder like {token} (got "Token ")`,
+		},
+		{
+			name: "header-carried cookie auth rejects malformed placeholder",
+			auth: AuthConfig{
+				Type:    "cookie",
+				Header:  "Authorization",
+				In:      "header",
+				Format:  "Token {token} {tenant-id}",
+				EnvVars: []string{"FOO_TOKEN"},
+			},
+			wantErr: `auth.format contains invalid placeholder syntax`,
+		},
+		{
+			name: "header-carried cookie auth rejects unmapped placeholder",
+			auth: AuthConfig{
+				Type:    "cookie",
+				Header:  "Authorization",
+				In:      "header",
+				Format:  "Token {missing}",
+				EnvVars: []string{"FOO_TOKEN"},
+			},
+			wantErr: `auth.format placeholder "{missing}" has no env_var mapping`,
+		},
+		{
 			name: "cookie auth without cookies still rejects Cookie header",
 			auth: AuthConfig{
 				Type:    "cookie",

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -891,6 +891,165 @@ func TestValidationRejectsUnknownSource(t *testing.T) {
 	require.ErrorContains(t, s.Validate(), `source "local-postgres" is not supported; valid values: local-sqlite`)
 }
 
+func TestValidateAuthConfigRejectsUnusableDeclarations(t *testing.T) {
+	baseSpec := func(auth AuthConfig) APISpec {
+		return APISpec{
+			Name:    "auth-api",
+			BaseURL: "https://api.example.com",
+			Auth:    auth,
+			Resources: map[string]Resource{
+				"items": {Endpoints: map[string]Endpoint{"list": {Method: "GET", Path: "/items"}}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		auth    AuthConfig
+		wantErr string
+	}{
+		{
+			name: "cookie auth with declared cookie",
+			auth: AuthConfig{Type: "cookie", Cookies: []string{"session"}},
+		},
+		{
+			name: "composed auth with declared cookie",
+			auth: AuthConfig{
+				Type:    "composed",
+				Format:  "Session {session}|{csrf}",
+				Cookies: []string{"session", "csrf"},
+			},
+		},
+		{
+			name:    "cookie auth without cookies",
+			auth:    AuthConfig{Type: "cookie"},
+			wantErr: `auth.type is "cookie" but auth.cookies is empty`,
+		},
+		{
+			name:    "composed auth without cookies",
+			auth:    AuthConfig{Type: "composed"},
+			wantErr: `auth.type is "composed" but auth.cookies is empty`,
+		},
+		{
+			name:    "cookie auth with blank cookie",
+			auth:    AuthConfig{Type: "cookie", Cookies: []string{" "}},
+			wantErr: `auth.type is "cookie" but auth.cookies is empty`,
+		},
+		{
+			name:    "cookie auth with a blank cookie entry",
+			auth:    AuthConfig{Type: "cookie", Cookies: []string{"session", " "}},
+			wantErr: `auth.cookies contains an empty cookie name`,
+		},
+		{
+			name: "standard token placeholder",
+			auth: AuthConfig{
+				Type:    "bearer_token",
+				Format:  "Bearer {token}",
+				EnvVars: []string{"FOO_TOKEN"},
+			},
+		},
+		{
+			name: "rich per-call env placeholder",
+			auth: AuthConfig{
+				Type:   "bearer_token",
+				Format: "Bearer {foo_token}",
+				EnvVarSpecs: []AuthEnvVar{{
+					Name:     "COMPANY_FOO_TOKEN",
+					Kind:     AuthEnvVarKindPerCall,
+					Required: true,
+				}},
+			},
+		},
+		{
+			name: "access token placeholder with flow input",
+			auth: AuthConfig{
+				Type:   "bearer_token",
+				Format: "Bearer {access_token}",
+				EnvVarSpecs: []AuthEnvVar{{
+					Name: "FOO_CLIENT_ID",
+					Kind: AuthEnvVarKindAuthFlowInput,
+				}},
+			},
+		},
+		{
+			name: "access token placeholder with per-call credential",
+			auth: AuthConfig{
+				Type:   "bearer_token",
+				Format: "Bearer {access_token}",
+				EnvVarSpecs: []AuthEnvVar{{
+					Name:     "FOO_TOKEN",
+					Kind:     AuthEnvVarKindPerCall,
+					Required: true,
+				}},
+			},
+			wantErr: `auth.format placeholder "{access_token}" has no env_var mapping; expected one of: {FOO_TOKEN, token}`,
+		},
+		{
+			name: "canonical and raw env var placeholders",
+			auth: AuthConfig{
+				Type:    "api_key",
+				Format:  "Contact {pp_contact_email} ({COMPANY_PP_CONTACT_EMAIL})",
+				EnvVars: []string{"COMPANY_PP_CONTACT_EMAIL"},
+			},
+		},
+		{
+			name: "api key format without credential mapping",
+			auth: AuthConfig{
+				Type:   "api_key",
+				Format: "Bearer {token}",
+			},
+			wantErr: `auth.format placeholder "{token}" has no env_var mapping; declare an auth env-var credential`,
+		},
+		{
+			name: "basic auth aliases",
+			auth: AuthConfig{
+				Type:    "api_key",
+				Format:  "Basic {username}:{password}",
+				EnvVars: []string{"TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN"},
+			},
+		},
+		{
+			name: "unmapped placeholder",
+			auth: AuthConfig{
+				Type:    "api_key",
+				Format:  "Contact {email}",
+				EnvVars: []string{"COMPANY_PP_CONTACT_EMAIL"},
+			},
+			wantErr: `auth.format placeholder "{email}" has no env_var mapping; expected one of: {COMPANY_PP_CONTACT_EMAIL, pp_contact_email, token}`,
+		},
+		{
+			name: "format without placeholder",
+			auth: AuthConfig{
+				Type:    "bearer_token",
+				Format:  "Bearer ",
+				EnvVars: []string{"FOO_TOKEN"},
+			},
+			wantErr: `auth.format must contain a placeholder like {token} (got "Bearer ")`,
+		},
+		{
+			name: "format with malformed placeholder",
+			auth: AuthConfig{
+				Type:    "bearer_token",
+				Format:  "Bearer {token} {tenant-id}",
+				EnvVars: []string{"FOO_TOKEN"},
+			},
+			wantErr: `auth.format contains invalid placeholder syntax`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := baseSpec(tt.auth)
+			err := candidate.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
 // validateAdditionalAuthHeaders covers six distinct error paths; this table
 // hits each one and confirms the happy path still validates.
 func TestValidateAdditionalAuthHeadersErrors(t *testing.T) {
@@ -2554,7 +2713,7 @@ resources:
 		assert.Equal(t, []string{"customerId", "authToken"}, s.Auth.Cookies)
 	})
 
-	t.Run("cookie auth without cookies field is nil", func(t *testing.T) {
+	t.Run("cookie auth without cookies field is rejected", func(t *testing.T) {
 		t.Parallel()
 		input := `name: notionapi
 base_url: https://api.notion.so
@@ -2571,10 +2730,77 @@ resources:
         path: /pages
         description: List pages
 `
+		_, err := ParseBytes([]byte(input))
+		require.ErrorContains(t, err, `auth.type is "cookie" but auth.cookies is empty`)
+	})
+
+	t.Run("unknown auth key is surfaced by name", func(t *testing.T) {
+		t.Parallel()
+		input := `name: notionapi
+base_url: https://api.notion.so
+auth:
+  type: cookie
+  cookie_domain: ".notion.so"
+  required_cookies:
+    - token_v2
+resources:
+  pages:
+    endpoints:
+      list:
+        method: GET
+        path: /pages
+`
+		_, err := ParseBytes([]byte(input))
+		require.ErrorContains(t, err, `auth contains unknown field "required_cookies"`)
+	})
+
+	t.Run("auth YAML merge is accepted and validated", func(t *testing.T) {
+		t.Parallel()
+		input := `name: merged-auth
+base_url: https://api.example.com
+auth_defaults: &auth_defaults
+  type: bearer_token
+  header: Authorization
+  env_vars:
+    - MERGED_AUTH_TOKEN
+auth:
+  <<: *auth_defaults
+  format: "Bearer {token}"
+resources:
+  pages:
+    endpoints:
+      list:
+        method: GET
+        path: /pages
+`
 		s, err := ParseBytes([]byte(input))
 		require.NoError(t, err)
-		assert.Equal(t, "cookie", s.Auth.Type)
-		assert.Nil(t, s.Auth.Cookies)
+		assert.Equal(t, "bearer_token", s.Auth.Type)
+		assert.Equal(t, []string{"MERGED_AUTH_TOKEN"}, s.Auth.EnvVars)
+	})
+
+	t.Run("unknown auth key in YAML merge is surfaced", func(t *testing.T) {
+		t.Parallel()
+		input := `name: merged-auth
+base_url: https://api.example.com
+auth_defaults: &auth_defaults
+  type: bearer_token
+  required_cookies:
+    - token_v2
+auth:
+  <<: *auth_defaults
+  format: "Bearer {token}"
+  env_vars:
+    - MERGED_AUTH_TOKEN
+resources:
+  pages:
+    endpoints:
+      list:
+        method: GET
+        path: /pages
+`
+		_, err := ParseBytes([]byte(input))
+		require.ErrorContains(t, err, `auth contains unknown field "required_cookies"`)
 	})
 
 	t.Run("invalid YAML still returns error", func(t *testing.T) {
@@ -6714,6 +6940,8 @@ func TestAuthHasCookies(t *testing.T) {
 		{name: "cookie-typed with cookie list", auth: AuthConfig{Type: "cookie", Cookies: []string{"session_id"}}, want: true},
 		{name: "composed-typed with cookie list", auth: AuthConfig{Type: "composed", Cookies: []string{"session_id", "csrf"}}, want: true},
 		{name: "composed-typed without cookie list", auth: AuthConfig{Type: "composed"}, want: false},
+		{name: "cookie-typed with blank-only list", auth: AuthConfig{Type: "cookie", Cookies: []string{" "}}, want: false},
+		{name: "cookie-typed with one real name", auth: AuthConfig{Type: "cookie", Cookies: []string{" ", "session_id"}}, want: true},
 		{name: "bearer with no cookies", auth: AuthConfig{Type: "bearer_token"}, want: false},
 		{name: "empty", auth: AuthConfig{}, want: false},
 	}


### PR DESCRIPTION
## Summary

Invalid auth declarations now fail during spec parsing instead of generating clients that silently omit cookies or interpolate unmapped credentials. Cookie and composed configs require concrete cookie names, and supported format strings must use valid placeholders backed by runtime env-var mappings. Browser sniffing preserves observed cookie names and declines to invent cookie auth when none were captured.

## Validation

- `go test ./internal/spec ./internal/browsersniff ./internal/generator ./internal/pipeline -count=1 -timeout 15m`
- affected `internal/cli` generation tests
- `scripts/golden.sh verify` (32 cases)
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...` (only an unchanged `internal/googlediscovery/parser.go` modernization warning remains)
- `go test ./...` (all non-CLI packages passed; `internal/cli` reached the repository's 10-minute package timeout, with affected paths passing separately)

Closes #3670
Closes #1339
