### PR TITLE
fix(cli): disambiguate colliding dependent resources

### DIFF
--- a/internal/generator/issue_3755_test.go
+++ b/internal/generator/issue_3755_test.go
@@ -1,0 +1,110 @@
+package generator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue3755DeepResourceNamesStayUnique(t *testing.T) {
+	apiSpec := issue3755Spec()
+	profile := profiler.Profile(apiSpec)
+	require.Len(t, profile.DependentSyncResources, 9)
+
+	expectedNames := map[string]string{
+		"/dashboard/{client_id}/google-ads/accounts/{account_id}/campaigns":                                          "dashboard_google_ads_accounts_campaigns",
+		"/dashboard/{client_id}/google-ads/accounts/{account_id}/campaigns/{campaign_id}/adgroups":                   "dashboard_google_ads_accounts_campaigns_adgroups",
+		"/dashboard/{client_id}/google-ads/accounts/{account_id}/campaigns/{campaign_id}/adgroups/{ad_group_id}/ads": "dashboard_google_ads_accounts_campaigns_adgroups_ads",
+		"/dashboard/{client_id}/meta-ads/accounts/{account_id}/campaigns":                                            "dashboard_meta_ads_accounts_campaigns",
+		"/dashboard/{client_id}/meta-ads/accounts/{account_id}/campaigns/{campaign_id}/adgroups":                     "dashboard_meta_ads_accounts_campaigns_adgroups",
+		"/dashboard/{client_id}/meta-ads/accounts/{account_id}/campaigns/{campaign_id}/adgroups/{ad_group_id}/ads":   "dashboard_meta_ads_accounts_campaigns_adgroups_ads",
+		"/dashboard/{client_id}/tiktok-ads/accounts/{account_id}/campaigns":                                          "dashboard_tiktok_ads_accounts_campaigns",
+		"/dashboard/{client_id}/tiktok-ads/accounts/{account_id}/campaigns/{campaign_id}/adgroups":                   "dashboard_tiktok_ads_accounts_campaigns_adgroups",
+		"/dashboard/{client_id}/tiktok-ads/accounts/{account_id}/campaigns/{campaign_id}/adgroups/{ad_group_id}/ads": "dashboard_tiktok_ads_accounts_campaigns_adgroups_ads",
+	}
+
+	seen := make(map[string]string, len(profile.DependentSyncResources))
+	namesByPath := make(map[string]string, len(profile.DependentSyncResources))
+	for _, resource := range profile.DependentSyncResources {
+		if previousPath, exists := seen[resource.Name]; exists {
+			t.Fatalf("dependent resource name %q is shared by %q and %q", resource.Name, previousPath, resource.Path)
+		}
+		seen[resource.Name] = resource.Path
+		namesByPath[resource.Path] = resource.Name
+	}
+	require.Equal(t, expectedNames, namesByPath)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{MCP: true, Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	syncSource, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	require.NotEmpty(t, syncSource)
+	for _, name := range expectedNames {
+		require.Contains(t, string(syncSource), fmt.Sprintf("case %q:", name))
+	}
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func issue3755Spec() *spec.APISpec {
+	list := func(path string) spec.Endpoint {
+		return spec.Endpoint{
+			Method:     "GET",
+			Path:       path,
+			Response:   spec.ResponseDef{Type: "array", Item: "Record"},
+			Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+		}
+	}
+
+	return &spec.APISpec{
+		Name:    "shared-leaf-resources",
+		Version: "1.0.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/shared-leaf-resources-pp-cli/config.toml",
+		},
+		Types: map[string]spec.TypeDef{
+			"Record": {Fields: []spec.TypeField{{Name: "id", Type: "string"}}},
+		},
+		Resources: map[string]spec.Resource{
+			"dashboard": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": list("/dashboard"),
+				},
+				SubResources: map[string]spec.Resource{
+					"google_ads": {
+						Endpoints: map[string]spec.Endpoint{
+							"campaigns": list("/dashboard/{client_id}/google-ads/accounts/{account_id}/campaigns"),
+							"adgroups":  list("/dashboard/{client_id}/google-ads/accounts/{account_id}/campaigns/{campaign_id}/adgroups"),
+							"ads":       list("/dashboard/{client_id}/google-ads/accounts/{account_id}/campaigns/{campaign_id}/adgroups/{ad_group_id}/ads"),
+						},
+					},
+					"meta_ads": {
+						Endpoints: map[string]spec.Endpoint{
+							"campaigns": list("/dashboard/{client_id}/meta-ads/accounts/{account_id}/campaigns"),
+							"adgroups":  list("/dashboard/{client_id}/meta-ads/accounts/{account_id}/campaigns/{campaign_id}/adgroups"),
+							"ads":       list("/dashboard/{client_id}/meta-ads/accounts/{account_id}/campaigns/{campaign_id}/adgroups/{ad_group_id}/ads"),
+						},
+					},
+					"tiktok_ads": {
+						Endpoints: map[string]spec.Endpoint{
+							"campaigns": list("/dashboard/{client_id}/tiktok-ads/accounts/{account_id}/campaigns"),
+							"adgroups":  list("/dashboard/{client_id}/tiktok-ads/accounts/{account_id}/campaigns/{campaign_id}/adgroups"),
+							"ads":       list("/dashboard/{client_id}/tiktok-ads/accounts/{account_id}/campaigns/{campaign_id}/adgroups/{ad_group_id}/ads"),
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -1657,24 +1657,6 @@ func updateDependentParentNames(deps []DependentResource, originalNames []string
 	}
 }
 
-func dependentPathPrefix(parentPath, childPath string) bool {
-	parentSegments := pathSegments(parentPath)
-	childSegments := pathSegments(childPath)
-	if len(parentSegments) == 0 || len(parentSegments) >= len(childSegments) {
-		return false
-	}
-	for i, parentSegment := range parentSegments {
-		childSegment := childSegments[i]
-		if isPathPlaceholder(parentSegment) && isPathPlaceholder(childSegment) {
-			continue
-		}
-		if parentSegment != childSegment {
-			return false
-		}
-	}
-	return true
-}
-
 func dependentPathResourceName(dep DependentResource) string {
 	segments := staticPathSegments(dep.Path)
 	if len(segments) == 0 {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -205,6 +205,8 @@ type DependentResource struct {
 	Method         string
 	Tier           string
 	PathParams     []DependentPathParam
+	parentPath     string
+	parentPathLock bool
 
 	// IDField is the primary-key field name resolved from the spec
 	// (x-resource-id extension or the four-tier fallback chain). Empty when
@@ -1637,27 +1639,20 @@ func uniquifyDependentResourceNames(deps []DependentResource, syncable map[strin
 			used[candidate] = true
 		}
 	}
-	updateDependentParentNames(deps, originalNames, syncable)
+	updateDependentParentNames(deps, originalNames)
 }
 
-func updateDependentParentNames(deps []DependentResource, originalNames []string, syncable map[string]syncableMeta) {
+func updateDependentParentNames(deps []DependentResource, originalNames []string) {
 	for i := range deps {
-		parentName := deps[i].ParentResource
-		if parent, ok := syncable[parentName]; ok && dependentPathPrefix(parent.Path, deps[i].Path) {
+		if deps[i].parentPathLock || deps[i].parentPath == "" {
 			continue
 		}
-		bestIndex := -1
 		for j := range deps {
-			if originalNames[j] != parentName || !dependentPathPrefix(deps[j].Path, deps[i].Path) {
+			if originalNames[j] != deps[i].ParentResource || deps[j].Path != deps[i].parentPath {
 				continue
 			}
-			if bestIndex < 0 || len(pathSegments(deps[j].Path)) > len(pathSegments(deps[bestIndex].Path)) ||
-				(len(pathSegments(deps[j].Path)) == len(pathSegments(deps[bestIndex].Path)) && deps[j].Name < deps[bestIndex].Name) {
-				bestIndex = j
-			}
-		}
-		if bestIndex >= 0 {
-			deps[i].ParentResource = deps[bestIndex].Name
+			deps[i].ParentResource = deps[j].Name
+			break
 		}
 	}
 }
@@ -1758,6 +1753,7 @@ func dependentResourceFromEntry(entry parameterizedEntry, knownParents map[strin
 		Method:                entry.meta.Method,
 		Tier:                  entry.meta.Tier,
 		PathParams:            dependentPathParams(entry.meta.Path, ctx.parentPathSegment, ctx.firstParam, keyField),
+		parentPath:            dependentParentPath(entry.meta.Path, ctx.parentPathSegment),
 		IDField:               entry.meta.IDField,
 		Critical:              entry.meta.Critical,
 		SinceParam:            entry.meta.SinceParam,
@@ -1974,6 +1970,8 @@ func applySpecWalkers(s *spec.APISpec, deps []DependentResource, syncable map[st
 			lookupKey := "GET " + e.Path
 			if idx, ok := byPath[lookupKey]; ok {
 				deps[idx].ParentResource = parent
+				deps[idx].parentPath = ""
+				deps[idx].parentPathLock = true
 				if keyParam != "" {
 					deps[idx].ParentIDParam = keyParam
 				}
@@ -1987,6 +1985,7 @@ func applySpecWalkers(s *spec.APISpec, deps []DependentResource, syncable map[st
 				ParentResource:        parent,
 				ParentIDParam:         keyParam,
 				Path:                  e.Path,
+				parentPathLock:        true,
 				Method:                meta.Method,
 				Tier:                  meta.Tier,
 				PathParams:            dependentPathParams(e.Path, parent, keyParam, keyField),
@@ -2053,6 +2052,15 @@ func dependentParentIDParam(path, parentResource, fallback string) string {
 		}
 	}
 	return fallback
+}
+
+func dependentParentPath(path, parentSegment string) string {
+	segments := pathSegments(path)
+	index := lastStaticSegmentIndex(segments, spec.ToSnakeCase(parentSegment))
+	if index < 0 {
+		return ""
+	}
+	return "/" + strings.Join(segments[:index+1], "/")
 }
 
 // parentFieldIrregulars maps plural parent resource names whose singular form a

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -675,6 +675,8 @@ func Profile(s *spec.APISpec) *APIProfile {
 
 	p.DependentSyncResources = detectDependentResources(parameterized, syncable, shardedSubResources)
 	p.DependentSyncResources = applySpecWalkers(s, p.DependentSyncResources, syncable, s.Types, resourceNameIndex)
+	uniquifyDependentResourceNames(p.DependentSyncResources, syncable)
+	sortDependentResources(p.DependentSyncResources, nil)
 	addUnresolvedPathTemplateCollections(syncable, parameterized, p.DependentSyncResources)
 	p.SyncableResources = sortedSyncableResources(syncable)
 	// Flat tenant-scoped reconcile: a flat resource is reconcilable only when it
@@ -1578,6 +1580,109 @@ func detectDependentResources(parameterized map[string]parameterizedEntry, synca
 	}
 	sortDependentResources(deps, depthByResource)
 	return deps
+}
+
+func uniquifyDependentResourceNames(deps []DependentResource, syncable map[string]syncableMeta) {
+	originalNames := make([]string, len(deps))
+	counts := make(map[string]int, len(deps))
+	for i, dep := range deps {
+		originalNames[i] = dep.Name
+		counts[dep.Name]++
+	}
+
+	used := make(map[string]bool, len(syncable)+len(deps))
+	for name := range syncable {
+		used[name] = true
+	}
+	for name, count := range counts {
+		if count == 1 {
+			used[name] = true
+		}
+	}
+
+	for _, name := range sortedKeys(counts) {
+		count := counts[name]
+		if count < 2 {
+			continue
+		}
+		indices := make([]int, 0, count)
+		for i := range deps {
+			if deps[i].Name == name {
+				indices = append(indices, i)
+			}
+		}
+		sort.Slice(indices, func(i, j int) bool {
+			left, right := deps[indices[i]], deps[indices[j]]
+			if left.Path != right.Path {
+				return left.Path < right.Path
+			}
+			return left.Method < right.Method
+		})
+
+		for _, index := range indices {
+			candidate := dependentPathResourceName(deps[index])
+			if candidate == "" {
+				candidate = name
+			}
+			if used[candidate] {
+				base := candidate
+				if method := strings.ToLower(strings.TrimSpace(deps[index].Method)); method != "" {
+					candidate = base + "_" + spec.ToSnakeCase(method)
+				}
+				for suffix := 2; used[candidate]; suffix++ {
+					candidate = fmt.Sprintf("%s_%d", base, suffix)
+				}
+			}
+			deps[index].Name = candidate
+			used[candidate] = true
+		}
+	}
+	updateDependentParentNames(deps, originalNames)
+}
+
+func updateDependentParentNames(deps []DependentResource, originalNames []string) {
+	for i := range deps {
+		parentName := deps[i].ParentResource
+		bestIndex := -1
+		for j := range deps {
+			if originalNames[j] != parentName || !dependentPathPrefix(deps[j].Path, deps[i].Path) {
+				continue
+			}
+			if bestIndex < 0 || len(pathSegments(deps[j].Path)) > len(pathSegments(deps[bestIndex].Path)) ||
+				(len(pathSegments(deps[j].Path)) == len(pathSegments(deps[bestIndex].Path)) && deps[j].Name < deps[bestIndex].Name) {
+				bestIndex = j
+			}
+		}
+		if bestIndex >= 0 {
+			deps[i].ParentResource = deps[bestIndex].Name
+		}
+	}
+}
+
+func dependentPathPrefix(parentPath, childPath string) bool {
+	parentSegments := pathSegments(parentPath)
+	childSegments := pathSegments(childPath)
+	if len(parentSegments) == 0 || len(parentSegments) >= len(childSegments) {
+		return false
+	}
+	for i, parentSegment := range parentSegments {
+		childSegment := childSegments[i]
+		if isPathPlaceholder(parentSegment) && isPathPlaceholder(childSegment) {
+			continue
+		}
+		if parentSegment != childSegment {
+			return false
+		}
+	}
+	return true
+}
+
+func dependentPathResourceName(dep DependentResource) string {
+	segments := staticPathSegments(dep.Path)
+	if len(segments) == 0 {
+		return ""
+	}
+	return spec.ToSnakeCase(strings.Join(segments, "_"))
 }
 
 func addUnresolvedPathTemplateCollections(syncable map[string]syncableMeta, parameterized map[string]parameterizedEntry, deps []DependentResource) {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -1643,7 +1643,7 @@ func uniquifyDependentResourceNames(deps []DependentResource, syncable map[strin
 func updateDependentParentNames(deps []DependentResource, originalNames []string, syncable map[string]syncableMeta) {
 	for i := range deps {
 		parentName := deps[i].ParentResource
-		if _, ok := syncable[parentName]; ok {
+		if parent, ok := syncable[parentName]; ok && dependentPathPrefix(parent.Path, deps[i].Path) {
 			continue
 		}
 		bestIndex := -1

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -1637,12 +1637,15 @@ func uniquifyDependentResourceNames(deps []DependentResource, syncable map[strin
 			used[candidate] = true
 		}
 	}
-	updateDependentParentNames(deps, originalNames)
+	updateDependentParentNames(deps, originalNames, syncable)
 }
 
-func updateDependentParentNames(deps []DependentResource, originalNames []string) {
+func updateDependentParentNames(deps []DependentResource, originalNames []string, syncable map[string]syncableMeta) {
 	for i := range deps {
 		parentName := deps[i].ParentResource
+		if _, ok := syncable[parentName]; ok {
+			continue
+		}
 		bestIndex := -1
 		for j := range deps {
 			if originalNames[j] != parentName || !dependentPathPrefix(deps[j].Path, deps[i].Path) {

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -1696,6 +1696,20 @@ func TestUniquifyDependentResourceNamesUpdatesDescendantParents(t *testing.T) {
 	assert.Equal(t, "root_alpha_child", deps[2].ParentResource)
 }
 
+func TestUniquifyDependentResourceNamesPreservesSyncableParents(t *testing.T) {
+	deps := []DependentResource{
+		{Name: "accounts", ParentResource: "accounts", Path: "/accounts/{account_id}/nested", Method: "GET"},
+		{Name: "accounts", ParentResource: "accounts", Path: "/accounts/{account_id}/other", Method: "GET"},
+		{Name: "items", ParentResource: "accounts", Path: "/accounts/{account_id}/nested/{nested_id}/items", Method: "GET"},
+	}
+
+	uniquifyDependentResourceNames(deps, map[string]syncableMeta{"accounts": {}})
+
+	assert.Equal(t, "accounts_nested", deps[0].Name)
+	assert.Equal(t, "accounts_other", deps[1].Name)
+	assert.Equal(t, "accounts", deps[2].ParentResource)
+}
+
 func TestUniquifyDependentResourceNamesUsesDeterministicFallbacks(t *testing.T) {
 	deps := []DependentResource{
 		{Name: "shared_child", Path: "/root/{root_id}/alpha/child", Method: "GET"},

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -1686,7 +1686,7 @@ func TestUniquifyDependentResourceNamesUpdatesDescendantParents(t *testing.T) {
 	deps := []DependentResource{
 		{Name: "shared_child", ParentResource: "root", Path: "/root/{root_id}/alpha/child", Method: "GET"},
 		{Name: "shared_child", ParentResource: "root", Path: "/root/{root_id}/beta/child", Method: "GET"},
-		{Name: "grandchildren", ParentResource: "shared_child", Path: "/root/{root_id}/alpha/child/{child_id}/grandchildren", Method: "GET"},
+		{Name: "grandchildren", ParentResource: "shared_child", Path: "/root/{root_id}/alpha/child/{child_id}/grandchildren", parentPath: "/root/{root_id}/alpha/child", Method: "GET"},
 	}
 
 	uniquifyDependentResourceNames(deps, nil)
@@ -1703,6 +1703,7 @@ func TestUniquifyDependentResourceNamesPreservesSyncableParents(t *testing.T) {
 		{Name: "items", ParentResource: "accounts", Path: "/accounts/{account_id}/nested/{nested_id}/items", Method: "GET"},
 	}
 
+	deps[2].parentPath = "/accounts"
 	uniquifyDependentResourceNames(deps, map[string]syncableMeta{"accounts": {Path: "/accounts"}})
 
 	assert.Equal(t, "accounts_nested", deps[0].Name)
@@ -1710,18 +1711,18 @@ func TestUniquifyDependentResourceNamesPreservesSyncableParents(t *testing.T) {
 	assert.Equal(t, "accounts", deps[2].ParentResource)
 }
 
-func TestUniquifyDependentResourceNamesRewiresPastUnrelatedSyncableParents(t *testing.T) {
+func TestUniquifyDependentResourceNamesRewiresToSpecificDependentParent(t *testing.T) {
 	deps := []DependentResource{
-		{Name: "accounts", ParentResource: "accounts", Path: "/projects/{project_id}/nested", Method: "GET"},
-		{Name: "accounts", ParentResource: "accounts", Path: "/projects/{project_id}/other", Method: "GET"},
-		{Name: "items", ParentResource: "accounts", Path: "/projects/{project_id}/nested/{nested_id}/items", Method: "GET"},
+		{Name: "accounts", ParentResource: "accounts", Path: "/accounts/{account_id}/nested", Method: "GET"},
+		{Name: "accounts", ParentResource: "accounts", Path: "/accounts/{account_id}/other", Method: "GET"},
+		{Name: "items", ParentResource: "accounts", Path: "/accounts/{account_id}/nested/{nested_id}/items", parentPath: "/accounts/{account_id}/nested", Method: "GET"},
 	}
 
 	uniquifyDependentResourceNames(deps, map[string]syncableMeta{"accounts": {Path: "/accounts"}})
 
-	assert.Equal(t, "projects_nested", deps[0].Name)
-	assert.Equal(t, "projects_other", deps[1].Name)
-	assert.Equal(t, "projects_nested", deps[2].ParentResource)
+	assert.Equal(t, "accounts_nested", deps[0].Name)
+	assert.Equal(t, "accounts_other", deps[1].Name)
+	assert.Equal(t, "accounts_nested", deps[2].ParentResource)
 }
 
 func TestUniquifyDependentResourceNamesUsesDeterministicFallbacks(t *testing.T) {

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -1703,11 +1703,25 @@ func TestUniquifyDependentResourceNamesPreservesSyncableParents(t *testing.T) {
 		{Name: "items", ParentResource: "accounts", Path: "/accounts/{account_id}/nested/{nested_id}/items", Method: "GET"},
 	}
 
-	uniquifyDependentResourceNames(deps, map[string]syncableMeta{"accounts": {}})
+	uniquifyDependentResourceNames(deps, map[string]syncableMeta{"accounts": {Path: "/accounts"}})
 
 	assert.Equal(t, "accounts_nested", deps[0].Name)
 	assert.Equal(t, "accounts_other", deps[1].Name)
 	assert.Equal(t, "accounts", deps[2].ParentResource)
+}
+
+func TestUniquifyDependentResourceNamesRewiresPastUnrelatedSyncableParents(t *testing.T) {
+	deps := []DependentResource{
+		{Name: "accounts", ParentResource: "accounts", Path: "/projects/{project_id}/nested", Method: "GET"},
+		{Name: "accounts", ParentResource: "accounts", Path: "/projects/{project_id}/other", Method: "GET"},
+		{Name: "items", ParentResource: "accounts", Path: "/projects/{project_id}/nested/{nested_id}/items", Method: "GET"},
+	}
+
+	uniquifyDependentResourceNames(deps, map[string]syncableMeta{"accounts": {Path: "/accounts"}})
+
+	assert.Equal(t, "projects_nested", deps[0].Name)
+	assert.Equal(t, "projects_other", deps[1].Name)
+	assert.Equal(t, "projects_nested", deps[2].ParentResource)
 }
 
 func TestUniquifyDependentResourceNamesUsesDeterministicFallbacks(t *testing.T) {

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -1682,6 +1682,35 @@ func TestProfileDependentResources_SharedSubResourceShardsByParent(t *testing.T)
 	assert.Equal(t, "/repos/{repo_id}/commits", reposDep.Path)
 }
 
+func TestUniquifyDependentResourceNamesUpdatesDescendantParents(t *testing.T) {
+	deps := []DependentResource{
+		{Name: "shared_child", ParentResource: "root", Path: "/root/{root_id}/alpha/child", Method: "GET"},
+		{Name: "shared_child", ParentResource: "root", Path: "/root/{root_id}/beta/child", Method: "GET"},
+		{Name: "grandchildren", ParentResource: "shared_child", Path: "/root/{root_id}/alpha/child/{child_id}/grandchildren", Method: "GET"},
+	}
+
+	uniquifyDependentResourceNames(deps, nil)
+
+	assert.Equal(t, "root_alpha_child", deps[0].Name)
+	assert.Equal(t, "root_beta_child", deps[1].Name)
+	assert.Equal(t, "root_alpha_child", deps[2].ParentResource)
+}
+
+func TestUniquifyDependentResourceNamesUsesDeterministicFallbacks(t *testing.T) {
+	deps := []DependentResource{
+		{Name: "shared_child", Path: "/root/{root_id}/alpha/child", Method: "GET"},
+		{Name: "shared_child", Path: "/root/{root_id}/beta/child", Method: "GET"},
+	}
+
+	uniquifyDependentResourceNames(deps, map[string]syncableMeta{
+		"root_alpha_child":     {},
+		"root_alpha_child_get": {},
+	})
+
+	assert.Equal(t, "root_alpha_child_2", deps[0].Name)
+	assert.Equal(t, "root_beta_child", deps[1].Name)
+}
+
 // TestProfileDependentResources_MultiParamParentPath confirms the walk-context
 // parent (from the SubResources tree) wins over the path-param heuristic when
 // the path has multiple params and the first one does not match a syncable


### PR DESCRIPTION
## Intent

Issue: Closes #3755

Valid API specs with repeated deep leaf names previously generated duplicate Go switch cases, so the printed CLI failed to compile. This PR preserves each dependent endpoint's path identity and keeps the generated sync surface buildable.

## Approach

Only colliding dependent resource names receive deterministic static-path-derived identities. Descendant parent links are rewired by matching the child's path to the renamed parent instance, and the final pass runs after walker-synthesized dependents are added. Existing unique names remain unchanged.

## Scope

Primary area: profiler resource identity and generated sync output.

Why this belongs in this repo: the failure is systemic generator behavior, so the fix raises the floor for every printed CLI with the same resource shape.

## Risk

Previously colliding dependent names now include path context, with method and numeric fallbacks for residual collisions. Non-colliding resource names and endpoint wire paths are unchanged.

## Output Contract

The regression test asserts all nine issue-shaped path-to-name mappings, checks the emitted sync cases, and compiles the generated MCP/store/sync CLI. Profiler tests cover descendant parent rewiring plus deterministic method and numeric collision fallbacks.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions and compiled generated CLI output
- [x] Generator/template change: covered the affected fallback and variant shapes
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands:

- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `scripts/golden.sh verify` (32 cases)
- `scripts/verify-generator-output.sh` (10 cases)
- `golangci-lint run ./internal/profiler ./internal/generator`
