### PR TITLE
fix(skills): skip output review when no passing samples

### DIFF
--- a/skills/printing-press-output-review/SKILL.md
+++ b/skills/printing-press-output-review/SKILL.md
@@ -60,6 +60,12 @@ cli-printing-press scorecard --dir "$CLI_DIR" "${RESEARCH_ARGS[@]}" --live-check
 
 If the scorecard call fails or `/tmp/output-review-livecheck.json` is empty, return the SKIP result (Step 3) without dispatching the reviewer.
 
+Before dispatch, count entries in `live_check.features[]` whose `status` is
+`pass`. If there are zero, return `SKIP` with the reason `no eligible passing
+samples; plausibility not assessed`. Do not dispatch the reviewer, and never
+report a clean `PASS` merely because all sampled commands failed or were
+excluded from review.
+
 ### Step 2: Dispatch the reviewer agent
 
 Use the Agent tool (general-purpose) with this prompt contract:
@@ -88,6 +94,9 @@ End the skill response with a `---OUTPUT-REVIEW-RESULT---` block the parent pars
 
 **On clean pass:**
 
+Use this result only when the reviewer assessed at least one eligible
+`status: pass` sample.
+
 ```
 ---OUTPUT-REVIEW-RESULT---
 status: PASS
@@ -109,7 +118,7 @@ findings:
 ---END-OUTPUT-REVIEW-RESULT---
 ```
 
-**On reviewer failure (timeout, agent-budget exhaustion, missing live-check data):**
+**On reviewer failure or absence of assessable output (timeout, agent-budget exhaustion, missing live-check data, or zero eligible `status: pass` samples):**
 
 ```
 ---OUTPUT-REVIEW-RESULT---


### PR DESCRIPTION
## Summary

- classify zero eligible `status: pass` live-check samples as `SKIP`
- prevent vacuous PASS results when every sampled command failed or was excluded
- reserve PASS for reviews that assessed at least one successful sample

## Evidence

A generated Video System CLI produced five `status: fail` samples and zero passing samples. The existing instructions excluded all five, then allowed the reviewer result to be recorded as PASS because there were no findings. Plausibility was not assessed.

## Validation

- `git diff --check`
- `skill-comply --dry-run` extracted an explicit `validate_livecheck_output` step requiring at least one eligible passing sample
- local vendored copy will use the identical patch with this PR recorded as provenance