### PR TITLE
fix(cli): validate generated unit tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,7 +217,7 @@ Add tests for new non-trivial logic. Match the package's existing style (typical
 Run `go test ./...` before considering your work done.
 
 ## Quality Gates
-Generated CLIs must pass 8 gates: `go mod tidy`, `govulncheck`, `go vet`, `go build`, binary build, `--help`, `version`, and `doctor`.
+Generated CLIs must pass 9 gates: `go mod tidy`, generated `go test ./...`, `govulncheck`, `go vet`, `go build`, binary build, `--help`, `version`, and `doctor`.
 Run `govulncheck` in default mode only, scoped to the generated or publishing CLI module (`./...` from that CLI directory). Do not use `-show verbose` or a whole public-library scan as a blocking gate; blocking CI scans only added or changed CLI modules, leaving whole-library sweeps to scheduled/reporting workflows.
 - For CLIs with `auth.type` of `cookie` or `composed`, `press-auth` (`cmd/press-auth/`) is the canonical cookie capture path. The generated `auth login --chrome` prefers it; the legacy extraction chain (pycookiecheat / browser-use / etc.) is the fallback when press-auth isn't installed. See [`skills/printing-press/references/auth-companion.md`](skills/printing-press/references/auth-companion.md).
 

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -109,7 +109,7 @@ Freshness ownership:
 - Freshness metadata belongs in the existing JSON provenance envelope at `meta.freshness`. It describes current-cache freshness for the covered path only; it must not be described as full historical backfill or API-specific enrichment.
 
 Gates:
-- All eight generator quality gates pass: `go mod tidy`, default-mode `govulncheck`, `go vet`, `go build`, binary build, `--help`, version, `doctor`
+- All nine generator quality gates pass: `go mod tidy`, generated `go test`, default-mode `govulncheck`, `go vet`, `go build`, binary build, `--help`, version, `doctor`
 
 Artifacts:
 - Full CLI source tree in the output directory
@@ -148,7 +148,7 @@ Outputs:
 
 Gates:
 - Overlay merge completes without conflicts
-- All eight generator quality gates pass again after regeneration, including default-mode `govulncheck`
+- All nine generator quality gates pass again after regeneration, including generated `go test` and default-mode `govulncheck`
 
 Artifacts:
 - Merged spec (format follows the source spec)

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -109,7 +109,7 @@ Freshness ownership:
 - Freshness metadata belongs in the existing JSON provenance envelope at `meta.freshness`. It describes current-cache freshness for the covered path only; it must not be described as full historical backfill or API-specific enrichment.
 
 Gates:
-- All nine generator quality gates pass: `go mod tidy`, generated `go test`, default-mode `govulncheck`, `go vet`, `go build`, binary build, `--help`, version, `doctor`
+- All ten generator quality gates pass: `go mod tidy`, safe `golang.org/x/net`, generated `go test`, default-mode `govulncheck`, `go vet`, `go build`, binary build, `--help`, version, `doctor`
 
 Artifacts:
 - Full CLI source tree in the output directory
@@ -148,7 +148,7 @@ Outputs:
 
 Gates:
 - Overlay merge completes without conflicts
-- All nine generator quality gates pass again after regeneration, including generated `go test` and default-mode `govulncheck`
+- All ten generator quality gates pass again after regeneration, including safe `golang.org/x/net`, generated `go test`, and default-mode `govulncheck`
 
 Artifacts:
 - Merged spec (format follows the source spec)

--- a/internal/generator/device.go
+++ b/internal/generator/device.go
@@ -166,6 +166,9 @@ func (g *DeviceGenerator) Validate() error {
 	if _, err := runCommand(g.OutputDir, qualityGateTimeout, "go", "mod", "tidy"); err != nil {
 		return fmt.Errorf("go mod tidy: %w", err)
 	}
+	if _, err := runCommand(g.OutputDir, qualityGateTimeout, "go", "test", "./..."); err != nil {
+		return fmt.Errorf("go test ./...: %w", err)
+	}
 	if _, err := runCommand(g.OutputDir, qualityGateTimeout, "go", "build", "./..."); err != nil {
 		return fmt.Errorf("go build ./...: %w", err)
 	}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2560,18 +2560,11 @@ func (g *Generator) renderOptionalSupportFiles() error {
 		}
 	}
 
-	if g.hasDataLayer() {
-		syncHintData := struct {
-			*spec.APISpec
-			HasSync bool
-		}{
-			APISpec: g.Spec,
-			HasSync: g.hasGeneratedSyncImplementation(),
-		}
-		if err := g.renderTemplate("sync_hint.go.tmpl", filepath.Join("internal", "cli", "sync_hint.go"), syncHintData); err != nil {
+	if g.hasGeneratedSyncImplementation() {
+		if err := g.renderTemplate("sync_hint.go.tmpl", filepath.Join("internal", "cli", "sync_hint.go"), g.Spec); err != nil {
 			return fmt.Errorf("rendering sync hint helper: %w", err)
 		}
-		if err := g.renderTemplate("sync_hint_test.go.tmpl", filepath.Join("internal", "cli", "sync_hint_test.go"), syncHintData); err != nil {
+		if err := g.renderTemplate("sync_hint_test.go.tmpl", filepath.Join("internal", "cli", "sync_hint_test.go"), g.Spec); err != nil {
 			return fmt.Errorf("rendering sync hint test: %w", err)
 		}
 	}
@@ -4466,7 +4459,7 @@ func (g *Generator) renderVisionCommands(visionData visionRenderData) error {
 			actualTmpl = "graphql_import.go.tmpl"
 		}
 		var tmplData any = g.Spec
-		if tmplName == "sync.go.tmpl" || tmplName == "search.go.tmpl" || tmplName == "export.go.tmpl" || tmplName == "import.go.tmpl" || tmplName == "tail.go.tmpl" {
+		if tmplName == "sync.go.tmpl" || tmplName == "search.go.tmpl" || tmplName == "export.go.tmpl" || tmplName == "import.go.tmpl" || tmplName == "tail.go.tmpl" || tmplName == "analytics.go.tmpl" {
 			tmplData = visionData
 		}
 		if err := g.renderTemplate(actualTmpl, outPath, tmplData); err != nil {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2571,7 +2571,7 @@ func TestGenerateWithNoAuth(t *testing.T) {
 		Version: "0.1.0",
 		BaseURL: "https://api.example.com",
 		Auth: spec.AuthConfig{
-			Type:    "",
+			Type:    "none",
 			EnvVars: nil,
 		},
 		Config: spec.ConfigSpec{

--- a/internal/generator/syncable_store_gate_test.go
+++ b/internal/generator/syncable_store_gate_test.go
@@ -62,7 +62,18 @@ func TestGenerateZeroSyncableAPIOmitsSyncAndDoctorCache(t *testing.T) {
 	apiSpec.Cache.Enabled = true
 	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
 	gen := New(apiSpec, outputDir)
-	gen.VisionSet = VisionTemplateSet{Import: true, Store: true, Search: true, Sync: true, MCP: true}
+	gen.VisionSet = VisionTemplateSet{
+		Import: true,
+		Store:  true,
+		Search: true,
+		Sync:   true,
+		MCP:    true,
+		Workflows: []string{
+			"workflows/pm_stale.go.tmpl",
+			"workflows/pm_orphans.go.tmpl",
+			"workflows/pm_load.go.tmpl",
+		},
+	}
 	require.NoError(t, gen.Generate())
 
 	require.NoFileExists(t, filepath.Join(outputDir, "internal", "cli", "sync.go"))
@@ -71,7 +82,6 @@ func TestGenerateZeroSyncableAPIOmitsSyncAndDoctorCache(t *testing.T) {
 	rootSrc := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
 	doctorSrc := readGeneratedFile(t, outputDir, "internal", "cli", "doctor.go")
 	dataSourceSrc := readGeneratedFile(t, outputDir, "internal", "cli", "data_source.go")
-	syncHintSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync_hint.go")
 	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
 	require.NotContains(t, rootSrc, "newSyncCmd(flags)")
 	require.NotContains(t, rootSrc, "newSearchCmd(flags)")
@@ -80,10 +90,16 @@ func TestGenerateZeroSyncableAPIOmitsSyncAndDoctorCache(t *testing.T) {
 	require.NotContains(t, dataSourceSrc, "emitSyncHints")
 	require.NotContains(t, dataSourceSrc, "Run 'zero-syncable-query-pp-cli sync' first")
 	require.Equal(t, 4, strings.Count(dataSourceSrc, "Populate the local store through a custom store-backed command first."))
-	require.Contains(t, syncHintSrc, "const syncHintsEnabled = false")
+	require.NoFileExists(t, filepath.Join(outputDir, "internal", "cli", "sync_hint.go"))
+	require.NoFileExists(t, filepath.Join(outputDir, "internal", "cli", "sync_hint_test.go"))
 	require.Contains(t, mcpSrc, `mcplib.NewTool("sql"`)
+	for _, file := range []string{"pm_stale.go", "pm_orphans.go", "pm_load.go"} {
+		workflowSrc := readGeneratedFile(t, outputDir, "internal", "cli", file)
+		require.NotContains(t, workflowSrc, "maybeEmitSyncHints")
+	}
 
 	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./...")
 }
 
 func TestConstrainVisionTemplatesKeepsStreamingSyncWhenProfileHasNoBulkResources(t *testing.T) {

--- a/internal/generator/templates/analytics.go.tmpl
+++ b/internal/generator/templates/analytics.go.tmpl
@@ -46,7 +46,9 @@ Data must be synced first with the sync command.`,
 			}
 			defer db.Close()
 
+			{{- if .HasSync }}
 			maybeEmitSyncHints(cmd, db, resourceType, flags.maxAge)
+			{{- end }}
 
 			if resourceType == "" {
 				// Show summary of all resource types

--- a/internal/generator/templates/search.go.tmpl
+++ b/internal/generator/templates/search.go.tmpl
@@ -195,7 +195,9 @@ Run sync first to populate the local search index.`,
 			}
 			defer db.Close()
 
+			{{- if .HasSync }}
 			maybeEmitSyncHints(cmd, db, resourceType, flags.maxAge)
+			{{- end }}
 
 			var results []json.RawMessage
 			switch resourceType {

--- a/internal/generator/templates/sync_hint.go.tmpl
+++ b/internal/generator/templates/sync_hint.go.tmpl
@@ -20,19 +20,14 @@ type syncHintState struct {
 	lastSynced time.Time
 }
 
-const syncHintsEnabled = {{.HasSync}}
-
 func maybeEmitSyncHints(cmd *cobra.Command, db *store.Store, resourceType string, maxAge time.Duration) {
-	if !syncHintsEnabled || cmd == nil {
+	if cmd == nil {
 		return
 	}
 	emitSyncHints(cmd.ErrOrStderr(), db, resourceType, maxAge)
 }
 
 func emitSyncHints(w io.Writer, db *store.Store, resourceType string, maxAge time.Duration) {
-	if !syncHintsEnabled {
-		return
-	}
 	state, err := readSyncHintState(db, resourceType)
 	if err != nil || w == nil {
 		return
@@ -52,7 +47,7 @@ func emitSyncHints(w io.Writer, db *store.Store, resourceType string, maxAge tim
 }
 
 func hintIfUnsynced(cmd *cobra.Command, db *store.Store, resourceType string) bool {
-	if !syncHintsEnabled || cmd == nil || db == nil {
+	if cmd == nil || db == nil {
 		return false
 	}
 	state, err := readSyncHintState(db, resourceType)
@@ -64,7 +59,7 @@ func hintIfUnsynced(cmd *cobra.Command, db *store.Store, resourceType string) bo
 }
 
 func hintIfStale(cmd *cobra.Command, db *store.Store, resourceType string, maxAge time.Duration) bool {
-	if !syncHintsEnabled || cmd == nil || db == nil || maxAge <= 0 {
+	if cmd == nil || db == nil || maxAge <= 0 {
 		return false
 	}
 	state, err := readSyncHintState(db, resourceType)

--- a/internal/generator/templates/workflows/pm_load.go.tmpl
+++ b/internal/generator/templates/workflows/pm_load.go.tmpl
@@ -41,7 +41,9 @@ person. Helps identify overloaded team members and unbalanced workload.`,
 			}
 			defer db.Close()
 
+			{{- if .HasSync }}
 			maybeEmitSyncHints(cmd, db, "", flags.maxAge)
+			{{- end }}
 
 			// Build user name lookup from synced users
 			userNames := map[string]string{}

--- a/internal/generator/templates/workflows/pm_orphans.go.tmpl
+++ b/internal/generator/templates/workflows/pm_orphans.go.tmpl
@@ -38,7 +38,9 @@ such as assignee, project, priority, or labels. Useful for triaging unowned work
 			}
 			defer db.Close()
 
+			{{- if .HasSync }}
 			maybeEmitSyncHints(cmd, db, "", flags.maxAge)
+			{{- end }}
 
 			// Fields that indicate an item is properly assigned/categorized
 			checkFields := []struct {

--- a/internal/generator/templates/workflows/pm_stale.go.tmpl
+++ b/internal/generator/templates/workflows/pm_stale.go.tmpl
@@ -131,7 +131,9 @@ the specified number of days. Useful for identifying forgotten or blocked work.`
 			}
 			defer db.Close()
 
+			{{- if .HasSync }}
 			maybeEmitSyncHints(cmd, db, "", flags.maxAge)
+			{{- end }}
 
 			cutoffTime := time.Now().AddDate(0, 0, -days)
 			cutoffStr := cutoffTime.Format(time.RFC3339)

--- a/internal/generator/validate.go
+++ b/internal/generator/validate.go
@@ -56,6 +56,13 @@ func (g *Generator) Validate() error {
 			},
 		},
 		{
+			name: "go test ./...",
+			run: func() error {
+				_, err := runCommand(g.OutputDir, qualityGateTimeout, "go", "test", "./...")
+				return err
+			},
+		},
+		{
 			name: "govulncheck ./...",
 			run: func() error {
 				env := govulncheck.ToolchainEnv(g.OutputDir)

--- a/internal/generator/validate_test.go
+++ b/internal/generator/validate_test.go
@@ -118,6 +118,100 @@ exit 0
 	assert.NotContains(t, string(calls), "verbose")
 }
 
+func TestValidateRunsGeneratedUnitTests(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake shell go binary is Unix-only")
+	}
+	outputDir := filepath.Join(t.TempDir(), "validate-pp-cli")
+	gen := New(minimalSpec("validate"), outputDir)
+	require.NoError(t, gen.Generate())
+
+	fakeBin := t.TempDir()
+	callsPath := filepath.Join(t.TempDir(), "go-calls.txt")
+	fakeGo := filepath.Join(fakeBin, "go")
+	require.NoError(t, os.WriteFile(fakeGo, []byte(`#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_GO_CALLS"
+if [ "$1" = "run" ]; then
+  echo "fake govulncheck failure" >&2
+  exit 42
+fi
+exit 0
+`), 0o755))
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FAKE_GO_CALLS", callsPath)
+
+	err := gen.Validate()
+	require.Error(t, err)
+
+	calls, err := os.ReadFile(callsPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(calls), "test ./...\n")
+}
+
+func TestValidateFailsWhenGeneratedUnitTestsFail(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake shell go binary is Unix-only")
+	}
+	outputDir := filepath.Join(t.TempDir(), "validate-pp-cli")
+	gen := New(minimalSpec("validate"), outputDir)
+	require.NoError(t, gen.Generate())
+
+	fakeBin := t.TempDir()
+	callsPath := filepath.Join(t.TempDir(), "go-calls.txt")
+	fakeGo := filepath.Join(fakeBin, "go")
+	require.NoError(t, os.WriteFile(fakeGo, []byte(`#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_GO_CALLS"
+if [ "$1" = "test" ]; then
+  echo "broken generated test" >&2
+  exit 42
+fi
+exit 0
+`), 0o755))
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FAKE_GO_CALLS", callsPath)
+
+	err := gen.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `gate "go test ./..." failed`)
+	assert.Contains(t, err.Error(), "broken generated test")
+
+	calls, err := os.ReadFile(callsPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(calls), "vet ./...\n")
+	assert.NotContains(t, string(calls), "build ")
+}
+
+func TestDeviceValidateRunsGeneratedUnitTests(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake shell go binary is Unix-only")
+	}
+	outputDir := t.TempDir()
+	gen := &DeviceGenerator{OutputDir: outputDir}
+
+	fakeBin := t.TempDir()
+	callsPath := filepath.Join(t.TempDir(), "go-calls.txt")
+	fakeGo := filepath.Join(fakeBin, "go")
+	require.NoError(t, os.WriteFile(fakeGo, []byte(`#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_GO_CALLS"
+if [ "$1" = "test" ]; then
+  echo "broken generated device test" >&2
+  exit 42
+fi
+exit 0
+`), 0o755))
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FAKE_GO_CALLS", callsPath)
+
+	err := gen.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "go test ./...")
+	assert.Contains(t, err.Error(), "broken generated device test")
+
+	calls, err := os.ReadFile(callsPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(calls), "build ")
+}
+
 func TestValidateBuildRunnableBinaryUsesReproducibleBuildFlags(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake shell go binary is Unix-only")

--- a/internal/pipeline/fullrun.go
+++ b/internal/pipeline/fullrun.go
@@ -16,7 +16,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const fullRunQualityGateCount = 9
+const fullRunQualityGateCount = 10
 
 // FullRunResult holds everything the press produced for one API.
 type FullRunResult struct {

--- a/internal/pipeline/fullrun.go
+++ b/internal/pipeline/fullrun.go
@@ -16,7 +16,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const fullRunQualityGateCount = 8
+const fullRunQualityGateCount = 9
 
 // FullRunResult holds everything the press produced for one API.
 type FullRunResult struct {

--- a/internal/pipeline/fullrun_test.go
+++ b/internal/pipeline/fullrun_test.go
@@ -83,8 +83,8 @@ func TestGenerateLearningsPlanUsesQualityGateCount(t *testing.T) {
 
 	content, err := os.ReadFile(outputPath)
 	require.NoError(t, err)
-	assert.Contains(t, string(content), "Gates 6/8")
-	assert.NotContains(t, string(content), "Gates 6/7")
+	assert.Contains(t, string(content), "Gates 6/9")
+	assert.NotContains(t, string(content), "Gates 6/8")
 }
 
 func TestPrintComparisonTableRows(t *testing.T) {
@@ -129,7 +129,7 @@ func TestPrintComparisonTableRows(t *testing.T) {
 		last = idx
 	}
 
-	assert.Contains(t, table, "6/8 PASS")
+	assert.Contains(t, table, "6/9 PASS")
 	assert.Contains(t, table, "72/80 (72%)")
 	assert.Contains(t, table, "1/2")
 	assert.Contains(t, table, "PASS 100%")

--- a/internal/pipeline/fullrun_test.go
+++ b/internal/pipeline/fullrun_test.go
@@ -83,8 +83,8 @@ func TestGenerateLearningsPlanUsesQualityGateCount(t *testing.T) {
 
 	content, err := os.ReadFile(outputPath)
 	require.NoError(t, err)
-	assert.Contains(t, string(content), "Gates 6/9")
-	assert.NotContains(t, string(content), "Gates 6/8")
+	assert.Contains(t, string(content), "Gates 6/10")
+	assert.NotContains(t, string(content), "Gates 6/9")
 }
 
 func TestPrintComparisonTableRows(t *testing.T) {
@@ -129,7 +129,7 @@ func TestPrintComparisonTableRows(t *testing.T) {
 		last = idx
 	}
 
-	assert.Contains(t, table, "6/9 PASS")
+	assert.Contains(t, table, "6/10 PASS")
 	assert.Contains(t, table, "72/80 (72%)")
 	assert.Contains(t, table, "1/2")
 	assert.Contains(t, table, "PASS 100%")

--- a/internal/pipeline/planner.go
+++ b/internal/pipeline/planner.go
@@ -123,7 +123,7 @@ func generateScaffoldPlan(ctx PlanContext) (string, error) {
 
 	b.WriteString("## What This Phase Must Produce\n\n")
 	fmt.Fprintf(&b, "- Generated CLI source tree in %s\n", ctx.SeedData.OutputDir)
-	b.WriteString("- All nine generator quality gates passing, including generated go test and default-mode govulncheck\n")
+	b.WriteString("- All ten generator quality gates passing, including safe golang.org/x/net, generated go test, and default-mode govulncheck\n")
 	fmt.Fprintf(&b, "- Working CLI binary for %s\n\n", ctx.SeedData.APIName)
 
 	b.WriteString("## Codebase Pointers\n\n")

--- a/internal/pipeline/planner.go
+++ b/internal/pipeline/planner.go
@@ -123,7 +123,7 @@ func generateScaffoldPlan(ctx PlanContext) (string, error) {
 
 	b.WriteString("## What This Phase Must Produce\n\n")
 	fmt.Fprintf(&b, "- Generated CLI source tree in %s\n", ctx.SeedData.OutputDir)
-	b.WriteString("- All eight generator quality gates passing, including default-mode govulncheck\n")
+	b.WriteString("- All nine generator quality gates passing, including generated go test and default-mode govulncheck\n")
 	fmt.Fprintf(&b, "- Working CLI binary for %s\n\n", ctx.SeedData.APIName)
 
 	b.WriteString("## Codebase Pointers\n\n")

--- a/internal/pipeline/planner_artifacts_test.go
+++ b/internal/pipeline/planner_artifacts_test.go
@@ -42,7 +42,8 @@ func TestGenerateNextPlanLoadsArtifactsFromRunstateDirs(t *testing.T) {
 	scaffoldPlan, err := GenerateNextPlan(state, PhaseScaffold)
 	require.NoError(t, err)
 	assert.Contains(t, scaffoldPlan, "Novelty score:** 8/10 (proceed)")
-	assert.Contains(t, scaffoldPlan, "All nine")
+	assert.Contains(t, scaffoldPlan, "All ten")
+	assert.Contains(t, scaffoldPlan, "safe golang.org/x/net")
 	assert.Contains(t, scaffoldPlan, "generated go test")
 	assert.Contains(t, scaffoldPlan, "govulncheck")
 

--- a/internal/pipeline/planner_artifacts_test.go
+++ b/internal/pipeline/planner_artifacts_test.go
@@ -42,7 +42,8 @@ func TestGenerateNextPlanLoadsArtifactsFromRunstateDirs(t *testing.T) {
 	scaffoldPlan, err := GenerateNextPlan(state, PhaseScaffold)
 	require.NoError(t, err)
 	assert.Contains(t, scaffoldPlan, "Novelty score:** 8/10 (proceed)")
-	assert.Contains(t, scaffoldPlan, "All eight")
+	assert.Contains(t, scaffoldPlan, "All nine")
+	assert.Contains(t, scaffoldPlan, "generated go test")
 	assert.Contains(t, scaffoldPlan, "govulncheck")
 
 	comparativePlan, err := GenerateNextPlan(state, PhaseComparative)

--- a/internal/pipeline/seeds.go
+++ b/internal/pipeline/seeds.go
@@ -173,7 +173,7 @@ Generate the first working {{.APIName}} CLI from the validated OpenAPI spec.
 ## What This Phase Must Produce
 
 - Generated CLI source tree in {{.OutputDir}}
-- All nine generator quality gates passing, including generated go test and default-mode govulncheck
+- All ten generator quality gates passing, including safe golang.org/x/net, generated go test, and default-mode govulncheck
 - Working CLI binary for {{.APIName}}
 
 ## Prior Phase Outputs
@@ -248,7 +248,7 @@ Merge the enrichments into the source spec and regenerate the CLI without losing
 
 - Re-generated CLI in {{.OutputDir}} using the merged overlay
 - Merged spec artifact suitable for regeneration
-- All nine quality gates still passing after regeneration, including generated go test and default-mode govulncheck
+- All ten quality gates still passing after regeneration, including safe golang.org/x/net, generated go test, and default-mode govulncheck
 
 ## Prior Phase Outputs
 

--- a/internal/pipeline/seeds.go
+++ b/internal/pipeline/seeds.go
@@ -173,7 +173,7 @@ Generate the first working {{.APIName}} CLI from the validated OpenAPI spec.
 ## What This Phase Must Produce
 
 - Generated CLI source tree in {{.OutputDir}}
-- All eight generator quality gates passing, including default-mode govulncheck
+- All nine generator quality gates passing, including generated go test and default-mode govulncheck
 - Working CLI binary for {{.APIName}}
 
 ## Prior Phase Outputs
@@ -248,7 +248,7 @@ Merge the enrichments into the source spec and regenerate the CLI without losing
 
 - Re-generated CLI in {{.OutputDir}} using the merged overlay
 - Merged spec artifact suitable for regeneration
-- All eight quality gates still passing after regeneration, including default-mode govulncheck
+- All nine quality gates still passing after regeneration, including generated go test and default-mode govulncheck
 
 ## Prior Phase Outputs
 

--- a/internal/pipeline/seeds_test.go
+++ b/internal/pipeline/seeds_test.go
@@ -34,7 +34,8 @@ func TestRenderSeedProducesThinSeedTemplates(t *testing.T) {
 			require.Contains(t, rendered, "type: feat")
 			require.Contains(t, rendered, "date: ")
 			if phase == PhaseScaffold || phase == PhaseRegenerate {
-				require.Contains(t, rendered, "All eight")
+				require.Contains(t, rendered, "All nine")
+				require.Contains(t, rendered, "generated go test")
 				require.Contains(t, rendered, "govulncheck")
 				require.NotContains(t, rendered, "All seven")
 			}

--- a/internal/pipeline/seeds_test.go
+++ b/internal/pipeline/seeds_test.go
@@ -34,7 +34,8 @@ func TestRenderSeedProducesThinSeedTemplates(t *testing.T) {
 			require.Contains(t, rendered, "type: feat")
 			require.Contains(t, rendered, "date: ")
 			if phase == PhaseScaffold || phase == PhaseRegenerate {
-				require.Contains(t, rendered, "All nine")
+				require.Contains(t, rendered, "All ten")
+				require.Contains(t, rendered, "safe golang.org/x/net")
 				require.Contains(t, rendered, "generated go test")
 				require.Contains(t, rendered, "govulncheck")
 				require.NotContains(t, rendered, "All seven")


### PR DESCRIPTION
## Summary

Fresh printed CLIs now keep their generated unit-test suite green across sync-enabled and non-sync data-layer variants. Validation runs that suite as a tenth quality gate for HTTP and device CLIs, so a broken generated test stops the pipeline before later build and runtime checks can pass.

Sync hints are now emitted only when the printed CLI has a real generated sync implementation, removing the contradictory disabled helper and its failing tests from non-sync outputs.

## Verification

- `go test -timeout 20m -parallel 4 ./...` (6,696 tests passed across 44 packages)
- `scripts/golden.sh verify` (32 cases passed)
- `scripts/verify-generator-output.sh` (10 generated modules compiled)
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...` (only the existing `modernize` finding in `internal/openapi/parser.go`)

Closes #3714
Closes #3456
