### PR TITLE
fix(cli): sanitize MCP property keys and emit deepObject query params

### DIFF
--- a/internal/generator/composite_query_value_test.go
+++ b/internal/generator/composite_query_value_test.go
@@ -1,0 +1,276 @@
+package generator
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// Task 6 of the aos-build#165 plan (severable commit):
+//
+//  1. CLI/MCP composite-value PARITY for a FORM-style array-of-objects query
+//     param (Type "array", ItemType "object", no QueryStyle): the CLI wire
+//     value must equal the MCP wire value, and both must be valid JSON
+//     ({"field":"Name"} percent-encoded) — never fmt's map[field:Name]
+//     rendering. formatMCPParamValue already JSON-encodes composites; this
+//     pins formatCLIParamValue to the same behavior.
+//  2. Mixed-pin (adversarial-reviewer-flagged gap from Task 5): one code-orch
+//     spec carrying BOTH a form-style array param AND a deepObject param
+//     generates, compiles, and routes both correctly — repeated k=A&k=B for
+//     the array, percent-encoded indexed keys for the deepObject.
+
+// compositeParitySpec declares one promoted endpoint (records get) with a
+// single form-style array-of-objects query param. No QueryStyle: style
+// defaults to "form", explode defaults to true, so both surfaces emit the
+// value list as repeated sort=<item> pairs.
+func compositeParitySpec(name, baseURL string) *spec.APISpec {
+	apiSpec := minimalSpec(name)
+	apiSpec.BaseURL = baseURL
+	apiSpec.Resources = map[string]spec.Resource{
+		"records": {
+			Description: "Records",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/records",
+					Description: "List records",
+					Params: []spec.Param{{
+						Name: "sort", Type: "array", ItemType: "object", Description: "Sort spec",
+						Fields: []spec.Param{
+							{Name: "field", Type: "string"},
+						},
+					}},
+					Response: spec.ResponseDef{Type: "array", Item: "Record"},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Record": {Fields: []spec.TypeField{{Name: "id", Type: "integer"}}},
+	}
+	return apiSpec
+}
+
+// mcpParityWireTest is the in-module MCP half of the parity proof. The
+// @WANT_SORT@ placeholder is replaced with the SAME expected wire values the
+// outer test asserts for the CLI, so both surfaces are pinned to one literal.
+const mcpParityWireTest = `package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFormArrayOfObjectsHandlerWire drives the REAL registered MCP tool
+// handler with a native array-of-objects value and proves each element leaves
+// the wire as valid JSON — the MCP half of the CLI/MCP parity pin.
+func TestFormArrayOfObjectsHandlerWire(t *testing.T) {
+	type captured struct {
+		uri   string
+		query []string
+	}
+	requests := make(chan captured, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- captured{uri: r.RequestURI, query: r.URL.Query()["sort"]}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("COMPOSITE_PARITY_BASE_URL", srv.URL)
+	t.Setenv("MYAPI_TOKEN", "test-token")
+	t.Setenv("HOME", t.TempDir())
+
+	s := server.NewMCPServer("test", "0.0.0")
+	RegisterTools(s)
+	tool := s.ListTools()["records_get"]
+	require.NotNil(t, tool, "records_get tool not registered")
+
+	req := mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Name: "records_get",
+		Arguments: map[string]any{
+			"sort": []any{
+				map[string]any{"field": "Name"},
+				map[string]any{"field": "Price"},
+			},
+		},
+	}}
+	result, err := tool.Handler(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.IsError, "tool handler returned error result: %+v", result)
+
+	got := <-requests
+	require.Equal(t, []string{@WANT_SORT@}, got.query)
+	require.Contains(t, got.uri, "sort=%7B%22field%22%3A%22Name%22%7D")
+}
+`
+
+// TestGeneratedFormArrayOfObjectsCLIMCPWireParity is the parity proof: both
+// generated surfaces must serialize a form-style array-of-objects query param
+// element as the same valid-JSON wire value.
+func TestGeneratedFormArrayOfObjectsCLIMCPWireParity(t *testing.T) {
+	t.Parallel()
+
+	// The single source of truth both surfaces are asserted against.
+	wantSortWire := []string{`{"field":"Name"}`, `{"field":"Price"}`}
+
+	requests := make(chan deepObjectCapturedRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- deepObjectCapturedRequest{uri: r.RequestURI, query: r.URL.Query()}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	apiSpec := compositeParitySpec("composite-parity", server.URL)
+	outputDir := filepath.Join(t.TempDir(), "composite-parity-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	// Emitted-source pin: a form-style array param stays on the array
+	// emitter (never the deepObject path) on both surfaces.
+	promotedSrc := readPromotedCommandFile(t, outputDir)
+	require.Contains(t, promotedSrc, `path = appendArrayQueryParam(path, "sort", flagSort, "form", true)`)
+	require.NotContains(t, promotedSrc, "appendDeepObjectQueryParam")
+	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
+	require.Contains(t, mcpSrc, `PublicName: "sort", WireName: "sort", Location: "query", QueryArray: true, QueryStyle: "form", QueryExplode: true`)
+
+	requireGeneratedCompiles(t, outputDir)
+
+	binaryPath := filepath.Join(outputDir, "composite-parity-pp-cli")
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/composite-parity-pp-cli")
+
+	// CLI half: each decoded object element must reach the wire as valid
+	// JSON, percent-encoded — never fmt's map[field:Name] rendering.
+	runGeneratedBinary(t, binaryPath, "records", "get",
+		"--sort", `[{"field":"Name"},{"field":"Price"}]`)
+	captured := <-requests
+	require.Equal(t, wantSortWire, captured.query["sort"],
+		"CLI wire values must be the JSON elements, not fmt's map[...] rendering")
+	require.Contains(t, captured.uri, "sort=%7B%22field%22%3A%22Name%22%7D")
+	require.NotContains(t, captured.uri, "map%5B")
+	for _, item := range captured.query["sort"] {
+		require.Truef(t, json.Valid([]byte(item)), "CLI wire value %q must be valid JSON", item)
+	}
+
+	// MCP half: drive the REAL registered handler in-module and assert the
+	// SAME wire values (injected below), which makes CLI wire == MCP wire.
+	configSrc := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+	require.Contains(t, configSrc, `"COMPOSITE_PARITY_BASE_URL"`,
+		"generated config must expose the BASE_URL env override the in-module test relies on")
+	require.Contains(t, configSrc, "MYAPI_TOKEN",
+		"generated config must reference the spec's credential env var")
+
+	handlerTest := strings.ReplaceAll(mcpParityWireTest, "@WANT_SORT@",
+		fmt.Sprintf("%q, %q", wantSortWire[0], wantSortWire[1]))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "mcp", "composite_parity_wire_test.go"),
+		[]byte(handlerTest), 0o600))
+	// go test exits 0 when -run matches nothing, so assert the PASS line to
+	// prove the in-module handler test actually executed.
+	wireOutput, wireErr := runGoCommandOutput(t, outputDir, "test", "-v", "./internal/mcp", "-run", "^TestFormArrayOfObjectsHandlerWire$")
+	require.NoError(t, wireErr, wireOutput)
+	require.Contains(t, wireOutput, "--- PASS: TestFormArrayOfObjectsHandlerWire",
+		"in-module registered-handler wire test must actually run and pass:\n%s", wireOutput)
+}
+
+// TestMixedFormArrayAndDeepObjectQueryParams is the Task-5 adversarial
+// reviewer's flagged gap, pinned: a code-orch spec with BOTH a form-style
+// array param AND a deepObject param generates, compiles, and routes both
+// through codeOrchSplitQuery correctly — repeated ids=A&ids=B for the array,
+// percent-encoded indexed keys for the deepObject.
+func TestMixedFormArrayAndDeepObjectQueryParams(t *testing.T) {
+	t.Parallel()
+
+	explode := true
+	apiSpec := minimalSpec("mixed-query-orch")
+	apiSpec.MCP = spec.MCPConfig{Orchestration: "code"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"records": {
+			Description: "Records",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/records",
+					Description: "List records",
+					Params: []spec.Param{
+						{Name: "ids", Type: "array", ItemType: "string", Description: "IDs"},
+						{
+							Name: "filter", Type: "object", Description: "Filter object",
+							QueryStyle: "deepObject", QueryExplode: &explode,
+						},
+					},
+					Response: spec.ResponseDef{Type: "array", Item: "Record"},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Record": {Fields: []spec.TypeField{{Name: "id", Type: "integer"}}},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "mixed-query-orch-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	codeOrchSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "code_orch.go")
+	require.Contains(t, codeOrchSrc, `PublicName: "ids", WireName: "ids", QueryArray: true, QueryStyle: "form", QueryExplode: true`)
+	require.Contains(t, codeOrchSrc, `PublicName: "filter", WireName: "filter", DeepObjectQuery: true`)
+
+	// Both template gates fire together: the module must compile with the
+	// array helpers AND the deepObject helpers emitted side by side.
+	requireGeneratedCompiles(t, outputDir)
+
+	const runtimeTest = `package mcp
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMixedQueryRouting routes a form-style array binding and a deepObject
+// binding through the same codeOrchSplitQuery call: repeated keys for the
+// array, indexed bracket keys for the deepObject, params map fully consumed.
+func TestMixedQueryRouting(t *testing.T) {
+	params := map[string]any{
+		"ids":    []any{"A", "B"},
+		"filter": map[string]any{"status": "active"},
+	}
+	routed, err := codeOrchSplitQuery("/records", []codeOrchParamBinding{
+		{PublicName: "ids", WireName: "ids", QueryArray: true, QueryStyle: "form", QueryExplode: true},
+		{PublicName: "filter", WireName: "filter", DeepObjectQuery: true},
+	}, params)
+	require.NoError(t, err)
+	require.Empty(t, params)
+	require.Contains(t, routed, "ids=A&ids=B")
+	require.Contains(t, routed, "filter%5Bstatus%5D=active")
+
+	parsed, perr := url.Parse(routed)
+	require.NoError(t, perr)
+	require.Equal(t, []string{"A", "B"}, parsed.Query()["ids"])
+	require.Equal(t, []string{"active"}, parsed.Query()["filter[status]"])
+}
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "mcp", "mixed_query_routing_test.go"),
+		[]byte(runtimeTest), 0o600))
+	output, err := runGoCommandOutput(t, outputDir, "test", "-v", "./internal/mcp", "-run", "^TestMixedQueryRouting$")
+	require.NoError(t, err, output)
+	require.Contains(t, output, "--- PASS: TestMixedQueryRouting",
+		"in-module mixed routing test must actually run and pass:\n%s", output)
+}

--- a/internal/generator/deep_object_query_param_test.go
+++ b/internal/generator/deep_object_query_param_test.go
@@ -1,0 +1,362 @@
+package generator
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// Case index (aos-build#165 plan, Task 5 Step 1):
+//  1. CLI wire: array-of-objects param, style=deepObject -> indexed bracket
+//     keys (sort[0][field]=Name) percent-encoded on r.RequestURI.
+//  2. CLI wire: object-typed param, style=deepObject -> filter[status]=active.
+//  3. deepObject-ONLY spec generates + compiles. The plain variant rides
+//     TestGeneratedDeepObjectQueryParamCLIWire's module; the genuinely
+//     gate-pinning variant (object-typed-only, so hasArrayQueryParams is
+//     FALSE and the shared net/url import + codeOrchSplitQuery signature
+//     gates must fire on the deepObject predicate alone) rides
+//     TestGeneratedDeepObjectMCPRuntimeSerialization's module, which also
+//     sets MCP.Orchestration "code" so mcp_code_orch.go is exercised.
+//  4. Injection, BOTH channels: (4a) hostile VALUE percent-encoded; (4b)
+//     hostile object FIELD NAME percent-encoded in the emitted KEY — the
+//     server sees exactly one literal key `sort[0][a&b=c#d]`, nothing split.
+//  5. Malformed CLI JSON -> non-zero exit naming the flag and the concrete
+//     example [{"field":"Name","direction":"desc"}].
+//  6. MCP runtime, THREE layers: (6a) bare appendMCPDeepObjectQueryParam
+//     returned-path-string assertion; (6b) routed codeOrchSplitQuery with a
+//     DeepObjectQuery binding; (6c) registered-handler wire proof through
+//     makeAPIHandler's DeepObjectQuery branch (in-module, Task-2
+//     TestBracketHandlerWire idiom).
+
+type deepObjectCapturedRequest struct {
+	uri   string
+	query url.Values
+}
+
+// deepObjectWireSpec declares one promoted endpoint (records get) carrying an
+// array-of-objects `sort` and an object-typed `filter`, both style=deepObject,
+// plus a sub-resource endpoint (records views get) carrying `sort` so
+// command_endpoint.go.tmpl renders the deepObject branch too (sub-resource
+// endpoints never promote, making that template's coverage deterministic).
+func deepObjectWireSpec(name, baseURL string) *spec.APISpec {
+	explode := true
+	sortParam := spec.Param{
+		Name: "sort", Type: "array", ItemType: "object", Description: "Sort spec",
+		QueryStyle: "deepObject", QueryExplode: &explode,
+		Fields: []spec.Param{
+			{Name: "field", Type: "string"},
+			{Name: "direction", Type: "string"},
+		},
+	}
+	apiSpec := minimalSpec(name)
+	apiSpec.BaseURL = baseURL
+	apiSpec.Resources = map[string]spec.Resource{
+		"records": {
+			Description: "Records",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/records",
+					Description: "List records",
+					Params: []spec.Param{
+						sortParam,
+						{
+							Name: "filter", Type: "object", Description: "Filter object",
+							QueryStyle: "deepObject", QueryExplode: &explode,
+						},
+					},
+					Response: spec.ResponseDef{Type: "array", Item: "Record"},
+				},
+			},
+			SubResources: map[string]spec.Resource{
+				"views": {
+					Description: "Record views",
+					Endpoints: map[string]spec.Endpoint{
+						"get": {
+							Method:      "GET",
+							Path:        "/records/views",
+							Description: "List record views",
+							Params:      []spec.Param{sortParam},
+							Response:    spec.ResponseDef{Type: "array", Item: "Record"},
+						},
+					},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Record": {Fields: []spec.TypeField{{Name: "id", Type: "integer"}}},
+	}
+	return apiSpec
+}
+
+// TestGeneratedDeepObjectQueryParamCLIWire covers cases 1, 2, 4a, 4b, 5 and
+// 6c on one generated module (plus the plain-orchestration half of case 3:
+// this spec has no form-style array query params, and it must generate,
+// compile, and run).
+func TestGeneratedDeepObjectQueryParamCLIWire(t *testing.T) {
+	t.Parallel()
+
+	requests := make(chan deepObjectCapturedRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- deepObjectCapturedRequest{uri: r.RequestURI, query: r.URL.Query()}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	apiSpec := deepObjectWireSpec("deep-object-wire", server.URL)
+	outputDir := filepath.Join(t.TempDir(), "deep-object-wire-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	// Emitted-source pins: CLI routes deepObject params through the new
+	// helper (never appendArrayQueryParam), in BOTH command templates.
+	promotedSrc := readPromotedCommandFile(t, outputDir)
+	require.Contains(t, promotedSrc, `path, err = appendDeepObjectQueryParam(path, "sort", flagSort)`)
+	require.Contains(t, promotedSrc, `path, err = appendDeepObjectQueryParam(path, "filter", flagFilter)`)
+	require.NotContains(t, promotedSrc, `appendArrayQueryParam(path, "sort"`)
+	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "records_views_get.go")
+	require.Contains(t, endpointSrc, `path, err = appendDeepObjectQueryParam(path, "sort", flagSort)`)
+	require.NotContains(t, endpointSrc, `appendArrayQueryParam(path, "sort"`)
+	// MCP surface: binding marker + handler routing through the new helper.
+	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
+	require.Contains(t, mcpSrc, `PublicName: "sort", WireName: "sort", Location: "query", DeepObjectQuery: true`)
+	require.Contains(t, mcpSrc, `PublicName: "filter", WireName: "filter", Location: "query", DeepObjectQuery: true`)
+	require.Contains(t, mcpSrc, `appendMCPDeepObjectQueryParam(path, binding.WireName, v)`)
+
+	requireGeneratedCompiles(t, outputDir)
+
+	binaryPath := filepath.Join(outputDir, "deep-object-wire-pp-cli")
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/deep-object-wire-pp-cli")
+
+	// Case 1 + 2: indexed keys, percent-encoded, on the raw RequestURI.
+	runGeneratedBinary(t, binaryPath, "records", "get",
+		"--sort", `[{"field":"Name","direction":"desc"},{"field":"Price","direction":"asc"}]`,
+		"--filter", `{"status":"active"}`)
+	captured := <-requests
+	require.Contains(t, captured.uri, "sort%5B0%5D%5Bfield%5D=Name")
+	require.Contains(t, captured.uri, "sort%5B0%5D%5Bdirection%5D=desc")
+	require.Contains(t, captured.uri, "sort%5B1%5D%5Bfield%5D=Price")
+	require.Contains(t, captured.uri, "filter%5Bstatus%5D=active")
+	// The flattened single-key blobs of the pre-fix behavior must be gone —
+	// and the params-map path must not double-send either param.
+	require.NotContains(t, captured.uri, "sort=")
+	require.NotContains(t, captured.uri, "filter=")
+	require.Equal(t, []string{"Name"}, captured.query["sort[0][field]"])
+	require.Equal(t, []string{"active"}, captured.query["filter[status]"])
+
+	// command_endpoint.go.tmpl at runtime (sub-resource endpoint).
+	runGeneratedBinary(t, binaryPath, "records", "views", "get",
+		"--sort", `[{"field":"Name","direction":"desc"}]`)
+	captured = <-requests
+	require.Contains(t, captured.uri, "sort%5B0%5D%5Bfield%5D=Name")
+
+	// Case 4a: hostile VALUE stays one percent-encoded value.
+	runGeneratedBinary(t, binaryPath, "records", "get",
+		"--sort", `[{"field":"a&b=c#d"}]`)
+	captured = <-requests
+	require.Contains(t, captured.uri, "sort%5B0%5D%5Bfield%5D=a%26b%3Dc%23d")
+	require.Equal(t, []string{"a&b=c#d"}, captured.query["sort[0][field]"])
+	require.Len(t, captured.query, 1)
+
+	// Case 4b: hostile FIELD NAME — the emitted KEY is percent-encoded; the
+	// server sees exactly one literal key, nothing split into extra params.
+	runGeneratedBinary(t, binaryPath, "records", "get",
+		"--sort", `[{"a&b=c#d":"v"}]`)
+	captured = <-requests
+	require.Contains(t, captured.uri, "sort%5B0%5D%5Ba%26b%3Dc%23d%5D=v")
+	require.Equal(t, []string{"v"}, captured.query["sort[0][a&b=c#d]"])
+	require.Len(t, captured.query, 1)
+
+	// Case 5: malformed JSON is a usage error naming the flag and showing
+	// the concrete example (no HTTP request is made). Short mode never gets
+	// here: the build runGoCommand above already skips.
+	cmd := exec.Command(binaryPath, "records", "get", "--sort", `[{broken`)
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err, "malformed --sort JSON must exit non-zero; output:\n%s", output)
+	require.Contains(t, string(output), "--sort")
+	require.Contains(t, string(output), `[{"field":"Name","direction":"desc"}]`)
+
+	// Case 6c: registered-handler wire proof — drive the REAL
+	// makeAPIHandler-registered records_get tool with the native MCP value
+	// and assert the SERVER-SIDE r.RequestURI carries the indexed keys
+	// percent-encoded, through the DeepObjectQuery routing branch.
+	configSrc := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+	require.Contains(t, configSrc, `"DEEP_OBJECT_WIRE_BASE_URL"`,
+		"generated config must expose the BASE_URL env override the in-module test relies on")
+	require.Contains(t, configSrc, "MYAPI_TOKEN",
+		"generated config must reference the spec's credential env var")
+
+	const handlerWireTest = `package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeepObjectHandlerWire drives the REAL registered MCP tool handler and
+// proves style=deepObject params leave as indexed bracket keys on the HTTP
+// request — the MCP-surface twin of the CLI wire proof.
+func TestDeepObjectHandlerWire(t *testing.T) {
+	uris := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uris <- r.RequestURI
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("DEEP_OBJECT_WIRE_BASE_URL", srv.URL)
+	t.Setenv("MYAPI_TOKEN", "test-token")
+	t.Setenv("HOME", t.TempDir())
+
+	s := server.NewMCPServer("test", "0.0.0")
+	RegisterTools(s)
+	tool := s.ListTools()["records_get"]
+	require.NotNil(t, tool, "records_get tool not registered")
+
+	req := mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Name: "records_get",
+		Arguments: map[string]any{
+			"sort": []any{map[string]any{"field": "Name", "direction": "desc"}},
+		},
+	}}
+	result, err := tool.Handler(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.IsError, "tool handler returned error result: %+v", result)
+	uri := <-uris
+	require.Contains(t, uri, "sort%5B0%5D%5Bfield%5D=Name")
+	require.Contains(t, uri, "sort%5B0%5D%5Bdirection%5D=desc")
+}
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "mcp", "deep_object_handler_wire_test.go"),
+		[]byte(handlerWireTest), 0o600))
+	// go test exits 0 when -run matches nothing, so assert the PASS line to
+	// prove the in-module handler test actually executed.
+	wireOutput, wireErr := runGoCommandOutput(t, outputDir, "test", "-v", "./internal/mcp", "-run", "^TestDeepObjectHandlerWire$")
+	require.NoError(t, wireErr, wireOutput)
+	require.Contains(t, wireOutput, "--- PASS: TestDeepObjectHandlerWire",
+		"in-module registered-handler wire test must actually run and pass:\n%s", wireOutput)
+}
+
+// TestGeneratedDeepObjectMCPRuntimeSerialization covers case 3's gate pin and
+// cases 6a + 6b. The spec carries ONLY an object-typed deepObject query param
+// — no array-typed query params anywhere — so hasArrayQueryParams is false
+// and the shared surfaces (helpers.go/tools.go net/url imports,
+// codeOrchSplitQuery's path-returning signature) must be gated by the
+// deepObject predicate alone; a missed combined gate fails compilation here.
+// MCP.Orchestration "code" makes mcp_code_orch.go render.
+func TestGeneratedDeepObjectMCPRuntimeSerialization(t *testing.T) {
+	t.Parallel()
+
+	explode := true
+	apiSpec := minimalSpec("deep-object-orch")
+	apiSpec.MCP = spec.MCPConfig{Orchestration: "code"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"records": {
+			Description: "Records",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/records",
+					Description: "List records",
+					Params: []spec.Param{{
+						Name: "filter", Type: "object", Description: "Filter object",
+						QueryStyle: "deepObject", QueryExplode: &explode,
+					}},
+					Response: spec.ResponseDef{Type: "array", Item: "Record"},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Record": {Fields: []spec.TypeField{{Name: "id", Type: "integer"}}},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "deep-object-orch-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	codeOrchSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "code_orch.go")
+	require.Contains(t, codeOrchSrc, `PublicName: "filter", WireName: "filter", DeepObjectQuery: true`)
+	require.Contains(t, codeOrchSrc, `appendMCPDeepObjectQueryParam(path, q.WireName, v)`)
+
+	// Case 3: the deepObject-only module must compile (import + signature
+	// gates fired on hasDeepObjectQueryParams alone).
+	requireGeneratedCompiles(t, outputDir)
+
+	// Cases 6a + 6b: in-module runtime test (array_query_param_test.go
+	// test-2 idiom) — the bare helper's RETURNED PATH STRING carries
+	// percent-encoded keys, and codeOrchSplitQuery routes a DeepObjectQuery
+	// binding through it.
+	const runtimeTest = `package mcp
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeepObjectQuerySerialization(t *testing.T) {
+	// 6a: bare helper, array-of-objects value — assert on the returned path
+	// string BEFORE url.Parse, pinning percent-encoded key emission.
+	path, err := appendMCPDeepObjectQueryParam("/records", "sort",
+		[]any{map[string]any{"field": "Name", "direction": "desc"}})
+	require.NoError(t, err)
+	require.Contains(t, path, "sort%5B0%5D%5Bfield%5D=Name")
+	require.Contains(t, path, "sort%5B0%5D%5Bdirection%5D=desc")
+
+	// 6a: native map value.
+	path, err = appendMCPDeepObjectQueryParam("/records", "filter",
+		map[string]any{"status": "active"})
+	require.NoError(t, err)
+	require.Contains(t, path, "filter%5Bstatus%5D=active")
+
+	// 6a: string values are JSON-decoded first (spec defaults / string
+	// agent inputs), matching the CLI's --flag JSON contract.
+	path, err = appendMCPDeepObjectQueryParam("/records", "filter", "{\"status\":\"active\"}")
+	require.NoError(t, err)
+	require.Contains(t, path, "filter%5Bstatus%5D=active")
+
+	// 6a: malformed string JSON is a loud error, not a silent blob.
+	_, err = appendMCPDeepObjectQueryParam("/records", "sort", "[{broken")
+	require.Error(t, err)
+
+	// 6b: routed code-orch binding — exercises the DeepObjectQuery routing
+	// branch inside codeOrchSplitQuery, not just the helper.
+	params := map[string]any{"sort": []any{map[string]any{"field": "Name"}}}
+	routed, err := codeOrchSplitQuery("/records", []codeOrchParamBinding{{
+		PublicName: "sort", WireName: "sort", DeepObjectQuery: true,
+	}}, params)
+	require.NoError(t, err)
+	require.Contains(t, routed, "sort%5B0%5D%5Bfield%5D=Name")
+	require.Empty(t, params)
+
+	parsed, perr := url.Parse(routed)
+	require.NoError(t, perr)
+	require.Equal(t, []string{"Name"}, parsed.Query()["sort[0][field]"])
+}
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "mcp", "deep_object_query_test.go"),
+		[]byte(runtimeTest), 0o600))
+	output, err := runGoCommandOutput(t, outputDir, "test", "-v", "./internal/mcp", "-run", "^TestDeepObjectQuerySerialization$")
+	require.NoError(t, err, output)
+	require.Contains(t, output, "--- PASS: TestDeepObjectQuerySerialization",
+		"in-module runtime serialization test must actually run and pass:\n%s", output)
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -326,9 +326,12 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"paramIdent":                          paramIdent,
 		"paramWireName":                       paramWireName,
 		"isArrayQueryParam":                   isArrayQueryParam,
+		"isDeepObjectQueryParam":              isDeepObjectQueryParam,
 		"queryParamStyle":                     queryParamStyle,
 		"queryParamExplodes":                  queryParamExplodes,
 		"hasArrayQueryParams":                 hasArrayQueryParams,
+		"hasDeepObjectQueryParams":            hasDeepObjectQueryParams,
+		"hasIndexedOrArrayQueryParams":        hasIndexedOrArrayQueryParams,
 		"typeFieldIdent":                      typeFieldIdent,
 		"typeFieldJSONTagComment":             typeFieldJSONTagComment,
 		"safeTypeName":                        safeTypeName,
@@ -6155,6 +6158,7 @@ type mcpParamBinding struct {
 	QueryArray         bool
 	QueryStyle         string
 	QueryExplode       bool
+	DeepObjectQuery    bool
 	RequestContentType string
 	Default            string
 }
@@ -6204,7 +6208,12 @@ func mcpParamBindings(endpoint spec.Endpoint, pathTemplate string) []mcpParamBin
 		// must match the cobra default rendering for CLI/MCP wire parity; keep in
 		// sync with that path (and cf. pipeline.stringifyParamDefault).
 		if loc == "query" || loc == "header" {
-			if isArrayQueryParam(p) {
+			// deepObject wins over the array marker: an array-typed
+			// style=deepObject param routes through the indexed-key emitter
+			// only, never the repeated/joined array path (deliberate).
+			if loc == "query" && isDeepObjectQueryParam(p) {
+				binding.DeepObjectQuery = true
+			} else if isArrayQueryParam(p) {
 				binding.QueryArray = true
 				binding.QueryStyle = queryParamStyle(p)
 				binding.QueryExplode = queryParamExplodes(p)
@@ -7794,6 +7803,33 @@ func hasArrayQueryParams(apiSpec *spec.APISpec) bool {
 	return anyEndpointMatches(apiSpec, func(endpoint spec.Endpoint) bool {
 		return slices.ContainsFunc(endpoint.Params, isArrayQueryParam)
 	})
+}
+
+// isDeepObjectQueryParam reports whether p is a query parameter declared with
+// OpenAPI style=deepObject — an array- or object-typed param whose wire form
+// is indexed bracket keys (name[i][field]=v / name[key]=v), never a repeated
+// or delimiter-joined value list. The parser stores serialization.Style
+// verbatim, so this compares against the literal (case-insensitively, to
+// tolerate hand-authored specs).
+func isDeepObjectQueryParam(p spec.Param) bool {
+	if p.Positional || p.PathParam {
+		return false
+	}
+	kind := primitiveKind(p.Type)
+	return (kind == "array" || kind == "object") && strings.EqualFold(strings.TrimSpace(p.QueryStyle), "deepObject")
+}
+
+func hasDeepObjectQueryParams(apiSpec *spec.APISpec) bool {
+	return anyEndpointMatches(apiSpec, func(endpoint spec.Endpoint) bool {
+		return slices.ContainsFunc(endpoint.Params, isDeepObjectQueryParam)
+	})
+}
+
+// hasIndexedOrArrayQueryParams gates the generated-code surfaces shared by
+// the repeated/joined array emission and the indexed deepObject emission:
+// the net/url imports and codeOrchSplitQuery's path-returning form.
+func hasIndexedOrArrayQueryParams(apiSpec *spec.APISpec) bool {
+	return hasArrayQueryParams(apiSpec) || hasDeepObjectQueryParams(apiSpec)
 }
 
 func csvArrayValueExpr(p spec.Param, inputExpr string) string {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2397,6 +2397,13 @@ func (g *Generator) prepareOutput() error {
 		return err
 	}
 
+	// Assert the FINAL per-endpoint MCP input-name set (post-dedup) is legal
+	// and collision-free before anything renders — an illegal or duplicate
+	// tool property key must fail generation, never ship (#165).
+	if err := g.validateMCPInputNames(); err != nil {
+		return err
+	}
+
 	g.dedupeTypeFieldIdentifiers()
 
 	return nil

--- a/internal/generator/mcp_input_validation.go
+++ b/internal/generator/mcp_input_validation.go
@@ -1,0 +1,103 @@
+package generator
+
+import (
+	"fmt"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+)
+
+// validateMCPInputNames asserts, AFTER the flag-collision dedup pass has
+// assigned final identifiers, that every model-facing MCP input name the
+// templates will emit for each endpoint (a) matches the Anthropic tool
+// property-key grammar spec.MCPPropertyKeyPattern and (b) is unique within
+// its tool's input schema, including generator-reserved inputs. An illegal
+// key bricks the calling agent session at schema load; a duplicate key makes
+// one agent-supplied value silently fan into two wire locations. Collisions
+// the dedup pass resolves never reach this check — only residual ones
+// (e.g. 64-char clamp truncations, reserved-name hits) fail, loudly.
+// It runs from prepareOutput, so both Generate and GenerateMCPSurface
+// entry points are covered before anything renders.
+func (g *Generator) validateMCPInputNames() error {
+	if g.Spec == nil {
+		return nil
+	}
+	vars := g.Spec.GlobalPathTemplateVars
+	for _, resName := range sortedKeys(g.Spec.Resources) {
+		res := g.Spec.Resources[resName]
+		for _, epName := range sortedKeys(res.Endpoints) {
+			ep := res.Endpoints[epName]
+			if err := validateEndpointMCPInputNames(resName, epName, ep, effectiveEndpointPath(res, ep), vars); err != nil {
+				return err
+			}
+		}
+		for _, subName := range sortedKeys(res.SubResources) {
+			sub := res.SubResources[subName]
+			for _, epName := range sortedKeys(sub.Endpoints) {
+				ep := sub.Endpoints[epName]
+				if err := validateEndpointMCPInputNames(resName+"/"+subName, epName, ep, effectiveSubEndpointPath(res, sub, ep), vars); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// validateEndpointMCPInputNames records every input name the MCP template
+// will emit for one endpoint's tool — the generator-reserved inputs first
+// (mirroring mcp_tools.go.tmpl's pageable cursor and raw-body blocks; the
+// body_json fallback input arrives via mcpParamBindings, so it is NOT
+// recorded as reserved here), then the same mcpParamBindings /
+// mcpGlobalTemplateBindings producers the template renders from — and fails
+// on the first illegal or duplicate key.
+func validateEndpointMCPInputNames(resKey, epName string, ep spec.Endpoint, pathTemplate string, vars []string) error {
+	type source struct{ label string }
+	seen := map[string]source{}
+	record := func(name, label string) error {
+		if !spec.MCPPropertyKeyRe.MatchString(name) {
+			return fmt.Errorf("resource %q endpoint %q: MCP input name %s is not a legal tool property key (must match %s, 1-64 chars); rename via flag_name or x-pp-param-url-names — an illegal key bricks the calling agent session at schema load", resKey, epName, truncateName(name), spec.MCPPropertyKeyPattern)
+		}
+		if prev, ok := seen[name]; ok {
+			return fmt.Errorf("resource %q endpoint %q: MCP input names collide: %s and %s both emit schema key %q; rename one via flag_name or x-pp-param-url-names", resKey, epName, prev.label, label, name)
+		}
+		seen[name] = source{label: label}
+		return nil
+	}
+	// Reserved, generator-injected inputs first — mirror mcp_tools.go.tmpl's
+	// pageable-cursor and raw-body WithString emissions.
+	if mcpEndpointPageable(ep) {
+		if err := record("cursor", "the generated pagination input"); err != nil {
+			return err
+		}
+	}
+	if ep.UsesRawRequestBody() {
+		for _, r := range []string{"body_base64", "content_type"} {
+			if err := record(r, "the generated raw-body input"); err != nil {
+				return err
+			}
+		}
+	}
+	// The template's own binding producers — validated set == emitted set.
+	// The binding's WireName is the raw wire-side name, so the failure
+	// message names both colliding sources by their wire identity.
+	for _, b := range mcpParamBindings(ep, pathTemplate) {
+		if err := record(b.PublicName, fmt.Sprintf("%s input from wire param %s", b.Location, truncateName(b.WireName))); err != nil {
+			return err
+		}
+	}
+	for _, b := range mcpGlobalTemplateBindings(ep, pathTemplate, vars) {
+		if err := record(b.PublicName, fmt.Sprintf("global path-template var %s", truncateName(b.WireName))); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// truncateName keeps failure messages readable for hostile-length names while
+// preserving the differing tail (clamp collisions differ only past char 64).
+func truncateName(name string) string {
+	if len(name) <= 80 {
+		return fmt.Sprintf("%q", name)
+	}
+	return fmt.Sprintf("%q…%q (len %d)", name[:40], name[len(name)-24:], len(name))
+}

--- a/internal/generator/mcp_input_validation_test.go
+++ b/internal/generator/mcp_input_validation_test.go
@@ -1,0 +1,100 @@
+package generator
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func bracketSpec(name string, params []spec.Param, pageable bool) *spec.APISpec {
+	apiSpec := minimalSpec(name)
+	ep := spec.Endpoint{
+		Method: "GET", Path: "/items", Description: "List items",
+		Params:   params,
+		Response: spec.ResponseDef{Type: "array", Item: "Item"},
+	}
+	if pageable {
+		ep.Pagination = &spec.Pagination{Type: "cursor", CursorParam: "cursor", NextCursorPath: "next_cursor"}
+	}
+	apiSpec.Resources = map[string]spec.Resource{
+		"items": {Description: "Items", Endpoints: map[string]spec.Endpoint{"get": ep}},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Item": {Fields: []spec.TypeField{{Name: "id", Type: "integer"}}},
+	}
+	return apiSpec
+}
+
+// Collisions the dedup pass already resolves must keep generating (CTO round-1
+// regression guard): foo[] + foo collide in the flag namespace and dedup
+// suffixes an IdentName, yielding distinct public names.
+func TestDedupResolvableCollisionStillGenerates(t *testing.T) {
+	t.Parallel()
+	apiSpec := bracketSpec("dedup-ok", []spec.Param{
+		{Name: "foo[]", Type: "array", ItemType: "string"},
+		{Name: "foo", Type: "string"},
+	}, false)
+	outputDir := filepath.Join(t.TempDir(), "dedup-ok-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+}
+
+// Two >64-char names identical in their first 64 chars clamp to the same
+// public key — the flag-space dedup never sees it, the assertion must.
+func TestClampCollisionFailsGeneration(t *testing.T) {
+	t.Parallel()
+	head := strings.Repeat("a", 64)
+	apiSpec := bracketSpec("clamp-collide", []spec.Param{
+		{Name: head + "[one]", Type: "string"},
+		{Name: head + "[two]", Type: "string"},
+	}, false)
+	err := New(apiSpec, filepath.Join(t.TempDir(), "clamp-collide-pp-cli")).Generate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "MCP input name")
+	require.Contains(t, err.Error(), "collide")
+}
+
+// A sanitized name landing on a generator-reserved input key must fail:
+// cursor[] -> cursor on a pageable endpoint would shadow the injected
+// pagination cursor input.
+func TestSanitizedNameHittingReservedCursorFails(t *testing.T) {
+	t.Parallel()
+	apiSpec := bracketSpec("reserved-hit", []spec.Param{
+		{Name: "cursor[]", Type: "array", ItemType: "string"},
+	}, true)
+	err := New(apiSpec, filepath.Join(t.TempDir(), "reserved-hit-pp-cli")).Generate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"cursor"`)
+}
+
+// A final name >64 chars must fail even when it arrives via a path the
+// sanitizer never sees (authored flag_name is unclamped today).
+func TestOverlongAuthoredFlagNameFailsGeneration(t *testing.T) {
+	t.Parallel()
+	apiSpec := bracketSpec("overlong", []spec.Param{
+		{Name: "q", Type: "string", FlagName: strings.Repeat("a", 65)},
+	}, false)
+	err := New(apiSpec, filepath.Join(t.TempDir(), "overlong-pp-cli")).Generate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "64")
+}
+
+// The Architect's round-1 hole, pinned exactly (design §4 test 3): a
+// dedup-SUFFIXED final name >64 chars must fail. Two 63-char names that
+// collide in the cobra flag namespace (the second differs only by a
+// flag-illegal ">" suffix, Twilio-style) force uniquifyIdentifiers to assign
+// IdentName "<name>_2", whose kebab public form is 65 chars — charset-legal,
+// length-illegal, and invisible to any pre-dedup check.
+func TestOverlongDedupSuffixedNameFailsGeneration(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("a", 63)
+	apiSpec := bracketSpec("dedup-overlong", []spec.Param{
+		{Name: long, Type: "string"},
+		{Name: long + ">", Type: "string"},
+	}, false)
+	err := New(apiSpec, filepath.Join(t.TempDir(), "dedup-overlong-pp-cli")).Generate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "64")
+}

--- a/internal/generator/mcp_property_key_test.go
+++ b/internal/generator/mcp_property_key_test.go
@@ -208,3 +208,71 @@ func TestBracketHandlerWire(t *testing.T) {
 	require.Contains(t, output, "--- PASS: TestBracketHandlerWire",
 		"in-module registered-handler wire test must actually run and pass:\n%s", output)
 }
+
+// TestIntentEmissionPropertyKeysAreAnthropicSafe generates a spec with a legal
+// intent and applies the corpus-scan guard to the intents surface: every
+// mcplib.NewTool name and every mcplib.With* schema property key emitted into
+// internal/mcp/intents.go must match the Anthropic tool property-key grammar.
+// Illegal intent param names are rejected at spec validation, so this pins the
+// remaining half of the intents hardening — the %q-quoted emission renders
+// byte-identically for legal names and the generated module still compiles.
+func TestIntentEmissionPropertyKeysAreAnthropicSafe(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("intent-keys")
+	items := apiSpec.Resources["items"]
+	items.Endpoints["search"] = spec.Endpoint{
+		Method:      "GET",
+		Path:        "/items/search",
+		Description: "Search items",
+		Params: []spec.Param{
+			{Name: "q", Type: "string", Required: true, Description: "query"},
+		},
+	}
+	apiSpec.Resources["items"] = items
+	apiSpec.MCP = spec.MCPConfig{
+		Intents: []spec.Intent{
+			{
+				Name:        "search_items",
+				Description: "Search for items",
+				Params: []spec.IntentParam{
+					{Name: "q", Type: "string", Required: true, Description: "query"},
+					{Name: "limit", Type: "integer", Description: "max results"},
+					{Name: "dry_run", Type: "boolean", Description: "no-op flag"},
+				},
+				Steps: []spec.IntentStep{
+					{Endpoint: "items.search", Bind: map[string]string{"q": "${input.q}"}, Capture: "results"},
+				},
+				Returns: "results",
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "intent-keys-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	intentsSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "intents.go")
+	// Every intent tool name registered via mcplib.NewTool must be legal.
+	toolNameRe := regexp.MustCompile(`mcplib\.NewTool\("([^"]+)"`)
+	nameMatches := toolNameRe.FindAllStringSubmatch(intentsSrc, -1)
+	require.NotEmpty(t, nameMatches, "expected mcplib.NewTool registrations in intents.go")
+	for _, m := range nameMatches {
+		assert.Regexp(t, spec.MCPPropertyKeyRe, m[1], "illegal MCP tool name emitted in intents.go: %q", m[1])
+	}
+	// Every quoted first argument of a mcplib.With* schema declaration must
+	// match the Anthropic grammar (the Task-2 corpus-scan idiom).
+	withKeyRe := regexp.MustCompile(`mcplib\.With(?:String|Number|Boolean|Array|Object)\("([^"]+)"`)
+	keyMatches := withKeyRe.FindAllStringSubmatch(intentsSrc, -1)
+	require.NotEmpty(t, keyMatches, "expected intent param schema declarations in intents.go")
+	for _, m := range keyMatches {
+		assert.Regexp(t, spec.MCPPropertyKeyRe, m[1], "illegal MCP schema key emitted in intents.go: %q", m[1])
+	}
+	// The concrete legal names render byte-identically under the %q emission.
+	require.Contains(t, intentsSrc, `mcplib.NewTool("search_items",`)
+	require.Contains(t, intentsSrc, `mcplib.WithString("q"`)
+	require.Contains(t, intentsSrc, `mcplib.WithNumber("limit"`)
+	require.Contains(t, intentsSrc, `mcplib.WithBoolean("dry_run"`)
+
+	// Proves the %q template change emits valid Go.
+	requireGeneratedCompiles(t, outputDir)
+}

--- a/internal/generator/mcp_property_key_test.go
+++ b/internal/generator/mcp_property_key_test.go
@@ -1,0 +1,210 @@
+package generator
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/openapi"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBracketParamPublicSurfacesAreSanitized parses an OpenAPI doc with a
+// vendor bracket param (fathom-style recorded_by[]), generates, and asserts
+// every model-facing surface exposes the sanitized name while the wire name
+// keeps the brackets. Companion to the sanitizer unit tests in internal/spec.
+func TestBracketParamPublicSurfacesAreSanitized(t *testing.T) {
+	t.Parallel()
+
+	const doc = `
+openapi: 3.0.0
+info:
+  title: Bracket API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /meetings:
+    get:
+      operationId: listMeetings
+      tags: [meetings]
+      parameters:
+        - name: "recorded_by[]"
+          in: query
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+        - name: "date[start]"
+          in: query
+          schema:
+            type: string
+        - name: "date[stop]"
+          in: query
+          schema:
+            type: string
+        - name: cursor
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ok
+`
+	apiSpec, err := openapi.Parse([]byte(doc))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), "bracket-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	toolsSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
+	// Schema key + binding: public sanitized, wire raw.
+	require.Contains(t, toolsSrc, `"recorded_by"`)
+	require.Contains(t, toolsSrc, `PublicName: "recorded_by", WireName: "recorded_by[]"`)
+	require.Contains(t, toolsSrc, `PublicName: "date_start", WireName: "date[start]"`)
+	require.Contains(t, toolsSrc, `PublicName: "date_stop", WireName: "date[stop]"`)
+	// The illegal forms must appear ONLY as WireName values, never as
+	// schema property keys: no With* declaration may carry them.
+	require.NotRegexp(t, regexp.MustCompile(`mcplib\.With\w+\("recorded_by\[\]"`), toolsSrc)
+	require.NotRegexp(t, regexp.MustCompile(`mcplib\.With\w+\("date\[`), toolsSrc)
+	// Tool description param list teaches the sanitized names — positive
+	// half (the description mentions recorded_by) AND negative half (never
+	// the bracket form).
+	assert.Regexp(t, regexp.MustCompile(`WithDescription\([^)]*recorded_by`), toolsSrc)
+	assert.NotRegexp(t, regexp.MustCompile(`WithDescription\([^)]*recorded_by\[\]`), toolsSrc)
+
+	// Corpus-style guard (the upstream analog of fathom's
+	// TestRegisterTools_PropertyKeysAreAnthropicSafe): EVERY quoted first
+	// argument of a mcplib.With* schema declaration in tools.go must match
+	// the Anthropic grammar.
+	withKeyRe := regexp.MustCompile(`mcplib\.With(?:String|Number|Boolean|Array|Object)\("([^"]+)"`)
+	for _, m := range withKeyRe.FindAllStringSubmatch(toolsSrc, -1) {
+		assert.Regexp(t, spec.MCPPropertyKeyRe, m[1], "illegal MCP schema key emitted: %q", m[1])
+	}
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
+// TestBracketParamWireNameIsPreserved proves sanitization never touches the
+// wire: the generated CLI still sends the literal bracket key repeated, and
+// the REAL registered MCP tool handler — driven with the SANITIZED argument
+// name — emits the same bracket wire key on its HTTP request.
+func TestBracketParamWireNameIsPreserved(t *testing.T) {
+	t.Parallel()
+
+	requests := make(chan []string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.URL.Query()["recorded_by[]"]
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	apiSpec := minimalSpec("bracket-wire")
+	apiSpec.BaseURL = server.URL
+	apiSpec.Resources = map[string]spec.Resource{
+		"meetings": {
+			Description: "Meetings",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/meetings",
+					Description: "List meetings",
+					Params: []spec.Param{
+						{Name: "recorded_by[]", Type: "array", ItemType: "string", Description: "Recorder emails"},
+					},
+					Response: spec.ResponseDef{Type: "array", Item: "Meeting"},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Meeting": {Fields: []spec.TypeField{{Name: "id", Type: "integer"}}},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "bracket-wire-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	requireGeneratedCompiles(t, outputDir)
+
+	binaryPath := filepath.Join(outputDir, "bracket-wire-pp-cli")
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/bracket-wire-pp-cli")
+	runGeneratedBinary(t, binaryPath, "meetings", "get", "--recorded-by", "a@x.com,b@x.com")
+	require.Equal(t, []string{"a@x.com", "b@x.com"}, <-requests)
+
+	// Registered-handler wire proof: write a Go test into the generated
+	// module (the array_query_param_test.go in-module idiom) that drives the
+	// makeAPIHandler-registered meetings_get tool with the sanitized arg name
+	// and asserts the bracket wire key reaches the server. The generated
+	// module's baked BaseURL is THIS test's httptest server, so the in-module
+	// test redirects to its own server via the generated config's
+	// <PREFIX>_BASE_URL env hook. Pin the exact env names against the
+	// generated config source before relying on them.
+	configSrc := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+	require.Contains(t, configSrc, `"BRACKET_WIRE_BASE_URL"`,
+		"generated config must expose the BASE_URL env override the in-module test relies on")
+	require.Contains(t, configSrc, "MYAPI_TOKEN",
+		"generated config must reference the spec's credential env var")
+
+	const handlerWireTest = `package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBracketHandlerWire drives the REAL registered MCP tool handler with the
+// SANITIZED argument name and proves the literal bracket wire key goes out on
+// the HTTP request — sanitization is public-surface only.
+func TestBracketHandlerWire(t *testing.T) {
+	requests := make(chan []string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.URL.Query()["recorded_by[]"]
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("BRACKET_WIRE_BASE_URL", srv.URL)
+	t.Setenv("MYAPI_TOKEN", "test-token")
+	t.Setenv("HOME", t.TempDir())
+
+	s := server.NewMCPServer("test", "0.0.0")
+	RegisterTools(s)
+	tool := s.ListTools()["meetings_get"]
+	require.NotNil(t, tool, "meetings_get tool not registered")
+
+	req := mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Name:      "meetings_get",
+		Arguments: map[string]any{"recorded_by": []any{"a@x.com"}},
+	}}
+	result, err := tool.Handler(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.IsError, "tool handler returned error result: %+v", result)
+	require.Equal(t, []string{"a@x.com"}, <-requests)
+}
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "mcp", "bracket_handler_wire_test.go"),
+		[]byte(handlerWireTest), 0o600))
+	// go test exits 0 when -run matches nothing, so assert the PASS line to
+	// prove the in-module handler test actually executed. (Short mode never
+	// reaches this point: the build runGoCommand above already skips.)
+	output, err := runGoCommandOutput(t, outputDir, "test", "-v", "./internal/mcp", "-run", "^TestBracketHandlerWire$")
+	require.NoError(t, err, output)
+	require.Contains(t, output, "--- PASS: TestBracketHandlerWire",
+		"in-module registered-handler wire test must actually run and pass:\n%s", output)
+}

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -222,7 +222,14 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- end}}
 {{- range .Endpoint.Params}}
-{{- if isArrayQueryParam .}}
+{{- if isDeepObjectQueryParam .}}
+			if flag{{camel (paramIdent .)}} != "" {
+				path, err = appendDeepObjectQueryParam(path, "{{paramWireName .}}", flag{{camel (paramIdent .)}})
+				if err != nil {
+					return err
+				}
+			}
+{{- else if isArrayQueryParam .}}
 			if flag{{camel (paramIdent .)}} != "" {
 				path = appendArrayQueryParam(path, "{{paramWireName .}}", flag{{camel (paramIdent .)}}, "{{queryParamStyle .}}", {{queryParamExplodes .}})
 			}
@@ -238,7 +245,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			htmlRequestParams["{{.Name}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .)) (not (isDeepObjectQueryParam .))}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
 				htmlRequestParams["{{.Name}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
@@ -377,7 +384,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .)) (not (isDeepObjectQueryParam .))}}
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
@@ -395,7 +402,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .)) (not (isDeepObjectQueryParam .))}}
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
@@ -407,7 +414,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .)) (not (isDeepObjectQueryParam .))}}
 				if {{if or (eq $.Endpoint.Method "GET") (eq $.Endpoint.Method "HEAD")}}flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}}{{else}}{{paramPresenceExpr .}}{{end}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
@@ -440,7 +447,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .)) (not (isDeepObjectQueryParam .))}}
 			if {{paramPresenceExpr .}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
@@ -526,7 +533,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .)) (not (isDeepObjectQueryParam .))}}
 			if {{paramPresenceExpr .}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
@@ -593,7 +600,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .)) (not (isDeepObjectQueryParam .))}}
 			if {{paramPresenceExpr .}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
@@ -686,7 +693,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .)) (not (isDeepObjectQueryParam .))}}
 			if {{paramPresenceExpr .}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -187,7 +187,14 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- end}}
 {{- range .Endpoint.Params}}
-{{- if isArrayQueryParam .}}
+{{- if isDeepObjectQueryParam .}}
+			if flag{{camel (paramIdent .)}} != "" {
+				path, err = appendDeepObjectQueryParam(path, "{{paramWireName .}}", flag{{camel (paramIdent .)}})
+				if err != nil {
+					return err
+				}
+			}
+{{- else if isArrayQueryParam .}}
 			if flag{{camel (paramIdent .)}} != "" {
 				path = appendArrayQueryParam(path, "{{paramWireName .}}", flag{{camel (paramIdent .)}}, "{{queryParamStyle .}}", {{queryParamExplodes .}})
 			}
@@ -200,7 +207,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			htmlRequestParams["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .)) (not (isDeepObjectQueryParam .))}}
 				if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
 					htmlRequestParams["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 				}
@@ -239,7 +246,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .)) (not (isDeepObjectQueryParam .))}}
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
@@ -257,7 +264,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .)) (not (isDeepObjectQueryParam .))}}
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
@@ -270,7 +277,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .)) (not (isDeepObjectQueryParam .))}}
 			if {{if $isReadVerb}}flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}}{{else}}{{paramPresenceExpr .}}{{end}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -49,10 +49,21 @@ var As = errors.As
 const paginatedGetMaxPages = 100
 
 func formatCLIParamValue(v any) string {
-	if f, ok := v.(float64); ok {
-		return strconv.FormatFloat(f, 'f', -1, 64)
+	switch tv := v.(type) {
+	case float64:
+		return strconv.FormatFloat(tv, 'f', -1, 64)
+	case map[string]any, []any:
+		// Composite values (a decoded JSON object/array element bound to a
+		// query slot) must stay valid JSON on the wire; fmt's rendering would
+		// emit "map[...]"/"[a b c]" garbage. Mirrors formatMCPParamValue's
+		// composite branch so the CLI and MCP surfaces serialize identically.
+		if b, err := json.Marshal(tv); err == nil {
+			return string(b)
+		}
+		return fmt.Sprintf("%v", tv)
+	default:
+		return fmt.Sprintf("%v", v)
 	}
-	return fmt.Sprintf("%v", v)
 }
 
 {{- if .HasRawRequest}}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-{{- if or .HasEmbeddedPaged (hasArrayQueryParams .APISpec)}}
+{{- if or .HasEmbeddedPaged (hasIndexedOrArrayQueryParams .APISpec)}}
 	"net/url"
 {{- end}}
 	"os"
@@ -121,6 +121,56 @@ func appendArrayQueryParam(path, name, raw, style string, explode bool) string {
 		separator = "&"
 	}
 	return path + separator + encoded
+}
+
+{{- end}}
+{{- if hasDeepObjectQueryParams .APISpec}}
+// appendDeepObjectQueryParam appends one style=deepObject query param to the
+// request path as indexed bracket keys: objects -> name[field]=v, arrays ->
+// name[i]=v / name[i][field]=v. raw is the flag's JSON string.
+func appendDeepObjectQueryParam(path, name, raw string) (string, error) {
+	var decoded any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return path, fmt.Errorf("--%s: expected JSON (e.g. [{\"field\":\"Name\",\"direction\":\"desc\"}] or {\"key\":\"value\"}): %w", name, err)
+	}
+	values := url.Values{}
+	expandDeepObjectValue(values, name, decoded)
+	if len(values) == 0 {
+		return path, nil
+	}
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return path + separator + values.Encode(), nil
+}
+
+// expandDeepObjectValue expands one deepObject-style query param into indexed
+// keys: objects -> name[field]=v, arrays -> name[i]=v / name[i][field]=v.
+// Scalar leaves use formatCLIParamValue; anything nested deeper JSON-encodes
+// fail-soft rather than inventing deeper bracket grammar. URL size is bounded
+// only by the server (414), matching appendArrayQueryParam's posture. Keep
+// structurally in sync with the MCP twin expandMCPDeepObjectValue in
+// internal/mcp.
+func expandDeepObjectValue(values url.Values, name string, decoded any) {
+	switch v := decoded.(type) {
+	case map[string]any:
+		for k, item := range v {
+			values.Set(name+"["+k+"]", formatCLIParamValue(item))
+		}
+	case []any:
+		for i, item := range v {
+			if obj, ok := item.(map[string]any); ok {
+				for k, field := range obj {
+					values.Set(fmt.Sprintf("%s[%d][%s]", name, i, k), formatCLIParamValue(field))
+				}
+			} else {
+				values.Set(fmt.Sprintf("%s[%d]", name, i), formatCLIParamValue(item))
+			}
+		}
+	default:
+		values.Set(name, formatCLIParamValue(decoded))
+	}
 }
 
 {{- end}}

--- a/internal/generator/templates/mcp_code_orch.go.tmpl
+++ b/internal/generator/templates/mcp_code_orch.go.tmpl
@@ -125,6 +125,9 @@ type codeOrchParamBinding struct {
 	QueryStyle string
 	QueryExplode bool
 {{- end}}
+{{- if hasDeepObjectQueryParams .APISpec}}
+	DeepObjectQuery bool
+{{- end}}
 }
 
 // codeOrchEndpoints is the generator-populated registry covering every
@@ -148,7 +151,7 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 		Summary: {{printf "%q" (oneline $endpoint.Description)}},
 		Positional: []string{ {{- range $endpoint.Params}}{{if .Positional}}"{{.Name}}",{{end}}{{end}} },
 		TemplateParams: []codeOrchParamBinding{ {{- range mcpGlobalTemplateBindings $endpoint $path $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}},{{end}} },
-		QueryParams: []codeOrchParamBinding{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "query"}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}},{{end}}{{end}} },
+		QueryParams: []codeOrchParamBinding{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "query"}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}{{if .DeepObjectQuery}}, DeepObjectQuery: true{{end}}},{{end}}{{end}} },
 		HeaderParams: []codeOrchParamBinding{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "header"}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{end}} },
 {{- if $endpoint.BodyIsArray}}
 		BodyIsArray: true,
@@ -183,7 +186,7 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 		Summary: {{printf "%q" (oneline $endpoint.Description)}},
 		Positional: []string{ {{- range $endpoint.Params}}{{if .Positional}}"{{.Name}}",{{end}}{{end}} },
 		TemplateParams: []codeOrchParamBinding{ {{- range mcpGlobalTemplateBindings $endpoint $path $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}},{{end}} },
-		QueryParams: []codeOrchParamBinding{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "query"}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}},{{end}}{{end}} },
+		QueryParams: []codeOrchParamBinding{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "query"}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}{{if .DeepObjectQuery}}, DeepObjectQuery: true{{end}}},{{end}}{{end}} },
 		HeaderParams: []codeOrchParamBinding{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "header"}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{end}} },
 {{- if $endpoint.BodyIsArray}}
 		BodyIsArray: true,
@@ -460,7 +463,13 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 	// remaining params used as the request body below.
 	query := map[string]string{}
 	if ep.Method == "GET" || ep.Method == "DELETE" {
-{{- if hasArrayQueryParams .APISpec}}
+{{- if hasDeepObjectQueryParams .APISpec}}
+		var splitErr error
+		path, splitErr = codeOrchSplitQuery(path, ep.QueryParams, params)
+		if splitErr != nil {
+			return mcplib.NewToolResultError(splitErr.Error()), nil
+		}
+{{- else if hasArrayQueryParams .APISpec}}
 		path = codeOrchSplitQuery(path, ep.QueryParams, params)
 {{- end}}
 		for k, v := range params {
@@ -472,7 +481,13 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 		// PUT /ledger/voucher/{id}) wrongly lands in the JSON body and the
 		// API silently ignores it or rejects the request. The remaining
 		// params stay in the map for codeOrchWriteBody (the JSON body).
-{{- if hasArrayQueryParams .APISpec}}
+{{- if hasDeepObjectQueryParams .APISpec}}
+		var splitErr error
+		path, splitErr = codeOrchSplitQuery(path, ep.QueryParams, params)
+		if splitErr != nil {
+			return mcplib.NewToolResultError(splitErr.Error()), nil
+		}
+{{- else if hasArrayQueryParams .APISpec}}
 		path = codeOrchSplitQuery(path, ep.QueryParams, params)
 {{- else}}
 		if enc := codeOrchSplitQuery(ep.QueryParams, params); enc != "" {
@@ -611,7 +626,7 @@ func codeOrchArrayBody(params map[string]any) any {
 }
 
 // codeOrchSplitQuery removes spec-declared in:query params from params and
-{{- if hasArrayQueryParams .APISpec}}
+{{- if hasIndexedOrArrayQueryParams .APISpec}}
 // appends them URL-encoded to the request path. The remaining
 {{- else}}
 // returns them URL-encoded for appending to the request path. The remaining
@@ -619,7 +634,7 @@ func codeOrchArrayBody(params map[string]any) any {
 // entries stay in the map for codeOrchWriteBody (the JSON body), so a write
 // method's query parameters never get buried in the body. Mutates params by
 // design (deletes the consumed query keys).
-func codeOrchSplitQuery({{if hasArrayQueryParams .APISpec}}path string, {{end}}queryParams []codeOrchParamBinding, params map[string]any) string {
+func codeOrchSplitQuery({{if hasIndexedOrArrayQueryParams .APISpec}}path string, {{end}}queryParams []codeOrchParamBinding, params map[string]any) {{if hasDeepObjectQueryParams .APISpec}}(string, error){{else}}string{{end}} {
 	uv := neturl.Values{}
 	for _, q := range queryParams {
 		for _, key := range []string{q.PublicName, q.WireName} {
@@ -627,7 +642,19 @@ func codeOrchSplitQuery({{if hasArrayQueryParams .APISpec}}path string, {{end}}q
 				continue
 			}
 			if v, ok := params[key]; ok {
-{{- if hasArrayQueryParams .APISpec}}
+{{- if hasDeepObjectQueryParams .APISpec}}
+				if q.DeepObjectQuery {
+					var derr error
+					path, derr = appendMCPDeepObjectQueryParam(path, q.WireName, v)
+					if derr != nil {
+						return path, fmt.Errorf("%s: %v; expected JSON like [{\"field\":\"Name\",\"direction\":\"desc\"}] or {\"key\":\"value\"}", q.PublicName, derr)
+					}
+				} else {{if hasArrayQueryParams .APISpec}}if q.QueryArray {
+					path = appendMCPArrayQueryParam(path, q.WireName, v, q.QueryStyle, q.QueryExplode)
+				} else {{end}}{
+					uv.Set(q.WireName, formatMCPParamValue(v))
+				}
+{{- else if hasArrayQueryParams .APISpec}}
 				if q.QueryArray {
 					path = appendMCPArrayQueryParam(path, q.WireName, v, q.QueryStyle, q.QueryExplode)
 				} else {
@@ -641,7 +668,7 @@ func codeOrchSplitQuery({{if hasArrayQueryParams .APISpec}}path string, {{end}}q
 			}
 		}
 	}
-{{- if hasArrayQueryParams .APISpec}}
+{{- if hasIndexedOrArrayQueryParams .APISpec}}
 	if enc := uv.Encode(); enc != "" {
 		sep := "?"
 		if strings.Contains(path, "?") {
@@ -649,7 +676,7 @@ func codeOrchSplitQuery({{if hasArrayQueryParams .APISpec}}path string, {{end}}q
 		}
 		path += sep + enc
 	}
-	return path
+	return path{{if hasDeepObjectQueryParams .APISpec}}, nil{{end}}
 {{- else}}
 	return uv.Encode()
 {{- end}}

--- a/internal/generator/templates/mcp_intents.go.tmpl
+++ b/internal/generator/templates/mcp_intents.go.tmpl
@@ -45,10 +45,10 @@ import (
 func RegisterIntents(s *server.MCPServer) {
 {{- range .MCP.Intents}}
 	s.AddTool(
-		mcplib.NewTool("{{.Name}}",
+		mcplib.NewTool({{printf "%q" .Name}},
 			mcplib.WithDescription({{printf "%q" .Description}}),
 {{- range .Params}}
-			mcplib.{{mcpBindingFunc .Type}}("{{.Name}}"{{if .Required}}, mcplib.Required(){{end}}, mcplib.Description({{printf "%q" .Description}})),
+			mcplib.{{mcpBindingFunc .Type}}({{printf "%q" .Name}}{{if .Required}}, mcplib.Required(){{end}}, mcplib.Description({{printf "%q" .Description}})),
 {{- end}}
 		),
 		handle{{pascal .Name}},
@@ -56,10 +56,10 @@ func RegisterIntents(s *server.MCPServer) {
 {{- end}}
 {{- range .RecipeIntents}}
 	s.AddTool(
-		mcplib.NewTool("{{.Name}}",
+		mcplib.NewTool({{printf "%q" .Name}},
 			mcplib.WithDescription({{printf "%q" .Description}}),
 {{- range .Params}}
-			mcplib.{{mcpBindingFunc (recipeParamTypeString .Type)}}("{{.InputName}}"{{if .Required}}, mcplib.Required(){{end}}, mcplib.Description({{printf "%q" .Description}})),
+			mcplib.{{mcpBindingFunc (recipeParamTypeString .Type)}}({{printf "%q" .InputName}}{{if .Required}}, mcplib.Required(){{end}}, mcplib.Description({{printf "%q" .Description}})),
 {{- end}}
 		),
 		handle{{pascal .Name}},

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	{{- if or (hasArrayQueryParams .APISpec) $hasFormRequest}}
+	{{- if or (hasIndexedOrArrayQueryParams .APISpec) $hasFormRequest}}
 	"net/url"
 	{{- end}}
 {{- if or .VisionSet.Search .VisionSet.Store}}
@@ -104,9 +104,9 @@ func RegisterTools(s *server.MCPServer) {
 {{- end}}
 		),
 {{- if $.HasTierRouting}}
-		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveEndpointPath $resource $endpoint)}}, {{printf "%q" (effectiveTier $.APISpec $resource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if or $endpoint.HeaderOverrides $endpoint.UsesTextResponse}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}}{{if $endpoint.UsesTextResponse}}client.TextResponseHeader: "true",{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- if $endpoint.UsesRawRequestBody}}{Location: "raw", RequestContentType: {{printf "%q" $endpoint.RequestContentType}}, RawBodyRequired: {{if $endpoint.BodyRequired}}true{{else}}false{{end}}},{{end}}{{- range mcpParamBindings $endpoint (effectiveEndpointPath $resource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}{{if and $hasMCPRequestContentType .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveEndpointPath $resource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
+		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveEndpointPath $resource $endpoint)}}, {{printf "%q" (effectiveTier $.APISpec $resource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if or $endpoint.HeaderOverrides $endpoint.UsesTextResponse}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}}{{if $endpoint.UsesTextResponse}}client.TextResponseHeader: "true",{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- if $endpoint.UsesRawRequestBody}}{Location: "raw", RequestContentType: {{printf "%q" $endpoint.RequestContentType}}, RawBodyRequired: {{if $endpoint.BodyRequired}}true{{else}}false{{end}}},{{end}}{{- range mcpParamBindings $endpoint (effectiveEndpointPath $resource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}{{if .DeepObjectQuery}}, DeepObjectQuery: true{{end}}{{if and $hasMCPRequestContentType .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveEndpointPath $resource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
 {{- else}}
-		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveEndpointPath $resource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if or $endpoint.HeaderOverrides $endpoint.UsesTextResponse}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}}{{if $endpoint.UsesTextResponse}}client.TextResponseHeader: "true",{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- if $endpoint.UsesRawRequestBody}}{Location: "raw", RequestContentType: {{printf "%q" $endpoint.RequestContentType}}, RawBodyRequired: {{if $endpoint.BodyRequired}}true{{else}}false{{end}}},{{end}}{{- range mcpParamBindings $endpoint (effectiveEndpointPath $resource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}{{if and $hasMCPRequestContentType .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveEndpointPath $resource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
+		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveEndpointPath $resource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if or $endpoint.HeaderOverrides $endpoint.UsesTextResponse}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}}{{if $endpoint.UsesTextResponse}}client.TextResponseHeader: "true",{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- if $endpoint.UsesRawRequestBody}}{Location: "raw", RequestContentType: {{printf "%q" $endpoint.RequestContentType}}, RawBodyRequired: {{if $endpoint.BodyRequired}}true{{else}}false{{end}}},{{end}}{{- range mcpParamBindings $endpoint (effectiveEndpointPath $resource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}{{if .DeepObjectQuery}}, DeepObjectQuery: true{{end}}{{if and $hasMCPRequestContentType .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveEndpointPath $resource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
 {{- end}}
 	)
 {{- end}}
@@ -147,9 +147,9 @@ func RegisterTools(s *server.MCPServer) {
 {{- end}}
 		),
 {{- if $.HasTierRouting}}
-		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveSubEndpointPath $resource $subResource $endpoint)}}, {{printf "%q" (effectiveSubTier $.APISpec $resource $subResource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if or $endpoint.HeaderOverrides $endpoint.UsesTextResponse}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}}{{if $endpoint.UsesTextResponse}}client.TextResponseHeader: "true",{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- if $endpoint.UsesRawRequestBody}}{Location: "raw", RequestContentType: {{printf "%q" $endpoint.RequestContentType}}, RawBodyRequired: {{if $endpoint.BodyRequired}}true{{else}}false{{end}}},{{end}}{{- range mcpParamBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}{{if and $hasMCPRequestContentType .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
+		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveSubEndpointPath $resource $subResource $endpoint)}}, {{printf "%q" (effectiveSubTier $.APISpec $resource $subResource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if or $endpoint.HeaderOverrides $endpoint.UsesTextResponse}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}}{{if $endpoint.UsesTextResponse}}client.TextResponseHeader: "true",{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- if $endpoint.UsesRawRequestBody}}{Location: "raw", RequestContentType: {{printf "%q" $endpoint.RequestContentType}}, RawBodyRequired: {{if $endpoint.BodyRequired}}true{{else}}false{{end}}},{{end}}{{- range mcpParamBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}{{if .DeepObjectQuery}}, DeepObjectQuery: true{{end}}{{if and $hasMCPRequestContentType .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
 {{- else}}
-		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveSubEndpointPath $resource $subResource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if or $endpoint.HeaderOverrides $endpoint.UsesTextResponse}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}}{{if $endpoint.UsesTextResponse}}client.TextResponseHeader: "true",{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- if $endpoint.UsesRawRequestBody}}{Location: "raw", RequestContentType: {{printf "%q" $endpoint.RequestContentType}}, RawBodyRequired: {{if $endpoint.BodyRequired}}true{{else}}false{{end}}},{{end}}{{- range mcpParamBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}{{if and $hasMCPRequestContentType .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
+		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveSubEndpointPath $resource $subResource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if or $endpoint.HeaderOverrides $endpoint.UsesTextResponse}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}}{{if $endpoint.UsesTextResponse}}client.TextResponseHeader: "true",{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- if $endpoint.UsesRawRequestBody}}{Location: "raw", RequestContentType: {{printf "%q" $endpoint.RequestContentType}}, RawBodyRequired: {{if $endpoint.BodyRequired}}true{{else}}false{{end}}},{{end}}{{- range mcpParamBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}{{if .DeepObjectQuery}}, DeepObjectQuery: true{{end}}{{if and $hasMCPRequestContentType .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
 {{- end}}
 	)
 {{- end}}
@@ -219,6 +219,9 @@ type mcpParamBinding struct {
 	QueryArray   bool
 	QueryStyle   string
 	QueryExplode bool
+{{- end}}
+{{- if hasDeepObjectQueryParams .APISpec}}
+	DeepObjectQuery bool
 {{- end}}
 {{- if $hasMCPRequestContentType}}
 	RequestContentType string
@@ -329,6 +332,64 @@ func appendMCPArrayQueryParam(path, name string, value any, style string, explod
 		separator = "&"
 	}
 	return path + separator + query.Encode()
+}
+
+{{- end}}
+
+{{- if hasDeepObjectQueryParams .APISpec}}
+// appendMCPDeepObjectQueryParam appends one style=deepObject query param to
+// the request path as indexed bracket keys: objects -> name[field]=v, arrays
+// -> name[i]=v / name[i][field]=v. value is the native MCP argument
+// (map[string]any / []any); a string value is JSON-decoded first so spec
+// defaults and string-typed agent inputs behave like the CLI's --flag JSON.
+// Shared by the per-endpoint handlers and codeOrchSplitQuery.
+func appendMCPDeepObjectQueryParam(path, name string, value any) (string, error) {
+	decoded := value
+	if raw, ok := value.(string); ok {
+		var parsed any
+		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+			return path, err
+		}
+		decoded = parsed
+	}
+	values := url.Values{}
+	expandMCPDeepObjectValue(values, name, decoded)
+	if len(values) == 0 {
+		return path, nil
+	}
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return path + separator + values.Encode(), nil
+}
+
+// expandMCPDeepObjectValue expands one deepObject-style query param into
+// indexed keys: objects -> name[field]=v, arrays -> name[i]=v /
+// name[i][field]=v. Scalar leaves use formatMCPParamValue; anything nested
+// deeper JSON-encodes fail-soft rather than inventing deeper bracket grammar.
+// URL size is bounded only by the server (414), matching
+// appendMCPArrayQueryParam's posture. Keep structurally in sync with the CLI
+// twin expandDeepObjectValue in internal/cli.
+func expandMCPDeepObjectValue(values url.Values, name string, decoded any) {
+	switch v := decoded.(type) {
+	case map[string]any:
+		for k, item := range v {
+			values.Set(name+"["+k+"]", formatMCPParamValue(item))
+		}
+	case []any:
+		for i, item := range v {
+			if obj, ok := item.(map[string]any); ok {
+				for k, field := range obj {
+					values.Set(fmt.Sprintf("%s[%d][%s]", name, i, k), formatMCPParamValue(field))
+				}
+			} else {
+				values.Set(fmt.Sprintf("%s[%d]", name, i), formatMCPParamValue(item))
+			}
+		}
+	default:
+		values.Set(name, formatMCPParamValue(decoded))
+	}
 }
 
 {{- end}}
@@ -632,7 +693,19 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 				}
 {{- end}}
 			default:
-{{- if hasArrayQueryParams .APISpec}}
+{{- if hasDeepObjectQueryParams .APISpec}}
+				if binding.DeepObjectQuery {
+					var derr error
+					path, derr = appendMCPDeepObjectQueryParam(path, binding.WireName, v)
+					if derr != nil {
+						return mcpToolError(fmt.Sprintf("%s: %v; expected JSON like [{\"field\":\"Name\",\"direction\":\"desc\"}] or {\"key\":\"value\"}", binding.PublicName, derr)), nil
+					}
+				} else {{if hasArrayQueryParams .APISpec}}if binding.QueryArray {
+					path = appendMCPArrayQueryParam(path, binding.WireName, v, binding.QueryStyle, binding.QueryExplode)
+				} else {{end}}{
+					params[binding.WireName] = formatMCPParamValue(v)
+				}
+{{- else if hasArrayQueryParams .APISpec}}
 				if binding.QueryArray {
 					path = appendMCPArrayQueryParam(path, binding.WireName, v, binding.QueryStyle, binding.QueryExplode)
 				} else {

--- a/internal/mcpdesc/compose.go
+++ b/internal/mcpdesc/compose.go
@@ -454,14 +454,56 @@ func appendMethodMarker(desc, method string) string {
 }
 
 func formatParam(p spec.Param) string {
-	if p.Default == nil {
-		return p.PublicInputName()
+	name := p.PublicInputName()
+	if p.Default != nil {
+		if val, ok := formatDefault(p.Default); ok {
+			name += " (default: " + val + ")"
+		}
 	}
-	val, ok := formatDefault(p.Default)
-	if !ok {
-		return p.PublicInputName()
+	if hint := deepObjectHint(p); hint != "" {
+		name += " (" + hint + ")"
 	}
-	return p.PublicInputName() + " (default: " + val + ")"
+	return name
+}
+
+// deepObjectHint returns the input-shape teaching hint for a style=deepObject
+// query param, or "" for every other param. deepObject params take structured
+// JSON input that the generated emitters expand into indexed bracket keys
+// (sort[0][field]=Name); without a shape example in the description, agents
+// guess flat scalars and get 4xxs. The example is built from up to two of the
+// param's Fields names, with a generic fallback when the spec carries no
+// field detail; object-typed params get the object form without the array
+// wrapper.
+func deepObjectHint(p spec.Param) string {
+	if !strings.EqualFold(strings.TrimSpace(p.QueryStyle), "deepObject") {
+		return ""
+	}
+	example := deepObjectExampleObject(p.Fields)
+	if strings.EqualFold(strings.TrimSpace(p.Type), "array") {
+		return "array of objects, e.g. [" + example + "]"
+	}
+	return "e.g. " + example
+}
+
+// deepObjectExampleObject builds a one-line JSON object example from up to
+// two field names, falling back to a generic {"key":"value"} when the spec
+// declares no fields (an empty {} would teach nothing).
+func deepObjectExampleObject(fields []spec.Param) string {
+	var parts []string
+	for _, f := range fields {
+		name := strings.TrimSpace(f.Name)
+		if name == "" {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%q:%q", name, "..."))
+		if len(parts) == 2 {
+			break
+		}
+	}
+	if len(parts) == 0 {
+		return `{"key":"value"}`
+	}
+	return "{" + strings.Join(parts, ",") + "}"
 }
 
 // formatDefault returns the value and true when usable inline, or

--- a/internal/mcpdesc/compose_test.go
+++ b/internal/mcpdesc/compose_test.go
@@ -544,3 +544,84 @@ func TestComposeWithSourceMarksAuthoredDescriptionsAsSpec(t *testing.T) {
 	assert.Equal(t, "Add a widget to inventory.", result.Description)
 	assert.Equal(t, SourceSpec, result.Source)
 }
+
+// --- deepObject shape hints (aos-build#165 plan, Task 6) ---
+//
+// style=deepObject params take structured JSON input that the generated
+// emitters expand into indexed bracket keys (sort[0][field]=Name). Without a
+// shape example in the tool description, agents guess flat scalars and get
+// 4xxs — the hint makes each description self-teaching.
+//
+// Expectations pin the RENDERED description: the hint is authored as real
+// JSON, but every Compose result passes through naming.MCPDescription →
+// OneLineNormalize, whose pre-existing policy rewrites double quotes to
+// single quotes so descriptions embed cleanly. Agents therefore see
+// [{'field':'...'}] — the shape survives, the quoting is normalized.
+
+// (i) An array-of-objects deepObject param's hint is built from its Fields,
+// capped at two field names.
+func TestCompose_DeepObjectArrayParamGainsFieldsShapeHint(t *testing.T) {
+	t.Parallel()
+
+	in := Input{
+		Endpoint: spec.Endpoint{
+			Method:      "GET",
+			Path:        "/records",
+			Description: "List records",
+			Params: []spec.Param{{
+				Name: "sort", Type: "array", ItemType: "object", QueryStyle: "deepObject",
+				Fields: []spec.Param{
+					{Name: "field", Type: "string"},
+					{Name: "direction", Type: "string"},
+					{Name: "third_field_beyond_cap", Type: "string"},
+				},
+			}},
+			Response: spec.ResponseDef{Type: "array", Item: "Record"},
+		},
+		AuthType: "none",
+	}
+	got := Compose(in)
+	assert.Equal(t, `List records. Optional: sort (array of objects, e.g. [{'field':'...','direction':'...'}]). Returns array of Record.`, got)
+}
+
+// (ii) A Fields-less deepObject param falls back to the generic example
+// rather than emitting an empty object (Designer round-2).
+func TestCompose_DeepObjectParamWithoutFieldsGetsGenericHint(t *testing.T) {
+	t.Parallel()
+
+	in := Input{
+		Endpoint: spec.Endpoint{
+			Method:      "GET",
+			Path:        "/records",
+			Description: "List records",
+			Params: []spec.Param{{
+				Name: "sort", Type: "array", ItemType: "object", QueryStyle: "deepObject",
+			}},
+			Response: spec.ResponseDef{Type: "array", Item: "Record"},
+		},
+		AuthType: "none",
+	}
+	got := Compose(in)
+	assert.Equal(t, `List records. Optional: sort (array of objects, e.g. [{'key':'value'}]). Returns array of Record.`, got)
+}
+
+// (iii) An OBJECT-typed deepObject param gets the object-form hint (no array
+// wrapper).
+func TestCompose_DeepObjectObjectParamGetsObjectFormHint(t *testing.T) {
+	t.Parallel()
+
+	in := Input{
+		Endpoint: spec.Endpoint{
+			Method:      "GET",
+			Path:        "/records",
+			Description: "List records",
+			Params: []spec.Param{{
+				Name: "filter", Type: "object", QueryStyle: "deepObject",
+			}},
+			Response: spec.ResponseDef{Type: "array", Item: "Record"},
+		},
+		AuthType: "none",
+	}
+	got := Compose(in)
+	assert.Equal(t, `List records. Optional: filter (e.g. {'key':'value'}). Returns array of Record.`, got)
+}

--- a/internal/mcpdesc/compose_test.go
+++ b/internal/mcpdesc/compose_test.go
@@ -625,3 +625,29 @@ func TestCompose_DeepObjectObjectParamGetsObjectFormHint(t *testing.T) {
 	got := Compose(in)
 	assert.Equal(t, `List records. Optional: filter (e.g. {'key':'value'}). Returns array of Record.`, got)
 }
+
+// (iv) Negative pin: the shape hint is gated on style=deepObject, NOT on
+// array-ness. A plain array query param (form/explode — the repeated-key
+// wire form, e.g. recorded_by[]) keeps its unadorned public name; appending
+// a JSON-shape hint here would teach agents to send JSON where the emitter
+// expects a scalar list. Guards deepObjectHint's early return.
+func TestCompose_ArrayParamWithoutDeepObjectStyleGetsNoShapeHint(t *testing.T) {
+	t.Parallel()
+
+	explode := true
+	in := Input{
+		Endpoint: spec.Endpoint{
+			Method:      "GET",
+			Path:        "/records",
+			Description: "List records",
+			Params: []spec.Param{{
+				Name: "recorded_by[]", Type: "array", ItemType: "string",
+				QueryStyle: "form", QueryExplode: &explode,
+			}},
+			Response: spec.ResponseDef{Type: "array", Item: "Record"},
+		},
+		AuthType: "none",
+	}
+	got := Compose(in)
+	assert.Equal(t, `List records. Optional: recorded_by. Returns array of Record.`, got)
+}

--- a/internal/pipeline/toolsmanifest_bracket_test.go
+++ b/internal/pipeline/toolsmanifest_bracket_test.go
@@ -1,0 +1,116 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/generator"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestManifestBracketParamNameAndWireName pins the manifest half of the MCP
+// property-key sanitization: a vendor bracket query param (fathom-style
+// recorded_by[]) must surface in tools-manifest.json with the SANITIZED
+// public name and the raw bracket form preserved as wire_name, while a clean
+// param keeps wire_name omitted (no churn for legal names).
+func TestManifestBracketParamNameAndWireName(t *testing.T) {
+	dir := t.TempDir()
+	parsed := &spec.APISpec{
+		Name:    "bracket-manifest",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Resources: map[string]spec.Resource{
+			"meetings": {
+				Description: "Meetings",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/meetings",
+						Description: "List meetings",
+						Params: []spec.Param{
+							{Name: "recorded_by[]", Type: "array", ItemType: "string", Description: "Recorder emails"},
+							{Name: "cursor", Type: "string", Description: "Pagination cursor"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, WriteToolsManifest(dir, parsed))
+	got, err := ReadToolsManifest(dir)
+	require.NoError(t, err)
+
+	require.Len(t, got.Tools, 1)
+	tool := got.Tools[0]
+	require.Equal(t, "meetings_list", tool.Name)
+	require.Len(t, tool.Params, 2)
+
+	assert.Equal(t, "recorded_by", tool.Params[0].Name,
+		"manifest param name must be the sanitized public input name")
+	assert.Equal(t, "recorded_by[]", tool.Params[0].WireName,
+		"manifest wire_name must preserve the raw bracket wire key")
+
+	assert.Equal(t, "cursor", tool.Params[1].Name)
+	assert.Equal(t, "", tool.Params[1].WireName,
+		"legal names must keep wire_name omitted — no churn when name == wire name")
+}
+
+// TestManifestNamesLockstepWithSchemaKeys pins the manifest-suffix residual:
+// uniqueManifestParamName's silent "-2" suffixing must be a NO-OP for every
+// spec that generates. foo[] and foo collide pre-dedup (their public names
+// both sanitize to "foo"); the generator's flag-collision dedup pass rescues
+// the collision by assigning an IdentName, so post-generation every manifest
+// param name must equal its param's PublicInputName() verbatim — the manifest
+// suffixer invents nothing and manifest names cannot diverge from the emitted
+// MCP schema keys on the Generate path. (Residual-collision specs never get
+// here — they fail generation via the generator's post-dedup assertion. The
+// direct-WriteToolsManifest publish path bypasses the generator gate by
+// construction; that pre-existing residual is dispositioned in the upstream
+// PR's Output Contract.)
+func TestManifestNamesLockstepWithSchemaKeys(t *testing.T) {
+	apiSpec := &spec.APISpec{
+		Name:    "lockstep",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/lockstep-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Description: "Items",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/items",
+						Description: "List items",
+						Params: []spec.Param{
+							{Name: "foo[]", Type: "array", ItemType: "string", Description: "Array form"},
+							{Name: "foo", Type: "string", Description: "Scalar form"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Generate() runs the flag-collision dedup pass over the SAME in-memory
+	// spec, assigning final IdentNames (internal/pipeline already imports
+	// internal/generator, so this direction is cycle-free).
+	require.NoError(t, generator.New(apiSpec, t.TempDir()).Generate())
+
+	ep := apiSpec.Resources["items"].Endpoints["list"]
+	require.NotEqual(t, ep.Params[0].PublicInputName(), ep.Params[1].PublicInputName(),
+		"dedup must have rescued the foo[]/foo public-name collision")
+
+	tool := buildManifestTool("items_list", ep.Description, "", ep,
+		func(p spec.Param) string { return p.Description })
+	require.Len(t, tool.Params, len(ep.Params))
+	for i, p := range ep.Params {
+		assert.Equal(t, p.PublicInputName(), tool.Params[i].Name,
+			"manifest param %d name must equal PublicInputName() verbatim — the manifest suffixer must be a no-op on the Generate path", i)
+	}
+}

--- a/internal/spec/public_input_name_test.go
+++ b/internal/spec/public_input_name_test.go
@@ -1,0 +1,68 @@
+package spec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublicInputNameSanitizesIllegalWireNames(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "bracket suffix (fathom precedent)", in: "recorded_by[]", want: "recorded_by"},
+		{name: "bracket infix", in: "date[start]", want: "date_start"},
+		{name: "bracket infix sibling stays distinct", in: "date[stop]", want: "date_stop"},
+		{name: "clean snake unchanged", in: "dry_run", want: "dry_run"},
+		{name: "clean camel unchanged", in: "locationId", want: "locationId"},
+		{name: "clean dotted unchanged", in: "type.params.limit", want: "type.params.limit"},
+		{name: "run of illegal chars collapses to one underscore", in: "a[<>]b", want: "a_b"},
+		{name: "leading illegal trimmed", in: "$top", want: "top"},
+		{name: "64-clamp with post-clamp re-trim", in: strings.Repeat("a", 63) + "[]" + "tail", want: strings.Repeat("a", 63)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Param{Name: tt.in}
+			require.Equal(t, tt.want, p.PublicInputName())
+		})
+	}
+}
+
+// Two long names identical in their first 64 chars clamp to the SAME public
+// key — documented here at the unit level; the generator's post-dedup
+// assertion (Task 3) is what turns this into a loud generation failure.
+func TestPublicInputNameClampCollision(t *testing.T) {
+	t.Parallel()
+	head := strings.Repeat("a", 64)
+	require.Equal(t,
+		Param{Name: head + "[one]"}.PublicInputName(),
+		Param{Name: head + "[two]"}.PublicInputName())
+}
+
+// The all-illegal floor returns the RAW name so the post-dedup generation
+// assertion (Task 3) fails loudly — never a synthetic placeholder.
+func TestPublicInputNameAllIllegalReturnsRaw(t *testing.T) {
+	t.Parallel()
+	p := Param{Name: "<<>>"}
+	require.Equal(t, "<<>>", p.PublicInputName())
+}
+
+// FlagName / IdentName branches are untouched by the sanitizer.
+func TestPublicInputNamePrecedenceUnchanged(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "explicit-name", Param{Name: "recorded_by[]", FlagName: "explicit-name"}.PublicInputName())
+	require.Equal(t, "recorded-by-2", Param{Name: "recorded_by[]", IdentName: "recorded_by[]_2"}.PublicInputName())
+}
+
+func TestMCPPropertyKeyRe(t *testing.T) {
+	t.Parallel()
+	require.True(t, MCPPropertyKeyRe.MatchString("recorded_by"))
+	require.True(t, MCPPropertyKeyRe.MatchString("locationId"))
+	require.False(t, MCPPropertyKeyRe.MatchString("recorded_by[]"))
+	require.False(t, MCPPropertyKeyRe.MatchString(""))
+	require.False(t, MCPPropertyKeyRe.MatchString(strings.Repeat("a", 65)))
+}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -2646,6 +2646,52 @@ func (p Param) BodyWireName() string {
 	return p.Name
 }
 
+// MCPPropertyKeyPattern is the grammar Anthropic's Messages API enforces on
+// tool input_schema property keys. A generated MCP tool whose schema carries a
+// key outside this pattern bricks the calling agent session at schema load:
+// every subsequent turn fails with a 400 pattern-mismatch because the poisoned
+// tool definition rides along in every request (HelpFlow/aos-build#165).
+const MCPPropertyKeyPattern = `^[a-zA-Z0-9_.-]{1,64}$`
+
+// MCPPropertyKeyRe is the compiled form of MCPPropertyKeyPattern, shared by
+// the sanitizer below and the generator's post-dedup input-name assertion.
+var MCPPropertyKeyRe = regexp.MustCompile(MCPPropertyKeyPattern)
+
+// sanitizePublicInputName makes a wire parameter name safe to expose as a
+// model-facing MCP property key while leaving legal names byte-identical.
+// Each run of illegal characters becomes one "_", the result is trimmed of
+// leading/trailing "_", clamped to 64 chars, and re-trimmed. A name that
+// sanitizes to empty is returned RAW so the generator's post-dedup assertion
+// fails generation loudly instead of shipping an invented public name.
+func sanitizePublicInputName(name string) string {
+	if MCPPropertyKeyRe.MatchString(name) {
+		return name
+	}
+	var b strings.Builder
+	pendingSep := false
+	for _, r := range name {
+		legal := r == '.' || r == '-' || r == '_' ||
+			(r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+		if legal {
+			if pendingSep && b.Len() > 0 {
+				b.WriteByte('_')
+			}
+			pendingSep = false
+			b.WriteRune(r)
+		} else {
+			pendingSep = true
+		}
+	}
+	out := strings.Trim(b.String(), "_")
+	if len(out) > 64 {
+		out = strings.Trim(out[:64], "_")
+	}
+	if out == "" {
+		return name
+	}
+	return out
+}
+
 func (p Param) PublicInputName() string {
 	if p.FlagName != "" {
 		return p.FlagName
@@ -2653,7 +2699,7 @@ func (p Param) PublicInputName() string {
 	if p.IdentName != "" {
 		return publicInputNameFromIdent(p.IdentName)
 	}
-	return p.Name
+	return sanitizePublicInputName(p.Name)
 }
 
 func publicInputNameFromIdent(name string) string {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -5727,6 +5727,9 @@ func validateIntents(intents []Intent, resources map[string]Resource) error {
 			if p.Name == "" {
 				return fmt.Errorf("mcp.intents[%d] (%s): params[%d].name is required", i, intent.Name, pi)
 			}
+			if !MCPPropertyKeyRe.MatchString(p.Name) {
+				return fmt.Errorf("mcp.intents[%d] (%s): param name %q must match %s (1-64 chars): it is emitted as an MCP tool property key, and an illegal key bricks the calling agent session", i, intent.Name, p.Name, MCPPropertyKeyPattern)
+			}
 			if _, ok := allowedIntentParamTypes[p.Type]; !ok {
 				return fmt.Errorf("mcp.intents[%d] (%s): params[%d] (%s): type %q must be one of string, integer, boolean", i, intent.Name, pi, p.Name, p.Type)
 			}

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -4277,6 +4277,40 @@ func TestMCPIntentsValidation(t *testing.T) {
 	}
 }
 
+// TestValidateIntentsRejectsIllegalParamName pins that intent param names are
+// validated against the Anthropic MCP tool property-key grammar
+// (MCPPropertyKeyPattern): intent params are emitted verbatim as MCP schema
+// keys, and an illegal key (e.g. the fathom-style recorded_by[]) bricks the
+// calling agent session at schema load (HelpFlow/aos-build#165).
+func TestValidateIntentsRejectsIllegalParamName(t *testing.T) {
+	t.Parallel()
+	s := APISpec{
+		Name:    "demo",
+		BaseURL: "http://x",
+		Resources: map[string]Resource{
+			"items": {
+				Endpoints: map[string]Endpoint{
+					"get":  {Method: "GET", Path: "/items/{id}"},
+					"list": {Method: "GET", Path: "/items"},
+				},
+			},
+		},
+		MCP: MCPConfig{Intents: []Intent{{
+			Name:        "get_item",
+			Description: "Get an item",
+			Params:      []IntentParam{{Name: "recorded_by[]", Type: "string", Required: true, Description: "id"}},
+			Steps: []IntentStep{
+				{Endpoint: "items.get", Capture: "item"},
+			},
+			Returns: "item",
+		}}},
+	}
+	err := s.Validate()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "recorded_by[]")
+	require.ErrorContains(t, err, MCPPropertyKeyPattern)
+}
+
 func TestMCPOrchestrationValidation(t *testing.T) {
 	base := func(mcp MCPConfig) APISpec {
 		return APISpec{

--- a/testdata/golden/cases/generate-public-param-names/artifacts.txt
+++ b/testdata/golden/cases/generate-public-param-names/artifacts.txt
@@ -1,5 +1,6 @@
 public-param-golden/internal/cli/stores_find.go
 public-param-golden/internal/cli/stores_create.go
+public-param-golden/internal/cli/helpers.go
 public-param-golden/internal/mcp/tools.go
 public-param-golden/tools-manifest.json
 public-param-golden/README.md

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -32,10 +32,21 @@ var As = errors.As
 const paginatedGetMaxPages = 100
 
 func formatCLIParamValue(v any) string {
-	if f, ok := v.(float64); ok {
-		return strconv.FormatFloat(f, 'f', -1, 64)
+	switch tv := v.(type) {
+	case float64:
+		return strconv.FormatFloat(tv, 'f', -1, 64)
+	case map[string]any, []any:
+		// Composite values (a decoded JSON object/array element bound to a
+		// query slot) must stay valid JSON on the wire; fmt's rendering would
+		// emit "map[...]"/"[a b c]" garbage. Mirrors formatMCPParamValue's
+		// composite branch so the CLI and MCP surfaces serialize identically.
+		if b, err := json.Marshal(tv); err == nil {
+			return string(b)
+		}
+		return fmt.Sprintf("%v", tv)
+	default:
+		return fmt.Sprintf("%v", v)
 	}
-	return fmt.Sprintf("%v", v)
 }
 
 // noColor is set by the --no-color flag

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -31,10 +31,21 @@ var As = errors.As
 const paginatedGetMaxPages = 100
 
 func formatCLIParamValue(v any) string {
-	if f, ok := v.(float64); ok {
-		return strconv.FormatFloat(f, 'f', -1, 64)
+	switch tv := v.(type) {
+	case float64:
+		return strconv.FormatFloat(tv, 'f', -1, 64)
+	case map[string]any, []any:
+		// Composite values (a decoded JSON object/array element bound to a
+		// query slot) must stay valid JSON on the wire; fmt's rendering would
+		// emit "map[...]"/"[a b c]" garbage. Mirrors formatMCPParamValue's
+		// composite branch so the CLI and MCP surfaces serialize identically.
+		if b, err := json.Marshal(tv); err == nil {
+			return string(b)
+		}
+		return fmt.Sprintf("%v", tv)
+	default:
+		return fmt.Sprintf("%v", v)
 	}
-	return fmt.Sprintf("%v", v)
 }
 
 // noColor is set by the --no-color flag

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
@@ -302,7 +302,7 @@ func detectPartialFailure(data []byte) *partialFailureReport {
 //	        return cmd.Help()
 //	    }
 //	    if dryRunOK(flags) {
-//	        return nil
+//	        return writeDryRun(cmd.OutOrStdout(), flags, "<command name>")
 //	    }
 //	    // ... real work ...
 //	}
@@ -310,6 +310,25 @@ func detectPartialFailure(data []byte) *partialFailureReport {
 // See SKILL.md "Phase 3: Build The GOAT" for the full pattern.
 func dryRunOK(flags *rootFlags) bool {
 	return flags != nil && flags.dryRun
+}
+
+type dryRunResult struct {
+	DryRun bool   `json:"dry_run"`
+	Action string `json:"action"`
+	Would  string `json:"would"`
+}
+
+// writeDryRun ends a --dry-run short-circuit by reporting the action that was
+// skipped. Returning silently leaves a --json caller with empty stdout, which
+// is indistinguishable from a broken command rather than a deliberate no-op.
+// Callers pass cmd.OutOrStdout() so the report follows any redirected writer.
+func writeDryRun(w io.Writer, flags *rootFlags, action string) error {
+	would := "run " + action + "; no changes made"
+	if flags != nil && flags.asJSON {
+		return json.NewEncoder(w).Encode(dryRunResult{DryRun: true, Action: action, Would: would})
+	}
+	_, err := fmt.Fprintf(w, "dry-run: would %s\n", would)
+	return err
 }
 
 // boundCtx applies the root --timeout flag to hand-written command work that

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
@@ -12,12 +12,12 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
-	"printing-press-golden-pp-cli/internal/client"
-	"printing-press-golden-pp-cli/internal/cliutil"
-	"printing-press-golden-pp-cli/internal/platform"
-	"regexp"
+	"public-param-golden-pp-cli/internal/client"
+	"public-param-golden-pp-cli/internal/cliutil"
+	"public-param-golden-pp-cli/internal/platform"
 	"sort"
 	"strconv"
 	"strings"
@@ -45,6 +45,97 @@ func formatCLIParamValue(v any) string {
 		return fmt.Sprintf("%v", tv)
 	default:
 		return fmt.Sprintf("%v", v)
+	}
+}
+func appendArrayQueryParam(path, name, raw, style string, explode bool) string {
+	values := make([]string, 0)
+	var decoded []any
+	if json.Unmarshal([]byte(raw), &decoded) == nil {
+		for _, value := range decoded {
+			values = append(values, formatCLIParamValue(value))
+		}
+	} else {
+		for _, value := range strings.Split(raw, ",") {
+			if value = strings.TrimSpace(value); value != "" {
+				values = append(values, value)
+			}
+		}
+	}
+	if len(values) == 0 {
+		return path
+	}
+
+	query := url.Values{}
+	switch style {
+	case "spaceDelimited":
+		query.Set(name, strings.Join(values, " "))
+	case "pipeDelimited":
+		query.Set(name, strings.Join(values, "|"))
+	case "form":
+		if explode {
+			for _, value := range values {
+				query.Add(name, value)
+			}
+		} else {
+			query.Set(name, strings.Join(values, ","))
+		}
+	default:
+		query.Set(name, raw)
+	}
+
+	encoded := query.Encode()
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return path + separator + encoded
+}
+
+// appendDeepObjectQueryParam appends one style=deepObject query param to the
+// request path as indexed bracket keys: objects -> name[field]=v, arrays ->
+// name[i]=v / name[i][field]=v. raw is the flag's JSON string.
+func appendDeepObjectQueryParam(path, name, raw string) (string, error) {
+	var decoded any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return path, fmt.Errorf("--%s: expected JSON (e.g. [{\"field\":\"Name\",\"direction\":\"desc\"}] or {\"key\":\"value\"}): %w", name, err)
+	}
+	values := url.Values{}
+	expandDeepObjectValue(values, name, decoded)
+	if len(values) == 0 {
+		return path, nil
+	}
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return path + separator + values.Encode(), nil
+}
+
+// expandDeepObjectValue expands one deepObject-style query param into indexed
+// keys: objects -> name[field]=v, arrays -> name[i]=v / name[i][field]=v.
+// Scalar leaves use formatCLIParamValue; anything nested deeper JSON-encodes
+// fail-soft rather than inventing deeper bracket grammar. URL size is bounded
+// only by the server (414), matching appendArrayQueryParam's posture. Keep
+// structurally in sync with the MCP twin expandMCPDeepObjectValue in
+// internal/mcp.
+func expandDeepObjectValue(values url.Values, name string, decoded any) {
+	switch v := decoded.(type) {
+	case map[string]any:
+		for k, item := range v {
+			values.Set(name+"["+k+"]", formatCLIParamValue(item))
+		}
+	case []any:
+		for i, item := range v {
+			if obj, ok := item.(map[string]any); ok {
+				for k, field := range obj {
+					values.Set(fmt.Sprintf("%s[%d][%s]", name, i, k), formatCLIParamValue(field))
+				}
+			} else {
+				values.Set(fmt.Sprintf("%s[%d]", name, i), formatCLIParamValue(item))
+			}
+		}
+	default:
+		values.Set(name, formatCLIParamValue(decoded))
 	}
 }
 
@@ -211,7 +302,7 @@ func detectPartialFailure(data []byte) *partialFailureReport {
 //	        return cmd.Help()
 //	    }
 //	    if dryRunOK(flags) {
-//	        return writeDryRun(cmd.OutOrStdout(), flags, "<command name>")
+//	        return nil
 //	    }
 //	    // ... real work ...
 //	}
@@ -219,25 +310,6 @@ func detectPartialFailure(data []byte) *partialFailureReport {
 // See SKILL.md "Phase 3: Build The GOAT" for the full pattern.
 func dryRunOK(flags *rootFlags) bool {
 	return flags != nil && flags.dryRun
-}
-
-type dryRunResult struct {
-	DryRun bool   `json:"dry_run"`
-	Action string `json:"action"`
-	Would  string `json:"would"`
-}
-
-// writeDryRun ends a --dry-run short-circuit by reporting the action that was
-// skipped. Returning silently leaves a --json caller with empty stdout, which
-// is indistinguishable from a broken command rather than a deliberate no-op.
-// Callers pass cmd.OutOrStdout() so the report follows any redirected writer.
-func writeDryRun(w io.Writer, flags *rootFlags, action string) error {
-	would := "run " + action + "; no changes made"
-	if flags != nil && flags.asJSON {
-		return json.NewEncoder(w).Encode(dryRunResult{DryRun: true, Action: action, Would: would})
-	}
-	_, err := fmt.Fprintf(w, "dry-run: would %s\n", would)
-	return err
 }
 
 // boundCtx applies the root --timeout flag to hand-written command work that
@@ -489,96 +561,11 @@ func (p *syncUserParams) validateResourceNames(known []string) error {
 		strings.Join(unknown, ", "), strings.Join(known, ", "))
 }
 
-// accessDenialPatterns matches API error bodies that indicate the request was
-// rejected for access-policy reasons rather than for input validity. Matching
-// is case-insensitive and uses word boundaries so common substrings inside
-// unrelated tokens (e.g. "author", "pagination_token", "insufficient_funds")
-// do not produce false positives. The set deliberately excludes brand names —
-// vendor-specific phrasings should be addressed at the spec/profiler level,
-// not in this universal classifier.
-var accessDenialPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`\bforbidden\b`),
-	regexp.MustCompile(`\bunauthorized\b`),
-	regexp.MustCompile(`\bnot[\s_-]?authorized\b`),
-	regexp.MustCompile(`\bpermission[\s_-]?denied\b`),
-	regexp.MustCompile(`\baccess[\s_-]?denied\b`),
-	regexp.MustCompile(`\binsufficient[\s_-]?(scope|permission|privilege)`),
-	regexp.MustCompile(`\binvalid[\s_-]?scope\b`),
-	regexp.MustCompile(`\bmissing[\s_-]?scope\b`),
-	regexp.MustCompile(`\brequires?\s+(elevated|admin|enterprise|business|workspace|enterprise[\s_-]?tier)`),
-}
-
-// looksLikeAccessDenial reports whether body text describes an access-policy
-// rejection. Use it on response-body content (apiErr.Body), not on the full
-// error string — the request path can contain words like "auth" or "tokens"
-// that would produce false positives if the whole error message were scanned.
-func looksLikeAccessDenial(body string) bool {
-	lower := strings.ToLower(body)
-	for _, p := range accessDenialPatterns {
-		if p.MatchString(lower) {
-			return true
-		}
-	}
-	return false
-}
-
-// argumentMissingPatterns matches API error bodies that indicate the endpoint
-// requires a filter or identifier the vendor spec did not mark as required.
-// Each pattern keeps the missing/required/not-provided signal adjacent to an
-// argument noun so an unrelated 400 (e.g. "required field 'email' format is
-// invalid and the avatar is missing", "no results were provided") is not
-// demoted from a hard failure to a warning.
-var argumentMissingPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`\bargument(?:\s+is)?\s+missing\b`),
-	regexp.MustCompile(`\bmissing\s+(?:a\s+|an\s+|the\s+)?(?:required\s+)?(?:argument|parameter|param|field|filter|identifier|id)\b`),
-	regexp.MustCompile(`\brequired\s+(?:argument|parameter|param|filter|identifier|id)\b[^.\n]*\b(?:is\s+)?(?:missing|not\s+provided|not\s+supplied)\b`),
-	regexp.MustCompile(`\b(?:argument|parameter|param|filter)\s+(?:is\s+)?required\b`),
-	regexp.MustCompile(`\bno\s+(?:argument|parameter|param|filter|identifier|id)\b[^.\n]*\bprovided\b`),
-}
-
-func looksLikeArgumentMissing(body string) bool {
-	lower := strings.ToLower(body)
-	for _, p := range argumentMissingPatterns {
-		if p.MatchString(lower) {
-			return true
-		}
-	}
-	return false
-}
-
-// isSyncAccessWarning classifies err as an access-denial warning suitable for
-// sync's warn-and-continue path. It returns nil, false for any error that
-// should remain a hard sync failure: HTTP 401 (token-level auth failure
-// requiring re-auth), 5xx, network errors, and HTTP 400 responses whose
-// bodies do not match an access-policy pattern.
-//
-// Recognized warning shapes:
-//   - HTTP 403 (per-resource ACL rejection)
-//   - HTTP 400 + access-denial body keyword (insufficient scope, etc.)
-//   - HTTP 400 + missing required argument body keyword
-//   - GraphQL response carrying only access-denial extension codes
-func isSyncAccessWarning(err error) (*accessWarning, bool) {
-	if err == nil {
-		return nil, false
-	}
-
-	var apiErr *client.APIError
-	if errors.As(err, &apiErr) {
-		switch apiErr.StatusCode {
-		case 403:
-			return &accessWarning{Status: 403, Reason: "forbidden", Message: apiErr.Body}, true
-		case 400:
-			if looksLikeAccessDenial(apiErr.Body) {
-				return &accessWarning{Status: 400, Reason: "insufficient_access", Message: apiErr.Body}, true
-			}
-			if looksLikeArgumentMissing(apiErr.Body) {
-				return &accessWarning{Status: 400, Reason: "argument_missing", Message: apiErr.Body}, true
-			}
-		}
-	}
-
-	return nil, false
-}
+// isSyncAccessWarning is a stub: this CLI has no auth, so the API cannot
+// reject sync requests on access-policy grounds. Every error stays a hard
+// failure. Defining the function unconditionally keeps sync.go agnostic to
+// auth presence.
+func isSyncAccessWarning(err error) (*accessWarning, bool) { return nil, false }
 
 type noopResult struct {
 	Status string `json:"status"`
@@ -619,22 +606,12 @@ func classifyAPIError(err error, flags *rootFlags) error {
 		classified := apiErr(err)
 		writeAPIErrorEnvelope(flags, classified, ExitCode(classified))
 		return classified
-	case errors.Is(err, client.ErrPlaceholderCredential):
-		return authErr(err)
-	case strings.Contains(msg, "HTTP 400") && cliutil.LooksLikeAuthError(msg):
-		return authErr(fmt.Errorf("%w\nhint: the API rejected the request — this usually means auth is missing or invalid."+
-			"\n      Set your API key with: export PRINTING_PRESS_GOLDEN_API_KEY=\"your-token-here\""+
-			"\n      Run 'printing-press-golden-pp-cli doctor' to check auth status."+
-			"\n      Response: "+cliutil.SanitizeErrorBody(msg), err))
 	case strings.Contains(msg, "HTTP 401"):
-		return authErr(fmt.Errorf("%w\nhint: check your API key."+
-			" Set your API key with: export PRINTING_PRESS_GOLDEN_API_KEY=\"your-token-here\""+
-			"\n      Run 'printing-press-golden-pp-cli doctor' to check auth status.", err))
+		return authErr(fmt.Errorf("%w\nhint: check your API credentials."+
+			"\n      Run 'public-param-golden-pp-cli doctor' to check auth status.", err))
 	case strings.Contains(msg, "HTTP 403"):
-		return authErr(fmt.Errorf("%w\nhint: permission denied. Your credentials are valid but lack access to this resource."+
-			"\n      Check that your credentials have the required permissions and match the API's expected auth scheme."+
-			"\n      Set your API key with: export PRINTING_PRESS_GOLDEN_API_KEY=\"your-token-here\""+
-			"\n      Run 'printing-press-golden-pp-cli doctor' to check auth status.", err))
+		return authErr(fmt.Errorf("%w\nhint: permission denied. This API is configured without credentials, so the service may be blocking the request by rate limit, geography, bot protection, or endpoint policy."+
+			"\n      Run 'public-param-golden-pp-cli doctor' to check connectivity.", err))
 	case strings.Contains(msg, "HTTP 404"):
 		return notFoundErr(fmt.Errorf("%w\nhint: resource not found. Run the 'list' command to see available items", err))
 	case strings.Contains(msg, "HTTP 429"):
@@ -656,64 +633,6 @@ func truncate(s string, max int) string {
 
 func newTabWriter(w io.Writer) *tabwriter.Writer {
 	return tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
-}
-
-// replacePathParam escapes path-param values before substituting them so
-// reserved characters within each segment remain safe in the request URL.
-func replacePathParam(path, name, value string) string {
-	return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(value))
-}
-
-const responsePathItemsKey = "__printing_press_response_path_items"
-
-type responsePathPaginatedClient struct {
-	client interface {
-		GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
-	}
-	responsePath string
-}
-
-func (c responsePathPaginatedClient) IsDryRun() bool {
-	dryRunClient, ok := c.client.(interface{ IsDryRun() bool })
-	return ok && dryRunClient.IsDryRun()
-}
-
-func (c responsePathPaginatedClient) GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
-	data, err := c.client.GetWithHeaders(ctx, path, params, headers)
-	if err != nil || isDryRunResponseForClient(c.client, data) {
-		return data, err
-	}
-	selected, ok := responsePayloadAtPath(data, c.responsePath)
-	if !ok {
-		return nil, fmt.Errorf("response_path %q not found in response", c.responsePath)
-	}
-	if !isJSONArray(selected) {
-		return nil, fmt.Errorf("response_path %q must resolve to an array", c.responsePath)
-	}
-	var root map[string]json.RawMessage
-	if err := json.Unmarshal(data, &root); err != nil {
-		return nil, fmt.Errorf("response_path %q requires an object response envelope: %w", c.responsePath, err)
-	}
-	root[responsePathItemsKey] = selected
-	transformed, err := json.Marshal(root)
-	if err != nil {
-		return nil, fmt.Errorf("wrap response_path %q: %w", c.responsePath, err)
-	}
-	return transformed, nil
-}
-
-func paginatedGetWithResponsePath(ctx context.Context, c interface {
-	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
-}, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string) (json.RawMessage, error) {
-	if responsePath == "" {
-		return paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
-	}
-	wrapped := responsePathPaginatedClient{client: c, responsePath: responsePath}
-	data, err := paginatedGet(ctx, wrapped, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
-	if err != nil || fetchAll {
-		return data, err
-	}
-	return applyResponsePath(data, responsePath), nil
 }
 
 // paginatedGet fetches pages and concatenates array results. The headers
@@ -770,9 +689,6 @@ func paginatedGet(ctx context.Context, c interface {
 
 	// Fetch all pages
 	allItems := make([]json.RawMessage, 0)
-	var collectionEnvelope map[string]json.RawMessage
-	collectionField := ""
-	collectionShapeSet := false
 	seenCursorTokens := map[string]struct{}{}
 	if sentCursor := clean[cursorParam]; sentCursor != "" {
 		seenCursorTokens[sentCursor] = struct{}{}
@@ -798,10 +714,6 @@ func paginatedGet(ctx context.Context, c interface {
 		// Try to extract items array
 		var items []json.RawMessage
 		if json.Unmarshal(data, &items) == nil {
-			if collectionShapeSet && collectionField != "" {
-				return nil, fmt.Errorf("paginated response collection changed from %q to a bare array", collectionField)
-			}
-			collectionShapeSet = true
 			allItems = append(allItems, items...)
 			if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, pageSize, len(items)); ok {
 				if page >= paginatedGetMaxPages {
@@ -816,24 +728,7 @@ func paginatedGet(ctx context.Context, c interface {
 			var obj map[string]json.RawMessage
 			if json.Unmarshal(data, &obj) == nil {
 				itemCount := 0
-				field, preserve := paginatedCollectionEnvelopeField(obj, path)
-				nested, ok := extractPaginatedItems(obj, path)
-				if !ok && preserve {
-					ok = json.Unmarshal(obj[field], &nested) == nil
-				}
-				if ok {
-					if !collectionShapeSet {
-						collectionShapeSet = true
-						if preserve {
-							collectionField = field
-							collectionEnvelope = cloneRawObject(obj)
-						}
-					} else if (collectionField != "" && (!preserve || !strings.EqualFold(collectionField, field))) || (collectionField == "" && preserve) {
-						if collectionField != "" {
-							return nil, fmt.Errorf("paginated response collection changed from %q", collectionField)
-						}
-						return nil, fmt.Errorf("paginated response collection changed from a canonical array to %q", field)
-					}
+				if nested, ok := extractPaginatedItems(obj, path); ok {
 					allItems = append(allItems, nested...)
 					itemCount = len(nested)
 				}
@@ -913,106 +808,10 @@ func paginatedGet(ctx context.Context, c interface {
 	} else {
 		fmt.Fprintf(os.Stderr, `{"event":"complete","total":%d,"pages":%d}`+"\n", len(allItems), page)
 	}
-	var result []byte
-	if collectionField != "" {
-		collectionEnvelope[collectionField], _ = json.Marshal(allItems)
-		deleteRawPath(collectionEnvelope, cursorLookupPath)
-		deleteRawPath(collectionEnvelope, hasMoreField)
-		if paginationType == "offset" || paginationType == "page" {
-			deleteRawPath(collectionEnvelope, cursorParam)
-		}
-		result, _ = json.Marshal(collectionEnvelope)
-	} else {
-		result, _ = json.Marshal(allItems)
-	}
+	result, _ := json.Marshal(allItems)
 	return json.RawMessage(result), nil
 }
 
-func cloneRawObject(obj map[string]json.RawMessage) map[string]json.RawMessage {
-	clone := make(map[string]json.RawMessage, len(obj))
-	for key, value := range obj {
-		clone[key] = append(json.RawMessage(nil), value...)
-	}
-	return clone
-}
-
-func paginatedCollectionEnvelopeField(obj map[string]json.RawMessage, requestPath string) (string, bool) {
-	for key, raw := range obj {
-		if canonicalPaginationCollectionKeys[key] && isJSONArray(raw) {
-			return "", false
-		}
-	}
-
-	pathWithoutQuery := strings.SplitN(requestPath, "?", 2)[0]
-	segments := strings.Split(strings.Trim(pathWithoutQuery, "/"), "/")
-	for i := len(segments) - 1; i >= 0; i-- {
-		segment := strings.TrimSuffix(strings.TrimSpace(segments[i]), ".json")
-		if segment == "" || (strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}")) {
-			continue
-		}
-		for key, raw := range obj {
-			if strings.EqualFold(key, segment) && isJSONArray(raw) && !envelopeMetadataArrayKeys[key] {
-				return key, true
-			}
-		}
-	}
-
-	var candidate string
-	for key, raw := range obj {
-		if envelopeMetadataArrayKeys[key] || canonicalPaginationCollectionKeys[key] || !isJSONArray(raw) {
-			continue
-		}
-		if _, ok := extractPaginatedObjectArray(raw); !ok {
-			continue
-		}
-		if candidate != "" {
-			return "", false
-		}
-		candidate = key
-	}
-	return candidate, candidate != ""
-}
-
-func isJSONArray(raw json.RawMessage) bool {
-	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 || trimmed[0] != '[' {
-		return false
-	}
-	var items []json.RawMessage
-	return json.Unmarshal(raw, &items) == nil
-}
-
-var canonicalPaginationCollectionKeys = map[string]bool{
-	responsePathItemsKey: true,
-	"data":               true, "items": true, "results": true, "messages": true, "members": true, "values": true,
-}
-
-func deleteRawPath(obj map[string]json.RawMessage, path string) {
-	if path == "" {
-		return
-	}
-	parts := strings.Split(path, ".")
-	key := ""
-	for candidate := range obj {
-		if strings.EqualFold(candidate, parts[0]) {
-			key = candidate
-			break
-		}
-	}
-	if key == "" {
-		return
-	}
-	if len(parts) == 1 {
-		delete(obj, key)
-		return
-	}
-	var child map[string]json.RawMessage
-	if json.Unmarshal(obj[key], &child) != nil {
-		return
-	}
-	deleteRawPath(child, strings.Join(parts[1:], "."))
-	obj[key], _ = json.Marshal(child)
-}
 func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationType string, pageSize, itemCount int) (string, bool) {
 	if (paginationType != "offset" && paginationType != "page") || itemCount == 0 {
 		return "", false
@@ -1148,39 +947,6 @@ func extractPaginatedItems(obj map[string]json.RawMessage, requestPath string) (
 	return extractPaginatedItemsFromObject(obj, requestPath, true)
 }
 
-// collectionItemsForOutput projects a paginated collection envelope to the
-// array expected by table, CSV, and plain renderers. JSON output keeps the
-// original envelope so resource-named response shapes remain available to
-// callers that need them.
-func collectionItemsForOutput(data json.RawMessage, requestPath string) json.RawMessage {
-	var items []json.RawMessage
-	if json.Unmarshal(data, &items) == nil {
-		return data
-	}
-
-	var obj map[string]json.RawMessage
-	if json.Unmarshal(data, &obj) != nil {
-		return data
-	}
-	if field, preserve := paginatedCollectionEnvelopeField(obj, requestPath); preserve {
-		if json.Unmarshal(obj[field], &items) == nil {
-			projected, err := json.Marshal(items)
-			if err == nil {
-				return projected
-			}
-		}
-	}
-	items, ok := extractPaginatedItems(obj, requestPath)
-	if !ok {
-		return data
-	}
-	projected, err := json.Marshal(items)
-	if err != nil {
-		return data
-	}
-	return projected
-}
-
 func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath string, allowEmbedded bool) ([]json.RawMessage, bool) {
 	if !allowEmbedded {
 		if nested, ok := extractPaginatedItemsMatchingPath(obj, requestPath); ok {
@@ -1189,7 +955,7 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath
 	}
 
 	if allowEmbedded {
-		for _, field := range []string{responsePathItemsKey, "data", "items", "results", "messages", "members", "values"} {
+		for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
 			if arr, ok := obj[field]; ok {
 				var nested []json.RawMessage
 				if json.Unmarshal(arr, &nested) == nil {
@@ -2035,17 +1801,8 @@ func compactObjectArrayValue(v any) (any, bool) {
 // printCSV renders JSON arrays as CSV with header row.
 func printCSV(w io.Writer, data json.RawMessage) error {
 	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil {
-		// Single object or invalid JSON - just print as JSON
-		fmt.Fprintln(w, string(data))
-		return nil
-	}
-	if len(items) == 0 {
-		// A valid empty array is an empty CSV stream, not a JSON document.
-		// Keep the single-object fallback above for non-array payloads.
-		if bytes.HasPrefix(bytes.TrimSpace(data), []byte("[")) {
-			return nil
-		}
+	if err := json.Unmarshal(data, &items); err != nil || len(items) == 0 {
+		// Single object or empty - just print as JSON
 		fmt.Fprintln(w, string(data))
 		return nil
 	}
@@ -2689,7 +2446,7 @@ func printProvenance(cmd *cobra.Command, count int, prov DataProvenance) {
 func nonJSONPayloadError(data json.RawMessage) error {
 	trimmed := bytes.TrimSpace(data)
 	if len(trimmed) > 0 && trimmed[0] == '<' {
-		return authErr(fmt.Errorf("not authenticated or session expired; API returned HTML instead of JSON. " + "Set your API key with: export PRINTING_PRESS_GOLDEN_API_KEY=\"your-token-here\""))
+		return authErr(fmt.Errorf("not authenticated or session expired; API returned HTML instead of JSON. " + ""))
 	}
 	if len(trimmed) == 0 {
 		return apiErr(fmt.Errorf("API returned an empty response body; expected JSON"))

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
@@ -635,6 +635,58 @@ func newTabWriter(w io.Writer) *tabwriter.Writer {
 	return tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
 }
 
+const responsePathItemsKey = "__printing_press_response_path_items"
+
+type responsePathPaginatedClient struct {
+	client interface {
+		GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+	}
+	responsePath string
+}
+
+func (c responsePathPaginatedClient) IsDryRun() bool {
+	dryRunClient, ok := c.client.(interface{ IsDryRun() bool })
+	return ok && dryRunClient.IsDryRun()
+}
+
+func (c responsePathPaginatedClient) GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	data, err := c.client.GetWithHeaders(ctx, path, params, headers)
+	if err != nil || isDryRunResponseForClient(c.client, data) {
+		return data, err
+	}
+	selected, ok := responsePayloadAtPath(data, c.responsePath)
+	if !ok {
+		return nil, fmt.Errorf("response_path %q not found in response", c.responsePath)
+	}
+	if !isJSONArray(selected) {
+		return nil, fmt.Errorf("response_path %q must resolve to an array", c.responsePath)
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("response_path %q requires an object response envelope: %w", c.responsePath, err)
+	}
+	root[responsePathItemsKey] = selected
+	transformed, err := json.Marshal(root)
+	if err != nil {
+		return nil, fmt.Errorf("wrap response_path %q: %w", c.responsePath, err)
+	}
+	return transformed, nil
+}
+
+func paginatedGetWithResponsePath(ctx context.Context, c interface {
+	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+}, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string) (json.RawMessage, error) {
+	if responsePath == "" {
+		return paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
+	}
+	wrapped := responsePathPaginatedClient{client: c, responsePath: responsePath}
+	data, err := paginatedGet(ctx, wrapped, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
+	if err != nil || fetchAll {
+		return data, err
+	}
+	return applyResponsePath(data, responsePath), nil
+}
+
 // paginatedGet fetches pages and concatenates array results. The headers
 // argument carries per-endpoint required headers (e.g. cal-api-version) that
 // must be sent on every page request, including the first; pass nil when the
@@ -689,6 +741,9 @@ func paginatedGet(ctx context.Context, c interface {
 
 	// Fetch all pages
 	allItems := make([]json.RawMessage, 0)
+	var collectionEnvelope map[string]json.RawMessage
+	collectionField := ""
+	collectionShapeSet := false
 	seenCursorTokens := map[string]struct{}{}
 	if sentCursor := clean[cursorParam]; sentCursor != "" {
 		seenCursorTokens[sentCursor] = struct{}{}
@@ -714,6 +769,10 @@ func paginatedGet(ctx context.Context, c interface {
 		// Try to extract items array
 		var items []json.RawMessage
 		if json.Unmarshal(data, &items) == nil {
+			if collectionShapeSet && collectionField != "" {
+				return nil, fmt.Errorf("paginated response collection changed from %q to a bare array", collectionField)
+			}
+			collectionShapeSet = true
 			allItems = append(allItems, items...)
 			if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, pageSize, len(items)); ok {
 				if page >= paginatedGetMaxPages {
@@ -728,7 +787,24 @@ func paginatedGet(ctx context.Context, c interface {
 			var obj map[string]json.RawMessage
 			if json.Unmarshal(data, &obj) == nil {
 				itemCount := 0
-				if nested, ok := extractPaginatedItems(obj, path); ok {
+				field, preserve := paginatedCollectionEnvelopeField(obj, path)
+				nested, ok := extractPaginatedItems(obj, path)
+				if !ok && preserve {
+					ok = json.Unmarshal(obj[field], &nested) == nil
+				}
+				if ok {
+					if !collectionShapeSet {
+						collectionShapeSet = true
+						if preserve {
+							collectionField = field
+							collectionEnvelope = cloneRawObject(obj)
+						}
+					} else if (collectionField != "" && (!preserve || !strings.EqualFold(collectionField, field))) || (collectionField == "" && preserve) {
+						if collectionField != "" {
+							return nil, fmt.Errorf("paginated response collection changed from %q", collectionField)
+						}
+						return nil, fmt.Errorf("paginated response collection changed from a canonical array to %q", field)
+					}
 					allItems = append(allItems, nested...)
 					itemCount = len(nested)
 				}
@@ -808,10 +884,106 @@ func paginatedGet(ctx context.Context, c interface {
 	} else {
 		fmt.Fprintf(os.Stderr, `{"event":"complete","total":%d,"pages":%d}`+"\n", len(allItems), page)
 	}
-	result, _ := json.Marshal(allItems)
+	var result []byte
+	if collectionField != "" {
+		collectionEnvelope[collectionField], _ = json.Marshal(allItems)
+		deleteRawPath(collectionEnvelope, cursorLookupPath)
+		deleteRawPath(collectionEnvelope, hasMoreField)
+		if paginationType == "offset" || paginationType == "page" {
+			deleteRawPath(collectionEnvelope, cursorParam)
+		}
+		result, _ = json.Marshal(collectionEnvelope)
+	} else {
+		result, _ = json.Marshal(allItems)
+	}
 	return json.RawMessage(result), nil
 }
 
+func cloneRawObject(obj map[string]json.RawMessage) map[string]json.RawMessage {
+	clone := make(map[string]json.RawMessage, len(obj))
+	for key, value := range obj {
+		clone[key] = append(json.RawMessage(nil), value...)
+	}
+	return clone
+}
+
+func paginatedCollectionEnvelopeField(obj map[string]json.RawMessage, requestPath string) (string, bool) {
+	for key, raw := range obj {
+		if canonicalPaginationCollectionKeys[key] && isJSONArray(raw) {
+			return "", false
+		}
+	}
+
+	pathWithoutQuery := strings.SplitN(requestPath, "?", 2)[0]
+	segments := strings.Split(strings.Trim(pathWithoutQuery, "/"), "/")
+	for i := len(segments) - 1; i >= 0; i-- {
+		segment := strings.TrimSuffix(strings.TrimSpace(segments[i]), ".json")
+		if segment == "" || (strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}")) {
+			continue
+		}
+		for key, raw := range obj {
+			if strings.EqualFold(key, segment) && isJSONArray(raw) && !envelopeMetadataArrayKeys[key] {
+				return key, true
+			}
+		}
+	}
+
+	var candidate string
+	for key, raw := range obj {
+		if envelopeMetadataArrayKeys[key] || canonicalPaginationCollectionKeys[key] || !isJSONArray(raw) {
+			continue
+		}
+		if _, ok := extractPaginatedObjectArray(raw); !ok {
+			continue
+		}
+		if candidate != "" {
+			return "", false
+		}
+		candidate = key
+	}
+	return candidate, candidate != ""
+}
+
+func isJSONArray(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		return false
+	}
+	var items []json.RawMessage
+	return json.Unmarshal(raw, &items) == nil
+}
+
+var canonicalPaginationCollectionKeys = map[string]bool{
+	responsePathItemsKey: true,
+	"data":               true, "items": true, "results": true, "messages": true, "members": true, "values": true,
+}
+
+func deleteRawPath(obj map[string]json.RawMessage, path string) {
+	if path == "" {
+		return
+	}
+	parts := strings.Split(path, ".")
+	key := ""
+	for candidate := range obj {
+		if strings.EqualFold(candidate, parts[0]) {
+			key = candidate
+			break
+		}
+	}
+	if key == "" {
+		return
+	}
+	if len(parts) == 1 {
+		delete(obj, key)
+		return
+	}
+	var child map[string]json.RawMessage
+	if json.Unmarshal(obj[key], &child) != nil {
+		return
+	}
+	deleteRawPath(child, strings.Join(parts[1:], "."))
+	obj[key], _ = json.Marshal(child)
+}
 func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationType string, pageSize, itemCount int) (string, bool) {
 	if (paginationType != "offset" && paginationType != "page") || itemCount == 0 {
 		return "", false
@@ -947,6 +1119,39 @@ func extractPaginatedItems(obj map[string]json.RawMessage, requestPath string) (
 	return extractPaginatedItemsFromObject(obj, requestPath, true)
 }
 
+// collectionItemsForOutput projects a paginated collection envelope to the
+// array expected by table, CSV, and plain renderers. JSON output keeps the
+// original envelope so resource-named response shapes remain available to
+// callers that need them.
+func collectionItemsForOutput(data json.RawMessage, requestPath string) json.RawMessage {
+	var items []json.RawMessage
+	if json.Unmarshal(data, &items) == nil {
+		return data
+	}
+
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(data, &obj) != nil {
+		return data
+	}
+	if field, preserve := paginatedCollectionEnvelopeField(obj, requestPath); preserve {
+		if json.Unmarshal(obj[field], &items) == nil {
+			projected, err := json.Marshal(items)
+			if err == nil {
+				return projected
+			}
+		}
+	}
+	items, ok := extractPaginatedItems(obj, requestPath)
+	if !ok {
+		return data
+	}
+	projected, err := json.Marshal(items)
+	if err != nil {
+		return data
+	}
+	return projected
+}
+
 func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath string, allowEmbedded bool) ([]json.RawMessage, bool) {
 	if !allowEmbedded {
 		if nested, ok := extractPaginatedItemsMatchingPath(obj, requestPath); ok {
@@ -955,7 +1160,7 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath
 	}
 
 	if allowEmbedded {
-		for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
+		for _, field := range []string{responsePathItemsKey, "data", "items", "results", "messages", "members", "values"} {
 			if arr, ok := obj[field]; ok {
 				var nested []json.RawMessage
 				if json.Unmarshal(arr, &nested) == nil {
@@ -1801,8 +2006,17 @@ func compactObjectArrayValue(v any) (any, bool) {
 // printCSV renders JSON arrays as CSV with header row.
 func printCSV(w io.Writer, data json.RawMessage) error {
 	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil || len(items) == 0 {
-		// Single object or empty - just print as JSON
+	if err := json.Unmarshal(data, &items); err != nil {
+		// Single object or invalid JSON - just print as JSON
+		fmt.Fprintln(w, string(data))
+		return nil
+	}
+	if len(items) == 0 {
+		// A valid empty array is an empty CSV stream, not a JSON document.
+		// Keep the single-object fallback above for non-array payloads.
+		if bytes.HasPrefix(bytes.TrimSpace(data), []byte("[")) {
+			return nil
+		}
 		fmt.Fprintln(w, string(data))
 		return nil
 	}

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
@@ -15,6 +15,8 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 	var flagS string
 	var flagC string
 	var flagLocationId string
+	var flagRecordedBy string
+	var flagSort string
 
 	cmd := &cobra.Command{
 		Use:   "find",
@@ -54,6 +56,15 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 			c, err := flags.newClient()
 			if err != nil {
 				return err
+			}
+			if flagRecordedBy != "" {
+				path = appendArrayQueryParam(path, "recorded_by[]", flagRecordedBy, "form", true)
+			}
+			if flagSort != "" {
+				path, err = appendDeepObjectQueryParam(path, "sort", flagSort)
+				if err != nil {
+					return err
+				}
 			}
 			params := map[string]string{}
 			if flagS != "" {
@@ -129,6 +140,8 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&flagC, "c", "", "City, state, zip")
 	_ = cmd.Flags().MarkHidden("c")
 	cmd.Flags().StringVar(&flagLocationId, "location-id", "", "Location identifier sent with this endpoint's snake-case query key")
+	cmd.Flags().StringVar(&flagRecordedBy, "recorded-by", "", "Filter by recorder emails, sent as repeated bracket query keys")
+	cmd.Flags().StringVar(&flagSort, "sort", "", "Sort specification sent as indexed deepObject query keys")
 
 	return cmd
 }

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -50,15 +51,17 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("stores_find",
-			mcplib.WithDescription("Find nearby stores by address. Required: address, city, locationId. Returns array of Store."),
+			mcplib.WithDescription("Find nearby stores by address. Required: address, city, locationId. Optional: recorded_by, sort (array of objects, e.g. [{'field':'...','direction':'...'}]). Returns array of Store."),
 			mcplib.WithString("address", mcplib.Required(), mcplib.Description("Street address")),
 			mcplib.WithString("city", mcplib.Required(), mcplib.Description("City, state, zip")),
 			mcplib.WithString("locationId", mcplib.Required(), mcplib.Description("Location identifier sent with this endpoint's snake-case query key")),
+			mcplib.WithArray("recorded_by", mcplib.Description("Filter by recorder emails, sent as repeated bracket query keys")),
+			mcplib.WithArray("sort", mcplib.Description("Sort specification sent as indexed deepObject query keys")),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/power/store-locator", true, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "address", WireName: "s", Location: "query"}, {PublicName: "city", WireName: "c", Location: "query"}, {PublicName: "locationId", WireName: "location_id", Location: "query"}}, []string{}),
+		makeAPIHandler("GET", "/power/store-locator", true, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "address", WireName: "s", Location: "query"}, {PublicName: "city", WireName: "c", Location: "query"}, {PublicName: "locationId", WireName: "location_id", Location: "query"}, {PublicName: "recorded_by", WireName: "recorded_by[]", Location: "query", QueryArray: true, QueryStyle: "form", QueryExplode: true}, {PublicName: "sort", WireName: "sort", Location: "query", DeepObjectQuery: true}}, []string{}),
 	)
 	// Search tool — faster than iterating list endpoints for finding specific items
 	s.AddTool(
@@ -99,9 +102,14 @@ func RegisterTools(s *server.MCPServer) {
 }
 
 type mcpParamBinding struct {
-	PublicName string
-	WireName   string
-	Location   string
+	PublicName      string
+	WireName        string
+	Location        string
+	Format          string
+	QueryArray      bool
+	QueryStyle      string
+	QueryExplode    bool
+	DeepObjectQuery bool
 }
 
 type mcpPageConfig struct {
@@ -147,6 +155,114 @@ func formatMCPParamValue(v any) string {
 
 func mcpPathValue(v any) string {
 	return cliutil.EscapePathParam(formatMCPParamValue(v))
+}
+func appendMCPArrayQueryParam(path, name string, value any, style string, explode bool) string {
+	var values []string
+	switch typed := value.(type) {
+	case []any:
+		values = make([]string, 0, len(typed))
+		for _, item := range typed {
+			values = append(values, formatMCPParamValue(item))
+		}
+	case []string:
+		values = typed
+	default:
+		raw := formatMCPParamValue(value)
+		var decoded []any
+		if json.Unmarshal([]byte(raw), &decoded) == nil {
+			for _, item := range decoded {
+				values = append(values, formatMCPParamValue(item))
+			}
+		} else {
+			for _, item := range strings.Split(raw, ",") {
+				if item = strings.TrimSpace(item); item != "" {
+					values = append(values, item)
+				}
+			}
+		}
+	}
+	if len(values) == 0 {
+		return path
+	}
+
+	query := url.Values{}
+	switch style {
+	case "spaceDelimited":
+		query.Set(name, strings.Join(values, " "))
+	case "pipeDelimited":
+		query.Set(name, strings.Join(values, "|"))
+	case "form":
+		if explode {
+			for _, item := range values {
+				query.Add(name, item)
+			}
+		} else {
+			query.Set(name, strings.Join(values, ","))
+		}
+	default:
+		query.Set(name, formatMCPParamValue(value))
+	}
+
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return path + separator + query.Encode()
+}
+
+// appendMCPDeepObjectQueryParam appends one style=deepObject query param to
+// the request path as indexed bracket keys: objects -> name[field]=v, arrays
+// -> name[i]=v / name[i][field]=v. value is the native MCP argument
+// (map[string]any / []any); a string value is JSON-decoded first so spec
+// defaults and string-typed agent inputs behave like the CLI's --flag JSON.
+// Shared by the per-endpoint handlers and codeOrchSplitQuery.
+func appendMCPDeepObjectQueryParam(path, name string, value any) (string, error) {
+	decoded := value
+	if raw, ok := value.(string); ok {
+		var parsed any
+		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+			return path, err
+		}
+		decoded = parsed
+	}
+	values := url.Values{}
+	expandMCPDeepObjectValue(values, name, decoded)
+	if len(values) == 0 {
+		return path, nil
+	}
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return path + separator + values.Encode(), nil
+}
+
+// expandMCPDeepObjectValue expands one deepObject-style query param into
+// indexed keys: objects -> name[field]=v, arrays -> name[i]=v /
+// name[i][field]=v. Scalar leaves use formatMCPParamValue; anything nested
+// deeper JSON-encodes fail-soft rather than inventing deeper bracket grammar.
+// URL size is bounded only by the server (414), matching
+// appendMCPArrayQueryParam's posture. Keep structurally in sync with the CLI
+// twin expandDeepObjectValue in internal/cli.
+func expandMCPDeepObjectValue(values url.Values, name string, decoded any) {
+	switch v := decoded.(type) {
+	case map[string]any:
+		for k, item := range v {
+			values.Set(name+"["+k+"]", formatMCPParamValue(item))
+		}
+	case []any:
+		for i, item := range v {
+			if obj, ok := item.(map[string]any); ok {
+				for k, field := range obj {
+					values.Set(fmt.Sprintf("%s[%d][%s]", name, i, k), formatMCPParamValue(field))
+				}
+			} else {
+				values.Set(fmt.Sprintf("%s[%d]", name, i), formatMCPParamValue(item))
+			}
+		}
+	default:
+		values.Set(name, formatMCPParamValue(decoded))
+	}
 }
 
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.
@@ -226,7 +342,17 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			case "body":
 				bodyArgs[binding.WireName] = v
 			default:
-				params[binding.WireName] = formatMCPParamValue(v)
+				if binding.DeepObjectQuery {
+					var derr error
+					path, derr = appendMCPDeepObjectQueryParam(path, binding.WireName, v)
+					if derr != nil {
+						return mcpToolError(fmt.Sprintf("%s: %v; expected JSON like [{\"field\":\"Name\",\"direction\":\"desc\"}] or {\"key\":\"value\"}", binding.PublicName, derr)), nil
+					}
+				} else if binding.QueryArray {
+					path = appendMCPArrayQueryParam(path, binding.WireName, v, binding.QueryStyle, binding.QueryExplode)
+				} else {
+					params[binding.WireName] = formatMCPParamValue(v)
+				}
 			}
 		}
 		for _, p := range positionalParams {

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/tools-manifest.json
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/tools-manifest.json
@@ -37,7 +37,7 @@
       "path": "/stores"
     },
     {
-      "description": "Find nearby stores by address. Required: address, city, locationId. Returns array of Store.",
+      "description": "Find nearby stores by address. Required: address, city, locationId. Optional: recorded_by, sort (array of objects, e.g. [{'field':'...','direction':'...'}]). Returns array of Store.",
       "method": "GET",
       "name": "stores_find",
       "no_auth": true,
@@ -71,6 +71,19 @@
           "required": true,
           "type": "string",
           "wire_name": "location_id"
+        },
+        {
+          "description": "Filter by recorder emails, sent as repeated bracket query keys",
+          "location": "query",
+          "name": "recorded_by",
+          "type": "array",
+          "wire_name": "recorded_by[]"
+        },
+        {
+          "description": "Sort specification sent as indexed deepObject query keys",
+          "location": "query",
+          "name": "sort",
+          "type": "array"
         }
       ],
       "path": "/power/store-locator"

--- a/testdata/golden/fixtures/public-param-names.yaml
+++ b/testdata/golden/fixtures/public-param-names.yaml
@@ -30,6 +30,25 @@ resources:
             type: string
             required: true
             description: Location identifier sent with this endpoint's snake-case query key
+          - name: recorded_by[]
+            type: array
+            item_type: string
+            query_style: form
+            query_explode: true
+            description: Filter by recorder emails, sent as repeated bracket query keys
+          - name: sort
+            type: array
+            item_type: object
+            query_style: deepObject
+            query_explode: true
+            fields:
+              - name: field
+                type: string
+                description: Field name to sort by
+              - name: direction
+                type: string
+                description: Sort direction (asc or desc)
+            description: Sort specification sent as indexed deepObject query keys
         response:
           type: array
           item: Store


### PR DESCRIPTION
## Intent

Issue: Part of a durable fix for HelpFlow/aos-build#165.

Two related MCP-codegen gaps around array-style query parameters:

1. **Illegal MCP property keys (session-bricking).** A parameter whose wire name falls outside Anthropic's tool property-key grammar (`^[a-zA-Z0-9_.-]{1,64}$`, most commonly vendor bracket names like `recorded_by[]`) is emitted RAW as the public MCP input-schema key. The moment a Claude Code / Anthropic-API session loads such a tool, every subsequent turn fails with a 400 pattern-mismatch — the poisoned schema rides along in every request. Both current release smokes miss it (the CLI never builds an Anthropic tools array; MCP `tools/list` emits valid JSON Schema), so the class ships silently — verified live: a bundle generated from a spec with `recorded_by[]` passes all quality gates and lands in a `.mcpb`.
2. **`deepObject` accepted but never emitted.** `supportedQuerySerialization` accepts `style=deepObject, explode=true` (since #3583), but no emit path honors it — the value falls to the flattening default and ships as one raw JSON blob. Real-world APIs need the indexed form (e.g. Airtable's `sort[0][field]=Name&sort[0][direction]=desc`, the concrete case that motivated this on our side — HelpFlow/aos-build#325).

## Approach

**Half 1 — sanitize at the single funnel + fail-closed assertion.**
- `Param.PublicInputName()`'s raw-name fallback now runs `sanitizePublicInputName`: names already matching the grammar return byte-identical (zero churn for every existing clean name); otherwise each run of illegal characters becomes one `_`, trimmed, clamped to 64 chars, re-trimmed (`recorded_by[]` → `recorded_by`, `date[start]` → `date_start`). A name that sanitizes to empty is returned raw so the new assertion fails generation loudly rather than shipping an invented name. Wire names (`WireName()`/`URLName`) are untouched — every request serializes exactly as before.
- Because `PublicInputName()` is the single funnel, the MCP schema key, the tool description's parameter list, `tools-manifest.json`'s `name` (its existing `wire_name` field now populates on divergence), and the handler binding's `PublicName` stay in lockstep automatically. The funnel's consumer list is broader than those four headline surfaces (`generator.go` mcp bindings/validators + `pipeline/public_param_audit.go`) — all covered by the same change.
- **Naming-convention note:** params the flag-collision dedup pass touches keep their existing *kebab* public names (`publicInputNameFromIdent` path, pre-existing behavior); fallback-sanitized params keep *snake* (`recorded_by`). The fallback deliberately preserves underscores rather than unifying on kebab: unchanged-if-legal already ships snake/camel names everywhere, and snake matches how deployed bundles have been hand-patched, so regens converge instead of churning.
- **New post-dedup validation** (`validateMCPInputNames`, hooked in `prepareOutput` after `dedupeFlagIdentifiers`): every FINAL emitted MCP input name per tool — params, body bindings, global path-template vars, plus the generator-reserved inputs (`cursor` when pageable, `body_base64`/`content_type` for raw bodies) — must match the grammar and be unique. Collisions the dedup pass already resolves keep resolving exactly as today; only residual ones (64-char clamp truncations, reserved-key hits, over-long authored `flag_name`s / dedup-suffixed names — previously unclamped paths) fail, with an error naming both sources, the shared key, and the remedy. Because it lives in `prepareOutput`, it also fires on the `GenerateMCPSurface`/mcp-sync path by design — published-CLI MCP-surface regen can now hard-fail on residual-illegal names; the golden corpus (32 cases) verifies clean, which is the evidence it doesn't in practice.
- Intent params (the second raw-name emission site) get the same grammar check in `validateIntents`, and `mcp_intents.go.tmpl`'s name emissions switch to `printf "%q"` as defense-in-depth (`%q` of a legal name is byte-identical — existing rendered-output pins pass unmodified).

**Half 2 — honor `deepObject` with indexed emission.**
- New `DeepObjectQuery` binding marker + structured-value emitters (`appendDeepObjectQueryParam` CLI-side, `appendMCPDeepObjectQueryParam` shared MCP/code-orch): objects → `name[field]=v`, arrays of objects → `name[i][field]=v`, scalar elements → `name[i]=v`, all via `url.Values` + `Encode()` (agent-supplied field names percent-encode as part of the key — injection-tested for `&`/`=`/`#` in both keys and values). Malformed CLI JSON produces a usage error with a concrete example; MCP string values JSON-decode with the error surfaced, never silently flattened.
- Every template gate the deepObject path needs moved to a combined `hasIndexedOrArrayQueryParams` predicate (incl. `codeOrchSplitQuery`'s signature); array-only specs render byte-identical to before (verified empirically by cross-commit tree diff), and comma-join/space/pipe/repeated behavior is pinned untouched.
- **Severable final commit:** generated `formatCLIParamValue` gains the same composite-value JSON branch `formatMCPParamValue` already documents, so a form-style array-of-objects serializes identically (valid JSON) on both surfaces instead of Go-map garbage on one; and `mcpdesc` appends a self-teaching shape hint to deepObject param descriptions (built from the param's fields, generic fallback otherwise). This commit is independent of the emission fix and drops cleanly if breadth is a concern.

## Scope

Primary area: cli

Why this belongs in this repo: both are generator-emission defects — every generated bundle inherits them, and downstream consumers currently re-apply hand-patches after every regen.

## Risk

- Sanitizer changes model-facing names ONLY for previously-illegal names — which were session-bricking, i.e. unusable — so no working consumer regresses.
- Manifest diff: `wire_name` starts populating for bracket params (existing `manifestWireName` machinery; snapshot updated in the golden fixture).
- Array-typed `deepObject` params previously got `QueryArray: true` and emitted a flattened blob; they now route only via the deepObject path (deliberate; called out in the commit body).
- Pre-existing, consciously out of scope: the reserved-`stdin` manifest-only rename (a manifest/schema divergence that predates this PR), and direct `WriteToolsManifest` pipeline calls that bypass generation (not the session-bricking surface).

## Output Contract

- Emitted-code assertions: `internal/generator/mcp_property_key_test.go` (sanitized schema keys/bindings/descriptions + corpus scan of every `With*` key against the grammar + in-module registered-handler wire proof), `internal/generator/deep_object_query_param_test.go` (percent-encoded `RequestURI` proof on CLI + MCP + code-orch layers, injection cases, deepObject-only-spec compile pins), `internal/generator/composite_query_value_test.go` (CLI/MCP parity + mixed array+deepObject routing), `internal/generator/mcp_input_validation_test.go` (five collision/legality classes incl. the previously-unclamped dedup-suffix path), `internal/pipeline/toolsmanifest_bracket_test.go` (manifest `name`/`wire_name` sync + lockstep-no-suffix pin), `internal/spec/public_input_name_test.go` (sanitizer table incl. 64-clamp re-trim + clamp-collision).
- Golden evidence: `public-param-names` fixture consciously extended with a bracket param + a deepObject param (per docs/GOLDEN.md — no prior fixture covered either shape); the only cross-case churn is the `formatCLIParamValue` composite branch in `internal/cli/helpers.go` (guard-only; scalar rendering byte-identical).
- Golden-corpus sweep: all 32 cases generate cleanly through the new assertion (zero hard-fails) — the no-regression evidence for the fail-closed check.

## Verification

- [x] `go build ./...` — clean
- [x] `go test ./... -count=1` — exit 0, 38 packages ok
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — zero findings in changed files (one pre-existing `modernize` finding in untouched `internal/googlediscovery/parser.go:455`, present on main; not touched here)
- [x] `bash scripts/golden.sh verify` — `Golden verify passed: 32 case(s).`
- [x] `bash scripts/verify-generator-output.sh` — `Generated-output verification passed for 10 case(s).`

Every test was written RED-first against the pre-fix generator (bracket keys shipped raw and passed all gates; deepObject flattened to a raw blob).

## AI / Automation Disclosure

AI-authored (Claude) with human operator supervision and review — same working model as #3596.
