### PR TITLE
fix(cli): prevent derived command surface collisions

### DIFF
--- a/internal/browsersniff/analysis.go
+++ b/internal/browsersniff/analysis.go
@@ -548,6 +548,35 @@ func WriteTrafficAnalysis(analysis *TrafficAnalysis, outputPath string) error {
 	return nil
 }
 
+// AddReservedResourceNameWarnings surfaces the rename while traffic context
+// can still suggest a domain-specific replacement; generation can only reject.
+func AddReservedResourceNameWarnings(apiSpec *spec.APISpec, analysis *TrafficAnalysis) {
+	if apiSpec == nil || analysis == nil {
+		return
+	}
+
+	resourceNames := make([]string, 0, len(apiSpec.Resources))
+	for name := range apiSpec.Resources {
+		resourceNames = append(resourceNames, name)
+	}
+	sort.Strings(resourceNames)
+	for _, name := range resourceNames {
+		resource := apiSpec.Resources[name]
+		if len(resource.Endpoints) == 0 && len(resource.SubResources) == 0 {
+			continue
+		}
+		if !apiSpec.ConflictsWithReservedCLIResourceName(name) && !apiSpec.ParseTimeReservedCobraUseName(name) {
+			continue
+		}
+		analysis.Warnings = append(analysis.Warnings, AnalysisWarning{
+			Type:       "reserved_resource_name",
+			Message:    fmt.Sprintf("resource name %q may conflict with a reserved Printing Press command or template; consider renaming it to a domain-specific command name", name),
+			Confidence: 1,
+		})
+	}
+	sortTrafficAnalysis(analysis)
+}
+
 func ReadTrafficAnalysis(inputPath string) (*TrafficAnalysis, error) {
 	if strings.TrimSpace(inputPath) == "" {
 		return nil, fmt.Errorf("input path is required")

--- a/internal/cli/browser_sniff.go
+++ b/internal/cli/browser_sniff.go
@@ -79,6 +79,7 @@ func newBrowserSniffCmd() *cobra.Command {
 			browsersniff.ApplyReachabilityDefaults(apiSpec, trafficAnalysis)
 
 			droppedEndpoints := browsersniff.FilterEndpointsByMinSamplesWithOptions(apiSpec, capture, minSamples, analyzeOptions)
+			browsersniff.AddReservedResourceNameWarnings(apiSpec, trafficAnalysis)
 
 			samplesWritten, err := writeBrowserSniffOutputs(apiSpec, trafficAnalysis, capture, outputPath, analysisOutputPath, samplesOutputPath, analyzeOptions)
 			if err != nil {

--- a/internal/cli/browser_sniff_test.go
+++ b/internal/cli/browser_sniff_test.go
@@ -152,6 +152,65 @@ func TestBrowserSniffCmdWritesLowConfidencePathHints(t *testing.T) {
 	assert.Contains(t, string(analysisData), `"segment": "2026-08-16"`)
 }
 
+func TestBrowserSniffCmdWarnsOnReservedDerivedResourceNames(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		wantWarning bool
+	}{
+		{name: "reserved search resource", path: "/search/item-1", wantWarning: true},
+		{name: "ordinary predict resource", path: "/predict/item-1", wantWarning: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			capturePath := filepath.Join(dir, "capture.json")
+			outputPath := filepath.Join(dir, "spec.yaml")
+			analysisPath := filepath.Join(dir, "traffic-analysis.json")
+			capture := browsersniff.EnrichedCapture{
+				TargetURL: "https://api.example.com",
+				Entries: []browsersniff.EnrichedEntry{
+					{
+						Method:              "GET",
+						URL:                 "https://api.example.com" + tt.path,
+						ResponseStatus:      200,
+						ResponseContentType: "application/json",
+						ResponseBody:        `{"id":"item-1"}`,
+					},
+					{
+						Method:              "GET",
+						URL:                 "https://api.example.com" + strings.ReplaceAll(tt.path, "item-1", "item-2"),
+						ResponseStatus:      200,
+						ResponseContentType: "application/json",
+						ResponseBody:        `{"id":"item-2"}`,
+					},
+				},
+			}
+			data, err := json.Marshal(capture)
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(capturePath, data, 0o600))
+
+			cmd := newBrowserSniffCmd()
+			cmd.SetArgs([]string{
+				"--har", capturePath,
+				"--output", outputPath,
+				"--analysis-output", analysisPath,
+			})
+			require.NoError(t, cmd.Execute())
+
+			analysisData, err := os.ReadFile(analysisPath)
+			require.NoError(t, err)
+			if tt.wantWarning {
+				assert.Contains(t, string(analysisData), `"reserved_resource_name"`)
+				assert.Contains(t, string(analysisData), `resource name \"search\" may conflict with a reserved Printing Press command or template`)
+			} else {
+				assert.NotContains(t, string(analysisData), `"reserved_resource_name"`)
+			}
+		})
+	}
+}
+
 func TestBrowserSniffCmdPreserveHostsWritesBaseURLOverrides(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/command_surface.go
+++ b/internal/generator/command_surface.go
@@ -1,0 +1,150 @@
+package generator
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+)
+
+type commandSurfaceEntry struct {
+	SpecPath    string
+	CommandPath string
+	Constructor string
+	OutputPath  string
+}
+
+func buildCommandSurface(apiSpec *spec.APISpec, promotedCommands []PromotedCommand) []commandSurfaceEntry {
+	if apiSpec == nil {
+		return nil
+	}
+
+	promotedByResource := make(map[string]PromotedCommand, len(promotedCommands))
+	for _, command := range promotedCommands {
+		promotedByResource[command.ResourceName] = command
+	}
+
+	resourceNames := make([]string, 0, len(apiSpec.Resources))
+	for name := range apiSpec.Resources {
+		resourceNames = append(resourceNames, name)
+	}
+	sort.Strings(resourceNames)
+
+	var entries []commandSurfaceEntry
+	for _, resourceName := range resourceNames {
+		resource := withoutOptionsEndpoints(apiSpec.Resources[resourceName])
+		resourceCommand := toKebab(resourceName)
+		promotedCommand, promoted := promotedByResource[resourceName]
+		if promoted {
+			entries = append(entries, commandSurfaceEntry{
+				SpecPath:    endpointSpecPath(resourceName, "", promotedCommand.EndpointName),
+				CommandPath: resourceCommand,
+				Constructor: "new" + commandIdent(promotedCommand.PromotedName) + "PromotedCmd",
+				OutputPath:  filepath.Join("internal", "cli", safeResourceFileStem("promoted_"+promotedCommand.PromotedName)+".go"),
+			})
+		} else {
+			entries = append(entries, commandSurfaceEntry{
+				SpecPath:    resourceSpecPath(resourceName, ""),
+				CommandPath: resourceCommand,
+				Constructor: "new" + commandIdent(resourceName) + "Cmd",
+				OutputPath:  filepath.Join("internal", "cli", safeResourceFileStem(resourceName)+".go"),
+			})
+		}
+		for _, endpointName := range sortedEndpointNames(resource.Endpoints) {
+			if promoted && endpointName == promotedCommand.EndpointName {
+				continue
+			}
+			entries = append(entries, commandSurfaceEntry{
+				SpecPath:    endpointSpecPath(resourceName, "", endpointName),
+				CommandPath: strings.Join([]string{resourceCommand, toKebab(endpointName)}, " "),
+				Constructor: "new" + commandIdent(resourceName, endpointName) + "Cmd",
+				OutputPath:  filepath.Join("internal", "cli", safeResourceFileStem(resourceName+"_"+endpointName)+".go"),
+			})
+		}
+
+		subResourceNames := make([]string, 0, len(resource.SubResources))
+		for name := range resource.SubResources {
+			subResourceNames = append(subResourceNames, name)
+		}
+		sort.Strings(subResourceNames)
+		for _, subResourceName := range subResourceNames {
+			subResource := withoutOptionsEndpoints(resource.SubResources[subResourceName])
+			subCommand := strings.Join([]string{resourceCommand, toKebab(subResourceName)}, " ")
+			entries = append(entries, commandSurfaceEntry{
+				SpecPath:    resourceSpecPath(resourceName, subResourceName),
+				CommandPath: subCommand,
+				Constructor: "new" + commandIdent(resourceName, subResourceName) + "Cmd",
+				OutputPath:  filepath.Join("internal", "cli", safeResourceFileStem(resourceName+"_"+subResourceName)+".go"),
+			})
+			for _, endpointName := range sortedEndpointNames(subResource.Endpoints) {
+				entries = append(entries, commandSurfaceEntry{
+					SpecPath:    endpointSpecPath(resourceName, subResourceName, endpointName),
+					CommandPath: strings.Join([]string{subCommand, toKebab(endpointName)}, " "),
+					Constructor: "new" + commandIdent(resourceName, subResourceName, endpointName) + "Cmd",
+					OutputPath:  filepath.Join("internal", "cli", safeResourceFileStem(resourceName+"_"+subResourceName+"_"+endpointName)+".go"),
+				})
+			}
+		}
+	}
+
+	return entries
+}
+
+func validateCommandSurface(entries []commandSurfaceEntry, frameworkCommandNames map[string]struct{}) error {
+	type collisionKey struct {
+		kind  string
+		value string
+	}
+	seen := make(map[collisionKey]commandSurfaceEntry, len(entries)*3)
+	for _, entry := range entries {
+		if !strings.Contains(entry.CommandPath, " ") {
+			if _, reserved := frameworkCommandNames[entry.CommandPath]; reserved {
+				return fmt.Errorf("derived command path %q for %s collides with an emitted framework command; rename the spec resource or endpoint",
+					entry.CommandPath, entry.SpecPath)
+			}
+		}
+		keys := []collisionKey{
+			{kind: "output path", value: entry.OutputPath},
+			{kind: "constructor", value: entry.Constructor},
+			{kind: "command path", value: entry.CommandPath},
+		}
+		for _, key := range keys {
+			if previous, ok := seen[key]; ok && previous.SpecPath != entry.SpecPath {
+				return fmt.Errorf("derived command %s %q collides between %s and %s; rename one spec resource or endpoint",
+					key.kind, key.value, previous.SpecPath, entry.SpecPath)
+			}
+			seen[key] = entry
+		}
+	}
+	return nil
+}
+
+func expectedCommandPaths(entries []commandSurfaceEntry) []string {
+	paths := make([]string, 0, len(entries))
+	seen := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		if _, ok := seen[entry.CommandPath]; ok {
+			continue
+		}
+		seen[entry.CommandPath] = struct{}{}
+		paths = append(paths, entry.CommandPath)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func resourceSpecPath(resourceName, subResourceName string) string {
+	if subResourceName == "" {
+		return fmt.Sprintf("resource %q", resourceName)
+	}
+	return fmt.Sprintf("resource %q sub-resource %q", resourceName, subResourceName)
+}
+
+func endpointSpecPath(resourceName, subResourceName, endpointName string) string {
+	if subResourceName == "" {
+		return fmt.Sprintf("resource %q endpoint %q", resourceName, endpointName)
+	}
+	return fmt.Sprintf("resource %q sub-resource %q endpoint %q", resourceName, subResourceName, endpointName)
+}

--- a/internal/generator/command_surface_test.go
+++ b/internal/generator/command_surface_test.go
@@ -1,0 +1,256 @@
+package generator
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateRejectsDerivedCommandNameCollisions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		resources map[string]spec.Resource
+		wantPaths []string
+	}{
+		{
+			name: "endpoint collides with top-level resource",
+			resources: map[string]spec.Resource{
+				"abilities": {
+					Description: "Manage abilities",
+					Endpoints: map[string]spec.Endpoint{
+						"categories": {Method: "GET", Path: "/abilities/categories", Description: "List ability categories"},
+						"list":       {Method: "GET", Path: "/abilities", Description: "List abilities"},
+					},
+				},
+				"abilities_categories": {
+					Description: "Manage ability categories",
+					Endpoints: map[string]spec.Endpoint{
+						"get":  {Method: "GET", Path: "/abilities/categories/{id}", Description: "Get an ability category"},
+						"list": {Method: "GET", Path: "/abilities/categories", Description: "List ability categories"},
+					},
+				},
+			},
+			wantPaths: []string{`resource "abilities" endpoint "categories"`, `resource "abilities_categories"`},
+		},
+		{
+			name: "normalized endpoint names collide",
+			resources: map[string]spec.Resource{
+				"abilities": {
+					Description: "Manage abilities",
+					Endpoints: map[string]spec.Endpoint{
+						"ability-categories": {Method: "GET", Path: "/abilities/categories", Description: "List ability categories"},
+						"ability_categories": {Method: "GET", Path: "/abilities/categories/{id}", Description: "Get an ability category"},
+					},
+				},
+			},
+			wantPaths: []string{`resource "abilities" endpoint "ability-categories"`, `resource "abilities" endpoint "ability_categories"`},
+		},
+		{
+			name: "normalized resource command paths collide",
+			resources: map[string]spec.Resource{
+				"ISteamUser": {
+					Description: "Manage Steam users",
+					Endpoints: map[string]spec.Endpoint{
+						"get":  {Method: "GET", Path: "/steam/users/{id}", Description: "Get a Steam user"},
+						"list": {Method: "GET", Path: "/steam/users", Description: "List Steam users"},
+					},
+				},
+				"SteamUser": {
+					Description: "Manage alternate Steam users",
+					Endpoints: map[string]spec.Endpoint{
+						"get":  {Method: "GET", Path: "/alternate/steam/users/{id}", Description: "Get an alternate Steam user"},
+						"list": {Method: "GET", Path: "/alternate/steam/users", Description: "List alternate Steam users"},
+					},
+				},
+			},
+			wantPaths: []string{`resource "ISteamUser"`, `resource "SteamUser"`},
+		},
+		{
+			name: "promoted output path collides after normalization",
+			resources: map[string]spec.Resource{
+				"foo_bar": {
+					Description: "List foo bars",
+					Endpoints: map[string]spec.Endpoint{
+						"list": {Method: "GET", Path: "/foo-bars", Description: "List foo bars"},
+					},
+				},
+				"promoted": {
+					Description: "Manage promoted records",
+					Endpoints: map[string]spec.Endpoint{
+						"foo-bar": {Method: "GET", Path: "/promoted/foo-bars", Description: "List promoted foo bars"},
+						"list":    {Method: "GET", Path: "/promoted", Description: "List promoted records"},
+					},
+				},
+			},
+			wantPaths: []string{`resource "foo_bar" endpoint "list"`, `resource "promoted" endpoint "foo-bar"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			apiSpec := minimalSpec("command-surface-collision")
+			apiSpec.Resources = tt.resources
+
+			outputDir := filepath.Join(t.TempDir(), "command-surface-collision-pp-cli")
+			err := New(apiSpec, outputDir).Generate()
+			require.Error(t, err)
+			for _, want := range tt.wantPaths {
+				assert.Contains(t, err.Error(), want)
+			}
+		})
+	}
+}
+
+func TestGenerateAllowsDistinctDerivedCommandNames(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("command-surface-distinct")
+	apiSpec.Resources = map[string]spec.Resource{
+		"abilities": {
+			Description: "Manage abilities",
+			Endpoints: map[string]spec.Endpoint{
+				"ability-categories": {Method: "GET", Path: "/abilities/categories", Description: "List ability categories"},
+				"list":               {Method: "GET", Path: "/abilities", Description: "List abilities"},
+			},
+		},
+		"abilities_categories": {
+			Description: "Manage ability categories",
+			Endpoints: map[string]spec.Endpoint{
+				"get":  {Method: "GET", Path: "/abilities/categories/{id}", Description: "Get an ability category"},
+				"list": {Method: "GET", Path: "/abilities/categories", Description: "List ability categories"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "command-surface-distinct-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestGenerateAllowsDistinctPromotedOutputPathsAfterNormalization(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("promoted-command-surface-distinct")
+	apiSpec.Resources = map[string]spec.Resource{
+		"foo_linux": {
+			Description: "List Linux foo records",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/foo-linux", Description: "List Linux foo records"},
+			},
+		},
+		"promoted_foo_linux": {
+			Description: "Manage promoted Linux foo records",
+			Endpoints: map[string]spec.Endpoint{
+				"get":  {Method: "GET", Path: "/promoted/foo-linux/{id}", Description: "Get a promoted Linux foo record"},
+				"list": {Method: "GET", Path: "/promoted/foo-linux", Description: "List promoted Linux foo records"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "promoted-command-surface-distinct-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	require.FileExists(t, filepath.Join(outputDir, "internal", "cli", "promoted_foo-linux.go"))
+	require.FileExists(t, filepath.Join(outputDir, "internal", "cli", "promoted_foo_linux_cmd.go"))
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestGenerateRejectsFrameworkCommandCollisionAfterNormalization(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("framework-command-surface-collision")
+	apiSpec.Resources = map[string]spec.Resource{
+		"AgentContext": {
+			Description: "Manage API agent context",
+			Endpoints: map[string]spec.Endpoint{
+				"get":  {Method: "GET", Path: "/agent-context/{id}", Description: "Get API agent context"},
+				"list": {Method: "GET", Path: "/agent-context", Description: "List API agent context"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "framework-command-surface-collision-pp-cli")
+	err := New(apiSpec, outputDir).Generate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `derived command path "agent-context"`)
+	assert.Contains(t, err.Error(), `resource "AgentContext"`)
+	assert.Contains(t, err.Error(), "emitted framework command")
+}
+
+func TestCommandSurfaceIncludesSiblingsOfPromotedEndpoint(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("promoted-command-surface")
+	apiSpec.GraphQLEndpointPath = "/graphql"
+	apiSpec.Resources = map[string]spec.Resource{
+		"custom_views": {
+			Description: "Manage custom views",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/graphql",
+					Description: "Get a custom view",
+					Params:      []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true}},
+				},
+				"list": {
+					Method:      "GET",
+					Path:        "/graphql",
+					Description: "List custom views",
+					Pagination:  &spec.Pagination{Type: "cursor", LimitParam: "first", CursorParam: "after"},
+				},
+			},
+		},
+	}
+
+	promotedCommands, _, promotedEndpointNames := buildPromotedCommandPlan(apiSpec)
+	assert.Equal(t, "get", promotedEndpointNames["custom_views"])
+	assert.Equal(t,
+		[]string{"custom-views", "custom-views list"},
+		expectedCommandPaths(buildCommandSurface(apiSpec, promotedCommands)),
+	)
+}
+
+func TestGeneratedSurfaceParityDetectsArtificialDrop(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("command-surface-parity")
+	apiSpec.Resources = map[string]spec.Resource{
+		"orders": {
+			Description: "Manage orders",
+			Endpoints: map[string]spec.Endpoint{
+				"create": {Method: "POST", Path: "/orders", Description: "Create an order"},
+				"list":   {Method: "GET", Path: "/orders", Description: "List orders"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "command-surface-parity-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	requireGeneratedCompiles(t, outputDir)
+
+	parentPath := filepath.Join(outputDir, "internal", "cli", "orders.go")
+	parentSource, err := os.ReadFile(parentPath)
+	require.NoError(t, err)
+	const registration = "\tcmd.AddCommand(newOrdersCreateCmd(flags))\n"
+	dropped := strings.Replace(string(parentSource), registration, "", 1)
+	require.NotEqual(t, string(parentSource), dropped, "fixture must remove the create endpoint registration")
+	require.NoError(t, os.WriteFile(parentPath, []byte(dropped), 0o644))
+
+	cmd := exec.Command("go", "test", "-mod=mod", "./internal/cli", "-run", "^TestDeclaredAPISurfaceReachable$", "-count=1")
+	cmd.Dir = outputDir
+	cacheDir, err := goBuildCacheDir(outputDir)
+	require.NoError(t, err)
+	cmd.Env = append(os.Environ(), "GOCACHE="+cacheDir)
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err, string(output))
+	assert.Contains(t, string(output), "orders create")
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1052,6 +1052,11 @@ type generatorTemplateData struct {
 	TrafficAnalysis    *trafficAnalysisTemplateData
 }
 
+type rootTestTemplateData struct {
+	*spec.APISpec
+	ExpectedCommandPaths []string
+}
+
 type trafficAnalysisTemplateData struct {
 	TargetURL         string
 	EntryCount        int
@@ -2445,6 +2450,11 @@ func (g *Generator) renderSingleFiles() error {
 				APISpec:     g.Spec,
 				HelperFlags: hFlags,
 			}
+		case "root_test.go.tmpl":
+			data = &rootTestTemplateData{
+				APISpec:              g.Spec,
+				ExpectedCommandPaths: expectedCommandPaths(buildCommandSurface(g.Spec, g.PromotedCommands)),
+			}
 		case "doctor.go.tmpl":
 			data = &doctorTemplateData{
 				APISpec:        g.Spec,
@@ -3002,6 +3012,9 @@ func (g *Generator) Generate() error {
 	// used to live, except the maps are now visible to readmeData() / template
 	// rendering.
 	g.PromotedCommands, g.PromotedResourceNames, g.PromotedEndpointNames = buildPromotedCommandPlan(g.Spec)
+	if err := validateCommandSurface(buildCommandSurface(g.Spec, g.PromotedCommands), g.activeFrameworkCobraUseNames()); err != nil {
+		return err
+	}
 
 	if err := g.renderSingleFiles(); err != nil {
 		return err
@@ -3033,7 +3046,7 @@ func (g *Generator) renameActiveFrameworkResourceCollisions() bool {
 	}
 	var renames []resourceRename
 	for name, resource := range g.Spec.Resources {
-		kebab := strings.ReplaceAll(strings.ToLower(name), "_", "-")
+		kebab := spec.NormalizeCobraCommandName(name)
 		if _, ok := active[kebab]; !ok {
 			continue
 		}
@@ -3159,6 +3172,9 @@ func (g *Generator) GenerateMCPSurface() error {
 		return err
 	}
 	g.PromotedCommands, g.PromotedResourceNames, g.PromotedEndpointNames = buildPromotedCommandPlan(g.Spec)
+	if err := validateCommandSurface(buildCommandSurface(g.Spec, g.PromotedCommands), g.activeFrameworkCobraUseNames()); err != nil {
+		return err
+	}
 	mcpFiles := map[string]string{
 		// cliutil files. Deliberately asymmetric with the marker-checked
 		// tools.go / handlers.go / root.go paths elsewhere in mcp-sync:
@@ -8355,31 +8371,7 @@ func goDurationExpr(d time.Duration) string {
 // toKebab converts PascalCase, camelCase, or mixed names to kebab-case.
 // It also strips a leading "I" if it looks like an interface prefix (e.g., ISteamUser → steam-user).
 func toKebab(s string) string {
-	// Strip leading "I" when followed by an uppercase letter (interface prefix convention)
-	if len(s) > 1 && s[0] == 'I' && unicode.IsUpper(rune(s[1])) {
-		s = s[1:]
-	}
-	var result strings.Builder
-	for i, r := range s {
-		// Snake-case underscores convert to dashes. Lets spec keys like
-		// `customer_feedback` and `slot_list_for_date` flow through to
-		// user-facing cobra `Use:` strings as `customer-feedback` and
-		// `slot-list-for-date` instead of preserving the snake form.
-		if r == '_' {
-			result.WriteByte('-')
-			continue
-		}
-		if unicode.IsUpper(r) && i > 0 {
-			prev := rune(s[i-1])
-			// Insert hyphen before uppercase letter if preceded by lowercase,
-			// or if preceding char is uppercase AND next char is lowercase (e.g., "APIKey" → "api-key")
-			if unicode.IsLower(prev) || (unicode.IsUpper(prev) && i+1 < len(s) && unicode.IsLower(rune(s[i+1]))) {
-				result.WriteByte('-')
-			}
-		}
-		result.WriteRune(unicode.ToLower(r))
-	}
-	return result.String()
+	return spec.NormalizeCobraCommandName(s)
 }
 
 // PromotedCommand represents a top-level user-friendly command that wraps a nested API endpoint.

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -9426,7 +9426,7 @@ func TestGeneratedCommandExampleEscapesQuotedNarrativeArgs(t *testing.T) {
 	t.Parallel()
 
 	apiSpec := minimalSpec("narrative-quotes")
-	apiSpec.Resources["search"] = spec.Resource{
+	apiSpec.Resources["lookup"] = spec.Resource{
 		Description: "Search",
 		Endpoints: map[string]spec.Endpoint{
 			"list": {
@@ -9450,13 +9450,13 @@ func TestGeneratedCommandExampleEscapesQuotedNarrativeArgs(t *testing.T) {
 	gen := New(apiSpec, outputDir)
 	gen.Narrative = &ReadmeNarrative{
 		QuickStart: []QuickStartStep{
-			{Command: `narrative-quotes-pp-cli search list --query "peace dollar"`},
+			{Command: `narrative-quotes-pp-cli lookup list --query "peace dollar"`},
 		},
 	}
 	require.NoError(t, gen.Generate())
 
-	source := readGeneratedFile(t, outputDir, "internal", "cli", "search_list.go")
-	assert.Contains(t, source, `"  narrative-quotes-pp-cli search list --query \"peace dollar\""`)
+	source := readGeneratedFile(t, outputDir, "internal", "cli", "lookup_list.go")
+	assert.Contains(t, source, `"  narrative-quotes-pp-cli lookup list --query \"peace dollar\""`)
 	assert.NotContains(t, source, "--query example-value")
 }
 
@@ -10455,7 +10455,7 @@ func TestGeneratedOutput_AgentContextIncludesResourceGroups(t *testing.T) {
 	assert.NotEmpty(t, subs, "resource parent must report its endpoint subcommands")
 }
 
-func TestGeneratedOutput_PromotedCommandNotForBuiltins(t *testing.T) {
+func TestGeneratedOutput_RejectsBuiltinResourceCollision(t *testing.T) {
 	t.Parallel()
 
 	apiSpec := &spec.APISpec{
@@ -10482,12 +10482,11 @@ func TestGeneratedOutput_PromotedCommandNotForBuiltins(t *testing.T) {
 
 	outputDir := filepath.Join(t.TempDir(), "builtintest-pp-cli")
 	gen := New(apiSpec, outputDir)
-	require.NoError(t, gen.Generate())
-
-	// "version" should NOT have a promoted command (collides with built-in)
-	assert.NoFileExists(t, filepath.Join(outputDir, "internal", "cli", "promoted_version.go"))
-	// "users" SHOULD have a promoted command (shortcut for the resource group)
-	assert.FileExists(t, filepath.Join(outputDir, "internal", "cli", "promoted_users.go"))
+	err := gen.Generate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `derived command path "version"`)
+	assert.Contains(t, err.Error(), `resource "version"`)
+	assert.Contains(t, err.Error(), "emitted framework command")
 }
 
 // --- Unit 3: Auth Error Handling Tests ---

--- a/internal/generator/html_sync_stub_test.go
+++ b/internal/generator/html_sync_stub_test.go
@@ -45,7 +45,7 @@ func TestGenerateHTMLMajoritySyncOmittedWhenOnlyPageModeCandidates(t *testing.T)
 				},
 			},
 		},
-		"api": {
+		"typed_api": {
 			Description: "Typed API data",
 			Endpoints: map[string]spec.Endpoint{
 				"status": {
@@ -164,7 +164,7 @@ func TestHTMLSyncStubFallbackUsesInclusiveThreshold(t *testing.T) {
 				"seven": htmlPageEndpoint("/pages/{id}/seven", "Page seven", "object"),
 			},
 		},
-		"api": {
+		"typed_api": {
 			Description: "JSON API",
 			Endpoints: map[string]spec.Endpoint{
 				"one":   {Method: "GET", Path: "/api/one", Description: "API one", Response: spec.ResponseDef{Type: "object"}},
@@ -191,7 +191,7 @@ func TestGenerateEmbeddedJSONHTMLMajorityKeepsGenericSync(t *testing.T) {
 				"archive": embeddedJSONHTMLEndpoint("/archive", "List archived pages", "array"),
 			},
 		},
-		"api": {
+		"typed_api": {
 			Description: "Typed API data",
 			Endpoints: map[string]spec.Endpoint{
 				"status": {

--- a/internal/generator/templates/root_test.go.tmpl
+++ b/internal/generator/templates/root_test.go.tmpl
@@ -7,8 +7,49 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
+
+func TestDeclaredAPISurfaceReachable(t *testing.T) {
+	expected := []string{
+{{- range .ExpectedCommandPaths}}
+		{{printf "%q" .}},
+{{- end}}
+	}
+	actual := make(map[string]struct{}, len(expected))
+	type pendingCommand struct {
+		command *cobra.Command
+		path    string
+	}
+	queue := make([]pendingCommand, 0, len(expected))
+	for _, child := range RootCmd().Commands() {
+		queue = append(queue, pendingCommand{command: child, path: child.Name()})
+	}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		actual[current.path] = struct{}{}
+		for _, child := range current.command.Commands() {
+			queue = append(queue, pendingCommand{
+				command: child,
+				path:    strings.TrimSpace(current.path + " " + child.Name()),
+			})
+		}
+	}
+
+	var missing []string
+	for _, commandPath := range expected {
+		if _, ok := actual[commandPath]; !ok {
+			missing = append(missing, commandPath)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("declared API command paths missing from generated Cobra tree: %s", strings.Join(missing, ", "))
+	}
+}
 
 // TestIsCobraUsageError covers the six pre-RunE error shapes Cobra and
 // pflag can produce before any user RunE runs. Each must be detected so

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -3270,7 +3270,7 @@ var ReservedCobraUseNames = map[string]struct{}{
 // profiling, so parsers must not reject or rename them before the generator
 // knows the actual root command set.
 func (s *APISpec) ParseTimeReservedCobraUseName(name string) bool {
-	kebab := snakeToKebab(name)
+	kebab := NormalizeCobraCommandName(name)
 	if kebab == "auth" {
 		return s.emitsAuthCommand()
 	}
@@ -3326,10 +3326,7 @@ func (s *APISpec) applyReservedResourceParentPrefixes() {
 
 	renames := map[string]string{}
 	for _, name := range keys {
-		if name == "auth" && !s.emitsAuthCommand() {
-			continue
-		}
-		if _, reserved := ReservedCLIResourceNames[name]; !reserved {
+		if !s.ConflictsWithReservedCLIResourceName(name) {
 			continue
 		}
 		candidate := s.uniqueReservedResourceParentPrefix(name, s.Resources[name], taken)
@@ -3440,16 +3437,23 @@ func (s *APISpec) emitsTopLevelOAuthLogin() bool {
 		(s.Auth.EffectiveOAuth2Grant() != OAuth2GrantClientCredentials || s.Auth.TokenURL == "")
 }
 
+// ConflictsWithReservedCLIResourceName reports whether a top-level resource
+// would collide with an emitted reserved Printing Press template.
+func (s *APISpec) ConflictsWithReservedCLIResourceName(name string) bool {
+	if name == "auth" && s != nil && !s.emitsAuthCommand() {
+		return false
+	}
+	_, reserved := ReservedCLIResourceNames[name]
+	return reserved
+}
+
 // validateReservedNames rejects specs whose top-level resource names would
 // collide with reserved Printing Press templates. Sub-resource names are not
 // checked because they emit under a parent prefix (`<parent>_<sub>.go`,
 // `new<Parent><Sub>Cmd`) that does not collide with single-file templates.
 func (s *APISpec) validateReservedNames() error {
 	for name := range s.Resources {
-		if name == "auth" && !s.emitsAuthCommand() {
-			continue
-		}
-		if _, reserved := ReservedCLIResourceNames[name]; reserved {
+		if s.ConflictsWithReservedCLIResourceName(name) {
 			return fmt.Errorf("resource name %q collides with reserved Printing Press template %q (would overwrite internal/cli/%s.go and produce a duplicate `new%sCmd` function). Rename to %q in your spec",
 				name, name, name, SnakeToPascal(name), name+"_resource")
 		}
@@ -3463,7 +3467,7 @@ func (s *APISpec) validateReservedNames() error {
 // root.
 func (s *APISpec) validateFrameworkCobraCollisions() error {
 	for name := range s.Resources {
-		kebab := snakeToKebab(name)
+		kebab := NormalizeCobraCommandName(name)
 		if s.ParseTimeReservedCobraUseName(kebab) {
 			suggestion := name + "_resource"
 			if s.Name != "" {
@@ -3474,6 +3478,30 @@ func (s *APISpec) validateFrameworkCobraCollisions() error {
 		}
 	}
 	return nil
+}
+
+// NormalizeCobraCommandName mirrors the command name emitted by the generator.
+// Sharing the interface-prefix and word-boundary rules keeps every collision
+// check aligned with the public Cobra surface.
+func NormalizeCobraCommandName(s string) string {
+	if len(s) > 1 && s[0] == 'I' && unicode.IsUpper(rune(s[1])) {
+		s = s[1:]
+	}
+	var result strings.Builder
+	for i, r := range s {
+		if r == '_' {
+			result.WriteByte('-')
+			continue
+		}
+		if unicode.IsUpper(r) && i > 0 {
+			previous := rune(s[i-1])
+			if unicode.IsLower(previous) || (unicode.IsUpper(previous) && i+1 < len(s) && unicode.IsLower(rune(s[i+1]))) {
+				result.WriteByte('-')
+			}
+		}
+		result.WriteRune(unicode.ToLower(r))
+	}
+	return result.String()
 }
 
 func snakeToKebab(s string) string {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -5524,6 +5524,28 @@ resources:
 		assert.Contains(t, err.Error(), "shadow framework cobra command", "error must explain the failure mode")
 	})
 
+	t.Run("CamelCase resource is normalized before framework collision check", func(t *testing.T) {
+		t.Parallel()
+		input := `name: testapi
+base_url: https://api.example.com
+auth:
+  type: bearer_token
+  env_vars: [TESTAPI_TOKEN]
+resources:
+  AgentContext:
+    description: API agent context
+    endpoints:
+      list:
+        method: GET
+        path: /agent-context
+        description: List API agent context
+`
+		_, err := ParseBytes([]byte(input))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `"AgentContext"`)
+		assert.Contains(t, err.Error(), `framework cobra command "agent-context"`)
+	})
+
 	t.Run("rename suggestion uses api slug when spec name is set", func(t *testing.T) {
 		t.Parallel()
 		input := `name: pokeapi

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/root_test.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/root_test.go
@@ -7,8 +7,47 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
+
+func TestDeclaredAPISurfaceReachable(t *testing.T) {
+	expected := []string{
+		"items",
+	}
+	actual := make(map[string]struct{}, len(expected))
+	type pendingCommand struct {
+		command *cobra.Command
+		path    string
+	}
+	queue := make([]pendingCommand, 0, len(expected))
+	for _, child := range RootCmd().Commands() {
+		queue = append(queue, pendingCommand{command: child, path: child.Name()})
+	}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		actual[current.path] = struct{}{}
+		for _, child := range current.command.Commands() {
+			queue = append(queue, pendingCommand{
+				command: child,
+				path:    strings.TrimSpace(current.path + " " + child.Name()),
+			})
+		}
+	}
+
+	var missing []string
+	for _, commandPath := range expected {
+		if _, ok := actual[commandPath]; !ok {
+			missing = append(missing, commandPath)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("declared API command paths missing from generated Cobra tree: %s", strings.Join(missing, ", "))
+	}
+}
 
 // TestIsCobraUsageError covers the six pre-RunE error shapes Cobra and
 // pflag can produce before any user RunE runs. Each must be detected so

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root_test.go
@@ -7,8 +7,62 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
+
+func TestDeclaredAPISurfaceReachable(t *testing.T) {
+	expected := []string{
+		"currencies",
+		"projects",
+		"projects avatar",
+		"projects avatar upload-project",
+		"projects create",
+		"projects get",
+		"projects list",
+		"projects tasks",
+		"projects tasks list-project",
+		"projects tasks update-project",
+		"public",
+		"reports",
+		"reports export",
+		"reports export report-year",
+		"reports summary",
+		"reports summary get-report-year",
+	}
+	actual := make(map[string]struct{}, len(expected))
+	type pendingCommand struct {
+		command *cobra.Command
+		path    string
+	}
+	queue := make([]pendingCommand, 0, len(expected))
+	for _, child := range RootCmd().Commands() {
+		queue = append(queue, pendingCommand{command: child, path: child.Name()})
+	}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		actual[current.path] = struct{}{}
+		for _, child := range current.command.Commands() {
+			queue = append(queue, pendingCommand{
+				command: child,
+				path:    strings.TrimSpace(current.path + " " + child.Name()),
+			})
+		}
+	}
+
+	var missing []string
+	for _, commandPath := range expected {
+		if _, ok := actual[commandPath]; !ok {
+			missing = append(missing, commandPath)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("declared API command paths missing from generated Cobra tree: %s", strings.Join(missing, ", "))
+	}
+}
 
 // TestIsCobraUsageError covers the six pre-RunE error shapes Cobra and
 // pflag can produce before any user RunE runs. Each must be detected so


### PR DESCRIPTION
## Summary

Browser-sniff now warns while traffic context can still guide a rename when a derived resource name conflicts with a reserved Printing Press command or template. If a conflicting spec still reaches generation, the Printing Press rejects normalized command-path, constructor, output-file, and active framework collisions instead of silently dropping API surface.

Generated CLIs also assert that every declared API command path appears in the real Cobra tree, covering future registration regressions that would otherwise compile and pass the existing gates.

## Verification

- `go test ./internal/generator` passed on the rebased head in 520.9s
- `scripts/golden.sh verify` passed all 32 cases on the rebased head
- `scripts/verify-generator-output.sh` passed all 10 cases
- Scoped `golangci-lint` passed for the touched packages
- `go test ./...` passed before the final rebase; on the rebased head every package passed except the aggregate `internal/generator` run hit its 10-minute timeout under package contention, then passed standalone

Closes #3698
Closes #3050
