### PR TITLE
fix(cli): scaffold Google service-account JWT bearer auth

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -909,12 +909,13 @@ components:
 ### `x-auth-subtype`
 
 Refines `Auth.Type` for runtime flows that need a different credential-capture
-path than the base type implies. Today the only recognized value is
-`auth0_spa_in_memory`: a bearer-token spec whose access token is held by the
-Auth0 SPA SDK with `cacheLocation: memory`. Cookie/localStorage extractors have
-no path to such a token (it lives in JS heap only), so the generator emits a
-`--auth0-spa` flag on `auth login --chrome` that drives a Chrome DevTools
-Protocol outbound-Authorization interceptor instead.
+path than the base type implies. Recognized values include
+`google_service_account`, which selects the generated Google service-account
+JWT bearer exchange scaffold, and `auth0_spa_in_memory`, a bearer-token spec
+whose access token is held by the Auth0 SPA SDK with `cacheLocation: memory`.
+Cookie/localStorage extractors have no path to the latter token (it lives in JS
+heap only), so the generator emits a `--auth0-spa` flag on `auth login --chrome`
+that drives a Chrome DevTools Protocol outbound-Authorization interceptor.
 
 Parsed field: `APISpec.Auth.Subtype`
 
@@ -922,9 +923,13 @@ Rules:
 
 - Optional.
 - Must be a string.
-- Recognized values: `auth0_spa_in_memory`. Other values are silently dropped
+- Recognized values: `google_service_account`, `auth0_spa_in_memory`. Other values are silently dropped
   by the parser; the in-spec value never round-trips unless it matches a known
   subtype.
+- `google_service_account` is valid only with a bearer-token auth type. It
+  emits `auth service-account`, accepts a service-account JSON key through
+  `GOOGLE_APPLICATION_CREDENTIALS`, and supports a pre-minted bearer override
+  through `GOOGLE_OAUTH_ACCESS_TOKEN`.
 - Spec-level validation rejects `auth.subtype: auth0_spa_in_memory` paired with
   any non-empty `auth.type` other than `bearer_token`. Auth0 SPA tokens are
   always Authorization-bearer values; combining the subtype with `api_key` or

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1442,6 +1442,12 @@ func compatibleOAuthScopeAuth(base, incoming spec.AuthConfig) bool {
 	if len(incoming.Scopes) == 0 {
 		return false
 	}
+	if base.Subtype == spec.AuthSubtypeGoogleServiceAccount && incoming.Subtype == spec.AuthSubtypeGoogleServiceAccount {
+		if base.Type != incoming.Type || base.EffectiveOAuth2Grant() != incoming.EffectiveOAuth2Grant() {
+			return false
+		}
+		return normalizeAuthURL(base.TokenURL) == normalizeAuthURL(incoming.TokenURL)
+	}
 	if strings.TrimSpace(base.AuthorizationURL) == "" {
 		return false
 	}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -167,6 +167,7 @@ type Generator struct {
 }
 
 func New(s *spec.APISpec, outputDir string) *Generator {
+	normalizeGoogleServiceAccountAuth(s)
 	s.InferEndpointTemplateVarsFromBaseURLs()
 	s.EnrichPathParams()
 	s.PromoteGlobalPathTemplateVars()
@@ -662,6 +663,15 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"firstCommandExample": firstCommandExample,
 	}
 	return g
+}
+
+func normalizeGoogleServiceAccountAuth(s *spec.APISpec) {
+	if s == nil || s.Auth.Subtype != spec.AuthSubtypeGoogleServiceAccount {
+		return
+	}
+	s.Auth.AuthorizationURL = ""
+	s.Auth.EnvVars = []string{"GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_OAUTH_ACCESS_TOKEN"}
+	s.Auth.EnvVarSpecs = spec.NewORCaseEnvVarSpecs(s.Auth.EnvVars)
 }
 
 func endpointTemplateVarsAny(vars []string, s *spec.APISpec, predicate func(string) bool) bool {
@@ -1277,6 +1287,8 @@ func authHarvestedEnvHint(auth spec.AuthConfig) string {
 	switch {
 	case auth.Type == "cookie" || auth.Type == "composed":
 		return "populated automatically by auth login --chrome"
+	case auth.Subtype == spec.AuthSubtypeGoogleServiceAccount:
+		return "set GOOGLE_APPLICATION_CREDENTIALS or GOOGLE_OAUTH_ACCESS_TOKEN"
 	case auth.EffectiveOAuth2Grant() == spec.OAuth2GrantClientCredentials && auth.TokenURL != "":
 		return "populated automatically by auth login --client-id/--client-secret"
 	case auth.EffectiveOAuth2Grant() == spec.OAuth2GrantDeviceCode && auth.DeviceAuthorizationURL != "" && auth.TokenURL != "":
@@ -1756,6 +1768,9 @@ func authErrorCheckHint(auth spec.AuthConfig) string {
 }
 
 func authSetupHint(auth spec.AuthConfig, cliName string) string {
+	if auth.Subtype == spec.AuthSubtypeGoogleServiceAccount {
+		return fmt.Sprintf("Run '%s-pp-cli auth service-account --key <service-account.json>' or set GOOGLE_OAUTH_ACCESS_TOKEN.", cliName)
+	}
 	switch auth.Type {
 	case "", "none":
 		return ""

--- a/internal/generator/google_service_account_test.go
+++ b/internal/generator/google_service_account_test.go
@@ -1,0 +1,244 @@
+package generator
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateGoogleServiceAccountAuthScaffold(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("google-service-account")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:        "bearer_token",
+		Subtype:     spec.AuthSubtypeGoogleServiceAccount,
+		Header:      "Authorization",
+		TokenURL:    "https://oauth2.googleapis.com/token",
+		Scopes:      []string{"https://www.googleapis.com/auth/cloud-platform"},
+		EnvVars:     []string{"GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_OAUTH_ACCESS_TOKEN"},
+		EnvVarSpecs: spec.NewORCaseEnvVarSpecs([]string{"GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_OAUTH_ACCESS_TOKEN"}),
+	}
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	authSrc := readGeneratedFile(t, outputDir, "internal", "cli", "auth.go")
+	assert.Contains(t, authSrc, `Use:   "service-account"`)
+	assert.Contains(t, authSrc, `google.JWTConfigFromJSON`)
+	assert.Contains(t, authSrc, `--impersonate`)
+	assert.Contains(t, authSrc, `--scopes`)
+
+	configSrc := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+	assert.Contains(t, configSrc, "GoogleImpersonate")
+	assert.Contains(t, configSrc, "GoogleScopes")
+	assert.Contains(t, configSrc, "GOOGLE_OAUTH_ACCESS_TOKEN")
+
+	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
+	assert.Contains(t, clientSrc, "context.WithTimeout")
+	assert.Contains(t, clientSrc, "googleServiceAccountAuthHeader")
+	assert.Contains(t, clientSrc, `return "Bearer " + token.AccessToken`)
+
+	doctorSrc := readGeneratedFile(t, outputDir, "internal", "cli", "doctor.go")
+	assert.Contains(t, doctorSrc, "Google service account")
+
+	goMod := readGeneratedFile(t, outputDir, "go.mod")
+	assert.Contains(t, goMod, "golang.org/x/oauth2 v0.36.0")
+
+	requireGeneratedCompiles(t, outputDir)
+
+	noTokenURLSpec := minimalSpec("google-service-account-no-token-url")
+	noTokenURLSpec.Auth = spec.AuthConfig{
+		Type:    "bearer_token",
+		Subtype: spec.AuthSubtypeGoogleServiceAccount,
+		Header:  "Authorization",
+		Scopes:  []string{"https://www.googleapis.com/auth/cloud-platform"},
+	}
+	noTokenURLDir := filepath.Join(t.TempDir(), naming.CLI(noTokenURLSpec.Name))
+	require.NoError(t, New(noTokenURLSpec, noTokenURLDir).Generate())
+	requireGeneratedCompiles(t, noTokenURLDir)
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	privateKey, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	keyJSON, err := json.Marshal(map[string]string{
+		"type":         "service_account",
+		"client_email": "service-account@example.com",
+		"private_key":  string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKey})),
+		"token_uri":    "https://oauth2.googleapis.com/token",
+	})
+	require.NoError(t, err)
+	keyPath := filepath.Join(outputDir, "service-account.json")
+	require.NoError(t, os.WriteFile(keyPath, keyJSON, 0o600))
+
+	runtimeTest := fmt.Sprintf(`package cli
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+func TestMintGoogleServiceAccountToken(t *testing.T) {
+	var gotGrantType, gotAssertion string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse token request: %%v", err)
+		}
+		gotGrantType = r.Form.Get("grant_type")
+		gotAssertion = r.Form.Get("assertion")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`+"`"+`{"access_token":"runtime-token","token_type":"Bearer","expires_in":3600}`+"`"+`))
+	}))
+	defer server.Close()
+
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, server.Client())
+	token, expiry, err := mintGoogleServiceAccountToken(ctx, %q, server.URL, "delegated@example.com", []string{"scope-one", "scope-two"})
+	if err != nil {
+		t.Fatalf("mint token: %%v", err)
+	}
+	if token != "runtime-token" {
+		t.Fatalf("token = %%q, want runtime-token", token)
+	}
+	if expiry.Before(time.Now().Add(30 * time.Minute)) {
+		t.Fatalf("expiry = %%s, want at least 30 minutes from now", expiry)
+	}
+	if gotGrantType != "urn:ietf:params:oauth:grant-type:jwt-bearer" {
+		t.Fatalf("grant_type = %%q", gotGrantType)
+	}
+	parts := strings.Split(gotAssertion, ".")
+	if len(parts) != 3 {
+		t.Fatalf("JWT assertion has %%d parts", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode JWT payload: %%v", err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatalf("decode JWT claims: %%v", err)
+	}
+	if claims["sub"] != "delegated@example.com" {
+		t.Fatalf("sub claim = %%v", claims["sub"])
+	}
+	if claims["scope"] != "scope-one scope-two" {
+		t.Fatalf("scope claim = %%v", claims["scope"])
+	}
+	if claims["aud"] != server.URL {
+		t.Fatalf("aud claim = %%v, want %%s", claims["aud"], server.URL)
+	}
+}
+
+`, keyPath)
+	runtimeTest = strings.ReplaceAll(runtimeTest, "{{MODULE}}", naming.CLI(apiSpec.Name))
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "google_service_account_runtime_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestMintGoogleServiceAccountToken", "-count=1")
+
+	clientRuntimeTest := fmt.Sprintf(`package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"{{MODULE}}/internal/config"
+	"golang.org/x/oauth2"
+)
+
+func TestGoogleServiceAccountAuthHeader(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse token request: %%v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(%q))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		BaseURL: server.URL,
+		GoogleApplicationCredentials: %q,
+		GoogleScopes: []string{"scope-one"},
+		TokenURL: server.URL,
+	}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, server.Client())
+	c := New(cfg, 5*time.Second, 0)
+	header, err := c.googleServiceAccountAuthHeader(ctx)
+	if err != nil {
+		t.Fatalf("first auth header: %%v", err)
+	}
+	if header != "Bearer runtime-token" {
+		t.Fatalf("first header = %%q", header)
+	}
+	header, err = c.googleServiceAccountAuthHeader(ctx)
+	if err != nil {
+		t.Fatalf("second auth header: %%v", err)
+	}
+	if header != "Bearer runtime-token" {
+		t.Fatalf("second header = %%q", header)
+	}
+	if requests != 1 {
+		t.Fatalf("token endpoint requests = %%d, want 1", requests)
+	}
+}
+
+`, `{"access_token":"runtime-token","token_type":"Bearer","expires_in":3600}`, keyPath)
+	clientRuntimeTest = strings.ReplaceAll(clientRuntimeTest, "{{MODULE}}", naming.CLI(apiSpec.Name))
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "google_service_account_runtime_test.go"), []byte(clientRuntimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "TestGoogleServiceAccountAuthHeader", "-count=1")
+
+	configRuntimeTest := `package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestGoogleServiceAccountSettingsPersist(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("load empty config: %v", err)
+	}
+	cfg.SetGoogleServiceAccount("/tmp/service-account.json", "delegated@example.com", []string{"scope-one", "scope-two"})
+	if err := cfg.save(); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	loaded, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if loaded.GoogleImpersonate != "delegated@example.com" {
+		t.Fatalf("impersonate = %q", loaded.GoogleImpersonate)
+	}
+	if len(loaded.GoogleScopes) != 2 || loaded.GoogleScopes[1] != "scope-two" {
+		t.Fatalf("scopes = %v", loaded.GoogleScopes)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "config", "google_service_account_runtime_test.go"), []byte(configRuntimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "TestGoogleServiceAccountSettingsPersist", "-count=1")
+}

--- a/internal/generator/google_service_account_test.go
+++ b/internal/generator/google_service_account_test.go
@@ -203,6 +203,21 @@ func TestGoogleServiceAccountAuthHeader(t *testing.T) {
 	if requests != 1 {
 		t.Fatalf("token endpoint requests = %%d, want 1", requests)
 	}
+
+	// An expired persisted token must not be returned by the authHeader fast
+	// path; it should fall through to the expiry-aware service-account exchange.
+	c.Config.AuthHeaderVal = "Bearer stale-token"
+	c.Config.TokenExpiry = time.Now().Add(-time.Minute)
+	header, err = c.authHeader(ctx)
+	if err != nil {
+		t.Fatalf("expired auth header: %%v", err)
+	}
+	if header != "Bearer runtime-token" {
+		t.Fatalf("expired header = %%q", header)
+	}
+	if requests != 2 {
+		t.Fatalf("token endpoint requests after expiry = %%d, want 2", requests)
+	}
 }
 
 `, `{"access_token":"runtime-token","token_type":"Bearer","expires_in":3600}`, keyPath)

--- a/internal/generator/templates/auth_simple.go.tmpl
+++ b/internal/generator/templates/auth_simple.go.tmpl
@@ -10,6 +10,9 @@ package cli
 {{- $basicAuthEnvVars := basicAuthEnvVars .Auth}}
 
 import (
+{{- if eq .Auth.Subtype "google_service_account"}}
+	"context"
+{{- end}}
 {{- if eq .Auth.Type "session_handshake"}}
 	"encoding/json"
 {{- end}}
@@ -28,8 +31,16 @@ import (
 	"strings"
 	"time"
 {{- end}}
+{{- if eq .Auth.Subtype "google_service_account"}}
+	"path/filepath"
+	"strings"
+	"time"
+{{- end}}
 
 	"github.com/spf13/cobra"
+{{- if eq .Auth.Subtype "google_service_account"}}
+	"golang.org/x/oauth2/google"
+{{- end}}
 {{- if eq .Auth.Type "session_handshake"}}
 	"{{modulePath}}/internal/client"
 {{- end}}
@@ -47,6 +58,9 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 {{ if eq .Auth.Type "session_handshake"}}
 	cmd.AddCommand(newAuthLoginCmd(flags))
 {{ end -}}
+{{- if eq .Auth.Subtype "google_service_account"}}
+	cmd.AddCommand(newAuthServiceAccountCmd(flags))
+{{- end}}
 	cmd.AddCommand(newAuthSetupCmd(flags))
 	cmd.AddCommand(newAuthStatusCmd(flags))
 {{- if $authSetTokenAvailable}}
@@ -59,6 +73,117 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 	return cmd
 }
+
+{{- if eq .Auth.Subtype "google_service_account"}}
+
+func newAuthServiceAccountCmd(flags *rootFlags) *cobra.Command {
+	var keyPath string
+	var impersonate string
+	var scopes []string
+	cmd := &cobra.Command{
+		Use:   "service-account",
+		Short: "Exchange a Google service-account key for a bearer token",
+		Example: strings.TrimSpace(`
+  {{.Name}}-pp-cli auth service-account --key service-account.json
+  {{.Name}}-pp-cli auth service-account --key service-account.json --impersonate admin@example.com --scopes https://www.googleapis.com/auth/cloud-platform
+`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cliutil.IsVerifyEnv() {
+				fmt.Fprintln(cmd.OutOrStdout(), "would exchange service-account JWT for a bearer token")
+				return nil
+			}
+			cfg, err := config.Load(flags.configPath)
+			if err != nil {
+				return configErr(err)
+			}
+			keyPath = strings.TrimSpace(keyPath)
+			if keyPath == "" {
+				keyPath = strings.TrimSpace(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"))
+			}
+			if keyPath == "" {
+				keyPath = strings.TrimSpace(cfg.{{resolveEnvVarField "GOOGLE_APPLICATION_CREDENTIALS"}})
+			}
+			if keyPath == "" {
+				return authErr(fmt.Errorf("service-account key required; set --key or GOOGLE_APPLICATION_CREDENTIALS"))
+			}
+			absoluteKeyPath, err := filepath.Abs(keyPath)
+			if err != nil {
+				return authErr(fmt.Errorf("resolving service-account key %q: %w", keyPath, err))
+			}
+			keyPath = absoluteKeyPath
+			impersonate = strings.TrimSpace(impersonate)
+			if impersonate == "" {
+				impersonate = strings.TrimSpace(cfg.GoogleImpersonate)
+			}
+			if len(scopes) == 0 {
+				scopes = append([]string(nil), cfg.GoogleScopes...)
+			}
+{{- if .Auth.Scopes}}
+			if len(scopes) == 0 {
+				scopes = []string{ {{- range .Auth.Scopes}}{{printf "%q" .}}, {{end}} }
+			}
+{{- end}}
+			tokenURL := ""
+{{- if .Auth.TokenURL}}
+			tokenURL = cfg.TokenURL
+			if tokenURL == "" {
+				tokenURL = {{printf "%q" .Auth.TokenURL}}
+			}
+{{- end}}
+			accessToken, expiry, err := mintGoogleServiceAccountToken(cmd.Context(), keyPath, tokenURL, impersonate, scopes)
+			if err != nil {
+				return authErr(err)
+			}
+			cfg.SetGoogleServiceAccount(keyPath, impersonate, scopes)
+			if err := cfg.SaveTokens("", "", accessToken, "", expiry); err != nil {
+				return configErr(fmt.Errorf("saving service-account token: %w", err))
+			}
+			if flags.asJSON {
+				return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+					"authenticated": true,
+					"expires_at":    expiry,
+				}, flags)
+			}
+			if expiry.IsZero() {
+				fmt.Fprintln(cmd.OutOrStdout(), "Service-account token saved. Token expiry not provided.")
+			} else {
+				fmt.Fprintf(cmd.OutOrStdout(), "Service-account token saved. Token expires %s.\n", expiry.Format(time.RFC3339))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&keyPath, "key", "", "Path to the Google service-account JSON key")
+	cmd.Flags().StringVar(&impersonate, "impersonate", "", "Workspace user to impersonate with domain-wide delegation")
+	cmd.Flags().StringSliceVar(&scopes, "scopes", nil, "OAuth scopes; defaults to scopes declared by the API spec")
+	return cmd
+}
+
+func mintGoogleServiceAccountToken(ctx context.Context, keyPath, tokenURL, subject string, scopes []string) (string, time.Time, error) {
+	keyJSON, err := os.ReadFile(keyPath)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("reading Google service-account key %q: %w", keyPath, err)
+	}
+	jwtConfig, err := google.JWTConfigFromJSON(keyJSON, scopes...)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("parsing Google service-account key: %w", err)
+	}
+	jwtConfig.Subject = strings.TrimSpace(subject)
+	if strings.TrimSpace(tokenURL) != "" {
+		jwtConfig.TokenURL = strings.TrimSpace(tokenURL)
+	}
+	exchangeCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	token, err := jwtConfig.TokenSource(exchangeCtx).Token()
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("exchanging Google service-account JWT: %w", err)
+	}
+	if token == nil || strings.TrimSpace(token.AccessToken) == "" {
+		return "", time.Time{}, fmt.Errorf("Google service-account token response missing access_token")
+	}
+	return token.AccessToken, token.Expiry, nil
+}
+
+{{- end}}
 
 // newAuthSetupCmd prints concrete steps for getting a credential. Side-effect
 // rule: print by default, --launch opt-in to open the URL, short-circuit when
@@ -310,6 +435,11 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 			w := cmd.OutOrStdout()
 			header := cfg.AuthHeader()
 			authed := header != ""
+{{- if eq .Auth.Subtype "google_service_account"}}
+			if cfg.AccessToken != "" {
+				authed = true
+			}
+{{- end}}
 {{- if eq .Auth.Type "oauth2_refresh"}}
 			if cfg.RefreshToken != "" {
 				authed = true

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -2469,7 +2469,12 @@ func (c *Client) authHeader(ctx context.Context) (string, error) {
 	// configured, exchange it lazily and reuse the resulting token until its
 	// expiry window is reached.
 	if header := c.Config.AuthHeader(); header != "" {
-		return header, nil
+		// A persisted service-account token must not bypass the expiry-aware
+		// exchange below. Explicit environment overrides have no persisted
+		// expiry, so they remain a valid fast path.
+		if strings.HasPrefix(c.Config.AuthSource, "env:") || c.Config.TokenExpiry.IsZero() || time.Until(c.Config.TokenExpiry) >= 60*time.Second {
+			return header, nil
+		}
 	}
 	return c.googleServiceAccountAuthHeader(ctx)
 {{- else if eq .Auth.EffectiveOAuth2Grant "client_credentials"}}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -30,6 +30,9 @@ import (
 	"sync"
 	"time"
 
+{{- if eq .Auth.Subtype "google_service_account"}}
+	"golang.org/x/oauth2/google"
+{{- end}}
 {{- if .UsesBrowserHTTPTransport}}
 	enetxhttp "github.com/enetx/http"
 	"github.com/enetx/surf"
@@ -82,6 +85,11 @@ type Client struct {
 	// API calls inside the 60s pre-expiry window don't all dial the token
 	// endpoint and race on Config field writes / file persistence.
 	ccMu *sync.Mutex
+{{- end}}
+{{- if eq .Auth.Subtype "google_service_account"}}
+	// googleMu serializes service-account token loading and keeps one reusable
+	// token cache per client so concurrent requests share the TTL cache.
+	googleMu           *sync.RWMutex
 {{- end}}
 {{- if eq .Auth.Type "session_handshake"}}
 	Session    *SessionManager
@@ -590,6 +598,9 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 {{- if eq .Auth.EffectiveOAuth2Grant "client_credentials"}}
 		ccMu:       &sync.Mutex{},
 {{- end}}
+{{- if eq .Auth.Subtype "google_service_account"}}
+		googleMu:   &sync.RWMutex{},
+{{- end}}
 		Session:    sess,
 {{- if .HasCostThrottling}}
 		Throttle:     NewThrottleState(),
@@ -628,6 +639,9 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 {{- end}}
 {{- if eq .Auth.EffectiveOAuth2Grant "client_credentials"}}
 		ccMu:       &sync.Mutex{},
+{{- end}}
+{{- if eq .Auth.Subtype "google_service_account"}}
+		googleMu:   &sync.RWMutex{},
 {{- end}}
 {{- if .HasCostThrottling}}
 		Throttle:     NewThrottleState(),
@@ -2450,7 +2464,15 @@ func (c *Client) authHeader(ctx context.Context) (string, error) {
 	if c.Config == nil {
 		return "", nil
 	}
-{{- if eq .Auth.EffectiveOAuth2Grant "client_credentials"}}
+{{- if eq .Auth.Subtype "google_service_account"}}
+	// A pre-minted token is the fast path. When only a service-account key is
+	// configured, exchange it lazily and reuse the resulting token until its
+	// expiry window is reached.
+	if header := c.Config.AuthHeader(); header != "" {
+		return header, nil
+	}
+	return c.googleServiceAccountAuthHeader(ctx)
+{{- else if eq .Auth.EffectiveOAuth2Grant "client_credentials"}}
 	if c.Config.AccessToken == "" && cliutil.IsVerifyEnv() {
 		c.Config.AccessToken = "mock-token-for-testing"
 		return c.Config.AuthHeader(), nil
@@ -2499,6 +2521,69 @@ func (c *Client) authHeader(ctx context.Context) (string, error) {
 {{- end}}
 	return authHeader, nil
 }
+
+{{- if eq .Auth.Subtype "google_service_account"}}
+
+func (c *Client) googleServiceAccountAuthHeader(ctx context.Context) (string, error) {
+	if c == nil || c.Config == nil {
+		return "", nil
+	}
+	if c.googleMu == nil {
+		c.googleMu = &sync.RWMutex{}
+	}
+
+	c.googleMu.RLock()
+	if c.Config.AccessToken != "" && (c.Config.TokenExpiry.IsZero() || time.Until(c.Config.TokenExpiry) >= 60*time.Second) {
+		header := "Bearer " + c.Config.AccessToken
+		c.googleMu.RUnlock()
+		return header, nil
+	}
+	c.googleMu.RUnlock()
+	c.googleMu.Lock()
+	defer c.googleMu.Unlock()
+
+	if c.Config.AccessToken != "" && (c.Config.TokenExpiry.IsZero() || time.Until(c.Config.TokenExpiry) >= 60*time.Second) {
+		return "Bearer " + c.Config.AccessToken, nil
+	}
+	keyPath := strings.TrimSpace(c.Config.{{resolveEnvVarField "GOOGLE_APPLICATION_CREDENTIALS"}})
+	if keyPath == "" {
+		return "", nil
+	}
+	keyJSON, err := os.ReadFile(keyPath)
+	if err != nil {
+		return "", fmt.Errorf("reading Google service-account key %q: %w", keyPath, err)
+	}
+	scopes := append([]string(nil), c.Config.GoogleScopes...)
+	if len(scopes) == 0 {
+		scopes = []string{ {{- range .Auth.Scopes}}{{printf "%q" .}}, {{end}} }
+	}
+	jwtConfig, err := google.JWTConfigFromJSON(keyJSON, scopes...)
+	if err != nil {
+		return "", fmt.Errorf("parsing Google service-account key: %w", err)
+	}
+	jwtConfig.Subject = strings.TrimSpace(c.Config.GoogleImpersonate)
+{{- if .Auth.TokenURL}}
+	if tokenURL := strings.TrimSpace(c.Config.TokenURL); tokenURL != "" {
+		jwtConfig.TokenURL = tokenURL
+	} else {
+		jwtConfig.TokenURL = {{printf "%q" .Auth.TokenURL}}
+	}
+{{- end}}
+	exchangeCtx, cancel := context.WithTimeout(ctx, c.ConfiguredTimeout())
+	defer cancel()
+	token, err := jwtConfig.TokenSource(exchangeCtx).Token()
+	if err != nil {
+		return "", fmt.Errorf("exchanging Google service-account JWT: %w", err)
+	}
+	if token == nil || strings.TrimSpace(token.AccessToken) == "" {
+		return "", errors.New("Google service-account token response missing access_token")
+	}
+	c.Config.AccessToken = token.AccessToken
+	c.Config.TokenExpiry = token.Expiry
+	return "Bearer " + token.AccessToken, nil
+}
+
+{{- end}}
 
 {{- if and .Auth.Type (ne .Auth.Type "none")}}
 

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -86,6 +86,10 @@ type Config struct {
 	// pattern as AuthorizationURL.
 	TokenURL       string `{{configTag .Config.Format}}:"token_url,omitempty"`
 {{- end}}
+{{- if eq .Auth.Subtype "google_service_account"}}
+	GoogleImpersonate string   `{{configTag .Config.Format}}:"google_impersonate,omitempty"`
+	GoogleScopes     []string `{{configTag .Config.Format}}:"google_scopes,omitempty"`
+{{- end}}
 {{- end}}
 	Path           string `{{configTag .Config.Format}}:"-"`
 	envOverrides   map[string]bool `{{configTag .Config.Format}}:"-"`
@@ -616,7 +620,17 @@ func (c *Config) AuthHeader() string {
 	{{- end}}
 {{- end}}
 {{- else if or (eq .Auth.Type "bearer_token") (eq .Auth.Type "oauth2") (eq .Auth.Type "oauth2_refresh")}}
-{{- if oauth2AccessTokenAuth .Auth}}
+{{- if eq .Auth.Subtype "google_service_account"}}
+	// GOOGLE_OAUTH_ACCESS_TOKEN is a pre-minted bearer override. A service
+	// account key is exchanged by the generated client instead.
+	if token := c.{{resolveEnvVarField "GOOGLE_OAUTH_ACCESS_TOKEN"}}; token != "" {
+		if c.AuthSource == "" {
+			c.AuthSource = "env:GOOGLE_OAUTH_ACCESS_TOKEN"
+		}
+		return "Bearer " + token
+	}
+	return ""
+{{- else if oauth2AccessTokenAuth .Auth}}
 	// Under OAuth2 (and bearer_token specs running OAuth grants such as
 	// client_credentials or device_code) the configured env vars hold flow
 	// inputs, not a usable bearer; the minted AccessToken must win. Sending
@@ -1089,6 +1103,10 @@ func (c *Config) clearCredentialFields() {
 	c.TokenExpiry = time.Time{}
 	c.ClientID = ""
 	c.ClientSecret = ""
+{{- if eq .Auth.Subtype "google_service_account"}}
+	c.GoogleImpersonate = ""
+	c.GoogleScopes = nil
+{{- end}}
 {{- if .BearerRefresh.Enabled}}
 	c.BearerTokenRefreshedAt = time.Time{}
 {{- end}}
@@ -1160,6 +1178,23 @@ func (c *Config) saveCredentialsFirst() error {
 	c.CredentialSource = "credentials file"
 	return nil
 }
+
+{{- if eq .Auth.Subtype "google_service_account"}}
+
+// SetGoogleServiceAccount records the service-account exchange inputs. The
+// access token itself is persisted through SaveTokens so both the key path and
+// the token follow the generated credential-storage policy.
+func (c *Config) SetGoogleServiceAccount(keyPath, subject string, scopes []string) {
+	c.{{resolveEnvVarField "GOOGLE_APPLICATION_CREDENTIALS"}} = keyPath
+	delete(c.envOverrides, "{{resolveEnvVarField "GOOGLE_APPLICATION_CREDENTIALS"}}")
+	c.updateFileConfigField("{{resolveEnvVarField "GOOGLE_APPLICATION_CREDENTIALS"}}")
+	c.GoogleImpersonate = strings.TrimSpace(subject)
+	c.GoogleScopes = append([]string(nil), scopes...)
+	c.updateFileConfigField("GoogleImpersonate")
+	c.updateFileConfigField("GoogleScopes")
+}
+
+{{- end}}
 
 func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken string, expiry time.Time) error {
 	c.ClientID = clientID
@@ -1313,6 +1348,10 @@ func (c *Config) ClearTokens() error {
 	c.TokenExpiry = time.Time{}
 	c.ClientID = ""
 	c.ClientSecret = ""
+{{- if eq .Auth.Subtype "google_service_account"}}
+	c.GoogleImpersonate = ""
+	c.GoogleScopes = nil
+{{- end}}
 	delete(c.envOverrides, "AuthHeaderVal")
 	delete(c.envOverrides, "AccessToken")
 	delete(c.envOverrides, "RefreshToken")
@@ -1325,6 +1364,10 @@ func (c *Config) ClearTokens() error {
 	c.updateFileConfigField("TokenExpiry")
 	c.updateFileConfigField("ClientID")
 	c.updateFileConfigField("ClientSecret")
+{{- if eq .Auth.Subtype "google_service_account"}}
+	c.updateFileConfigField("GoogleImpersonate")
+	c.updateFileConfigField("GoogleScopes")
+{{- end}}
 {{- if .HasRequiredRoles}}
 	c.AuthRole = ""
 	delete(c.envOverrides, "AuthRole")
@@ -1453,6 +1496,12 @@ func (c *Config) updateFileConfigField(field string) {
 		c.fileConfig.ClientID = c.ClientID
 	case "ClientSecret":
 		c.fileConfig.ClientSecret = c.ClientSecret
+{{- if eq .Auth.Subtype "google_service_account"}}
+	case "GoogleImpersonate":
+		c.fileConfig.GoogleImpersonate = c.GoogleImpersonate
+	case "GoogleScopes":
+		c.fileConfig.GoogleScopes = append([]string(nil), c.GoogleScopes...)
+{{- end}}
 {{- if .BearerRefresh.Enabled}}
 	case "BearerTokenRefreshedAt":
 		c.fileConfig.BearerTokenRefreshedAt = c.BearerTokenRefreshedAt
@@ -1594,6 +1643,10 @@ type persistedConfig struct {
 {{- if .Auth.TokenURL}}
 	TokenURL string `{{configTag .Config.Format}}:"token_url,omitempty"`
 {{- end}}
+{{- if eq .Auth.Subtype "google_service_account"}}
+	GoogleImpersonate string `{{configTag .Config.Format}}:"google_impersonate,omitempty"`
+	GoogleScopes []string `{{configTag .Config.Format}}:"google_scopes,omitempty"`
+{{- end}}
 {{- if or .EndpointTemplateVars .GlobalPathTemplateVars}}
 	TemplateVars map[string]string `{{configTag .Config.Format}}:"template_vars,omitempty"`
 {{- end}}
@@ -1623,6 +1676,10 @@ func (c *Config) persisted() persistedConfig {
 {{- end}}
 {{- if .Auth.TokenURL}}
 		TokenURL: c.TokenURL,
+{{- end}}
+{{- if eq .Auth.Subtype "google_service_account"}}
+		GoogleImpersonate: c.GoogleImpersonate,
+		GoogleScopes: append([]string(nil), c.GoogleScopes...),
 {{- end}}
 {{- if or .EndpointTemplateVars .GlobalPathTemplateVars}}
 		TemplateVars: c.TemplateVars,

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -331,6 +331,29 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			}
 {{- else}}
 			if cfg != nil {
+				{{- if eq .Auth.Subtype "google_service_account"}}
+				googleKeyPath := strings.TrimSpace(cfg.{{resolveEnvVarField "GOOGLE_APPLICATION_CREDENTIALS"}})
+				if googleKeyPath != "" && cfg.AuthHeader() == "" && cfg.AccessToken == "" {
+					if _, statErr := os.Stat(googleKeyPath); statErr != nil {
+						report["auth"] = "misconfigured (Google service-account key is not readable)"
+						report["auth_hint"] = "set GOOGLE_APPLICATION_CREDENTIALS to a readable service-account JSON file"
+					} else {
+						authConfigured = true
+						report["auth"] = "configured (Google service account; token exchange deferred until request)"
+						report["auth_source"] = "google_service_account"
+					}
+				} else {
+					header := cfg.AuthHeader()
+					if header == "" && cfg.AccessToken == "" {
+						report["auth"] = "not configured"
+						report["auth_hint"] = "{{.Name}}-pp-cli auth service-account --key <service-account.json>"
+					} else {
+						authConfigured = true
+						report["auth"] = "configured"
+						report["auth_source"] = cfg.AuthSource
+					}
+				}
+				{{- else}}
 				header := cfg.AuthHeader()
 				if header == "" {
 {{- if .Auth.Optional}}
@@ -358,6 +381,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					report["auth"] = "configured"
 					report["auth_source"] = cfg.AuthSource
 				}
+				{{- end}}
 			}
 {{- end}}
 {{- if not (or .Auth.EnvVarSpecs .Auth.EnvVars .Auth.AdditionalHeaders)}}

--- a/internal/generator/templates/go.mod.tmpl
+++ b/internal/generator/templates/go.mod.tmpl
@@ -12,6 +12,9 @@ require (
 	github.com/chromedp/cdproto v0.0.0-20260321001828-e3e3800016bc
 	github.com/chromedp/chromedp v0.15.1
 {{- end}}
+{{- if eq .Auth.Subtype "google_service_account"}}
+	golang.org/x/oauth2 v0.36.0
+{{- end}}
 {{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed") .Streaming.Enabled}}
 	github.com/gorilla/websocket v1.5.3
 {{- end}}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -1304,8 +1304,24 @@ func mapAuthWithDescriptionInference(doc *openapi3.T, name string, allowDescript
 	applyAuthEnvVarDefaults(&auth, envPrefix)
 	applyAuthVarsRichOverride(&auth, scheme.Extensions, fmt.Sprintf("components.securitySchemes.%s.%s", schemeName, extensionAuthVars))
 	applyAuthCompanionFromInfo(&auth, doc)
+	if isGoogleServiceAccountOAuth2(doc, scheme, auth) || auth.Subtype == spec.AuthSubtypeGoogleServiceAccount {
+		applyGoogleServiceAccountAuth(&auth)
+	}
 	auth.AdditionalHeaders = collectAdditionalAuthHeaders(doc, schemeName, envPrefix)
 	return auth
+}
+
+func applyGoogleServiceAccountAuth(auth *spec.AuthConfig) {
+	if auth == nil {
+		return
+	}
+	auth.Subtype = spec.AuthSubtypeGoogleServiceAccount
+	// Google service-account JWT exchange is a non-interactive bearer flow.
+	// Keep the OAuth2 scheme's token URL and scopes, but remove the browser
+	// authorization URL so the generator selects the service-account scaffold.
+	auth.AuthorizationURL = ""
+	auth.EnvVars = []string{"GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_OAUTH_ACCESS_TOKEN"}
+	auth.EnvVarSpecs = spec.NewORCaseEnvVarSpecs(auth.EnvVars)
 }
 
 // collectAdditionalAuthHeaders scans AND-group siblings of the winning
@@ -1852,6 +1868,8 @@ func applyAuthOverrideExtensions(auth *spec.AuthConfig, extensions map[string]an
 		// keeps the error close to the typo, matching how unknown auth types are
 		// handled elsewhere in this parser.
 		switch subtype {
+		case spec.AuthSubtypeGoogleServiceAccount:
+			auth.Subtype = subtype
 		case spec.AuthSubtypeAuth0SPAInMemory:
 			auth.Subtype = subtype
 		}
@@ -7689,6 +7707,16 @@ func isGoogleAPIsServerURL(raw string) bool {
 		}
 	}
 	return false
+}
+
+// isGoogleServiceAccountOAuth2 narrows the Google auth scaffold to OAuth2
+// schemes. A plain bearer scheme on a Google-hosted proxy still represents a
+// user-supplied token and must keep the normal bearer path.
+func isGoogleServiceAccountOAuth2(doc *openapi3.T, scheme *openapi3.SecurityScheme, auth spec.AuthConfig) bool {
+	if scheme == nil || !strings.EqualFold(strings.TrimSpace(scheme.Type), "oauth2") || auth.Type != "bearer_token" {
+		return false
+	}
+	return hasGoogleAPIsServer(doc)
 }
 
 func operationIDResourceVariants(resourceName string) []string {

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -7716,6 +7716,11 @@ func isGoogleServiceAccountOAuth2(doc *openapi3.T, scheme *openapi3.SecuritySche
 	if scheme == nil || !strings.EqualFold(strings.TrimSpace(scheme.Type), "oauth2") || auth.Type != "bearer_token" {
 		return false
 	}
+	// Preserve an explicitly declared browser flow. Google-hosted APIs can
+	// expose ordinary user OAuth alongside service-account-compatible scopes.
+	if strings.TrimSpace(auth.AuthorizationURL) != "" {
+		return false
+	}
 	return hasGoogleAPIsServer(doc)
 }
 

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -1826,12 +1826,117 @@ func TestParseGmailOAuth2(t *testing.T) {
 
 	assert.Equal(t, "bearer_token", parsed.Auth.Type)
 	assert.Equal(t, "Authorization", parsed.Auth.Header)
-	assert.Equal(t, "https://accounts.google.com/o/oauth2/auth", parsed.Auth.AuthorizationURL)
+	assert.Equal(t, spec.AuthSubtypeGoogleServiceAccount, parsed.Auth.Subtype)
+	assert.Empty(t, parsed.Auth.AuthorizationURL, "Google service-account auth must not select a browser redirect")
 	assert.Equal(t, "https://accounts.google.com/o/oauth2/token", parsed.Auth.TokenURL)
+	assert.Equal(t, []string{"GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_OAUTH_ACCESS_TOKEN"}, parsed.Auth.EnvVars)
 	assert.NotEmpty(t, parsed.Auth.Scopes)
-	// gmail uses authorization_code flow; OAuth2Grant stays empty so the
-	// EffectiveOAuth2Grant() default of "authorization_code" applies.
+	// The source uses authorization_code, but the Google service-account
+	// scaffold deliberately replaces the interactive grant at generation time.
 	assert.Equal(t, "", parsed.Auth.OAuth2Grant)
+}
+
+func TestParseGoogleServiceAccountAuthByServerHost(t *testing.T) {
+	t.Parallel()
+
+	specBytes := []byte(`openapi: "3.0.3"
+info:
+  title: GoogleService
+  version: "1.0"
+servers:
+  - url: https://example.googleapis.com
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://accounts.google.com/o/oauth2/auth
+          tokenUrl: https://oauth2.googleapis.com/token
+          scopes:
+            https://www.googleapis.com/auth/cloud-platform: Cloud platform
+paths:
+  /v1/items:
+    get:
+      security:
+        - OAuth2: []
+      responses: {"200": {description: ok}}
+`)
+
+	parsed, err := Parse(specBytes)
+	require.NoError(t, err)
+
+	assert.Equal(t, spec.AuthSubtypeGoogleServiceAccount, parsed.Auth.Subtype)
+	assert.Equal(t, "https://oauth2.googleapis.com/token", parsed.Auth.TokenURL)
+	assert.Equal(t, []string{"https://www.googleapis.com/auth/cloud-platform"}, parsed.Auth.Scopes)
+	assert.Empty(t, parsed.Auth.AuthorizationURL)
+	assert.Equal(t, []string{"GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_OAUTH_ACCESS_TOKEN"}, parsed.Auth.EnvVars)
+}
+
+func TestParseGenericOAuth2DoesNotUseGoogleServiceAccountAuth(t *testing.T) {
+	t.Parallel()
+
+	specBytes := []byte(`openapi: "3.0.3"
+info:
+  title: GenericOAuth
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      description: Generic service-account JWT bearer authorization
+      flows:
+        authorizationCode:
+          authorizationUrl: https://accounts.google.com/o/oauth2/auth
+          tokenUrl: https://oauth2.googleapis.com/token
+          scopes:
+            read: Read access
+paths:
+  /items:
+    get:
+      security:
+        - OAuth2: []
+      responses: {"200": {description: ok}}
+`)
+
+	parsed, err := Parse(specBytes)
+	require.NoError(t, err)
+
+	assert.Empty(t, parsed.Auth.Subtype)
+	assert.Equal(t, "https://accounts.google.com/o/oauth2/auth", parsed.Auth.AuthorizationURL)
+	assert.Equal(t, "https://oauth2.googleapis.com/token", parsed.Auth.TokenURL)
+}
+
+func TestParseGoogleHostPlainBearerDoesNotUseServiceAccountAuth(t *testing.T) {
+	t.Parallel()
+
+	specBytes := []byte(`openapi: "3.0.3"
+info:
+  title: GoogleProxy
+  version: "1.0"
+servers:
+  - url: https://proxy.googleapis.com
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+paths:
+  /items:
+    get:
+      security:
+        - BearerAuth: []
+      responses: {"200": {description: ok}}
+`)
+
+	parsed, err := Parse(specBytes)
+	require.NoError(t, err)
+
+	assert.Equal(t, "bearer_token", parsed.Auth.Type)
+	assert.Empty(t, parsed.Auth.Subtype)
+	assert.NotEmpty(t, parsed.Auth.EnvVars)
 }
 
 func TestParseOAuth2ClientCredentialsFlow(t *testing.T) {
@@ -5264,7 +5369,8 @@ paths:
 }
 
 // TestOpenAPIAuthSubtype covers the x-auth-subtype extension on a bearer
-// security scheme. The parser accepts the auth0_spa_in_memory value and
+// security scheme. The parser accepts the Google service-account and
+// auth0_spa_in_memory values and
 // silently drops unrecognized values (typos surface as the field being
 // empty, not as a confusing later validation error).
 func TestOpenAPIAuthSubtype(t *testing.T) {
@@ -5296,6 +5402,38 @@ paths:
 		require.NoError(t, err)
 		assert.Equal(t, "bearer_token", parsed.Auth.Type)
 		assert.Equal(t, "auth0_spa_in_memory", parsed.Auth.Subtype)
+	})
+
+	t.Run("google_service_account round-trips", func(t *testing.T) {
+		t.Parallel()
+		yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: GoogleService
+  version: "1.0.0"
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    BearerAuth:
+      type: oauth2
+      x-auth-subtype: google_service_account
+      flows:
+        authorizationCode:
+          authorizationUrl: https://login.example.com/authorize
+          tokenUrl: https://login.example.com/token
+paths:
+  /me:
+    get:
+      responses:
+        "200":
+          description: OK
+`)
+		parsed, err := Parse(yamlSpec)
+		require.NoError(t, err)
+		assert.Equal(t, "bearer_token", parsed.Auth.Type)
+		assert.Equal(t, spec.AuthSubtypeGoogleServiceAccount, parsed.Auth.Subtype)
+		assert.Empty(t, parsed.Auth.AuthorizationURL)
+		assert.Equal(t, []string{"GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_OAUTH_ACCESS_TOKEN"}, parsed.Auth.EnvVars)
 	})
 
 	t.Run("unknown subtype is dropped", func(t *testing.T) {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -1826,17 +1826,14 @@ func TestParseGmailOAuth2(t *testing.T) {
 
 	assert.Equal(t, "bearer_token", parsed.Auth.Type)
 	assert.Equal(t, "Authorization", parsed.Auth.Header)
-	assert.Equal(t, spec.AuthSubtypeGoogleServiceAccount, parsed.Auth.Subtype)
-	assert.Empty(t, parsed.Auth.AuthorizationURL, "Google service-account auth must not select a browser redirect")
+	assert.Empty(t, parsed.Auth.Subtype, "interactive Gmail OAuth must not select service-account auth")
+	assert.Equal(t, "https://accounts.google.com/o/oauth2/auth", parsed.Auth.AuthorizationURL)
 	assert.Equal(t, "https://accounts.google.com/o/oauth2/token", parsed.Auth.TokenURL)
-	assert.Equal(t, []string{"GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_OAUTH_ACCESS_TOKEN"}, parsed.Auth.EnvVars)
 	assert.NotEmpty(t, parsed.Auth.Scopes)
-	// The source uses authorization_code, but the Google service-account
-	// scaffold deliberately replaces the interactive grant at generation time.
 	assert.Equal(t, "", parsed.Auth.OAuth2Grant)
 }
 
-func TestParseGoogleServiceAccountAuthByServerHost(t *testing.T) {
+func TestParseGoogleHostInteractiveOAuth2PreservesBrowserAuth(t *testing.T) {
 	t.Parallel()
 
 	specBytes := []byte(`openapi: "3.0.3"
@@ -1852,6 +1849,41 @@ components:
       flows:
         authorizationCode:
           authorizationUrl: https://accounts.google.com/o/oauth2/auth
+          tokenUrl: https://oauth2.googleapis.com/token
+          scopes:
+            https://www.googleapis.com/auth/cloud-platform: Cloud platform
+paths:
+  /v1/items:
+    get:
+      security:
+        - OAuth2: []
+      responses: {"200": {description: ok}}
+`)
+
+	parsed, err := Parse(specBytes)
+	require.NoError(t, err)
+
+	assert.Empty(t, parsed.Auth.Subtype)
+	assert.Equal(t, "https://oauth2.googleapis.com/token", parsed.Auth.TokenURL)
+	assert.Equal(t, []string{"https://www.googleapis.com/auth/cloud-platform"}, parsed.Auth.Scopes)
+	assert.Equal(t, "https://accounts.google.com/o/oauth2/auth", parsed.Auth.AuthorizationURL)
+}
+
+func TestParseGoogleServiceAccountAuthByServerHostForClientCredentials(t *testing.T) {
+	t.Parallel()
+
+	specBytes := []byte(`openapi: "3.0.3"
+info:
+  title: GoogleService
+  version: "1.0"
+servers:
+  - url: https://example.googleapis.com
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        clientCredentials:
           tokenUrl: https://oauth2.googleapis.com/token
           scopes:
             https://www.googleapis.com/auth/cloud-platform: Cloud platform

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1129,7 +1129,7 @@ func (c BearerRefreshConfig) Enabled() bool {
 
 type AuthConfig struct {
 	Type                   string       `yaml:"type" json:"type"`                           // api_key, oauth2, oauth2_refresh, bearer_token, cookie, composed, session_handshake, none
-	Subtype                string       `yaml:"subtype,omitempty" json:"subtype,omitempty"` // optional refinement of Type. Currently used for "auth0_spa_in_memory": bearer_token whose JWT lives in JS heap (Auth0 SPA SDK v2+ with cacheLocation: memory) and is reachable only via CDP runtime interception, not via cookie/localStorage extraction. Mirrors x-auth-subtype on the OpenAPI security scheme.
+	Subtype                string       `yaml:"subtype,omitempty" json:"subtype,omitempty"` // optional refinement of Type. Recognized values include "google_service_account" for service-account JWT exchange and "auth0_spa_in_memory" for bearer tokens whose JWT lives in JS heap (Auth0 SPA SDK v2+ with cacheLocation: memory) and is reachable only via CDP runtime interception, not via cookie/localStorage extraction. Mirrors x-auth-subtype on the OpenAPI security scheme.
 	Header                 string       `yaml:"header" json:"header"`
 	Prefix                 string       `yaml:"prefix,omitempty" json:"prefix,omitempty"` // Authorization scheme word (e.g., "Token", "PRIVATE-TOKEN"); empty defaults to "Bearer". Ignored when Format is set.
 	Format                 string       `yaml:"format" json:"format"`
@@ -1247,6 +1247,10 @@ const (
 	RefreshTokenMechanismKindScope = "scope"
 	RefreshTokenMechanismKindQuery = "query"
 )
+
+// AuthSubtypeGoogleServiceAccount marks a Google OAuth2 bearer spec whose
+// generated CLI can exchange a service-account JSON key for a bearer token.
+const AuthSubtypeGoogleServiceAccount = "google_service_account"
 
 // AuthSubtypeAuth0SPAInMemory marks a bearer_token spec whose access token is
 // held in JS heap by the Auth0 SPA SDK (cacheLocation: memory) and is reachable
@@ -1719,14 +1723,18 @@ func validateAuthPrefix(c AuthConfig) error {
 }
 
 // validateAuthSubtype rejects unrecognized auth.subtype values so authoring
-// typos fail fast rather than silently bypassing the runtime emission. Only
-// auth0_spa_in_memory is recognized today; the field is otherwise expected to
-// be empty.
+// typos fail fast rather than silently bypassing the runtime emission.
 func validateAuthSubtype(c AuthConfig) error {
 	if c.Subtype == "" {
 		return nil
 	}
 	switch c.Subtype {
+	case AuthSubtypeGoogleServiceAccount:
+		if c.Type != "" && c.Type != "bearer_token" {
+			return fmt.Errorf("auth.subtype %q requires auth.type %q (got %q)",
+				c.Subtype, "bearer_token", c.Type)
+		}
+		return nil
 	case AuthSubtypeAuth0SPAInMemory:
 		// Subtype refines bearer_token; reject the combination if the
 		// underlying type doesn't fit. Auth0 SPA tokens are always
@@ -1737,8 +1745,8 @@ func validateAuthSubtype(c AuthConfig) error {
 		}
 		return nil
 	default:
-		return fmt.Errorf("auth.subtype %q is not recognized (valid: %q)",
-			c.Subtype, AuthSubtypeAuth0SPAInMemory)
+		return fmt.Errorf("auth.subtype %q is not recognized (valid: %q, %q)",
+			c.Subtype, AuthSubtypeGoogleServiceAccount, AuthSubtypeAuth0SPAInMemory)
 	}
 }
 

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -1939,12 +1939,21 @@ func TestAuthSubtypeValidate(t *testing.T) {
 			auth: AuthConfig{Type: "bearer_token", Subtype: AuthSubtypeAuth0SPAInMemory},
 		},
 		{
+			name: "google_service_account with bearer_token is valid",
+			auth: AuthConfig{Type: "bearer_token", Subtype: AuthSubtypeGoogleServiceAccount},
+		},
+		{
 			name: "auth0_spa_in_memory with empty Type is valid",
 			auth: AuthConfig{Subtype: AuthSubtypeAuth0SPAInMemory},
 		},
 		{
 			name:    "auth0_spa_in_memory with api_key is rejected",
 			auth:    AuthConfig{Type: "api_key", Subtype: AuthSubtypeAuth0SPAInMemory},
+			wantErr: `requires auth.type "bearer_token"`,
+		},
+		{
+			name:    "google_service_account with api_key is rejected",
+			auth:    AuthConfig{Type: "api_key", Subtype: AuthSubtypeGoogleServiceAccount},
 			wantErr: `requires auth.type "bearer_token"`,
 		},
 		{

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -2310,6 +2310,10 @@ browser-sniffed and crowd-sniffed specs where the mechanical auth detection may 
 - For internal YAML specs: look for `auth:` section with `type:` not equal to `"none"`
 - For OpenAPI specs: look for `components.securitySchemes` or `security` sections
 
+| Spec signal | Generator auth path |
+|---|---|
+| Provider-specific OAuth2 server or auth marker identifies a service-account JWT bearer flow | Emit the guarded service-account scaffold. It accepts the provider's credential file or pre-minted bearer override, exchanges service-account JWTs for cached bearer tokens, and preserves generic OAuth2 behavior for other hosts. |
+
 **If auth is missing** (`type: none` or no auth section) AND Phase 1 research found
 auth signals, enrich the spec before generation:
 


### PR DESCRIPTION
## Summary

Generated CLIs for Google-style OAuth2 APIs can now authenticate with service-account credentials through a guarded JWT bearer scaffold, while generic OAuth2 and plain bearer specs retain their existing behavior.

## Approach

- Detect Google API server hosts or the explicit `google_service_account` auth subtype and normalize the generated auth surface.
- Emit `auth service-account`, credential and token persistence, bounded JWT exchange, cached bearer injection, and doctor/status guidance.
- Preserve declared scopes across multi-spec auth merging and cover omitted extension defaults with generated compile and runtime tests.

## Validation

- Focused parser, subtype, generator, and multi-spec tests pass.
- `go vet ./...` passes.
- `go build -o ./cli-printing-press ./cmd/cli-printing-press` passes.
- `scripts/verify-generator-output.sh` passes for 10 cases.
- `scripts/golden.sh verify` passes for 32 cases.
- `go test ./...` remains blocked by existing HTML extraction and pagination tests failing with `invalid character 'w' looking for beginning of value`; those tests and files are unrelated to this change.
- `golangci-lint run ./...` remains blocked by the existing `internal/googlediscovery/parser.go:455` `slicesbackward` finding; that file is unchanged.

## New concepts

A service-account JWT bearer flow lets a CLI sign a short-lived assertion with a local service-account key, exchange it at the provider token endpoint, and reuse the returned bearer token until expiry. This fits non-interactive API authentication and keeps the key exchange separate from generic browser-based OAuth2; it should not be used when the API requires user consent or delegated user authorization.

Closes #3379
Closes #2454