### PR TITLE
fix(generator): stat real default DB path in teach isolation test

### DIFF
--- a/internal/generator/templates/teach_test.go.tmpl
+++ b/internal/generator/templates/teach_test.go.tmpl
@@ -529,7 +529,7 @@ func TestSkipLearnHook_NovelCommandsNotSkipped(t *testing.T) {
 }
 
 func TestSkipLearnHook_FrameworkCommandsDoNotCreateDefaultDB(t *testing.T) {
-	home := withTempLearnHome(t)
+	withTempLearnHome(t)
 	learnInitOnce = sync.Once{}
 
 	cases := [][]string{
@@ -541,10 +541,11 @@ func TestSkipLearnHook_FrameworkCommandsDoNotCreateDefaultDB(t *testing.T) {
 	}
 	for _, args := range cases {
 		_, _, _ = runRootArgs(t, args...)
-		if _, err := os.Stat(defaultDBPath("{{.Name}}-pp-cli")); err == nil {
-			t.Fatalf("%s created default DB under %s", strings.Join(args, " "), home)
+		dbPath := defaultDBPath("{{.Name}}-pp-cli")
+		if _, err := os.Stat(dbPath); err == nil {
+			t.Fatalf("%s created default DB at %s", strings.Join(args, " "), dbPath)
 		} else if !os.IsNotExist(err) {
-			t.Fatalf("%s stat default DB: %v", strings.Join(args, " "), err)
+			t.Fatalf("%s stat default DB at %s: %v", strings.Join(args, " "), dbPath, err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

On Windows, `TestSkipLearnHook_FrameworkCommandsDoNotCreateDefaultDB` could fail with a misleading message: it printed the temp HOME while `os.Stat` checked the resolved default DB path. Failures now cite the path actually stat'ed, so escapes from incomplete isolation are diagnosable without chasing the wrong directory.

Complements #3692/`testenv.Isolate` (HOME + USERPROFILE); this PR is the teach-test assertion hardening called out in #3853.

## Validation

- `go test ./internal/generator/... -run 'TestGenerateWith' -count=1 -short` passes on macOS.

Related to #3853