### PR TITLE
fix(cli): migrate legacy parent-key store rows

### DIFF
--- a/internal/generator/learn_schema_v9_test.go
+++ b/internal/generator/learn_schema_v9_test.go
@@ -31,16 +31,15 @@ func generateLearnStore(t *testing.T, name string, learnEnabled bool) (string, s
 	return string(storeGo), outputDir
 }
 
-// TestLearnSchemaV9_EnabledEmitsV9WithCandidateAndEventTables pins the v9
-// schema bump: a learn-enabled store advances StoreSchemaVersion to 9 and
-// carries the learn_candidates and learn_events tables (with their CHECK
-// constraints and indexes) as additive CREATE IF NOT EXISTS migrations.
-func TestLearnSchemaV9_EnabledEmitsV9WithCandidateAndEventTables(t *testing.T) {
+// TestLearnSchemaV9_EnabledEmitsCandidateAndEventTables pins the tables
+// introduced at v9 while allowing later store migrations to advance the
+// current schema version.
+func TestLearnSchemaV9_EnabledEmitsCandidateAndEventTables(t *testing.T) {
 	t.Parallel()
 
 	src, _ := generateLearnStore(t, "learn-v9-enabled", true)
 
-	require.Contains(t, src, "const StoreSchemaVersion = 9")
+	require.Contains(t, src, "const StoreSchemaVersion = 10")
 	require.NotContains(t, src, "const StoreSchemaVersion = 8")
 	for _, want := range []string{
 		"CREATE TABLE IF NOT EXISTS learn_candidates",
@@ -62,7 +61,7 @@ func TestLearnSchemaV9_EnabledEmitsV9WithCandidateAndEventTables(t *testing.T) {
 // resourcesFTSContentSchemaVersion stays 4 in BOTH learn shapes. The old
 // conditional 8 rode the learn bump by accident and forced a full FTS
 // content rewrite on every v4-v7 learn store open; with the pin, v4 and v8
-// stores opened by a v9 binary take the additive-only migration path.
+// stores opened by the current binary take the additive-only FTS path.
 func TestLearnSchemaV9_FTSContentPinIsUnconditional(t *testing.T) {
 	t.Parallel()
 
@@ -72,7 +71,7 @@ func TestLearnSchemaV9_FTSContentPinIsUnconditional(t *testing.T) {
 
 	disabled, _ := generateLearnStore(t, "learn-v9-fts-disabled", false)
 	require.Contains(t, disabled, "const resourcesFTSContentSchemaVersion = 4")
-	require.Contains(t, disabled, "const StoreSchemaVersion = 4")
+	require.Contains(t, disabled, "const StoreSchemaVersion = 5")
 	for _, gone := range []string{"learn_candidates", "learn_events"} {
 		require.NotContains(t, disabled, gone,
 			"learn-disabled spec must not emit the %s migration", gone)
@@ -95,9 +94,9 @@ func TestLearnSchemaV9_ReadmeDocumentsOneWayStamp(t *testing.T) {
 
 // TestLearnSchemaV9_EmittedStoreTestsPass runs the emitted store package
 // tests under -race. This executes the emitted migration scenarios for real:
-// fresh v9 open with both new tables, the v4->v9 additive open with the FTS
-// content preserved (no rewrite), the v8->v9 additive upgrade with learn
-// data intact, and the newer-store refusal.
+// a fresh current-version open with both v9 tables, the v4->current additive
+// open with FTS content preserved, the v8->current additive upgrade with
+// learn data intact, and the newer-store refusal.
 func TestLearnSchemaV9_EmittedStoreTestsPass(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/learn_store_test.go
+++ b/internal/generator/learn_store_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 )
 
-func TestGenerateStoreSchemaVersion_DisabledAdvancesToV4(t *testing.T) {
+func TestGenerateStoreSchemaVersion_DisabledAdvancesToV5(t *testing.T) {
 	t.Parallel()
 
 	apiSpec := minimalSpec("learn-version-disabled")
@@ -25,14 +25,14 @@ func TestGenerateStoreSchemaVersion_DisabledAdvancesToV4(t *testing.T) {
 	storeGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
 	require.NoError(t, err)
 	src := string(storeGo)
-	require.Contains(t, src, "const StoreSchemaVersion = 4")
-	require.NotContains(t, src, "const StoreSchemaVersion = 9")
+	require.Contains(t, src, "const StoreSchemaVersion = 5")
+	require.NotContains(t, src, "const StoreSchemaVersion = 10")
 	for _, table := range []string{"search_learnings", "search_patterns", "entity_lookups", "learning_playbooks"} {
 		require.NotContains(t, src, table, "learn-disabled spec must not emit %s migration", table)
 	}
 }
 
-func TestGenerateStoreSchemaVersion_EnabledAdvancesToV9WithLearnTables(t *testing.T) {
+func TestGenerateStoreSchemaVersion_EnabledAdvancesToV10WithLearnTables(t *testing.T) {
 	t.Parallel()
 
 	apiSpec := minimalSpec("learn-version-enabled")
@@ -45,8 +45,8 @@ func TestGenerateStoreSchemaVersion_EnabledAdvancesToV9WithLearnTables(t *testin
 	storeGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
 	require.NoError(t, err)
 	src := string(storeGo)
-	require.Contains(t, src, "const StoreSchemaVersion = 9")
-	require.NotContains(t, src, "const StoreSchemaVersion = 4")
+	require.Contains(t, src, "const StoreSchemaVersion = 10")
+	require.NotContains(t, src, "const StoreSchemaVersion = 5")
 	for _, want := range []string{
 		"CREATE TABLE IF NOT EXISTS search_learnings",
 		"CREATE TABLE IF NOT EXISTS search_patterns",

--- a/internal/generator/store_parent_key_migration_test.go
+++ b/internal/generator/store_parent_key_migration_test.go
@@ -1,0 +1,221 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGeneratedStoreMigratesLegacyParentKeyRows exercises the emitted store,
+// not the template text. It seeds the pre-v5 bare-id shape alongside current
+// composite rows, downgrades the version stamp, and proves Open migrates the
+// generic table, typed projection, and both FTS indexes atomically.
+func TestGeneratedStoreMigratesLegacyParentKeyRows(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("parent-key-migration")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Learn.Disabled = true
+	apiSpec.Resources = map[string]spec.Resource{
+		"parents": {
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:   "GET",
+					Path:     "/parents",
+					Response: spec.ResponseDef{Type: "array", Item: "Parent"},
+					IDField:  "id",
+				},
+			},
+		},
+		"children": {
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:   "GET",
+					Path:     "/parents/{parent_id}/children",
+					Response: spec.ResponseDef{Type: "array", Item: "Child"},
+					IDField:  "id",
+					Walker: &spec.WalkerConfig{
+						Parent:   "parents",
+						KeyField: "id",
+						KeyParam: "parent_id",
+					},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Parent": {
+			Fields: []spec.TypeField{
+				{Name: "id", Type: "string"},
+				{Name: "name", Type: "string"},
+			},
+		},
+		"Child": {
+			Fields: []spec.TypeField{
+				{Name: "id", Type: "string"},
+				{Name: "parent_id", Type: "string"},
+				{Name: "name", Type: "string"},
+				{Name: "description", Type: "string"},
+				{Name: "summary", Type: "string"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "parent-key-migration-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	storeSource, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(storeSource), `"children": {"parent_id"}`)
+	require.Contains(t, string(storeSource), "migrateParentKeyStorageIDs")
+	require.Contains(t, string(storeSource), "const StoreSchemaVersion = 5")
+
+	inlineTest := `package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func seedLegacyParentKeyRow(t *testing.T, s *Store, id string, data json.RawMessage) {
+	t.Helper()
+	obj, err := DecodeJSONObject(data)
+	if err != nil {
+		t.Fatalf("decode legacy row %s: %v", id, err)
+	}
+	tx, err := s.DB().Begin()
+	if err != nil {
+		t.Fatalf("begin legacy row %s: %v", id, err)
+	}
+	defer tx.Rollback()
+	if err := s.upsertGenericResourceTx(tx, "children", id, data); err != nil {
+		t.Fatalf("seed legacy generic row %s: %v", id, err)
+	}
+	if err := s.upsertChildrenTx(tx, id, obj, data); err != nil {
+		t.Fatalf("seed legacy typed row %s: %v", id, err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit legacy row %s: %v", id, err)
+	}
+}
+
+func requireParentKeyRowData(t *testing.T, db *sql.DB, table, id string, want json.RawMessage) {
+	t.Helper()
+	var got string
+	query := fmt.Sprintf("SELECT data FROM \"%s\" WHERE id = ?", table)
+	if err := db.QueryRow(query, id).Scan(&got); err != nil {
+		t.Fatalf("read %s/%q: %v", table, id, err)
+	}
+	if got != string(want) {
+		t.Fatalf("%s/%q data = %s, want %s", table, id, got, want)
+	}
+}
+
+func requireParentKeyCount(t *testing.T, db *sql.DB, query string, want int, args ...any) {
+	t.Helper()
+	var got int
+	if err := db.QueryRow(query, args...).Scan(&got); err != nil {
+		t.Fatalf("count %q: %v", query, err)
+	}
+	if got != want {
+		t.Fatalf("count %q = %d, want %d", query, got, want)
+	}
+}
+
+func TestMigrateParentKeyStorageIDs(t *testing.T) {
+	if StoreSchemaVersion != 5 {
+		t.Fatalf("StoreSchemaVersion = %d, want 5 for the v5 migration fixture", StoreSchemaVersion)
+	}
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("create current store: %v", err)
+	}
+
+	duplicateCurrent := json.RawMessage("{\"id\":\"child-duplicate\",\"parent_id\":\"parent-A\",\"name\":\"currenttoken3691\",\"description\":\"current description\",\"summary\":\"current summary\"}")
+	duplicateStale := json.RawMessage("{\"id\":\"child-duplicate\",\"parent_id\":\"parent-A\",\"name\":\"staletoken3691\",\"description\":\"stale description\",\"summary\":\"stale summary\"}")
+	legacyOnly := json.RawMessage("{\"id\":\"child-legacy\",\"parent_id\":\"parent-B\",\"name\":\"legacyonlytoken3691\",\"description\":\"legacy description\",\"summary\":\"legacy summary\"}")
+	compositeOnly := json.RawMessage("{\"id\":\"child-current\",\"parent_id\":\"parent-C\",\"name\":\"compositeonlytoken3691\",\"description\":\"composite description\",\"summary\":\"composite summary\"}")
+
+	if err := s.UpsertChildren(duplicateCurrent); err != nil {
+		t.Fatalf("seed maintained duplicate row: %v", err)
+	}
+	seedLegacyParentKeyRow(t, s, "child-duplicate", duplicateStale)
+	seedLegacyParentKeyRow(t, s, "child-legacy", legacyOnly)
+	if err := s.UpsertChildren(compositeOnly); err != nil {
+		t.Fatalf("seed composite-only row: %v", err)
+	}
+	if _, err := s.DB().Exec(` + "`" + `PRAGMA user_version = 4` + "`" + `); err != nil {
+		t.Fatalf("stamp pre-migration version: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close seeded store: %v", err)
+	}
+
+	upgraded, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open pre-v5 store: %v", err)
+	}
+	db := upgraded.DB()
+
+	const duplicateComposite = "child-duplicate\x00parent-A"
+	const legacyComposite = "child-legacy\x00parent-B"
+	const currentComposite = "child-current\x00parent-C"
+
+	requireParentKeyCount(t, db, ` + "`" + `SELECT COUNT(*) FROM resources WHERE resource_type = 'children'` + "`" + `, 3)
+	requireParentKeyCount(t, db, ` + "`" + `SELECT COUNT(*) FROM children` + "`" + `, 3)
+	for _, bare := range []string{"child-duplicate", "child-legacy", "child-current"} {
+		requireParentKeyCount(t, db, ` + "`" + `SELECT COUNT(*) FROM resources WHERE resource_type = 'children' AND id = ?` + "`" + `, 0, bare)
+		requireParentKeyCount(t, db, ` + "`" + `SELECT COUNT(*) FROM children WHERE id = ?` + "`" + `, 0, bare)
+		requireParentKeyCount(t, db, ` + "`" + `SELECT COUNT(*) FROM resources_fts WHERE rowid = ?` + "`" + `, 0, ftsRowID("children", bare))
+	}
+
+	requireParentKeyRowData(t, db, "resources", duplicateComposite, duplicateCurrent)
+	requireParentKeyRowData(t, db, "children", duplicateComposite, duplicateCurrent)
+	requireParentKeyRowData(t, db, "resources", legacyComposite, legacyOnly)
+	requireParentKeyRowData(t, db, "children", legacyComposite, legacyOnly)
+	requireParentKeyRowData(t, db, "resources", currentComposite, compositeOnly)
+	requireParentKeyRowData(t, db, "children", currentComposite, compositeOnly)
+
+	for _, composite := range []string{duplicateComposite, legacyComposite, currentComposite} {
+		requireParentKeyCount(t, db, ` + "`" + `SELECT COUNT(*) FROM resources_fts WHERE rowid = ? AND id = ? AND resource_type = 'children'` + "`" + `, 1, ftsRowID("children", composite), composite)
+	}
+	requireParentKeyCount(t, db, ` + "`" + `SELECT COUNT(*) FROM resources_fts WHERE resources_fts MATCH 'staletoken3691'` + "`" + `, 0)
+	requireParentKeyCount(t, db, ` + "`" + `SELECT COUNT(*) FROM resources_fts WHERE resources_fts MATCH 'currenttoken3691'` + "`" + `, 1)
+	requireParentKeyCount(t, db, ` + "`" + `SELECT COUNT(*) FROM children_fts` + "`" + `, 3)
+	requireParentKeyCount(t, db, ` + "`" + `SELECT COUNT(*) FROM children_fts WHERE children_fts MATCH 'staletoken3691'` + "`" + `, 0)
+	requireParentKeyCount(t, db, ` + "`" + `SELECT COUNT(*) FROM children_fts WHERE children_fts MATCH 'currenttoken3691'` + "`" + `, 1)
+
+	if version, err := upgraded.SchemaVersion(); err != nil {
+		t.Fatalf("read upgraded version: %v", err)
+	} else if version != StoreSchemaVersion {
+		t.Fatalf("upgraded version = %d, want %d", version, StoreSchemaVersion)
+	}
+	if err := upgraded.Close(); err != nil {
+		t.Fatalf("close upgraded store: %v", err)
+	}
+
+	// A current-version reopen must be a data no-op.
+	reopened, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("reopen current store: %v", err)
+	}
+	defer reopened.Close()
+	requireParentKeyCount(t, reopened.DB(), ` + "`" + `SELECT COUNT(*) FROM resources WHERE resource_type = 'children'` + "`" + `, 3)
+	requireParentKeyCount(t, reopened.DB(), ` + "`" + `SELECT COUNT(*) FROM children` + "`" + `, 3)
+	requireParentKeyCount(t, reopened.DB(), ` + "`" + `SELECT COUNT(*) FROM resources_fts WHERE resource_type = 'children'` + "`" + `, 3)
+	requireParentKeyCount(t, reopened.DB(), ` + "`" + `SELECT COUNT(*) FROM children_fts` + "`" + `, 3)
+}
+`
+	testPath := filepath.Join(outputDir, "internal", "store", "parent_key_migration_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "TestMigrateParentKeyStorageIDs", "-count=1")
+}

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -48,14 +48,20 @@ func IsUUID(s string) bool {
 
 // StoreSchemaVersion is the on-disk schema version this binary understands.
 // It is stamped into SQLite's PRAGMA user_version on fresh databases and
-// checked on every open. {{if .Learn.Enabled}}Learn-enabled CLIs advance to v9 for the
-// learn_candidates and learn_events tables (CLI-side capture and
-// measurement), on top of the v8 learning_playbooks table for
-// hand-authored choreography keyed by query family and the v6 canonical
-// learn-loop tables ported from prediction-goat (including the v3
-// resources_fts rowid rehash and v4 resources_fts content extraction).{{else}}Non-learn CLIs advance to v4 for the
-// resources_fts content extraction.{{end}}
-const StoreSchemaVersion = {{if .Learn.Enabled}}9{{else}}4{{end}}
+// checked on every open. {{if .Learn.Enabled}}Learn-enabled CLIs advance to v10 for the
+// parent-key storage-id migration, on top of the v9 learn_candidates and
+// learn_events tables (CLI-side capture and measurement), the v8
+// learning_playbooks table for hand-authored choreography keyed by query
+// family, and the v6 canonical learn-loop tables ported from prediction-goat
+// (including the v3 resources_fts rowid rehash and v4 resources_fts content
+// extraction).{{else}}Non-learn CLIs advance to v5 for the parent-key storage-id migration, on
+// top of the v4 resources_fts content extraction.{{end}}
+const StoreSchemaVersion = {{if .Learn.Enabled}}10{{else}}5{{end}}
+
+// parentKeyStorageIDSchemaVersion follows StoreSchemaVersion intentionally.
+// Re-keying is idempotent, so any future schema bump also sweeps legacy bare
+// rows for resource types newly emitted in resourceParentKeyColumns.
+const parentKeyStorageIDSchemaVersion = StoreSchemaVersion
 
 // resourcesFTSContentSchemaVersion pins the schema bump that rewrote
 // resources_fts content from raw JSON to searchable leaf values. Keep this
@@ -723,6 +729,11 @@ func (s *Store) migrate(ctx context.Context) error {
 				return fmt.Errorf("migrating resources FTS content: %w", err)
 			}
 		}
+		if current < parentKeyStorageIDSchemaVersion {
+			if err := s.migrateParentKeyStorageIDs(ctx, conn); err != nil {
+				return fmt.Errorf("migrating parent-key storage ids: %w", err)
+			}
+		}
 		// Stamp the schema version. On a fresh DB this writes the current
 		// StoreSchemaVersion; on an already-stamped DB this is a no-op
 		// write of the same value.
@@ -896,6 +907,157 @@ func rebuildResourcesFTS(ctx context.Context, conn *sql.Conn) error {
 		); err != nil {
 			return fmt.Errorf("indexing resource %s/%s: %w", r.resourceType, r.id, err)
 		}
+	}
+	return nil
+}
+
+// migrateParentKeyStorageIDs upgrades dependent-resource rows written before
+// their resource type entered resourceParentKeyColumns. Those rows use the
+// bare API id while current upserts use "<id>\x00<parent>". When both shapes
+// exist, the composite row wins because it is the row current upserts maintain;
+// otherwise the legacy row is re-keyed in place. The generic FTS entry is
+// replaced because its deterministic rowid includes the storage id.
+func (s *Store) migrateParentKeyStorageIDs(ctx context.Context, conn *sql.Conn) error {
+	if len(resourceParentKeyColumns) == 0 {
+		return nil
+	}
+	exists, err := tableExists(ctx, conn, "resources")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
+	type legacyRow struct {
+		id           string
+		resourceType string
+		data         string
+		storageID    string
+	}
+	rows, err := conn.QueryContext(ctx, `SELECT id, resource_type, data FROM resources ORDER BY resource_type, id`)
+	if err != nil {
+		return fmt.Errorf("querying parent-key resources: %w", err)
+	}
+	var legacy []legacyRow
+	for rows.Next() {
+		var row legacyRow
+		if err := rows.Scan(&row.id, &row.resourceType, &row.data); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scanning parent-key resource: %w", err)
+		}
+		if strings.IndexByte(row.id, 0) >= 0 || len(resourceParentKeyColumns[row.resourceType]) == 0 {
+			continue
+		}
+		obj, err := DecodeJSONObject(json.RawMessage(row.data))
+		if err != nil {
+			continue // malformed legacy JSON cannot be re-keyed safely
+		}
+		row.storageID = resourceStorageID(row.resourceType, row.id, obj)
+		if row.storageID == row.id {
+			continue // no usable parent value in this legacy payload
+		}
+		legacy = append(legacy, row)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("reading parent-key resources: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("closing parent-key resources: %w", err)
+	}
+
+	ftsExists, err := tableExists(ctx, conn, "resources_fts")
+	if err != nil {
+		return err
+	}
+	for _, row := range legacy {
+		canonicalData := row.data
+		err := conn.QueryRowContext(ctx,
+			`SELECT data FROM resources WHERE resource_type = ? AND id = ?`,
+			row.resourceType, row.storageID,
+		).Scan(&canonicalData)
+		switch {
+		case err == nil:
+			// The maintained composite row already exists. Remove only the
+			// stale bare duplicate after the typed projection is reconciled.
+		case err == sql.ErrNoRows:
+			if _, err := conn.ExecContext(ctx,
+				`UPDATE resources SET id = ? WHERE resource_type = ? AND id = ?`,
+				row.storageID, row.resourceType, row.id,
+			); err != nil {
+				return fmt.Errorf("re-keying resource %s/%s: %w", row.resourceType, row.id, err)
+			}
+		default:
+			return fmt.Errorf("checking composite resource %s/%s: %w", row.resourceType, row.id, err)
+		}
+
+		if err := migrateParentKeyTypedID(ctx, conn, row.resourceType, row.id, row.storageID); err != nil {
+			return err
+		}
+		if _, err := conn.ExecContext(ctx,
+			`DELETE FROM resources WHERE resource_type = ? AND id = ?`,
+			row.resourceType, row.id,
+		); err != nil {
+			return fmt.Errorf("deleting bare resource %s/%s: %w", row.resourceType, row.id, err)
+		}
+
+		if !ftsExists {
+			continue
+		}
+		if _, err := conn.ExecContext(ctx, `DELETE FROM resources_fts WHERE rowid = ?`, ftsRowID(row.resourceType, row.id)); err != nil {
+			return fmt.Errorf("deleting bare resource FTS row %s/%s: %w", row.resourceType, row.id, err)
+		}
+		if _, err := conn.ExecContext(ctx, `DELETE FROM resources_fts WHERE rowid = ?`, ftsRowID(row.resourceType, row.storageID)); err != nil {
+			return fmt.Errorf("replacing composite resource FTS row %s/%s: %w", row.resourceType, row.storageID, err)
+		}
+		if _, err := conn.ExecContext(ctx,
+			`INSERT INTO resources_fts (rowid, id, resource_type, content) VALUES (?, ?, ?, ?)`,
+			ftsRowID(row.resourceType, row.storageID), row.storageID, row.resourceType,
+			searchableResourceContent(json.RawMessage(canonicalData)),
+		); err != nil {
+			return fmt.Errorf("indexing composite resource %s/%s: %w", row.resourceType, row.storageID, err)
+		}
+	}
+	return nil
+}
+
+// migrateParentKeyTypedID mirrors a generic storage-id transition into the
+// generated typed projection. The generated switch is deliberately driven by
+// table metadata rather than API-specific names. Content-sync FTS triggers fire
+// for the UPDATE/DELETE operations and remove the discarded typed FTS row.
+func migrateParentKeyTypedID(ctx context.Context, conn *sql.Conn, resourceType, bareID, storageID string) error {
+	switch resourceType {
+{{- range .Tables}}
+{{- if emitsDomainTable .}}
+	case {{printf "%q" .Resource}}:
+		return migrateParentKeyTypedTableID(ctx, conn, {{printf "%q" .Name}}, bareID, storageID)
+{{- end}}
+{{- end}}
+	default:
+		return nil // generic-only resource
+	}
+}
+
+func migrateParentKeyTypedTableID(ctx context.Context, conn *sql.Conn, table, bareID, storageID string) error {
+	var compositeCount int
+	if err := conn.QueryRowContext(ctx,
+		fmt.Sprintf(`SELECT COUNT(*) FROM "%s" WHERE id = ?`, table), storageID,
+	).Scan(&compositeCount); err != nil {
+		return fmt.Errorf("checking typed composite row %s/%s: %w", table, storageID, err)
+	}
+	if compositeCount > 0 {
+		if _, err := conn.ExecContext(ctx,
+			fmt.Sprintf(`DELETE FROM "%s" WHERE id = ?`, table), bareID,
+		); err != nil {
+			return fmt.Errorf("deleting typed bare row %s/%s: %w", table, bareID, err)
+		}
+		return nil
+	}
+	if _, err := conn.ExecContext(ctx,
+		fmt.Sprintf(`UPDATE "%s" SET id = ? WHERE id = ?`, table), storageID, bareID,
+	); err != nil {
+		return fmt.Errorf("re-keying typed row %s/%s: %w", table, bareID, err)
 	}
 	return nil
 }

--- a/internal/generator/templates/store_schema_version_test.go.tmpl
+++ b/internal/generator/templates/store_schema_version_test.go.tmpl
@@ -1056,8 +1056,8 @@ func requireTableExists(t *testing.T, s *Store, name string) {
 }
 
 // TestSchemaVersion_FreshDBHasCandidateAndEventTables verifies a fresh
-// learn-enabled database opens at the current (v9) version with both new
-// tables queryable and their CHECK constraints enforced. Candidates are the
+// learn-enabled database opens at the current version with both v9 tables
+// queryable and their CHECK constraints enforced. Candidates are the
 // structural quarantine for CLI-derived observations; events are the
 // measurement substrate — neither may silently regress to a missing table
 // or an unchecked enum column.
@@ -1106,13 +1106,13 @@ func TestSchemaVersion_FreshDBHasCandidateAndEventTables(t *testing.T) {
 	}
 }
 
-// TestMigrate_V4ToV9AdditiveNoFTSContentRewrite verifies the FTS decouple:
-// a v4-stamped store opened by the v9 binary takes the additive-only path.
+// TestMigrate_V4ToCurrentAdditiveNoFTSContentRewrite verifies the FTS decouple:
+// a v4-stamped store opened by the current binary takes the additive-only FTS path.
 // The learn tables are created, the version advances, and the FTS content
 // rewrite does NOT run — resourcesFTSContentSchemaVersion is pinned at 4,
 // so a store stamped at 4 already carries extracted-leaf content and a
 // sentinel FTS row must survive the open byte-for-byte at its rowid.
-func TestMigrate_V4ToV9AdditiveNoFTSContentRewrite(t *testing.T) {
+func TestMigrate_V4ToCurrentAdditiveNoFTSContentRewrite(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "data.db")
 
 	raw, err := sql.Open("sqlite", dbPath)
@@ -1150,7 +1150,7 @@ func TestMigrate_V4ToV9AdditiveNoFTSContentRewrite(t *testing.T) {
 
 	s, err := Open(dbPath)
 	if err != nil {
-		t.Fatalf("open v4 db with v9 binary: %v", err)
+		t.Fatalf("open v4 db with current binary: %v", err)
 	}
 	defer s.Close()
 
@@ -1173,7 +1173,7 @@ func TestMigrate_V4ToV9AdditiveNoFTSContentRewrite(t *testing.T) {
 		t.Fatalf("read resources_fts after v4 open: %v", err)
 	}
 	if content != "sentinel fts" {
-		t.Fatalf("resources_fts content = %q; the v4->v9 open must not rewrite FTS content", content)
+		t.Fatalf("resources_fts content = %q; the v4->current open must not rewrite FTS content", content)
 	}
 	if want := ftsRowID("user", "user-1"); rowid != want {
 		t.Fatalf("resources_fts rowid = %d, want preserved %d", rowid, want)
@@ -1188,11 +1188,11 @@ func TestMigrate_V4ToV9AdditiveNoFTSContentRewrite(t *testing.T) {
 	}
 }
 
-// TestMigrate_V8ToV9AddsCandidatesAndEvents verifies the v8->v9 upgrade is
-// purely additive: a v8-stamped store (learn tables through
+// TestMigrate_V8AddsV9CandidatesAndEvents verifies the v8 upgrade is purely
+// additive: a v8-stamped store (learn tables through
 // learning_playbooks) gains learn_candidates and learn_events, keeps every
 // learn row intact, and never touches FTS content.
-func TestMigrate_V8ToV9AddsCandidatesAndEvents(t *testing.T) {
+func TestMigrate_V8AddsV9CandidatesAndEvents(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "data.db")
 
 	raw, err := sql.Open("sqlite", dbPath)
@@ -1302,7 +1302,7 @@ func TestMigrate_V8ToV9AddsCandidatesAndEvents(t *testing.T) {
 		t.Fatalf("read resources_fts after v8 open: %v", err)
 	}
 	if content != "sentinel fts" {
-		t.Fatalf("resources_fts content = %q; the v8->v9 open must not rewrite FTS content", content)
+		t.Fatalf("resources_fts content = %q; the v8->current open must not rewrite FTS content", content)
 	}
 }
 {{- end}}

--- a/testdata/golden/cases/generate-learn-loop-api/artifacts.txt
+++ b/testdata/golden/cases/generate-learn-loop-api/artifacts.txt
@@ -31,9 +31,9 @@ learn-loop-example/internal/cli/learnings_stats.go
 # this file.
 learn-loop-example/internal/cli/root.go
 
-# Store schema v9: StoreSchemaVersion = 9 + CREATE TABLE statements for
-# search_patterns, entity_lookups, teach_log_metadata, learning_playbooks,
-# learn_candidates, and learn_events.
+# Store schema v10: StoreSchemaVersion = 10, the parent-key storage-id
+# migration, and CREATE TABLE statements for search_patterns, entity_lookups,
+# learning_playbooks, learn_candidates, and learn_events.
 learn-loop-example/internal/store/store.go
 learn-loop-example/internal/store/extras.go
 learn-loop-example/internal/store/candidates.go

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -48,9 +48,14 @@ func IsUUID(s string) bool {
 
 // StoreSchemaVersion is the on-disk schema version this binary understands.
 // It is stamped into SQLite's PRAGMA user_version on fresh databases and
-// checked on every open. Non-learn CLIs advance to v4 for the
-// resources_fts content extraction.
-const StoreSchemaVersion = 4
+// checked on every open. Non-learn CLIs advance to v5 for the parent-key storage-id migration, on
+// top of the v4 resources_fts content extraction.
+const StoreSchemaVersion = 5
+
+// parentKeyStorageIDSchemaVersion follows StoreSchemaVersion intentionally.
+// Re-keying is idempotent, so any future schema bump also sweeps legacy bare
+// rows for resource types newly emitted in resourceParentKeyColumns.
+const parentKeyStorageIDSchemaVersion = StoreSchemaVersion
 
 // resourcesFTSContentSchemaVersion pins the schema bump that rewrote
 // resources_fts content from raw JSON to searchable leaf values. Keep this
@@ -489,6 +494,11 @@ func (s *Store) migrate(ctx context.Context) error {
 				return fmt.Errorf("migrating resources FTS content: %w", err)
 			}
 		}
+		if current < parentKeyStorageIDSchemaVersion {
+			if err := s.migrateParentKeyStorageIDs(ctx, conn); err != nil {
+				return fmt.Errorf("migrating parent-key storage ids: %w", err)
+			}
+		}
 		// Stamp the schema version. On a fresh DB this writes the current
 		// StoreSchemaVersion; on an already-stamped DB this is a no-op
 		// write of the same value.
@@ -662,6 +672,151 @@ func rebuildResourcesFTS(ctx context.Context, conn *sql.Conn) error {
 		); err != nil {
 			return fmt.Errorf("indexing resource %s/%s: %w", r.resourceType, r.id, err)
 		}
+	}
+	return nil
+}
+
+// migrateParentKeyStorageIDs upgrades dependent-resource rows written before
+// their resource type entered resourceParentKeyColumns. Those rows use the
+// bare API id while current upserts use "<id>\x00<parent>". When both shapes
+// exist, the composite row wins because it is the row current upserts maintain;
+// otherwise the legacy row is re-keyed in place. The generic FTS entry is
+// replaced because its deterministic rowid includes the storage id.
+func (s *Store) migrateParentKeyStorageIDs(ctx context.Context, conn *sql.Conn) error {
+	if len(resourceParentKeyColumns) == 0 {
+		return nil
+	}
+	exists, err := tableExists(ctx, conn, "resources")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
+	type legacyRow struct {
+		id           string
+		resourceType string
+		data         string
+		storageID    string
+	}
+	rows, err := conn.QueryContext(ctx, `SELECT id, resource_type, data FROM resources ORDER BY resource_type, id`)
+	if err != nil {
+		return fmt.Errorf("querying parent-key resources: %w", err)
+	}
+	var legacy []legacyRow
+	for rows.Next() {
+		var row legacyRow
+		if err := rows.Scan(&row.id, &row.resourceType, &row.data); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scanning parent-key resource: %w", err)
+		}
+		if strings.IndexByte(row.id, 0) >= 0 || len(resourceParentKeyColumns[row.resourceType]) == 0 {
+			continue
+		}
+		obj, err := DecodeJSONObject(json.RawMessage(row.data))
+		if err != nil {
+			continue // malformed legacy JSON cannot be re-keyed safely
+		}
+		row.storageID = resourceStorageID(row.resourceType, row.id, obj)
+		if row.storageID == row.id {
+			continue // no usable parent value in this legacy payload
+		}
+		legacy = append(legacy, row)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("reading parent-key resources: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("closing parent-key resources: %w", err)
+	}
+
+	ftsExists, err := tableExists(ctx, conn, "resources_fts")
+	if err != nil {
+		return err
+	}
+	for _, row := range legacy {
+		canonicalData := row.data
+		err := conn.QueryRowContext(ctx,
+			`SELECT data FROM resources WHERE resource_type = ? AND id = ?`,
+			row.resourceType, row.storageID,
+		).Scan(&canonicalData)
+		switch {
+		case err == nil:
+			// The maintained composite row already exists. Remove only the
+			// stale bare duplicate after the typed projection is reconciled.
+		case err == sql.ErrNoRows:
+			if _, err := conn.ExecContext(ctx,
+				`UPDATE resources SET id = ? WHERE resource_type = ? AND id = ?`,
+				row.storageID, row.resourceType, row.id,
+			); err != nil {
+				return fmt.Errorf("re-keying resource %s/%s: %w", row.resourceType, row.id, err)
+			}
+		default:
+			return fmt.Errorf("checking composite resource %s/%s: %w", row.resourceType, row.id, err)
+		}
+
+		if err := migrateParentKeyTypedID(ctx, conn, row.resourceType, row.id, row.storageID); err != nil {
+			return err
+		}
+		if _, err := conn.ExecContext(ctx,
+			`DELETE FROM resources WHERE resource_type = ? AND id = ?`,
+			row.resourceType, row.id,
+		); err != nil {
+			return fmt.Errorf("deleting bare resource %s/%s: %w", row.resourceType, row.id, err)
+		}
+
+		if !ftsExists {
+			continue
+		}
+		if _, err := conn.ExecContext(ctx, `DELETE FROM resources_fts WHERE rowid = ?`, ftsRowID(row.resourceType, row.id)); err != nil {
+			return fmt.Errorf("deleting bare resource FTS row %s/%s: %w", row.resourceType, row.id, err)
+		}
+		if _, err := conn.ExecContext(ctx, `DELETE FROM resources_fts WHERE rowid = ?`, ftsRowID(row.resourceType, row.storageID)); err != nil {
+			return fmt.Errorf("replacing composite resource FTS row %s/%s: %w", row.resourceType, row.storageID, err)
+		}
+		if _, err := conn.ExecContext(ctx,
+			`INSERT INTO resources_fts (rowid, id, resource_type, content) VALUES (?, ?, ?, ?)`,
+			ftsRowID(row.resourceType, row.storageID), row.storageID, row.resourceType,
+			searchableResourceContent(json.RawMessage(canonicalData)),
+		); err != nil {
+			return fmt.Errorf("indexing composite resource %s/%s: %w", row.resourceType, row.storageID, err)
+		}
+	}
+	return nil
+}
+
+// migrateParentKeyTypedID mirrors a generic storage-id transition into the
+// generated typed projection. The generated switch is deliberately driven by
+// table metadata rather than API-specific names. Content-sync FTS triggers fire
+// for the UPDATE/DELETE operations and remove the discarded typed FTS row.
+func migrateParentKeyTypedID(ctx context.Context, conn *sql.Conn, resourceType, bareID, storageID string) error {
+	switch resourceType {
+	default:
+		return nil // generic-only resource
+	}
+}
+
+func migrateParentKeyTypedTableID(ctx context.Context, conn *sql.Conn, table, bareID, storageID string) error {
+	var compositeCount int
+	if err := conn.QueryRowContext(ctx,
+		fmt.Sprintf(`SELECT COUNT(*) FROM "%s" WHERE id = ?`, table), storageID,
+	).Scan(&compositeCount); err != nil {
+		return fmt.Errorf("checking typed composite row %s/%s: %w", table, storageID, err)
+	}
+	if compositeCount > 0 {
+		if _, err := conn.ExecContext(ctx,
+			fmt.Sprintf(`DELETE FROM "%s" WHERE id = ?`, table), bareID,
+		); err != nil {
+			return fmt.Errorf("deleting typed bare row %s/%s: %w", table, bareID, err)
+		}
+		return nil
+	}
+	if _, err := conn.ExecContext(ctx,
+		fmt.Sprintf(`UPDATE "%s" SET id = ? WHERE id = ?`, table), storageID, bareID,
+	); err != nil {
+		return fmt.Errorf("re-keying typed row %s/%s: %w", table, bareID, err)
 	}
 	return nil
 }

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -48,13 +48,19 @@ func IsUUID(s string) bool {
 
 // StoreSchemaVersion is the on-disk schema version this binary understands.
 // It is stamped into SQLite's PRAGMA user_version on fresh databases and
-// checked on every open. Learn-enabled CLIs advance to v9 for the
-// learn_candidates and learn_events tables (CLI-side capture and
-// measurement), on top of the v8 learning_playbooks table for
-// hand-authored choreography keyed by query family and the v6 canonical
-// learn-loop tables ported from prediction-goat (including the v3
-// resources_fts rowid rehash and v4 resources_fts content extraction).
-const StoreSchemaVersion = 9
+// checked on every open. Learn-enabled CLIs advance to v10 for the
+// parent-key storage-id migration, on top of the v9 learn_candidates and
+// learn_events tables (CLI-side capture and measurement), the v8
+// learning_playbooks table for hand-authored choreography keyed by query
+// family, and the v6 canonical learn-loop tables ported from prediction-goat
+// (including the v3 resources_fts rowid rehash and v4 resources_fts content
+// extraction).
+const StoreSchemaVersion = 10
+
+// parentKeyStorageIDSchemaVersion follows StoreSchemaVersion intentionally.
+// Re-keying is idempotent, so any future schema bump also sweeps legacy bare
+// rows for resource types newly emitted in resourceParentKeyColumns.
+const parentKeyStorageIDSchemaVersion = StoreSchemaVersion
 
 // resourcesFTSContentSchemaVersion pins the schema bump that rewrote
 // resources_fts content from raw JSON to searchable leaf values. Keep this
@@ -651,6 +657,11 @@ func (s *Store) migrate(ctx context.Context) error {
 				return fmt.Errorf("migrating resources FTS content: %w", err)
 			}
 		}
+		if current < parentKeyStorageIDSchemaVersion {
+			if err := s.migrateParentKeyStorageIDs(ctx, conn); err != nil {
+				return fmt.Errorf("migrating parent-key storage ids: %w", err)
+			}
+		}
 		// Stamp the schema version. On a fresh DB this writes the current
 		// StoreSchemaVersion; on an already-stamped DB this is a no-op
 		// write of the same value.
@@ -824,6 +835,153 @@ func rebuildResourcesFTS(ctx context.Context, conn *sql.Conn) error {
 		); err != nil {
 			return fmt.Errorf("indexing resource %s/%s: %w", r.resourceType, r.id, err)
 		}
+	}
+	return nil
+}
+
+// migrateParentKeyStorageIDs upgrades dependent-resource rows written before
+// their resource type entered resourceParentKeyColumns. Those rows use the
+// bare API id while current upserts use "<id>\x00<parent>". When both shapes
+// exist, the composite row wins because it is the row current upserts maintain;
+// otherwise the legacy row is re-keyed in place. The generic FTS entry is
+// replaced because its deterministic rowid includes the storage id.
+func (s *Store) migrateParentKeyStorageIDs(ctx context.Context, conn *sql.Conn) error {
+	if len(resourceParentKeyColumns) == 0 {
+		return nil
+	}
+	exists, err := tableExists(ctx, conn, "resources")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
+	type legacyRow struct {
+		id           string
+		resourceType string
+		data         string
+		storageID    string
+	}
+	rows, err := conn.QueryContext(ctx, `SELECT id, resource_type, data FROM resources ORDER BY resource_type, id`)
+	if err != nil {
+		return fmt.Errorf("querying parent-key resources: %w", err)
+	}
+	var legacy []legacyRow
+	for rows.Next() {
+		var row legacyRow
+		if err := rows.Scan(&row.id, &row.resourceType, &row.data); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scanning parent-key resource: %w", err)
+		}
+		if strings.IndexByte(row.id, 0) >= 0 || len(resourceParentKeyColumns[row.resourceType]) == 0 {
+			continue
+		}
+		obj, err := DecodeJSONObject(json.RawMessage(row.data))
+		if err != nil {
+			continue // malformed legacy JSON cannot be re-keyed safely
+		}
+		row.storageID = resourceStorageID(row.resourceType, row.id, obj)
+		if row.storageID == row.id {
+			continue // no usable parent value in this legacy payload
+		}
+		legacy = append(legacy, row)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("reading parent-key resources: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("closing parent-key resources: %w", err)
+	}
+
+	ftsExists, err := tableExists(ctx, conn, "resources_fts")
+	if err != nil {
+		return err
+	}
+	for _, row := range legacy {
+		canonicalData := row.data
+		err := conn.QueryRowContext(ctx,
+			`SELECT data FROM resources WHERE resource_type = ? AND id = ?`,
+			row.resourceType, row.storageID,
+		).Scan(&canonicalData)
+		switch {
+		case err == nil:
+			// The maintained composite row already exists. Remove only the
+			// stale bare duplicate after the typed projection is reconciled.
+		case err == sql.ErrNoRows:
+			if _, err := conn.ExecContext(ctx,
+				`UPDATE resources SET id = ? WHERE resource_type = ? AND id = ?`,
+				row.storageID, row.resourceType, row.id,
+			); err != nil {
+				return fmt.Errorf("re-keying resource %s/%s: %w", row.resourceType, row.id, err)
+			}
+		default:
+			return fmt.Errorf("checking composite resource %s/%s: %w", row.resourceType, row.id, err)
+		}
+
+		if err := migrateParentKeyTypedID(ctx, conn, row.resourceType, row.id, row.storageID); err != nil {
+			return err
+		}
+		if _, err := conn.ExecContext(ctx,
+			`DELETE FROM resources WHERE resource_type = ? AND id = ?`,
+			row.resourceType, row.id,
+		); err != nil {
+			return fmt.Errorf("deleting bare resource %s/%s: %w", row.resourceType, row.id, err)
+		}
+
+		if !ftsExists {
+			continue
+		}
+		if _, err := conn.ExecContext(ctx, `DELETE FROM resources_fts WHERE rowid = ?`, ftsRowID(row.resourceType, row.id)); err != nil {
+			return fmt.Errorf("deleting bare resource FTS row %s/%s: %w", row.resourceType, row.id, err)
+		}
+		if _, err := conn.ExecContext(ctx, `DELETE FROM resources_fts WHERE rowid = ?`, ftsRowID(row.resourceType, row.storageID)); err != nil {
+			return fmt.Errorf("replacing composite resource FTS row %s/%s: %w", row.resourceType, row.storageID, err)
+		}
+		if _, err := conn.ExecContext(ctx,
+			`INSERT INTO resources_fts (rowid, id, resource_type, content) VALUES (?, ?, ?, ?)`,
+			ftsRowID(row.resourceType, row.storageID), row.storageID, row.resourceType,
+			searchableResourceContent(json.RawMessage(canonicalData)),
+		); err != nil {
+			return fmt.Errorf("indexing composite resource %s/%s: %w", row.resourceType, row.storageID, err)
+		}
+	}
+	return nil
+}
+
+// migrateParentKeyTypedID mirrors a generic storage-id transition into the
+// generated typed projection. The generated switch is deliberately driven by
+// table metadata rather than API-specific names. Content-sync FTS triggers fire
+// for the UPDATE/DELETE operations and remove the discarded typed FTS row.
+func migrateParentKeyTypedID(ctx context.Context, conn *sql.Conn, resourceType, bareID, storageID string) error {
+	switch resourceType {
+	case "leagues":
+		return migrateParentKeyTypedTableID(ctx, conn, "leagues", bareID, storageID)
+	default:
+		return nil // generic-only resource
+	}
+}
+
+func migrateParentKeyTypedTableID(ctx context.Context, conn *sql.Conn, table, bareID, storageID string) error {
+	var compositeCount int
+	if err := conn.QueryRowContext(ctx,
+		fmt.Sprintf(`SELECT COUNT(*) FROM "%s" WHERE id = ?`, table), storageID,
+	).Scan(&compositeCount); err != nil {
+		return fmt.Errorf("checking typed composite row %s/%s: %w", table, storageID, err)
+	}
+	if compositeCount > 0 {
+		if _, err := conn.ExecContext(ctx,
+			fmt.Sprintf(`DELETE FROM "%s" WHERE id = ?`, table), bareID,
+		); err != nil {
+			return fmt.Errorf("deleting typed bare row %s/%s: %w", table, bareID, err)
+		}
+		return nil
+	}
+	if _, err := conn.ExecContext(ctx,
+		fmt.Sprintf(`UPDATE "%s" SET id = ? WHERE id = ?`, table), storageID, bareID,
+	); err != nil {
+		return fmt.Errorf("re-keying typed row %s/%s: %w", table, bareID, err)
 	}
 	return nil
 }

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -48,13 +48,19 @@ func IsUUID(s string) bool {
 
 // StoreSchemaVersion is the on-disk schema version this binary understands.
 // It is stamped into SQLite's PRAGMA user_version on fresh databases and
-// checked on every open. Learn-enabled CLIs advance to v9 for the
-// learn_candidates and learn_events tables (CLI-side capture and
-// measurement), on top of the v8 learning_playbooks table for
-// hand-authored choreography keyed by query family and the v6 canonical
-// learn-loop tables ported from prediction-goat (including the v3
-// resources_fts rowid rehash and v4 resources_fts content extraction).
-const StoreSchemaVersion = 9
+// checked on every open. Learn-enabled CLIs advance to v10 for the
+// parent-key storage-id migration, on top of the v9 learn_candidates and
+// learn_events tables (CLI-side capture and measurement), the v8
+// learning_playbooks table for hand-authored choreography keyed by query
+// family, and the v6 canonical learn-loop tables ported from prediction-goat
+// (including the v3 resources_fts rowid rehash and v4 resources_fts content
+// extraction).
+const StoreSchemaVersion = 10
+
+// parentKeyStorageIDSchemaVersion follows StoreSchemaVersion intentionally.
+// Re-keying is idempotent, so any future schema bump also sweeps legacy bare
+// rows for resource types newly emitted in resourceParentKeyColumns.
+const parentKeyStorageIDSchemaVersion = StoreSchemaVersion
 
 // resourcesFTSContentSchemaVersion pins the schema bump that rewrote
 // resources_fts content from raw JSON to searchable leaf values. Keep this
@@ -657,6 +663,11 @@ func (s *Store) migrate(ctx context.Context) error {
 				return fmt.Errorf("migrating resources FTS content: %w", err)
 			}
 		}
+		if current < parentKeyStorageIDSchemaVersion {
+			if err := s.migrateParentKeyStorageIDs(ctx, conn); err != nil {
+				return fmt.Errorf("migrating parent-key storage ids: %w", err)
+			}
+		}
 		// Stamp the schema version. On a fresh DB this writes the current
 		// StoreSchemaVersion; on an already-stamped DB this is a no-op
 		// write of the same value.
@@ -830,6 +841,155 @@ func rebuildResourcesFTS(ctx context.Context, conn *sql.Conn) error {
 		); err != nil {
 			return fmt.Errorf("indexing resource %s/%s: %w", r.resourceType, r.id, err)
 		}
+	}
+	return nil
+}
+
+// migrateParentKeyStorageIDs upgrades dependent-resource rows written before
+// their resource type entered resourceParentKeyColumns. Those rows use the
+// bare API id while current upserts use "<id>\x00<parent>". When both shapes
+// exist, the composite row wins because it is the row current upserts maintain;
+// otherwise the legacy row is re-keyed in place. The generic FTS entry is
+// replaced because its deterministic rowid includes the storage id.
+func (s *Store) migrateParentKeyStorageIDs(ctx context.Context, conn *sql.Conn) error {
+	if len(resourceParentKeyColumns) == 0 {
+		return nil
+	}
+	exists, err := tableExists(ctx, conn, "resources")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
+	type legacyRow struct {
+		id           string
+		resourceType string
+		data         string
+		storageID    string
+	}
+	rows, err := conn.QueryContext(ctx, `SELECT id, resource_type, data FROM resources ORDER BY resource_type, id`)
+	if err != nil {
+		return fmt.Errorf("querying parent-key resources: %w", err)
+	}
+	var legacy []legacyRow
+	for rows.Next() {
+		var row legacyRow
+		if err := rows.Scan(&row.id, &row.resourceType, &row.data); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scanning parent-key resource: %w", err)
+		}
+		if strings.IndexByte(row.id, 0) >= 0 || len(resourceParentKeyColumns[row.resourceType]) == 0 {
+			continue
+		}
+		obj, err := DecodeJSONObject(json.RawMessage(row.data))
+		if err != nil {
+			continue // malformed legacy JSON cannot be re-keyed safely
+		}
+		row.storageID = resourceStorageID(row.resourceType, row.id, obj)
+		if row.storageID == row.id {
+			continue // no usable parent value in this legacy payload
+		}
+		legacy = append(legacy, row)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("reading parent-key resources: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("closing parent-key resources: %w", err)
+	}
+
+	ftsExists, err := tableExists(ctx, conn, "resources_fts")
+	if err != nil {
+		return err
+	}
+	for _, row := range legacy {
+		canonicalData := row.data
+		err := conn.QueryRowContext(ctx,
+			`SELECT data FROM resources WHERE resource_type = ? AND id = ?`,
+			row.resourceType, row.storageID,
+		).Scan(&canonicalData)
+		switch {
+		case err == nil:
+			// The maintained composite row already exists. Remove only the
+			// stale bare duplicate after the typed projection is reconciled.
+		case err == sql.ErrNoRows:
+			if _, err := conn.ExecContext(ctx,
+				`UPDATE resources SET id = ? WHERE resource_type = ? AND id = ?`,
+				row.storageID, row.resourceType, row.id,
+			); err != nil {
+				return fmt.Errorf("re-keying resource %s/%s: %w", row.resourceType, row.id, err)
+			}
+		default:
+			return fmt.Errorf("checking composite resource %s/%s: %w", row.resourceType, row.id, err)
+		}
+
+		if err := migrateParentKeyTypedID(ctx, conn, row.resourceType, row.id, row.storageID); err != nil {
+			return err
+		}
+		if _, err := conn.ExecContext(ctx,
+			`DELETE FROM resources WHERE resource_type = ? AND id = ?`,
+			row.resourceType, row.id,
+		); err != nil {
+			return fmt.Errorf("deleting bare resource %s/%s: %w", row.resourceType, row.id, err)
+		}
+
+		if !ftsExists {
+			continue
+		}
+		if _, err := conn.ExecContext(ctx, `DELETE FROM resources_fts WHERE rowid = ?`, ftsRowID(row.resourceType, row.id)); err != nil {
+			return fmt.Errorf("deleting bare resource FTS row %s/%s: %w", row.resourceType, row.id, err)
+		}
+		if _, err := conn.ExecContext(ctx, `DELETE FROM resources_fts WHERE rowid = ?`, ftsRowID(row.resourceType, row.storageID)); err != nil {
+			return fmt.Errorf("replacing composite resource FTS row %s/%s: %w", row.resourceType, row.storageID, err)
+		}
+		if _, err := conn.ExecContext(ctx,
+			`INSERT INTO resources_fts (rowid, id, resource_type, content) VALUES (?, ?, ?, ?)`,
+			ftsRowID(row.resourceType, row.storageID), row.storageID, row.resourceType,
+			searchableResourceContent(json.RawMessage(canonicalData)),
+		); err != nil {
+			return fmt.Errorf("indexing composite resource %s/%s: %w", row.resourceType, row.storageID, err)
+		}
+	}
+	return nil
+}
+
+// migrateParentKeyTypedID mirrors a generic storage-id transition into the
+// generated typed projection. The generated switch is deliberately driven by
+// table metadata rather than API-specific names. Content-sync FTS triggers fire
+// for the UPDATE/DELETE operations and remove the discarded typed FTS row.
+func migrateParentKeyTypedID(ctx context.Context, conn *sql.Conn, resourceType, bareID, storageID string) error {
+	switch resourceType {
+	case "gadgets":
+		return migrateParentKeyTypedTableID(ctx, conn, "gadgets", bareID, storageID)
+	case "widgets":
+		return migrateParentKeyTypedTableID(ctx, conn, "widgets", bareID, storageID)
+	default:
+		return nil // generic-only resource
+	}
+}
+
+func migrateParentKeyTypedTableID(ctx context.Context, conn *sql.Conn, table, bareID, storageID string) error {
+	var compositeCount int
+	if err := conn.QueryRowContext(ctx,
+		fmt.Sprintf(`SELECT COUNT(*) FROM "%s" WHERE id = ?`, table), storageID,
+	).Scan(&compositeCount); err != nil {
+		return fmt.Errorf("checking typed composite row %s/%s: %w", table, storageID, err)
+	}
+	if compositeCount > 0 {
+		if _, err := conn.ExecContext(ctx,
+			fmt.Sprintf(`DELETE FROM "%s" WHERE id = ?`, table), bareID,
+		); err != nil {
+			return fmt.Errorf("deleting typed bare row %s/%s: %w", table, bareID, err)
+		}
+		return nil
+	}
+	if _, err := conn.ExecContext(ctx,
+		fmt.Sprintf(`UPDATE "%s" SET id = ? WHERE id = ?`, table), storageID, bareID,
+	); err != nil {
+		return fmt.Errorf("re-keying typed row %s/%s: %w", table, bareID, err)
 	}
 	return nil
 }

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -48,13 +48,19 @@ func IsUUID(s string) bool {
 
 // StoreSchemaVersion is the on-disk schema version this binary understands.
 // It is stamped into SQLite's PRAGMA user_version on fresh databases and
-// checked on every open. Learn-enabled CLIs advance to v9 for the
-// learn_candidates and learn_events tables (CLI-side capture and
-// measurement), on top of the v8 learning_playbooks table for
-// hand-authored choreography keyed by query family and the v6 canonical
-// learn-loop tables ported from prediction-goat (including the v3
-// resources_fts rowid rehash and v4 resources_fts content extraction).
-const StoreSchemaVersion = 9
+// checked on every open. Learn-enabled CLIs advance to v10 for the
+// parent-key storage-id migration, on top of the v9 learn_candidates and
+// learn_events tables (CLI-side capture and measurement), the v8
+// learning_playbooks table for hand-authored choreography keyed by query
+// family, and the v6 canonical learn-loop tables ported from prediction-goat
+// (including the v3 resources_fts rowid rehash and v4 resources_fts content
+// extraction).
+const StoreSchemaVersion = 10
+
+// parentKeyStorageIDSchemaVersion follows StoreSchemaVersion intentionally.
+// Re-keying is idempotent, so any future schema bump also sweeps legacy bare
+// rows for resource types newly emitted in resourceParentKeyColumns.
+const parentKeyStorageIDSchemaVersion = StoreSchemaVersion
 
 // resourcesFTSContentSchemaVersion pins the schema bump that rewrote
 // resources_fts content from raw JSON to searchable leaf values. Keep this
@@ -651,6 +657,11 @@ func (s *Store) migrate(ctx context.Context) error {
 				return fmt.Errorf("migrating resources FTS content: %w", err)
 			}
 		}
+		if current < parentKeyStorageIDSchemaVersion {
+			if err := s.migrateParentKeyStorageIDs(ctx, conn); err != nil {
+				return fmt.Errorf("migrating parent-key storage ids: %w", err)
+			}
+		}
 		// Stamp the schema version. On a fresh DB this writes the current
 		// StoreSchemaVersion; on an already-stamped DB this is a no-op
 		// write of the same value.
@@ -824,6 +835,153 @@ func rebuildResourcesFTS(ctx context.Context, conn *sql.Conn) error {
 		); err != nil {
 			return fmt.Errorf("indexing resource %s/%s: %w", r.resourceType, r.id, err)
 		}
+	}
+	return nil
+}
+
+// migrateParentKeyStorageIDs upgrades dependent-resource rows written before
+// their resource type entered resourceParentKeyColumns. Those rows use the
+// bare API id while current upserts use "<id>\x00<parent>". When both shapes
+// exist, the composite row wins because it is the row current upserts maintain;
+// otherwise the legacy row is re-keyed in place. The generic FTS entry is
+// replaced because its deterministic rowid includes the storage id.
+func (s *Store) migrateParentKeyStorageIDs(ctx context.Context, conn *sql.Conn) error {
+	if len(resourceParentKeyColumns) == 0 {
+		return nil
+	}
+	exists, err := tableExists(ctx, conn, "resources")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
+	type legacyRow struct {
+		id           string
+		resourceType string
+		data         string
+		storageID    string
+	}
+	rows, err := conn.QueryContext(ctx, `SELECT id, resource_type, data FROM resources ORDER BY resource_type, id`)
+	if err != nil {
+		return fmt.Errorf("querying parent-key resources: %w", err)
+	}
+	var legacy []legacyRow
+	for rows.Next() {
+		var row legacyRow
+		if err := rows.Scan(&row.id, &row.resourceType, &row.data); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scanning parent-key resource: %w", err)
+		}
+		if strings.IndexByte(row.id, 0) >= 0 || len(resourceParentKeyColumns[row.resourceType]) == 0 {
+			continue
+		}
+		obj, err := DecodeJSONObject(json.RawMessage(row.data))
+		if err != nil {
+			continue // malformed legacy JSON cannot be re-keyed safely
+		}
+		row.storageID = resourceStorageID(row.resourceType, row.id, obj)
+		if row.storageID == row.id {
+			continue // no usable parent value in this legacy payload
+		}
+		legacy = append(legacy, row)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("reading parent-key resources: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("closing parent-key resources: %w", err)
+	}
+
+	ftsExists, err := tableExists(ctx, conn, "resources_fts")
+	if err != nil {
+		return err
+	}
+	for _, row := range legacy {
+		canonicalData := row.data
+		err := conn.QueryRowContext(ctx,
+			`SELECT data FROM resources WHERE resource_type = ? AND id = ?`,
+			row.resourceType, row.storageID,
+		).Scan(&canonicalData)
+		switch {
+		case err == nil:
+			// The maintained composite row already exists. Remove only the
+			// stale bare duplicate after the typed projection is reconciled.
+		case err == sql.ErrNoRows:
+			if _, err := conn.ExecContext(ctx,
+				`UPDATE resources SET id = ? WHERE resource_type = ? AND id = ?`,
+				row.storageID, row.resourceType, row.id,
+			); err != nil {
+				return fmt.Errorf("re-keying resource %s/%s: %w", row.resourceType, row.id, err)
+			}
+		default:
+			return fmt.Errorf("checking composite resource %s/%s: %w", row.resourceType, row.id, err)
+		}
+
+		if err := migrateParentKeyTypedID(ctx, conn, row.resourceType, row.id, row.storageID); err != nil {
+			return err
+		}
+		if _, err := conn.ExecContext(ctx,
+			`DELETE FROM resources WHERE resource_type = ? AND id = ?`,
+			row.resourceType, row.id,
+		); err != nil {
+			return fmt.Errorf("deleting bare resource %s/%s: %w", row.resourceType, row.id, err)
+		}
+
+		if !ftsExists {
+			continue
+		}
+		if _, err := conn.ExecContext(ctx, `DELETE FROM resources_fts WHERE rowid = ?`, ftsRowID(row.resourceType, row.id)); err != nil {
+			return fmt.Errorf("deleting bare resource FTS row %s/%s: %w", row.resourceType, row.id, err)
+		}
+		if _, err := conn.ExecContext(ctx, `DELETE FROM resources_fts WHERE rowid = ?`, ftsRowID(row.resourceType, row.storageID)); err != nil {
+			return fmt.Errorf("replacing composite resource FTS row %s/%s: %w", row.resourceType, row.storageID, err)
+		}
+		if _, err := conn.ExecContext(ctx,
+			`INSERT INTO resources_fts (rowid, id, resource_type, content) VALUES (?, ?, ?, ?)`,
+			ftsRowID(row.resourceType, row.storageID), row.storageID, row.resourceType,
+			searchableResourceContent(json.RawMessage(canonicalData)),
+		); err != nil {
+			return fmt.Errorf("indexing composite resource %s/%s: %w", row.resourceType, row.storageID, err)
+		}
+	}
+	return nil
+}
+
+// migrateParentKeyTypedID mirrors a generic storage-id transition into the
+// generated typed projection. The generated switch is deliberately driven by
+// table metadata rather than API-specific names. Content-sync FTS triggers fire
+// for the UPDATE/DELETE operations and remove the discarded typed FTS row.
+func migrateParentKeyTypedID(ctx context.Context, conn *sql.Conn, resourceType, bareID, storageID string) error {
+	switch resourceType {
+	case "leagues":
+		return migrateParentKeyTypedTableID(ctx, conn, "leagues", bareID, storageID)
+	default:
+		return nil // generic-only resource
+	}
+}
+
+func migrateParentKeyTypedTableID(ctx context.Context, conn *sql.Conn, table, bareID, storageID string) error {
+	var compositeCount int
+	if err := conn.QueryRowContext(ctx,
+		fmt.Sprintf(`SELECT COUNT(*) FROM "%s" WHERE id = ?`, table), storageID,
+	).Scan(&compositeCount); err != nil {
+		return fmt.Errorf("checking typed composite row %s/%s: %w", table, storageID, err)
+	}
+	if compositeCount > 0 {
+		if _, err := conn.ExecContext(ctx,
+			fmt.Sprintf(`DELETE FROM "%s" WHERE id = ?`, table), bareID,
+		); err != nil {
+			return fmt.Errorf("deleting typed bare row %s/%s: %w", table, bareID, err)
+		}
+		return nil
+	}
+	if _, err := conn.ExecContext(ctx,
+		fmt.Sprintf(`UPDATE "%s" SET id = ? WHERE id = ?`, table), storageID, bareID,
+	); err != nil {
+		return fmt.Errorf("re-keying typed row %s/%s: %w", table, bareID, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Intent

Fixes #3691.

Existing stores can retain bare-ID rows after a dependent resource begins using parent-keyed storage IDs. Current syncs then maintain a second composite-ID row, while reconcile treats the stale bare ID as seen and never removes it. Agents consequently see duplicate counts, duplicate FTS hits, and plausible stale payloads.

## Approach

Bump the emitted store schema version and add an idempotent migration driven by the generated `resourceParentKeyColumns` map. For each legacy bare row, the migration computes the current composite key, preserves the maintained composite row when both shapes exist, or re-keys the bare row when it is the only copy. It mirrors the transition into generated typed tables, removes the obsolete generic FTS rowid, and indexes the canonical composite payload; typed-table FTS triggers handle the corresponding typed cleanup.

Generated runtime coverage seeds duplicate, bare-only, and composite-only rows, then verifies the generic table, typed projection, generic FTS, typed FTS, payload precedence, schema stamp, and current-version no-op reopen.

## Scope

Primary area: generated SQLite store migrations and their generated-output fixtures/tests.

Why this belongs in this repo: the key-shape transition is emitted by the Printing Press for every dependent resource. Fixing one printed CLI would leave the same permanent-duplicate failure in every future print.

## Risk

This changes the database-open path for stores below schema v5 (learn-disabled) or v10 (learn-enabled). The migration runs inside the existing `BEGIN IMMEDIATE` migration transaction, is driven only by generated resource/table metadata, skips resources without a usable parent value, and is a no-op when no legacy bare shape exists.

## Output Contract

Generated `internal/store/store.go` now emits schema v5/v10 plus the parent-key migration and typed-table dispatch. Four existing golden store fixtures were intentionally refreshed. The emitted contract is exercised by `TestGeneratedStoreMigratesLegacyParentKeyRows`, which compiles the generated module and executes the migration against SQLite rather than asserting template text alone.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Passing checks:

- `go fmt ./...`
- `go vet ./...`
- `go test ./... -run '^$'`
- `go test ./internal/generator -run '^TestGeneratedStoreMigratesLegacyParentKeyRows$' -count=1`
- targeted schema-version generator tests
- generated learn-enabled CLI: `go test ./internal/store -count=1`
- `scripts/verify-generator-output.sh generate-sync-walker-api generate-learn-loop-api generate-learn-disabled-api`
- default generated-output sweep: 9/10 generated modules built; the unrelated existing GraphQL fixture still emits an unused `internal/client` import
- `scripts/golden.sh verify`: all four changed `internal/store/store.go` fixtures pass; the Windows checkout still reports 23 unrelated baseline cases involving exit codes, CRLF-sensitive manifests/docs, and existing GraphQL/async output drift

`go test ./...` was run in full. It completed but is not green on this Windows host because of unrelated existing platform/environment failures, including Unix path/file-mode assertions and a generated `-race` test while `CGO_ENABLED=0`. `golangci-lint` was unavailable on this machine.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
