### PR TITLE
fix(cli): preserve CLI and MCP command reachability

### DIFF
--- a/internal/cli/tools_audit.go
+++ b/internal/cli/tools_audit.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"go/ast"
-	"go/parser"
 	"go/token"
 	"io"
 	"os"
@@ -206,43 +205,6 @@ func runToolsAudit(cliDir string, manifest *pipeline.ToolsManifest) ([]ToolsAudi
 	return findings, nil
 }
 
-func auditCobraSource(cliDir string) ([]ToolsAuditFinding, error) {
-	pkgDir := filepath.Join(cliDir, "internal", "cli")
-	entries, err := os.ReadDir(pkgDir)
-	if err != nil {
-		return nil, fmt.Errorf("reading %s: %w", pkgDir, err)
-	}
-	var findings []ToolsAuditFinding
-	fset := token.NewFileSet()
-	for _, e := range entries {
-		name := e.Name()
-		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-			continue
-		}
-		full := filepath.Join(pkgDir, name)
-		// Skip unparseable files — the agent can run go build separately
-		// to surface syntax errors without failing the audit.
-		file, err := parser.ParseFile(fset, full, nil, 0)
-		if err != nil {
-			continue
-		}
-		ast.Inspect(file, func(n ast.Node) bool {
-			lit, ok := n.(*ast.CompositeLit)
-			if !ok || !isCobraCommandType(lit.Type) {
-				return true
-			}
-			fields := extractCommandFields(lit)
-			if fields.use == "" {
-				return true
-			}
-			line := fset.Position(lit.Pos()).Line
-			findings = append(findings, auditCommandFields(name, line, fields)...)
-			return true
-		})
-	}
-	return findings, nil
-}
-
 // auditMCPManifest flags MCP tool descriptions that fall below the
 // agent-grade bar. The manifest is the source of truth for typed
 // endpoint tools' descriptions; for shell-out tools, descriptions
@@ -286,6 +248,8 @@ type commandFields struct {
 	// writing "false" has done the right thing and shouldn't be flagged.
 	hasExplicitReadOnly       bool
 	hasEndpoint               bool
+	cobraHidden               bool
+	mcpHidden                 bool
 	hasRunE                   bool
 	hasParentNoSubcommandRunE bool
 }
@@ -324,7 +288,9 @@ func extractCommandFields(lit *ast.CompositeLit) commandFields {
 		case "Short":
 			f.short = stringLit(kv.Value)
 		case "Annotations":
-			f.hasExplicitReadOnly, f.hasEndpoint = inspectAnnotations(kv.Value)
+			f.hasExplicitReadOnly, f.hasEndpoint, f.mcpHidden = inspectAnnotations(kv.Value)
+		case "Hidden":
+			f.cobraHidden = identIsTrue(kv.Value)
 		case "Run", "RunE":
 			f.hasRunE = true
 			if key.Name == "RunE" && isParentNoSubcommandRunE(kv.Value) {
@@ -368,10 +334,10 @@ func stringLit(e ast.Expr) string {
 // the author already classified correctly; the audit's job is to flag
 // unannotated commands, not to enforce that every read-shaped name be
 // read-only.
-func inspectAnnotations(e ast.Expr) (hasExplicitReadOnly, hasEndpoint bool) {
+func inspectAnnotations(e ast.Expr) (hasExplicitReadOnly, hasEndpoint, mcpHidden bool) {
 	lit, ok := e.(*ast.CompositeLit)
 	if !ok {
-		return false, false
+		return false, false, false
 	}
 	for _, el := range lit.Elts {
 		kv, ok := el.(*ast.KeyValueExpr)
@@ -383,9 +349,25 @@ func inspectAnnotations(e ast.Expr) (hasExplicitReadOnly, hasEndpoint bool) {
 			hasExplicitReadOnly = true
 		case "pp:endpoint":
 			hasEndpoint = stringLit(kv.Value) != ""
+		case "mcp:hidden":
+			mcpHidden = annotationValueIsTrue(stringLit(kv.Value))
 		}
 	}
-	return hasExplicitReadOnly, hasEndpoint
+	return hasExplicitReadOnly, hasEndpoint, mcpHidden
+}
+
+func identIsTrue(e ast.Expr) bool {
+	ident, ok := e.(*ast.Ident)
+	return ok && ident.Name == "true"
+}
+
+func annotationValueIsTrue(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "true", "1", "yes":
+		return true
+	default:
+		return false
+	}
 }
 
 func auditCommandFields(file string, line int, f commandFields) []ToolsAuditFinding {

--- a/internal/cli/tools_audit_cobra.go
+++ b/internal/cli/tools_audit_cobra.go
@@ -1,0 +1,163 @@
+package cli
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func auditCobraSource(cliDir string) ([]ToolsAuditFinding, error) {
+	pkgDir := filepath.Join(cliDir, "internal", "cli")
+	entries, err := os.ReadDir(pkgDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", pkgDir, err)
+	}
+	var findings []ToolsAuditFinding
+	fset := token.NewFileSet()
+	var candidates []cobraAuditCandidate
+	childrenByConstructor := map[string][]string{}
+	mcpHiddenConstructors := map[string]bool{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		full := filepath.Join(pkgDir, name)
+		// Skip unparseable files because a separate build surfaces syntax errors.
+		file, err := parser.ParseFile(fset, full, nil, 0)
+		if err != nil {
+			continue
+		}
+		literalOwners := map[token.Pos]string{}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name == nil || fn.Body == nil {
+				continue
+			}
+			constructor := fn.Name.Name
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				switch node := n.(type) {
+				case *ast.FuncLit:
+					return false
+				case *ast.CompositeLit:
+					if isCobraCommandType(node.Type) {
+						literalOwners[node.Pos()] = constructor
+						if extractCommandFields(node).mcpHidden {
+							mcpHiddenConstructors[constructor] = true
+						}
+					}
+				case *ast.CallExpr:
+					if !isAuditAddCommandCall(node) {
+						return true
+					}
+					for _, arg := range node.Args {
+						if child := auditCobraConstructorCallName(arg); child != "" {
+							childrenByConstructor[constructor] = append(childrenByConstructor[constructor], child)
+						}
+					}
+				}
+				return true
+			})
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if !ok || !isCobraCommandType(lit.Type) {
+				return true
+			}
+			fields := extractCommandFields(lit)
+			if fields.use == "" {
+				return true
+			}
+			candidates = append(candidates, cobraAuditCandidate{
+				file:        name,
+				line:        fset.Position(lit.Pos()).Line,
+				fields:      fields,
+				constructor: literalOwners[lit.Pos()],
+			})
+			return true
+		})
+	}
+
+	hiddenReachable := map[string]bool{}
+	var markHidden func(string)
+	markHidden = func(constructor string) {
+		if constructor == "" || hiddenReachable[constructor] {
+			return
+		}
+		hiddenReachable[constructor] = true
+		for _, child := range childrenByConstructor[constructor] {
+			markHidden(child)
+		}
+	}
+	for constructor := range mcpHiddenConstructors {
+		markHidden(constructor)
+	}
+
+	hasParent := map[string]bool{}
+	constructors := map[string]bool{}
+	for constructor, children := range childrenByConstructor {
+		constructors[constructor] = true
+		for _, child := range children {
+			constructors[child] = true
+			hasParent[child] = true
+		}
+	}
+	for _, candidate := range candidates {
+		if candidate.constructor != "" {
+			constructors[candidate.constructor] = true
+		}
+	}
+	visibleReachable := map[string]bool{}
+	var markVisible func(string)
+	markVisible = func(constructor string) {
+		if constructor == "" || visibleReachable[constructor] || mcpHiddenConstructors[constructor] {
+			return
+		}
+		visibleReachable[constructor] = true
+		for _, child := range childrenByConstructor[constructor] {
+			markVisible(child)
+		}
+	}
+	for constructor := range constructors {
+		if !hasParent[constructor] {
+			markVisible(constructor)
+		}
+	}
+
+	for _, candidate := range candidates {
+		hiddenOnly := hiddenReachable[candidate.constructor] && !visibleReachable[candidate.constructor]
+		if candidate.fields.cobraHidden || candidate.fields.mcpHidden || hiddenOnly {
+			continue
+		}
+		findings = append(findings, auditCommandFields(candidate.file, candidate.line, candidate.fields)...)
+	}
+	return findings, nil
+}
+
+type cobraAuditCandidate struct {
+	file        string
+	line        int
+	fields      commandFields
+	constructor string
+}
+
+func isAuditAddCommandCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "AddCommand"
+}
+
+func auditCobraConstructorCallName(expr ast.Expr) string {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return ""
+	}
+	ident, ok := call.Fun.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	return ident.Name
+}

--- a/internal/cli/tools_audit_test.go
+++ b/internal/cli/tools_audit_test.go
@@ -724,6 +724,103 @@ func newReportRealCmd(flags *rootFlags) *cobra.Command {
 	}
 }
 
+func TestAuditCobraSourceDescendsThroughCobraHiddenAndPrunesMCPHidden(t *testing.T) {
+	root := t.TempDir()
+	cliDir := filepath.Join(root, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatalf("mkdir cli dir: %v", err)
+	}
+	src := `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "root"}
+	cmd.AddCommand(newCobraHiddenGroupCmd(), newMCPHiddenGroupCmd())
+	return cmd
+}
+func newCobraHiddenGroupCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "orders", Hidden: true}
+	cmd.AddCommand(newVisibleListCmd())
+	return cmd
+}
+func newVisibleListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use: "list", Short: "List", RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+}
+func newMCPHiddenGroupCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "secrets", Annotations: map[string]string{"mcp:hidden": "true"}}
+	cmd.AddCommand(newPrunedListCmd())
+	return cmd
+}
+func newPrunedListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use: "show", Short: "Show", RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+}`
+	if err := os.WriteFile(filepath.Join(cliDir, "groups.go"), []byte(src), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	findings, err := auditCobraSource(root)
+	if err != nil {
+		t.Fatalf("auditCobraSource: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("findings = %+v, want thin-short and missing-read-only for visible descendant only", findings)
+	}
+	for _, finding := range findings {
+		if finding.Command != "list" {
+			t.Fatalf("unexpected finding from pruned command: %+v", finding)
+		}
+	}
+}
+
+func TestAuditCobraSourceAuditsConstructorWithVisibleAndMCPHiddenPaths(t *testing.T) {
+	root := t.TempDir()
+	cliDir := filepath.Join(root, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatalf("mkdir cli dir: %v", err)
+	}
+	src := `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "root"}
+	cmd.AddCommand(newVisibleGroupCmd(), newMCPHiddenGroupCmd())
+	return cmd
+}
+func newVisibleGroupCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "orders"}
+	cmd.AddCommand(newSharedReportCmd())
+	return cmd
+}
+func newMCPHiddenGroupCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "secrets", Annotations: map[string]string{"mcp:hidden": "true"}}
+	cmd.AddCommand(newSharedReportCmd())
+	return cmd
+}
+func newSharedReportCmd() *cobra.Command {
+	return &cobra.Command{
+		Use: "report", Short: "Report", RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+}`
+	if err := os.WriteFile(filepath.Join(cliDir, "groups.go"), []byte(src), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	findings, err := auditCobraSource(root)
+	if err != nil {
+		t.Fatalf("auditCobraSource: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("findings = %+v, want thin-short and missing-read-only for shared visible constructor", findings)
+	}
+	for _, finding := range findings {
+		if finding.Command != "report" {
+			t.Fatalf("unexpected finding: %+v", finding)
+		}
+	}
+}
+
 // TestInspectAnnotationsExplicitReadOnlyFalse pins the AST-level
 // helper: any value for `mcp:read-only` — including "false" — sets
 // hasExplicitReadOnly. The old behavior treated "false" as absent.
@@ -769,7 +866,7 @@ func TestInspectAnnotationsExplicitReadOnlyFalse(t *testing.T) {
 			if lit == nil {
 				t.Fatalf("no map literal found")
 			}
-			gotRO, _ := inspectAnnotations(lit)
+			gotRO, _, _ := inspectAnnotations(lit)
 			if gotRO != tc.wantSetRO {
 				t.Errorf("hasExplicitReadOnly = %v, want %v", gotRO, tc.wantSetRO)
 			}

--- a/internal/generator/digit_leading_identifier_test.go
+++ b/internal/generator/digit_leading_identifier_test.go
@@ -83,14 +83,14 @@ func TestGenerateDigitLeadingPathSegmentsUseConsistentCommandIdentifiers(t *test
 
 	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
 	gen := New(apiSpec, outputDir)
-	gen.VisionSet = VisionTemplateSet{Export: true}
+	gen.VisionSet = VisionTemplateSet{Export: true, MCP: true}
 	require.NoError(t, gen.Generate())
 
 	promotedUser := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_user.go")
 	user2FAParent := readGeneratedFile(t, outputDir, "internal", "cli", "user_2fa.go")
 	userV2FAParent := readGeneratedFile(t, outputDir, "internal", "cli", "user_v2fa.go")
-	require.Contains(t, promotedUser, "sub := newUser2faCmd(flags)")
-	require.Contains(t, promotedUser, "sub := newUserV2faCmd(flags)")
+	require.Contains(t, promotedUser, "cmd.AddCommand(newUser2faCmd(flags))")
+	require.Contains(t, promotedUser, "cmd.AddCommand(newUserV2faCmd(flags))")
 	require.Contains(t, user2FAParent, "func newUser2faCmd(flags *rootFlags) *cobra.Command")
 	require.Contains(t, userV2FAParent, "func newUserV2faCmd(flags *rootFlags) *cobra.Command")
 
@@ -100,5 +100,5 @@ func TestGenerateDigitLeadingPathSegmentsUseConsistentCommandIdentifiers(t *test
 	require.Contains(t, promoted3DSecure, "func newV3dSecurePromotedCmd(flags *rootFlags) *cobra.Command")
 	assert.NotContains(t, root, "new3dSecure", "digit-leading resource must not produce an invalid constructor")
 
-	runGoCommand(t, outputDir, "build", "./internal/cli")
+	requireGeneratedCompiles(t, outputDir)
 }

--- a/internal/generator/doctor_credentials_probe_test.go
+++ b/internal/generator/doctor_credentials_probe_test.go
@@ -143,18 +143,17 @@ func TestGeneratedDoctor_SuggestReadCommandHelperGatesOnEndpointAndArgs(t *testi
 	assert.Contains(t, content, `cmd.Args(cmd, []string{}) == nil`,
 		"helper must probe the Args validator with an empty arg list as a final defense")
 
-	// Hidden-parent traversal: printed CLIs mark raw resource parents Hidden
-	// to keep --help curated, but their endpoint leaves stay runnable. The
-	// walk MUST recurse into hidden parents (otherwise the suggestion is ""
-	// in nearly every CLI), while isSuggestableReadLeaf MUST still reject a
-	// leaf that is itself hidden.
+	// Hidden-parent traversal: grouping commands can be hidden from help while
+	// their descendants remain directly runnable. The walk MUST recurse into
+	// hidden parents, while isSuggestableReadLeaf MUST still reject a leaf
+	// that is itself hidden.
 	assert.Contains(t, content, `if cmd == nil || cmd.Hidden || cmd.HasSubCommands() || !cmd.Runnable()`,
 		"isSuggestableReadLeaf must reject a leaf that is itself hidden")
 	assert.NotContains(t, content, `for _, child := range cmd.Commands() {
 			if child.Hidden {
 				continue
 			}`,
-		"the walk must recurse through hidden resource parents, not skip them — skipping makes the suggestion empty in nearly every CLI")
+		"the walk must recurse through hidden grouping commands")
 }
 
 // TestGeneratedDoctor_SuggestHelperOnlyEmittedWhenNeeded pins the template

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3482,14 +3482,6 @@ func withoutOptionsEndpoints(r spec.Resource) spec.Resource {
 }
 
 func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool, promotedEndpointNames map[string]string) error {
-	// When the spec emits promoted commands, the generator also emits the api
-	// browser (api_discovery.go), whose RunE filters root.Commands() by
-	// child.Hidden. Mark the raw top-level resource groups Hidden so they
-	// surface there instead of cluttering --help. Direct invocation still
-	// works (Cobra's Hidden only suppresses listing). For specs without
-	// promoted commands the api browser is not generated, so leave resources
-	// visible.
-	hideTopLevelResources := len(g.PromotedCommands) > 0
 	var apiDescriptionShort string
 	if len(g.Spec.Resources) == 1 {
 		apiDescriptionShort = parentCommandInfoDescriptionShort(g.Spec.Description)
@@ -3517,7 +3509,7 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 				Short         string
 				Resource      spec.Resource
 				NovelChildren []novelFeatureChildRender
-				Hidden        bool
+				APIResource   bool
 				*spec.APISpec
 			}{
 				ResourceName:  name,
@@ -3526,7 +3518,7 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 				Short:         parentCommandShort(name, "", resource, apiDescriptionShort),
 				Resource:      resource,
 				NovelChildren: novelChildrenByParent[toKebab(name)],
-				Hidden:        hideTopLevelResources,
+				APIResource:   true,
 				APISpec:       g.Spec,
 			}
 			parentPath := filepath.Join("internal", "cli", safeResourceFileStem(name)+".go")
@@ -3579,7 +3571,7 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 				Short         string
 				Resource      spec.Resource
 				NovelChildren []novelFeatureChildRender
-				Hidden        bool
+				APIResource   bool
 				*spec.APISpec
 			}{
 				ResourceName:  subName,
@@ -3588,7 +3580,7 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 				Short:         parentCommandShort(subName, name, subResource, ""),
 				Resource:      subResource,
 				NovelChildren: novelChildrenByParent[toKebab(name)+" "+toKebab(subName)],
-				Hidden:        false,
+				APIResource:   false,
 				APISpec:       g.Spec,
 			}
 			subParentPath := filepath.Join("internal", "cli", safeResourceFileStem(name+"_"+subName)+".go")

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10263,13 +10263,13 @@ func TestGeneratedOutput_PromotedCommand_TestResourceCompiles(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "./...")
 }
 
-func TestGeneratedOutput_ResourceParentsHiddenWhenAPIBrowserGenerated(t *testing.T) {
+func TestGeneratedOutput_ResourceParentsVisibleWhenAPIBrowserGenerated(t *testing.T) {
 	t.Parallel()
 
 	// Multi-endpoint resource -> parent group; single-endpoint resource -> promoted command.
-	// The promoted command's presence is what triggers api_discovery.go emission, and the
-	// api browser's RunE filters on child.Hidden. Without this fix the browser was empty by
-	// construction (issue #872).
+	// The promoted command's presence triggers api_discovery.go emission, but resource
+	// parents must remain visible in root help. API discovery identifies them from command
+	// metadata instead of repurposing Cobra's Hidden bit.
 	apiSpec := &spec.APISpec{
 		Name:    "hiddentest",
 		Version: "0.1.0",
@@ -10302,8 +10302,24 @@ func TestGeneratedOutput_ResourceParentsHiddenWhenAPIBrowserGenerated(t *testing
 
 	orders, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "orders.go"))
 	require.NoError(t, err)
-	assert.Regexp(t, `Hidden:\s+true`, string(orders),
-		"raw resource parent must be Hidden so the api browser finds it")
+	assert.NotContains(t, string(orders), "Hidden: true",
+		"raw resource parents must remain visible when the api browser is generated")
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	binaryPath := filepath.Join(outputDir, "hiddentest-pp-cli")
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/hiddentest-pp-cli")
+
+	helpOut, err := exec.Command(binaryPath, "--help").Output()
+	require.NoError(t, err)
+	assert.Contains(t, string(helpOut), "orders",
+		"root help must advertise raw resource parents")
+
+	apiOut, err := exec.Command(binaryPath, "api").Output()
+	require.NoError(t, err)
+	assert.Contains(t, string(apiOut), "orders",
+		"api discovery must still list visible resource parents")
+
+	requireGeneratedCompiles(t, outputDir)
 }
 
 func TestGeneratedOutput_ResourceParentsNotHiddenWithoutAPIBrowser(t *testing.T) {
@@ -10348,12 +10364,11 @@ func TestGeneratedOutput_ResourceParentsNotHiddenWithoutAPIBrowser(t *testing.T)
 		"raw resource parent must not be Hidden when no api browser is generated")
 }
 
-func TestGeneratedOutput_AgentContextIncludesHiddenResourceGroups(t *testing.T) {
+func TestGeneratedOutput_AgentContextIncludesResourceGroups(t *testing.T) {
 	t.Parallel()
 
-	// Cobra's Hidden flag is a --help curation tool; the agent-context surface
-	// must still enumerate hidden resource parents and their endpoint subcommands
-	// so agents can reach every action a CLI user could.
+	// The agent-context surface must enumerate resource parents and their
+	// endpoint subcommands so agents can reach every action a CLI user could.
 	apiSpec := &spec.APISpec{
 		Name:    "agentctxhide",
 		Version: "0.1.0",
@@ -10394,10 +10409,10 @@ func TestGeneratedOutput_AgentContextIncludesHiddenResourceGroups(t *testing.T) 
 	orders := findAgentContextCommand(payload["commands"], func(c map[string]any) bool {
 		return c["name"] == "orders"
 	})
-	require.NotNil(t, orders, "hidden resource parent must appear in agent-context")
+	require.NotNil(t, orders, "resource parent must appear in agent-context")
 	subs, ok := orders["subcommands"].([]any)
-	require.True(t, ok, "hidden resource parent must report its endpoint subcommands")
-	assert.NotEmpty(t, subs, "hidden resource parent must report its endpoint subcommands")
+	require.True(t, ok, "resource parent must report its endpoint subcommands")
+	assert.NotEmpty(t, subs, "resource parent must report its endpoint subcommands")
 }
 
 func TestGeneratedOutput_PromotedCommandNotForBuiltins(t *testing.T) {
@@ -11713,9 +11728,8 @@ func TestGenerateGraphQLBFFUsesSemanticCommandSurface(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/example-pp-cli")
 	helpOut, err := exec.Command(binaryPath, "--help").CombinedOutput()
 	require.NoError(t, err, string(helpOut))
-	// Multi-endpoint resources are now Hidden so the generated `api` browser can
-	// surface them; --help stays curated. Direct invocation and the api browser
-	// listing must both still work.
+	// GraphQL transport commands stay suppressed while generated resource
+	// parents remain directly invocable and available through the api browser.
 	assert.NotContains(t, string(helpOut), "graphql")
 	apiOut, err := exec.Command(binaryPath, "api").CombinedOutput()
 	require.NoError(t, err, string(apiOut))

--- a/internal/generator/mcp_novel_features_test.go
+++ b/internal/generator/mcp_novel_features_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -244,6 +245,68 @@ func TestFrameworkCommandClassificationIsTopLevelOnly(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "mcp", "cobratree", "framework_depth_test.go"), []byte(testSrc.String()), 0o644))
 
 	runGoCommandRequired(t, outputDir, "test", "./internal/mcp/cobratree")
+}
+
+func TestMCPEndpointToolsHiddenPreservesNovelDescendantReachability(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("surfacecheck")
+	apiSpec.MCP = spec.MCPConfig{EndpointTools: "hidden"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"orders": {
+			Description: "Manage orders",
+			Endpoints: map[string]spec.Endpoint{
+				"list":   {Method: "GET", Path: "/orders", Description: "List orders"},
+				"create": {Method: "POST", Path: "/orders", Description: "Create order"},
+			},
+		},
+		"customers": {
+			Description: "Single-endpoint customers resource",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/customers", Description: "List customers"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "surfacecheck-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.NovelFeatures = []NovelFeature{{
+		Name:        "Order triage",
+		Command:     "orders triage",
+		Description: "Prioritize orders that need attention.",
+		Rationale:   "Combines multiple order signals.",
+	}}
+	require.NoError(t, gen.Generate())
+
+	const runtimeTest = `package mcp
+
+import (
+	"testing"
+
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func TestEndpointToolsHiddenSurfaceReachability(t *testing.T) {
+	s := server.NewMCPServer("test", "0.0.0")
+	RegisterTools(s)
+	tools := s.ListTools()
+	if _, ok := tools["orders_triage"]; !ok {
+		t.Fatalf("novel descendant missing from MCP tools: %#v", tools)
+	}
+	if _, ok := tools["orders"]; ok {
+		t.Fatalf("API resource grouping command leaked into MCP tools: %#v", tools)
+	}
+	for _, endpointTool := range []string{"orders_list", "orders_create", "customers_list"} {
+		if _, ok := tools[endpointTool]; ok {
+			t.Fatalf("endpoint tool %q leaked into MCP tools: %#v", endpointTool, tools)
+		}
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "mcp", "surface_reachability_test.go"), []byte(runtimeTest), 0o644))
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommandRequired(t, outputDir, "test", "./internal/mcp/...", "-run", "TestEndpointToolsHiddenSurfaceReachability|TestRegisterAllDescendsThroughCobraHiddenButPrunesMCPHidden")
 }
 
 func TestMCPCobraTreeSiblingCLIPathUsesWindowsExecutableSuffix(t *testing.T) {

--- a/internal/generator/templates/agent_context.go.tmpl
+++ b/internal/generator/templates/agent_context.go.tmpl
@@ -231,10 +231,9 @@ func buildAgentDiscoveryContext() *agentContextDiscovery {
 // command name for stable diffs across regenerations.
 //
 // Cobra's Hidden flag suppresses listing in --help but does not gate
-// agent discovery. Raw resource parents are Hidden so --help stays
-// curated and the `api` browser populates; the agent-context surface
-// must still enumerate them and their endpoints so agents can call any
-// action a CLI user could.
+// agent discovery. The agent-context surface still traverses Hidden
+// grouping commands so agents can reach any visible descendant that a
+// CLI user can invoke directly.
 func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 	children := c.Commands()
 	sort.Slice(children, func(i, j int) bool { return children[i].Name() < children[j].Name() })

--- a/internal/generator/templates/api_discovery.go.tmpl
+++ b/internal/generator/templates/api_discovery.go.tmpl
@@ -35,7 +35,7 @@ Run 'api <interface>' to see that interface's methods.`,
 			if len(args) > 0 {
 				target := strings.ToLower(args[0])
 				for _, child := range root.Commands() {
-					if child.Hidden && strings.ToLower(child.Name()) == target {
+					if child.Annotations["pp:api-resource"] == "true" && strings.ToLower(child.Name()) == target {
 						methods := child.Commands()
 						// JSON envelope: {interface, short, methods: [{name, short}, ...]}.
 						if flags.asJSON {
@@ -75,7 +75,7 @@ Run 'api <interface>' to see that interface's methods.`,
 			}
 			var ifaces []ifaceEntry
 			for _, child := range root.Commands() {
-				if child.Hidden {
+				if child.Annotations["pp:api-resource"] == "true" {
 					ifaces = append(ifaces, ifaceEntry{Name: child.Name(), Short: child.Short})
 				}
 			}
@@ -86,13 +86,13 @@ Run 'api <interface>' to see that interface's methods.`,
 				out := map[string]any{"interfaces": ifaces}
 				if len(ifaces) == 0 {
 					out["interfaces"] = []ifaceEntry{}
-					out["note"] = "No hidden API interfaces found."
+					out["note"] = "No API interfaces found."
 				}
 				return printJSONFiltered(cmd.OutOrStdout(), out, flags)
 			}
 
 			if len(ifaces) == 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), "No hidden API interfaces found.")
+				fmt.Fprintln(cmd.OutOrStdout(), "No API interfaces found.")
 				return nil
 			}
 

--- a/internal/generator/templates/cobratree/classify.go.tmpl
+++ b/internal/generator/templates/cobratree/classify.go.tmpl
@@ -13,6 +13,7 @@ import (
 const (
 	EndpointAnnotation = "pp:endpoint"
 	HiddenAnnotation   = "mcp:hidden"
+	APIResourceAnnotation = "pp:api-resource"
 	// ReadOnlyAnnotation, when set on a Cobra command to "true"/"1"/"yes",
 	// causes the runtime walker to register the resulting MCP tool with
 	// readOnlyHint=true. Use for novel CLI commands that don't mutate
@@ -40,6 +41,7 @@ type commandKind int
 const (
 	commandNovel commandKind = iota
 	commandEndpoint
+	commandGroup
 	commandFramework
 	commandHidden
 )
@@ -88,6 +90,9 @@ func classify(cmd *cobra.Command) commandKind {
 	}
 	if endpointID(cmd) != "" {
 		return commandEndpoint
+	}
+	if annotationIsTrue(cmd, APIResourceAnnotation) {
+		return commandGroup
 	}
 	if isTopLevelFrameworkCommand(cmd) {
 		return commandFramework

--- a/internal/generator/templates/cobratree/shellout_test.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout_test.go.tmpl
@@ -501,6 +501,42 @@ func TestRegisterAllPreservesTypedToolsAndExposesHandBuiltSearchWithoutTypedEqui
 	}
 }
 
+func TestRegisterAllDescendsThroughCobraHiddenButPrunesMCPHidden(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	cobraHidden := &cobra.Command{Use: "orders", Hidden: true}
+	cobraHidden.AddCommand(&cobra.Command{
+		Use:  "triage",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	})
+	mcpHidden := &cobra.Command{
+		Use:         "secrets",
+		Annotations: map[string]string{"mcp:hidden": "true"},
+	}
+	mcpHidden.AddCommand(&cobra.Command{
+		Use:  "inspect",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	})
+	hiddenFramework := &cobra.Command{Use: "auth", Hidden: true}
+	hiddenFramework.AddCommand(&cobra.Command{
+		Use:  "status",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	})
+	root.AddCommand(cobraHidden, mcpHidden, hiddenFramework)
+
+	s := server.NewMCPServer("test", "0.0.0")
+	RegisterAll(s, root, func() (string, error) { return "missing-binary", nil })
+	tools := s.ListTools()
+
+	if _, ok := tools["orders_triage"]; !ok {
+		t.Fatalf("visible descendant under Cobra-hidden parent was not mirrored: %#v", tools)
+	}
+	for _, excluded := range []string{"orders", "secrets", "secrets_inspect", "auth_status"} {
+		if _, ok := tools[excluded]; ok {
+			t.Fatalf("excluded command %q was mirrored: %#v", excluded, tools)
+		}
+	}
+}
+
 func TestShellOutSinglePositionalArgsFieldPreservesWhitespace(t *testing.T) {
 	bin := writeArgvHelper(t)
 	positionals := []positionalArg{positionalArg{

--- a/internal/generator/templates/cobratree/walker.go.tmpl
+++ b/internal/generator/templates/cobratree/walker.go.tmpl
@@ -19,7 +19,7 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		switch classify(cmd) {
 		case commandHidden:
 			return
-		case commandEndpoint, commandFramework:
+		case commandEndpoint, commandGroup, commandFramework:
 			return
 		}
 		if !cmd.Runnable() {
@@ -68,12 +68,14 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 
 func walk(cmd *cobra.Command, path []string, visit func(*cobra.Command, []string)) {
 	for _, child := range cmd.Commands() {
-		if child.Hidden || isMCPHidden(child) {
+		if isMCPHidden(child) {
 			continue
 		}
 		childPath := append(append([]string{}, path...), child.Name())
-		visit(child, childPath)
-		if kind := classify(child); kind != commandHidden && kind != commandFramework {
+		if !child.Hidden {
+			visit(child, childPath)
+		}
+		if !isTopLevelFrameworkCommand(child) {
 			walk(child, childPath, visit)
 		}
 	}

--- a/internal/generator/templates/command_parent.go.tmpl
+++ b/internal/generator/templates/command_parent.go.tmpl
@@ -11,10 +11,7 @@ func new{{cmdIdent .FuncPrefix}}Cmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "{{kebab .ResourceName}}",
 		Short: "{{.Short}}",
-{{- if .Hidden}}
-		Hidden: true,
-{{- end}}
-		Annotations: map[string]string{"mcp:read-only": "true", "pp:typed-exit-codes": "0,2"},
+		Annotations: map[string]string{"mcp:read-only": "true", {{if .APIResource}}"pp:api-resource": "true", {{end}}"pp:typed-exit-codes": "0,2"},
 		RunE: parentNoSubcommandRunE(flags),
 	}
 {{range $eName, $endpoint := .Resource.Endpoints}}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -532,11 +532,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- end}}
 {{- range $subName, $sub := .Resource.SubResources}}
-	{
-		sub := new{{cmdIdent $.FuncPrefix $subName}}Cmd(flags)
-		sub.Hidden = false // unhide: the raw parent is hidden but these are useful under the promoted command
-		cmd.AddCommand(sub)
-	}
+	cmd.AddCommand(new{{cmdIdent $.FuncPrefix $subName}}Cmd(flags))
 {{- end}}
 {{- range .NovelChildren}}
 	cmd.AddCommand(newNovel{{.Ident}}Cmd(flags))

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -123,12 +123,10 @@ func suggestReadCommand(root *cobra.Command) string {
 				found = strings.Join(childPath, " ")
 				return
 			}
-			// Recurse even into Hidden parents: printed CLIs mark raw
-			// resource parents Hidden to keep --help curated, but their
-			// endpoint leaves remain runnable (`<cli> projects list`
-			// works). Skipping hidden subtrees would make this return ""
-			// in nearly every CLI. isSuggestableReadLeaf still rejects a
-			// leaf that is itself Hidden.
+			// Recurse even into Hidden grouping commands because their
+			// descendants can remain runnable and discoverable by direct
+			// invocation. isSuggestableReadLeaf still rejects a leaf that
+			// is itself Hidden.
 			walk(child, childPath)
 			if found != "" {
 				return

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -1217,7 +1217,7 @@ func TestCheckCommandTree_IndirectWiring(t *testing.T) {
 	require.NoError(t, os.MkdirAll(cliDir, 0o755))
 
 	// Test indirect wiring: sub := newXxxCmd(flags); cmd.AddCommand(sub)
-	// This pattern is used by command_promoted.go.tmpl for multi-endpoint subresources.
+	// The command-tree audit supports this valid hand-authored wiring shape.
 	writeTestFile(t, filepath.Join(cliDir, "root.go"), `package cli
 func newRootCmd() {
 	rootCmd.AddCommand(newParentCmd(&flags))

--- a/internal/pipeline/mcp_size.go
+++ b/internal/pipeline/mcp_size.go
@@ -230,6 +230,7 @@ type mcpCobraCommandKind int
 const (
 	mcpCobraNovel mcpCobraCommandKind = iota
 	mcpCobraEndpoint
+	mcpCobraGroup
 	mcpCobraFramework
 	mcpCobraHidden
 )
@@ -428,11 +429,14 @@ func estimateCobratreeCommandTool(cmd cobraCommandLiteral, path []string) (MCPTo
 
 func cobratreeCommandKind(cmd cobraCommandLiteral, depth int) mcpCobraCommandKind {
 	name := mcpCobraUseName(cmd.use)
-	if name == "" || cmd.hidden || annotationIsTrueValue(cmd.annotations["mcp:hidden"]) {
+	if name == "" || annotationIsTrueValue(cmd.annotations["mcp:hidden"]) {
 		return mcpCobraHidden
 	}
 	if strings.TrimSpace(cmd.annotations["pp:endpoint"]) != "" {
 		return mcpCobraEndpoint
+	}
+	if annotationIsTrueValue(cmd.annotations["pp:api-resource"]) {
+		return mcpCobraGroup
 	}
 	if depth == 1 && cobratreeFrameworkCommands[name] {
 		return mcpCobraFramework

--- a/internal/pipeline/mcp_size_test.go
+++ b/internal/pipeline/mcp_size_test.go
@@ -152,6 +152,10 @@ func RootCmd() *cobra.Command {
 	rootCmd.AddCommand(newEndpointCmd())
 	rootCmd.AddCommand(newAuthCmd())
 	rootCmd.AddCommand(newHiddenCmd())
+	rootCmd.AddCommand(newCobraHiddenGroupCmd())
+	rootCmd.AddCommand(newMCPHiddenGroupCmd())
+	rootCmd.AddCommand(newCobraHiddenFrameworkCmd())
+	rootCmd.AddCommand(newAPIResourceGroupCmd())
 	return rootCmd
 }
 
@@ -213,10 +217,72 @@ func newHiddenCmd() *cobra.Command {
 		RunE:        func(cmd *cobra.Command, args []string) error { return nil },
 	}
 }
+
+func newCobraHiddenGroupCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "orders", Hidden: true}
+	cmd.AddCommand(newCobraHiddenChildCmd())
+	return cmd
+}
+
+func newCobraHiddenChildCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "triage",
+		Short: "Triage orders.",
+		RunE:  func(cmd *cobra.Command, args []string) error { return nil },
+	}
+}
+
+func newMCPHiddenGroupCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         "secrets",
+		Annotations: map[string]string{"mcp:hidden": "true"},
+	}
+	cmd.AddCommand(newMCPHiddenChildCmd())
+	return cmd
+}
+
+func newMCPHiddenChildCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "inspect",
+		Short: "Inspect secrets.",
+		RunE:  func(cmd *cobra.Command, args []string) error { return nil },
+	}
+}
+
+func newCobraHiddenFrameworkCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "auth", Hidden: true}
+	cmd.AddCommand(newCobraHiddenFrameworkChildCmd())
+	return cmd
+}
+
+func newCobraHiddenFrameworkChildCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show auth status.",
+		RunE:  func(cmd *cobra.Command, args []string) error { return nil },
+	}
+}
+
+func newAPIResourceGroupCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         "catalog",
+		Annotations: map[string]string{"pp:api-resource": "true"},
+	}
+	cmd.AddCommand(newAPIResourceChildCmd())
+	return cmd
+}
+
+func newAPIResourceChildCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "summary",
+		Short: "Summarize the catalog.",
+		RunE:  func(cmd *cobra.Command, args []string) error { return nil },
+	}
+}
 `)
 
 	est := estimateMCPTokens(dir)
-	require.Equal(t, 4, est.ToolCount, "typed tool plus top-level and nested cobratree runtime tools should all count")
+	require.Equal(t, 6, est.ToolCount, "typed tool plus reachable cobratree runtime tools should all count")
 	names := make([]string, 0, len(est.PerTool))
 	for _, tool := range est.PerTool {
 		names = append(names, tool.Name)
@@ -225,7 +291,13 @@ func newHiddenCmd() *cobra.Command {
 	assert.Contains(t, names, "cobratree:digest")
 	assert.Contains(t, names, "cobratree:trends")
 	assert.Contains(t, names, "cobratree:items_search")
+	assert.Contains(t, names, "cobratree:orders_triage")
+	assert.Contains(t, names, "cobratree:catalog_summary")
 	assert.NotContains(t, names, "cobratree:auth")
+	assert.NotContains(t, names, "cobratree:orders")
+	assert.NotContains(t, names, "cobratree:secrets_inspect")
+	assert.NotContains(t, names, "cobratree:auth_status")
+	assert.NotContains(t, names, "cobratree:catalog")
 }
 
 func TestEstimateMCPTokens_CountsSharedConstructorsAtDistinctPaths(t *testing.T) {

--- a/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/internal/mcp/cobratree/walker.go
+++ b/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/internal/mcp/cobratree/walker.go
@@ -19,7 +19,7 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		switch classify(cmd) {
 		case commandHidden:
 			return
-		case commandEndpoint, commandFramework:
+		case commandEndpoint, commandGroup, commandFramework:
 			return
 		}
 		if !cmd.Runnable() {
@@ -68,12 +68,14 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 
 func walk(cmd *cobra.Command, path []string, visit func(*cobra.Command, []string)) {
 	for _, child := range cmd.Commands() {
-		if child.Hidden || isMCPHidden(child) {
+		if isMCPHidden(child) {
 			continue
 		}
 		childPath := append(append([]string{}, path...), child.Name())
-		visit(child, childPath)
-		if kind := classify(child); kind != commandHidden && kind != commandFramework {
+		if !child.Hidden {
+			visit(child, childPath)
+		}
+		if !isTopLevelFrameworkCommand(child) {
 			walk(child, childPath, visit)
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/agent_context.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/agent_context.go
@@ -213,10 +213,9 @@ func buildAgentDiscoveryContext() *agentContextDiscovery {
 // command name for stable diffs across regenerations.
 //
 // Cobra's Hidden flag suppresses listing in --help but does not gate
-// agent discovery. Raw resource parents are Hidden so --help stays
-// curated and the `api` browser populates; the agent-context surface
-// must still enumerate them and their endpoints so agents can call any
-// action a CLI user could.
+// agent discovery. The agent-context surface still traverses Hidden
+// grouping commands so agents can reach any visible descendant that a
+// CLI user can invoke directly.
 func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 	children := c.Commands()
 	sort.Slice(children, func(i, j int) bool { return children[i].Name() < children[j].Name() })

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/doctor.go
@@ -89,12 +89,10 @@ func suggestReadCommand(root *cobra.Command) string {
 				found = strings.Join(childPath, " ")
 				return
 			}
-			// Recurse even into Hidden parents: printed CLIs mark raw
-			// resource parents Hidden to keep --help curated, but their
-			// endpoint leaves remain runnable (`<cli> projects list`
-			// works). Skipping hidden subtrees would make this return ""
-			// in nearly every CLI. isSuggestableReadLeaf still rejects a
-			// leaf that is itself Hidden.
+			// Recurse even into Hidden grouping commands because their
+			// descendants can remain runnable and discoverable by direct
+			// invocation. isSuggestableReadLeaf still rejects a leaf that
+			// is itself Hidden.
 			walk(child, childPath)
 			if found != "" {
 				return

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/api_discovery.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/api_discovery.go
@@ -35,7 +35,7 @@ Run 'api <interface>' to see that interface's methods.`,
 			if len(args) > 0 {
 				target := strings.ToLower(args[0])
 				for _, child := range root.Commands() {
-					if child.Hidden && strings.ToLower(child.Name()) == target {
+					if child.Annotations["pp:api-resource"] == "true" && strings.ToLower(child.Name()) == target {
 						methods := child.Commands()
 						// JSON envelope: {interface, short, methods: [{name, short}, ...]}.
 						if flags.asJSON {
@@ -75,7 +75,7 @@ Run 'api <interface>' to see that interface's methods.`,
 			}
 			var ifaces []ifaceEntry
 			for _, child := range root.Commands() {
-				if child.Hidden {
+				if child.Annotations["pp:api-resource"] == "true" {
 					ifaces = append(ifaces, ifaceEntry{Name: child.Name(), Short: child.Short})
 				}
 			}
@@ -86,13 +86,13 @@ Run 'api <interface>' to see that interface's methods.`,
 				out := map[string]any{"interfaces": ifaces}
 				if len(ifaces) == 0 {
 					out["interfaces"] = []ifaceEntry{}
-					out["note"] = "No hidden API interfaces found."
+					out["note"] = "No API interfaces found."
 				}
 				return printJSONFiltered(cmd.OutOrStdout(), out, flags)
 			}
 
 			if len(ifaces) == 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), "No hidden API interfaces found.")
+				fmt.Fprintln(cmd.OutOrStdout(), "No API interfaces found.")
 				return nil
 			}
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/doctor.go
@@ -89,12 +89,10 @@ func suggestReadCommand(root *cobra.Command) string {
 				found = strings.Join(childPath, " ")
 				return
 			}
-			// Recurse even into Hidden parents: printed CLIs mark raw
-			// resource parents Hidden to keep --help curated, but their
-			// endpoint leaves remain runnable (`<cli> projects list`
-			// works). Skipping hidden subtrees would make this return ""
-			// in nearly every CLI. isSuggestableReadLeaf still rejects a
-			// leaf that is itself Hidden.
+			// Recurse even into Hidden grouping commands because their
+			// descendants can remain runnable and discoverable by direct
+			// invocation. isSuggestableReadLeaf still rejects a leaf that
+			// is itself Hidden.
 			walk(child, childPath)
 			if found != "" {
 				return

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/classify.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/classify.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	EndpointAnnotation = "pp:endpoint"
-	HiddenAnnotation   = "mcp:hidden"
+	EndpointAnnotation    = "pp:endpoint"
+	HiddenAnnotation      = "mcp:hidden"
+	APIResourceAnnotation = "pp:api-resource"
 	// ReadOnlyAnnotation, when set on a Cobra command to "true"/"1"/"yes",
 	// causes the runtime walker to register the resulting MCP tool with
 	// readOnlyHint=true. Use for novel CLI commands that don't mutate
@@ -40,6 +41,7 @@ type commandKind int
 const (
 	commandNovel commandKind = iota
 	commandEndpoint
+	commandGroup
 	commandFramework
 	commandHidden
 )
@@ -88,6 +90,9 @@ func classify(cmd *cobra.Command) commandKind {
 	}
 	if endpointID(cmd) != "" {
 		return commandEndpoint
+	}
+	if annotationIsTrue(cmd, APIResourceAnnotation) {
+		return commandGroup
 	}
 	if isTopLevelFrameworkCommand(cmd) {
 		return commandFramework

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
@@ -501,6 +501,42 @@ func TestRegisterAllPreservesTypedToolsAndExposesHandBuiltSearchWithoutTypedEqui
 	}
 }
 
+func TestRegisterAllDescendsThroughCobraHiddenButPrunesMCPHidden(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	cobraHidden := &cobra.Command{Use: "orders", Hidden: true}
+	cobraHidden.AddCommand(&cobra.Command{
+		Use:  "triage",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	})
+	mcpHidden := &cobra.Command{
+		Use:         "secrets",
+		Annotations: map[string]string{"mcp:hidden": "true"},
+	}
+	mcpHidden.AddCommand(&cobra.Command{
+		Use:  "inspect",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	})
+	hiddenFramework := &cobra.Command{Use: "auth", Hidden: true}
+	hiddenFramework.AddCommand(&cobra.Command{
+		Use:  "status",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	})
+	root.AddCommand(cobraHidden, mcpHidden, hiddenFramework)
+
+	s := server.NewMCPServer("test", "0.0.0")
+	RegisterAll(s, root, func() (string, error) { return "missing-binary", nil })
+	tools := s.ListTools()
+
+	if _, ok := tools["orders_triage"]; !ok {
+		t.Fatalf("visible descendant under Cobra-hidden parent was not mirrored: %#v", tools)
+	}
+	for _, excluded := range []string{"orders", "secrets", "secrets_inspect", "auth_status"} {
+		if _, ok := tools[excluded]; ok {
+			t.Fatalf("excluded command %q was mirrored: %#v", excluded, tools)
+		}
+	}
+}
+
 func TestShellOutSinglePositionalArgsFieldPreservesWhitespace(t *testing.T) {
 	bin := writeArgvHelper(t)
 	positionals := []positionalArg{positionalArg{

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/walker.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/walker.go
@@ -19,7 +19,7 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		switch classify(cmd) {
 		case commandHidden:
 			return
-		case commandEndpoint, commandFramework:
+		case commandEndpoint, commandGroup, commandFramework:
 			return
 		}
 		if !cmd.Runnable() {
@@ -68,12 +68,14 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 
 func walk(cmd *cobra.Command, path []string, visit func(*cobra.Command, []string)) {
 	for _, child := range cmd.Commands() {
-		if child.Hidden || isMCPHidden(child) {
+		if isMCPHidden(child) {
 			continue
 		}
 		childPath := append(append([]string{}, path...), child.Name())
-		visit(child, childPath)
-		if kind := classify(child); kind != commandHidden && kind != commandFramework {
+		if !child.Hidden {
+			visit(child, childPath)
+		}
+		if !isTopLevelFrameworkCommand(child) {
 			walk(child, childPath, visit)
 		}
 	}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/doctor.go
@@ -89,12 +89,10 @@ func suggestReadCommand(root *cobra.Command) string {
 				found = strings.Join(childPath, " ")
 				return
 			}
-			// Recurse even into Hidden parents: printed CLIs mark raw
-			// resource parents Hidden to keep --help curated, but their
-			// endpoint leaves remain runnable (`<cli> projects list`
-			// works). Skipping hidden subtrees would make this return ""
-			// in nearly every CLI. isSuggestableReadLeaf still rejects a
-			// leaf that is itself Hidden.
+			// Recurse even into Hidden grouping commands because their
+			// descendants can remain runnable and discoverable by direct
+			// invocation. isSuggestableReadLeaf still rejects a leaf that
+			// is itself Hidden.
 			walk(child, childPath)
 			if found != "" {
 				return


### PR DESCRIPTION
## Summary

Generated API resource groups are visible in root help again without becoming redundant MCP tools. Cobra-hidden grouping commands now keep reachable novel descendants in the agent surface, while `mcp:hidden`, framework commands, and hidden endpoint mirrors retain their intended exclusions.

The runtime walker, static token estimator, and tools audit now share that visibility contract, including path-sensitive handling for constructors mounted under both visible and MCP-hidden parents.

## Validation

- `go test -p 1 -timeout 20m ./...`
- `scripts/golden.sh verify` (32 cases)
- `scripts/verify-generator-output.sh` (10 generated modules)
- `golangci-lint run ./internal/cli/... ./internal/generator/... ./internal/pipeline/...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`

Closes #3680
Closes #3693
