### PR TITLE
fix(cli): isolate explicit config credentials

### DIFF
--- a/internal/generator/templates/cliutil_credentials.go.tmpl
+++ b/internal/generator/templates/cliutil_credentials.go.tmpl
@@ -76,6 +76,16 @@ func credentialsPath() (string, error) {
 	return filepath.Join(dir, credentialsFileName), nil
 }
 
+// CredentialsFilePathForConfig keeps explicit config homes isolated by resolving
+// their colocated data store instead of falling back to the process-global one.
+func CredentialsFilePathForConfig(configPath string) (string, error) {
+	configPath = strings.TrimSpace(configPath)
+	if configPath == "" {
+		return "", errors.New("config path must not be empty")
+	}
+	return filepath.Join(filepath.Dir(filepath.Clean(configPath)), "data", credentialsFileName), nil
+}
+
 func CredentialsFilePath() (string, error) {
 	return credentialsPath()
 }
@@ -85,15 +95,27 @@ func LoadCredentials() (*Credentials, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
+	return loadCredentials(path, false)
+}
+
+func LoadCredentialsForConfig(configPath string) (*Credentials, bool, error) {
+	path, err := CredentialsFilePathForConfig(configPath)
+	if err != nil {
+		return nil, false, err
+	}
+	return loadCredentials(path, true)
+}
+
+func loadCredentials(path string, rejectInvalid bool) (*Credentials, bool, error) {
 	// Read-time credentials-perms guard (S1): this file holds a live token and,
 	// though written 0600, can later drift to group/world-readable (a stray
 	// chmod, a broad-umask copy, a loose-perms backup restore). Canonicalize
 	// first with filepath.EvalSymlinks so a symlink pointing at a loose-perms
 	// target is caught (and a missing/dangling path resolves to an error), then
-	// refuse an over-permissive file. Refusal maps to LoadCredentials' EXISTING
-	// soft-miss disposition — the not-found sentinel (nil, false, nil), NOT a
-	// hard error — so an exposed credentials file is ignored exactly like a
-	// missing one and the tool re-mints. A missing/unresolvable path stays silent
+	// refuse an over-permissive file. The default LoadCredentials path preserves
+	// its existing soft-miss behavior for rejected files. The explicit-config
+	// path uses rejectInvalid so a rejected sibling cannot fall through to a
+	// different home's credentials. A missing/unresolvable path stays silent
 	// (matching the prior ErrNotExist branch); a resolvable-but-over-permissive
 	// file warns like the existing read/parse paths, with a message that names
 	// path + mode + remediation only, never the file contents (S3). This file is
@@ -102,24 +124,43 @@ func LoadCredentials() (*Credentials, bool, error) {
 	if evalErr != nil {
 		if !errors.Is(evalErr, os.ErrNotExist) {
 			warnCredentialsIssue(path, "resolve", evalErr)
+			if rejectInvalid {
+				return nil, false, fmt.Errorf("resolving credentials %s: %w", path, evalErr)
+			}
+		} else if rejectInvalid {
+			if _, statErr := os.Lstat(path); statErr == nil || !errors.Is(statErr, os.ErrNotExist) {
+				return nil, false, fmt.Errorf("resolving credentials %s: %w", path, evalErr)
+			}
 		}
 		return nil, false, nil
 	}
 	if permErr := VerifyCredsPerms(real); permErr != nil {
 		warnCredentialsIssue(path, "perms", permErr)
+		if rejectInvalid {
+			return nil, false, fmt.Errorf("credentials permissions %s: %w", path, permErr)
+		}
 		return nil, false, nil
 	}
 	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 -- app-owned credentials path from cliutil.DataDir.
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
+			if rejectInvalid {
+				return nil, false, fmt.Errorf("reading credentials %s: %w", path, err)
+			}
 			return nil, false, nil
 		}
 		warnCredentialsIssue(path, "read", err)
+		if rejectInvalid {
+			return nil, false, fmt.Errorf("reading credentials %s: %w", path, err)
+		}
 		return nil, false, nil
 	}
 	var creds Credentials
 	if err := toml.Unmarshal(data, &creds); err != nil {
 		warnCredentialsIssue(path, "parse", err)
+		if rejectInvalid {
+			return nil, false, fmt.Errorf("parsing credentials %s: %w", path, err)
+		}
 		return nil, false, nil
 	}
 	return &creds, true, nil

--- a/internal/generator/templates/cliutil_credentials.go.tmpl
+++ b/internal/generator/templates/cliutil_credentials.go.tmpl
@@ -77,13 +77,23 @@ func credentialsPath() (string, error) {
 }
 
 // CredentialsFilePathForConfig keeps explicit config homes isolated by resolving
-// their colocated data store instead of falling back to the process-global one.
+// the config path before locating its colocated data store.
 func CredentialsFilePathForConfig(configPath string) (string, error) {
 	configPath = strings.TrimSpace(configPath)
 	if configPath == "" {
 		return "", errors.New("config path must not be empty")
 	}
-	return filepath.Join(filepath.Dir(filepath.Clean(configPath)), "data", credentialsFileName), nil
+	if resolved, err := filepath.EvalSymlinks(configPath); err == nil {
+		configPath = resolved
+	} else if errors.Is(err, os.ErrNotExist) {
+		resolvedDir, dirErr := filepath.EvalSymlinks(filepath.Dir(configPath))
+		if dirErr == nil {
+			configPath = filepath.Join(resolvedDir, filepath.Base(configPath))
+		}
+	} else {
+		return "", fmt.Errorf("resolving config path %s: %w", configPath, err)
+	}
+	return filepath.Join(filepath.Dir(configPath), "data", credentialsFileName), nil
 }
 
 func CredentialsFilePath() (string, error) {

--- a/internal/generator/templates/cliutil_credentials_test.go.tmpl
+++ b/internal/generator/templates/cliutil_credentials_test.go.tmpl
@@ -17,6 +17,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 {{- if not (and (eq .Auth.Type "api_key") .Auth.CanonicalEnvVar)}}
@@ -90,6 +91,75 @@ func TestConfigFileWinsWhenCredentialsFileAlsoHasSecrets(t *testing.T) {
 		t.Fatalf("AuthHeader() = %q, want config-file value and not credentials-file value", got)
 	}
 {{- end}}
+}
+
+{{- if and (ne .Auth.Type "oauth2_refresh") (ne .Auth.EffectiveOAuth2Grant "device_code")}}
+func TestPartialConfigCredentialsMergeMissingFields(t *testing.T) {
+	_, configPath := resetCredentialEnv(t)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	if err := os.WriteFile(configPath, partialConfigData(t), 0o600); err != nil {
+		t.Fatalf("write partial config: %v", err)
+	}
+	creds := &cliutil.Credentials{AccessToken: "credentials-access", RefreshToken: "credentials-refresh"}
+	data, err := toml.Marshal(creds)
+	if err != nil {
+		t.Fatalf("marshal credentials: %v", err)
+	}
+	credentialsPath, err := cliutil.CredentialsFilePath()
+	if err != nil {
+		t.Fatalf("credentials path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(credentialsPath), 0o700); err != nil {
+		t.Fatalf("mkdir credentials dir: %v", err)
+	}
+	if err := os.WriteFile(credentialsPath, data, 0o600); err != nil {
+		t.Fatalf("write credentials: %v", err)
+	}
+
+	cfg, err := config.Load("")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.RefreshToken != "config-refresh" {
+		t.Fatalf("RefreshToken = %q, want config-refresh", cfg.RefreshToken)
+	}
+	if cfg.AccessToken != "credentials-access" {
+		t.Fatalf("AccessToken = %q, want credentials-access", cfg.AccessToken)
+	}
+}
+{{- end}}
+
+func TestSymlinkedExplicitConfigUsesResolvedSiblingCredentials(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX symlink test")
+	}
+	home, _ := resetCredentialEnv(t)
+	realDir := filepath.Join(home, "real-home")
+	linkDir := filepath.Join(home, "linked-home")
+	realConfigPath := filepath.Join(realDir, "config.{{or .Config.Format "json"}}")
+	linkConfigPath := filepath.Join(linkDir, filepath.Base(realConfigPath))
+	if err := os.MkdirAll(filepath.Dir(realConfigPath), 0o700); err != nil {
+		t.Fatalf("mkdir real config dir: %v", err)
+	}
+	if err := os.WriteFile(realConfigPath, legacyConfigData(t, "https://real.example", ""), 0o600); err != nil {
+		t.Fatalf("write real config: %v", err)
+	}
+	if err := os.MkdirAll(linkDir, 0o700); err != nil {
+		t.Fatalf("mkdir link config dir: %v", err)
+	}
+	if err := os.Symlink(realConfigPath, linkConfigPath); err != nil {
+		t.Fatalf("symlink config: %v", err)
+	}
+	writeCredentialsFile(t, filepath.Join(realDir, "data", "credentials.toml"), "real-secret")
+	writeCredentialsFile(t, filepath.Join(linkDir, "data", "credentials.toml"), "link-secret")
+
+	cfg, err := config.Load(linkConfigPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	assertConfigCredential(t, cfg, "real-secret")
 }
 
 func TestExplicitConfigUsesSiblingCredentialsBeforeGlobal(t *testing.T) {
@@ -582,6 +652,24 @@ func legacyConfigData(t *testing.T, baseURL, token string) []byte {
 	return data
 {{- end}}
 }
+
+{{- if and (ne .Auth.Type "oauth2_refresh") (ne .Auth.EffectiveOAuth2Grant "device_code")}}
+func partialConfigData(t *testing.T) []byte {
+	t.Helper()
+{{- if eq .Config.Format "toml"}}
+	return []byte("base_url = \"https://partial.example\"\nrefresh_token = \"config-refresh\"\n")
+{{- else}}
+	data, err := json.Marshal(map[string]string{
+		"base_url":      "https://partial.example",
+		"refresh_token": "config-refresh",
+	})
+	if err != nil {
+		t.Fatalf("marshal partial config: %v", err)
+	}
+	return data
+{{- end}}
+}
+{{- end}}
 
 func writeConfigCredential(t *testing.T, cfg *config.Config, token string) {
 	t.Helper()

--- a/internal/generator/templates/cliutil_credentials_test.go.tmpl
+++ b/internal/generator/templates/cliutil_credentials_test.go.tmpl
@@ -26,6 +26,7 @@ import (
 	"testing"
 {{- end}}
 
+	"github.com/pelletier/go-toml/v2"
 	"{{modulePath}}/internal/cliutil"
 	"{{modulePath}}/internal/config"
 )
@@ -65,7 +66,7 @@ func resetCredentialEnv(t *testing.T) (home, configPath string) {
 	return home, filepath.Join(home, ".config", "{{.Name}}-pp-cli", "config.{{or .Config.Format "json"}}")
 }
 
-func TestCredentialsFileWinsWhenLegacyConfigAlsoHasSecrets(t *testing.T) {
+func TestConfigFileWinsWhenCredentialsFileAlsoHasSecrets(t *testing.T) {
 	_, configPath := resetCredentialEnv(t)
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
@@ -81,17 +82,154 @@ func TestCredentialsFileWinsWhenLegacyConfigAlsoHasSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}
-	assertConfigCredential(t, cfg, "data-secret")
+	assertConfigCredential(t, cfg, "legacy-secret")
 {{- if $hasMultiVariableBasicAuth}}
-	assertAuthHeaderCredential(t, cfg, "data-secret", "legacy-secret")
+	assertAuthHeaderCredential(t, cfg, "legacy-secret", "data-secret")
 {{- else}}
-	if got := cfg.AuthHeader(); !strings.Contains(got, "data-secret") || strings.Contains(got, "legacy-secret") {
-		t.Fatalf("AuthHeader() = %q, want credentials-file value and not legacy value", got)
+	if got := cfg.AuthHeader(); !strings.Contains(got, "legacy-secret") || strings.Contains(got, "data-secret") {
+		t.Fatalf("AuthHeader() = %q, want config-file value and not credentials-file value", got)
 	}
 {{- end}}
 }
 
-func TestCorruptCredentialsFallsBackToLegacyConfig(t *testing.T) {
+func TestExplicitConfigUsesSiblingCredentialsBeforeGlobal(t *testing.T) {
+	home, _ := resetCredentialEnv(t)
+	explicitDir := filepath.Join(home, "store-b")
+	configPath := filepath.Join(explicitDir, "config.{{or .Config.Format "json"}}")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("mkdir explicit config: %v", err)
+	}
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://store-b.example", ""), 0o600); err != nil {
+		t.Fatalf("write explicit config: %v", err)
+	}
+	siblingPath := filepath.Join(explicitDir, "data", "credentials.toml")
+	writeCredentialsFile(t, siblingPath, "sibling-secret")
+	if err := cliutil.SaveCredentials(testCredentials("global-secret")); err != nil {
+		t.Fatalf("SaveCredentials() error = %v", err)
+	}
+	t.Setenv("{{envName .Name}}_CONFIG", configPath)
+
+	cfg, err := config.Load("")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	{{- if $hasMultiVariableBasicAuth}}
+	assertAuthHeaderCredential(t, cfg, "sibling-secret", "global-secret")
+	{{- else}}
+	assertConfigCredential(t, cfg, "sibling-secret")
+	{{- end}}
+}
+
+func TestExplicitConfigFallsBackToGlobalCredentialsWhenSiblingMissing(t *testing.T) {
+	home, _ := resetCredentialEnv(t)
+	explicitDir := filepath.Join(home, "store-b")
+	configPath := filepath.Join(explicitDir, "config.{{or .Config.Format "json"}}")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("mkdir explicit config: %v", err)
+	}
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://store-b.example", ""), 0o600); err != nil {
+		t.Fatalf("write explicit config: %v", err)
+	}
+	if err := cliutil.SaveCredentials(testCredentials("global-secret")); err != nil {
+		t.Fatalf("SaveCredentials() error = %v", err)
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	{{- if $hasMultiVariableBasicAuth}}
+	assertAuthHeaderCredential(t, cfg, "global-secret", "")
+	{{- else}}
+	assertConfigCredential(t, cfg, "global-secret")
+{{- end}}
+}
+
+func TestExplicitConfigFallsBackToGlobalCredentialsWhenSiblingEmpty(t *testing.T) {
+	home, _ := resetCredentialEnv(t)
+	explicitDir := filepath.Join(home, "store-b")
+	configPath := filepath.Join(explicitDir, "config.{{or .Config.Format "json"}}")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("mkdir explicit config: %v", err)
+	}
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://store-b.example", ""), 0o600); err != nil {
+		t.Fatalf("write explicit config: %v", err)
+	}
+	emptySiblingPath := filepath.Join(explicitDir, "data", "credentials.toml")
+	if err := os.MkdirAll(filepath.Dir(emptySiblingPath), 0o700); err != nil {
+		t.Fatalf("mkdir empty sibling credentials dir: %v", err)
+	}
+	if err := os.WriteFile(emptySiblingPath, []byte{}, 0o600); err != nil {
+		t.Fatalf("write empty sibling credentials: %v", err)
+	}
+	if err := cliutil.SaveCredentials(testCredentials("global-secret")); err != nil {
+		t.Fatalf("SaveCredentials() error = %v", err)
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	{{- if $hasMultiVariableBasicAuth}}
+	assertAuthHeaderCredential(t, cfg, "global-secret", "")
+	{{- else}}
+	assertConfigCredential(t, cfg, "global-secret")
+{{- end}}
+}
+
+func TestExplicitConfigRejectsMalformedSiblingInsteadOfUsingGlobal(t *testing.T) {
+	home, _ := resetCredentialEnv(t)
+	explicitDir := filepath.Join(home, "store-b")
+	configPath := filepath.Join(explicitDir, "config.{{or .Config.Format "json"}}")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("mkdir explicit config: %v", err)
+	}
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://store-b.example", ""), 0o600); err != nil {
+		t.Fatalf("write explicit config: %v", err)
+	}
+	malformedSiblingPath := filepath.Join(explicitDir, "data", "credentials.toml")
+	if err := os.MkdirAll(filepath.Dir(malformedSiblingPath), 0o700); err != nil {
+		t.Fatalf("mkdir malformed sibling credentials dir: %v", err)
+	}
+	if err := os.WriteFile(malformedSiblingPath, []byte("not = [toml"), 0o600); err != nil {
+		t.Fatalf("write malformed sibling credentials: %v", err)
+	}
+	if err := cliutil.SaveCredentials(testCredentials("global-secret")); err != nil {
+		t.Fatalf("SaveCredentials() error = %v", err)
+	}
+
+	if _, err := config.Load(configPath); err == nil {
+		t.Fatal("Load() succeeded with malformed explicit sibling credentials")
+	}
+}
+
+func TestExplicitConfigFileCredentialsWinOverSiblingAndGlobal(t *testing.T) {
+	home, _ := resetCredentialEnv(t)
+	explicitDir := filepath.Join(home, "store-b")
+	configPath := filepath.Join(explicitDir, "config.{{or .Config.Format "json"}}")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("mkdir explicit config: %v", err)
+	}
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://store-b.example", "config-secret"), 0o600); err != nil {
+		t.Fatalf("write explicit config: %v", err)
+	}
+	writeCredentialsFile(t, filepath.Join(explicitDir, "data", "credentials.toml"), "sibling-secret")
+	if err := cliutil.SaveCredentials(testCredentials("global-secret")); err != nil {
+		t.Fatalf("SaveCredentials() error = %v", err)
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	{{- if $hasMultiVariableBasicAuth}}
+	assertAuthHeaderCredential(t, cfg, "config-secret", "sibling-secret")
+	{{- else}}
+	assertConfigCredential(t, cfg, "config-secret")
+	{{- end}}
+}
+
+func TestCorruptCredentialsDoesNotOverrideLegacyConfig(t *testing.T) {
 	home, configPath := resetCredentialEnv(t)
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
@@ -121,8 +259,8 @@ func TestCorruptCredentialsFallsBackToLegacyConfig(t *testing.T) {
 		}
 {{- end}}
 	})
-	if !strings.Contains(stderr, credentialsPath) || !strings.Contains(stderr, "parse") {
-		t.Fatalf("stderr %q does not mention corrupt credentials path and parse action", stderr)
+	if strings.Contains(stderr, credentialsPath) {
+		t.Fatalf("config credentials should avoid reading the corrupt global file, stderr=%q", stderr)
 	}
 }
 
@@ -384,6 +522,20 @@ func testCredentials(token string) *cliutil.Credentials {
 	return creds
 }
 
+func writeCredentialsFile(t *testing.T, path, token string) {
+	t.Helper()
+	data, err := toml.Marshal(testCredentials(token))
+	if err != nil {
+		t.Fatalf("marshal credentials: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir credentials dir: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write credentials: %v", err)
+	}
+}
+
 func legacyCredentialKey() string {
 {{- if and (eq .Auth.Type "api_key") .Auth.CanonicalEnvVar}}
 	return "{{envVarPlaceholder .Auth.CanonicalEnvVar.Name}}"
@@ -397,24 +549,33 @@ func legacyConfigData(t *testing.T, baseURL, token string) []byte {
 {{- if eq .Config.Format "toml"}}
 {{- if $hasMultiVariableBasicAuth}}
 	data := "base_url = \"" + baseURL + "\"\n"
+	if token != "" {
 {{- range $i, $env := $basicCredentialVars}}
 	data += "{{envVarPlaceholder .Name}} = \"" + token{{if gt $i 0}} + "-secondary"{{end}} + "\"\n"
 {{- end}}
+	}
 	return []byte(data)
 {{- else}}
-	return []byte("base_url = \"" + baseURL + "\"\n" + legacyCredentialKey() + " = \"" + token + "\"\n")
+	data := "base_url = \"" + baseURL + "\"\n"
+	if token != "" {
+		data += legacyCredentialKey() + " = \"" + token + "\"\n"
+	}
+	return []byte(data)
 {{- end}}
 {{- else}}
-	data, err := json.Marshal(map[string]string{
-		"base_url": baseURL,
+	values := map[string]string{"base_url": baseURL}
 {{- if $hasMultiVariableBasicAuth}}
+	if token != "" {
 {{- range $i, $env := $basicCredentialVars}}
-		"{{envVarPlaceholder .Name}}": token{{if gt $i 0}} + "-secondary"{{end}},
+	values["{{envVarPlaceholder .Name}}"] = token{{if gt $i 0}} + "-secondary"{{end}}
 {{- end}}
+	}
 {{- else}}
-		legacyCredentialKey(): token,
+	if token != "" {
+		values[legacyCredentialKey()] = token
+	}
 {{- end}}
-	})
+	data, err := json.Marshal(values)
 	if err != nil {
 		t.Fatalf("marshal legacy config fixture: %v", err)
 	}

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -194,9 +194,9 @@ func Load(configPath string) (*Config, error) {
 	if cfg.AgentcookieManagedByExternalStore() {
 		cfg.markAgentcookieManaged()
 	} else {
-		if !cfg.hasCredentialFields() {
-			var creds *cliutil.Credentials
-			var ok bool
+		var creds *cliutil.Credentials
+		var ok bool
+		if !cfg.hasCompleteCredentialFields() {
 			if explicitConfigFile {
 				creds, ok, err = cliutil.LoadCredentialsForConfig(path)
 				if err != nil {
@@ -982,6 +982,106 @@ func (c *Config) hasCredentialFields() bool {
 	return false
 }
 
+func (c *Config) hasCompleteCredentialFields() bool {
+	if c.AuthHeaderVal != "" {
+		return true
+	}
+	{{- if eq .Auth.Type "api_key"}}
+	{{- $basicAuthEnvVars := basicAuthEnvVars .Auth}}
+	{{- if $basicAuthEnvVars}}
+	{{- range $basicAuthEnvVars}}
+	{{- if .Required}}
+	if c.{{resolveEnvVarField .Name}} == "" {
+		return false
+	}
+	{{- end}}
+	{{- end}}
+	return true
+	{{- else if .Auth.IsAuthEnvVarORCase}}
+	{{- if .Auth.EnvVarSpecs}}
+	{{- range .Auth.EnvVarSpecs}}
+	if c.{{resolveEnvVarField .Name}} != "" {
+		return true
+	}
+	{{- end}}
+	{{- else}}
+	{{- range .Auth.EnvVars}}
+	if c.{{resolveEnvVarField .}} != "" {
+		return true
+	}
+	{{- end}}
+	{{- end}}
+	return false
+	{{- else}}
+	{{- with .Auth.CanonicalEnvVar}}
+	if c.{{resolveEnvVarField .Name}} == "" {
+		return false
+	}
+	{{- end}}
+	{{- if .Auth.EnvVarSpecs}}
+	{{- range .Auth.EnvVarSpecs}}
+	{{- if and (eq .Kind "per_call") .Required}}
+	if c.{{resolveEnvVarField .Name}} == "" {
+		return false
+	}
+	{{- end}}
+	{{- end}}
+	{{- else}}
+	{{- range .Auth.EnvVars}}
+	if c.{{resolveEnvVarField .}} == "" {
+		return false
+	}
+	{{- end}}
+	{{- end}}
+	return true
+	{{- end}}
+	{{- else if eq .Auth.EffectiveOAuth2Grant "client_credentials"}}
+	if c.AccessToken != "" {
+		return true
+	}
+	return c.ClientID != "" && c.ClientSecret != ""
+	{{- else if oauth2AccessTokenAuth .Auth}}
+	if c.AccessToken != "" || c.RefreshToken != "" {
+		return true
+	}
+	{{- with .Auth.CanonicalEnvVar}}
+	if c.{{resolveEnvVarField .Name}} != "" {
+		return true
+	}
+	{{- end}}
+	{{- range .Auth.EnvVarSpecs}}
+	{{- if eq .Kind "per_call"}}
+	if c.{{resolveEnvVarField .Name}} != "" {
+		return true
+	}
+	{{- end}}
+	{{- end}}
+	return false
+	{{- else}}
+	if c.AccessToken != "" {
+		return true
+	}
+	{{- with .Auth.CanonicalEnvVar}}
+	if c.{{resolveEnvVarField .Name}} != "" {
+		return true
+	}
+	{{- end}}
+	{{- range .Auth.EnvVarSpecs}}
+	{{- if eq .Kind "per_call"}}
+	if c.{{resolveEnvVarField .Name}} != "" {
+		return true
+	}
+	{{- end}}
+	{{- end}}
+	{{- range .Auth.EnvVars}}
+	if c.{{resolveEnvVarField .}} != "" {
+		return true
+	}
+	{{- end}}
+	return false
+	{{- end}}
+}
+
 func (c *Config) clearCredentialFields() {
 	c.AuthHeaderVal = ""
 	c.AccessToken = ""
@@ -1018,17 +1118,33 @@ func (c *Config) applyCredentials(creds *cliutil.Credentials) {
 	if creds == nil {
 		return
 	}
-	c.AuthHeaderVal = creds.AuthHeaderVal
-	c.AccessToken = creds.AccessToken
-	c.RefreshToken = creds.RefreshToken
-	c.TokenExpiry = creds.TokenExpiry
+	if c.AuthHeaderVal == "" {
+		c.AuthHeaderVal = creds.AuthHeaderVal
+	}
+	if c.AccessToken == "" {
+		c.AccessToken = creds.AccessToken
+	}
+	if c.RefreshToken == "" {
+		c.RefreshToken = creds.RefreshToken
+	}
+	if c.TokenExpiry.IsZero() {
+		c.TokenExpiry = creds.TokenExpiry
+	}
 {{- if .BearerRefresh.Enabled}}
-	c.BearerTokenRefreshedAt = creds.BearerTokenRefreshedAt
+	if c.BearerTokenRefreshedAt.IsZero() {
+		c.BearerTokenRefreshedAt = creds.BearerTokenRefreshedAt
+	}
 {{- end}}
-	c.ClientID = creds.ClientID
-	c.ClientSecret = creds.ClientSecret
+	if c.ClientID == "" {
+		c.ClientID = creds.ClientID
+	}
+	if c.ClientSecret == "" {
+		c.ClientSecret = creds.ClientSecret
+	}
 {{- range .CredentialFields}}
-	c.{{.GoField}} = creds.{{.GoField}}
+	if c.{{.GoField}} == "" {
+		c.{{.GoField}} = creds.{{.GoField}}
+	}
 {{- end}}
 }
 

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -194,16 +194,27 @@ func Load(configPath string) (*Config, error) {
 	if cfg.AgentcookieManagedByExternalStore() {
 		cfg.markAgentcookieManaged()
 	} else {
-		creds, ok, err := cliutil.LoadCredentials()
-		if err != nil {
-			return nil, err
-		}
-		if ok && creds.HasValues() {
-			cfg.clearCredentialFields()
-			cfg.applyCredentials(creds)
-			if cfg.hasCredentialFields() {
-				cfg.AuthSource = "config"
-				cfg.CredentialSource = "credentials file"
+		if !cfg.hasCredentialFields() {
+			var creds *cliutil.Credentials
+			var ok bool
+			if explicitConfigFile {
+				creds, ok, err = cliutil.LoadCredentialsForConfig(path)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if !ok || creds == nil || !creds.HasValues() {
+				creds, ok, err = cliutil.LoadCredentials()
+				if err != nil {
+					return nil, err
+				}
+			}
+			if ok && creds.HasValues() {
+				cfg.applyCredentials(creds)
+				if cfg.hasCredentialFields() {
+					cfg.AuthSource = "config"
+					cfg.CredentialSource = "credentials file"
+				}
 			}
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/cliutil/credentials_test.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/cliutil/credentials_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pelletier/go-toml/v2"
 	"printing-press-oauth2-pp-cli/internal/cliutil"
 	"printing-press-oauth2-pp-cli/internal/config"
 )
@@ -44,7 +45,7 @@ func resetCredentialEnv(t *testing.T) (home, configPath string) {
 	return home, filepath.Join(home, ".config", "printing-press-oauth2-pp-cli", "config.toml")
 }
 
-func TestCredentialsFileWinsWhenLegacyConfigAlsoHasSecrets(t *testing.T) {
+func TestConfigFileWinsWhenCredentialsFileAlsoHasSecrets(t *testing.T) {
 	_, configPath := resetCredentialEnv(t)
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
@@ -60,13 +61,134 @@ func TestCredentialsFileWinsWhenLegacyConfigAlsoHasSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}
-	assertConfigCredential(t, cfg, "data-secret")
-	if got := cfg.AuthHeader(); !strings.Contains(got, "data-secret") || strings.Contains(got, "legacy-secret") {
-		t.Fatalf("AuthHeader() = %q, want credentials-file value and not legacy value", got)
+	assertConfigCredential(t, cfg, "legacy-secret")
+	if got := cfg.AuthHeader(); !strings.Contains(got, "legacy-secret") || strings.Contains(got, "data-secret") {
+		t.Fatalf("AuthHeader() = %q, want config-file value and not credentials-file value", got)
 	}
 }
 
-func TestCorruptCredentialsFallsBackToLegacyConfig(t *testing.T) {
+func TestExplicitConfigUsesSiblingCredentialsBeforeGlobal(t *testing.T) {
+	home, _ := resetCredentialEnv(t)
+	explicitDir := filepath.Join(home, "store-b")
+	configPath := filepath.Join(explicitDir, "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("mkdir explicit config: %v", err)
+	}
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://store-b.example", ""), 0o600); err != nil {
+		t.Fatalf("write explicit config: %v", err)
+	}
+	siblingPath := filepath.Join(explicitDir, "data", "credentials.toml")
+	writeCredentialsFile(t, siblingPath, "sibling-secret")
+	if err := cliutil.SaveCredentials(testCredentials("global-secret")); err != nil {
+		t.Fatalf("SaveCredentials() error = %v", err)
+	}
+	t.Setenv("PRINTING_PRESS_OAUTH2_CONFIG", configPath)
+
+	cfg, err := config.Load("")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	assertConfigCredential(t, cfg, "sibling-secret")
+}
+
+func TestExplicitConfigFallsBackToGlobalCredentialsWhenSiblingMissing(t *testing.T) {
+	home, _ := resetCredentialEnv(t)
+	explicitDir := filepath.Join(home, "store-b")
+	configPath := filepath.Join(explicitDir, "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("mkdir explicit config: %v", err)
+	}
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://store-b.example", ""), 0o600); err != nil {
+		t.Fatalf("write explicit config: %v", err)
+	}
+	if err := cliutil.SaveCredentials(testCredentials("global-secret")); err != nil {
+		t.Fatalf("SaveCredentials() error = %v", err)
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	assertConfigCredential(t, cfg, "global-secret")
+}
+
+func TestExplicitConfigFallsBackToGlobalCredentialsWhenSiblingEmpty(t *testing.T) {
+	home, _ := resetCredentialEnv(t)
+	explicitDir := filepath.Join(home, "store-b")
+	configPath := filepath.Join(explicitDir, "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("mkdir explicit config: %v", err)
+	}
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://store-b.example", ""), 0o600); err != nil {
+		t.Fatalf("write explicit config: %v", err)
+	}
+	emptySiblingPath := filepath.Join(explicitDir, "data", "credentials.toml")
+	if err := os.MkdirAll(filepath.Dir(emptySiblingPath), 0o700); err != nil {
+		t.Fatalf("mkdir empty sibling credentials dir: %v", err)
+	}
+	if err := os.WriteFile(emptySiblingPath, []byte{}, 0o600); err != nil {
+		t.Fatalf("write empty sibling credentials: %v", err)
+	}
+	if err := cliutil.SaveCredentials(testCredentials("global-secret")); err != nil {
+		t.Fatalf("SaveCredentials() error = %v", err)
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	assertConfigCredential(t, cfg, "global-secret")
+}
+
+func TestExplicitConfigRejectsMalformedSiblingInsteadOfUsingGlobal(t *testing.T) {
+	home, _ := resetCredentialEnv(t)
+	explicitDir := filepath.Join(home, "store-b")
+	configPath := filepath.Join(explicitDir, "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("mkdir explicit config: %v", err)
+	}
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://store-b.example", ""), 0o600); err != nil {
+		t.Fatalf("write explicit config: %v", err)
+	}
+	malformedSiblingPath := filepath.Join(explicitDir, "data", "credentials.toml")
+	if err := os.MkdirAll(filepath.Dir(malformedSiblingPath), 0o700); err != nil {
+		t.Fatalf("mkdir malformed sibling credentials dir: %v", err)
+	}
+	if err := os.WriteFile(malformedSiblingPath, []byte("not = [toml"), 0o600); err != nil {
+		t.Fatalf("write malformed sibling credentials: %v", err)
+	}
+	if err := cliutil.SaveCredentials(testCredentials("global-secret")); err != nil {
+		t.Fatalf("SaveCredentials() error = %v", err)
+	}
+
+	if _, err := config.Load(configPath); err == nil {
+		t.Fatal("Load() succeeded with malformed explicit sibling credentials")
+	}
+}
+
+func TestExplicitConfigFileCredentialsWinOverSiblingAndGlobal(t *testing.T) {
+	home, _ := resetCredentialEnv(t)
+	explicitDir := filepath.Join(home, "store-b")
+	configPath := filepath.Join(explicitDir, "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("mkdir explicit config: %v", err)
+	}
+	if err := os.WriteFile(configPath, legacyConfigData(t, "https://store-b.example", "config-secret"), 0o600); err != nil {
+		t.Fatalf("write explicit config: %v", err)
+	}
+	writeCredentialsFile(t, filepath.Join(explicitDir, "data", "credentials.toml"), "sibling-secret")
+	if err := cliutil.SaveCredentials(testCredentials("global-secret")); err != nil {
+		t.Fatalf("SaveCredentials() error = %v", err)
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	assertConfigCredential(t, cfg, "config-secret")
+}
+
+func TestCorruptCredentialsDoesNotOverrideLegacyConfig(t *testing.T) {
 	home, configPath := resetCredentialEnv(t)
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
@@ -92,8 +214,8 @@ func TestCorruptCredentialsFallsBackToLegacyConfig(t *testing.T) {
 			t.Fatalf("AuthHeader() = %q, want legacy credential", got)
 		}
 	})
-	if !strings.Contains(stderr, credentialsPath) || !strings.Contains(stderr, "parse") {
-		t.Fatalf("stderr %q does not mention corrupt credentials path and parse action", stderr)
+	if strings.Contains(stderr, credentialsPath) {
+		t.Fatalf("config credentials should avoid reading the corrupt global file, stderr=%q", stderr)
 	}
 }
 func TestCorruptCredentialsFallsBackToEnvCredential(t *testing.T) {
@@ -329,13 +451,31 @@ func testCredentials(token string) *cliutil.Credentials {
 	return creds
 }
 
+func writeCredentialsFile(t *testing.T, path, token string) {
+	t.Helper()
+	data, err := toml.Marshal(testCredentials(token))
+	if err != nil {
+		t.Fatalf("marshal credentials: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir credentials dir: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write credentials: %v", err)
+	}
+}
+
 func legacyCredentialKey() string {
 	return "access_token"
 }
 
 func legacyConfigData(t *testing.T, baseURL, token string) []byte {
 	t.Helper()
-	return []byte("base_url = \"" + baseURL + "\"\n" + legacyCredentialKey() + " = \"" + token + "\"\n")
+	data := "base_url = \"" + baseURL + "\"\n"
+	if token != "" {
+		data += legacyCredentialKey() + " = \"" + token + "\"\n"
+	}
+	return []byte(data)
 }
 
 func writeConfigCredential(t *testing.T, cfg *config.Config, token string) {

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/cliutil/credentials_test.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/cliutil/credentials_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -65,6 +66,72 @@ func TestConfigFileWinsWhenCredentialsFileAlsoHasSecrets(t *testing.T) {
 	if got := cfg.AuthHeader(); !strings.Contains(got, "legacy-secret") || strings.Contains(got, "data-secret") {
 		t.Fatalf("AuthHeader() = %q, want config-file value and not credentials-file value", got)
 	}
+}
+func TestPartialConfigCredentialsMergeMissingFields(t *testing.T) {
+	_, configPath := resetCredentialEnv(t)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	if err := os.WriteFile(configPath, partialConfigData(t), 0o600); err != nil {
+		t.Fatalf("write partial config: %v", err)
+	}
+	creds := &cliutil.Credentials{AccessToken: "credentials-access", RefreshToken: "credentials-refresh"}
+	data, err := toml.Marshal(creds)
+	if err != nil {
+		t.Fatalf("marshal credentials: %v", err)
+	}
+	credentialsPath, err := cliutil.CredentialsFilePath()
+	if err != nil {
+		t.Fatalf("credentials path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(credentialsPath), 0o700); err != nil {
+		t.Fatalf("mkdir credentials dir: %v", err)
+	}
+	if err := os.WriteFile(credentialsPath, data, 0o600); err != nil {
+		t.Fatalf("write credentials: %v", err)
+	}
+
+	cfg, err := config.Load("")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.RefreshToken != "config-refresh" {
+		t.Fatalf("RefreshToken = %q, want config-refresh", cfg.RefreshToken)
+	}
+	if cfg.AccessToken != "credentials-access" {
+		t.Fatalf("AccessToken = %q, want credentials-access", cfg.AccessToken)
+	}
+}
+
+func TestSymlinkedExplicitConfigUsesResolvedSiblingCredentials(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX symlink test")
+	}
+	home, _ := resetCredentialEnv(t)
+	realDir := filepath.Join(home, "real-home")
+	linkDir := filepath.Join(home, "linked-home")
+	realConfigPath := filepath.Join(realDir, "config.toml")
+	linkConfigPath := filepath.Join(linkDir, filepath.Base(realConfigPath))
+	if err := os.MkdirAll(filepath.Dir(realConfigPath), 0o700); err != nil {
+		t.Fatalf("mkdir real config dir: %v", err)
+	}
+	if err := os.WriteFile(realConfigPath, legacyConfigData(t, "https://real.example", ""), 0o600); err != nil {
+		t.Fatalf("write real config: %v", err)
+	}
+	if err := os.MkdirAll(linkDir, 0o700); err != nil {
+		t.Fatalf("mkdir link config dir: %v", err)
+	}
+	if err := os.Symlink(realConfigPath, linkConfigPath); err != nil {
+		t.Fatalf("symlink config: %v", err)
+	}
+	writeCredentialsFile(t, filepath.Join(realDir, "data", "credentials.toml"), "real-secret")
+	writeCredentialsFile(t, filepath.Join(linkDir, "data", "credentials.toml"), "link-secret")
+
+	cfg, err := config.Load(linkConfigPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	assertConfigCredential(t, cfg, "real-secret")
 }
 
 func TestExplicitConfigUsesSiblingCredentialsBeforeGlobal(t *testing.T) {
@@ -476,6 +543,10 @@ func legacyConfigData(t *testing.T, baseURL, token string) []byte {
 		data += legacyCredentialKey() + " = \"" + token + "\"\n"
 	}
 	return []byte(data)
+}
+func partialConfigData(t *testing.T) []byte {
+	t.Helper()
+	return []byte("base_url = \"https://partial.example\"\nrefresh_token = \"config-refresh\"\n")
 }
 
 func writeConfigCredential(t *testing.T, cfg *config.Config, token string) {

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/config/config.go
@@ -117,16 +117,27 @@ func Load(configPath string) (*Config, error) {
 	if cfg.AgentcookieManagedByExternalStore() {
 		cfg.markAgentcookieManaged()
 	} else {
-		creds, ok, err := cliutil.LoadCredentials()
-		if err != nil {
-			return nil, err
-		}
-		if ok && creds.HasValues() {
-			cfg.clearCredentialFields()
-			cfg.applyCredentials(creds)
-			if cfg.hasCredentialFields() {
-				cfg.AuthSource = "config"
-				cfg.CredentialSource = "credentials file"
+		if !cfg.hasCredentialFields() {
+			var creds *cliutil.Credentials
+			var ok bool
+			if explicitConfigFile {
+				creds, ok, err = cliutil.LoadCredentialsForConfig(path)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if !ok || creds == nil || !creds.HasValues() {
+				creds, ok, err = cliutil.LoadCredentials()
+				if err != nil {
+					return nil, err
+				}
+			}
+			if ok && creds.HasValues() {
+				cfg.applyCredentials(creds)
+				if cfg.hasCredentialFields() {
+					cfg.AuthSource = "config"
+					cfg.CredentialSource = "credentials file"
+				}
 			}
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/config/config.go
@@ -117,9 +117,9 @@ func Load(configPath string) (*Config, error) {
 	if cfg.AgentcookieManagedByExternalStore() {
 		cfg.markAgentcookieManaged()
 	} else {
-		if !cfg.hasCredentialFields() {
-			var creds *cliutil.Credentials
-			var ok bool
+		var creds *cliutil.Credentials
+		var ok bool
+		if !cfg.hasCompleteCredentialFields() {
 			if explicitConfigFile {
 				creds, ok, err = cliutil.LoadCredentialsForConfig(path)
 				if err != nil {
@@ -318,6 +318,22 @@ func (c *Config) hasCredentialFields() bool {
 	return false
 }
 
+func (c *Config) hasCompleteCredentialFields() bool {
+	if c.AuthHeaderVal != "" {
+		return true
+	}
+	if c.AccessToken != "" || c.RefreshToken != "" {
+		return true
+	}
+	if c.PrintingPressOauth2Oauth2AuthCode != "" {
+		return true
+	}
+	if c.PrintingPressOauth2Oauth2AuthCode != "" {
+		return true
+	}
+	return false
+}
+
 func (c *Config) clearCredentialFields() {
 	c.AuthHeaderVal = ""
 	c.AccessToken = ""
@@ -344,13 +360,27 @@ func (c *Config) applyCredentials(creds *cliutil.Credentials) {
 	if creds == nil {
 		return
 	}
-	c.AuthHeaderVal = creds.AuthHeaderVal
-	c.AccessToken = creds.AccessToken
-	c.RefreshToken = creds.RefreshToken
-	c.TokenExpiry = creds.TokenExpiry
-	c.ClientID = creds.ClientID
-	c.ClientSecret = creds.ClientSecret
-	c.PrintingPressOauth2Oauth2AuthCode = creds.PrintingPressOauth2Oauth2AuthCode
+	if c.AuthHeaderVal == "" {
+		c.AuthHeaderVal = creds.AuthHeaderVal
+	}
+	if c.AccessToken == "" {
+		c.AccessToken = creds.AccessToken
+	}
+	if c.RefreshToken == "" {
+		c.RefreshToken = creds.RefreshToken
+	}
+	if c.TokenExpiry.IsZero() {
+		c.TokenExpiry = creds.TokenExpiry
+	}
+	if c.ClientID == "" {
+		c.ClientID = creds.ClientID
+	}
+	if c.ClientSecret == "" {
+		c.ClientSecret = creds.ClientSecret
+	}
+	if c.PrintingPressOauth2Oauth2AuthCode == "" {
+		c.PrintingPressOauth2Oauth2AuthCode = creds.PrintingPressOauth2Oauth2AuthCode
+	}
 }
 
 func (c *Config) saveCredentialsFirst() error {

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
@@ -113,9 +113,9 @@ func Load(configPath string) (*Config, error) {
 	if cfg.AgentcookieManagedByExternalStore() {
 		cfg.markAgentcookieManaged()
 	} else {
-		if !cfg.hasCredentialFields() {
-			var creds *cliutil.Credentials
-			var ok bool
+		var creds *cliutil.Credentials
+		var ok bool
+		if !cfg.hasCompleteCredentialFields() {
 			if explicitConfigFile {
 				creds, ok, err = cliutil.LoadCredentialsForConfig(path)
 				if err != nil {
@@ -313,6 +313,16 @@ func (c *Config) hasCredentialFields() bool {
 	return false
 }
 
+func (c *Config) hasCompleteCredentialFields() bool {
+	if c.AuthHeaderVal != "" {
+		return true
+	}
+	if c.AccessToken != "" {
+		return true
+	}
+	return c.ClientID != "" && c.ClientSecret != ""
+}
+
 func (c *Config) clearCredentialFields() {
 	c.AuthHeaderVal = ""
 	c.AccessToken = ""
@@ -341,14 +351,30 @@ func (c *Config) applyCredentials(creds *cliutil.Credentials) {
 	if creds == nil {
 		return
 	}
-	c.AuthHeaderVal = creds.AuthHeaderVal
-	c.AccessToken = creds.AccessToken
-	c.RefreshToken = creds.RefreshToken
-	c.TokenExpiry = creds.TokenExpiry
-	c.ClientID = creds.ClientID
-	c.ClientSecret = creds.ClientSecret
-	c.PrintingPressOauth2ClientId = creds.PrintingPressOauth2ClientId
-	c.PrintingPressOauth2ClientSecret = creds.PrintingPressOauth2ClientSecret
+	if c.AuthHeaderVal == "" {
+		c.AuthHeaderVal = creds.AuthHeaderVal
+	}
+	if c.AccessToken == "" {
+		c.AccessToken = creds.AccessToken
+	}
+	if c.RefreshToken == "" {
+		c.RefreshToken = creds.RefreshToken
+	}
+	if c.TokenExpiry.IsZero() {
+		c.TokenExpiry = creds.TokenExpiry
+	}
+	if c.ClientID == "" {
+		c.ClientID = creds.ClientID
+	}
+	if c.ClientSecret == "" {
+		c.ClientSecret = creds.ClientSecret
+	}
+	if c.PrintingPressOauth2ClientId == "" {
+		c.PrintingPressOauth2ClientId = creds.PrintingPressOauth2ClientId
+	}
+	if c.PrintingPressOauth2ClientSecret == "" {
+		c.PrintingPressOauth2ClientSecret = creds.PrintingPressOauth2ClientSecret
+	}
 }
 
 func (c *Config) saveCredentialsFirst() error {

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
@@ -113,16 +113,27 @@ func Load(configPath string) (*Config, error) {
 	if cfg.AgentcookieManagedByExternalStore() {
 		cfg.markAgentcookieManaged()
 	} else {
-		creds, ok, err := cliutil.LoadCredentials()
-		if err != nil {
-			return nil, err
-		}
-		if ok && creds.HasValues() {
-			cfg.clearCredentialFields()
-			cfg.applyCredentials(creds)
-			if cfg.hasCredentialFields() {
-				cfg.AuthSource = "config"
-				cfg.CredentialSource = "credentials file"
+		if !cfg.hasCredentialFields() {
+			var creds *cliutil.Credentials
+			var ok bool
+			if explicitConfigFile {
+				creds, ok, err = cliutil.LoadCredentialsForConfig(path)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if !ok || creds == nil || !creds.HasValues() {
+				creds, ok, err = cliutil.LoadCredentials()
+				if err != nil {
+					return nil, err
+				}
+			}
+			if ok && creds.HasValues() {
+				cfg.applyCredentials(creds)
+				if cfg.hasCredentialFields() {
+					cfg.AuthSource = "config"
+					cfg.CredentialSource = "credentials file"
+				}
 			}
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/config/config.go
@@ -117,16 +117,27 @@ func Load(configPath string) (*Config, error) {
 	if cfg.AgentcookieManagedByExternalStore() {
 		cfg.markAgentcookieManaged()
 	} else {
-		creds, ok, err := cliutil.LoadCredentials()
-		if err != nil {
-			return nil, err
-		}
-		if ok && creds.HasValues() {
-			cfg.clearCredentialFields()
-			cfg.applyCredentials(creds)
-			if cfg.hasCredentialFields() {
-				cfg.AuthSource = "config"
-				cfg.CredentialSource = "credentials file"
+		if !cfg.hasCredentialFields() {
+			var creds *cliutil.Credentials
+			var ok bool
+			if explicitConfigFile {
+				creds, ok, err = cliutil.LoadCredentialsForConfig(path)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if !ok || creds == nil || !creds.HasValues() {
+				creds, ok, err = cliutil.LoadCredentials()
+				if err != nil {
+					return nil, err
+				}
+			}
+			if ok && creds.HasValues() {
+				cfg.applyCredentials(creds)
+				if cfg.hasCredentialFields() {
+					cfg.AuthSource = "config"
+					cfg.CredentialSource = "credentials file"
+				}
 			}
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/config/config.go
@@ -117,9 +117,9 @@ func Load(configPath string) (*Config, error) {
 	if cfg.AgentcookieManagedByExternalStore() {
 		cfg.markAgentcookieManaged()
 	} else {
-		if !cfg.hasCredentialFields() {
-			var creds *cliutil.Credentials
-			var ok bool
+		var creds *cliutil.Credentials
+		var ok bool
+		if !cfg.hasCompleteCredentialFields() {
 			if explicitConfigFile {
 				creds, ok, err = cliutil.LoadCredentialsForConfig(path)
 				if err != nil {
@@ -311,6 +311,19 @@ func (c *Config) hasCredentialFields() bool {
 	return false
 }
 
+func (c *Config) hasCompleteCredentialFields() bool {
+	if c.AuthHeaderVal != "" {
+		return true
+	}
+	if c.AccessToken != "" || c.RefreshToken != "" {
+		return true
+	}
+	if c.DeviceCodeClientId != "" {
+		return true
+	}
+	return false
+}
+
 func (c *Config) clearCredentialFields() {
 	c.AuthHeaderVal = ""
 	c.AccessToken = ""
@@ -337,13 +350,27 @@ func (c *Config) applyCredentials(creds *cliutil.Credentials) {
 	if creds == nil {
 		return
 	}
-	c.AuthHeaderVal = creds.AuthHeaderVal
-	c.AccessToken = creds.AccessToken
-	c.RefreshToken = creds.RefreshToken
-	c.TokenExpiry = creds.TokenExpiry
-	c.ClientID = creds.ClientID
-	c.ClientSecret = creds.ClientSecret
-	c.DeviceCodeClientId = creds.DeviceCodeClientId
+	if c.AuthHeaderVal == "" {
+		c.AuthHeaderVal = creds.AuthHeaderVal
+	}
+	if c.AccessToken == "" {
+		c.AccessToken = creds.AccessToken
+	}
+	if c.RefreshToken == "" {
+		c.RefreshToken = creds.RefreshToken
+	}
+	if c.TokenExpiry.IsZero() {
+		c.TokenExpiry = creds.TokenExpiry
+	}
+	if c.ClientID == "" {
+		c.ClientID = creds.ClientID
+	}
+	if c.ClientSecret == "" {
+		c.ClientSecret = creds.ClientSecret
+	}
+	if c.DeviceCodeClientId == "" {
+		c.DeviceCodeClientId = creds.DeviceCodeClientId
+	}
 }
 
 func (c *Config) saveCredentialsFirst() error {

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/config/config.go
@@ -115,16 +115,27 @@ func Load(configPath string) (*Config, error) {
 	if cfg.AgentcookieManagedByExternalStore() {
 		cfg.markAgentcookieManaged()
 	} else {
-		creds, ok, err := cliutil.LoadCredentials()
-		if err != nil {
-			return nil, err
-		}
-		if ok && creds.HasValues() {
-			cfg.clearCredentialFields()
-			cfg.applyCredentials(creds)
-			if cfg.hasCredentialFields() {
-				cfg.AuthSource = "config"
-				cfg.CredentialSource = "credentials file"
+		if !cfg.hasCredentialFields() {
+			var creds *cliutil.Credentials
+			var ok bool
+			if explicitConfigFile {
+				creds, ok, err = cliutil.LoadCredentialsForConfig(path)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if !ok || creds == nil || !creds.HasValues() {
+				creds, ok, err = cliutil.LoadCredentials()
+				if err != nil {
+					return nil, err
+				}
+			}
+			if ok && creds.HasValues() {
+				cfg.applyCredentials(creds)
+				if cfg.hasCredentialFields() {
+					cfg.AuthSource = "config"
+					cfg.CredentialSource = "credentials file"
+				}
 			}
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/config/config.go
@@ -115,9 +115,9 @@ func Load(configPath string) (*Config, error) {
 	if cfg.AgentcookieManagedByExternalStore() {
 		cfg.markAgentcookieManaged()
 	} else {
-		if !cfg.hasCredentialFields() {
-			var creds *cliutil.Credentials
-			var ok bool
+		var creds *cliutil.Credentials
+		var ok bool
+		if !cfg.hasCompleteCredentialFields() {
 			if explicitConfigFile {
 				creds, ok, err = cliutil.LoadCredentialsForConfig(path)
 				if err != nil {
@@ -353,6 +353,19 @@ func (c *Config) hasCredentialFields() bool {
 	return false
 }
 
+func (c *Config) hasCompleteCredentialFields() bool {
+	if c.AuthHeaderVal != "" {
+		return true
+	}
+	if c.RichAuthApiKey == "" {
+		return false
+	}
+	if c.RichAuthApiKey == "" {
+		return false
+	}
+	return true
+}
+
 func (c *Config) clearCredentialFields() {
 	c.AuthHeaderVal = ""
 	c.AccessToken = ""
@@ -391,19 +404,45 @@ func (c *Config) applyCredentials(creds *cliutil.Credentials) {
 	if creds == nil {
 		return
 	}
-	c.AuthHeaderVal = creds.AuthHeaderVal
-	c.AccessToken = creds.AccessToken
-	c.RefreshToken = creds.RefreshToken
-	c.TokenExpiry = creds.TokenExpiry
-	c.ClientID = creds.ClientID
-	c.ClientSecret = creds.ClientSecret
-	c.RichAuthApiKey = creds.RichAuthApiKey
-	c.RichAuthClientId = creds.RichAuthClientId
-	c.RichAuthClientSecret = creds.RichAuthClientSecret
-	c.RichAuthSessionCookie = creds.RichAuthSessionCookie
-	c.RichAuthOptionalToken = creds.RichAuthOptionalToken
-	c.RichAuthBotToken = creds.RichAuthBotToken
-	c.RichAuthUserToken = creds.RichAuthUserToken
+	if c.AuthHeaderVal == "" {
+		c.AuthHeaderVal = creds.AuthHeaderVal
+	}
+	if c.AccessToken == "" {
+		c.AccessToken = creds.AccessToken
+	}
+	if c.RefreshToken == "" {
+		c.RefreshToken = creds.RefreshToken
+	}
+	if c.TokenExpiry.IsZero() {
+		c.TokenExpiry = creds.TokenExpiry
+	}
+	if c.ClientID == "" {
+		c.ClientID = creds.ClientID
+	}
+	if c.ClientSecret == "" {
+		c.ClientSecret = creds.ClientSecret
+	}
+	if c.RichAuthApiKey == "" {
+		c.RichAuthApiKey = creds.RichAuthApiKey
+	}
+	if c.RichAuthClientId == "" {
+		c.RichAuthClientId = creds.RichAuthClientId
+	}
+	if c.RichAuthClientSecret == "" {
+		c.RichAuthClientSecret = creds.RichAuthClientSecret
+	}
+	if c.RichAuthSessionCookie == "" {
+		c.RichAuthSessionCookie = creds.RichAuthSessionCookie
+	}
+	if c.RichAuthOptionalToken == "" {
+		c.RichAuthOptionalToken = creds.RichAuthOptionalToken
+	}
+	if c.RichAuthBotToken == "" {
+		c.RichAuthBotToken = creds.RichAuthBotToken
+	}
+	if c.RichAuthUserToken == "" {
+		c.RichAuthUserToken = creds.RichAuthUserToken
+	}
 }
 
 func (c *Config) saveCredentialsFirst() error {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/config/config.go
@@ -109,9 +109,9 @@ func Load(configPath string) (*Config, error) {
 	if cfg.AgentcookieManagedByExternalStore() {
 		cfg.markAgentcookieManaged()
 	} else {
-		if !cfg.hasCredentialFields() {
-			var creds *cliutil.Credentials
-			var ok bool
+		var creds *cliutil.Credentials
+		var ok bool
+		if !cfg.hasCompleteCredentialFields() {
 			if explicitConfigFile {
 				creds, ok, err = cliutil.LoadCredentialsForConfig(path)
 				if err != nil {
@@ -293,6 +293,19 @@ func (c *Config) hasCredentialFields() bool {
 	return false
 }
 
+func (c *Config) hasCompleteCredentialFields() bool {
+	if c.AuthHeaderVal != "" {
+		return true
+	}
+	if c.PrintingPressGoldenApiKey == "" {
+		return false
+	}
+	if c.PrintingPressGoldenApiKey == "" {
+		return false
+	}
+	return true
+}
+
 func (c *Config) clearCredentialFields() {
 	c.AuthHeaderVal = ""
 	c.AccessToken = ""
@@ -319,13 +332,27 @@ func (c *Config) applyCredentials(creds *cliutil.Credentials) {
 	if creds == nil {
 		return
 	}
-	c.AuthHeaderVal = creds.AuthHeaderVal
-	c.AccessToken = creds.AccessToken
-	c.RefreshToken = creds.RefreshToken
-	c.TokenExpiry = creds.TokenExpiry
-	c.ClientID = creds.ClientID
-	c.ClientSecret = creds.ClientSecret
-	c.PrintingPressGoldenApiKey = creds.PrintingPressGoldenApiKey
+	if c.AuthHeaderVal == "" {
+		c.AuthHeaderVal = creds.AuthHeaderVal
+	}
+	if c.AccessToken == "" {
+		c.AccessToken = creds.AccessToken
+	}
+	if c.RefreshToken == "" {
+		c.RefreshToken = creds.RefreshToken
+	}
+	if c.TokenExpiry.IsZero() {
+		c.TokenExpiry = creds.TokenExpiry
+	}
+	if c.ClientID == "" {
+		c.ClientID = creds.ClientID
+	}
+	if c.ClientSecret == "" {
+		c.ClientSecret = creds.ClientSecret
+	}
+	if c.PrintingPressGoldenApiKey == "" {
+		c.PrintingPressGoldenApiKey = creds.PrintingPressGoldenApiKey
+	}
 }
 
 func (c *Config) saveCredentialsFirst() error {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/config/config.go
@@ -109,16 +109,27 @@ func Load(configPath string) (*Config, error) {
 	if cfg.AgentcookieManagedByExternalStore() {
 		cfg.markAgentcookieManaged()
 	} else {
-		creds, ok, err := cliutil.LoadCredentials()
-		if err != nil {
-			return nil, err
-		}
-		if ok && creds.HasValues() {
-			cfg.clearCredentialFields()
-			cfg.applyCredentials(creds)
-			if cfg.hasCredentialFields() {
-				cfg.AuthSource = "config"
-				cfg.CredentialSource = "credentials file"
+		if !cfg.hasCredentialFields() {
+			var creds *cliutil.Credentials
+			var ok bool
+			if explicitConfigFile {
+				creds, ok, err = cliutil.LoadCredentialsForConfig(path)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if !ok || creds == nil || !creds.HasValues() {
+				creds, ok, err = cliutil.LoadCredentials()
+				if err != nil {
+					return nil, err
+				}
+			}
+			if ok && creds.HasValues() {
+				cfg.applyCredentials(creds)
+				if cfg.hasCredentialFields() {
+					cfg.AuthSource = "config"
+					cfg.CredentialSource = "credentials file"
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Intent

Explicit config homes could inherit the process-global credentials file, allowing one account's token to be sent when another account was selected. This makes credential resolution follow the selected config home and prevents trusted per-config credentials from being overwritten.

## Approach

Generated config loading now keeps trusted config-file credentials first. For `--config` and `<API>_CONFIG`, it reads the sibling `data/credentials.toml` first, falls back to the global credentials file only when the sibling is missing or empty, and fails closed when the explicit sibling file is malformed or unsafe. Default-home resolution retains the existing global credentials behavior.

## Scope

Primary area: generator templates for config loading and generated credential-path resolution.

Why this belongs in this repo: this is a systemic Printing Press behavior affecting every generated CLI with an auth surface, not an API-specific printed-CLI repair.

## Risk

This changes generated auth loading and intentionally fails explicit-config loads for rejected sibling credential files to prevent cross-tenant fallback. It does not change the MCP surface, endpoint generation, or default-home credential soft-miss behavior.

## Output Contract

Updated generated golden fixtures and added generated regression coverage for config-file, sibling, global, empty-sibling, malformed-sibling, JSON, TOML, Basic-pair, browser, and device-code shapes. `scripts/verify-generator-output.sh` compiled 10 representative generated CLI cases.

## Verification

- [x] `go fmt ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- [x] `golangci-lint run ./internal/generator/...`
- [x] `scripts/verify-generator-output.sh`
- [x] `scripts/golden.sh verify` passed all 32 cases
- Full `golangci-lint run ./...` remains blocked by one unrelated existing `modernize` finding in `../issues-3683-3751/internal/googlediscovery/parser.go:455`; the changed generator package is clean.

Closes #3694
Closes #3741
