### PR TITLE
fix(cli): preserve deep hierarchy sync identity

### DIFF
--- a/internal/generator/deep_hierarchy_sync_test.go
+++ b/internal/generator/deep_hierarchy_sync_test.go
@@ -17,12 +17,13 @@ func TestGeneratedSyncPreservesDeepHierarchyIdentity(t *testing.T) {
 
 	apiSpec := deepHierarchySpec()
 	profile := profiler.Profile(apiSpec)
-	require.Len(t, profile.DependentSyncResources, 3)
+	require.Len(t, profile.DependentSyncResources, 4)
 
 	depsByPath := make(map[string]profiler.DependentResource, len(profile.DependentSyncResources))
 	for _, dep := range profile.DependentSyncResources {
 		depsByPath[dep.Path] = dep
 	}
+	assert.Equal(t, "account_assets", depsByPath["/accounts/{accountId}/things"].Name)
 	assert.Equal(t, []profiler.DependentPathParam{
 		{Param: "accountId", Field: "accounts_id"},
 		{Param: "containerId", Field: "id"},
@@ -79,6 +80,11 @@ func deepHierarchySpec() *spec.APISpec {
 			"accounts": {
 				Endpoints: map[string]spec.Endpoint{
 					"list": list("/accounts"),
+				},
+			},
+			"account_assets": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": list("/accounts/{accountId}/things", "accountId"),
 				},
 			},
 			"containers": {
@@ -141,6 +147,10 @@ func (c *deepHierarchyClient) Get(_ context.Context, path string, _ map[string]s
 		]` + "`" + `), nil
 	case "/flat-things":
 		return json.RawMessage(` + "`" + `[{"id":"flat-1","flatThingId":"flat-wrong","name":"Flat Thing"}]` + "`" + `), nil
+	case "/accounts/100/things":
+		return json.RawMessage(` + "`" + `[{"thingId":"thing-1","accountAssetId":"asset-wrong","name":"Account Thing"}]` + "`" + `), nil
+	case "/accounts/200/things":
+		return json.RawMessage(` + "`" + `[]` + "`" + `), nil
 	case "/accounts/100/containers":
 		return json.RawMessage(` + "`" + `[
 			{"accountId":"100","containerId":"c-1","name":"Web"},
@@ -202,9 +212,11 @@ func TestDeepHierarchySync(t *testing.T) {
 	assertResourceIDs(t, db, "flat_things", []string{"flat-1"})
 
 	defs := dependentResourceDefs()
-	var containersResource, customWorkspacesResource, tagsResource string
+	var accountAssetsResource, containersResource, customWorkspacesResource, tagsResource string
 	for _, def := range defs {
 		switch def.PathTemplate {
+		case "/accounts/{accountId}/things":
+			accountAssetsResource = def.Name
 		case "/accounts/{accountId}/containers":
 			containersResource = def.Name
 		case "/accounts/{accountId}/containers/{containerId}/custom-workspaces":
@@ -213,10 +225,11 @@ func TestDeepHierarchySync(t *testing.T) {
 			tagsResource = def.Name
 		}
 	}
-	if containersResource == "" || customWorkspacesResource == "" || tagsResource == "" {
+	if accountAssetsResource == "" || containersResource == "" || customWorkspacesResource == "" || tagsResource == "" {
 		t.Fatalf("missing generated dependent defs: %#v", defs)
 	}
 
+	assertResourceIDs(t, db, accountAssetsResource, []string{"thing-1\x00100"})
 	assertResourceIDs(t, db, containersResource, []string{
 		"c-1\x00100",
 		"c-1\x00200",

--- a/internal/generator/deep_hierarchy_sync_test.go
+++ b/internal/generator/deep_hierarchy_sync_test.go
@@ -1,0 +1,278 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedSyncPreservesDeepHierarchyIdentity(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := deepHierarchySpec()
+	profile := profiler.Profile(apiSpec)
+	require.Len(t, profile.DependentSyncResources, 3)
+
+	depsByPath := make(map[string]profiler.DependentResource, len(profile.DependentSyncResources))
+	for _, dep := range profile.DependentSyncResources {
+		depsByPath[dep.Path] = dep
+	}
+	assert.Equal(t, []profiler.DependentPathParam{
+		{Param: "accountId", Field: "accounts_id"},
+		{Param: "containerId", Field: "id"},
+	}, depsByPath["/accounts/{accountId}/containers/{containerId}/custom-workspaces"].PathParams)
+	assert.Equal(t, []profiler.DependentPathParam{
+		{Param: "accountId", Field: "accounts_id"},
+		{Param: "containerId", Field: "containers_id"},
+		{Param: "customWorkspaceId", Field: "id"},
+	}, depsByPath["/accounts/{accountId}/containers/{containerId}/custom-workspaces/{customWorkspaceId}/tags"].PathParams)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, Search: true, MCP: true}
+	gen.profile = profile
+	require.NoError(t, gen.Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "deep_hierarchy_sync_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(deepHierarchyGeneratedTest(apiSpec.Name)), 0o644))
+
+	runGoCommandRequired(t, outputDir, "mod", "tidy")
+	runGoCommandRequired(t, outputDir, "test", "-run", "TestDeepHierarchySync", "./internal/cli")
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func deepHierarchySpec() *spec.APISpec {
+	list := func(path string, params ...string) spec.Endpoint {
+		endpoint := spec.Endpoint{
+			Method:     "GET",
+			Path:       path,
+			Response:   spec.ResponseDef{Type: "array"},
+			Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+		}
+		for _, param := range params {
+			endpoint.Params = append(endpoint.Params, spec.Param{
+				Name:       param,
+				Type:       "string",
+				Required:   true,
+				Positional: true,
+			})
+		}
+		return endpoint
+	}
+
+	return &spec.APISpec{
+		Name:    "deep-hierarchy",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/deep-hierarchy-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"accounts": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": list("/accounts"),
+				},
+			},
+			"containers": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": list("/accounts/{accountId}/containers", "accountId"),
+				},
+			},
+			"custom_workspaces": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": list(
+						"/accounts/{accountId}/containers/{containerId}/custom-workspaces",
+						"accountId", "containerId",
+					),
+				},
+			},
+			"tags": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": list(
+						"/accounts/{accountId}/containers/{containerId}/custom-workspaces/{customWorkspaceId}/tags",
+						"accountId", "containerId", "customWorkspaceId",
+					),
+				},
+			},
+			"flat_things": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": list("/flat-things"),
+				},
+			},
+		},
+	}
+}
+
+func deepHierarchyGeneratedTest(moduleName string) string {
+	return `package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"` + naming.CLI(moduleName) + `/internal/store"
+)
+
+type deepHierarchyClient struct {
+	paths []string
+}
+
+func (c *deepHierarchyClient) Get(_ context.Context, path string, _ map[string]string) (json.RawMessage, error) {
+	c.paths = append(c.paths, path)
+	switch path {
+	case "/accounts":
+		return json.RawMessage(` + "`" + `[
+			{"accountId":"100","name":"Primary Account"},
+			{"accountId":"200","name":"Secondary Account"}
+		]` + "`" + `), nil
+	case "/flat-things":
+		return json.RawMessage(` + "`" + `[{"id":"flat-1","flatThingId":"flat-wrong","name":"Flat Thing"}]` + "`" + `), nil
+	case "/accounts/100/containers":
+		return json.RawMessage(` + "`" + `[
+			{"accountId":"100","containerId":"c-1","name":"Web"},
+			{"accountId":"100","containerId":"c-2","name":"Server"}
+		]` + "`" + `), nil
+	case "/accounts/200/containers":
+		return json.RawMessage(` + "`" + `[{"accountId":"200","containerId":"c-1","name":"Web"}]` + "`" + `), nil
+	case "/accounts/100/containers/c-1/custom-workspaces":
+		return json.RawMessage(` + "`" + `[
+			{"accountId":"100","containerId":"c-1","customWorkspaceId":"cw-1","name":"Default Workspace"},
+			{"accountId":"100","containerId":"c-1","customWorkspaceId":"cw-2","name":"Preview Workspace"}
+		]` + "`" + `), nil
+	case "/accounts/100/containers/c-2/custom-workspaces":
+		return json.RawMessage(` + "`" + `[{"accountId":"100","containerId":"c-2","customWorkspaceId":"cw-1","name":"Default Workspace"}]` + "`" + `), nil
+	case "/accounts/200/containers/c-1/custom-workspaces":
+		return json.RawMessage(` + "`" + `[]` + "`" + `), nil
+	case "/accounts/100/containers/c-1/custom-workspaces/cw-1/tags":
+		return json.RawMessage(` + "`" + `[{"accountId":"100","containerId":"c-1","customWorkspaceId":"cw-1","tagId":"t-1","name":"Purchase"}]` + "`" + `), nil
+	case "/accounts/100/containers/c-1/custom-workspaces/cw-2/tags":
+		return json.RawMessage(` + "`" + `[{"accountId":"100","containerId":"c-1","customWorkspaceId":"cw-2","tagId":"t-1","name":"Purchase"}]` + "`" + `), nil
+	case "/accounts/100/containers/c-2/custom-workspaces/cw-1/tags":
+		return json.RawMessage(` + "`" + `[]` + "`" + `), nil
+	default:
+		return nil, fmt.Errorf("unexpected sync path %q", path)
+	}
+}
+
+func (*deepHierarchyClient) RateLimit() float64 {
+	return 0
+}
+
+func TestDeepHierarchySync(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	client := &deepHierarchyClient{}
+	var events bytes.Buffer
+	for _, resource := range []string{"accounts", "flat_things"} {
+		result := syncResource(context.Background(), client, db, resource, "", false, 1, false, false, nil, &events)
+		if result.Err != nil {
+			t.Fatalf("sync %s: %v", resource, result.Err)
+		}
+	}
+
+	results := syncDependentResources(
+		context.Background(), client, db, "", false, 1, false, false,
+		nil, nil, &events, 1,
+	)
+	for _, result := range results {
+		if result.Err != nil {
+			t.Fatalf("sync dependent %s: %v", result.Resource, result.Err)
+		}
+	}
+
+	assertResourceIDs(t, db, "accounts", []string{"100", "200"})
+	assertResourceIDs(t, db, "flat_things", []string{"flat-1"})
+
+	defs := dependentResourceDefs()
+	var containersResource, customWorkspacesResource, tagsResource string
+	for _, def := range defs {
+		switch def.PathTemplate {
+		case "/accounts/{accountId}/containers":
+			containersResource = def.Name
+		case "/accounts/{accountId}/containers/{containerId}/custom-workspaces":
+			customWorkspacesResource = def.Name
+		case "/accounts/{accountId}/containers/{containerId}/custom-workspaces/{customWorkspaceId}/tags":
+			tagsResource = def.Name
+		}
+	}
+	if containersResource == "" || customWorkspacesResource == "" || tagsResource == "" {
+		t.Fatalf("missing generated dependent defs: %#v", defs)
+	}
+
+	assertResourceIDs(t, db, containersResource, []string{
+		"c-1\x00100",
+		"c-1\x00200",
+		"c-2\x00100",
+	})
+	assertResourceIDs(t, db, customWorkspacesResource, []string{
+		"cw-1\x00c-1\x00100",
+		"cw-1\x00c-2\x00100",
+		"cw-2\x00c-1\x00100",
+	})
+	assertResourceIDs(t, db, tagsResource, []string{
+		"t-1\x00cw-1\x00c-1\x00100",
+		"t-1\x00cw-2\x00c-1\x00100",
+	})
+
+	for _, path := range client.paths {
+		if strings.Contains(path, "Account") || strings.Contains(path, "Default") {
+			t.Fatalf("dependent path used display name as identity: %q", path)
+		}
+	}
+}
+
+func assertResourceIDs(t *testing.T, db *store.Store, resource string, want []string) {
+	t.Helper()
+	rows, err := db.DB().Query(` + "`" + `SELECT id FROM resources WHERE resource_type = ? ORDER BY id` + "`" + `, resource)
+	if err != nil {
+		t.Fatalf("query %s ids: %v", resource, err)
+	}
+	defer rows.Close()
+
+	var got []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan %s id: %v", resource, err)
+		}
+		got = append(got, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate %s ids: %v", resource, err)
+	}
+	sort.Strings(want)
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("%s ids = %v, want %v", resource, got, want)
+	}
+}
+
+func assertResourceCount(t *testing.T, db *store.Store, resource string, want int) {
+	t.Helper()
+	var got int
+	if err := db.DB().QueryRow(` + "`" + `SELECT COUNT(*) FROM resources WHERE resource_type = ?` + "`" + `, resource).Scan(&got); err != nil {
+		t.Fatalf("count %s: %v", resource, err)
+	}
+	if got != want {
+		t.Fatalf("%s count = %d, want %d", resource, got, want)
+	}
+}
+`
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -465,6 +465,8 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"substackPublicationIDTemplatePath":        substackPublicationIDTemplatePath,
 		"safeName":                                 safeSQLName,
 		"resourceIDFieldOverrideEntries":           resourceIDFieldOverrideEntries,
+		"resourceIDBaseOverrideEntries":            resourceIDBaseOverrideEntries,
+		"resourceParentKeyColumnEntries":           resourceParentKeyColumnEntries,
 		"criticalResourceEntries":                  criticalResourceEntries,
 		"isBackfillColumn":                         isStoreBackfillColumn,
 		"hasBackfillColumns":                       hasStoreBackfillColumns,
@@ -3911,6 +3913,11 @@ type resourceIDFieldOverrideEntry struct {
 	Value string
 }
 
+type resourceParentKeyColumnEntry struct {
+	Name   string
+	Values []string
+}
+
 type criticalResourceEntry struct {
 	Name string
 }
@@ -4034,6 +4041,85 @@ func resourceIDFieldOverrideEntries(syncable []profiler.SyncableResource, depend
 		entries[i] = resourceIDFieldOverrideEntry{Name: name, Value: overrides[name]}
 	}
 	return entries
+}
+
+func resourceParentKeyColumnEntries(tables []TableDef, dependent []profiler.DependentResource) []resourceParentKeyColumnEntry {
+	columns := make(map[string][]string)
+	add := func(resource, column string, first bool) {
+		if resource == "" || column == "" {
+			return
+		}
+		values := columns[resource]
+		for _, existing := range values {
+			if existing == column {
+				return
+			}
+		}
+		if first {
+			columns[resource] = append([]string{column}, values...)
+			return
+		}
+		columns[resource] = append(values, column)
+	}
+	for _, table := range tables {
+		if table.ParentKeyColumn != "" {
+			add(table.Resource, table.ParentKeyColumn, false)
+		}
+	}
+	for _, resource := range dependent {
+		add(resource.Name, "parent_id", true)
+	}
+
+	names := make([]string, 0, len(columns))
+	for name := range columns {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	entries := make([]resourceParentKeyColumnEntry, 0, len(names))
+	for _, name := range names {
+		entries = append(entries, resourceParentKeyColumnEntry{
+			Name:   name,
+			Values: columns[name],
+		})
+	}
+	return entries
+}
+
+func resourceIDBaseOverrideEntries(dependent []profiler.DependentResource) []resourceIDFieldOverrideEntry {
+	overrides := make(map[string]string)
+	for _, resource := range dependent {
+		if leaf := dependentResourcePathLeaf(resource.Path); leaf != "" {
+			overrides[resource.Name] = leaf
+		}
+	}
+
+	names := make([]string, 0, len(overrides))
+	for name := range overrides {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	entries := make([]resourceIDFieldOverrideEntry, len(names))
+	for i, name := range names {
+		entries[i] = resourceIDFieldOverrideEntry{Name: name, Value: overrides[name]}
+	}
+	return entries
+}
+
+func dependentResourcePathLeaf(path string) string {
+	if before, _, ok := strings.Cut(path, "?"); ok {
+		path = before
+	}
+	segments := strings.Split(strings.Trim(path, "/"), "/")
+	for i := len(segments) - 1; i >= 0; i-- {
+		segment := strings.TrimSpace(segments[i])
+		if segment == "" || (strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}")) {
+			continue
+		}
+		return spec.ToSnakeCase(segment)
+	}
+	return ""
 }
 
 func htmlPageModeResourceEntries(api *spec.APISpec, syncable []profiler.SyncableResource, dependent []profiler.DependentResource) []criticalResourceEntry {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -4050,10 +4050,8 @@ func resourceParentKeyColumnEntries(tables []TableDef, dependent []profiler.Depe
 			return
 		}
 		values := columns[resource]
-		for _, existing := range values {
-			if existing == column {
-				return
-			}
+		if slices.Contains(values, column) {
+			return
 		}
 		if first {
 			columns[resource] = append([]string{column}, values...)
@@ -4112,8 +4110,8 @@ func dependentResourcePathLeaf(path string) string {
 		path = before
 	}
 	segments := strings.Split(strings.Trim(path, "/"), "/")
-	for i := len(segments) - 1; i >= 0; i-- {
-		segment := strings.TrimSpace(segments[i])
+	for _, segment := range slices.Backward(segments) {
+		segment = strings.TrimSpace(segment)
 		if segment == "" || (strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}")) {
 			continue
 		}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -5967,6 +5967,7 @@ func TestGenerateDependentSyncInjectsSubResourceParentFK(t *testing.T) {
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -6032,8 +6033,46 @@ func TestSyncDependentResourcePopulatesTypedParentFK(t *testing.T) {
 	if got["contact-injected\x00list-A"] != "list-A" {
 		t.Fatalf("injected contact lists_id = %q, want list-A", got["contact-injected\x00list-A"])
 	}
-	if got["contact-preserved\x00api-list"] != "api-list" {
-		t.Fatalf("preserved contact lists_id = %q, want api-list", got["contact-preserved\x00api-list"])
+	if got["contact-preserved\x00list-A"] != "api-list" {
+		t.Fatalf("preserved contact lists_id = %q, want api-list", got["contact-preserved\x00list-A"])
+	}
+}
+
+func TestStoreFallsBackToTypedParentKey(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	items := []json.RawMessage{
+		json.RawMessage(` + "`" + `{"id":"contact-shared","lists_id":"list-A","email":"a@example.test"}` + "`" + `),
+		json.RawMessage(` + "`" + `{"id":"contact-shared","lists_id":"list-B","email":"b@example.test"}` + "`" + `),
+	}
+	if _, _, err := db.UpsertBatch("contacts", items); err != nil {
+		t.Fatalf("upsert raw contacts: %v", err)
+	}
+
+	rows, err := db.DB().Query(` + "`" + `SELECT id FROM resources WHERE resource_type = 'contacts' ORDER BY id` + "`" + `)
+	if err != nil {
+		t.Fatalf("query contact ids: %v", err)
+	}
+	defer rows.Close()
+
+	var got []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan contact id: %v", err)
+		}
+		got = append(got, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate contact ids: %v", err)
+	}
+	want := []string{"contact-shared\x00list-A", "contact-shared\x00list-B"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("contact ids = %v, want %v", got, want)
 	}
 }
 `
@@ -6041,7 +6080,7 @@ func TestSyncDependentResourcePopulatesTypedParentFK(t *testing.T) {
 	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "mod", "tidy")
-	runGoCommandRequired(t, outputDir, "test", "-run", "TestSyncDependentResourcePopulatesTypedParentFK", "./internal/cli")
+	runGoCommandRequired(t, outputDir, "test", "-run", "Test(SyncDependentResourcePopulatesTypedParentFK|StoreFallsBackToTypedParentKey)", "./internal/cli")
 }
 
 func TestSyncDependentResourceSubstitutesChainedPathParams(t *testing.T) {
@@ -6190,8 +6229,8 @@ func TestSyncDependentResourceSubstitutesChainedPathParams(t *testing.T) {
 	if err := rows.Scan(&id, &messagesID, &channelsID); err != nil {
 		t.Fatalf("scan reaction: %v", err)
 	}
-	if id != "react-1" || messagesID != "msg-1" || channelsID != "chan-1" {
-		t.Fatalf("row = (%q, %q, %q), want (react-1, msg-1, chan-1)", id, messagesID, channelsID)
+	if id != "react-1\x00msg-1" || messagesID != "msg-1" || channelsID != "chan-1" {
+		t.Fatalf("row = (%q, %q, %q), want (react-1\\x00msg-1, msg-1, chan-1)", id, messagesID, channelsID)
 	}
 }
 `
@@ -15211,14 +15250,17 @@ func TestGeneratedSyncIDFieldOverridesAndProbes(t *testing.T) {
 		`"events": "event_id",`,
 		"store.go resourceIDFieldOverrides must include events: event_id")
 
-	// (b) Generic fallback list reduced — kalshi-specific names dropped.
+	// (b) Generic fallback lists reduced — kalshi-specific names dropped.
 	// The user owns the kalshi CLI and will regenerate with x-resource-id
 	// annotations; no other public-library CLIs depend on these names.
-	// Vendor identifiers (gid, sid, uid, uuid, guid) precede `name` so
-	// APIs like Asana don't fall through to a display field — see #1394.
+	// Vendor identifiers (gid, sid, uid, uuid, guid) and resource-specific
+	// suffixes precede descriptive fields so APIs do not key rows by names.
 	assert.Contains(t, storeContent,
-		`var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}`,
-		"store.go genericIDFieldFallbacks must include vendor identifiers before name")
+		`var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id"}`,
+		"store.go genericIDFieldFallbacks must include stable vendor identifiers")
+	assert.Contains(t, storeContent,
+		`var genericDescriptiveIDFieldFallbacks = []string{"name", "slug", "key", "code"}`,
+		"store.go must keep descriptive fallbacks separate from stable identifiers")
 	// Negative: kalshi-specific names must not be in the fallback list.
 	// We assert a robust shape: no occurrence of "ticker" inside the fallback
 	// declaration. The generic check below also pins the absence at a

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -12549,7 +12549,7 @@ func TestGenerateReservedStoreTableCollisionUsesGenericStore(t *testing.T) {
 		"learn table names must stay reserved while learn is disabled")
 	assert.NotContains(t, store, "func (s *Store) upsertCollisionAPIStreamFramesTx(",
 		"stream table names must stay reserved while streaming is disabled")
-	assert.Regexp(t, `"resources":\s+"parent_id"`, store)
+	assert.Regexp(t, `"resources":\s*\{\s*"parent_id"`, store)
 	assert.NotContains(t, store, `CREATE TABLE IF NOT EXISTS "resources" (
 		id TEXT PRIMARY KEY,
 		data TEXT NOT NULL,

--- a/internal/generator/sync_store_template_fixes_test.go
+++ b/internal/generator/sync_store_template_fixes_test.go
@@ -97,8 +97,8 @@ import (
 
 func TestCurrencyCodeSuffixExtractsResourceID(t *testing.T) {
 	obj := map[string]any{"currency_code": "USD", "name": "US Dollar"}
-	if got := ExtractResourceID("currencies", obj); got != "US Dollar" {
-		t.Fatalf("exact fallback should still prefer name before suffix scan, got %q", got)
+	if got := ExtractResourceID("currencies", obj); got != "USD" {
+		t.Fatalf("resource-specific id must win over display name, got %q", got)
 	}
 
 	obj = map[string]any{"currency_code": "USD", "symbol": "$"}

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1480,23 +1480,28 @@ var resourceIDFieldOverrides = map[string]string{
 {{- end}}
 }
 
-// genericIDFieldFallbacks is the runtime safety net for resources that did
-// NOT receive a templated IDField. API-specific names belong in spec
-// annotations (x-resource-id), not this list. Order matters: vendor
-// identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
-// so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
-// field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
+// Generic ID fields are split around the resource-specific suffix probe.
+// Stable vendor identifiers win first; then fields derived from the resource
+// name (accountId, workspaceId); descriptive fallbacks are last. Keeping name
+// ahead of the resource-specific probe silently keys rows by display labels.
+var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id"}
+var genericDescriptiveIDFieldFallbacks = []string{"name", "slug", "key", "code"}
+
+// resourceIDBaseOverrides preserves the complete final collection name for
+// composed dependents whose child segment is itself multiword.
+var resourceIDBaseOverrides = map[string]string{
+{{- range resourceIDBaseOverrideEntries .DependentSyncResources}}
+	{{printf "%q" .Name}}: {{printf "%q" .Value}},
+{{- end}}
+}
 
 // resourceParentKeyColumns identifies generated dependent resources whose
 // local mirror rows need the parent context in the storage key. Without this,
 // many-to-many sub-collections collapse every parent association onto the
 // child's bare id and silently keep only the last synced parent.
-var resourceParentKeyColumns = map[string]string{
-{{- range .Tables}}
-{{- if .ParentKeyColumn}}
-	{{printf "%q" .Resource}}: {{printf "%q" .ParentKeyColumn}},
-{{- end}}
+var resourceParentKeyColumns = map[string][]string{
+{{- range resourceParentKeyColumnEntries .Tables .DependentSyncResources}}
+	{{printf "%q" .Name}}: { {{- range .Values}}{{printf "%q" .}}, {{- end}}},
 {{- end}}
 }
 
@@ -1525,6 +1530,14 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 	}
 	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
 		return s
+	}
+	for _, key := range genericDescriptiveIDFieldFallbacks {
+		if v := lookupFieldValue(obj, key); v != nil {
+			s := ResourceIDString(v)
+			if s != "" && s != "<nil>" {
+				return s
+			}
+		}
 	}
 	return ""
 }
@@ -1558,18 +1571,32 @@ func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 
 // resourceIDBaseNames returns lowercase candidate singular/plural stems of a
 // resource name to build "<base>_id"-style key probes from (e.g. "currencies"
-// -> ["currencies","currency"]). OpenAPI-/path-derived names can carry a
-// leading verb token ("get-currencies"), so the same probes are also attempted
-// on the de-verbed stem. Minimal English depluralization; the raw name is
-// always included so already-singular names work too.
+// -> ["currencies","currency"]). Composed dependent names also probe their
+// final segment ("containers_workspaces" -> "workspaces","workspace"), which
+// is the child entity's own ID convention. OpenAPI-/path-derived names can
+// carry a leading verb token ("get-currencies"), so the same probes are also
+// attempted on the de-verbed stem.
 func resourceIDBaseNames(resourceType string) []string {
 	r := strings.ToLower(strings.TrimSpace(resourceType))
 	if r == "" {
 		return nil
 	}
-	stems := []string{r}
+	var stems []string
+	addStem := func(stem string) {
+		if stem == "" {
+			return
+		}
+		for _, existing := range stems {
+			if existing == stem {
+				return
+			}
+		}
+		stems = append(stems, stem)
+	}
+	addStem(resourceIDBaseOverrides[r])
+	addStem(r)
 	if d := stripLeadingResourceVerb(r); d != "" && d != r {
-		stems = append(stems, d)
+		addStem(d)
 	}
 	var bases []string
 	seen := map[string]bool{}
@@ -1582,6 +1609,11 @@ func resourceIDBaseNames(resourceType string) []string {
 	for _, stem := range stems {
 		add(stem)
 		add(depluralizeResourceStem(stem))
+		if i := strings.LastIndexAny(stem, "_-"); i >= 0 && i+1 < len(stem) {
+			leaf := stem[i+1:]
+			add(leaf)
+			add(depluralizeResourceStem(leaf))
+		}
 	}
 	return bases
 }
@@ -1648,15 +1680,13 @@ func scalarIDString(value any) string {
 }
 
 func resourceStorageID(resourceType, id string, obj map[string]any) string {
-	parentKey := resourceParentKeyColumns[resourceType]
-	if parentKey == "" {
-		return id
+	for _, parentKey := range resourceParentKeyColumns[resourceType] {
+		parentValue := ResourceIDString(lookupFieldValue(obj, parentKey))
+		if parentValue != "" && parentValue != "<nil>" {
+			return id + string([]byte{0}) + parentValue
+		}
 	}
-	parentValue := ResourceIDString(lookupFieldValue(obj, parentKey))
-	if parentValue == "" || parentValue == "<nil>" {
-		return id
-	}
-	return id + string([]byte{0}) + parentValue
+	return id
 }
 
 // BareResourceID strips the NUL-delimited parent suffix that resourceStorageID

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -2441,7 +2441,7 @@ func upsertSingleObject(db *store.Store, resource string, data json.RawMessage) 
 		id, _ = resourceIDFieldOverrideID(resource, obj)
 {{- end}}
 		if id == "" {
-			id = extractIDFallback(resource, obj)
+			id = store.ExtractResourceID(resource, obj)
 {{- if $hasDomainTable}}
 			forceTypedID = id != ""
 {{- end}}
@@ -3733,14 +3733,6 @@ const (
 )
 {{- end}}
 
-// genericIDFieldFallbacks is the runtime safety net for resources that did
-// NOT receive a templated IDField. API-specific names belong in spec
-// annotations (x-resource-id), not this list. Order matters: vendor
-// identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
-// so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
-// field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
-
 // pageItemKeys is scanned in priority order; lowercase REST-convention keys
 // come first, PascalCase .NET variants second. Without the PascalCase row,
 // {"Items": [...]} envelopes fall through to the ambiguity scan and a
@@ -3818,58 +3810,30 @@ var criticalResources = map[string]bool{
 {{- end}}
 }
 
-// extractID resolves an item's primary-key field. It consults the
-// per-resource templated override first; on miss, it falls through to the
-// generic fallback list. resource may be empty for callers that don't have
-// a resource context (only the generic list applies in that case).
-//
-// Field lookups go through store.LookupFieldValue so snake_case overrides
-// match camelCase JSON renderings. UpsertBatch resolves fields the same
-// way — divergence between the two paths produces silent drops on
-// heterogeneous payloads.
+// extractID delegates the shared identity contract to the store so sync paths
+// and UpsertBatch cannot select different fields from the same payload.
 func extractID(resource string, obj map[string]any) string {
 {{- if $hasHTMLPageModeSync}}
 	if s, ok := resourceIDFieldOverrideID(resource, obj); ok {
 		return s
 	}
-	return extractIDFallback(resource, obj)
+{{- end}}
+	return store.ExtractResourceID(resource, obj)
 }
 
+{{- if $hasHTMLPageModeSync}}
 func resourceIDFieldOverrideID(resource string, obj map[string]any) (string, bool) {
-{{- end}}
 	if override, ok := resourceIDFieldOverrides[resource]; ok && override != "" {
 		if v := store.LookupFieldValue(obj, override); v != nil {
 			s := store.ResourceIDString(v)
 			if s != "" && s != "<nil>" {
-{{- if $hasHTMLPageModeSync}}
 				return s, true
-{{- else}}
-				return s
-{{- end}}
 			}
 		}
 	}
-{{- if $hasHTMLPageModeSync}}
 	return "", false
 }
 
-func extractIDFallback(resource string, obj map[string]any) string {
-{{- end}}
-	for _, key := range genericIDFieldFallbacks {
-		if v := store.LookupFieldValue(obj, key); v != nil {
-			s := store.ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
-		}
-	}
-	if s := suffixIDFieldFallback(resource, obj); s != "" {
-		return s
-	}
-	return ""
-}
-
-{{- if $hasHTMLPageModeSync}}
 
 func synthesizeHTMLPageModeID(resource string, obj map[string]any) string {
 	if !htmlPageModeResources[resource] {
@@ -3902,124 +3866,6 @@ func objectWithSyntheticID(obj map[string]any, id string) (json.RawMessage, erro
 	return json.Marshal(withID)
 }
 {{- end}}
-
-// suffixIDFieldFallback resolves an id-less resource that keys on its own
-// "<name>_code" / "<name>_id" / "<name>_key" / "<name>_slug" field (e.g. the
-// "currencies" resource keying on "currency_code" — see #2327). It is scoped to
-// the resource's OWN name so a foreign key like account_id/parent_id is never
-// promoted to the primary key, and it uses direct map lookups in a fixed suffix
-// order so the chosen id is deterministic.
-func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
-	for _, base := range resourceIDBaseNames(resourceType) {
-		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
-			if v, ok := obj[base+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
-			}
-		}
-		camelBase := lowerCamelResourceIDBase(base)
-		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
-			if v, ok := obj[camelBase+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
-			}
-		}
-	}
-	return ""
-}
-
-// resourceIDBaseNames returns lowercase candidate singular/plural stems of a
-// resource name to build "<base>_id"-style key probes from (e.g. "currencies"
-// -> ["currencies","currency"]). OpenAPI-/path-derived names can carry a
-// leading verb token ("get-currencies"), so the same probes are also attempted
-// on the de-verbed stem. Minimal English depluralization; the raw name is
-// always included so already-singular names work too.
-func resourceIDBaseNames(resourceType string) []string {
-	r := strings.ToLower(strings.TrimSpace(resourceType))
-	if r == "" {
-		return nil
-	}
-	stems := []string{r}
-	if d := stripLeadingResourceVerb(r); d != "" && d != r {
-		stems = append(stems, d)
-	}
-	var bases []string
-	seen := map[string]bool{}
-	add := func(s string) {
-		if s != "" && !seen[s] {
-			seen[s] = true
-			bases = append(bases, s)
-		}
-	}
-	for _, stem := range stems {
-		add(stem)
-		add(depluralizeResourceStem(stem))
-	}
-	return bases
-}
-
-func stripLeadingResourceVerb(r string) string {
-	for _, verb := range []string{"get", "list", "fetch", "find", "retrieve", "read", "show", "all"} {
-		for _, sep := range []string{"-", "_"} {
-			prefix := verb + sep
-			if strings.HasPrefix(r, prefix) && len(r) > len(prefix) {
-				return r[len(prefix):]
-			}
-		}
-	}
-	return ""
-}
-
-func depluralizeResourceStem(r string) string {
-	switch {
-	case strings.HasSuffix(r, "ies") && len(r) > 3:
-		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
-	// Plurals formed by adding "es" to a base ending in s/x/z/ch/sh. The
-	// double-s "sses" guard (not bare "ses") keeps soft-e plurals — where the
-	// singular already ends in a silent "e" (cases, databases, licenses,
-	// purchases) — out of this branch; they fall through to the "-s" case below
-	// (cases -> case, not cas). Trade-off: a genuine "-es" plural of an s-ending
-	// singular (buses, statuses) depluralizes imperfectly, but those are rare as
-	// resource names and this stem only feeds best-effort id-field probing.
-	case strings.HasSuffix(r, "sses") || strings.HasSuffix(r, "xes") ||
-		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
-		strings.HasSuffix(r, "shes"):
-		return strings.TrimSuffix(r, "es") // classes -> class, boxes -> box, dishes -> dish
-	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
-		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
-	}
-	return r
-}
-
-func lowerCamelResourceIDBase(base string) string {
-	parts := strings.FieldsFunc(base, func(r rune) bool {
-		return r == '_' || r == '-'
-	})
-	if len(parts) == 0 {
-		return base
-	}
-	for i := range parts {
-		if i == 0 {
-			parts[i] = strings.ToLower(parts[i])
-			continue
-		}
-		parts[i] = strings.ToUpper(parts[i][:1]) + strings.ToLower(parts[i][1:])
-	}
-	return strings.Join(parts, "")
-}
-
-func scalarIDString(value any) string {
-	switch value.(type) {
-	case string, bool, int, int8, int16, int32, int64,
-		uint, uint8, uint16, uint32, uint64,
-		float32, float64, json.Number, []byte:
-		return store.ResourceIDString(value)
-	default:
-		return ""
-	}
-}
 
 {{- if .Learn.Enabled}}
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -2581,14 +2581,6 @@ var resolveTenantID = func() string { return "" }
 // fan-out. Empty when no parent is annotated.
 var parentTenantScopeColumns = map[string]string{}
 
-// genericIDFieldFallbacks is the runtime safety net for resources that did
-// NOT receive a templated IDField. API-specific names belong in spec
-// annotations (x-resource-id), not this list. Order matters: vendor
-// identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
-// so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
-// field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
-
 // pageItemKeys is scanned in priority order; lowercase REST-convention keys
 // come first, PascalCase .NET variants second. Without the PascalCase row,
 // {"Items": [...]} envelopes fall through to the ambiguity scan and a
@@ -2655,154 +2647,10 @@ var criticalResources = map[string]bool{
 	"projects": true,
 }
 
-// extractID resolves an item's primary-key field. It consults the
-// per-resource templated override first; on miss, it falls through to the
-// generic fallback list. resource may be empty for callers that don't have
-// a resource context (only the generic list applies in that case).
-//
-// Field lookups go through store.LookupFieldValue so snake_case overrides
-// match camelCase JSON renderings. UpsertBatch resolves fields the same
-// way — divergence between the two paths produces silent drops on
-// heterogeneous payloads.
+// extractID delegates the shared identity contract to the store so sync paths
+// and UpsertBatch cannot select different fields from the same payload.
 func extractID(resource string, obj map[string]any) string {
-	if override, ok := resourceIDFieldOverrides[resource]; ok && override != "" {
-		if v := store.LookupFieldValue(obj, override); v != nil {
-			s := store.ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
-		}
-	}
-	for _, key := range genericIDFieldFallbacks {
-		if v := store.LookupFieldValue(obj, key); v != nil {
-			s := store.ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
-		}
-	}
-	if s := suffixIDFieldFallback(resource, obj); s != "" {
-		return s
-	}
-	return ""
-}
-
-// suffixIDFieldFallback resolves an id-less resource that keys on its own
-// "<name>_code" / "<name>_id" / "<name>_key" / "<name>_slug" field (e.g. the
-// "currencies" resource keying on "currency_code" — see #2327). It is scoped to
-// the resource's OWN name so a foreign key like account_id/parent_id is never
-// promoted to the primary key, and it uses direct map lookups in a fixed suffix
-// order so the chosen id is deterministic.
-func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
-	for _, base := range resourceIDBaseNames(resourceType) {
-		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
-			if v, ok := obj[base+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
-			}
-		}
-		camelBase := lowerCamelResourceIDBase(base)
-		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
-			if v, ok := obj[camelBase+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
-			}
-		}
-	}
-	return ""
-}
-
-// resourceIDBaseNames returns lowercase candidate singular/plural stems of a
-// resource name to build "<base>_id"-style key probes from (e.g. "currencies"
-// -> ["currencies","currency"]). OpenAPI-/path-derived names can carry a
-// leading verb token ("get-currencies"), so the same probes are also attempted
-// on the de-verbed stem. Minimal English depluralization; the raw name is
-// always included so already-singular names work too.
-func resourceIDBaseNames(resourceType string) []string {
-	r := strings.ToLower(strings.TrimSpace(resourceType))
-	if r == "" {
-		return nil
-	}
-	stems := []string{r}
-	if d := stripLeadingResourceVerb(r); d != "" && d != r {
-		stems = append(stems, d)
-	}
-	var bases []string
-	seen := map[string]bool{}
-	add := func(s string) {
-		if s != "" && !seen[s] {
-			seen[s] = true
-			bases = append(bases, s)
-		}
-	}
-	for _, stem := range stems {
-		add(stem)
-		add(depluralizeResourceStem(stem))
-	}
-	return bases
-}
-
-func stripLeadingResourceVerb(r string) string {
-	for _, verb := range []string{"get", "list", "fetch", "find", "retrieve", "read", "show", "all"} {
-		for _, sep := range []string{"-", "_"} {
-			prefix := verb + sep
-			if strings.HasPrefix(r, prefix) && len(r) > len(prefix) {
-				return r[len(prefix):]
-			}
-		}
-	}
-	return ""
-}
-
-func depluralizeResourceStem(r string) string {
-	switch {
-	case strings.HasSuffix(r, "ies") && len(r) > 3:
-		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
-	// Plurals formed by adding "es" to a base ending in s/x/z/ch/sh. The
-	// double-s "sses" guard (not bare "ses") keeps soft-e plurals — where the
-	// singular already ends in a silent "e" (cases, databases, licenses,
-	// purchases) — out of this branch; they fall through to the "-s" case below
-	// (cases -> case, not cas). Trade-off: a genuine "-es" plural of an s-ending
-	// singular (buses, statuses) depluralizes imperfectly, but those are rare as
-	// resource names and this stem only feeds best-effort id-field probing.
-	case strings.HasSuffix(r, "sses") || strings.HasSuffix(r, "xes") ||
-		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
-		strings.HasSuffix(r, "shes"):
-		return strings.TrimSuffix(r, "es") // classes -> class, boxes -> box, dishes -> dish
-	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
-		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
-	}
-	return r
-}
-
-func lowerCamelResourceIDBase(base string) string {
-	parts := strings.FieldsFunc(base, func(r rune) bool {
-		return r == '_' || r == '-'
-	})
-	if len(parts) == 0 {
-		return base
-	}
-	for i := range parts {
-		if i == 0 {
-			parts[i] = strings.ToLower(parts[i])
-			continue
-		}
-		parts[i] = strings.ToUpper(parts[i][:1]) + strings.ToLower(parts[i][1:])
-	}
-	return strings.Join(parts, "")
-}
-
-func scalarIDString(value any) string {
-	switch value.(type) {
-	case string, bool, int, int8, int16, int32, int64,
-		uint, uint8, uint16, uint32, uint64,
-		float32, float64, json.Number, []byte:
-		return store.ResourceIDString(value)
-	default:
-		return ""
-	}
+	return store.ExtractResourceID(resource, obj)
 }
 
 // lookupRefreshEntityFields names the generic identity-bearing JSON

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -1120,19 +1120,22 @@ var resourceIDFieldOverrides = map[string]string{
 	"games": "game_key",
 }
 
-// genericIDFieldFallbacks is the runtime safety net for resources that did
-// NOT receive a templated IDField. API-specific names belong in spec
-// annotations (x-resource-id), not this list. Order matters: vendor
-// identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
-// so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
-// field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
+// Generic ID fields are split around the resource-specific suffix probe.
+// Stable vendor identifiers win first; then fields derived from the resource
+// name (accountId, workspaceId); descriptive fallbacks are last. Keeping name
+// ahead of the resource-specific probe silently keys rows by display labels.
+var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id"}
+var genericDescriptiveIDFieldFallbacks = []string{"name", "slug", "key", "code"}
+
+// resourceIDBaseOverrides preserves the complete final collection name for
+// composed dependents whose child segment is itself multiword.
+var resourceIDBaseOverrides = map[string]string{}
 
 // resourceParentKeyColumns identifies generated dependent resources whose
 // local mirror rows need the parent context in the storage key. Without this,
 // many-to-many sub-collections collapse every parent association onto the
 // child's bare id and silently keep only the last synced parent.
-var resourceParentKeyColumns = map[string]string{}
+var resourceParentKeyColumns = map[string][]string{}
 
 // ExtractResourceID resolves the bare resource id field that UpsertBatch
 // extracts from a resource item. For dependent resource types, UpsertBatch
@@ -1159,6 +1162,14 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 	}
 	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
 		return s
+	}
+	for _, key := range genericDescriptiveIDFieldFallbacks {
+		if v := lookupFieldValue(obj, key); v != nil {
+			s := ResourceIDString(v)
+			if s != "" && s != "<nil>" {
+				return s
+			}
+		}
 	}
 	return ""
 }
@@ -1192,18 +1203,32 @@ func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 
 // resourceIDBaseNames returns lowercase candidate singular/plural stems of a
 // resource name to build "<base>_id"-style key probes from (e.g. "currencies"
-// -> ["currencies","currency"]). OpenAPI-/path-derived names can carry a
-// leading verb token ("get-currencies"), so the same probes are also attempted
-// on the de-verbed stem. Minimal English depluralization; the raw name is
-// always included so already-singular names work too.
+// -> ["currencies","currency"]). Composed dependent names also probe their
+// final segment ("containers_workspaces" -> "workspaces","workspace"), which
+// is the child entity's own ID convention. OpenAPI-/path-derived names can
+// carry a leading verb token ("get-currencies"), so the same probes are also
+// attempted on the de-verbed stem.
 func resourceIDBaseNames(resourceType string) []string {
 	r := strings.ToLower(strings.TrimSpace(resourceType))
 	if r == "" {
 		return nil
 	}
-	stems := []string{r}
+	var stems []string
+	addStem := func(stem string) {
+		if stem == "" {
+			return
+		}
+		for _, existing := range stems {
+			if existing == stem {
+				return
+			}
+		}
+		stems = append(stems, stem)
+	}
+	addStem(resourceIDBaseOverrides[r])
+	addStem(r)
 	if d := stripLeadingResourceVerb(r); d != "" && d != r {
-		stems = append(stems, d)
+		addStem(d)
 	}
 	var bases []string
 	seen := map[string]bool{}
@@ -1216,6 +1241,11 @@ func resourceIDBaseNames(resourceType string) []string {
 	for _, stem := range stems {
 		add(stem)
 		add(depluralizeResourceStem(stem))
+		if i := strings.LastIndexAny(stem, "_-"); i >= 0 && i+1 < len(stem) {
+			leaf := stem[i+1:]
+			add(leaf)
+			add(depluralizeResourceStem(leaf))
+		}
 	}
 	return bases
 }
@@ -1282,15 +1312,13 @@ func scalarIDString(value any) string {
 }
 
 func resourceStorageID(resourceType, id string, obj map[string]any) string {
-	parentKey := resourceParentKeyColumns[resourceType]
-	if parentKey == "" {
-		return id
+	for _, parentKey := range resourceParentKeyColumns[resourceType] {
+		parentValue := ResourceIDString(lookupFieldValue(obj, parentKey))
+		if parentValue != "" && parentValue != "<nil>" {
+			return id + string([]byte{0}) + parentValue
+		}
 	}
-	parentValue := ResourceIDString(lookupFieldValue(obj, parentKey))
-	if parentValue == "" || parentValue == "<nil>" {
-		return id
-	}
-	return id + string([]byte{0}) + parentValue
+	return id
 }
 
 // BareResourceID strips the NUL-delimited parent suffix that resourceStorageID

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1334,20 +1334,25 @@ var resourceIDFieldOverrides = map[string]string{
 	"games": "game_key",
 }
 
-// genericIDFieldFallbacks is the runtime safety net for resources that did
-// NOT receive a templated IDField. API-specific names belong in spec
-// annotations (x-resource-id), not this list. Order matters: vendor
-// identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
-// so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
-// field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
+// Generic ID fields are split around the resource-specific suffix probe.
+// Stable vendor identifiers win first; then fields derived from the resource
+// name (accountId, workspaceId); descriptive fallbacks are last. Keeping name
+// ahead of the resource-specific probe silently keys rows by display labels.
+var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id"}
+var genericDescriptiveIDFieldFallbacks = []string{"name", "slug", "key", "code"}
+
+// resourceIDBaseOverrides preserves the complete final collection name for
+// composed dependents whose child segment is itself multiword.
+var resourceIDBaseOverrides = map[string]string{
+	"leagues": "leagues",
+}
 
 // resourceParentKeyColumns identifies generated dependent resources whose
 // local mirror rows need the parent context in the storage key. Without this,
 // many-to-many sub-collections collapse every parent association onto the
 // child's bare id and silently keep only the last synced parent.
-var resourceParentKeyColumns = map[string]string{
-	"leagues": "parent_id",
+var resourceParentKeyColumns = map[string][]string{
+	"leagues": {"parent_id"},
 }
 
 // ExtractResourceID resolves the bare resource id field that UpsertBatch
@@ -1375,6 +1380,14 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 	}
 	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
 		return s
+	}
+	for _, key := range genericDescriptiveIDFieldFallbacks {
+		if v := lookupFieldValue(obj, key); v != nil {
+			s := ResourceIDString(v)
+			if s != "" && s != "<nil>" {
+				return s
+			}
+		}
 	}
 	return ""
 }
@@ -1408,18 +1421,32 @@ func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 
 // resourceIDBaseNames returns lowercase candidate singular/plural stems of a
 // resource name to build "<base>_id"-style key probes from (e.g. "currencies"
-// -> ["currencies","currency"]). OpenAPI-/path-derived names can carry a
-// leading verb token ("get-currencies"), so the same probes are also attempted
-// on the de-verbed stem. Minimal English depluralization; the raw name is
-// always included so already-singular names work too.
+// -> ["currencies","currency"]). Composed dependent names also probe their
+// final segment ("containers_workspaces" -> "workspaces","workspace"), which
+// is the child entity's own ID convention. OpenAPI-/path-derived names can
+// carry a leading verb token ("get-currencies"), so the same probes are also
+// attempted on the de-verbed stem.
 func resourceIDBaseNames(resourceType string) []string {
 	r := strings.ToLower(strings.TrimSpace(resourceType))
 	if r == "" {
 		return nil
 	}
-	stems := []string{r}
+	var stems []string
+	addStem := func(stem string) {
+		if stem == "" {
+			return
+		}
+		for _, existing := range stems {
+			if existing == stem {
+				return
+			}
+		}
+		stems = append(stems, stem)
+	}
+	addStem(resourceIDBaseOverrides[r])
+	addStem(r)
 	if d := stripLeadingResourceVerb(r); d != "" && d != r {
-		stems = append(stems, d)
+		addStem(d)
 	}
 	var bases []string
 	seen := map[string]bool{}
@@ -1432,6 +1459,11 @@ func resourceIDBaseNames(resourceType string) []string {
 	for _, stem := range stems {
 		add(stem)
 		add(depluralizeResourceStem(stem))
+		if i := strings.LastIndexAny(stem, "_-"); i >= 0 && i+1 < len(stem) {
+			leaf := stem[i+1:]
+			add(leaf)
+			add(depluralizeResourceStem(leaf))
+		}
 	}
 	return bases
 }
@@ -1498,15 +1530,13 @@ func scalarIDString(value any) string {
 }
 
 func resourceStorageID(resourceType, id string, obj map[string]any) string {
-	parentKey := resourceParentKeyColumns[resourceType]
-	if parentKey == "" {
-		return id
+	for _, parentKey := range resourceParentKeyColumns[resourceType] {
+		parentValue := ResourceIDString(lookupFieldValue(obj, parentKey))
+		if parentValue != "" && parentValue != "<nil>" {
+			return id + string([]byte{0}) + parentValue
+		}
 	}
-	parentValue := ResourceIDString(lookupFieldValue(obj, parentKey))
-	if parentValue == "" || parentValue == "<nil>" {
-		return id
-	}
-	return id + string([]byte{0}) + parentValue
+	return id
 }
 
 // BareResourceID strips the NUL-delimited parent suffix that resourceStorageID

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -1930,14 +1930,6 @@ const (
 	queryPageSize = 2
 )
 
-// genericIDFieldFallbacks is the runtime safety net for resources that did
-// NOT receive a templated IDField. API-specific names belong in spec
-// annotations (x-resource-id), not this list. Order matters: vendor
-// identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
-// so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
-// field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
-
 // pageItemKeys is scanned in priority order; lowercase REST-convention keys
 // come first, PascalCase .NET variants second. Without the PascalCase row,
 // {"Items": [...]} envelopes fall through to the ambiguity scan and a
@@ -2009,154 +2001,10 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 // flat-resource critical failure.
 var criticalResources = map[string]bool{}
 
-// extractID resolves an item's primary-key field. It consults the
-// per-resource templated override first; on miss, it falls through to the
-// generic fallback list. resource may be empty for callers that don't have
-// a resource context (only the generic list applies in that case).
-//
-// Field lookups go through store.LookupFieldValue so snake_case overrides
-// match camelCase JSON renderings. UpsertBatch resolves fields the same
-// way — divergence between the two paths produces silent drops on
-// heterogeneous payloads.
+// extractID delegates the shared identity contract to the store so sync paths
+// and UpsertBatch cannot select different fields from the same payload.
 func extractID(resource string, obj map[string]any) string {
-	if override, ok := resourceIDFieldOverrides[resource]; ok && override != "" {
-		if v := store.LookupFieldValue(obj, override); v != nil {
-			s := store.ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
-		}
-	}
-	for _, key := range genericIDFieldFallbacks {
-		if v := store.LookupFieldValue(obj, key); v != nil {
-			s := store.ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
-		}
-	}
-	if s := suffixIDFieldFallback(resource, obj); s != "" {
-		return s
-	}
-	return ""
-}
-
-// suffixIDFieldFallback resolves an id-less resource that keys on its own
-// "<name>_code" / "<name>_id" / "<name>_key" / "<name>_slug" field (e.g. the
-// "currencies" resource keying on "currency_code" — see #2327). It is scoped to
-// the resource's OWN name so a foreign key like account_id/parent_id is never
-// promoted to the primary key, and it uses direct map lookups in a fixed suffix
-// order so the chosen id is deterministic.
-func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
-	for _, base := range resourceIDBaseNames(resourceType) {
-		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
-			if v, ok := obj[base+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
-			}
-		}
-		camelBase := lowerCamelResourceIDBase(base)
-		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
-			if v, ok := obj[camelBase+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
-			}
-		}
-	}
-	return ""
-}
-
-// resourceIDBaseNames returns lowercase candidate singular/plural stems of a
-// resource name to build "<base>_id"-style key probes from (e.g. "currencies"
-// -> ["currencies","currency"]). OpenAPI-/path-derived names can carry a
-// leading verb token ("get-currencies"), so the same probes are also attempted
-// on the de-verbed stem. Minimal English depluralization; the raw name is
-// always included so already-singular names work too.
-func resourceIDBaseNames(resourceType string) []string {
-	r := strings.ToLower(strings.TrimSpace(resourceType))
-	if r == "" {
-		return nil
-	}
-	stems := []string{r}
-	if d := stripLeadingResourceVerb(r); d != "" && d != r {
-		stems = append(stems, d)
-	}
-	var bases []string
-	seen := map[string]bool{}
-	add := func(s string) {
-		if s != "" && !seen[s] {
-			seen[s] = true
-			bases = append(bases, s)
-		}
-	}
-	for _, stem := range stems {
-		add(stem)
-		add(depluralizeResourceStem(stem))
-	}
-	return bases
-}
-
-func stripLeadingResourceVerb(r string) string {
-	for _, verb := range []string{"get", "list", "fetch", "find", "retrieve", "read", "show", "all"} {
-		for _, sep := range []string{"-", "_"} {
-			prefix := verb + sep
-			if strings.HasPrefix(r, prefix) && len(r) > len(prefix) {
-				return r[len(prefix):]
-			}
-		}
-	}
-	return ""
-}
-
-func depluralizeResourceStem(r string) string {
-	switch {
-	case strings.HasSuffix(r, "ies") && len(r) > 3:
-		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
-	// Plurals formed by adding "es" to a base ending in s/x/z/ch/sh. The
-	// double-s "sses" guard (not bare "ses") keeps soft-e plurals — where the
-	// singular already ends in a silent "e" (cases, databases, licenses,
-	// purchases) — out of this branch; they fall through to the "-s" case below
-	// (cases -> case, not cas). Trade-off: a genuine "-es" plural of an s-ending
-	// singular (buses, statuses) depluralizes imperfectly, but those are rare as
-	// resource names and this stem only feeds best-effort id-field probing.
-	case strings.HasSuffix(r, "sses") || strings.HasSuffix(r, "xes") ||
-		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
-		strings.HasSuffix(r, "shes"):
-		return strings.TrimSuffix(r, "es") // classes -> class, boxes -> box, dishes -> dish
-	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
-		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
-	}
-	return r
-}
-
-func lowerCamelResourceIDBase(base string) string {
-	parts := strings.FieldsFunc(base, func(r rune) bool {
-		return r == '_' || r == '-'
-	})
-	if len(parts) == 0 {
-		return base
-	}
-	for i := range parts {
-		if i == 0 {
-			parts[i] = strings.ToLower(parts[i])
-			continue
-		}
-		parts[i] = strings.ToUpper(parts[i][:1]) + strings.ToLower(parts[i][1:])
-	}
-	return strings.Join(parts, "")
-}
-
-func scalarIDString(value any) string {
-	switch value.(type) {
-	case string, bool, int, int8, int16, int32, int64,
-		uint, uint8, uint16, uint32, uint64,
-		float32, float64, json.Number, []byte:
-		return store.ResourceIDString(value)
-	default:
-		return ""
-	}
+	return store.ExtractResourceID(resource, obj)
 }
 
 // lookupRefreshEntityFields names the generic identity-bearing JSON

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1390,19 +1390,22 @@ func (s *Store) UpsertWidgets(data json.RawMessage) error {
 // path-item.
 var resourceIDFieldOverrides = map[string]string{}
 
-// genericIDFieldFallbacks is the runtime safety net for resources that did
-// NOT receive a templated IDField. API-specific names belong in spec
-// annotations (x-resource-id), not this list. Order matters: vendor
-// identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
-// so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
-// field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
+// Generic ID fields are split around the resource-specific suffix probe.
+// Stable vendor identifiers win first; then fields derived from the resource
+// name (accountId, workspaceId); descriptive fallbacks are last. Keeping name
+// ahead of the resource-specific probe silently keys rows by display labels.
+var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id"}
+var genericDescriptiveIDFieldFallbacks = []string{"name", "slug", "key", "code"}
+
+// resourceIDBaseOverrides preserves the complete final collection name for
+// composed dependents whose child segment is itself multiword.
+var resourceIDBaseOverrides = map[string]string{}
 
 // resourceParentKeyColumns identifies generated dependent resources whose
 // local mirror rows need the parent context in the storage key. Without this,
 // many-to-many sub-collections collapse every parent association onto the
 // child's bare id and silently keep only the last synced parent.
-var resourceParentKeyColumns = map[string]string{}
+var resourceParentKeyColumns = map[string][]string{}
 
 // ExtractResourceID resolves the bare resource id field that UpsertBatch
 // extracts from a resource item. For dependent resource types, UpsertBatch
@@ -1429,6 +1432,14 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 	}
 	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
 		return s
+	}
+	for _, key := range genericDescriptiveIDFieldFallbacks {
+		if v := lookupFieldValue(obj, key); v != nil {
+			s := ResourceIDString(v)
+			if s != "" && s != "<nil>" {
+				return s
+			}
+		}
 	}
 	return ""
 }
@@ -1462,18 +1473,32 @@ func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 
 // resourceIDBaseNames returns lowercase candidate singular/plural stems of a
 // resource name to build "<base>_id"-style key probes from (e.g. "currencies"
-// -> ["currencies","currency"]). OpenAPI-/path-derived names can carry a
-// leading verb token ("get-currencies"), so the same probes are also attempted
-// on the de-verbed stem. Minimal English depluralization; the raw name is
-// always included so already-singular names work too.
+// -> ["currencies","currency"]). Composed dependent names also probe their
+// final segment ("containers_workspaces" -> "workspaces","workspace"), which
+// is the child entity's own ID convention. OpenAPI-/path-derived names can
+// carry a leading verb token ("get-currencies"), so the same probes are also
+// attempted on the de-verbed stem.
 func resourceIDBaseNames(resourceType string) []string {
 	r := strings.ToLower(strings.TrimSpace(resourceType))
 	if r == "" {
 		return nil
 	}
-	stems := []string{r}
+	var stems []string
+	addStem := func(stem string) {
+		if stem == "" {
+			return
+		}
+		for _, existing := range stems {
+			if existing == stem {
+				return
+			}
+		}
+		stems = append(stems, stem)
+	}
+	addStem(resourceIDBaseOverrides[r])
+	addStem(r)
 	if d := stripLeadingResourceVerb(r); d != "" && d != r {
-		stems = append(stems, d)
+		addStem(d)
 	}
 	var bases []string
 	seen := map[string]bool{}
@@ -1486,6 +1511,11 @@ func resourceIDBaseNames(resourceType string) []string {
 	for _, stem := range stems {
 		add(stem)
 		add(depluralizeResourceStem(stem))
+		if i := strings.LastIndexAny(stem, "_-"); i >= 0 && i+1 < len(stem) {
+			leaf := stem[i+1:]
+			add(leaf)
+			add(depluralizeResourceStem(leaf))
+		}
 	}
 	return bases
 }
@@ -1552,15 +1582,13 @@ func scalarIDString(value any) string {
 }
 
 func resourceStorageID(resourceType, id string, obj map[string]any) string {
-	parentKey := resourceParentKeyColumns[resourceType]
-	if parentKey == "" {
-		return id
+	for _, parentKey := range resourceParentKeyColumns[resourceType] {
+		parentValue := ResourceIDString(lookupFieldValue(obj, parentKey))
+		if parentValue != "" && parentValue != "<nil>" {
+			return id + string([]byte{0}) + parentValue
+		}
 	}
-	parentValue := ResourceIDString(lookupFieldValue(obj, parentKey))
-	if parentValue == "" || parentValue == "<nil>" {
-		return id
-	}
-	return id + string([]byte{0}) + parentValue
+	return id
 }
 
 // BareResourceID strips the NUL-delimited parent suffix that resourceStorageID

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -2547,14 +2547,6 @@ var resolveTenantID = func() string { return "" }
 // fan-out. Empty when no parent is annotated.
 var parentTenantScopeColumns = map[string]string{}
 
-// genericIDFieldFallbacks is the runtime safety net for resources that did
-// NOT receive a templated IDField. API-specific names belong in spec
-// annotations (x-resource-id), not this list. Order matters: vendor
-// identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
-// so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
-// field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
-
 // pageItemKeys is scanned in priority order; lowercase REST-convention keys
 // come first, PascalCase .NET variants second. Without the PascalCase row,
 // {"Items": [...]} envelopes fall through to the ambiguity scan and a
@@ -2619,154 +2611,10 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 // flat-resource critical failure.
 var criticalResources = map[string]bool{}
 
-// extractID resolves an item's primary-key field. It consults the
-// per-resource templated override first; on miss, it falls through to the
-// generic fallback list. resource may be empty for callers that don't have
-// a resource context (only the generic list applies in that case).
-//
-// Field lookups go through store.LookupFieldValue so snake_case overrides
-// match camelCase JSON renderings. UpsertBatch resolves fields the same
-// way — divergence between the two paths produces silent drops on
-// heterogeneous payloads.
+// extractID delegates the shared identity contract to the store so sync paths
+// and UpsertBatch cannot select different fields from the same payload.
 func extractID(resource string, obj map[string]any) string {
-	if override, ok := resourceIDFieldOverrides[resource]; ok && override != "" {
-		if v := store.LookupFieldValue(obj, override); v != nil {
-			s := store.ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
-		}
-	}
-	for _, key := range genericIDFieldFallbacks {
-		if v := store.LookupFieldValue(obj, key); v != nil {
-			s := store.ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
-		}
-	}
-	if s := suffixIDFieldFallback(resource, obj); s != "" {
-		return s
-	}
-	return ""
-}
-
-// suffixIDFieldFallback resolves an id-less resource that keys on its own
-// "<name>_code" / "<name>_id" / "<name>_key" / "<name>_slug" field (e.g. the
-// "currencies" resource keying on "currency_code" — see #2327). It is scoped to
-// the resource's OWN name so a foreign key like account_id/parent_id is never
-// promoted to the primary key, and it uses direct map lookups in a fixed suffix
-// order so the chosen id is deterministic.
-func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
-	for _, base := range resourceIDBaseNames(resourceType) {
-		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
-			if v, ok := obj[base+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
-			}
-		}
-		camelBase := lowerCamelResourceIDBase(base)
-		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
-			if v, ok := obj[camelBase+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
-			}
-		}
-	}
-	return ""
-}
-
-// resourceIDBaseNames returns lowercase candidate singular/plural stems of a
-// resource name to build "<base>_id"-style key probes from (e.g. "currencies"
-// -> ["currencies","currency"]). OpenAPI-/path-derived names can carry a
-// leading verb token ("get-currencies"), so the same probes are also attempted
-// on the de-verbed stem. Minimal English depluralization; the raw name is
-// always included so already-singular names work too.
-func resourceIDBaseNames(resourceType string) []string {
-	r := strings.ToLower(strings.TrimSpace(resourceType))
-	if r == "" {
-		return nil
-	}
-	stems := []string{r}
-	if d := stripLeadingResourceVerb(r); d != "" && d != r {
-		stems = append(stems, d)
-	}
-	var bases []string
-	seen := map[string]bool{}
-	add := func(s string) {
-		if s != "" && !seen[s] {
-			seen[s] = true
-			bases = append(bases, s)
-		}
-	}
-	for _, stem := range stems {
-		add(stem)
-		add(depluralizeResourceStem(stem))
-	}
-	return bases
-}
-
-func stripLeadingResourceVerb(r string) string {
-	for _, verb := range []string{"get", "list", "fetch", "find", "retrieve", "read", "show", "all"} {
-		for _, sep := range []string{"-", "_"} {
-			prefix := verb + sep
-			if strings.HasPrefix(r, prefix) && len(r) > len(prefix) {
-				return r[len(prefix):]
-			}
-		}
-	}
-	return ""
-}
-
-func depluralizeResourceStem(r string) string {
-	switch {
-	case strings.HasSuffix(r, "ies") && len(r) > 3:
-		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
-	// Plurals formed by adding "es" to a base ending in s/x/z/ch/sh. The
-	// double-s "sses" guard (not bare "ses") keeps soft-e plurals — where the
-	// singular already ends in a silent "e" (cases, databases, licenses,
-	// purchases) — out of this branch; they fall through to the "-s" case below
-	// (cases -> case, not cas). Trade-off: a genuine "-es" plural of an s-ending
-	// singular (buses, statuses) depluralizes imperfectly, but those are rare as
-	// resource names and this stem only feeds best-effort id-field probing.
-	case strings.HasSuffix(r, "sses") || strings.HasSuffix(r, "xes") ||
-		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
-		strings.HasSuffix(r, "shes"):
-		return strings.TrimSuffix(r, "es") // classes -> class, boxes -> box, dishes -> dish
-	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
-		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
-	}
-	return r
-}
-
-func lowerCamelResourceIDBase(base string) string {
-	parts := strings.FieldsFunc(base, func(r rune) bool {
-		return r == '_' || r == '-'
-	})
-	if len(parts) == 0 {
-		return base
-	}
-	for i := range parts {
-		if i == 0 {
-			parts[i] = strings.ToLower(parts[i])
-			continue
-		}
-		parts[i] = strings.ToUpper(parts[i][:1]) + strings.ToLower(parts[i][1:])
-	}
-	return strings.Join(parts, "")
-}
-
-func scalarIDString(value any) string {
-	switch value.(type) {
-	case string, bool, int, int8, int16, int32, int64,
-		uint, uint8, uint16, uint32, uint64,
-		float32, float64, json.Number, []byte:
-		return store.ResourceIDString(value)
-	default:
-		return ""
-	}
+	return store.ExtractResourceID(resource, obj)
 }
 
 // lookupRefreshEntityFields names the generic identity-bearing JSON

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1334,20 +1334,25 @@ var resourceIDFieldOverrides = map[string]string{
 	"games": "game_key",
 }
 
-// genericIDFieldFallbacks is the runtime safety net for resources that did
-// NOT receive a templated IDField. API-specific names belong in spec
-// annotations (x-resource-id), not this list. Order matters: vendor
-// identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
-// so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
-// field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
+// Generic ID fields are split around the resource-specific suffix probe.
+// Stable vendor identifiers win first; then fields derived from the resource
+// name (accountId, workspaceId); descriptive fallbacks are last. Keeping name
+// ahead of the resource-specific probe silently keys rows by display labels.
+var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id"}
+var genericDescriptiveIDFieldFallbacks = []string{"name", "slug", "key", "code"}
+
+// resourceIDBaseOverrides preserves the complete final collection name for
+// composed dependents whose child segment is itself multiword.
+var resourceIDBaseOverrides = map[string]string{
+	"leagues": "leagues",
+}
 
 // resourceParentKeyColumns identifies generated dependent resources whose
 // local mirror rows need the parent context in the storage key. Without this,
 // many-to-many sub-collections collapse every parent association onto the
 // child's bare id and silently keep only the last synced parent.
-var resourceParentKeyColumns = map[string]string{
-	"leagues": "parent_id",
+var resourceParentKeyColumns = map[string][]string{
+	"leagues": {"parent_id"},
 }
 
 // ExtractResourceID resolves the bare resource id field that UpsertBatch
@@ -1375,6 +1380,14 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 	}
 	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
 		return s
+	}
+	for _, key := range genericDescriptiveIDFieldFallbacks {
+		if v := lookupFieldValue(obj, key); v != nil {
+			s := ResourceIDString(v)
+			if s != "" && s != "<nil>" {
+				return s
+			}
+		}
 	}
 	return ""
 }
@@ -1408,18 +1421,32 @@ func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 
 // resourceIDBaseNames returns lowercase candidate singular/plural stems of a
 // resource name to build "<base>_id"-style key probes from (e.g. "currencies"
-// -> ["currencies","currency"]). OpenAPI-/path-derived names can carry a
-// leading verb token ("get-currencies"), so the same probes are also attempted
-// on the de-verbed stem. Minimal English depluralization; the raw name is
-// always included so already-singular names work too.
+// -> ["currencies","currency"]). Composed dependent names also probe their
+// final segment ("containers_workspaces" -> "workspaces","workspace"), which
+// is the child entity's own ID convention. OpenAPI-/path-derived names can
+// carry a leading verb token ("get-currencies"), so the same probes are also
+// attempted on the de-verbed stem.
 func resourceIDBaseNames(resourceType string) []string {
 	r := strings.ToLower(strings.TrimSpace(resourceType))
 	if r == "" {
 		return nil
 	}
-	stems := []string{r}
+	var stems []string
+	addStem := func(stem string) {
+		if stem == "" {
+			return
+		}
+		for _, existing := range stems {
+			if existing == stem {
+				return
+			}
+		}
+		stems = append(stems, stem)
+	}
+	addStem(resourceIDBaseOverrides[r])
+	addStem(r)
 	if d := stripLeadingResourceVerb(r); d != "" && d != r {
-		stems = append(stems, d)
+		addStem(d)
 	}
 	var bases []string
 	seen := map[string]bool{}
@@ -1432,6 +1459,11 @@ func resourceIDBaseNames(resourceType string) []string {
 	for _, stem := range stems {
 		add(stem)
 		add(depluralizeResourceStem(stem))
+		if i := strings.LastIndexAny(stem, "_-"); i >= 0 && i+1 < len(stem) {
+			leaf := stem[i+1:]
+			add(leaf)
+			add(depluralizeResourceStem(leaf))
+		}
 	}
 	return bases
 }
@@ -1498,15 +1530,13 @@ func scalarIDString(value any) string {
 }
 
 func resourceStorageID(resourceType, id string, obj map[string]any) string {
-	parentKey := resourceParentKeyColumns[resourceType]
-	if parentKey == "" {
-		return id
+	for _, parentKey := range resourceParentKeyColumns[resourceType] {
+		parentValue := ResourceIDString(lookupFieldValue(obj, parentKey))
+		if parentValue != "" && parentValue != "<nil>" {
+			return id + string([]byte{0}) + parentValue
+		}
 	}
-	parentValue := ResourceIDString(lookupFieldValue(obj, parentKey))
-	if parentValue == "" || parentValue == "<nil>" {
-		return id
-	}
-	return id + string([]byte{0}) + parentValue
+	return id
 }
 
 // BareResourceID strips the NUL-delimited parent suffix that resourceStorageID

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -1864,14 +1864,6 @@ var resolveTenantID = func() string { return "" }
 // fan-out. Empty when no parent is annotated.
 var parentTenantScopeColumns = map[string]string{}
 
-// genericIDFieldFallbacks is the runtime safety net for resources that did
-// NOT receive a templated IDField. API-specific names belong in spec
-// annotations (x-resource-id), not this list. Order matters: vendor
-// identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
-// so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
-// field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
-
 // pageItemKeys is scanned in priority order; lowercase REST-convention keys
 // come first, PascalCase .NET variants second. Without the PascalCase row,
 // {"Items": [...]} envelopes fall through to the ambiguity scan and a
@@ -1936,154 +1928,10 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 // flat-resource critical failure.
 var criticalResources = map[string]bool{}
 
-// extractID resolves an item's primary-key field. It consults the
-// per-resource templated override first; on miss, it falls through to the
-// generic fallback list. resource may be empty for callers that don't have
-// a resource context (only the generic list applies in that case).
-//
-// Field lookups go through store.LookupFieldValue so snake_case overrides
-// match camelCase JSON renderings. UpsertBatch resolves fields the same
-// way — divergence between the two paths produces silent drops on
-// heterogeneous payloads.
+// extractID delegates the shared identity contract to the store so sync paths
+// and UpsertBatch cannot select different fields from the same payload.
 func extractID(resource string, obj map[string]any) string {
-	if override, ok := resourceIDFieldOverrides[resource]; ok && override != "" {
-		if v := store.LookupFieldValue(obj, override); v != nil {
-			s := store.ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
-		}
-	}
-	for _, key := range genericIDFieldFallbacks {
-		if v := store.LookupFieldValue(obj, key); v != nil {
-			s := store.ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
-		}
-	}
-	if s := suffixIDFieldFallback(resource, obj); s != "" {
-		return s
-	}
-	return ""
-}
-
-// suffixIDFieldFallback resolves an id-less resource that keys on its own
-// "<name>_code" / "<name>_id" / "<name>_key" / "<name>_slug" field (e.g. the
-// "currencies" resource keying on "currency_code" — see #2327). It is scoped to
-// the resource's OWN name so a foreign key like account_id/parent_id is never
-// promoted to the primary key, and it uses direct map lookups in a fixed suffix
-// order so the chosen id is deterministic.
-func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
-	for _, base := range resourceIDBaseNames(resourceType) {
-		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
-			if v, ok := obj[base+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
-			}
-		}
-		camelBase := lowerCamelResourceIDBase(base)
-		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
-			if v, ok := obj[camelBase+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
-			}
-		}
-	}
-	return ""
-}
-
-// resourceIDBaseNames returns lowercase candidate singular/plural stems of a
-// resource name to build "<base>_id"-style key probes from (e.g. "currencies"
-// -> ["currencies","currency"]). OpenAPI-/path-derived names can carry a
-// leading verb token ("get-currencies"), so the same probes are also attempted
-// on the de-verbed stem. Minimal English depluralization; the raw name is
-// always included so already-singular names work too.
-func resourceIDBaseNames(resourceType string) []string {
-	r := strings.ToLower(strings.TrimSpace(resourceType))
-	if r == "" {
-		return nil
-	}
-	stems := []string{r}
-	if d := stripLeadingResourceVerb(r); d != "" && d != r {
-		stems = append(stems, d)
-	}
-	var bases []string
-	seen := map[string]bool{}
-	add := func(s string) {
-		if s != "" && !seen[s] {
-			seen[s] = true
-			bases = append(bases, s)
-		}
-	}
-	for _, stem := range stems {
-		add(stem)
-		add(depluralizeResourceStem(stem))
-	}
-	return bases
-}
-
-func stripLeadingResourceVerb(r string) string {
-	for _, verb := range []string{"get", "list", "fetch", "find", "retrieve", "read", "show", "all"} {
-		for _, sep := range []string{"-", "_"} {
-			prefix := verb + sep
-			if strings.HasPrefix(r, prefix) && len(r) > len(prefix) {
-				return r[len(prefix):]
-			}
-		}
-	}
-	return ""
-}
-
-func depluralizeResourceStem(r string) string {
-	switch {
-	case strings.HasSuffix(r, "ies") && len(r) > 3:
-		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
-	// Plurals formed by adding "es" to a base ending in s/x/z/ch/sh. The
-	// double-s "sses" guard (not bare "ses") keeps soft-e plurals — where the
-	// singular already ends in a silent "e" (cases, databases, licenses,
-	// purchases) — out of this branch; they fall through to the "-s" case below
-	// (cases -> case, not cas). Trade-off: a genuine "-es" plural of an s-ending
-	// singular (buses, statuses) depluralizes imperfectly, but those are rare as
-	// resource names and this stem only feeds best-effort id-field probing.
-	case strings.HasSuffix(r, "sses") || strings.HasSuffix(r, "xes") ||
-		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
-		strings.HasSuffix(r, "shes"):
-		return strings.TrimSuffix(r, "es") // classes -> class, boxes -> box, dishes -> dish
-	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
-		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
-	}
-	return r
-}
-
-func lowerCamelResourceIDBase(base string) string {
-	parts := strings.FieldsFunc(base, func(r rune) bool {
-		return r == '_' || r == '-'
-	})
-	if len(parts) == 0 {
-		return base
-	}
-	for i := range parts {
-		if i == 0 {
-			parts[i] = strings.ToLower(parts[i])
-			continue
-		}
-		parts[i] = strings.ToUpper(parts[i][:1]) + strings.ToLower(parts[i][1:])
-	}
-	return strings.Join(parts, "")
-}
-
-func scalarIDString(value any) string {
-	switch value.(type) {
-	case string, bool, int, int8, int16, int32, int64,
-		uint, uint8, uint16, uint32, uint64,
-		float32, float64, json.Number, []byte:
-		return store.ResourceIDString(value)
-	default:
-		return ""
-	}
+	return store.ExtractResourceID(resource, obj)
 }
 
 // lookupRefreshEntityFields names the generic identity-bearing JSON


### PR DESCRIPTION
## Summary

Deep dependent sync now keeps stable resource IDs and full parent scope instead of building request paths from display names or collapsing repeated child IDs across ancestors. ID fallback is shared between sync and storage, multiword child collection names derive their ID base from the resource path, and raw write-through rows retain typed parent-key fallback.

## Validation

- Focused generated hierarchy, HTML, and write-through regression tests
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- Full non-generator test packages passed; the isolated generator suite later stopped at a generated `govulncheck` gate after the change-specific runtime and compile proofs passed
- `golangci-lint run ./...` reports one pre-existing unchanged `modernize` finding in `internal/googlediscovery/parser.go`

Closes #3700
