### PR TITLE
fix(cli): bound decompressed size in crowd-sniff tarball extraction

### DIFF
--- a/internal/crowdsniff/npm.go
+++ b/internal/crowdsniff/npm.go
@@ -486,7 +486,9 @@ func (s *NPMSource) processPackageTarball(ctx context.Context, tarballURL, pkgNa
 // extractTarball extracts a gzipped tar archive to the destination directory.
 // Security: rejects symlinks, hard links, path traversal, and limits total size.
 func extractTarball(r io.Reader, destDir string) error {
-	// Limit total bytes read.
+	// Bound the compressed input as a coarse first guard. This alone is not
+	// enough: a small gzip stream can expand far past maxTarballSize, so the
+	// decompressed output is bounded separately below.
 	limited := io.LimitReader(r, maxTarballSize)
 
 	gz, err := gzip.NewReader(limited)
@@ -500,6 +502,11 @@ func extractTarball(r io.Reader, destDir string) error {
 	if err != nil {
 		return fmt.Errorf("resolving dest dir: %w", err)
 	}
+
+	// remaining is the decompressed-byte budget shared across every extracted
+	// regular file, so a decompression bomb cannot exceed maxTarballSize in
+	// aggregate no matter how many entries it is split across.
+	remaining := int64(maxTarballSize)
 
 	for {
 		header, err := tr.Next()
@@ -543,17 +550,33 @@ func extractTarball(r io.Reader, destDir string) error {
 			return fmt.Errorf("creating parent dir for %s: %w", header.Name, err)
 		}
 
+		// Reject an entry whose declared size alone would blow the remaining
+		// decompressed budget, before creating the file.
+		if header.Size > remaining {
+			return fmt.Errorf("tarball exceeds decompressed size limit of %d bytes", maxTarballSize)
+		}
+
 		f, err := os.Create(absTarget)
 		if err != nil {
 			return fmt.Errorf("creating file %s: %w", header.Name, err)
 		}
 
-		// Copy with size limit per file (same global limit via LimitReader on outer reader).
-		if _, err := io.Copy(f, tr); err != nil {
+		// Copy under a hard cap of the remaining budget, independent of the
+		// declared header size, so misleading tar metadata that understates the
+		// real payload still cannot write past the aggregate limit. Reading one
+		// byte past the budget is enough to detect the overflow.
+		written, err := io.Copy(f, io.LimitReader(tr, remaining+1))
+		if err != nil {
 			_ = f.Close()
+			_ = os.Remove(absTarget)
 			return fmt.Errorf("writing file %s: %w", header.Name, err)
 		}
 		_ = f.Close()
+		if written > remaining {
+			_ = os.Remove(absTarget)
+			return fmt.Errorf("tarball exceeds decompressed size limit of %d bytes", maxTarballSize)
+		}
+		remaining -= written
 	}
 
 	return nil

--- a/internal/crowdsniff/npm.go
+++ b/internal/crowdsniff/npm.go
@@ -561,25 +561,30 @@ func extractTarball(r io.Reader, destDir string) error {
 			return fmt.Errorf("creating file %s: %w", header.Name, err)
 		}
 
-		// Copy under a hard cap of the remaining budget, independent of the
-		// declared header size, so misleading tar metadata that understates the
-		// real payload still cannot write past the aggregate limit. Reading one
-		// byte past the budget is enough to detect the overflow.
-		written, err := io.Copy(f, io.LimitReader(tr, remaining+1))
+		written, err := copyTarEntryWithBudget(f, tr, remaining)
 		if err != nil {
 			_ = f.Close()
 			_ = os.Remove(absTarget)
 			return fmt.Errorf("writing file %s: %w", header.Name, err)
 		}
 		_ = f.Close()
-		if written > remaining {
-			_ = os.Remove(absTarget)
-			return fmt.Errorf("tarball exceeds decompressed size limit of %d bytes", maxTarballSize)
-		}
 		remaining -= written
 	}
 
 	return nil
+}
+
+func copyTarEntryWithBudget(dst io.Writer, src io.Reader, remaining int64) (int64, error) {
+	// Read one byte past the budget so an overlong stream is distinguishable
+	// from an entry that ends exactly at the limit.
+	written, err := io.Copy(dst, io.LimitReader(src, remaining+1))
+	if err != nil {
+		return written, err
+	}
+	if written > remaining {
+		return written, fmt.Errorf("tarball exceeds decompressed size limit of %d bytes", maxTarballSize)
+	}
+	return written, nil
 }
 
 // classifyPackage determines whether a package is an official or community SDK.

--- a/internal/crowdsniff/npm_test.go
+++ b/internal/crowdsniff/npm_test.go
@@ -430,7 +430,7 @@ func TestExtractTarball(t *testing.T) {
 		gw := gzip.NewWriter(&buf)
 		tw := tar.NewWriter(gw)
 		const perEntry = 4 * 1024 * 1024 // 4 MB x 3 = 12 MB > 10 MB
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			hdr := &tar.Header{
 				Name:     fmt.Sprintf("package/chunk%d.js", i),
 				Mode:     0o644,

--- a/internal/crowdsniff/npm_test.go
+++ b/internal/crowdsniff/npm_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -387,6 +388,67 @@ func TestExtractTarball(t *testing.T) {
 		assert.FileExists(t, tmpDir+"/package/index.js")
 		// Symlink should NOT exist.
 		assert.NoFileExists(t, tmpDir+"/package/evil-link")
+	})
+
+	t.Run("rejects decompression bomb exceeding decompressed limit", func(t *testing.T) {
+		t.Parallel()
+
+		// One highly compressible entry whose decompressed size exceeds
+		// maxTarballSize while the compressed archive stays well under it.
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gw)
+		oversized := int64(maxTarballSize) + 2*1024*1024
+		hdr := &tar.Header{
+			Name:     "package/huge.js",
+			Mode:     0o644,
+			Size:     oversized,
+			Typeflag: tar.TypeReg,
+		}
+		require.NoError(t, tw.WriteHeader(hdr))
+		_, err := io.Copy(tw, io.LimitReader(zeroReader{}, oversized))
+		require.NoError(t, err)
+		require.NoError(t, tw.Close())
+		require.NoError(t, gw.Close())
+
+		require.Less(t, buf.Len(), maxTarballSize, "compressed archive should stay under the limit")
+
+		tmpDir := t.TempDir()
+		err = extractTarball(bytes.NewReader(buf.Bytes()), tmpDir)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decompressed size limit")
+		// No oversized partial file should remain after rejection.
+		assert.NoFileExists(t, tmpDir+"/package/huge.js")
+	})
+
+	t.Run("rejects cumulative decompressed size across entries", func(t *testing.T) {
+		t.Parallel()
+
+		// Several entries each under the limit whose cumulative size exceeds it.
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gw)
+		const perEntry = 4 * 1024 * 1024 // 4 MB x 3 = 12 MB > 10 MB
+		for i := 0; i < 3; i++ {
+			hdr := &tar.Header{
+				Name:     fmt.Sprintf("package/chunk%d.js", i),
+				Mode:     0o644,
+				Size:     perEntry,
+				Typeflag: tar.TypeReg,
+			}
+			require.NoError(t, tw.WriteHeader(hdr))
+			_, err := io.Copy(tw, io.LimitReader(zeroReader{}, perEntry))
+			require.NoError(t, err)
+		}
+		require.NoError(t, tw.Close())
+		require.NoError(t, gw.Close())
+
+		tmpDir := t.TempDir()
+		err := extractTarball(bytes.NewReader(buf.Bytes()), tmpDir)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decompressed size limit")
 	})
 
 	t.Run("rejects path traversal", func(t *testing.T) {
@@ -1888,4 +1950,15 @@ func TestProcessPackageTarball_RedirectPolicy(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "HTTPS")
 	})
+}
+
+// zeroReader yields an endless stream of zero bytes. Paired with io.LimitReader
+// it builds highly compressible fixed-size payloads for decompression-limit tests.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
 }

--- a/internal/crowdsniff/npm_test.go
+++ b/internal/crowdsniff/npm_test.go
@@ -3,6 +3,7 @@ package crowdsniff
 import (
 	"archive/tar"
 	"bytes"
+	"compress/flate"
 	"compress/gzip"
 	"context"
 	"encoding/json"
@@ -449,6 +450,40 @@ func TestExtractTarball(t *testing.T) {
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "decompressed size limit")
+		assert.FileExists(t, tmpDir+"/package/chunk0.js")
+		assert.FileExists(t, tmpDir+"/package/chunk1.js")
+		assert.NoFileExists(t, tmpDir+"/package/chunk2.js")
+	})
+
+	t.Run("cleans up partial file when entry stream fails", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		gw, err := gzip.NewWriterLevel(&buf, flate.NoCompression)
+		require.NoError(t, err)
+		tw := tar.NewWriter(gw)
+		payload := make([]byte, 64*1024)
+		for i := range payload {
+			payload[i] = byte(i)
+		}
+		hdr := &tar.Header{
+			Name:     "package/partial.js",
+			Mode:     0o644,
+			Size:     int64(len(payload)),
+			Typeflag: tar.TypeReg,
+		}
+		require.NoError(t, tw.WriteHeader(hdr))
+		_, err = tw.Write(payload)
+		require.NoError(t, err)
+		require.NoError(t, tw.Close())
+		require.NoError(t, gw.Close())
+
+		truncated := buf.Bytes()[:len(buf.Bytes())/2]
+		tmpDir := t.TempDir()
+		err = extractTarball(bytes.NewReader(truncated), tmpDir)
+
+		require.Error(t, err)
+		assert.NoFileExists(t, tmpDir+"/package/partial.js")
 	})
 
 	t.Run("rejects path traversal", func(t *testing.T) {
@@ -1961,4 +1996,15 @@ func (zeroReader) Read(p []byte) (int, error) {
 		p[i] = 0
 	}
 	return len(p), nil
+}
+
+func TestCopyTarEntryWithBudget(t *testing.T) {
+	t.Parallel()
+
+	var dst bytes.Buffer
+	written, err := copyTarEntryWithBudget(&dst, strings.NewReader("12345"), 4)
+
+	require.Error(t, err)
+	assert.Equal(t, int64(5), written)
+	assert.Equal(t, "12345", dst.String())
 }


### PR DESCRIPTION
## Intent

`crowd-sniff` documents a 10 MB cap on npm tarball extraction, but the cap was applied to the **compressed** response stream, not the decompressed output. A small, highly-compressible gzip archive could expand far past the limit, so a malicious or compromised npm package could act as a decompression bomb that exhausts local temp-disk (and, downstream, memory when the extracted JS/TS is read back in).

Issue: Fixes #3784

## Approach

Track a decompressed-byte budget shared across all regular-file entries in `extractTarball`:

- reject an entry whose declared header size already exceeds the remaining budget, before creating the file;
- copy each entry under a hard `io.LimitReader` cap of the remaining budget, so tar metadata that understates the real payload still cannot stream past the aggregate limit;
- on overflow, remove the partial file and fail;
- decrement the budget by bytes actually written.

The coarse compressed-stream `io.LimitReader` is kept as a cheap first guard.

## Scope

Primary area: `internal/crowdsniff` (crowd-sniff npm source, discovery-time only).

Why this belongs in this repo: this is machine code — the crowd-sniff pipeline that every generation run may invoke. Not a printed-CLI concern.

## Risk

Low. Normal npm tarballs (well under 10 MB decompressed) extract unchanged; only archives that exceed the documented decompressed limit are now rejected instead of silently extracted. No generated-output, MCP, auth, or publish surface is touched.

## Output Contract

N/A — no templates, generated files, or command output change.

## Verification

- `go test ./internal/crowdsniff/` — passes, incl. two new cases (single oversized entry; cumulative size across entries).
- `go build ./...`, `go vet ./internal/crowdsniff/`, `gofmt -l` — clean.

- [ ] Generator/template change: N/A
- [ ] Generator/template change: N/A
- [ ] Generator/template change: N/A

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission