### PR TITLE
fix(cli): JSON-string body params send the decoded value, not the raw flag string

### DIFF
--- a/internal/generator/body_map_test.go
+++ b/internal/generator/body_map_test.go
@@ -16,6 +16,17 @@ import (
 func TestBodyMap(t *testing.T) {
 	t.Parallel()
 
+	encodedSettingsPresence := bodyLeafPresenceExpr(spec.Param{
+		Name:        "settings",
+		Type:        "string",
+		Description: "JSON-encoded string of widget settings",
+	}, "Settings", "settings")
+	encodedPayloadPresence := bodyLeafPresenceExpr(spec.Param{
+		Name:   "payload",
+		Type:   "string",
+		Format: "json-string",
+	}, "Payload", "payload")
+
 	cases := []struct {
 		name   string
 		body   []spec.Param
@@ -122,7 +133,7 @@ func TestBodyMap(t *testing.T) {
 				Description: "JSON-encoded string of widget settings",
 			}},
 			indent: "\t\t\t",
-			want: "\t\t\tif bodySettings != \"\" {\n" +
+			want: "\t\t\tif " + encodedSettingsPresence + " {\n" +
 				"\t\t\t\tvar parsedSettings any\n" +
 				"\t\t\t\tif err := json.Unmarshal([]byte(bodySettings), &parsedSettings); err != nil {\n" +
 				"\t\t\t\t\treturn fmt.Errorf(\"parsing --settings JSON: %w\", err)\n" +
@@ -135,7 +146,7 @@ func TestBodyMap(t *testing.T) {
 			name:   "format json-string keeps raw bytes",
 			body:   []spec.Param{{Name: "payload", Type: "string", Format: "json-string"}},
 			indent: "\t\t\t",
-			want: "\t\t\tif bodyPayload != \"\" {\n" +
+			want: "\t\t\tif " + encodedPayloadPresence + " {\n" +
 				"\t\t\t\tvar parsedPayload any\n" +
 				"\t\t\t\tif err := json.Unmarshal([]byte(bodyPayload), &parsedPayload); err != nil {\n" +
 				"\t\t\t\t\treturn fmt.Errorf(\"parsing --payload JSON: %w\", err)\n" +

--- a/internal/generator/body_map_test.go
+++ b/internal/generator/body_map_test.go
@@ -94,10 +94,12 @@ func TestBodyMap(t *testing.T) {
 		},
 		{
 			// JSON-string params: type is "string" but the format/description
-			// signal JSON content. The branch validates JSON before sending
-			// but stores the raw string (not the parsed value) so the API
-			// receives the user's exact bytes.
-			name:   "jsonString branch validates but stores raw",
+			// signal JSON content — spec authors write these when describing
+			// the *flag input* format. JSON-body APIs expect the decoded
+			// object/array on the wire; storing the raw flag bytes double-
+			// encodes the field (live-hit: Bird CRM 422 on contact create,
+			// Title Toolbox farm create).
+			name:   "jsonString branch validates and stores the decoded value",
 			body:   []spec.Param{{Name: "config", Type: "string", Format: "json"}},
 			indent: "\t\t\t",
 			want: "\t\t\tif bodyConfig != \"\" {\n" +
@@ -105,7 +107,40 @@ func TestBodyMap(t *testing.T) {
 				"\t\t\t\tif err := json.Unmarshal([]byte(bodyConfig), &parsedConfig); err != nil {\n" +
 				"\t\t\t\t\treturn fmt.Errorf(\"parsing --config JSON: %w\", err)\n" +
 				"\t\t\t\t}\n" +
-				"\t\t\t\tbody[\"config\"] = bodyConfig\n" +
+				"\t\t\t\tbody[\"config\"] = parsedConfig\n" +
+				"\t\t\t}\n",
+		},
+		{
+			// Params that explicitly declare an encoded-string wire type
+			// keep the user's exact bytes: the API field genuinely carries
+			// a JSON-encoded string, so decoding it would change the wire
+			// value.
+			name: "explicitly JSON-encoded string param keeps raw bytes",
+			body: []spec.Param{{
+				Name:        "settings",
+				Type:        "string",
+				Description: "JSON-encoded string of widget settings",
+			}},
+			indent: "\t\t\t",
+			want: "\t\t\tif bodySettings != \"\" {\n" +
+				"\t\t\t\tvar parsedSettings any\n" +
+				"\t\t\t\tif err := json.Unmarshal([]byte(bodySettings), &parsedSettings); err != nil {\n" +
+				"\t\t\t\t\treturn fmt.Errorf(\"parsing --settings JSON: %w\", err)\n" +
+				"\t\t\t\t}\n" +
+				"\t\t\t\tbody[\"settings\"] = bodySettings\n" +
+				"\t\t\t}\n",
+		},
+		{
+			// Same exception via an explicit format value.
+			name:   "format json-string keeps raw bytes",
+			body:   []spec.Param{{Name: "payload", Type: "string", Format: "json-string"}},
+			indent: "\t\t\t",
+			want: "\t\t\tif bodyPayload != \"\" {\n" +
+				"\t\t\t\tvar parsedPayload any\n" +
+				"\t\t\t\tif err := json.Unmarshal([]byte(bodyPayload), &parsedPayload); err != nil {\n" +
+				"\t\t\t\t\treturn fmt.Errorf(\"parsing --payload JSON: %w\", err)\n" +
+				"\t\t\t\t}\n" +
+				"\t\t\t\tbody[\"payload\"] = bodyPayload\n" +
 				"\t\t\t}\n",
 		},
 		{

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -6702,11 +6702,18 @@ func renderBodyMap(b *strings.Builder, body []spec.Param, depth int, indent, map
 		if isComplex || isJSONStringParam(p) {
 			// object/array: store the parsed value (so the API receives
 			// real JSON) after checking its top-level shape.
-			// jsonStringParam: validate then store the raw string (the API
-			// expects a JSON-encoded string field).
-			rhs := "body" + ident
-			if isComplex {
-				rhs = "parsed" + ident
+			// jsonStringParam: parse and store the decoded value too. These
+			// params are string-typed only because the spec author described
+			// the *flag input* as JSON ("as JSON", "JSON object of ...");
+			// JSON-body APIs expect the real object/array on the wire, and
+			// sending the raw flag bytes double-encodes the field (live-hit
+			// on two printed CLIs: Bird CRM returned 422 on contact create,
+			// Title Toolbox's backend expects a criteria object). Only
+			// params that explicitly declare an encoded-string wire format
+			// (isEncodedJSONStringParam) keep the user's exact bytes.
+			rhs := "parsed" + ident
+			if isEncodedJSONStringParam(p) {
+				rhs = "body" + ident
 			}
 			fmt.Fprintf(b, "%sif %s {\n", indent, bodyLeafPresenceExpr(p, ident, flag))
 			fmt.Fprintf(b, "%s\tvar parsed%s any\n", indent, ident)
@@ -7354,7 +7361,8 @@ func isJSONStringParam(p spec.Param) bool {
 
 	format := strings.ToLower(strings.TrimSpace(p.Format))
 	switch format {
-	case "json", "application/json":
+	case "json", "application/json",
+		"json-string", "json_string", "jsonstring", "json-encoded", "json_encoded":
 		return true
 	}
 
@@ -7377,6 +7385,37 @@ func isJSONStringParam(p spec.Param) bool {
 		"serialized json",
 	}
 	for _, marker := range jsonDescriptionMarkers {
+		if strings.Contains(lowerDescription, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// isEncodedJSONStringParam reports whether a JSON-string param explicitly
+// declares that the wire field carries a JSON-*encoded string* (double-encoded),
+// so the generated command must send the user's raw flag bytes instead of the
+// decoded value. This is the exception, not the default: description phrases
+// like "as JSON" or "JSON object of ..." describe the flag's input format and
+// map to the decoded value; only wording that names an encoded/serialized
+// string wire type ("JSON-encoded string", "serialized JSON string",
+// "stringified JSON") or an explicit encoded-string format keeps raw bytes.
+func isEncodedJSONStringParam(p spec.Param) bool {
+	if !isJSONStringParam(p) {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(p.Format)) {
+	case "json-string", "json_string", "jsonstring", "json-encoded", "json_encoded":
+		return true
+	}
+	lowerDescription := strings.ToLower(strings.TrimSpace(p.Description))
+	encodedMarkers := []string{
+		"json-encoded string",
+		"json encoded string",
+		"serialized json string",
+		"stringified json",
+	}
+	for _, marker := range encodedMarkers {
 		if strings.Contains(lowerDescription, marker) {
 			return true
 		}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -7383,6 +7383,7 @@ func isJSONStringParam(p spec.Param) bool {
 		"json-formatted",
 		"json formatted",
 		"serialized json",
+		"stringified json",
 	}
 	for _, marker := range jsonDescriptionMarkers {
 		if strings.Contains(lowerDescription, marker) {

--- a/internal/generator/json_string_validation_test.go
+++ b/internal/generator/json_string_validation_test.go
@@ -176,6 +176,41 @@ func TestJSONStringBodyParamEmitsLocalValidation(t *testing.T) {
 	code := string(src)
 
 	require.Contains(t, code, `json.Unmarshal([]byte(bodyMetadata), &parsedMetadata)`)
+	require.Contains(t, code, `bodyMap["metadata"] = parsedMetadata`)
+	require.NotContains(t, code, `bodyMap["metadata"] = bodyMetadata`)
+}
+
+func TestEncodedJSONStringBodyParamKeepsRawBytes(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("json-encoded-body-param")
+	apiSpec.Resources["items"] = spec.Resource{
+		Description: "Items",
+		Endpoints: map[string]spec.Endpoint{
+			"list": {
+				Method:      "GET",
+				Path:        "/items",
+				Description: "List items",
+			},
+			"create": {
+				Method:      "POST",
+				Path:        "/items",
+				Description: "Create item",
+				Body: []spec.Param{
+					{Name: "metadata", Type: "string", Description: "Metadata as a JSON-encoded string"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "json-encoded-body-param-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	src, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "items_create.go"))
+	require.NoError(t, err)
+	code := string(src)
+
+	require.Contains(t, code, `json.Unmarshal([]byte(bodyMetadata), &parsedMetadata)`)
 	require.Contains(t, code, `bodyMap["metadata"] = bodyMetadata`)
 	require.NotContains(t, code, `bodyMap["metadata"] = parsedMetadata`)
 }

--- a/internal/generator/json_string_validation_test.go
+++ b/internal/generator/json_string_validation_test.go
@@ -198,6 +198,7 @@ func TestEncodedJSONStringBodyParamKeepsRawBytes(t *testing.T) {
 				Description: "Create item",
 				Body: []spec.Param{
 					{Name: "metadata", Type: "string", Description: "Metadata as a JSON-encoded string"},
+					{Name: "settings", Type: "string", Description: "Settings as a stringified JSON"},
 				},
 			},
 		},
@@ -213,6 +214,9 @@ func TestEncodedJSONStringBodyParamKeepsRawBytes(t *testing.T) {
 	require.Contains(t, code, `json.Unmarshal([]byte(bodyMetadata), &parsedMetadata)`)
 	require.Contains(t, code, `bodyMap["metadata"] = bodyMetadata`)
 	require.NotContains(t, code, `bodyMap["metadata"] = parsedMetadata`)
+	require.Contains(t, code, `json.Unmarshal([]byte(bodySettings), &parsedSettings)`)
+	require.Contains(t, code, `bodyMap["settings"] = bodySettings`)
+	require.NotContains(t, code, `bodyMap["settings"] = parsedSettings`)
 }
 
 func TestHTMLStringBodyParamDoesNotEmitJSONValidation(t *testing.T) {


### PR DESCRIPTION
## Summary

String-typed body params whose format/description signal JSON content (`"as JSON"`, `"JSON object of ..."`, `format: json`) were validated with `json.Unmarshal` and then assigned to the request body as the **raw flag string**, so JSON-body APIs received a double-encoded field (`"query": "{...}"`) instead of the object. The generated command in `renderBodyMap` now stores the **decoded value** for these params.

Params that explicitly declare an encoded-string wire type keep the raw bytes via a new `isEncodedJSONStringParam` exception — formats `json-string` / `json_string` / `jsonstring` / `json-encoded` / `json_encoded`, or descriptions naming a `"JSON-encoded string"` / `"serialized JSON string"` / `"stringified JSON"`. Multipart and form-encoded body paths are unchanged (string fields by nature), and object/array-typed params keep the shape-checked parsed assignment from #3647.

## Live evidence (two printed CLIs)

- **Bird CRM** (internal spec, params like `identifiers: type string, "JSON array of identifiers, e.g. [{...}]"`): every mutate with an object/array field returned **422** until the printed CLI was hand-patched to send the parsed value — 23 assignments across 14 files. After the patch, the same contact create returned 201 (live write-fixture dogfood, 264/264).
- **Title Toolbox** (`query: type string, "Search criteria as JSON"`): the emitted `farm create` / `leads purchase` sent `"query": "{...}"`. The vendor's own web bundle proves the backend expects a criteria **object** (payloads are built from a parsed-object form model and response handlers read `query.geometry`; the app even warns `"got {... query: false ...} instead of search criteria object"`).

In both cases the spec author used `type: string` + a JSON marker to describe the **flag input format**, not the wire type — which is what these markers overwhelmingly mean in hand-authored internal specs. The decoded value is the right default; the double-encode case is the explicit exception.

## Changes

- `internal/generator/generator.go`
  - `renderBodyMap`: JSON-string params now assign `parsed<Ident>`; raw bytes only when `isEncodedJSONStringParam(p)`.
  - New `isEncodedJSONStringParam` predicate (explicit encoded formats + encoded-string description markers).
  - `isJSONStringParam` also accepts the explicit encoded formats so those params still get the `json.Unmarshal` validation guard.
- `internal/generator/body_map_test.go`: updated the `jsonString` case to expect the decoded value; added raw-bytes cases for the description-marker and `format: json-string` exceptions.
- `internal/generator/json_string_validation_test.go`: `TestJSONStringBodyParamEmitsLocalValidation` now expects the decoded assignment; new `TestEncodedJSONStringBodyParamKeepsRawBytes` covers the exception end-to-end through `Generate()`.

## Validation

- `go build ./...`
- `go test ./internal/generator`: zero `--- FAIL` across the package. The full-package run hit the global timeout on this sandbox with four generate-and-compile auth/transport tests still running under contention (`TestGenerateBearerRefreshDoctorCommand`, `TestGenerateBrowserChromeH3Transport`, `TestGenerateOAuth2AuthTemplateConditionally`, `TestGenerateOAuth2DeviceCodeAuth`) — all four pass standalone in 108s. Setup-contract subprocess checks report `FAIL govulncheck ./...` because the sandbox has no network for the vuln DB (same environmental caveat #3647 noted).
- `scripts/golden.sh verify` — 32/32 (no golden spec carries a JSON-marker string param, so no fixtures change)
- `scripts/verify-generator-output.sh` — 10/10 generate+compile cases
- End-to-end smoke: generated a CLI from a minimal internal spec with both param shapes; emitted code assigns `parsedQuery` for the `"as JSON"` param and keeps raw bytes for the `"JSON-encoded string"` param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
