### PR TITLE
docs(skill): prevent shared-helper symbol collisions in novel commands

### DIFF
--- a/internal/cli/printing_press_skill_test.go
+++ b/internal/cli/printing_press_skill_test.go
@@ -32,6 +32,8 @@ func TestPrintingPressSkillDocumentsGeneratedHelpers(t *testing.T) {
 	require.Contains(t, content, "Helpers already emitted by the generator")
 	require.Contains(t, content, "internal/cli/helpers.go")
 	require.Contains(t, content, "Do not reinvent these helpers in novel command files")
+	require.Contains(t, content, "check `internal/cli/helpers.go` first")
+	require.Contains(t, content, "Put utilities shared by multiple novel commands in `internal/cli/helpers.go`")
 }
 
 func TestPrintingPressSkillMCPEnrichmentGate(t *testing.T) {

--- a/internal/cli/printing_press_skill_test.go
+++ b/internal/cli/printing_press_skill_test.go
@@ -22,6 +22,18 @@ func TestPrintingPressSkillSideEffectNarrativeGuidance(t *testing.T) {
 	require.Contains(t, content, "Non-side-effect unsupported examples still fail strict mode")
 }
 
+func TestPrintingPressSkillDocumentsGeneratedHelpers(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../../skills/printing-press/SKILL.md")
+	require.NoError(t, err)
+
+	content := string(data)
+	require.Contains(t, content, "Helpers already emitted by the generator")
+	require.Contains(t, content, "internal/cli/helpers.go")
+	require.Contains(t, content, "Do not reinvent these helpers in novel command files")
+}
+
 func TestPrintingPressSkillMCPEnrichmentGate(t *testing.T) {
 	t.Parallel()
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -3382,6 +3382,8 @@ The generator handles Priority 0 (data layer) and most of Priority 1 (absorbed A
 
 **Helpers already emitted by the generator.** Do not reinvent these helpers in novel command files. They live in `internal/cli/helpers.go` after generation and are available to every hand-written command in package `cli`:
 
+Before defining any new utility in a novel command, check `internal/cli/helpers.go` first and reuse an existing package helper when it fits. Put utilities shared by multiple novel commands in `internal/cli/helpers.go`, not individual command files, so package-level symbols stay unique.
+
 - `printJSONFiltered(w io.Writer, v any, flags *rootFlags) error` - apply `--select`, `--compact`, `--csv`, and `--quiet` while writing JSON from a Go value.
 - `printAutoTable(w io.Writer, items []map[string]any) error` - render JSON-like rows as the generated human table format.
 - `defaultDBPath(name string) string` - resolve the local SQLite database path for `<name>`.


### PR DESCRIPTION
## Summary

Implements #3463 — plan `docs/plans/2026-07-23-shared-helper-collision-guidance.md`.

## Commits

- **8dc1e20f** `plan: 2026-07-23-shared-helper-collision-guidance: Phase 1 — Cover existing generated-helper guidance`
  Adds a regression test in `internal/cli/printing_press_skill_test.go` asserting the SKILL.md already documents generated-helper guidance, establishing the baseline before the new collision-prevention guidance is added.
- **2a4e06ca** `plan: 2026-07-23-shared-helper-collision-guidance: Phase 2 — Add collision-prevention guidance`
  Adds guidance to `skills/printing-press/SKILL.md` telling agents to inspect and reuse `internal/cli/helpers.go` before defining utilities in hand-written novel command files, preventing package-level Go symbol collisions (e.g. duplicate `openBrowser` functions). Extends the regression test in `internal/cli/printing_press_skill_test.go` to cover the new guidance.

## Audit

Verdict: **READY (100%)**

## Test plan

- [x] `go test ./...`
- [x] Plan-to-PR per-phase gates passed for both phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
