### PR TITLE
fix(cli): make generated synonym registration race-safe

### DIFF
--- a/internal/generator/learn_synonyms_test.go
+++ b/internal/generator/learn_synonyms_test.go
@@ -157,3 +157,21 @@ func TestGenerateLearnSynonymsCompileAndTest(t *testing.T) {
 		"TestLearnNormalizers_SynonymFoldSymmetry|TestLearnConfig_SpecSynonymsRegisteredBothSides",
 		"./internal/cli")
 }
+
+func TestGenerateLearnSynonymsConcurrentRegistrationIsRaceSafe(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("race test of emitted synonym registration skipped in -short mode")
+	}
+
+	apiSpec := minimalSpec("learn-syn-race")
+	apiSpec.Learn.Enabled = true
+	apiSpec.Learn.Synonyms = map[string]string{"foo bar": "baz"}
+	outputDir := filepath.Join(t.TempDir(), "learn-syn-race-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	runGoCommand(t, outputDir, "test", "-race", "-count=5", "-run",
+		"^TestPlaybookInit_ConcurrentSafe$", "./internal/cli")
+}

--- a/internal/generator/learn_synonyms_test.go
+++ b/internal/generator/learn_synonyms_test.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -172,6 +173,57 @@ func TestGenerateLearnSynonymsConcurrentRegistrationIsRaceSafe(t *testing.T) {
 	gen.VisionSet = VisionTemplateSet{Store: true}
 	require.NoError(t, gen.Generate())
 
-	runGoCommand(t, outputDir, "test", "-race", "-count=5", "-run",
-		"^TestPlaybookInit_ConcurrentSafe$", "./internal/cli")
+	const runtimeRaceTest = `package store
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestRegisterQuerySynonymsConcurrentNormalize(t *testing.T) {
+	synonyms := map[string]string{"foo bar": "baz"}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < 8; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 200; j++ {
+				RegisterQuerySynonyms(synonyms)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 200; j++ {
+				_ = NormalizeQuery("foo bar qux")
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	if got := NormalizeQuery("foo bar"); got != "baz" {
+		t.Fatalf("NormalizeQuery(foo bar) = %q, want baz", got)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "store", "query_synonyms_race_test.go"),
+		[]byte(runtimeRaceTest),
+		0o644,
+	))
+
+	cacheDir, err := goBuildCacheDir(outputDir)
+	require.NoError(t, err)
+	cmd := exec.Command("go", "test", "-mod=mod", "-race", "-count=5", "-v", "-run",
+		"^TestRegisterQuerySynonymsConcurrentNormalize$", "./internal/store")
+	cmd.Dir = outputDir
+	cmd.Env = append(os.Environ(), "GOCACHE="+cacheDir)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	require.Contains(t, string(output), "=== RUN   TestRegisterQuerySynonymsConcurrentNormalize")
+	require.Contains(t, string(output), "--- PASS: TestRegisterQuerySynonymsConcurrentNormalize")
 }

--- a/internal/generator/templates/learnings.go.tmpl
+++ b/internal/generator/templates/learnings.go.tmpl
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -91,6 +92,7 @@ var (
 	// by necessity: NormalizeQuery is a package function with no config
 	// receiver. Registration is one-shot at CLI startup (before any
 	// store use), matching the entities.Config mutation contract.
+	querySynonymMu    sync.RWMutex
 	querySynonyms     = copyQuerySynonymDefaults()
 	querySynonymRules = compileQuerySynonyms(querySynonyms)
 )
@@ -110,6 +112,9 @@ func copyQuerySynonymDefaults() map[string]string {
 // entities.Config, keeping the two normalizers symmetric. Entries
 // with an empty side are dropped; folding is a single hop.
 func RegisterQuerySynonyms(synonyms map[string]string) {
+	querySynonymMu.Lock()
+	defer querySynonymMu.Unlock()
+
 	changed := false
 	for v, canonical := range synonyms {
 		v = strings.ToLower(strings.TrimSpace(v))
@@ -173,8 +178,15 @@ func queryCharTokens(s string) []string {
 // BEFORE stopword filtering so a variant containing a stopword-shaped
 // token ("to" in "to-day" -> "to day") still folds as a unit.
 func foldQueryTokens(tokens []string) []string {
+	if len(tokens) == 0 {
+		return tokens
+	}
+
+	querySynonymMu.RLock()
+	defer querySynonymMu.RUnlock()
+
 	rules := querySynonymRules
-	if len(rules) == 0 || len(tokens) == 0 {
+	if len(rules) == 0 {
 		return tokens
 	}
 	out := make([]string, 0, len(tokens))

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/learnings.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/learnings.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -91,6 +92,7 @@ var (
 	// by necessity: NormalizeQuery is a package function with no config
 	// receiver. Registration is one-shot at CLI startup (before any
 	// store use), matching the entities.Config mutation contract.
+	querySynonymMu    sync.RWMutex
 	querySynonyms     = copyQuerySynonymDefaults()
 	querySynonymRules = compileQuerySynonyms(querySynonyms)
 )
@@ -110,6 +112,9 @@ func copyQuerySynonymDefaults() map[string]string {
 // entities.Config, keeping the two normalizers symmetric. Entries
 // with an empty side are dropped; folding is a single hop.
 func RegisterQuerySynonyms(synonyms map[string]string) {
+	querySynonymMu.Lock()
+	defer querySynonymMu.Unlock()
+
 	changed := false
 	for v, canonical := range synonyms {
 		v = strings.ToLower(strings.TrimSpace(v))
@@ -173,8 +178,15 @@ func queryCharTokens(s string) []string {
 // BEFORE stopword filtering so a variant containing a stopword-shaped
 // token ("to" in "to-day" -> "to day") still folds as a unit.
 func foldQueryTokens(tokens []string) []string {
+	if len(tokens) == 0 {
+		return tokens
+	}
+
+	querySynonymMu.RLock()
+	defer querySynonymMu.RUnlock()
+
 	rules := querySynonymRules
-	if len(rules) == 0 || len(tokens) == 0 {
+	if len(rules) == 0 {
 		return tokens
 	}
 	out := make([]string, 0, len(tokens))


### PR DESCRIPTION
## Summary

Generated CLIs with spec-declared learn synonyms can now install playbooks concurrently without racing package-level synonym normalization. The Printing Press synchronizes registration and normalization, then proves the emitted behavior with the race detector.

Closes #3695.

## Validation

- `go test ./internal/generator -run '^TestGenerateLearnSynonymsConcurrentRegistrationIsRaceSafe$' -count=1`
- `go test ./...` (6,688 tests passed across 44 packages)
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh generate-learn-loop-api`
- `golangci-lint run ./...`
- `git diff --check`
