### PR TITLE
fix(cli): preserve empty-result output formats

### DIFF
--- a/internal/cli/printing_press_skill_test.go
+++ b/internal/cli/printing_press_skill_test.go
@@ -62,6 +62,32 @@ func TestPrintingPressSkillTranscendenceCollectorSliceInit(t *testing.T) {
 	require.NotContains(t, content, "var successfulItems []yourEntryType")
 }
 
+func TestPrintingPressSkillEmptyResultOutputContract(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../../skills/printing-press/SKILL.md")
+	require.NoError(t, err)
+
+	content := string(data)
+	require.Contains(t, content, "Empty results and output modes")
+	require.Contains(t, content, "wantsHumanTable(cmd.OutOrStdout(), flags)")
+	require.Contains(t, content, "printJSONFiltered(cmd.OutOrStdout(), rows, flags)")
+	require.Contains(t, content, "printJSONFiltered(cmd.OutOrStdout(), make([]yourRowType, 0), flags)")
+	require.Contains(t, content, "make([]yourRowType, 0)")
+	require.NotContains(t, content, "if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly)")
+	require.Contains(t, content, "// human-only empty-result prose;")
+	for _, flag := range []string{"`--json`", "`--agent`", "`--csv`"} {
+		require.Contains(t, content, flag)
+	}
+
+	machineIdx := strings.Index(content, "wantsHumanTable(cmd.OutOrStdout(), flags)")
+	humanProseIdx := strings.Index(content, "// human-only empty-result prose;")
+	require.GreaterOrEqual(t, machineIdx, 0)
+	require.GreaterOrEqual(t, humanProseIdx, 0)
+	require.Less(t, machineIdx, humanProseIdx,
+		"machine output must be selected before human-only empty-result prose")
+}
+
 func TestPrintingPressSkillSQLiteNovelCommandsGuardMissingMirror(t *testing.T) {
 	t.Parallel()
 
@@ -72,7 +98,8 @@ func TestPrintingPressSkillSQLiteNovelCommandsGuardMissingMirror(t *testing.T) {
 	require.Contains(t, content, "For SQLite-backed novel commands only")
 	require.Contains(t, content, "live execution without `--dry-run`, before the user has run `sync`")
 	require.Contains(t, content, "os.Stat(dbPath); os.IsNotExist(statErr)")
-	require.Contains(t, content, "flags.asJSON || flags.agent")
+	require.Contains(t, content, "!wantsHumanTable(cmd.OutOrStdout(), flags)")
+	require.Contains(t, content, "printJSONFiltered(cmd.OutOrStdout(), make([]yourRowType, 0), flags)")
 	require.Contains(t, content, "The unconditional `return nil` is intentional")
 	require.Contains(t, content, "store.OpenWithContext")
 

--- a/internal/generator/output_flags_contract_test.go
+++ b/internal/generator/output_flags_contract_test.go
@@ -15,6 +15,7 @@ func TestGeneratedHelpersHonorPlainAndHumanFriendlyFlags(t *testing.T) {
 	apiSpec := minimalSpec("output-flags")
 	outputDir := filepath.Join(t.TempDir(), "output-flags-pp-cli")
 	require.NoError(t, New(apiSpec, outputDir).Generate())
+	requireGeneratedCompiles(t, outputDir)
 
 	testPath := filepath.Join(outputDir, "internal", "cli", "output_flags_runtime_test.go")
 	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
@@ -52,6 +53,61 @@ func TestPrintOutputWithFlagsPlainEmptyArrayIsEmpty(t *testing.T) {
 	}
 	if got := out.String(); got != "" {
 		t.Fatalf("--plain should render empty arrays as an empty stream, got %q", got)
+	}
+}
+
+func TestPrintOutputWithFlagsCSVEmptyArrayIsEmpty(t *testing.T) {
+	data := json.RawMessage("[]")
+	var out bytes.Buffer
+
+	if err := printOutputWithFlags(&out, data, &rootFlags{csv: true}); err != nil {
+		t.Fatalf("printOutputWithFlags returned error: %v", err)
+	}
+	if got := out.String(); got != "" {
+		t.Fatalf("--csv should render an empty array as an empty CSV stream, got %q", got)
+	}
+}
+
+func TestPrintOutputWithFlagsCSVNonEmptyArrayUsesCSV(t *testing.T) {
+	data := json.RawMessage("[{\"id\":\"one\",\"name\":\"Alpha\"}]")
+	var out bytes.Buffer
+
+	if err := printOutputWithFlags(&out, data, &rootFlags{csv: true}); err != nil {
+		t.Fatalf("printOutputWithFlags returned error: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "id,name\n") || !strings.Contains(got, "one,Alpha\n") {
+		t.Fatalf("--csv should keep non-empty arrays in CSV form, got %q", got)
+	}
+	if strings.Contains(got, "[") || strings.Contains(got, "{") {
+		t.Fatalf("--csv should not fall back to JSON for non-empty arrays, got %q", got)
+	}
+}
+
+func TestPrintOutputWithFlagsMachineEmptyArrayIsValidJSON(t *testing.T) {
+	for _, flags := range []*rootFlags{
+		{asJSON: true},
+		{asJSON: true, agent: true},
+	} {
+		var out bytes.Buffer
+		if err := printOutputWithFlags(&out, json.RawMessage("[]"), flags); err != nil {
+			t.Fatalf("printOutputWithFlags returned error: %v", err)
+		}
+		if !json.Valid(out.Bytes()) {
+			t.Fatalf("machine output should be valid JSON for empty arrays, got %q", out.String())
+		}
+	}
+}
+
+func TestPrintOutputWithFlagsCSVSingleObjectKeepsJSONFallback(t *testing.T) {
+	data := json.RawMessage("{\"id\":\"one\"}")
+	var out bytes.Buffer
+
+	if err := printOutputWithFlags(&out, data, &rootFlags{csv: true}); err != nil {
+		t.Fatalf("printOutputWithFlags returned error: %v", err)
+	}
+	if got, want := out.String(), "{\"id\":\"one\"}\n"; got != want {
+		t.Fatalf("--csv should keep the single-object JSON fallback, got %q want %q", got, want)
 	}
 }
 
@@ -152,7 +208,7 @@ func TestTerminalControlCharactersRemainInJSONOutput(t *testing.T) {
 }
 `), 0o644))
 
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPrintOutputWithFlagsPlainRendersTSV|TestPrintOutputWithFlagsPlainEmptyArrayIsEmpty|TestHumanFriendlyForcesTableAndNoColorStripsANSI|TestTerminalControl", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPrintOutputWithFlagsPlainRendersTSV|TestPrintOutputWithFlagsPlainEmptyArrayIsEmpty|TestPrintOutputWithFlagsCSVEmptyArrayIsEmpty|TestPrintOutputWithFlagsCSVNonEmptyArrayUsesCSV|TestPrintOutputWithFlagsMachineEmptyArrayIsValidJSON|TestPrintOutputWithFlagsCSVSingleObjectKeepsJSONFallback|TestHumanFriendlyForcesTableAndNoColorStripsANSI|TestTerminalControl", "-count=1")
 }
 
 func TestLocalAnalysisTemplatesRouteMachineFormatsThroughSharedGate(t *testing.T) {

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -2437,8 +2437,17 @@ func compactObjectArrayValue(v any) (any, bool) {
 // printCSV renders JSON arrays as CSV with header row.
 func printCSV(w io.Writer, data json.RawMessage) error {
 	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil || len(items) == 0 {
-		// Single object or empty - just print as JSON
+	if err := json.Unmarshal(data, &items); err != nil {
+		// Single object or invalid JSON - just print as JSON
+		fmt.Fprintln(w, string(data))
+		return nil
+	}
+	if len(items) == 0 {
+		// A valid empty array is an empty CSV stream, not a JSON document.
+		// Keep the single-object fallback above for non-array payloads.
+		if bytes.HasPrefix(bytes.TrimSpace(data), []byte("[")) {
+			return nil
+		}
 		fmt.Fprintln(w, string(data))
 		return nil
 	}

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -3395,14 +3395,14 @@ For SQLite-backed novel commands only, add this missing-mirror guard after `dryR
 ```go
 if _, statErr := os.Stat(dbPath); os.IsNotExist(statErr) {
 	fmt.Fprintf(cmd.ErrOrStderr(), "no local mirror at %s\nrun: <cli> sync --resources <resource> --db %s\n", dbPath, dbPath)
-	if flags.asJSON || flags.agent {
-		fmt.Fprintln(cmd.OutOrStdout(), "[]")
+	if !wantsHumanTable(cmd.OutOrStdout(), flags) {
+		return printJSONFiltered(cmd.OutOrStdout(), make([]yourRowType, 0), flags)
 	}
 	return nil
 }
 ```
 
-The missing-mirror branch covers a different probe layer from `dryRunOK`: live execution without `--dry-run`, before the user has run `sync`. Return empty JSON (`[]`) for `--json` / `--agent` so agents receive a valid empty result instead of a SQLite open failure; print a human hint to stderr that names the sync command needed to populate the mirror. The unconditional `return nil` is intentional for both machine and human paths: a missing local mirror is an empty local-cache state, not a usage or API failure. Do not add this branch to novel commands that call live API endpoints directly or do not use the local store.
+The missing-mirror branch covers a different probe layer from `dryRunOK`: live execution without `--dry-run`, before the user has run `sync`. Route every non-human format through `printJSONFiltered` so agents receive a valid empty result instead of a SQLite open failure; print a human hint to stderr that names the sync command needed to populate the mirror. The unconditional `return nil` is intentional for both machine and human paths: a missing local mirror is an empty local-cache state, not a usage or API failure. Do not add this branch to novel commands that call live API endpoints directly or do not use the local store.
 
 Multi-positional commands (N >= 2 required args) must use a two-check shape so only the bare help probe returns exit 0:
 
@@ -3526,6 +3526,34 @@ The generator handles Priority 0 (data layer) and most of Priority 1 (absorbed A
 - `isTerminal(w io.Writer) bool` - detect terminal output versus pipes.
 - `wantsHumanTable(w io.Writer, flags *rootFlags) bool` - detect when output should use the generated human table instead of machine JSON.
 
+**Empty results and output modes.** Any novel command that can return zero rows
+MUST choose the output mode before printing empty-result prose. Initialize
+list-shaped results with `make(..., 0)` so JSON mode emits `[]`, never `null`.
+Route JSON, agent, and CSV output through the generated helpers, and keep
+human-only empty-result prose inside the human branch:
+
+```go
+rows := make([]yourRowType, 0)
+// populate rows...
+if !wantsHumanTable(cmd.OutOrStdout(), flags) {
+	return printJSONFiltered(cmd.OutOrStdout(), rows, flags)
+}
+if len(rows) == 0 {
+	// human-only empty-result prose; never write this before the machine branch
+	fmt.Fprintln(cmd.OutOrStdout(), "No matching items found.")
+	return nil
+}
+// Render the non-empty human table here.
+return nil
+```
+
+Do not put a `len(rows) == 0` prose return before the mode check, and do not
+manually branch only on `flags.asJSON`. `wantsHumanTable` covers `--json`,
+`--agent`, `--csv`, `--plain`, `--quiet`, `--compact`, `--select`, and piped
+output. The Phase 5 dogfood run must exercise a known zero-result case when
+available: `--json` and `--agent` stdout must parse as JSON, `--csv` must be an
+empty or valid CSV stream, and human mode may retain the explanatory prose.
+
 ```go
 // internal/cli/<command>.go — replace <command> with the kebab leaf
 // of NovelFeature.Command (e.g., "issues stale" → "issues_stale.go").
@@ -3609,10 +3637,8 @@ RunE: func(cmd *cobra.Command, args []string) error {
 	// text extracted from HTML or schema.org JSON-LD; re-implementing
 	// HTML-entity unescape inline is the &#39; bug class.
 	var view yourViewType // = parse(data)
-	if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly) {
-		enc := json.NewEncoder(cmd.OutOrStdout())
-		enc.SetIndent("", "  ")
-		return enc.Encode(view)
+	if !wantsHumanTable(cmd.OutOrStdout(), flags) {
+		return printJSONFiltered(cmd.OutOrStdout(), view, flags)
 	}
 	// Human/terminal output (table or pretty print).
 	return nil
@@ -3700,10 +3726,8 @@ RunE: func(cmd *cobra.Command, args []string) error {
 		AverageMetric: safeAverage(total, denominator),
 		FetchFailures: failures, // json tag: `json:"fetch_failures,omitempty"`
 	}
-	if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly) {
-		enc := json.NewEncoder(cmd.OutOrStdout())
-		enc.SetIndent("", "  ")
-		return enc.Encode(view)
+	if !wantsHumanTable(cmd.OutOrStdout(), flags) {
+		return printJSONFiltered(cmd.OutOrStdout(), view, flags)
 	}
 	// Human/terminal output, including a visible partial-failure note.
 	for _, entry := range view.Items {
@@ -3746,8 +3770,8 @@ RunE: func(cmd *cobra.Command, args []string) error {
 	}
 	if _, statErr := os.Stat(dbPath); os.IsNotExist(statErr) {
 		fmt.Fprintf(cmd.ErrOrStderr(), "no local mirror at %s\nrun: <cli> sync --resources <resource> --db %s\n", dbPath, dbPath)
-		if flags.asJSON || flags.agent {
-			fmt.Fprintln(cmd.OutOrStdout(), "[]")
+		if !wantsHumanTable(cmd.OutOrStdout(), flags) {
+			return printJSONFiltered(cmd.OutOrStdout(), make([]yourRowType, 0), flags)
 		}
 		return nil
 	}
@@ -3798,10 +3822,8 @@ RunE: func(cmd *cobra.Command, args []string) error {
 		// Resolve IDs, expand child rows, or perform local joins, then append.
 		_ = raw
 	}
-	if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly) {
-		enc := json.NewEncoder(cmd.OutOrStdout())
-		enc.SetIndent("", "  ")
-		return enc.Encode(results)
+	if !wantsHumanTable(cmd.OutOrStdout(), flags) {
+		return printJSONFiltered(cmd.OutOrStdout(), results, flags)
 	}
 	// Human/terminal output.
 	return nil

--- a/skills/printing-press/references/dogfood-testing.md
+++ b/skills/printing-press/references/dogfood-testing.md
@@ -11,6 +11,8 @@
 | All list commands return empty | Response envelope not unwrapped | Client or output helpers |
 | `--select` strips everything | filterFields can't parse envelope | Add extractResponseData call |
 | `--csv` shows JSON | CSV check after JSON pipe check | Promoted template output path |
+| `--json` or `--agent` prints empty-result prose | Human empty-result branch runs before the machine-mode check | Select `wantsHumanTable` first and route machine output through `printJSONFiltered` |
+| `--csv` prints `[]` for no rows | Empty array falls through the single-object JSON fallback | Keep empty arrays as an empty CSV stream in `printCSV` |
 | `search` returns no results | FTS table not wired into search cmd | search.go switch statement |
 | `sync` gets 404 on some endpoints | API version header mismatch | Client header per-path |
 | Mutation command requires ugly name | operationId not cleaned up | Command Use: field |
@@ -27,6 +29,12 @@
 - Endpoints the user doesn't have access to (org-level when user is individual)
 
 ## Full Dogfood Confirmation
+
+For list-shaped or novel commands with a reproducible zero-result case, run the
+case with `--json`, `--agent`, and `--csv`. JSON and agent stdout must parse
+without a leading human message. CSV may be empty when there is no schema or
+rows, but must never contain the JSON literal `[]`; non-empty rows must remain
+CSV, and human mode may retain the explanatory empty-result prose.
 
 When the user selects "Full dogfood", confirm before creating test data:
 

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -1850,8 +1850,17 @@ func compactObjectArrayValue(v any) (any, bool) {
 // printCSV renders JSON arrays as CSV with header row.
 func printCSV(w io.Writer, data json.RawMessage) error {
 	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil || len(items) == 0 {
-		// Single object or empty - just print as JSON
+	if err := json.Unmarshal(data, &items); err != nil {
+		// Single object or invalid JSON - just print as JSON
+		fmt.Fprintln(w, string(data))
+		return nil
+	}
+	if len(items) == 0 {
+		// A valid empty array is an empty CSV stream, not a JSON document.
+		// Keep the single-object fallback above for non-array payloads.
+		if bytes.HasPrefix(bytes.TrimSpace(data), []byte("[")) {
+			return nil
+		}
 		fmt.Fprintln(w, string(data))
 		return nil
 	}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -1716,8 +1716,17 @@ func compactObjectArrayValue(v any) (any, bool) {
 // printCSV renders JSON arrays as CSV with header row.
 func printCSV(w io.Writer, data json.RawMessage) error {
 	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil || len(items) == 0 {
-		// Single object or empty - just print as JSON
+	if err := json.Unmarshal(data, &items); err != nil {
+		// Single object or invalid JSON - just print as JSON
+		fmt.Fprintln(w, string(data))
+		return nil
+	}
+	if len(items) == 0 {
+		// A valid empty array is an empty CSV stream, not a JSON document.
+		// Keep the single-object fallback above for non-array payloads.
+		if bytes.HasPrefix(bytes.TrimSpace(data), []byte("[")) {
+			return nil
+		}
 		fmt.Fprintln(w, string(data))
 		return nil
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -1800,8 +1800,17 @@ func compactObjectArrayValue(v any) (any, bool) {
 // printCSV renders JSON arrays as CSV with header row.
 func printCSV(w io.Writer, data json.RawMessage) error {
 	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil || len(items) == 0 {
-		// Single object or empty - just print as JSON
+	if err := json.Unmarshal(data, &items); err != nil {
+		// Single object or invalid JSON - just print as JSON
+		fmt.Fprintln(w, string(data))
+		return nil
+	}
+	if len(items) == 0 {
+		// A valid empty array is an empty CSV stream, not a JSON document.
+		// Keep the single-object fallback above for non-array payloads.
+		if bytes.HasPrefix(bytes.TrimSpace(data), []byte("[")) {
+			return nil
+		}
 		fmt.Fprintln(w, string(data))
 		return nil
 	}


### PR DESCRIPTION
## Intent

Generated CLIs could contaminate zero-result `--json` and `--agent` stdout with human prose, and `--csv` rendered an empty array as the JSON literal `[]`. This breaks machine consumers even though the underlying command succeeded.

Closes #3450
Closes #3371

## Approach

The shared generated `printCSV` helper now treats a valid empty array as an empty CSV stream while preserving non-empty CSV and single-object JSON fallback behavior. The novel-command authoring and dogfood guidance now requires selecting the output mode before empty-result prose and routing machine formats through `wantsHumanTable` and `printJSONFiltered`.

## Scope

Primary area: Printing Press generator output helpers, generated-output fixtures, and novel-command authoring guidance.

Why this belongs in this repo: both reported symptoms are systemic generated-CLI behavior, so the source-of-truth fix prevents the same contract drift in future prints.

## Risk

The change affects generated output formatting and skill guidance. Human rendering and non-empty machine output remain covered, while the golden fixtures record the intentional helper change.

## Output Contract

- Empty JSON and agent results remain valid machine-readable JSON.
- Empty CSV is an empty stream, not `[]`; non-empty arrays remain CSV.
- Single-object `--csv` fallback remains JSON for compatibility.
- Human-only empty-result prose remains allowed only after the machine-mode branch.

## Verification

- `go test ./internal/cli -run 'TestPrintingPressSkill(EmptyResultOutputContract|SQLiteNovelCommandsGuardMissingMirror)$' -count=1`
- Focused generator output tests, including compiled generated module coverage, passed.
- Decoy-profile HTML extraction and paginated-read regressions passed.
- `scripts/golden.sh verify` passed all 32 cases.
- `scripts/verify-generator-output.sh` passed 10 generated cases.
- `go fmt ./...`, `go build -o ./cli-printing-press ./cmd/cli-printing-press`, and `git diff --check` passed.
- Full `go test ./...` reached unrelated environment limits: generator tests hit the existing 10-minute parallel timeout under shared worker load, and macOS Keychain blocked `pressauth` at `SecItemAdd`; changed-package and decoy-profile targeted coverage passed.
- `golangci-lint run ./...` reported one unchanged `modernize` warning in `internal/googlediscovery/parser.go`.
