### PR TITLE
fix(cli): prevent docs-scraper endpoint-name collisions from dropping routes

### DIFF
--- a/internal/docspec/docspec.go
+++ b/internal/docspec/docspec.go
@@ -129,13 +129,19 @@ func groupByResource(endpoints []rawEndpoint) map[string]spec.Resource {
 			Description: fmt.Sprintf("Operations on %s", seg),
 			Endpoints:   map[string]spec.Endpoint{},
 		}
-		nameCount := map[string]int{}
+		// Allocate names against the set already used in this resource, not a
+		// per-base-name counter: a generated suffix (get_users_2) can otherwise
+		// collide with another route's natural name and silently overwrite it in
+		// the endpoints map. Iterating eps in documentation order keeps naming
+		// deterministic.
+		used := map[string]bool{}
 		for _, ep := range eps {
-			name := endpointName(ep.Method, ep.Path)
-			nameCount[name]++
-			if nameCount[name] > 1 {
-				name = fmt.Sprintf("%s_%d", name, nameCount[name])
+			base := endpointName(ep.Method, ep.Path)
+			name := base
+			for i := 2; used[name]; i++ {
+				name = fmt.Sprintf("%s_%d", base, i)
 			}
+			used[name] = true
 
 			pathParams := extractPathParams(ep.Path)
 

--- a/internal/docspec/docspec_test.go
+++ b/internal/docspec/docspec_test.go
@@ -333,3 +333,50 @@ func TestExtractYAML(t *testing.T) {
 		})
 	}
 }
+
+func TestGroupByResourceNoNameCollisionDrop(t *testing.T) {
+	// A generated disambiguation suffix must not overwrite another route whose
+	// natural name already equals that suffix. All documented routes must
+	// survive with distinct endpoint names.
+	endpoints := []rawEndpoint{
+		{Method: "GET", Path: "/users"},         // -> get_users
+		{Method: "GET", Path: "/users/{id}"},    // -> get_users (disambiguated)
+		{Method: "GET", Path: "/users/users_2"}, // natural name -> get_users_2
+	}
+
+	resources := groupByResource(endpoints)
+
+	res, ok := resources["users"]
+	require.True(t, ok, "expected a users resource")
+	assert.Len(t, res.Endpoints, 3, "all three routes must be preserved, none overwritten")
+
+	// Every documented path must appear exactly once across the generated names.
+	gotPaths := map[string]int{}
+	for _, ep := range res.Endpoints {
+		gotPaths[ep.Path]++
+	}
+	assert.Equal(t, 1, gotPaths["/users"])
+	assert.Equal(t, 1, gotPaths["/users/{id}"])
+	assert.Equal(t, 1, gotPaths["/users/users_2"])
+
+	// Names are unique by construction (map keys), and deterministic in doc order.
+	assert.Contains(t, res.Endpoints, "get_users")
+	assert.Contains(t, res.Endpoints, "get_users_2")
+	assert.Contains(t, res.Endpoints, "get_users_2_2")
+}
+
+func TestGroupByResourceDeterministicSuffixing(t *testing.T) {
+	// Plain repeated collisions keep the existing _2, _3 ... sequence so the
+	// fix does not perturb ordinary disambiguation.
+	endpoints := []rawEndpoint{
+		{Method: "GET", Path: "/items"},
+		{Method: "GET", Path: "/items/{id}"},   // last param -> derives get_items
+		{Method: "GET", Path: "/items/{name}"}, // last param -> derives get_items too
+	}
+	resources := groupByResource(endpoints)
+	res := resources["items"]
+	require.Len(t, res.Endpoints, 3)
+	assert.Contains(t, res.Endpoints, "get_items")
+	assert.Contains(t, res.Endpoints, "get_items_2")
+	assert.Contains(t, res.Endpoints, "get_items_3")
+}


### PR DESCRIPTION
## Intent

The docs scraper's endpoint-name disambiguation could assign the same generated name to two different documented routes. Because endpoints are stored in a map, the later assignment silently overwrote the earlier one — a real API operation disappeared from the generated spec with no error. It happened when a generated suffix (e.g. `get_users_2` for a second `GET /users`) collided with another route's **natural** name (e.g. `GET /users/users_2`).

Issue: Fixes #3786

## Approach

In `groupByResource`, allocate each endpoint name against the set of names already used in the resource, incrementing the numeric suffix until an unused name is found — instead of counting collisions only by the original derived name. Iterating in documentation order keeps naming deterministic; ordinary `_2`/`_3` disambiguation is unchanged; and a natural name that already ends in a numeric suffix can no longer be clobbered.

## Scope

Primary area: `internal/docspec` (documentation-derived spec builder).

Why this belongs in this repo: machine code — endpoint-name derivation in the docs-to-spec path, shared by every doc-sourced generation.

## Risk

Low. The only behavioral change is in the previously-broken collision case (a route that used to be dropped is now kept under a unique name). Ordinary disambiguation output is identical.

## Output Contract

Endpoint-name derivation can affect generated command names, so this is output-relevant. `scripts/golden.sh verify` passes all 32 cases unchanged — no existing fixture exercises the pathological collision, and ordinary suffixing is byte-identical, so the fix only adds a previously-missing endpoint in the collision case. Regression coverage is added at the unit level in `internal/docspec` rather than as a new golden fixture.

## Verification

- `go test ./internal/docspec/` — passes, incl. new cases: three-route collision (none dropped) and ordinary deterministic `_2`/`_3` suffixing.
- `scripts/golden.sh verify` — 32/32 cases pass (no generated-output drift).
- `go build ./...`, `go vet ./internal/docspec/`, `gofmt -l` — clean.

- [x] Generator/template change: verified generated output via `scripts/golden.sh verify` (32 cases) plus unit regression tests on the naming logic
- [x] Generator/template change: covered the collision variant and ordinary-suffix variant, not only happy path
- [x] Generator/template change: change is localized to name allocation in `groupByResource`; no emitted definition/call-site gates involved

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission