### PR TITLE
fix(cli): classify vendor 401s as credential skips in live dogfood

### DIFF
--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -1982,7 +1982,7 @@ func validLiveDogfoodJSONOutput(stdout string) bool {
 func liveDogfoodUnavailableForRunner(run liveDogfoodRun) bool {
 	output := strings.ToLower(run.stdout + run.stderr)
 	return strings.Contains(output, "http 403") ||
-		liveDogfoodAuth401Output(output) ||
+		liveDogfoodAuth401(run) ||
 		strings.Contains(output, "permission denied") ||
 		strings.Contains(output, "your credentials are valid but lack access")
 }
@@ -2041,19 +2041,39 @@ func liveDogfoodRequiresTierSkipReason(annotations map[string]string, activeTier
 	return fmt.Sprintf("blocked-fixture: requires auth tier %q", requiredTier)
 }
 
+// liveDogfoodAuthExitCode is the typed exit code a printed CLI returns from
+// authErr, so it is authoritative about the failure class regardless of how the
+// vendor worded the 401 body.
+const liveDogfoodAuthExitCode = 4
+
 func liveDogfoodAuth401(run liveDogfoodRun) bool {
-	return liveDogfoodAuth401Output(strings.ToLower(run.stdout + run.stderr))
+	output := strings.ToLower(run.stdout + run.stderr)
+	if run.exitCode == liveDogfoodAuthExitCode && strings.Contains(output, "http 401") {
+		return true
+	}
+	return liveDogfoodAuth401Output(output)
 }
 
 func liveDogfoodAuth401Output(output string) bool {
 	if !strings.Contains(output, "http 401") {
 		return false
 	}
-	return strings.Contains(output, "couldn't authenticate") ||
-		strings.Contains(output, "could not authenticate") ||
-		strings.Contains(output, "login required") ||
-		strings.Contains(output, "request is missing required authentication credential") ||
-		strings.Contains(output, "not authenticated")
+	return containsAnyOf(output, liveDogfoodAuth401Phrases)
+}
+
+// Vendor 401 bodies are unstandardized; each entry is a lowercase substring
+// observed in a real provider's unauthenticated response.
+var liveDogfoodAuth401Phrases = []string{
+	"couldn't authenticate",
+	"could not authenticate",
+	"login required",
+	"request is missing required authentication credential",
+	"not authenticated",
+	"invalid access token",
+	"invalid token",
+	"expired token",
+	"token expired",
+	"unauthorized",
 }
 
 func commandSupportsDryRun(help string) bool {

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -2337,6 +2337,7 @@ func TestLiveDogfoodUnavailableForRunnerDoesNotHideNotFound(t *testing.T) {
 	assert.True(t, liveDogfoodUnavailableForRunner(liveDogfoodRun{stderr: "HTTP 403 permission denied"}))
 	assert.True(t, liveDogfoodUnavailableForRunner(liveDogfoodRun{stderr: "your credentials are valid but lack access"}))
 	assert.True(t, liveDogfoodUnavailableForRunner(liveDogfoodRun{stderr: `HTTP 401: {"error":"Couldn't authenticate you"}`}))
+	assert.True(t, liveDogfoodUnavailableForRunner(liveDogfoodRun{stderr: `HTTP 401: {"code":124,"message":"Invalid access token."}`}))
 	assert.False(t, liveDogfoodUnavailableForRunner(liveDogfoodRun{stderr: "HTTP 404 NotFound"}))
 }
 
@@ -2363,8 +2364,23 @@ func TestLiveDogfoodAuth401OutputMatchesGooglePhrases(t *testing.T) {
 			want: true,
 		},
 		{
+			name:   "invalid access token",
+			output: `Error: GET /users/me returned HTTP 401: {"code":124,"message":"Invalid access token."}`,
+			want:   true,
+		},
+		{
+			name:   "bare unauthorized",
+			output: `Error: GET /users/me returned HTTP 401: {"error":"Unauthorized"}`,
+			want:   true,
+		},
+		{
 			name:   "non 401",
 			output: `Error: GET /widgets returned HTTP 404: {"error":"not found"}`,
+			want:   false,
+		},
+		{
+			name:   "404 with auth-ish wording",
+			output: `Error: GET /widgets returned HTTP 404: {"error":"invalid access token"}`,
 			want:   false,
 		},
 	}
@@ -2374,6 +2390,58 @@ func TestLiveDogfoodAuth401OutputMatchesGooglePhrases(t *testing.T) {
 			t.Parallel()
 
 			assert.Equal(t, tt.want, liveDogfoodAuth401Output(strings.ToLower(tt.output)))
+		})
+	}
+}
+
+func TestLiveDogfoodAuth401TypedExitCode(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		run  liveDogfoodRun
+		want bool
+	}{
+		{
+			name: "typed auth exit with unrecognized vendor wording",
+			run: liveDogfoodRun{
+				exitCode: liveDogfoodAuthExitCode,
+				stderr:   `Error: GET /users/me returned HTTP 401: {"code":9999,"message":"Nope."}`,
+			},
+			want: true,
+		},
+		{
+			name: "typed auth exit without a 401",
+			run: liveDogfoodRun{
+				exitCode: liveDogfoodAuthExitCode,
+				stderr:   `Error: no credentials configured`,
+			},
+			want: false,
+		},
+		{
+			name: "unrecognized wording on a generic failure exit",
+			run: liveDogfoodRun{
+				exitCode: 1,
+				stderr:   `Error: GET /users/me returned HTTP 401: {"code":9999,"message":"Nope."}`,
+			},
+			want: false,
+		},
+		{
+			name: "recognized wording on a generic failure exit",
+			run: liveDogfoodRun{
+				exitCode: 1,
+				stderr:   `Error: GET /users/me returned HTTP 401: {"code":124,"message":"Invalid access token."}`,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, liveDogfoodAuth401(tt.run))
+			assert.Equal(t, tt.want, liveDogfoodUnavailableForRunner(tt.run))
 		})
 	}
 }

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -2419,6 +2419,14 @@ func TestLiveDogfoodAuth401TypedExitCode(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "typed auth exit with auth wording on a non-401",
+			run: liveDogfoodRun{
+				exitCode: liveDogfoodAuthExitCode,
+				stderr:   `Error: GET /users/me returned HTTP 404: {"message":"Invalid access token."}`,
+			},
+			want: false,
+		},
+		{
 			name: "unrecognized wording on a generic failure exit",
 			run: liveDogfoodRun{
 				exitCode: 1,


### PR DESCRIPTION
## Intent

The live-dogfood runner scores a command that failed purely because the runner has no credentials as a `skip` (`unavailable for runner credentials`), not a `fail`. That conversion was gated on the 401 body matching one of five hardcoded phrases. Vendor 401 bodies are unstandardized, so an API answering `{"code":124,"message":"Invalid access token."}` matched nothing and 44 correct no-credential outcomes were scored as `http_4xx` failures.

Issue: Closes #3827

## Approach

Trust the printed CLI's own typed exit code as the primary signal instead of guessing from prose. Printed CLIs return exit `4` from `authErr` for auth failures, so `exit 4` + an `HTTP 401` in the output is a credential-unavailable skip regardless of how the vendor worded the body.

The phrase list is kept as the fallback for runs that surface a 401 but exit with a generic failure code, and it gains the wordings observed in the wild (`invalid access token`, `invalid token`, `expired token`, `token expired`, `unauthorized`). It moved to a package-level slice consumed by the existing `containsAnyOf` helper, matching the shape of the neighbouring `liveDogfoodRequiredParamFixturePhrases`.

Both signals remain gated on `http 401` being present, so a 404 whose body happens to contain auth-ish wording is still a genuine failure.

## Scope

Primary area: `internal/pipeline` (live dogfood result classification)

Why this belongs in this repo: this is the Printing Press's own dogfood scorer, not a printed CLI. Every printed CLI's live-dogfood matrix is misscored by the phrase gate, and the fix generalizes across APIs by keying on the generator-emitted typed exit code rather than on any one vendor's message.

## Risk

Slightly widens what counts as a credential skip. The widening is bounded by the `http 401` precondition, so a real 401 that a runner *with* valid credentials would still hit could now be skipped instead of failed — an acceptable trade against the current behavior of reporting dozens of false regressions. No generated output, MCP surface, auth, publish, or release behavior changes.

## Output Contract

N/A — no template, generated-file, manifest, MCP-schema, scorecard, or pipeline-artifact shape changes. `scripts/golden.sh verify` was run anyway and passed 32/32 unchanged.

## Verification

- `go test ./...` — every package green. `internal/generator` (untouched by this change) needs more than the local default deadline on this machine and was re-run alone: `go test ./internal/generator/ -timeout 40m` -> `ok ... 1734s`. CI shards that package with its own 12-15m budget.
- `scripts/golden.sh verify` — pass, 32 cases, no diff
- `golangci-lint run ./internal/pipeline/` — 0 issues
- New table-driven test `TestLiveDogfoodAuth401TypedExitCode` covers the typed-exit-4 path (recognized and unrecognized wording, 401 present and absent, and the generic-exit-code fallback), asserting both `liveDogfoodAuth401` and `liveDogfoodUnavailableForRunner`.
- `TestLiveDogfoodAuth401OutputMatchesGooglePhrases` extended with the reported vendor shape, a bare `Unauthorized` body, and a negative case proving a 404 carrying auth wording still fails.
- `TestLiveDogfoodUnavailableForRunnerDoesNotHideNotFound` extended with the reported vendor shape.

- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates

(Not a generator/template change — no emitted Go is affected.)

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRGzpiy4LuvcAF5QG6dYJc
