### PR TITLE
fix(cli): preserve dry-run read provenance and cache boundaries

### DIFF
--- a/internal/generator/binary_paginated_promoted_test.go
+++ b/internal/generator/binary_paginated_promoted_test.go
@@ -66,7 +66,7 @@ func TestGenerateBinaryPaginatedPromotedThreadsHeader(t *testing.T) {
 		"non-HasStore pagination must use paginatedGet")
 	assert.NotContains(t, endpointSrc, `}, nil, flagAll,`,
 		"paginated binary endpoint must pass headerOverrides, not nil")
-	assert.Contains(t, endpointSrc, `}, headerOverrides, flagAll,`,
+	assert.Contains(t, endpointSrc, `}, headerOverrides, flagAll && !flags.dryRun,`,
 		"paginated binary endpoint must thread headerOverrides into paginatedGet")
 }
 

--- a/internal/generator/dry_run_read_test.go
+++ b/internal/generator/dry_run_read_test.go
@@ -1,0 +1,257 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func dryRunReadSpec(name string) *spec.APISpec {
+	apiSpec := minimalSpec(name)
+	apiSpec.Learn.Disabled = true
+	apiSpec.Resources = map[string]spec.Resource{
+		"items": {
+			Description: "Manage items",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/items",
+					Description: "List items",
+					Response:    spec.ResponseDef{Type: "array", Item: "Item"},
+					Pagination: &spec.Pagination{
+						Type:           "cursor",
+						CursorParam:    "cursor",
+						LimitParam:     "limit",
+						NextCursorPath: "next_cursor",
+						HasMoreField:   "has_more",
+					},
+				},
+				"get": {
+					Method:      "GET",
+					Path:        "/items/{id}",
+					Description: "Get an item",
+					Response:    spec.ResponseDef{Type: "object", Item: "Item"},
+					Params: []spec.Param{{
+						Name:       "id",
+						Type:       "string",
+						Required:   true,
+						Positional: true,
+						PathParam:  true,
+					}},
+				},
+			},
+		},
+		"widgets": {
+			Description: "Manage widgets",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/widgets",
+					Description: "List widgets",
+					Response:    spec.ResponseDef{Type: "array", Item: "Widget"},
+					Pagination: &spec.Pagination{
+						Type:           "cursor",
+						CursorParam:    "cursor",
+						LimitParam:     "limit",
+						NextCursorPath: "next_cursor",
+						HasMoreField:   "has_more",
+					},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Item":   {Fields: []spec.TypeField{{Name: "id", Type: "string"}, {Name: "name", Type: "string"}}},
+		"Widget": {Fields: []spec.TypeField{{Name: "id", Type: "string"}, {Name: "name", Type: "string"}}},
+	}
+	return apiSpec
+}
+
+func TestGeneratedDryRunReadGuardsEndpointAndPromotedOutputs(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := dryRunReadSpec("dry-run-read-guards")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	dataSourceSrc := readGeneratedFile(t, outputDir, "internal", "cli", "data_source.go")
+	dryRunIdx := strings.Index(dataSourceSrc, "if isDryRunResponse(data)")
+	cacheIdx := strings.Index(dataSourceSrc, "writeThroughCache(ctx, resourceType, data)")
+	require.GreaterOrEqual(t, dryRunIdx, 0)
+	require.GreaterOrEqual(t, cacheIdx, 0)
+	assert.Less(t, dryRunIdx, cacheIdx, "dry-run reads must return before the live cache write")
+	assert.Contains(t, dataSourceSrc, `DataProvenance{Source: "dry-run"}`)
+
+	noStoreDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name)+"-nostore")
+	noStoreGen := New(apiSpec, noStoreDir)
+	noStoreGen.VisionSet = VisionTemplateSet{Export: true}
+	require.NoError(t, noStoreGen.Generate())
+
+	endpointSrc := readGeneratedFile(t, noStoreDir, "internal", "cli", "items_list.go")
+	assert.Contains(t, endpointSrc, "if isDryRunResponse(data)")
+	assert.Contains(t, endpointSrc, `map[string]any{"source": "dry-run"}`)
+	assert.Contains(t, endpointSrc, "flagAll && !flags.dryRun")
+
+	promotedSrc := readGeneratedFile(t, noStoreDir, "internal", "cli", "promoted_widgets.go")
+	assert.Contains(t, promotedSrc, "if isDryRunResponse(data)")
+	assert.Contains(t, promotedSrc, `map[string]any{"source": "dry-run"}`)
+	assert.Contains(t, promotedSrc, "flagAll && !flags.dryRun")
+}
+
+func TestGeneratedDryRunReadPreservesProvenanceAndSkipsStore(t *testing.T) {
+	apiSpec := dryRunReadSpec("dry-run-read")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	behaviorTest := `package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func executeDryRunRead(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	var flags rootFlags
+	root := newRootCmd(&flags)
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stdout)
+	root.SetArgs(args)
+
+	oldStderr := os.Stderr
+	pipeReader, pipeWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = pipeWriter
+	stderrDone := make(chan string, 1)
+	go func() {
+		data, _ := io.ReadAll(pipeReader)
+		stderrDone <- string(data)
+	}()
+	execErr := root.Execute()
+	_ = pipeWriter.Close()
+	os.Stderr = oldStderr
+	stderr := <-stderrDone
+	_ = pipeReader.Close()
+	return stdout.String(), stderr, execErr
+}
+
+func assertDryRunEnvelope(t *testing.T, output string) {
+	t.Helper()
+	var payload struct {
+		Meta struct {
+			Source string ` + "`" + `json:"source"` + "`" + `
+		} ` + "`" + `json:"meta"` + "`" + `
+		Results json.RawMessage ` + "`" + `json:"results"` + "`" + `
+	}
+	if err := json.Unmarshal([]byte(output), &payload); err != nil {
+		t.Fatalf("parse agent output: %v\n%s", err, output)
+	}
+	if payload.Meta.Source != "dry-run" {
+		t.Fatalf("meta.source = %q, want dry-run; output=%s", payload.Meta.Source, output)
+	}
+	if !bytes.Contains(payload.Results, []byte(` + "`" + `"dry_run"` + "`" + `)) {
+		t.Fatalf("results = %s, want dry-run sentinel", payload.Results)
+	}
+}
+
+func TestPromotedDryRunReadDoesNotOpenStore(t *testing.T) {
+	home := t.TempDir()
+	stdout, stderr, err := executeDryRunRead(t, "--home", home, "--dry-run", "--agent", "widgets", "--all")
+	if err != nil {
+		t.Fatalf("promoted dry-run: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	assertDryRunEnvelope(t, stdout)
+	if strings.Contains(stderr, "warning:") || strings.Contains(stderr, "not cached locally") {
+		t.Fatalf("dry-run emitted cache warning: %s", stderr)
+	}
+	if _, err := os.Stat(filepath.Join(home, "data", "data.db")); !os.IsNotExist(err) {
+		t.Fatalf("dry-run created store: stat error = %v", err)
+	}
+}
+
+func TestEndpointDryRunReadDoesNotOpenStore(t *testing.T) {
+	home := t.TempDir()
+	stdout, stderr, err := executeDryRunRead(t, "--home", home, "--dry-run", "--agent", "items", "list", "--all")
+	if err != nil {
+		t.Fatalf("endpoint dry-run: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	assertDryRunEnvelope(t, stdout)
+	if strings.Contains(stderr, "warning:") || strings.Contains(stderr, "not cached locally") {
+		t.Fatalf("dry-run emitted cache warning: %s", stderr)
+	}
+	if _, err := os.Stat(filepath.Join(home, "data", "data.db")); !os.IsNotExist(err) {
+		t.Fatalf("dry-run created store: stat error = %v", err)
+	}
+}
+
+func TestLiveReadsStillWriteThroughCache(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/items" {
+			_, _ = w.Write([]byte(` + "`" + `[{"id":"item-1","name":"Live item"}]` + "`" + `))
+			return
+		}
+		if r.URL.Path == "/widgets" {
+			_, _ = w.Write([]byte(` + "`" + `[{"id":"widget-1","name":"Live widget"}]` + "`" + `))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+	t.Setenv("DRY_RUN_READ_BASE_URL", server.URL)
+
+	home := t.TempDir()
+	stdout, stderr, err := executeDryRunRead(t, "--home", home, "--agent", "items", "list")
+	if err != nil {
+		t.Fatalf("live endpoint read: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	var payload struct {
+		Meta struct {
+			Source string ` + "`" + `json:"source"` + "`" + `
+		} ` + "`" + `json:"meta"` + "`" + `
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("parse live output: %v\n%s", err, stdout)
+	}
+	if payload.Meta.Source != "live" {
+		t.Fatalf("live meta.source = %q, want live; output=%s", payload.Meta.Source, stdout)
+	}
+	if calls != 1 {
+		t.Fatalf("live endpoint request count = %d, want 1", calls)
+	}
+	if _, err := os.Stat(filepath.Join(home, "data", "data.db")); err != nil {
+		t.Fatalf("live read did not create cache store: %v", err)
+	}
+	if strings.Contains(stderr, "not cached locally") {
+		t.Fatalf("live read unexpectedly warned about cacheability: %s", stderr)
+	}
+}
+`
+	testPath := filepath.Join(outputDir, "internal", "cli", "dry_run_read_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(behaviorTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "mod", "tidy")
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "Test(Promoted|Endpoint)DryRunReadDoesNotOpenStore|TestLiveReadsStillWriteThroughCache", "-count=1")
+}

--- a/internal/generator/dry_run_read_test.go
+++ b/internal/generator/dry_run_read_test.go
@@ -83,7 +83,7 @@ func TestGeneratedDryRunReadGuardsEndpointAndPromotedOutputs(t *testing.T) {
 	require.NoError(t, gen.Generate())
 
 	dataSourceSrc := readGeneratedFile(t, outputDir, "internal", "cli", "data_source.go")
-	dryRunIdx := strings.Index(dataSourceSrc, "if isDryRunResponse(data)")
+	dryRunIdx := strings.Index(dataSourceSrc, "if isDryRunResponse(c.IsDryRun(), data)")
 	cacheIdx := strings.Index(dataSourceSrc, "writeThroughCache(ctx, resourceType, data)")
 	require.GreaterOrEqual(t, dryRunIdx, 0)
 	require.GreaterOrEqual(t, cacheIdx, 0)
@@ -96,12 +96,12 @@ func TestGeneratedDryRunReadGuardsEndpointAndPromotedOutputs(t *testing.T) {
 	require.NoError(t, noStoreGen.Generate())
 
 	endpointSrc := readGeneratedFile(t, noStoreDir, "internal", "cli", "items_list.go")
-	assert.Contains(t, endpointSrc, "if isDryRunResponse(data)")
+	assert.Contains(t, endpointSrc, "if isDryRunResponse(c.IsDryRun(), data)")
 	assert.Contains(t, endpointSrc, `map[string]any{"source": "dry-run"}`)
 	assert.Contains(t, endpointSrc, "flagAll && !flags.dryRun")
 
 	promotedSrc := readGeneratedFile(t, noStoreDir, "internal", "cli", "promoted_widgets.go")
-	assert.Contains(t, promotedSrc, "if isDryRunResponse(data)")
+	assert.Contains(t, promotedSrc, "if isDryRunResponse(c.IsDryRun(), data)")
 	assert.Contains(t, promotedSrc, `map[string]any{"source": "dry-run"}`)
 	assert.Contains(t, promotedSrc, "flagAll && !flags.dryRun")
 }
@@ -248,10 +248,44 @@ func TestLiveReadsStillWriteThroughCache(t *testing.T) {
 		t.Fatalf("live read unexpectedly warned about cacheability: %s", stderr)
 	}
 }
+
+func TestLivePayloadMatchingDryRunSentinelRemainsLive(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(` + "`" + `{"dry_run":true}` + "`" + `))
+	}))
+	defer server.Close()
+	t.Setenv("DRY_RUN_READ_BASE_URL", server.URL)
+
+	stdout, _, err := executeDryRunRead(t, "--home", t.TempDir(), "--agent", "items", "list")
+	if err != nil {
+		t.Fatalf("live sentinel-shaped read: %v\nstdout=%s", err, stdout)
+	}
+	var payload struct {
+		Meta struct {
+			Source string ` + "`" + `json:"source"` + "`" + `
+		} ` + "`" + `json:"meta"` + "`" + `
+		Results json.RawMessage ` + "`" + `json:"results"` + "`" + `
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("parse live sentinel-shaped output: %v\n%s", err, stdout)
+	}
+	if payload.Meta.Source != "live" {
+		t.Fatalf("sentinel-shaped live meta.source = %q, want live; output=%s", payload.Meta.Source, stdout)
+	}
+	if !bytes.Contains(payload.Results, []byte(` + "`" + `"dry_run"` + "`" + `)) {
+		t.Fatalf("live response lost the sentinel-shaped payload: %s", payload.Results)
+	}
+	if calls != 1 {
+		t.Fatalf("live sentinel-shaped endpoint request count = %d, want 1", calls)
+	}
+}
 `
 	testPath := filepath.Join(outputDir, "internal", "cli", "dry_run_read_test.go")
 	require.NoError(t, os.WriteFile(testPath, []byte(behaviorTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "mod", "tidy")
-	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "Test(Promoted|Endpoint)DryRunReadDoesNotOpenStore|TestLiveReadsStillWriteThroughCache", "-count=1")
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "Test(Promoted|Endpoint)DryRunReadDoesNotOpenStore|TestLiveReadsStillWriteThroughCache|TestLivePayloadMatchingDryRunSentinelRemainsLive", "-count=1")
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -19479,20 +19479,23 @@ func TestStaleTemplateCoversCommonTimestampFields(t *testing.T) {
 // error.
 func TestSyncTemplateShortCircuitsOnDryRunSentinel(t *testing.T) {
 	t.Parallel()
-	data, err := os.ReadFile(filepath.Join("templates", "sync.go.tmpl"))
+	data, err := os.ReadFile(filepath.Join("templates", "helpers.go.tmpl"))
 	require.NoError(t, err)
 	body := string(data)
 
 	assert.Contains(t, body, "func isDryRunResponse(data json.RawMessage) bool",
-		"sync.go.tmpl must define isDryRunResponse helper that detects the client.dryRun sentinel")
-	assert.Contains(t, body, `"sync_dryrun"`,
+		"helpers.go.tmpl must define isDryRunResponse helper that detects the client.dryRun sentinel")
+	syncData, err := os.ReadFile(filepath.Join("templates", "sync.go.tmpl"))
+	require.NoError(t, err)
+	syncBody := string(syncData)
+	assert.Contains(t, syncBody, `"sync_dryrun"`,
 		"sync.go.tmpl must emit a sync_dryrun event on the short-circuit path so validate-narrative sees a structured success")
 
 	// Ordering pin: the dry-run check must run BEFORE upsertSingleObject,
 	// otherwise the sentinel reaches the upsert path and triggers a spurious
 	// "missing id for <resource>" error.
-	dryRunCheckIdx := strings.Index(body, "if isDryRunResponse(data)")
-	upsertSingleIdx := strings.Index(body, "if err := upsertSingleObject(db, resource, data)")
+	dryRunCheckIdx := strings.Index(syncBody, "if isDryRunResponse(data)")
+	upsertSingleIdx := strings.Index(syncBody, "if err := upsertSingleObject(db, resource, data)")
 	require.GreaterOrEqual(t, dryRunCheckIdx, 0, "sync.go.tmpl must call isDryRunResponse on the response")
 	require.GreaterOrEqual(t, upsertSingleIdx, 0, "sync.go.tmpl must still call upsertSingleObject for live single-object responses")
 	assert.Less(t, dryRunCheckIdx, upsertSingleIdx,

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -19483,7 +19483,7 @@ func TestSyncTemplateShortCircuitsOnDryRunSentinel(t *testing.T) {
 	require.NoError(t, err)
 	body := string(data)
 
-	assert.Contains(t, body, "func isDryRunResponse(data json.RawMessage) bool",
+	assert.Contains(t, body, "func isDryRunResponse(dryRun bool, data json.RawMessage) bool",
 		"helpers.go.tmpl must define isDryRunResponse helper that detects the client.dryRun sentinel")
 	syncData, err := os.ReadFile(filepath.Join("templates", "sync.go.tmpl"))
 	require.NoError(t, err)
@@ -19494,7 +19494,7 @@ func TestSyncTemplateShortCircuitsOnDryRunSentinel(t *testing.T) {
 	// Ordering pin: the dry-run check must run BEFORE upsertSingleObject,
 	// otherwise the sentinel reaches the upsert path and triggers a spurious
 	// "missing id for <resource>" error.
-	dryRunCheckIdx := strings.Index(syncBody, "if isDryRunResponse(data)")
+	dryRunCheckIdx := strings.Index(syncBody, "if isDryRunResponseForClient(c, data)")
 	upsertSingleIdx := strings.Index(syncBody, "if err := upsertSingleObject(db, resource, data)")
 	require.GreaterOrEqual(t, dryRunCheckIdx, 0, "sync.go.tmpl must call isDryRunResponse on the response")
 	require.GreaterOrEqual(t, upsertSingleIdx, 0, "sync.go.tmpl must still call upsertSingleObject for live single-object responses")

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -1137,7 +1137,7 @@ func TestIssue3497BareAllOffsetUsesEndpointPageSize(t *testing.T) {
 			}
 			require.NoError(t, gen.Generate())
 
-			generatedCLISourceContaining(t, outputDir, `flagAll, "offset", "offset", "limit", 2, "", ""`)
+			generatedCLISourceContaining(t, outputDir, `flagAll && !flags.dryRun, "offset", "offset", "limit", 2, "", ""`)
 
 			behaviorTest := `package cli
 

--- a/internal/generator/sync_dependent_fanout_race_test.go
+++ b/internal/generator/sync_dependent_fanout_race_test.go
@@ -117,6 +117,7 @@ import (
 // asserted for "each parent fetched exactly once"; respond returns the page body.
 type fakeDependentGetter struct {
 	mu      sync.Mutex
+	dryRun  bool
 	onGet   func(path string, params map[string]string)
 	respond func(path string, params map[string]string) (json.RawMessage, error)
 }
@@ -134,6 +135,7 @@ func (f *fakeDependentGetter) Get(_ context.Context, path string, params map[str
 }
 
 func (f *fakeDependentGetter) RateLimit() float64 { return 0 }
+func (f *fakeDependentGetter) IsDryRun() bool     { return f.dryRun }
 
 // modulesDep: a per_parent dependent keyed on projects.id, single path param.
 func modulesDep() dependentResourceDef {
@@ -227,6 +229,7 @@ func TestSyncDependentResource_DryRunShortCircuitsUnderConcurrency(t *testing.T)
 	defer db.Close()
 
 	fake := &fakeDependentGetter{
+		dryRun: true,
 		respond: func(_ string, _ map[string]string) (json.RawMessage, error) {
 			return json.RawMessage(` + "`" + `{"dry_run": true}` + "`" + `), nil
 		},

--- a/internal/generator/sync_dryrun_test.go
+++ b/internal/generator/sync_dryrun_test.go
@@ -59,7 +59,7 @@ func TestGeneratedSyncDryRunDoesNotMutateSyncState(t *testing.T) {
 	// Both the flat loop and the dependent loop must short-circuit on the
 	// dry-run sentinel before any SaveSyncState. The dependent guard is the
 	// #2935 fix; the flat guard pre-existed. Two occurrences == both guarded.
-	if n := strings.Count(syncSrc, "if isDryRunResponse(data) {"); n < 2 {
+	if n := strings.Count(syncSrc, "if isDryRunResponseForClient(c, data) {"); n < 2 {
 		t.Fatalf("expected the dry-run sentinel guard in both the flat and dependent sync loops (>=2 occurrences), found %d", n)
 	}
 	// The --full and --latest-only cursor clears must skip under --dry-run.

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -106,6 +106,10 @@ type Client struct {
 {{- end}}
 }
 
+func (c *Client) IsDryRun() bool {
+	return c != nil && c.DryRun
+}
+
 // BindPlatformSession installs the result of the live fail-closed tenant gate.
 // Cache and state paths are switched only after the gate has verified both the
 // credential and the immutable provider identity.

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -394,7 +394,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}headerOverrides{{else}}nil{{end}}, flagAll && !flags.dryRun, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
 {{- end}}
 {{- else}}
 			params := map[string]string{}
@@ -777,6 +777,14 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
+{{- if and .IsReadOnly (not .HasStore)}}
+			if isDryRunResponse(data) {
+				if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+					return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "dry-run"})
+				}
+				return nil
+			}
+{{- end}}
 {{- end}}
 {{- if .Endpoint.UsesTextResponse}}
 			_ = os.Stderr

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -778,8 +778,8 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				return classifyAPIError(err, flags)
 			}
 {{- if and .IsReadOnly (not .HasStore)}}
-			if isDryRunResponse(data) {
-				if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+			if isDryRunResponse(c.IsDryRun(), data) {
+				if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
 					return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "dry-run"})
 				}
 				return nil

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -399,8 +399,8 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				return classifyAPIError(err, flags)
 			}
 {{- if and .IsReadOnly (not .HasStore)}}
-			if isDryRunResponse(data) {
-				if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+			if isDryRunResponse(c.IsDryRun(), data) {
+				if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
 					return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "dry-run"})
 				}
 				return nil

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -256,7 +256,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}headerOverrides{{else}}nil{{end}}, flagAll && !flags.dryRun, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
 {{- end}}
 {{- else}}
 {{- if not $deleteBodyWithoutParams}}
@@ -398,6 +398,14 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
+{{- if and .IsReadOnly (not .HasStore)}}
+			if isDryRunResponse(data) {
+				if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+					return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "dry-run"})
+				}
+				return nil
+			}
+{{- end}}
 {{- if and .HasStore (ne (upper .Endpoint.Method) "GET") (not $supportsAllPagination)}}
 			prov := attachFreshness(DataProvenance{Source: "live"}, flags)
 {{- end}}

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -159,6 +159,9 @@ func resolveReadWithStrategyResponsePathAndJSONGuard(ctx context.Context, c *cli
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		if isDryRunResponse(data) {
+			return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
+		}
 		if guardLiveJSON {
 			if err := assertLiveJSONBody(data); err != nil {
 				return nil, DataProvenance{}, err
@@ -177,6 +180,9 @@ func resolveReadWithStrategyResponsePathAndJSONGuard(ctx context.Context, c *cli
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		if isDryRunResponse(data) {
+			return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
+		}
 		if guardLiveJSON {
 			if err := assertLiveJSONBody(data); err != nil {
 				return nil, DataProvenance{}, err
@@ -188,6 +194,9 @@ func resolveReadWithStrategyResponsePathAndJSONGuard(ctx context.Context, c *cli
 	default: // "auto"
 		data, err := c.GetWithHeaders(ctx, path, params, headers)
 		if err == nil {
+			if isDryRunResponse(data) {
+				return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
+			}
 			if guardLiveJSON {
 				if err := assertLiveJSONBody(data); err != nil {
 					return nil, DataProvenance{}, err
@@ -226,6 +235,9 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 	if err := validateDataSourceStrategy(flags, strategy); err != nil {
 		return nil, DataProvenance{}, err
 	}
+	if flags != nil && flags.dryRun {
+		fetchAll = false
+	}
 	if strategy == "local" {
 		data, prov, err := resolveLocal(ctx, flags, hintWriter, resourceType, true, path, params, "strategy_local")
 		return data, attachFreshness(prov, flags), err
@@ -237,6 +249,9 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
 		if err != nil {
 			return nil, DataProvenance{}, err
+		}
+		if isDryRunResponse(data) {
+			return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
 		}
 		if guardLiveJSON {
 			if err := assertLiveJSONBody(data); err != nil {
@@ -258,6 +273,9 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		if isDryRunResponse(data) {
+			return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
+		}
 		if guardLiveJSON {
 			if err := assertLiveJSONBody(data); err != nil {
 				return nil, DataProvenance{}, err
@@ -271,6 +289,9 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		}
 		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
 		if err == nil {
+			if isDryRunResponse(data) {
+				return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
+			}
 			if guardLiveJSON {
 				if err := assertLiveJSONBody(data); err != nil {
 					return nil, DataProvenance{}, err

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -159,7 +159,7 @@ func resolveReadWithStrategyResponsePathAndJSONGuard(ctx context.Context, c *cli
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
-		if isDryRunResponse(data) {
+		if isDryRunResponse(c.IsDryRun(), data) {
 			return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
 		}
 		if guardLiveJSON {
@@ -180,7 +180,7 @@ func resolveReadWithStrategyResponsePathAndJSONGuard(ctx context.Context, c *cli
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
-		if isDryRunResponse(data) {
+		if isDryRunResponse(c.IsDryRun(), data) {
 			return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
 		}
 		if guardLiveJSON {
@@ -194,7 +194,7 @@ func resolveReadWithStrategyResponsePathAndJSONGuard(ctx context.Context, c *cli
 	default: // "auto"
 		data, err := c.GetWithHeaders(ctx, path, params, headers)
 		if err == nil {
-			if isDryRunResponse(data) {
+			if isDryRunResponse(c.IsDryRun(), data) {
 				return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
 			}
 			if guardLiveJSON {
@@ -250,7 +250,7 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
-		if isDryRunResponse(data) {
+		if isDryRunResponse(c.IsDryRun(), data) {
 			return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
 		}
 		if guardLiveJSON {
@@ -273,7 +273,7 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
-		if isDryRunResponse(data) {
+		if isDryRunResponse(c.IsDryRun(), data) {
 			return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
 		}
 		if guardLiveJSON {
@@ -289,7 +289,7 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		}
 		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
 		if err == nil {
-			if isDryRunResponse(data) {
+			if isDryRunResponse(c.IsDryRun(), data) {
 				return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
 			}
 			if guardLiveJSON {

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1138,7 +1138,7 @@ func paginatedGet(ctx context.Context, c interface {
 		if err != nil {
 			return nil, err
 		}
-		if isDryRunResponse(data) {
+		if isDryRunResponseForClient(c, data) {
 			return data, nil
 		}
 		emitTruncationWarning(ctx, data, cursorLookupPath, hasMoreField, paginationType)
@@ -1183,7 +1183,7 @@ func paginatedGet(ctx context.Context, c interface {
 		if err != nil {
 			return nil, err
 		}
-		if isDryRunResponse(data) {
+		if isDryRunResponseForClient(c, data) {
 			return data, nil
 		}
 
@@ -2127,7 +2127,10 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 }
 
 // isDryRunResponse detects the exact sentinel returned by client.dryRun.
-func isDryRunResponse(data json.RawMessage) bool {
+func isDryRunResponse(dryRun bool, data json.RawMessage) bool {
+	if !dryRun {
+		return false
+	}
 	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal(data, &envelope); err != nil || len(envelope) != 1 {
 		return false
@@ -2138,6 +2141,11 @@ func isDryRunResponse(data json.RawMessage) bool {
 	}
 	var v bool
 	return json.Unmarshal(raw, &v) == nil && v
+}
+
+func isDryRunResponseForClient(c any, data json.RawMessage) bool {
+	dryRunClient, ok := c.(interface{ IsDryRun() bool })
+	return ok && isDryRunResponse(dryRunClient.IsDryRun(), data)
 }
 
 func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any) error {

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1138,6 +1138,9 @@ func paginatedGet(ctx context.Context, c interface {
 		if err != nil {
 			return nil, err
 		}
+		if isDryRunResponse(data) {
+			return data, nil
+		}
 		emitTruncationWarning(ctx, data, cursorLookupPath, hasMoreField, paginationType)
 		return data, nil
 	}
@@ -1179,6 +1182,9 @@ func paginatedGet(ctx context.Context, c interface {
 		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
 			return nil, err
+		}
+		if isDryRunResponse(data) {
+			return data, nil
 		}
 
 		// Try to extract items array
@@ -2118,6 +2124,20 @@ func camelToKebab(s string) string {
 // printOutputWithFlags routes output through the right format based on flags.
 func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) error {
 	return printOutputWithFlagsMeta(w, data, flags, map[string]any{"source": "local"})
+}
+
+// isDryRunResponse detects the exact sentinel returned by client.dryRun.
+func isDryRunResponse(data json.RawMessage) bool {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil || len(envelope) != 1 {
+		return false
+	}
+	raw, ok := envelope["dry_run"]
+	if !ok {
+		return false
+	}
+	var v bool
+	return json.Unmarshal(raw, &v) == nil && v
 }
 
 func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any) error {

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -813,7 +813,7 @@ func syncResource(ctx context.Context, c interface {
 	// sentinel has no items and no id; emit a synthetic success event so
 	// validate-narrative --full-examples (which auto-appends --dry-run)
 	// sees a clean exit.
-	if isDryRunResponse(data) {
+	if isDryRunResponseForClient(c, data) {
 		if !humanFriendly {
 			fmt.Fprintf(syncEvents, `{"event":"sync_dryrun","resource":"%s"}`+"\n", resource)
 		}
@@ -3065,7 +3065,7 @@ func syncOneParent(
 		// of a real response when --dry-run is set. A preview must not mutate
 		// sync-state, so return before any reconcile; the aggregator emits the
 		// single sync_dryrun event. (issue #2935)
-		if isDryRunResponse(data) {
+		if isDryRunResponseForClient(c, data) {
 			rep.dryRun = true
 			return rep
 		}

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1886,30 +1886,6 @@ func numericIDWalkValue(value any) (int64, bool) {
 }
 {{- end}}
 
-// isDryRunResponse detects the `{"dry_run": true}` sentinel that
-// client.dryRun returns instead of a real API response. The sync loop
-// uses this to short-circuit before the upsert path, which would
-// otherwise fail with "missing id for <resource>" against a sentinel
-// that has no items and no id. The check requires exactly one key
-// (dry_run) so a live API response that happens to include a top-level
-// dry_run field alongside real data isn't misclassified as the
-// sentinel and silently zero out the sync count.
-func isDryRunResponse(data json.RawMessage) bool {
-	var envelope map[string]json.RawMessage
-	if err := json.Unmarshal(data, &envelope); err != nil {
-		return false
-	}
-	if len(envelope) != 1 {
-		return false
-	}
-	raw, ok := envelope["dry_run"]
-	if !ok {
-		return false
-	}
-	var v bool
-	return json.Unmarshal(raw, &v) == nil && v
-}
-
 func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 	var direct []json.RawMessage
 	if err := json.Unmarshal(data, &direct); err == nil && !isJSONNull(data) {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -584,6 +584,9 @@ func paginatedGet(ctx context.Context, c interface {
 		if err != nil {
 			return nil, err
 		}
+		if isDryRunResponse(data) {
+			return data, nil
+		}
 		emitTruncationWarning(ctx, data, cursorLookupPath, hasMoreField, paginationType)
 		return data, nil
 	}
@@ -625,6 +628,9 @@ func paginatedGet(ctx context.Context, c interface {
 		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
 			return nil, err
+		}
+		if isDryRunResponse(data) {
+			return data, nil
 		}
 
 		// Try to extract items array
@@ -1561,6 +1567,20 @@ func camelToKebab(s string) string {
 // printOutputWithFlags routes output through the right format based on flags.
 func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) error {
 	return printOutputWithFlagsMeta(w, data, flags, map[string]any{"source": "local"})
+}
+
+// isDryRunResponse detects the exact sentinel returned by client.dryRun.
+func isDryRunResponse(data json.RawMessage) bool {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil || len(envelope) != 1 {
+		return false
+	}
+	raw, ok := envelope["dry_run"]
+	if !ok {
+		return false
+	}
+	var v bool
+	return json.Unmarshal(raw, &v) == nil && v
 }
 
 func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any) error {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -584,7 +584,7 @@ func paginatedGet(ctx context.Context, c interface {
 		if err != nil {
 			return nil, err
 		}
-		if isDryRunResponse(data) {
+		if isDryRunResponseForClient(c, data) {
 			return data, nil
 		}
 		emitTruncationWarning(ctx, data, cursorLookupPath, hasMoreField, paginationType)
@@ -629,7 +629,7 @@ func paginatedGet(ctx context.Context, c interface {
 		if err != nil {
 			return nil, err
 		}
-		if isDryRunResponse(data) {
+		if isDryRunResponseForClient(c, data) {
 			return data, nil
 		}
 
@@ -1570,7 +1570,10 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 }
 
 // isDryRunResponse detects the exact sentinel returned by client.dryRun.
-func isDryRunResponse(data json.RawMessage) bool {
+func isDryRunResponse(dryRun bool, data json.RawMessage) bool {
+	if !dryRun {
+		return false
+	}
 	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal(data, &envelope); err != nil || len(envelope) != 1 {
 		return false
@@ -1581,6 +1584,11 @@ func isDryRunResponse(data json.RawMessage) bool {
 	}
 	var v bool
 	return json.Unmarshal(raw, &v) == nil && v
+}
+
+func isDryRunResponseForClient(c any, data json.RawMessage) bool {
+	dryRunClient, ok := c.(interface{ IsDryRun() bool })
+	return ok && isDryRunResponse(dryRunClient.IsDryRun(), data)
 }
 
 func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any) error {

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -46,6 +46,10 @@ type Client struct {
 	platformBudgets   map[string]platform.EndpointBudget
 }
 
+func (c *Client) IsDryRun() bool {
+	return c != nil && c.DryRun
+}
+
 // BindPlatformSession installs the result of the live fail-closed tenant gate.
 // Cache and state paths are switched only after the gate has verified both the
 // credential and the immutable provider identity.

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -46,6 +46,10 @@ type Client struct {
 	platformBudgets   map[string]platform.EndpointBudget
 }
 
+func (c *Client) IsDryRun() bool {
+	return c != nil && c.DryRun
+}
+
 // BindPlatformSession installs the result of the live fail-closed tenant gate.
 // Cache and state paths are switched only after the gate has verified both the
 // credential and the immutable provider identity.

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -50,6 +50,10 @@ type Client struct {
 	ccMu *sync.Mutex
 }
 
+func (c *Client) IsDryRun() bool {
+	return c != nil && c.DryRun
+}
+
 // BindPlatformSession installs the result of the live fail-closed tenant gate.
 // Cache and state paths are switched only after the gate has verified both the
 // credential and the immutable provider identity.

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -46,6 +46,10 @@ type Client struct {
 	platformBudgets   map[string]platform.EndpointBudget
 }
 
+func (c *Client) IsDryRun() bool {
+	return c != nil && c.DryRun
+}
+
 // BindPlatformSession installs the result of the live fail-closed tenant gate.
 // Cache and state paths are switched only after the gate has verified both the
 // credential and the immutable provider identity.

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -577,7 +577,7 @@ func paginatedGet(ctx context.Context, c interface {
 		if err != nil {
 			return nil, err
 		}
-		if isDryRunResponse(data) {
+		if isDryRunResponseForClient(c, data) {
 			return data, nil
 		}
 		emitTruncationWarning(ctx, data, cursorLookupPath, hasMoreField, paginationType)
@@ -622,7 +622,7 @@ func paginatedGet(ctx context.Context, c interface {
 		if err != nil {
 			return nil, err
 		}
-		if isDryRunResponse(data) {
+		if isDryRunResponseForClient(c, data) {
 			return data, nil
 		}
 
@@ -1436,7 +1436,10 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 }
 
 // isDryRunResponse detects the exact sentinel returned by client.dryRun.
-func isDryRunResponse(data json.RawMessage) bool {
+func isDryRunResponse(dryRun bool, data json.RawMessage) bool {
+	if !dryRun {
+		return false
+	}
 	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal(data, &envelope); err != nil || len(envelope) != 1 {
 		return false
@@ -1447,6 +1450,11 @@ func isDryRunResponse(data json.RawMessage) bool {
 	}
 	var v bool
 	return json.Unmarshal(raw, &v) == nil && v
+}
+
+func isDryRunResponseForClient(c any, data json.RawMessage) bool {
+	dryRunClient, ok := c.(interface{ IsDryRun() bool })
+	return ok && isDryRunResponse(dryRunClient.IsDryRun(), data)
 }
 
 func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any) error {

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -577,6 +577,9 @@ func paginatedGet(ctx context.Context, c interface {
 		if err != nil {
 			return nil, err
 		}
+		if isDryRunResponse(data) {
+			return data, nil
+		}
 		emitTruncationWarning(ctx, data, cursorLookupPath, hasMoreField, paginationType)
 		return data, nil
 	}
@@ -618,6 +621,9 @@ func paginatedGet(ctx context.Context, c interface {
 		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
 			return nil, err
+		}
+		if isDryRunResponse(data) {
+			return data, nil
 		}
 
 		// Try to extract items array
@@ -1427,6 +1433,20 @@ func camelToKebab(s string) string {
 // printOutputWithFlags routes output through the right format based on flags.
 func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) error {
 	return printOutputWithFlagsMeta(w, data, flags, map[string]any{"source": "local"})
+}
+
+// isDryRunResponse detects the exact sentinel returned by client.dryRun.
+func isDryRunResponse(data json.RawMessage) bool {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil || len(envelope) != 1 {
+		return false
+	}
+	raw, ok := envelope["dry_run"]
+	if !ok {
+		return false
+	}
+	var v bool
+	return json.Unmarshal(raw, &v) == nil && v
 }
 
 func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any) error {

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 81
+    "total": 82
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 80
+    "total": 81
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -159,6 +159,9 @@ func resolveReadWithStrategyResponsePathAndJSONGuard(ctx context.Context, c *cli
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		if isDryRunResponse(data) {
+			return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
+		}
 		if guardLiveJSON {
 			if err := assertLiveJSONBody(data); err != nil {
 				return nil, DataProvenance{}, err
@@ -177,6 +180,9 @@ func resolveReadWithStrategyResponsePathAndJSONGuard(ctx context.Context, c *cli
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		if isDryRunResponse(data) {
+			return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
+		}
 		if guardLiveJSON {
 			if err := assertLiveJSONBody(data); err != nil {
 				return nil, DataProvenance{}, err
@@ -188,6 +194,9 @@ func resolveReadWithStrategyResponsePathAndJSONGuard(ctx context.Context, c *cli
 	default: // "auto"
 		data, err := c.GetWithHeaders(ctx, path, params, headers)
 		if err == nil {
+			if isDryRunResponse(data) {
+				return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
+			}
 			if guardLiveJSON {
 				if err := assertLiveJSONBody(data); err != nil {
 					return nil, DataProvenance{}, err
@@ -226,6 +235,9 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 	if err := validateDataSourceStrategy(flags, strategy); err != nil {
 		return nil, DataProvenance{}, err
 	}
+	if flags != nil && flags.dryRun {
+		fetchAll = false
+	}
 	if strategy == "local" {
 		data, prov, err := resolveLocal(ctx, flags, hintWriter, resourceType, true, path, params, "strategy_local")
 		return data, attachFreshness(prov, flags), err
@@ -237,6 +249,9 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
 		if err != nil {
 			return nil, DataProvenance{}, err
+		}
+		if isDryRunResponse(data) {
+			return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
 		}
 		if guardLiveJSON {
 			if err := assertLiveJSONBody(data); err != nil {
@@ -258,6 +273,9 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		if isDryRunResponse(data) {
+			return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
+		}
 		if guardLiveJSON {
 			if err := assertLiveJSONBody(data); err != nil {
 				return nil, DataProvenance{}, err
@@ -271,6 +289,9 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		}
 		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
 		if err == nil {
+			if isDryRunResponse(data) {
+				return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
+			}
 			if guardLiveJSON {
 				if err := assertLiveJSONBody(data); err != nil {
 					return nil, DataProvenance{}, err

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -159,7 +159,7 @@ func resolveReadWithStrategyResponsePathAndJSONGuard(ctx context.Context, c *cli
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
-		if isDryRunResponse(data) {
+		if isDryRunResponse(c.IsDryRun(), data) {
 			return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
 		}
 		if guardLiveJSON {
@@ -180,7 +180,7 @@ func resolveReadWithStrategyResponsePathAndJSONGuard(ctx context.Context, c *cli
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
-		if isDryRunResponse(data) {
+		if isDryRunResponse(c.IsDryRun(), data) {
 			return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
 		}
 		if guardLiveJSON {
@@ -194,7 +194,7 @@ func resolveReadWithStrategyResponsePathAndJSONGuard(ctx context.Context, c *cli
 	default: // "auto"
 		data, err := c.GetWithHeaders(ctx, path, params, headers)
 		if err == nil {
-			if isDryRunResponse(data) {
+			if isDryRunResponse(c.IsDryRun(), data) {
 				return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
 			}
 			if guardLiveJSON {
@@ -250,7 +250,7 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
-		if isDryRunResponse(data) {
+		if isDryRunResponse(c.IsDryRun(), data) {
 			return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
 		}
 		if guardLiveJSON {
@@ -273,7 +273,7 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
-		if isDryRunResponse(data) {
+		if isDryRunResponse(c.IsDryRun(), data) {
 			return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
 		}
 		if guardLiveJSON {
@@ -289,7 +289,7 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		}
 		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
 		if err == nil {
-			if isDryRunResponse(data) {
+			if isDryRunResponse(c.IsDryRun(), data) {
 				return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil
 			}
 			if guardLiveJSON {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -661,7 +661,7 @@ func paginatedGet(ctx context.Context, c interface {
 		if err != nil {
 			return nil, err
 		}
-		if isDryRunResponse(data) {
+		if isDryRunResponseForClient(c, data) {
 			return data, nil
 		}
 		emitTruncationWarning(ctx, data, cursorLookupPath, hasMoreField, paginationType)
@@ -706,7 +706,7 @@ func paginatedGet(ctx context.Context, c interface {
 		if err != nil {
 			return nil, err
 		}
-		if isDryRunResponse(data) {
+		if isDryRunResponseForClient(c, data) {
 			return data, nil
 		}
 
@@ -1520,7 +1520,10 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 }
 
 // isDryRunResponse detects the exact sentinel returned by client.dryRun.
-func isDryRunResponse(data json.RawMessage) bool {
+func isDryRunResponse(dryRun bool, data json.RawMessage) bool {
+	if !dryRun {
+		return false
+	}
 	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal(data, &envelope); err != nil || len(envelope) != 1 {
 		return false
@@ -1531,6 +1534,11 @@ func isDryRunResponse(data json.RawMessage) bool {
 	}
 	var v bool
 	return json.Unmarshal(raw, &v) == nil && v
+}
+
+func isDryRunResponseForClient(c any, data json.RawMessage) bool {
+	dryRunClient, ok := c.(interface{ IsDryRun() bool })
+	return ok && isDryRunResponse(dryRunClient.IsDryRun(), data)
 }
 
 func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any) error {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -661,6 +661,9 @@ func paginatedGet(ctx context.Context, c interface {
 		if err != nil {
 			return nil, err
 		}
+		if isDryRunResponse(data) {
+			return data, nil
+		}
 		emitTruncationWarning(ctx, data, cursorLookupPath, hasMoreField, paginationType)
 		return data, nil
 	}
@@ -702,6 +705,9 @@ func paginatedGet(ctx context.Context, c interface {
 		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
 			return nil, err
+		}
+		if isDryRunResponse(data) {
+			return data, nil
 		}
 
 		// Try to extract items array
@@ -1511,6 +1517,20 @@ func camelToKebab(s string) string {
 // printOutputWithFlags routes output through the right format based on flags.
 func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) error {
 	return printOutputWithFlagsMeta(w, data, flags, map[string]any{"source": "local"})
+}
+
+// isDryRunResponse detects the exact sentinel returned by client.dryRun.
+func isDryRunResponse(data json.RawMessage) bool {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil || len(envelope) != 1 {
+		return false
+	}
+	raw, ok := envelope["dry_run"]
+	if !ok {
+		return false
+	}
+	var v bool
+	return json.Unmarshal(raw, &v) == nil && v
 }
 
 func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any) error {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -1150,30 +1150,6 @@ func extractObjectArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	return items, true
 }
 
-// isDryRunResponse detects the `{"dry_run": true}` sentinel that
-// client.dryRun returns instead of a real API response. The sync loop
-// uses this to short-circuit before the upsert path, which would
-// otherwise fail with "missing id for <resource>" against a sentinel
-// that has no items and no id. The check requires exactly one key
-// (dry_run) so a live API response that happens to include a top-level
-// dry_run field alongside real data isn't misclassified as the
-// sentinel and silently zero out the sync count.
-func isDryRunResponse(data json.RawMessage) bool {
-	var envelope map[string]json.RawMessage
-	if err := json.Unmarshal(data, &envelope); err != nil {
-		return false
-	}
-	if len(envelope) != 1 {
-		return false
-	}
-	raw, ok := envelope["dry_run"]
-	if !ok {
-		return false
-	}
-	var v bool
-	return json.Unmarshal(raw, &v) == nil && v
-}
-
 func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 	var direct []json.RawMessage
 	if err := json.Unmarshal(data, &direct); err == nil && !isJSONNull(data) {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -568,7 +568,7 @@ func syncResource(ctx context.Context, c interface {
 		// sentinel has no items and no id; emit a synthetic success event so
 		// validate-narrative --full-examples (which auto-appends --dry-run)
 		// sees a clean exit.
-		if isDryRunResponse(data) {
+		if isDryRunResponseForClient(c, data) {
 			if !humanFriendly {
 				fmt.Fprintf(syncEvents, `{"event":"sync_dryrun","resource":"%s"}`+"\n", resource)
 			}
@@ -2029,7 +2029,7 @@ func syncOneParent(
 		// of a real response when --dry-run is set. A preview must not mutate
 		// sync-state, so return before any reconcile; the aggregator emits the
 		// single sync_dryrun event. (issue #2935)
-		if isDryRunResponse(data) {
+		if isDryRunResponseForClient(c, data) {
 			rep.dryRun = true
 			return rep
 		}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -47,6 +47,10 @@ type Client struct {
 	platformBudgets   map[string]platform.EndpointBudget
 }
 
+func (c *Client) IsDryRun() bool {
+	return c != nil && c.DryRun
+}
+
 // BindPlatformSession installs the result of the live fail-closed tenant gate.
 // Cache and state paths are switched only after the gate has verified both the
 // credential and the immutable provider identity.

--- a/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/promoted_things.go
+++ b/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/promoted_things.go
@@ -52,8 +52,8 @@ func newThingsPromotedCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
-			if isDryRunResponse(data) {
-				if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+			if isDryRunResponse(c.IsDryRun(), data) {
+				if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
 					return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "dry-run"})
 				}
 				return nil

--- a/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/promoted_things.go
+++ b/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/promoted_things.go
@@ -52,6 +52,12 @@ func newThingsPromotedCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
+			if isDryRunResponse(data) {
+				if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+					return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "dry-run"})
+				}
+				return nil
+			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				var items []map[string]any
 				if json.Unmarshal(data, &items) == nil && len(items) > 0 {

--- a/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/things_list.go
+++ b/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/things_list.go
@@ -49,6 +49,12 @@ func newThingsListCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
+			if isDryRunResponse(data) {
+				if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+					return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "dry-run"})
+				}
+				return nil
+			}
 			// Inspect the mutate response body for a partial-failure-shaped
 			// field (e.g. Google Ads `partialFailureError`). Several Google
 			// APIs return 200 OK with a partial-failure field when some

--- a/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/things_list.go
+++ b/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/things_list.go
@@ -49,8 +49,8 @@ func newThingsListCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
-			if isDryRunResponse(data) {
-				if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+			if isDryRunResponse(c.IsDryRun(), data) {
+				if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
 					return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "dry-run"})
 				}
 				return nil

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -552,7 +552,7 @@ func syncResource(ctx context.Context, c interface {
 		// sentinel has no items and no id; emit a synthetic success event so
 		// validate-narrative --full-examples (which auto-appends --dry-run)
 		// sees a clean exit.
-		if isDryRunResponse(data) {
+		if isDryRunResponseForClient(c, data) {
 			if !humanFriendly {
 				fmt.Fprintf(syncEvents, `{"event":"sync_dryrun","resource":"%s"}`+"\n", resource)
 			}

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -1152,30 +1152,6 @@ func extractObjectArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	return items, true
 }
 
-// isDryRunResponse detects the `{"dry_run": true}` sentinel that
-// client.dryRun returns instead of a real API response. The sync loop
-// uses this to short-circuit before the upsert path, which would
-// otherwise fail with "missing id for <resource>" against a sentinel
-// that has no items and no id. The check requires exactly one key
-// (dry_run) so a live API response that happens to include a top-level
-// dry_run field alongside real data isn't misclassified as the
-// sentinel and silently zero out the sync count.
-func isDryRunResponse(data json.RawMessage) bool {
-	var envelope map[string]json.RawMessage
-	if err := json.Unmarshal(data, &envelope); err != nil {
-		return false
-	}
-	if len(envelope) != 1 {
-		return false
-	}
-	raw, ok := envelope["dry_run"]
-	if !ok {
-		return false
-	}
-	var v bool
-	return json.Unmarshal(raw, &v) == nil && v
-}
-
 func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 	var direct []json.RawMessage
 	if err := json.Unmarshal(data, &direct); err == nil && !isJSONNull(data) {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -1132,30 +1132,6 @@ func extractObjectArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	return items, true
 }
 
-// isDryRunResponse detects the `{"dry_run": true}` sentinel that
-// client.dryRun returns instead of a real API response. The sync loop
-// uses this to short-circuit before the upsert path, which would
-// otherwise fail with "missing id for <resource>" against a sentinel
-// that has no items and no id. The check requires exactly one key
-// (dry_run) so a live API response that happens to include a top-level
-// dry_run field alongside real data isn't misclassified as the
-// sentinel and silently zero out the sync count.
-func isDryRunResponse(data json.RawMessage) bool {
-	var envelope map[string]json.RawMessage
-	if err := json.Unmarshal(data, &envelope); err != nil {
-		return false
-	}
-	if len(envelope) != 1 {
-		return false
-	}
-	raw, ok := envelope["dry_run"]
-	if !ok {
-		return false
-	}
-	var v bool
-	return json.Unmarshal(raw, &v) == nil && v
-}
-
 func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 	var direct []json.RawMessage
 	if err := json.Unmarshal(data, &direct); err == nil && !isJSONNull(data) {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -568,7 +568,7 @@ func syncResource(ctx context.Context, c interface {
 		// sentinel has no items and no id; emit a synthetic success event so
 		// validate-narrative --full-examples (which auto-appends --dry-run)
 		// sees a clean exit.
-		if isDryRunResponse(data) {
+		if isDryRunResponseForClient(c, data) {
 			if !humanFriendly {
 				fmt.Fprintf(syncEvents, `{"event":"sync_dryrun","resource":"%s"}`+"\n", resource)
 			}
@@ -2000,7 +2000,7 @@ func syncOneParent(
 		// of a real response when --dry-run is set. A preview must not mutate
 		// sync-state, so return before any reconcile; the aggregator emits the
 		// single sync_dryrun event. (issue #2935)
-		if isDryRunResponse(data) {
+		if isDryRunResponseForClient(c, data) {
 			rep.dryRun = true
 			return rep
 		}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -1102,30 +1102,6 @@ func extractObjectArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	return items, true
 }
 
-// isDryRunResponse detects the `{"dry_run": true}` sentinel that
-// client.dryRun returns instead of a real API response. The sync loop
-// uses this to short-circuit before the upsert path, which would
-// otherwise fail with "missing id for <resource>" against a sentinel
-// that has no items and no id. The check requires exactly one key
-// (dry_run) so a live API response that happens to include a top-level
-// dry_run field alongside real data isn't misclassified as the
-// sentinel and silently zero out the sync count.
-func isDryRunResponse(data json.RawMessage) bool {
-	var envelope map[string]json.RawMessage
-	if err := json.Unmarshal(data, &envelope); err != nil {
-		return false
-	}
-	if len(envelope) != 1 {
-		return false
-	}
-	raw, ok := envelope["dry_run"]
-	if !ok {
-		return false
-	}
-	var v bool
-	return json.Unmarshal(raw, &v) == nil && v
-}
-
 func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 	var direct []json.RawMessage
 	if err := json.Unmarshal(data, &direct); err == nil && !isJSONNull(data) {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -529,7 +529,7 @@ func syncResource(ctx context.Context, c interface {
 		// sentinel has no items and no id; emit a synthetic success event so
 		// validate-narrative --full-examples (which auto-appends --dry-run)
 		// sees a clean exit.
-		if isDryRunResponse(data) {
+		if isDryRunResponseForClient(c, data) {
 			if !humanFriendly {
 				fmt.Fprintf(syncEvents, `{"event":"sync_dryrun","resource":"%s"}`+"\n", resource)
 			}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -48,6 +48,10 @@ type Client struct {
 	limiters          map[string]*cliutil.AdaptiveLimiter
 }
 
+func (c *Client) IsDryRun() bool {
+	return c != nil && c.DryRun
+}
+
 // BindPlatformSession installs the result of the live fail-closed tenant gate.
 // Cache and state paths are switched only after the gate has verified both the
 // credential and the immutable provider identity.


### PR DESCRIPTION
## Summary

Generated read commands now recognize the client dry-run sentinel before pagination, response-path handling, provenance, or write-through caching. Dry-run agent output reports `meta.source: "dry-run"` and leaves the local store untouched, while normal live reads keep their existing cache behavior across promoted and endpoint command paths.

## Validation

- Focused generated endpoint and promoted pagination tests cover dry-run provenance, no cache warning, no `data/data.db`, and live cache creation.
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go vet ./...`
- Full `go test ./... -count=1` reached the generator package timeout on the shared host; focused regression and generated-output gates passed.
- `golangci-lint run ./...` remains blocked by the pre-existing `internal/googlediscovery/parser.go:455` modernize finding.

Closes #3683
Closes #3751
