### PR TITLE
fix(generator): propagate export flush and sync SaveSyncState errors

### DIFF
--- a/internal/generator/export_sync_persistence_test.go
+++ b/internal/generator/export_sync_persistence_test.go
@@ -19,7 +19,10 @@ func TestExportTemplate_PropagatesPersistenceErrors(t *testing.T) {
 	require.NotContains(t, content, "defer writer.Flush()",
 		"export must check flush errors explicitly, not defer-discard them")
 	require.Contains(t, content, "finishExport")
-	require.Contains(t, content, "defer outFile.Close()")
+	require.NotContains(t, content, "defer outFile.Close()",
+		"export must check close errors in finishExport before success, not defer-discard them")
+	require.Contains(t, content, `fmt.Errorf("closing export file: %w", err)`)
+	require.Contains(t, content, "if err != nil && outFile != nil")
 	require.Contains(t, content, `fmt.Errorf("flushing export: %w", err)`)
 	require.Contains(t, content, `fmt.Errorf("writing export: %w", err)`)
 }
@@ -60,5 +63,9 @@ func TestGeneratedExport_FinishExportBeforeSuccessMessage(t *testing.T) {
 	require.NoError(t, err)
 	content := string(exportGo)
 	require.Contains(t, content, "finishExport")
+	require.Contains(t, content, `fmt.Errorf("closing export file: %w", err)`)
 	require.NotContains(t, content, "defer writer.Flush()")
+	successIdx := strings.Index(content, "Exported %d records")
+	finishIdx := strings.LastIndex(content, "finishExport()")
+	require.Greater(t, successIdx, finishIdx, "success message must follow finishExport in generated export")
 }

--- a/internal/generator/export_sync_persistence_test.go
+++ b/internal/generator/export_sync_persistence_test.go
@@ -1,0 +1,53 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExportTemplate_PropagatesPersistenceErrors(t *testing.T) {
+	t.Parallel()
+
+	src, err := os.ReadFile(filepath.Join("templates", "export.go.tmpl"))
+	require.NoError(t, err)
+	content := string(src)
+
+	require.NotContains(t, content, "defer writer.Flush()",
+		"export must check flush errors explicitly, not defer-discard them")
+	require.Contains(t, content, "finishExport")
+	require.Contains(t, content, `fmt.Errorf("flushing export: %w", err)`)
+	require.Contains(t, content, `fmt.Errorf("writing export: %w", err)`)
+}
+
+func TestSyncTemplates_DoNotDiscardSaveSyncStateErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, tmpl := range []string{"sync.go.tmpl", "graphql_sync.go.tmpl"} {
+		tmpl := tmpl
+		t.Run(tmpl, func(t *testing.T) {
+			t.Parallel()
+			src, err := os.ReadFile(filepath.Join("templates", tmpl))
+			require.NoError(t, err)
+			content := string(src)
+			require.NotContains(t, content, "_ = db.SaveSyncState",
+				"%s must propagate SaveSyncState errors", tmpl)
+			require.True(t, strings.Contains(content, "saving sync state for"),
+				"%s should wrap final SaveSyncState failures", tmpl)
+		})
+	}
+}
+
+func TestGeneratedExport_FinishExportBeforeSuccessMessage(t *testing.T) {
+	t.Parallel()
+
+	outputDir := generatePetstore(t)
+	exportGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "export.go"))
+	require.NoError(t, err)
+	content := string(exportGo)
+	require.Contains(t, content, "finishExport")
+	require.NotContains(t, content, "defer writer.Flush()")
+}

--- a/internal/generator/export_sync_persistence_test.go
+++ b/internal/generator/export_sync_persistence_test.go
@@ -19,6 +19,7 @@ func TestExportTemplate_PropagatesPersistenceErrors(t *testing.T) {
 	require.NotContains(t, content, "defer writer.Flush()",
 		"export must check flush errors explicitly, not defer-discard them")
 	require.Contains(t, content, "finishExport")
+	require.Contains(t, content, "defer outFile.Close()")
 	require.Contains(t, content, `fmt.Errorf("flushing export: %w", err)`)
 	require.Contains(t, content, `fmt.Errorf("writing export: %w", err)`)
 }
@@ -27,7 +28,6 @@ func TestSyncTemplates_DoNotDiscardSaveSyncStateErrors(t *testing.T) {
 	t.Parallel()
 
 	for _, tmpl := range []string{"sync.go.tmpl", "graphql_sync.go.tmpl"} {
-		tmpl := tmpl
 		t.Run(tmpl, func(t *testing.T) {
 			t.Parallel()
 			src, err := os.ReadFile(filepath.Join("templates", tmpl))
@@ -39,6 +39,17 @@ func TestSyncTemplates_DoNotDiscardSaveSyncStateErrors(t *testing.T) {
 				"%s should wrap final SaveSyncState failures", tmpl)
 		})
 	}
+}
+
+func TestSyncTemplate_TreatsPersistenceErrorsAsCritical(t *testing.T) {
+	t.Parallel()
+
+	src, err := os.ReadFile(filepath.Join("templates", "sync.go.tmpl"))
+	require.NoError(t, err)
+	content := string(src)
+
+	require.Contains(t, content, "isSyncStatePersistenceError")
+	require.Contains(t, content, "isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource]")
 }
 
 func TestGeneratedExport_FinishExportBeforeSuccessMessage(t *testing.T) {

--- a/internal/generator/export_sync_persistence_test.go
+++ b/internal/generator/export_sync_persistence_test.go
@@ -38,6 +38,10 @@ func TestSyncTemplates_DoNotDiscardSaveSyncStateErrors(t *testing.T) {
 			content := string(src)
 			require.NotContains(t, content, "_ = db.SaveSyncState",
 				"%s must propagate SaveSyncState errors", tmpl)
+			require.NotContains(t, content, "warning: failed to save sync state",
+				"%s must not downgrade checkpoint failures to warnings", tmpl)
+			require.Equal(t, 4, strings.Count(content, "if err := db.SaveSyncState(resource"),
+				"%s must check reset, latest-only, per-page, and final checkpoints", tmpl)
 			require.True(t, strings.Contains(content, "saving sync state for"),
 				"%s should wrap final SaveSyncState failures", tmpl)
 		})
@@ -79,4 +83,17 @@ func TestGeneratedExport_FinishExportBeforeSuccessMessage(t *testing.T) {
 	successIdx := strings.Index(content, "Exported %d records")
 	finishIdx := strings.LastIndex(content, "finishExport()")
 	require.Greater(t, successIdx, finishIdx, "success message must follow finishExport in generated export")
+}
+
+func TestGeneratedSync_PropagatesEveryResourceCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	outputDir := generatePetstore(t)
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	content := string(syncGo)
+
+	require.NotContains(t, content, "warning: failed to save sync state")
+	require.Equal(t, 4, strings.Count(content, "if err := db.SaveSyncState(resource"))
+	require.Contains(t, content, `return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err)`)
 }

--- a/internal/generator/export_sync_persistence_test.go
+++ b/internal/generator/export_sync_persistence_test.go
@@ -55,6 +55,17 @@ func TestSyncTemplate_TreatsPersistenceErrorsAsCritical(t *testing.T) {
 	require.Contains(t, content, "isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource]")
 }
 
+func TestWorkflowArchiveTemplate_FailsOnPersistenceErrors(t *testing.T) {
+	t.Parallel()
+
+	src, err := os.ReadFile(filepath.Join("templates", "channel_workflow.go.tmpl"))
+	require.NoError(t, err)
+	content := string(src)
+
+	require.Contains(t, content, "isSyncStatePersistenceError(res.Err)")
+	require.Contains(t, content, `return fmt.Errorf("archiving %s: %w", resource, res.Err)`)
+}
+
 func TestGeneratedExport_FinishExportBeforeSuccessMessage(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -15183,8 +15183,8 @@ func TestGeneratedSyncExitPolicy(t *testing.T) {
 	// criticalResources map. This pins the lookup mechanism so a refactor
 	// can't accidentally drop the per-resource classification.
 	assert.Contains(t, syncContent,
-		`if criticalResources[res.Resource] {`,
-		"sync.go must classify each errored resource against criticalResources")
+		`isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource]`,
+		"sync.go must classify each errored resource against persistence failures and criticalResources")
 
 	// (d) In-band default-flip signal. Fires once when the new default
 	// suppressed a non-zero exit under the old contract.

--- a/internal/generator/templates/channel_workflow.go.tmpl
+++ b/internal/generator/templates/channel_workflow.go.tmpl
@@ -308,6 +308,9 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 {{- end}}
 				res := syncResource(cmd.Context(), {{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, s, resource, "", full, 100, false{{if not (isGraphQL .APISpec)}}, false{{end}}{{if .Pagination.DateRangeParam}}, ""{{end}}{{if not (isGraphQL .APISpec)}}, nil, syncEventWriter{{end}})
 				if res.Err != nil {
+					if isSyncStatePersistenceError(res.Err) {
+						return fmt.Errorf("archiving %s: %w", resource, res.Err)
+					}
 					fmt.Fprintf(cmd.ErrOrStderr(), "  %s: error: %v\n", resource, res.Err)
 					continue
 				}

--- a/internal/generator/templates/channel_workflow.go.tmpl
+++ b/internal/generator/templates/channel_workflow.go.tmpl
@@ -291,7 +291,9 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 			// since filter, not cursor reset. Mirrors newSyncCmd's pattern.
 			if full {
 				for _, resource := range resources {
-					_ = s.SaveSyncState(resource, "", 0)
+					if err := s.SaveSyncState(resource, "", 0); err != nil {
+						return fmt.Errorf("clearing sync state for %s: %w", resource, err)
+					}
 				}
 			}
 

--- a/internal/generator/templates/export.go.tmpl
+++ b/internal/generator/templates/export.go.tmpl
@@ -81,6 +81,7 @@ large datasets as it has no memory pressure.`,
 					return fmt.Errorf("creating output file: %w", err)
 				}
 				outFile = f
+				defer outFile.Close()
 				writer = bufio.NewWriter(f)
 			} else {
 				writer = bufio.NewWriter(os.Stdout)
@@ -88,11 +89,6 @@ large datasets as it has no memory pressure.`,
 			finishExport := func() error {
 				if err := writer.Flush(); err != nil {
 					return fmt.Errorf("flushing export: %w", err)
-				}
-				if outFile != nil {
-					if err := outFile.Close(); err != nil {
-						return fmt.Errorf("closing export file: %w", err)
-					}
 				}
 				return nil
 			}

--- a/internal/generator/templates/export.go.tmpl
+++ b/internal/generator/templates/export.go.tmpl
@@ -74,17 +74,27 @@ large datasets as it has no memory pressure.`,
 			}
 
 			var writer *bufio.Writer
+			var outFile *os.File
 			if outputFile != "" {
 				f, err := os.Create(outputFile)
 				if err != nil {
 					return fmt.Errorf("creating output file: %w", err)
 				}
-				defer f.Close()
+				outFile = f
 				writer = bufio.NewWriter(f)
-				defer writer.Flush()
 			} else {
 				writer = bufio.NewWriter(os.Stdout)
-				defer writer.Flush()
+			}
+			finishExport := func() error {
+				if err := writer.Flush(); err != nil {
+					return fmt.Errorf("flushing export: %w", err)
+				}
+				if outFile != nil {
+					if err := outFile.Close(); err != nil {
+						return fmt.Errorf("closing export file: %w", err)
+					}
+				}
+				return nil
 			}
 
 			config := resourceReadConfigFor(resource)
@@ -107,7 +117,9 @@ large datasets as it has no memory pressure.`,
 				if singleItem {
 					count = 1
 					if format == "jsonl" {
-						fmt.Fprintln(writer, string(data))
+						if _, err := fmt.Fprintln(writer, string(data)); err != nil {
+							return fmt.Errorf("writing export: %w", err)
+						}
 					} else {
 						singlePayload = data
 					}
@@ -122,7 +134,9 @@ large datasets as it has no memory pressure.`,
 						break
 					}
 					if format == "jsonl" {
-						fmt.Fprintln(writer, string(item))
+						if _, err := fmt.Fprintln(writer, string(item)); err != nil {
+							return fmt.Errorf("writing export: %w", err)
+						}
 					} else {
 						allItems = append(allItems, item)
 					}
@@ -166,6 +180,9 @@ large datasets as it has no memory pressure.`,
 				if err := enc.Encode(output); err != nil {
 					return err
 				}
+			}
+			if err := finishExport(); err != nil {
+				return err
 			}
 			if outputFile != "" {
 				fmt.Fprintf(os.Stderr, "Exported %d records to %s\n", count, outputFile)

--- a/internal/generator/templates/export.go.tmpl
+++ b/internal/generator/templates/export.go.tmpl
@@ -37,7 +37,7 @@ large datasets as it has no memory pressure.`,
   # Pipe to another tool
   {{.Name}}-pp-cli export <resource> --format jsonl | jq '.id'`,
 		Args: cobra.RangeArgs(1, 2),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			validResources := map[string]bool{
 {{- range $exportableResources}}
 				{{printf "%q" .}}: true,
@@ -81,14 +81,24 @@ large datasets as it has no memory pressure.`,
 					return fmt.Errorf("creating output file: %w", err)
 				}
 				outFile = f
-				defer outFile.Close()
 				writer = bufio.NewWriter(f)
+				defer func() {
+					if err != nil && outFile != nil {
+						_ = outFile.Close()
+					}
+				}()
 			} else {
 				writer = bufio.NewWriter(os.Stdout)
 			}
 			finishExport := func() error {
 				if err := writer.Flush(); err != nil {
 					return fmt.Errorf("flushing export: %w", err)
+				}
+				if outFile != nil {
+					if err := outFile.Close(); err != nil {
+						return fmt.Errorf("closing export file: %w", err)
+					}
+					outFile = nil
 				}
 				return nil
 			}

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -692,3 +692,9 @@ func parseSinceDuration(s string) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("unknown unit %q", matches[2])
 	}
 }
+
+// isSyncStatePersistenceError reports failures to persist sync checkpoints.
+// Shared with workflow archive and the primary sync command's exit policy.
+func isSyncStatePersistenceError(err error) bool {
+	return err != nil && strings.HasPrefix(err.Error(), "saving sync state for ")
+}

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -98,7 +98,9 @@ Exit codes & warnings:
 			// --full: clear all sync cursors before starting
 			if full {
 				for _, resource := range resources {
-					_ = db.SaveSyncState(resource, "", 0)
+					if err := db.SaveSyncState(resource, "", 0); err != nil {
+						return fmt.Errorf("clearing sync state for %s: %w", resource, err)
+					}
 				}
 			}
 
@@ -115,7 +117,9 @@ Exit codes & warnings:
 					for _, resource := range resources {
 						existing, _, _, _ := db.GetSyncState(resource)
 						if existing != "" {
-							_ = db.SaveSyncState(resource, "", 0)
+							if err := db.SaveSyncState(resource, "", 0); err != nil {
+								return fmt.Errorf("clearing sync state for %s: %w", resource, err)
+							}
 						}
 					}
 				} else if humanFriendly {
@@ -448,7 +452,9 @@ func syncResource(ctx context.Context, c *client.Client, db *store.Store, resour
 	if capExitHit {
 		finalCursor = capExitCursor
 	}
-	_ = db.SaveSyncState(resource, finalCursor, totalCount)
+	if err := db.SaveSyncState(resource, finalCursor, totalCount); err != nil {
+		return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
+	}
 
 	// F4b symptom probe: rows extracted successfully but none landed.
 	// Likely cause is below the PK-extraction layer (FTS5 trigger,

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -420,7 +420,7 @@ func syncResource(ctx context.Context, c *client.Client, db *store.Store, resour
 
 		// Save cursor after each page for resumability
 		if err := db.SaveSyncState(resource, conn.PageInfo.EndCursor, totalCount); err != nil {
-			fmt.Fprintf(os.Stderr, "\nwarning: failed to save sync state for %s: %v\n", resource, err)
+			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
 		}
 
 		pagesFetched++

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -426,7 +426,7 @@ Resource scoping:
 						firstPlaceholderErr = res.Err
 					}
 {{- end}}
-					if criticalResources[res.Resource] {
+					if isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
 						criticalErrCount++
 						criticalFailedResources = append(criticalFailedResources, res.Resource)
 					}
@@ -463,7 +463,7 @@ Resource scoping:
 						firstPlaceholderErr = res.Err
 					}
 {{- end}}
-					if criticalResources[res.Resource] {
+					if isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
 						criticalErrCount++
 						criticalFailedResources = append(criticalFailedResources, res.Resource)
 					}
@@ -3781,6 +3781,13 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 	"response_metadata": true, "paging": true,
 	// links shape
 	"next": true, "prev": true, "previous": true, "first": true, "last": true,
+}
+
+// isSyncStatePersistenceError reports failures to persist sync checkpoints.
+// These are always treated as critical because a silent exit 0 would leave
+// resume cursors inconsistent with stored data.
+func isSyncStatePersistenceError(err error) bool {
+	return err != nil && strings.HasPrefix(err.Error(), "saving sync state for ")
 }
 
 // criticalResources is the template-time projection of per-resource Critical

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -278,7 +278,9 @@ Resource scoping:
 			// Skip under --dry-run: a preview must not mutate sync-state (issue #2935).
 			if full && !c.DryRun {
 				for _, resource := range resources {
-					_ = db.SaveSyncState(resource, "", 0)
+					if err := db.SaveSyncState(resource, "", 0); err != nil {
+						return fmt.Errorf("clearing sync state for %s: %w", resource, err)
+					}
 				}
 			}
 
@@ -303,7 +305,9 @@ Resource scoping:
 						for _, resource := range resources {
 							existing, _, _, _ := db.GetSyncState(resource)
 							if existing != "" {
-								_ = db.SaveSyncState(resource, "", 0)
+								if err := db.SaveSyncState(resource, "", 0); err != nil {
+									return fmt.Errorf("clearing sync state for %s: %w", resource, err)
+								}
 							}
 						}
 					}
@@ -1194,7 +1198,9 @@ func syncResource(ctx context.Context, c interface {
 	if capExitHit {
 		finalCursor = capExitCursor
 	}
-	_ = db.SaveSyncState(resource, finalCursor, totalCount)
+	if err := db.SaveSyncState(resource, finalCursor, totalCount); err != nil {
+		return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
+	}
 
 	// F4b symptom probe: if items were consumed and successfully
 	// extracted (extractFailures < consumed) but nothing landed in
@@ -3488,7 +3494,9 @@ func syncDependentResource(ctx context.Context, c interface {
 		return syncResult{Resource: dep.Name, Count: totalCount, Warn: failure, Duration: time.Since(started)}
 	}
 
-	_ = db.SaveSyncState(dep.Name, "", totalCount)
+	if err := db.SaveSyncState(dep.Name, "", totalCount); err != nil {
+		return syncResult{Resource: dep.Name, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", dep.Name, err), Duration: time.Since(started)}
+	}
 
 	// F4b symptom probe: items consumed and extracted but nothing landed.
 	// See syncResource for rationale.

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1152,8 +1152,7 @@ func syncResource(ctx context.Context, c interface {
 
 		// Save cursor after each page for resumability
 		if err := db.SaveSyncState(resource, nextCursor, totalCount); err != nil {
-			// Non-fatal: log and continue
-			fmt.Fprintf(os.Stderr, "\nwarning: failed to save sync state for %s: %v\n", resource, err)
+			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
 		}
 
 		cursor = nextCursor

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -812,8 +812,7 @@ func syncResource(ctx context.Context, c interface {
 
 		// Save cursor after each page for resumability
 		if err := db.SaveSyncState(resource, nextCursor, totalCount); err != nil {
-			// Non-fatal: log and continue
-			fmt.Fprintf(os.Stderr, "\nwarning: failed to save sync state for %s: %v\n", resource, err)
+			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
 		}
 
 		cursor = nextCursor

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -155,7 +155,9 @@ Resource scoping:
 			// Skip under --dry-run: a preview must not mutate sync-state (issue #2935).
 			if full && !c.DryRun {
 				for _, resource := range resources {
-					_ = db.SaveSyncState(resource, "", 0)
+					if err := db.SaveSyncState(resource, "", 0); err != nil {
+						return fmt.Errorf("clearing sync state for %s: %w", resource, err)
+					}
 				}
 			}
 
@@ -180,7 +182,9 @@ Resource scoping:
 						for _, resource := range resources {
 							existing, _, _, _ := db.GetSyncState(resource)
 							if existing != "" {
-								_ = db.SaveSyncState(resource, "", 0)
+								if err := db.SaveSyncState(resource, "", 0); err != nil {
+									return fmt.Errorf("clearing sync state for %s: %w", resource, err)
+								}
 							}
 						}
 					}
@@ -854,7 +858,9 @@ func syncResource(ctx context.Context, c interface {
 	if capExitHit {
 		finalCursor = capExitCursor
 	}
-	_ = db.SaveSyncState(resource, finalCursor, totalCount)
+	if err := db.SaveSyncState(resource, finalCursor, totalCount); err != nil {
+		return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
+	}
 
 	// F4b symptom probe: if items were consumed and successfully
 	// extracted (extractFailures < consumed) but nothing landed in
@@ -2396,7 +2402,9 @@ func syncDependentResource(ctx context.Context, c interface {
 		return syncResult{Resource: dep.Name, Count: totalCount, Warn: failure, Duration: time.Since(started)}
 	}
 
-	_ = db.SaveSyncState(dep.Name, "", totalCount)
+	if err := db.SaveSyncState(dep.Name, "", totalCount); err != nil {
+		return syncResult{Resource: dep.Name, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", dep.Name, err), Duration: time.Since(started)}
+	}
 
 	// F4b symptom probe: items consumed and extracted but nothing landed.
 	// See syncResource for rationale.

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -279,7 +279,7 @@ Resource scoping:
 					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
 						firstPlaceholderErr = res.Err
 					}
-					if criticalResources[res.Resource] {
+					if isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
 						criticalErrCount++
 						criticalFailedResources = append(criticalFailedResources, res.Resource)
 					}
@@ -312,7 +312,7 @@ Resource scoping:
 					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
 						firstPlaceholderErr = res.Err
 					}
-					if criticalResources[res.Resource] {
+					if isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
 						criticalErrCount++
 						criticalFailedResources = append(criticalFailedResources, res.Resource)
 					}
@@ -2620,6 +2620,13 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 	"response_metadata": true, "paging": true,
 	// links shape
 	"next": true, "prev": true, "previous": true, "first": true, "last": true,
+}
+
+// isSyncStatePersistenceError reports failures to persist sync checkpoints.
+// These are always treated as critical because a silent exit 0 would leave
+// resume cursors inconsistent with stored data.
+func isSyncStatePersistenceError(err error) bool {
+	return err != nil && strings.HasPrefix(err.Error(), "saving sync state for ")
 }
 
 // criticalResources is the template-time projection of per-resource Critical

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -273,7 +273,7 @@ Resource scoping:
 					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
 						firstPlaceholderErr = res.Err
 					}
-					if criticalResources[res.Resource] {
+					if isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
 						criticalErrCount++
 						criticalFailedResources = append(criticalFailedResources, res.Resource)
 					}
@@ -1974,6 +1974,13 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 	"response_metadata": true, "paging": true,
 	// links shape
 	"next": true, "prev": true, "previous": true, "first": true, "last": true,
+}
+
+// isSyncStatePersistenceError reports failures to persist sync checkpoints.
+// These are always treated as critical because a silent exit 0 would leave
+// resume cursors inconsistent with stored data.
+func isSyncStatePersistenceError(err error) bool {
+	return err != nil && strings.HasPrefix(err.Error(), "saving sync state for ")
 }
 
 // criticalResources is the template-time projection of per-resource Critical

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -149,7 +149,9 @@ Resource scoping:
 			// Skip under --dry-run: a preview must not mutate sync-state (issue #2935).
 			if full && !c.DryRun {
 				for _, resource := range resources {
-					_ = db.SaveSyncState(resource, "", 0)
+					if err := db.SaveSyncState(resource, "", 0); err != nil {
+						return fmt.Errorf("clearing sync state for %s: %w", resource, err)
+					}
 				}
 			}
 
@@ -174,7 +176,9 @@ Resource scoping:
 						for _, resource := range resources {
 							existing, _, _, _ := db.GetSyncState(resource)
 							if existing != "" {
-								_ = db.SaveSyncState(resource, "", 0)
+								if err := db.SaveSyncState(resource, "", 0); err != nil {
+									return fmt.Errorf("clearing sync state for %s: %w", resource, err)
+								}
 							}
 						}
 					}
@@ -874,7 +878,9 @@ func syncResource(ctx context.Context, c interface {
 	if capExitHit {
 		finalCursor = capExitCursor
 	}
-	_ = db.SaveSyncState(resource, finalCursor, totalCount)
+	if err := db.SaveSyncState(resource, finalCursor, totalCount); err != nil {
+		return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
+	}
 
 	// F4b symptom probe: if items were consumed and successfully
 	// extracted (extractFailures < consumed) but nothing landed in

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -832,8 +832,7 @@ func syncResource(ctx context.Context, c interface {
 
 		// Save cursor after each page for resumability
 		if err := db.SaveSyncState(resource, nextCursor, totalCount); err != nil {
-			// Non-fatal: log and continue
-			fmt.Fprintf(os.Stderr, "\nwarning: failed to save sync state for %s: %v\n", resource, err)
+			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
 		}
 
 		cursor = nextCursor

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -812,8 +812,7 @@ func syncResource(ctx context.Context, c interface {
 
 		// Save cursor after each page for resumability
 		if err := db.SaveSyncState(resource, nextCursor, totalCount); err != nil {
-			// Non-fatal: log and continue
-			fmt.Fprintf(os.Stderr, "\nwarning: failed to save sync state for %s: %v\n", resource, err)
+			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
 		}
 
 		cursor = nextCursor

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -155,7 +155,9 @@ Resource scoping:
 			// Skip under --dry-run: a preview must not mutate sync-state (issue #2935).
 			if full && !c.DryRun {
 				for _, resource := range resources {
-					_ = db.SaveSyncState(resource, "", 0)
+					if err := db.SaveSyncState(resource, "", 0); err != nil {
+						return fmt.Errorf("clearing sync state for %s: %w", resource, err)
+					}
 				}
 			}
 
@@ -180,7 +182,9 @@ Resource scoping:
 						for _, resource := range resources {
 							existing, _, _, _ := db.GetSyncState(resource)
 							if existing != "" {
-								_ = db.SaveSyncState(resource, "", 0)
+								if err := db.SaveSyncState(resource, "", 0); err != nil {
+									return fmt.Errorf("clearing sync state for %s: %w", resource, err)
+								}
 							}
 						}
 					}
@@ -854,7 +858,9 @@ func syncResource(ctx context.Context, c interface {
 	if capExitHit {
 		finalCursor = capExitCursor
 	}
-	_ = db.SaveSyncState(resource, finalCursor, totalCount)
+	if err := db.SaveSyncState(resource, finalCursor, totalCount); err != nil {
+		return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
+	}
 
 	// F4b symptom probe: if items were consumed and successfully
 	// extracted (extractFailures < consumed) but nothing landed in
@@ -2367,7 +2373,9 @@ func syncDependentResource(ctx context.Context, c interface {
 		return syncResult{Resource: dep.Name, Count: totalCount, Warn: failure, Duration: time.Since(started)}
 	}
 
-	_ = db.SaveSyncState(dep.Name, "", totalCount)
+	if err := db.SaveSyncState(dep.Name, "", totalCount); err != nil {
+		return syncResult{Resource: dep.Name, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", dep.Name, err), Duration: time.Since(started)}
+	}
 
 	// F4b symptom probe: items consumed and extracted but nothing landed.
 	// See syncResource for rationale.

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -279,7 +279,7 @@ Resource scoping:
 					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
 						firstPlaceholderErr = res.Err
 					}
-					if criticalResources[res.Resource] {
+					if isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
 						criticalErrCount++
 						criticalFailedResources = append(criticalFailedResources, res.Resource)
 					}
@@ -312,7 +312,7 @@ Resource scoping:
 					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
 						firstPlaceholderErr = res.Err
 					}
-					if criticalResources[res.Resource] {
+					if isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
 						criticalErrCount++
 						criticalFailedResources = append(criticalFailedResources, res.Resource)
 					}
@@ -2586,6 +2586,13 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 	"response_metadata": true, "paging": true,
 	// links shape
 	"next": true, "prev": true, "previous": true, "first": true, "last": true,
+}
+
+// isSyncStatePersistenceError reports failures to persist sync checkpoints.
+// These are always treated as critical because a silent exit 0 would leave
+// resume cursors inconsistent with stored data.
+func isSyncStatePersistenceError(err error) bool {
+	return err != nil && strings.HasPrefix(err.Error(), "saving sync state for ")
 }
 
 // criticalResources is the template-time projection of per-resource Critical

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -273,7 +273,7 @@ Resource scoping:
 					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
 						firstPlaceholderErr = res.Err
 					}
-					if criticalResources[res.Resource] {
+					if isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
 						criticalErrCount++
 						criticalFailedResources = append(criticalFailedResources, res.Resource)
 					}
@@ -1901,6 +1901,13 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 	"response_metadata": true, "paging": true,
 	// links shape
 	"next": true, "prev": true, "previous": true, "first": true, "last": true,
+}
+
+// isSyncStatePersistenceError reports failures to persist sync checkpoints.
+// These are always treated as critical because a silent exit 0 would leave
+// resume cursors inconsistent with stored data.
+func isSyncStatePersistenceError(err error) bool {
+	return err != nil && strings.HasPrefix(err.Error(), "saving sync state for ")
 }
 
 // criticalResources is the template-time projection of per-resource Critical

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -149,7 +149,9 @@ Resource scoping:
 			// Skip under --dry-run: a preview must not mutate sync-state (issue #2935).
 			if full && !c.DryRun {
 				for _, resource := range resources {
-					_ = db.SaveSyncState(resource, "", 0)
+					if err := db.SaveSyncState(resource, "", 0); err != nil {
+						return fmt.Errorf("clearing sync state for %s: %w", resource, err)
+					}
 				}
 			}
 
@@ -174,7 +176,9 @@ Resource scoping:
 						for _, resource := range resources {
 							existing, _, _, _ := db.GetSyncState(resource)
 							if existing != "" {
-								_ = db.SaveSyncState(resource, "", 0)
+								if err := db.SaveSyncState(resource, "", 0); err != nil {
+									return fmt.Errorf("clearing sync state for %s: %w", resource, err)
+								}
 							}
 						}
 					}
@@ -815,7 +819,9 @@ func syncResource(ctx context.Context, c interface {
 	if capExitHit {
 		finalCursor = capExitCursor
 	}
-	_ = db.SaveSyncState(resource, finalCursor, totalCount)
+	if err := db.SaveSyncState(resource, finalCursor, totalCount); err != nil {
+		return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
+	}
 
 	// F4b symptom probe: if items were consumed and successfully
 	// extracted (extractFailures < consumed) but nothing landed in

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -773,8 +773,7 @@ func syncResource(ctx context.Context, c interface {
 
 		// Save cursor after each page for resumability
 		if err := db.SaveSyncState(resource, nextCursor, totalCount); err != nil {
-			// Non-fatal: log and continue
-			fmt.Fprintf(os.Stderr, "\nwarning: failed to save sync state for %s: %v\n", resource, err)
+			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
 		}
 
 		cursor = nextCursor


### PR DESCRIPTION
## Summary

Generated export and sync commands could report success while persistence failed: export deferred `Flush`/`Close` without checking errors, and sync discarded final `SaveSyncState` writes. Operators could get truncated export files or resume sync from a stale cursor after a state-store write failure. Templates now propagate I/O and cursor-save errors on operator-critical paths.

## Validation

- `go test ./internal/generator/... -run 'Export|SyncTemplate|SyncDryRun' -count=1 -short` passes.
- New `export_sync_persistence_test.go` guards template emission; golden sync outputs updated for four fixtures.

Fixes #3736
