### PR TITLE
fix(cli): preserve declared request parameters

### DIFF
--- a/internal/generator/body_map_test.go
+++ b/internal/generator/body_map_test.go
@@ -26,7 +26,7 @@ func TestBodyMap(t *testing.T) {
 			name:   "scalar string",
 			body:   []spec.Param{{Name: "name", Type: "string"}},
 			indent: "\t\t\t\t",
-			want: "\t\t\t\tif bodyName != \"\" {\n" +
+			want: "\t\t\t\tif (cmd.Flags().Changed(\"name\") || bodyName != \"\") {\n" +
 				"\t\t\t\t\tbody[\"name\"] = bodyName\n" +
 				"\t\t\t\t}\n",
 		},
@@ -34,7 +34,7 @@ func TestBodyMap(t *testing.T) {
 			name:   "scalar int",
 			body:   []spec.Param{{Name: "count", Type: "int"}},
 			indent: "\t\t\t",
-			want: "\t\t\tif bodyCount != 0 {\n" +
+			want: "\t\t\tif (cmd.Flags().Changed(\"count\") || bodyCount != 0) {\n" +
 				"\t\t\t\tbody[\"count\"] = bodyCount\n" +
 				"\t\t\t}\n",
 		},
@@ -64,7 +64,7 @@ func TestBodyMap(t *testing.T) {
 			name:   "object branch parses JSON and stores parsed value",
 			body:   []spec.Param{{Name: "metadata", Type: "object"}},
 			indent: "\t\t\t",
-			want: "\t\t\tif bodyMetadata != \"\" {\n" +
+			want: "\t\t\tif (cmd.Flags().Changed(\"metadata\") || bodyMetadata != \"\") {\n" +
 				"\t\t\t\tvar parsedMetadata any\n" +
 				"\t\t\t\tif err := json.Unmarshal([]byte(bodyMetadata), &parsedMetadata); err != nil {\n" +
 				"\t\t\t\t\treturn fmt.Errorf(\"parsing --metadata JSON: %w\", err)\n" +
@@ -80,7 +80,7 @@ func TestBodyMap(t *testing.T) {
 			name:   "array branch matches object branch shape",
 			body:   []spec.Param{{Name: "tags", Type: "array"}},
 			indent: "\t\t\t",
-			want: "\t\t\tif bodyTags != \"\" {\n" +
+			want: "\t\t\tif (cmd.Flags().Changed(\"tags\") || bodyTags != \"\") {\n" +
 				"\t\t\t\tvar parsedTags any\n" +
 				"\t\t\t\tif err := json.Unmarshal([]byte(bodyTags), &parsedTags); err != nil {\n" +
 				"\t\t\t\t\treturn fmt.Errorf(\"parsing --tags JSON: %w\", err)\n" +
@@ -100,7 +100,7 @@ func TestBodyMap(t *testing.T) {
 			name:   "jsonString branch validates but stores raw",
 			body:   []spec.Param{{Name: "config", Type: "string", Format: "json"}},
 			indent: "\t\t\t",
-			want: "\t\t\tif bodyConfig != \"\" {\n" +
+			want: "\t\t\tif (cmd.Flags().Changed(\"config\") || bodyConfig != \"\") {\n" +
 				"\t\t\t\tvar parsedConfig any\n" +
 				"\t\t\t\tif err := json.Unmarshal([]byte(bodyConfig), &parsedConfig); err != nil {\n" +
 				"\t\t\t\t\treturn fmt.Errorf(\"parsing --config JSON: %w\", err)\n" +
@@ -116,7 +116,7 @@ func TestBodyMap(t *testing.T) {
 			name:   "json-or-scalar branch parses composite values and keeps scalar fallback",
 			body:   []spec.Param{{Name: "response_engine", Type: "string", Format: "json_or_scalar"}},
 			indent: "\t\t\t",
-			want: "\t\t\tif bodyResponseEngine != \"\" {\n" +
+			want: "\t\t\tif (cmd.Flags().Changed(\"response-engine\") || bodyResponseEngine != \"\") {\n" +
 				"\t\t\t\tif looksLikeJSONComposite(bodyResponseEngine) {\n" +
 				"\t\t\t\t\tvar parsedResponseEngine any\n" +
 				"\t\t\t\t\tif err := json.Unmarshal([]byte(bodyResponseEngine), &parsedResponseEngine); err != nil {\n" +
@@ -135,10 +135,10 @@ func TestBodyMap(t *testing.T) {
 				{Name: "tags", Type: "array"},
 			},
 			indent: "\t",
-			want: "\tif bodyName != \"\" {\n" +
+			want: "\tif (cmd.Flags().Changed(\"name\") || bodyName != \"\") {\n" +
 				"\t\tbody[\"name\"] = bodyName\n" +
 				"\t}\n" +
-				"\tif bodyTags != \"\" {\n" +
+				"\tif (cmd.Flags().Changed(\"tags\") || bodyTags != \"\") {\n" +
 				"\t\tvar parsedTags any\n" +
 				"\t\tif err := json.Unmarshal([]byte(bodyTags), &parsedTags); err != nil {\n" +
 				"\t\t\treturn fmt.Errorf(\"parsing --tags JSON: %w\", err)\n" +
@@ -158,7 +158,7 @@ func TestBodyMap(t *testing.T) {
 			name:   "required bool without default parses string-backed flag",
 			body:   []spec.Param{{Name: "all_day", Type: "boolean", Required: true}},
 			indent: "\t\t\t",
-			want: "\t\t\tif bodyAllDay != \"\" {\n" +
+			want: "\t\t\tif (cmd.Flags().Changed(\"all-day\") || bodyAllDay != \"\") {\n" +
 				"\t\t\t\tparsedAllDay, err := strconv.ParseBool(bodyAllDay)\n" +
 				"\t\t\t\tif err != nil {\n" +
 				"\t\t\t\t\treturn fmt.Errorf(\"parsing --all-day as bool: %w\", err)\n" +
@@ -248,10 +248,10 @@ func TestBodyMap_NestedObject(t *testing.T) {
 	}}, "\t")
 	want := "\t{\n" +
 		"\t\tnestedStart := map[string]any{}\n" +
-		"\t\tif bodyStartDateTime != \"\" {\n" +
+		"\t\tif (cmd.Flags().Changed(\"start-date-time\") || bodyStartDateTime != \"\") {\n" +
 		"\t\t\tnestedStart[\"dateTime\"] = bodyStartDateTime\n" +
 		"\t\t}\n" +
-		"\t\tif bodyStartTimeZone != \"\" {\n" +
+		"\t\tif (cmd.Flags().Changed(\"start-time-zone\") || bodyStartTimeZone != \"\") {\n" +
 		"\t\t\tnestedStart[\"timeZone\"] = bodyStartTimeZone\n" +
 		"\t\t}\n" +
 		"\t\tif len(nestedStart) > 0 {\n" +
@@ -315,7 +315,7 @@ func TestBodyMap_NestedObject_PreservesScalarSiblings(t *testing.T) {
 		{Name: "subject", Type: "string"},
 		{Name: "start", Type: "object", Fields: []spec.Param{{Name: "dateTime", Type: "string"}}},
 	}, "\t")
-	if !strings.Contains(got, `if bodySubject != "" {`) {
+	if !strings.Contains(got, `if (cmd.Flags().Changed("subject") || bodySubject != "") {`) {
 		t.Errorf("scalar branch missing, got:\n%s", got)
 	}
 	if !strings.Contains(got, `body["subject"] = bodySubject`) {
@@ -411,6 +411,37 @@ func TestBodyVarDecls_Flat(t *testing.T) {
 	want := "\n\tvar bodyName string\n\tvar bodyCount int"
 	if got != want {
 		t.Errorf("bodyVarDecls flat mismatch.\n got:%q\nwant:%q", got, want)
+	}
+}
+
+func TestBodyParamTypesHonorDeclaredScalarTypes(t *testing.T) {
+	t.Parallel()
+
+	endpoint := spec.Endpoint{Body: []spec.Param{
+		{Name: "offset", Type: "int"},
+		{Name: "page", Type: "integer"},
+		{Name: "id", Type: "int", Required: true},
+		{Name: "enabled", Type: "bool", Required: true},
+	}}
+
+	decls := bodyVarDecls(endpoint)
+	for _, want := range []string{
+		"var bodyOffset int",
+		"var bodyPage int",
+		"var bodyId int",
+		"var bodyEnabled string",
+	} {
+		require.Contains(t, decls, want)
+	}
+
+	flags := bodyFlagRegs(endpoint)
+	for _, want := range []string{
+		`cmd.Flags().IntVar(&bodyOffset, "offset"`,
+		`cmd.Flags().IntVar(&bodyPage, "page"`,
+		`cmd.Flags().IntVar(&bodyId, "id"`,
+		`cmd.Flags().StringVar(&bodyEnabled, "enabled"`,
+	} {
+		require.Contains(t, flags, want)
 	}
 }
 
@@ -786,14 +817,14 @@ func TestNonJSONBodyMaps_RequiredBoolNoDefaultUsesStringZero(t *testing.T) {
 	t.Parallel()
 	body := []spec.Param{{Name: "all_day", Type: "boolean", Required: true}}
 	multipart := multipartBodyMaps(body, "\t")
-	if !strings.Contains(multipart, `if bodyAllDay != "" {`) {
+	if !strings.Contains(multipart, `if (cmd.Flags().Changed("all-day") || bodyAllDay != "") {`) {
 		t.Errorf("multipart required bool must compare against string zero value, got:\n%s", multipart)
 	}
 	if strings.Contains(multipart, `bodyAllDay != false`) {
 		t.Errorf("multipart required bool must not compare string var to bool false, got:\n%s", multipart)
 	}
 	form := formBodyMaps(body, "\t")
-	if !strings.Contains(form, `if bodyAllDay != "" {`) {
+	if !strings.Contains(form, `if (cmd.Flags().Changed("all-day") || bodyAllDay != "") {`) {
 		t.Errorf("form required bool must compare against string zero value, got:\n%s", form)
 	}
 	if strings.Contains(form, `bodyAllDay != false`) {

--- a/internal/generator/body_map_test.go
+++ b/internal/generator/body_map_test.go
@@ -580,7 +580,7 @@ func TestBodyRequiredChecks_OptionalNestedObject(t *testing.T) {
 			},
 		}},
 	}, "\t\t\t")
-	require.Contains(t, got, `if bodyStartDateTime != "" || bodyStartTimeZone != "" {`)
+	require.Contains(t, got, `if (cmd.Flags().Changed("start-date-time") || bodyStartDateTime != "") || (cmd.Flags().Changed("start-time-zone") || bodyStartTimeZone != "") {`)
 	require.Contains(t, got, `if !cmd.Flags().Changed("start-date-time") && !flags.dryRun {`)
 	require.Contains(t, got, `"required flag \"%s\" not set", "start-date-time"`)
 }
@@ -597,7 +597,7 @@ func TestBodyRequiredChecks_OptionalNestedObjectDefaultActivatesParent(t *testin
 			},
 		}},
 	}, "\t\t\t")
-	require.Contains(t, got, `if bodyStartDateTime != "" || bodyStartTimeZone != "" {`)
+	require.Contains(t, got, `if (cmd.Flags().Changed("start-date-time") || bodyStartDateTime != "") || (cmd.Flags().Changed("start-time-zone") || bodyStartTimeZone != "") {`)
 	require.Contains(t, got, `if !cmd.Flags().Changed("start-date-time") && !flags.dryRun {`)
 }
 
@@ -620,8 +620,8 @@ func TestBodyRequiredChecks_RecursiveOptionalObjects(t *testing.T) {
 			},
 		}},
 	}, "\t\t\t")
-	require.Contains(t, got, `if bodyOuterLabel != "" || bodyOuterConfigMode != "" || bodyOuterConfigNote != "" {`)
-	require.Contains(t, got, `if bodyOuterConfigMode != "" || bodyOuterConfigNote != "" {`)
+	require.Contains(t, got, `if (cmd.Flags().Changed("outer-label") || bodyOuterLabel != "") || (cmd.Flags().Changed("outer-config-mode") || bodyOuterConfigMode != "") || (cmd.Flags().Changed("outer-config-note") || bodyOuterConfigNote != "") {`)
+	require.Contains(t, got, `if (cmd.Flags().Changed("outer-config-mode") || bodyOuterConfigMode != "") || (cmd.Flags().Changed("outer-config-note") || bodyOuterConfigNote != "") {`)
 	require.Contains(t, got, `if !cmd.Flags().Changed("outer-config-mode") && !flags.dryRun {`)
 }
 

--- a/internal/generator/body_nested_object_test.go
+++ b/internal/generator/body_nested_object_test.go
@@ -95,7 +95,7 @@ func TestGenerateNestedObjectBodyEmitsFieldFlags(t *testing.T) {
 	// Required-flag validation: the nested requirement applies only when the
 	// optional start object is populated, and the parent-prefixed flag in the
 	// error message matches the registered flag name.
-	require.Contains(t, got, `if bodyStartDateTime != "" || bodyStartTimeZone != "" {`)
+	require.Contains(t, got, `if (cmd.Flags().Changed("start-date-time") || bodyStartDateTime != "") || (cmd.Flags().Changed("start-time-zone") || bodyStartTimeZone != "") {`)
 	require.Contains(t, got, `cmd.Flags().Changed("start-date-time")`, "required check must use parent-prefixed flag")
 	require.Contains(t, got, `"required flag \"%s\" not set", "start-date-time"`)
 
@@ -178,7 +178,7 @@ func TestOptionalNestedRequiredRuntime(t *testing.T) {
 	promotedOutputDir := filepath.Join(t.TempDir(), "nested-body-promoted-pp-cli")
 	require.NoError(t, New(promotedSpec, promotedOutputDir).Generate())
 	promoted := readGeneratedFile(t, promotedOutputDir, "internal", "cli", "promoted_events.go")
-	require.Contains(t, promoted, `if bodyStartDateTime != "" || bodyStartTimeZone != "" {`)
+	require.Contains(t, promoted, `if (cmd.Flags().Changed("start-date-time") || bodyStartDateTime != "") || (cmd.Flags().Changed("start-time-zone") || bodyStartTimeZone != "") {`)
 	require.Contains(t, promoted, `if !cmd.Flags().Changed("start-date-time") && !flags.dryRun {`)
 	requireGeneratedCompiles(t, promotedOutputDir)
 }

--- a/internal/generator/code_orch_query_split_test.go
+++ b/internal/generator/code_orch_query_split_test.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -21,6 +22,7 @@ func TestCodeOrchRoutesQueryParamsOnWriteMethods(t *testing.T) {
 	t.Parallel()
 
 	apiSpec := minimalSpec("qsplit")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
 	apiSpec.MCP = spec.MCPConfig{Orchestration: "code"}
 	apiSpec.Resources["ledger"] = spec.Resource{
 		Description: "Ledger",
@@ -30,7 +32,9 @@ func TestCodeOrchRoutesQueryParamsOnWriteMethods(t *testing.T) {
 				Path:        "/ledger/voucher/{id}",
 				Description: "Update a voucher; sendToLedger is an in-query flag",
 				Params: []spec.Param{
-					{Name: "sendToLedger", Type: "string", Description: "Post to ledger immediately (query)"},
+					{Name: "id", Type: "string", Positional: true, PathParam: true, Description: "Voucher ID"},
+					{Name: "sendToLedger", In: "query", Type: "string", Description: "Post to ledger immediately (query)"},
+					{Name: "X-Request-ID", In: "header", Type: "string", Description: "Request identifier"},
 				},
 				Body: []spec.Param{
 					{Name: "voucherDescription", Type: "string", Description: "Voucher text (body)"},
@@ -49,6 +53,8 @@ func TestCodeOrchRoutesQueryParamsOnWriteMethods(t *testing.T) {
 	// The PUT endpoint emits its in:query param into QueryParams.
 	require.Regexp(t, `QueryParams:\s*\[\]codeOrchParamBinding\{\s*\{PublicName: "sendToLedger", WireName: "sendToLedger"\}\s*,?\s*\}`, src,
 		"PUT endpoint must list sendToLedger in QueryParams")
+	require.Regexp(t, `HeaderParams:\s*\[\]codeOrchParamBinding\{\s*\{PublicName: "X-Request-ID", WireName: "X-Request-ID"\}\s*,?\s*\}`, src,
+		"PUT endpoint must list X-Request-ID in HeaderParams")
 	// A body param must never be classified as a query param.
 	require.NotRegexp(t, `QueryParams:\s*\[\]codeOrchParamBinding\{[^}]*voucherDescription[^}]*\}`, src,
 		"body param must not appear inside any QueryParams literal")
@@ -61,6 +67,102 @@ func TestCodeOrchRoutesQueryParamsOnWriteMethods(t *testing.T) {
 		"codeOrchSplitQuery helper must be emitted")
 	require.Contains(t, src, "codeOrchSplitQuery(ep.QueryParams, params)",
 		"the write branch must route query params via codeOrchSplitQuery")
+	require.Contains(t, src, "for _, binding := range ep.HeaderParams",
+		"the execute path must route spec-declared header params before query/body splitting")
 	require.NotContains(t, src, "delete(params, q.WireName)",
 		"query routing must not delete a same-named body field when the public query name was consumed")
+
+	runtimeTest := `package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestCodeOrchestrationRoutesHeaderAndEmptyValues(t *testing.T) {
+	var gotQuery url.Values
+	var gotHeader string
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		gotHeader = r.Header.Get("X-Request-ID")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"ok\":true}"))
+	}))
+	defer server.Close()
+	t.Setenv("QSPLIT_BASE_URL", server.URL)
+
+	request := mcplib.CallToolRequest{Params: mcplib.CallToolParams{Arguments: map[string]any{
+		"endpoint_id": "ledger.voucher-update",
+			"params": map[string]any{
+				"id": "voucher-1", "sendToLedger": "", "X-Request-ID": "request-1", "voucherDescription": "",
+		},
+	}}}
+	result, err := handleCodeOrchExecute(context.Background(), request)
+	if err != nil || result.IsError {
+		t.Fatalf("code orchestration request failed: result=%#v err=%v", result, err)
+	}
+	if values, ok := gotQuery["sendToLedger"]; !ok || len(values) != 1 || values[0] != "" {
+		t.Fatalf("sendToLedger query = %#v, want one explicit empty value", gotQuery)
+	}
+	if gotHeader != "request-1" {
+		t.Fatalf("X-Request-ID = %q, want request-1", gotHeader)
+	}
+	if value, ok := gotBody["voucherDescription"]; !ok || value != "" {
+		t.Fatalf("voucherDescription body = %#v, want explicit empty string", gotBody)
+	}
+	if _, ok := gotBody["sendToLedger"]; ok {
+		t.Fatalf("query param leaked into body: %#v", gotBody)
+	}
+	if _, ok := gotBody["X-Request-ID"]; ok {
+		t.Fatalf("header param leaked into body: %#v", gotBody)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "mcp", "code_orch_query_runtime_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/mcp", "-run", "TestCodeOrchestrationRoutesHeaderAndEmptyValues", "-count=1")
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestMCPParamBindingsHonorExplicitLocations(t *testing.T) {
+	t.Parallel()
+
+	endpoint := spec.Endpoint{
+		Method: "GET",
+		Path:   "/things/{cursor}",
+		Pagination: &spec.Pagination{
+			CursorParam: "cursor",
+			Type:        "cursor",
+		},
+		Params: []spec.Param{
+			{Name: "cursor", In: "header", Type: "string", Default: "request-default"},
+			{Name: "cursor", In: "path", Type: "string", PathParam: true},
+			{Name: "page", In: "query", Type: "integer", Positional: true},
+		},
+	}
+
+	bindings := mcpParamBindings(endpoint, endpoint.Path)
+	var headerCount, queryCount int
+	for _, binding := range bindings {
+		switch binding.Location {
+		case "header":
+			headerCount++
+			require.Equal(t, "cursor", binding.WireName)
+			require.Equal(t, "request-default", binding.Default)
+		case "query":
+			queryCount++
+			require.Equal(t, "page", binding.WireName)
+		}
+	}
+	require.Equal(t, 1, headerCount, "same-named header must not be treated as the pagination cursor")
+	require.Equal(t, 1, queryCount, "positional query params must remain routable")
 }

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -245,20 +245,27 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"goStructType":                        goStructType,
 		"goTypeForParam":                      goTypeForParam,
 		"goTypeForParamRequired":              goTypeForParamRequired,
+		"goTypeForBodyParam":                  goTypeForBodyParam,
 		"goStoreType":                         goStoreType,
 		"cobraFlagFunc":                       cobraFlagFunc,
 		"cobraFlagFuncForParam":               cobraFlagFuncForParam,
 		"cobraFlagFuncForParamRequired":       cobraFlagFuncForParamRequired,
+		"cobraFlagFuncForBodyParam":           cobraFlagFuncForBodyParam,
 		"mcpBindingFunc":                      mcpBindingFunc,
 		"recipeParamTypeString":               func(t RecipeIntentParamType) string { return string(t) },
 		"defaultVal":                          defaultVal,
 		"defaultValForParam":                  defaultValForParam,
 		"defaultValForParamRequired":          defaultValForParamRequired,
+		"defaultValForBodyParam":              defaultValForBodyParam,
 		"hasDefault":                          paramHasDefault,
 		"isConstDefault":                      paramIsConstDefault,
 		"zeroVal":                             zeroVal,
 		"zeroValForParam":                     zeroValForParam,
 		"zeroValForParamRequired":             zeroValForParamRequired,
+		"zeroValForBodyParam":                 zeroValForBodyParam,
+		"paramIsHeader":                       paramIsHeader,
+		"paramPresenceExpr":                   paramPresenceExpr,
+		"endpointHasHeaderParams":             endpointHasHeaderParams,
 		"positionalArgs":                      positionalArgs,
 		"configTag":                           configTag,
 		"camelToJSON":                         camelToJSON,
@@ -5664,6 +5671,17 @@ func goTypeForParamRequired(name, t string, required bool, hasDefault bool) stri
 	return goType(t)
 }
 
+// Body fields preserve their declared scalar type in JSON. The identifier,
+// cursor, and limit overrides are for URL-facing flags; applying them to a
+// JSON body changes the payload type. Required booleans still use a string
+// backing value so omitted and explicit false remain distinguishable.
+func goTypeForBodyParam(p spec.Param) string {
+	if isStringBackedBoolParam(p) {
+		return "string"
+	}
+	return goType(p.Type)
+}
+
 // cobraFlagFuncForParam returns the cobra flag function, overriding BoolVar→StringVar
 // for required bools without defaults, IntVar→StringVar for ID-like parameters,
 // Float64Var/IntVar→StringVar for pagination cursors,
@@ -5687,6 +5705,13 @@ func cobraFlagFuncForParamRequired(name, t string, required bool, hasDefault boo
 		return "IntVar"
 	}
 	return cobraFlagFunc(t)
+}
+
+func cobraFlagFuncForBodyParam(p spec.Param) string {
+	if isStringBackedBoolParam(p) {
+		return "StringVar"
+	}
+	return cobraFlagFunc(p.Type)
 }
 
 // defaultValForParam returns the default value for a flag parameter,
@@ -5723,6 +5748,13 @@ func defaultValForParamRequired(p spec.Param, required bool, hasDefault bool) st
 	return defaultVal(p)
 }
 
+func defaultValForBodyParam(p spec.Param) string {
+	if isStringBackedBoolParam(p) {
+		return `""`
+	}
+	return defaultVal(p)
+}
+
 func zeroValForParam(name, t string) string {
 	return zeroValForParamRequired(name, t, false, false)
 }
@@ -5739,6 +5771,13 @@ func zeroValForParamRequired(name, t string, required bool, hasDefault bool) str
 		return `""`
 	}
 	return zeroVal(t)
+}
+
+func zeroValForBodyParam(p spec.Param) string {
+	if isStringBackedBoolParam(p) {
+		return `""`
+	}
+	return zeroVal(p.Type)
 }
 
 func paramHasDefault(p spec.Param) bool {
@@ -6037,12 +6076,16 @@ func mcpParamBindings(endpoint spec.Endpoint, pathTemplate string) []mcpParamBin
 		if isMCPPaginationCursorParam(endpoint, p) {
 			continue
 		}
-		loc := "query"
-		if strings.Contains(pathTemplate, "{"+p.Name+"}") {
+		declaredLoc := strings.ToLower(strings.TrimSpace(p.In))
+		loc := declaredLoc
+		if loc == "" {
+			loc = "query"
+		}
+		if p.PathParam || (strings.Contains(pathTemplate, "{"+p.Name+"}") && (declaredLoc == "" || declaredLoc == "path")) {
 			loc = "path"
 		}
 		wireName := p.WireName()
-		if loc == "path" {
+		if loc == "path" || loc == "header" {
 			wireName = p.Name
 		}
 		binding := mcpParamBinding{
@@ -6055,7 +6098,7 @@ func mcpParamBindings(endpoint spec.Endpoint, pathTemplate string) []mcpParamBin
 		// omitted arg sends the same value the cobra flag would (#2679). Format
 		// must match the cobra default rendering for CLI/MCP wire parity; keep in
 		// sync with that path (and cf. pipeline.stringifyParamDefault).
-		if loc == "query" {
+		if loc == "query" || loc == "header" {
 			if isArrayQueryParam(p) {
 				binding.QueryArray = true
 				binding.QueryStyle = queryParamStyle(p)
@@ -6129,10 +6172,15 @@ func isMCPPaginationCursorParam(endpoint spec.Endpoint, p spec.Param) bool {
 	if !mcpEndpointPageable(endpoint) {
 		return false
 	}
-	if p.PathParam || p.Positional {
+	if p.PathParam || p.Positional || paramIsHeader(p) || !isQueryParamLocation(p) {
 		return false
 	}
 	return p.Name == endpoint.Pagination.CursorParam || p.WireName() == endpoint.Pagination.CursorParam
+}
+
+func isQueryParamLocation(p spec.Param) bool {
+	loc := strings.TrimSpace(p.In)
+	return loc == "" || strings.EqualFold(loc, "query")
 }
 
 func mcpGlobalTemplateInputParams(endpoint spec.Endpoint, pathTemplate string, vars []string) []spec.Param {
@@ -6758,10 +6806,14 @@ func renderBodyMap(b *strings.Builder, body []spec.Param, depth int, indent, map
 }
 
 func bodyLeafPresenceExpr(p spec.Param, ident, flag string) string {
-	if (p.Type == "boolean" || p.Type == "bool") && (!p.Required || p.Default != nil) {
-		return fmt.Sprintf("cmd.Flags().Changed(%q)", flag)
+	changed := fmt.Sprintf("cmd.Flags().Changed(%q)", flag)
+	if flag == publicFlagName(p) {
+		changed = flagChangedExpr(p)
 	}
-	return fmt.Sprintf("body%s != %s", ident, zeroValForParamRequired(p.Name, p.Type, p.Required, paramHasDefault(p)))
+	if (p.Type == "boolean" || p.Type == "bool") && (!p.Required || p.Default != nil) {
+		return changed
+	}
+	return fmt.Sprintf("(%s || body%s != %s)", changed, ident, zeroValForBodyParam(p))
 }
 
 func bodyHasStringBackedBool(endpoint spec.Endpoint) bool {
@@ -6813,7 +6865,7 @@ func bodyVarDecls(endpoint spec.Endpoint) string {
 	}
 	if bodyUsesFlatEmission(endpoint) {
 		for _, p := range endpoint.Body {
-			fmt.Fprintf(&b, "\n\tvar body%s %s", toCamel(paramIdent(p)), goTypeForParamRequired(p.Name, p.Type, p.Required, paramHasDefault(p)))
+			fmt.Fprintf(&b, "\n\tvar body%s %s", toCamel(paramIdent(p)), goTypeForBodyParam(p))
 		}
 		return b.String()
 	}
@@ -6840,7 +6892,7 @@ func renderBodyVarDecls(b *strings.Builder, body []spec.Param, depth int, identP
 			renderBodyVarDecls(b, p.Fields, depth+1, ident)
 			continue
 		}
-		fmt.Fprintf(b, "\n\tvar body%s %s", ident, goTypeForParamRequired(p.Name, p.Type, p.Required, paramHasDefault(p)))
+		fmt.Fprintf(b, "\n\tvar body%s %s", ident, goTypeForBodyParam(p))
 	}
 }
 
@@ -6897,11 +6949,11 @@ func renderFlatBodyFlagReg(b *strings.Builder, p spec.Param, identPrefix, flagPr
 	flag := joinFlag(flagPrefix, publicFlagName(p))
 	desc := naming.OneLine(p.Description)
 	fmt.Fprintf(b, "\n\tcmd.Flags().%s(&body%s, \"%s\", %s, \"%s\")",
-		cobraFlagFuncForParamRequired(p.Name, p.Type, p.Required, paramHasDefault(p)), ident, flag, defaultValForParamRequired(p, p.Required, paramHasDefault(p)), desc)
+		cobraFlagFuncForBodyParam(p), ident, flag, defaultValForBodyParam(p), desc)
 	if topLevel {
 		for _, alias := range publicFlagAliases(p) {
 			fmt.Fprintf(b, "\n\tcmd.Flags().%s(&body%s, \"%s\", %s, \"%s\")",
-				cobraFlagFuncForParamRequired(p.Name, p.Type, p.Required, paramHasDefault(p)), ident, alias, defaultValForParamRequired(p, p.Required, paramHasDefault(p)), desc)
+				cobraFlagFuncForBodyParam(p), ident, alias, defaultValForBodyParam(p), desc)
 			fmt.Fprintf(b, "\n\t_ = cmd.Flags().MarkHidden(\"%s\")", alias)
 		}
 	}
@@ -7052,7 +7104,7 @@ func multipartBodyMaps(body []spec.Param, indent string) string {
 		ident := toCamel(id)
 		flag := publicFlagName(p)
 		if isComplexBodyField(p) || isJSONStringParam(p) {
-			fmt.Fprintf(&b, "%sif body%s != \"\" {\n", indent, ident)
+			fmt.Fprintf(&b, "%sif %s {\n", indent, bodyLeafPresenceExpr(p, ident, flag))
 			fmt.Fprintf(&b, "%s\tif !json.Valid([]byte(body%s)) {\n", indent, ident)
 			fmt.Fprintf(&b, "%s\t\treturn fmt.Errorf(\"parsing --%s JSON: invalid JSON\")\n", indent, flag)
 			fmt.Fprintf(&b, "%s\t}\n", indent)
@@ -7061,22 +7113,34 @@ func multipartBodyMaps(body []spec.Param, indent string) string {
 			continue
 		}
 		if isBinaryParam(p) {
-			fmt.Fprintf(&b, "%sif body%s != \"\" {\n", indent, ident)
+			fmt.Fprintf(&b, "%sif %s {\n", indent, bodyLeafPresenceExpr(p, ident, flag))
 			fmt.Fprintf(&b, "%s\tfileFields[%q] = body%s\n", indent, p.BodyWireName(), ident)
 			fmt.Fprintf(&b, "%s}\n", indent)
 			continue
 		}
 		if p.Type == "string" {
-			fmt.Fprintf(&b, "%sif body%s != \"\" {\n", indent, ident)
+			fmt.Fprintf(&b, "%sif %s {\n", indent, bodyLeafPresenceExpr(p, ident, flag))
 			fmt.Fprintf(&b, "%s\tfields[%q] = body%s\n", indent, p.BodyWireName(), ident)
 			fmt.Fprintf(&b, "%s}\n", indent)
 			continue
 		}
-		fmt.Fprintf(&b, "%sif body%s != %s {\n", indent, ident, zeroValForParamRequired(p.Name, p.Type, p.Required, paramHasDefault(p)))
+		fmt.Fprintf(&b, "%sif %s {\n", indent, bodyLeafPresenceExpr(p, ident, flag))
 		fmt.Fprintf(&b, "%s\tfields[%q] = fmt.Sprintf(\"%%v\", body%s)\n", indent, p.BodyWireName(), ident)
 		fmt.Fprintf(&b, "%s}\n", indent)
 	}
 	return b.String()
+}
+
+func paramIsHeader(p spec.Param) bool {
+	return strings.EqualFold(strings.TrimSpace(p.In), "header")
+}
+
+func paramPresenceExpr(p spec.Param) string {
+	return fmt.Sprintf("(%s || flag%s != %s)", flagChangedExpr(p), toCamel(paramIdent(p)), zeroValForParamRequired(p.Name, p.Type, p.Required, paramHasDefault(p)))
+}
+
+func endpointHasHeaderParams(endpoint spec.Endpoint) bool {
+	return slices.ContainsFunc(endpoint.Params, paramIsHeader)
 }
 
 // endpointHasQueryFlags reports whether the endpoint declares any non-positional,
@@ -7087,7 +7151,7 @@ func multipartBodyMaps(body []spec.Param, indent string) string {
 // instead of being silently dropped into the JSON body or omitted.
 func endpointHasQueryFlags(endpoint spec.Endpoint) bool {
 	for _, p := range endpoint.Params {
-		if !p.Positional && !p.PathParam {
+		if !p.Positional && !p.PathParam && !paramIsHeader(p) {
 			return true
 		}
 	}
@@ -7176,7 +7240,7 @@ func freeTextStringParam(p spec.Param) bool {
 // consumed by the URL path.
 func endpointHasRequestParams(endpoint spec.Endpoint) bool {
 	for _, p := range endpoint.Params {
-		if !p.PathParam {
+		if !p.PathParam && !paramIsHeader(p) {
 			return true
 		}
 	}
@@ -7318,7 +7382,7 @@ func formBodyMaps(body []spec.Param, indent string) string {
 		ident := toCamel(id)
 		flag := publicFlagName(p)
 		if isComplexBodyField(p) || isJSONStringParam(p) {
-			fmt.Fprintf(&b, "%sif body%s != \"\" {\n", indent, ident)
+			fmt.Fprintf(&b, "%sif %s {\n", indent, bodyLeafPresenceExpr(p, ident, flag))
 			fmt.Fprintf(&b, "%s\tif !json.Valid([]byte(body%s)) {\n", indent, ident)
 			fmt.Fprintf(&b, "%s\t\treturn fmt.Errorf(\"parsing --%s JSON: invalid JSON\")\n", indent, flag)
 			fmt.Fprintf(&b, "%s\t}\n", indent)
@@ -7327,12 +7391,12 @@ func formBodyMaps(body []spec.Param, indent string) string {
 			continue
 		}
 		if p.Type == "string" {
-			fmt.Fprintf(&b, "%sif body%s != \"\" {\n", indent, ident)
+			fmt.Fprintf(&b, "%sif %s {\n", indent, bodyLeafPresenceExpr(p, ident, flag))
 			fmt.Fprintf(&b, "%s\tfields.Set(%q, body%s)\n", indent, p.BodyWireName(), ident)
 			fmt.Fprintf(&b, "%s}\n", indent)
 			continue
 		}
-		fmt.Fprintf(&b, "%sif body%s != %s {\n", indent, ident, zeroValForParamRequired(p.Name, p.Type, p.Required, paramHasDefault(p)))
+		fmt.Fprintf(&b, "%sif %s {\n", indent, bodyLeafPresenceExpr(p, ident, flag))
 		fmt.Fprintf(&b, "%s\tfields.Set(%q, fmt.Sprintf(\"%%v\", body%s))\n", indent, p.BodyWireName(), ident)
 		fmt.Fprintf(&b, "%s}\n", indent)
 	}
@@ -7567,7 +7631,7 @@ func isStringCSVArrayParam(p spec.Param) bool {
 }
 
 func isArrayQueryParam(p spec.Param) bool {
-	return !p.Positional && !p.PathParam && primitiveKind(p.Type) == "array"
+	return !p.Positional && !p.PathParam && !paramIsHeader(p) && primitiveKind(p.Type) == "array"
 }
 
 func queryParamStyle(p spec.Param) string {

--- a/internal/generator/mutating_query_params_test.go
+++ b/internal/generator/mutating_query_params_test.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -9,6 +10,202 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGeneratedPostPreservesEmptyValuesAndHeaderParameters(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("emptywire")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"messages": {
+			Description: "Manage messages",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/messages",
+					Description: "List messages",
+					Params:      []spec.Param{{Name: "offset", In: "query", Type: "int"}},
+				},
+				"create": {
+					Method:      "POST",
+					Path:        "/messages",
+					Description: "Create a message",
+					Params: []spec.Param{
+						{Name: "mode", In: "query", Type: "string"},
+						{Name: "X-Request-ID", In: "header", Type: "string"},
+					},
+					Body: []spec.Param{
+						{Name: "text", Type: "string"},
+						{Name: "offset", Type: "int"},
+					},
+				},
+				"reset": {
+					Method:      "PATCH",
+					Path:        "/messages/{id}",
+					Description: "Reset message credentials",
+					Params: []spec.Param{
+						{Name: "id", Type: "string", Required: true, Positional: true, PathParam: true},
+						{Name: "X-Request-ID", In: "header", Type: "string"},
+					},
+					Body: []spec.Param{
+						{Name: "currentPassword", Type: "string", Required: true},
+						{Name: "password", Type: "string", Required: true},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{MCP: true}
+	require.NoError(t, gen.Generate())
+
+	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "messages_create.go")
+	listSrc := readGeneratedFile(t, outputDir, "internal", "cli", "messages_list.go")
+	assert.Contains(t, listSrc, `if flagOffset != "" {`, "GET query flags must retain their existing zero-value omission")
+	assert.Contains(t, endpointSrc, `PostWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)`)
+	assert.Contains(t, endpointSrc, `headerOverrides["X-Request-ID"]`)
+	assert.Contains(t, endpointSrc, `cmd.Flags().Changed("mode")`)
+	assert.Contains(t, endpointSrc, `cmd.Flags().Changed("text")`)
+	assert.Contains(t, endpointSrc, `cmd.Flags().Changed("offset")`)
+	assert.Contains(t, endpointSrc, `var bodyOffset int`)
+	patchSrc := readGeneratedFile(t, outputDir, "internal", "cli", "messages_reset.go")
+	assert.Contains(t, patchSrc, `var bodyCurrentPassword string`)
+	assert.Contains(t, patchSrc, `var bodyPassword string`)
+	assert.Contains(t, patchSrc, `headerOverrides["X-Request-ID"]`)
+	assert.Contains(t, patchSrc, `PatchWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)`)
+
+	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
+	assert.Contains(t, mcpSrc, `PublicName: "X-Request-ID", WireName: "X-Request-ID", Location: "header"`)
+	assert.Contains(t, mcpSrc, "case \"header\":")
+
+	behaviorTest := `package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestPostPreservesExplicitEmptyAndZeroValues(t *testing.T) {
+	var gotQuery url.Values
+	var gotHeader string
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		gotHeader = r.Header.Get("X-Request-ID")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"ok\":true}"))
+	}))
+	defer server.Close()
+
+	t.Setenv("EMPTYWIRE_BASE_URL", server.URL)
+	flags := &rootFlags{asJSON: true}
+	cmd := newMessagesCreateCmd(flags)
+	cmd.SetArgs([]string{"--mode", "", "--text", "", "--offset", "0", "--x-request-id", "request-1"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if values, ok := gotQuery["mode"]; !ok || len(values) != 1 || values[0] != "" {
+		t.Fatalf("mode query = %#v, want one explicit empty value", gotQuery)
+	}
+	if gotHeader != "request-1" {
+		t.Fatalf("X-Request-ID = %q, want request-1", gotHeader)
+	}
+	if value, ok := gotBody["text"]; !ok || value != "" {
+		t.Fatalf("text body = %#v, want explicit empty string", gotBody)
+	}
+	if value, ok := gotBody["offset"]; !ok || value != float64(0) {
+		t.Fatalf("offset body = %#v, want numeric zero", gotBody)
+	}
+	if _, ok := gotBody["mode"]; ok {
+		t.Fatalf("query param leaked into body: %#v", gotBody)
+	}
+	if _, ok := gotBody["X-Request-ID"]; ok {
+		t.Fatalf("header param leaked into body: %#v", gotBody)
+	}
+}
+	`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "empty_wire_test.go"), []byte(behaviorTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPostPreservesExplicitEmptyAndZeroValues", "-count=1")
+
+	mcpRuntimeTest := `package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestEndpointMCPPreservesHeaderAndEmptyValues(t *testing.T) {
+	var gotQuery url.Values
+	var gotHeader string
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		gotHeader = r.Header.Get("X-Request-ID")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"ok\":true}"))
+	}))
+	defer server.Close()
+
+	t.Setenv("EMPTYWIRE_BASE_URL", server.URL)
+	bindings := []mcpParamBinding{
+		{PublicName: "mode", WireName: "mode", Location: "query"},
+		{PublicName: "X-Request-ID", WireName: "X-Request-ID", Location: "header"},
+		{PublicName: "text", WireName: "text", Location: "body"},
+		{PublicName: "offset", WireName: "offset", Location: "body"},
+	}
+	handler := makeAPIHandler("POST", "/messages", false, false, nil, mcpPageConfig{}, bindings, nil)
+	request := mcplib.CallToolRequest{Params: mcplib.CallToolParams{Arguments: map[string]any{
+		"mode": "", "X-Request-ID": "request-1", "text": "", "offset": 0,
+	}}}
+	result, err := handler(context.Background(), request)
+	if err != nil || result.IsError {
+		t.Fatalf("MCP request failed: result=%#v err=%v", result, err)
+	}
+	if values, ok := gotQuery["mode"]; !ok || len(values) != 1 || values[0] != "" {
+		t.Fatalf("mode query = %#v, want one explicit empty value", gotQuery)
+	}
+	if gotHeader != "request-1" {
+		t.Fatalf("X-Request-ID = %q, want request-1", gotHeader)
+	}
+	if value, ok := gotBody["text"]; !ok || value != "" {
+		t.Fatalf("text body = %#v, want explicit empty string", gotBody)
+	}
+	if value, ok := gotBody["offset"]; !ok || value != float64(0) {
+		t.Fatalf("offset body = %#v, want numeric zero", gotBody)
+	}
+	if _, ok := gotBody["mode"]; ok {
+		t.Fatalf("query param leaked into body: %#v", gotBody)
+	}
+	if _, ok := gotBody["X-Request-ID"]; ok {
+		t.Fatalf("header param leaked into body: %#v", gotBody)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "mcp", "empty_wire_runtime_test.go"), []byte(mcpRuntimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/mcp", "-run", "TestEndpointMCPPreservesHeaderAndEmptyValues", "-count=1")
+	requireGeneratedCompiles(t, outputDir)
+}
 
 func TestGenerateMutatingEndpointPassesQueryParams(t *testing.T) {
 	t.Parallel()
@@ -25,7 +222,8 @@ func TestGenerateMutatingEndpointPassesQueryParams(t *testing.T) {
 					ResponseFormat: spec.ResponseFormatBinary,
 					Params: []spec.Param{
 						{Name: "voice_id", Type: "string", Required: true, Positional: true, PathParam: true, Description: "Voice ID"},
-						{Name: "output_format", Type: "string", Description: "Output format"},
+						{Name: "output_format", In: "query", Type: "string", Description: "Output format"},
+						{Name: "X-Request-ID", In: "header", Type: "string", Description: "Request identifier"},
 					},
 					Body: []spec.Param{
 						{Name: "text", Type: "string", Required: true, Description: "Text"},
@@ -44,6 +242,7 @@ func TestGenerateMutatingEndpointPassesQueryParams(t *testing.T) {
 	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_text-to-speech.go")
 	assert.Contains(t, endpointSrc, `params := map[string]string{}`)
 	assert.Contains(t, endpointSrc, `params["output_format"] = formatCLIParamValue(flagOutputFormat)`)
+	assert.Contains(t, endpointSrc, `headerOverrides["X-Request-ID"] = formatCLIParamValue(flagXRequestID)`)
 	assert.Contains(t, endpointSrc, `c.PostWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)`)
 
 	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -1560,6 +1560,15 @@ func sleepContext(ctx context.Context, wait time.Duration) error {
 	}
 }
 
+{{- if eq .ClientPattern "proxy-envelope"}}
+func buildClientPath(method, path string, params map[string]string) string {
+	if method == "GET" {
+		return cliutil.BuildPath(path, params)
+	}
+	return cliutil.BuildPathPreserveEmpty(path, params)
+}
+{{- end}}
+
 // do executes an HTTP request. headerOverrides, when non-nil, override global
 // RequiredHeaders for this specific request (used for per-endpoint API versioning).
 func (c *Client) do(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {
@@ -1804,7 +1813,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		envelope := proxyEnvelope{
 			Service: serviceForPath(path),
 			Method:  method,
-			Path:    cliutil.BuildPath(path, params),
+			Path:    buildClientPath(method, path, params),
 		}
 		if bodyBytes != nil {
 			envelope.Body = json.RawMessage(bodyBytes)
@@ -1840,7 +1849,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		if params != nil {
 			q := req.URL.Query()
 			for k, v := range params {
-				if v != "" {
+				if v != "" || method != "GET" {
 					q.Set(k, v)
 				}
 			}
@@ -2196,7 +2205,7 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 	envelope := proxyEnvelope{
 		Service: serviceForPath(path),
 		Method:  method,
-		Path:    c.displayURL(cliutil.BuildPath(path, params), authHeader),
+		Path:    c.displayURL(buildClientPath(method, path, params), authHeader),
 	}
 	if body != nil {
 		envelope.Body = json.RawMessage(body)
@@ -2210,7 +2219,7 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 	if params != nil {
 		keys := make([]string, 0, len(params))
 		for k := range params {
-			if params[k] != "" {
+			if params[k] != "" || method != "GET" {
 				keys = append(keys, k)
 			}
 		}

--- a/internal/generator/templates/cliutil_proxypath.go.tmpl
+++ b/internal/generator/templates/cliutil_proxypath.go.tmpl
@@ -7,8 +7,8 @@ import (
 	"net/url"
 )
 
-// BuildPath appends query params to a request path for proxy-envelope
-// clients. Non-obvious contract:
+// BuildPath appends non-empty query params to a request path for
+// proxy-envelope clients. Non-obvious contract:
 //
 //   - Empty param values are dropped (not encoded as `key=`).
 //   - When a key appears in both the path's existing query string and
@@ -22,6 +22,16 @@ import (
 // blocks on a network call (~tens to hundreds of ms); a few extra
 // allocations here are invisible against that.
 func BuildPath(path string, params map[string]string) string {
+	return buildPath(path, params, false)
+}
+
+// Write requests retain explicitly supplied empty query values because an
+// empty query flag is still a meaningful caller-provided value.
+func BuildPathPreserveEmpty(path string, params map[string]string) string {
+	return buildPath(path, params, true)
+}
+
+func buildPath(path string, params map[string]string, preserveEmpty bool) string {
 	if len(params) == 0 {
 		return path
 	}
@@ -33,7 +43,7 @@ func BuildPath(path string, params map[string]string) string {
 
 	q := u.Query()
 	for k, v := range params {
-		if v == "" {
+		if v == "" && !preserveEmpty {
 			continue
 		}
 		q.Set(k, v)

--- a/internal/generator/templates/cliutil_proxypath_test.go.tmpl
+++ b/internal/generator/templates/cliutil_proxypath_test.go.tmpl
@@ -123,6 +123,15 @@ func TestBuildPath(t *testing.T) {
 	}
 }
 
+func TestBuildPathPreserveEmpty(t *testing.T) {
+	t.Parallel()
+
+	got := BuildPathPreserveEmpty("/api/things", map[string]string{"mode": ""})
+	if got != "/api/things?mode=" {
+		t.Fatalf("BuildPathPreserveEmpty() = %q, want /api/things?mode=", got)
+	}
+}
+
 // TestBuildPath_Deterministic asserts the same input produces the same
 // output across calls. The prior map-range implementation was non-stable
 // on multi-key inputs, which broke fingerprint-based caching anywhere

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -238,7 +238,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			htmlRequestParams["{{.Name}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
 				htmlRequestParams["{{.Name}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
@@ -246,7 +246,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- end}}
 
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 			headerOverrides := map[string]string{
 {{- range .Endpoint.HeaderOverrides}}
 				"{{.Name}}": "{{.Value}}",
@@ -258,6 +258,11 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				"X-Printing-Press-Text-Response": "true",
 {{- end}}
 			}
+			{{ range .Endpoint.Params}}{{if and (paramIsHeader .) (not .Positional)}}
+				if {{paramPresenceExpr .}} {
+				headerOverrides[{{printf "%q" .Name}}] = formatCLIParamValue(flag{{camel (paramIdent .)}})
+			}
+			{{ end}}{{ end}}
 {{- end}}
 
 {{- if or (eq .Endpoint.Method "GET") (eq .Endpoint.Method "HEAD")}}
@@ -372,11 +377,11 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{if eq .Endpoint.ResponseFormat "html"}}false, {{end}}cmd.ErrOrStderr())
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{if eq .Endpoint.ResponseFormat "html"}}false, {{end}}cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")
@@ -390,11 +395,11 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}headerOverrides{{else}}nil{{end}}, flagAll && !flags.dryRun, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll && !flags.dryRun, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
 {{- end}}
 {{- else}}
 			params := map[string]string{}
@@ -402,17 +407,17 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
-			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+				if {{if or (eq $.Endpoint.Method "GET") (eq $.Endpoint.Method "HEAD")}}flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}}{{else}}{{paramPresenceExpr .}}{{end}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
 {{- if .HasStore}}
 {{- if eq .Endpoint.ResponseFormat "html"}}
-			data, prov, err := resolveReadWithStrategyResponsePathAndJSONGuard(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, false, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyResponsePathAndJSONGuard(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, false, cmd.ErrOrStderr())
 {{- else}}
-			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, cmd.ErrOrStderr())
 {{- end}}
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
@@ -422,7 +427,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				return fmt.Errorf("no local data source for this command; use --data-source live or --data-source auto")
 			}
 {{- end}}
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 			data, err := c.GetWithHeaders(cmd.Context(), path, params, headerOverrides)
 {{- else}}
 			data, err := c.Get(cmd.Context(), path, params)
@@ -435,8 +440,8 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
-			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+			if {{paramPresenceExpr .}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
@@ -446,12 +451,12 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			if err != nil {
 				return err
 			}
-			data, statusCode, err := c.{{if .IsReadOnly}}SendRawRead{{else}}SendRaw{{end}}(cmd.Context(), "POST", path, params, rawBody, rawContentType, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}headerOverrides{{else}}nil{{end}})
+			data, statusCode, err := c.{{if .IsReadOnly}}SendRawRead{{else}}SendRaw{{end}}(cmd.Context(), "POST", path, params, rawBody, rawContentType, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}})
 {{- else if $isMultipart}}
 			fields := map[string]string{}
 			fileFields := map[string]string{}
 {{multipartBodyMaps .Endpoint.Body "\t\t\t"}}
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 			data, statusCode, err := c.PostMultipartWithParamsAndHeaders(cmd.Context(), path, params, fields, fileFields, headerOverrides)
 {{- else}}
 			data, statusCode, err := c.PostMultipartWithParams(cmd.Context(), path, params, fields, fileFields)
@@ -459,7 +464,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- else if $isForm}}
 			fields := url.Values{}
 {{formBodyMaps .Endpoint.Body "\t\t\t"}}
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 {{- if .IsReadOnly}}
 			data, statusCode, err := c.PostQueryFormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
 {{- else}}
@@ -500,7 +505,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				bodyMap := map[string]any{}
 				body = bodyMap
 {{bodyMapForEndpointVars .Endpoint "\t\t\t\t" "bodyMap" "body"}}{{- end}}			}
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 {{- if .IsReadOnly}}
 			data, statusCode, err := c.PostQueryWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
 {{- else}}
@@ -521,8 +526,8 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
-			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+			if {{paramPresenceExpr .}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
@@ -533,7 +538,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			if err != nil {
 				return err
 			}
-			data, statusCode, err := c.{{if .IsReadOnly}}SendRawRead{{else}}SendRaw{{end}}(cmd.Context(), "DELETE", path, params, rawBody, rawContentType, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}headerOverrides{{else}}nil{{end}})
+			data, statusCode, err := c.{{if .IsReadOnly}}SendRawRead{{else}}SendRaw{{end}}(cmd.Context(), "DELETE", path, params, rawBody, rawContentType, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}})
 {{- else if $hasJSONBody}}
 			var body any
 			if stdinBody {
@@ -562,7 +567,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				bodyMap := map[string]any{}
 				body = bodyMap
 {{bodyMapForEndpointVars .Endpoint "\t\t\t\t" "bodyMap" "body"}}{{- end}}			}
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 {{- if endpointHasRequestParams .Endpoint}}
 			data, statusCode, err := c.DeleteWithParamsAndBodyAndHeaders(cmd.Context(), path, params, body, headerOverrides)
 {{- else}}
@@ -576,7 +581,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- end}}
 {{- else}}
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 			data, statusCode, err := c.DeleteWithParamsAndHeaders(cmd.Context(), path, params, headerOverrides)
 {{- else}}
 			data, statusCode, err := c.DeleteWithParams(cmd.Context(), path, params)
@@ -588,8 +593,8 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
-			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+			if {{paramPresenceExpr .}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
@@ -599,12 +604,12 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			if err != nil {
 				return err
 			}
-			data, statusCode, err := c.{{if .IsReadOnly}}SendRawRead{{else}}SendRaw{{end}}(cmd.Context(), "PUT", path, params, rawBody, rawContentType, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}headerOverrides{{else}}nil{{end}})
+			data, statusCode, err := c.{{if .IsReadOnly}}SendRawRead{{else}}SendRaw{{end}}(cmd.Context(), "PUT", path, params, rawBody, rawContentType, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}})
 {{- else if $isMultipart}}
 			fields := map[string]string{}
 			fileFields := map[string]string{}
 {{multipartBodyMaps .Endpoint.Body "\t\t\t"}}
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 {{- if .IsReadOnly}}
 			data, statusCode, err := c.PutQueryMultipartWithParamsAndHeaders(cmd.Context(), path, params, fields, fileFields, headerOverrides)
 {{- else}}
@@ -620,7 +625,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- else if $isForm}}
 			fields := url.Values{}
 {{formBodyMaps .Endpoint.Body "\t\t\t"}}
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 {{- if .IsReadOnly}}
 			data, statusCode, err := c.PutQueryFormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
 {{- else}}
@@ -661,7 +666,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				bodyMap := map[string]any{}
 				body = bodyMap
 {{bodyMapForEndpointVars .Endpoint "\t\t\t\t" "bodyMap" "body"}}{{- end}}			}
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 {{- if .IsReadOnly}}
 			data, statusCode, err := c.PutQueryWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
 {{- else}}
@@ -681,8 +686,8 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
-			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+			if {{paramPresenceExpr .}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
@@ -692,12 +697,12 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			if err != nil {
 				return err
 			}
-			data, statusCode, err := c.{{if .IsReadOnly}}SendRawRead{{else}}SendRaw{{end}}(cmd.Context(), "PATCH", path, params, rawBody, rawContentType, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}headerOverrides{{else}}nil{{end}})
+			data, statusCode, err := c.{{if .IsReadOnly}}SendRawRead{{else}}SendRaw{{end}}(cmd.Context(), "PATCH", path, params, rawBody, rawContentType, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}})
 {{- else if $isMultipart}}
 			fields := map[string]string{}
 			fileFields := map[string]string{}
 {{multipartBodyMaps .Endpoint.Body "\t\t\t"}}
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 {{- if .IsReadOnly}}
 			data, statusCode, err := c.PatchQueryMultipartWithParamsAndHeaders(cmd.Context(), path, params, fields, fileFields, headerOverrides)
 {{- else}}
@@ -713,7 +718,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- else if $isForm}}
 			fields := url.Values{}
 {{formBodyMaps .Endpoint.Body "\t\t\t"}}
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 {{- if .IsReadOnly}}
 			data, statusCode, err := c.PatchQueryFormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
 {{- else}}
@@ -754,7 +759,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				bodyMap := map[string]any{}
 				body = bodyMap
 {{bodyMapForEndpointVars .Endpoint "\t\t\t\t" "bodyMap" "body"}}{{- end}}			}
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 {{- if .IsReadOnly}}
 			data, statusCode, err := c.PatchQueryWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
 {{- else}}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -200,15 +200,15 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			htmlRequestParams["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
-			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
-				htmlRequestParams["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
-			}
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+				if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
+					htmlRequestParams["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
+				}
 {{- end}}
 {{- end}}
 {{- end}}
 
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 			headerOverrides := map[string]string{
 {{- range .Endpoint.HeaderOverrides}}
 				"{{.Name}}": "{{.Value}}",
@@ -220,6 +220,11 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				"X-Printing-Press-Text-Response": "true",
 {{- end}}
 			}
+			{{ range .Endpoint.Params}}{{if and (paramIsHeader .) (not .Positional)}}
+			if {{paramPresenceExpr .}} {
+				headerOverrides[{{printf "%q" .Name}}] = formatCLIParamValue(flag{{camel (paramIdent .)}})
+			}
+			{{ end}}{{ end}}
 {{- end}}
 
 {{- if $supportsAllPagination}}
@@ -234,11 +239,11 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{if eq .Endpoint.ResponseFormat "html"}}false, {{end}}cmd.ErrOrStderr())
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{if eq .Endpoint.ResponseFormat "html"}}false, {{end}}cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")
@@ -252,11 +257,11 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}headerOverrides{{else}}nil{{end}}, flagAll && !flags.dryRun, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll && !flags.dryRun, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
 {{- end}}
 {{- else}}
 {{- if not $deleteBodyWithoutParams}}
@@ -265,8 +270,8 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
-{{- if and (not .Positional) (not .PathParam) (not (isArrayQueryParam .))}}
-			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
+{{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .))}}
+			if {{if $isReadVerb}}flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}}{{else}}{{paramPresenceExpr .}}{{end}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
@@ -274,9 +279,9 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- if and .HasStore (eq (upper .Endpoint.Method) "GET")}}
 {{- if eq .Endpoint.ResponseFormat "html"}}
-			data, prov, err := resolveReadWithStrategyResponsePathAndJSONGuard(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, false, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyResponsePathAndJSONGuard(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, false, cmd.ErrOrStderr())
 {{- else}}
-			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, cmd.ErrOrStderr())
 {{- end}}
 {{- else if eq $method "GET"}}
 {{- if eq $dataSourceStrategy "local"}}
@@ -286,7 +291,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				return fmt.Errorf("no local data source for this command; use --data-source live or --data-source auto")
 			}
 {{- end}}
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 			data, err := c.GetWithHeaders(cmd.Context(), path, params, headerOverrides)
 {{- else}}
 			data, err := c.Get(cmd.Context(), path, params)
@@ -297,20 +302,20 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.{{if .IsReadOnly}}SendRawRead{{else}}SendRaw{{end}}(cmd.Context(), "DELETE", path, params, rawBody, rawContentType, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}headerOverrides{{else}}nil{{end}})
+			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.{{if .IsReadOnly}}SendRawRead{{else}}SendRaw{{end}}(cmd.Context(), "DELETE", path, params, rawBody, rawContentType, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}})
 {{- else if $hasJSONBody}}
 {{- if and .Endpoint.BodyJSONFallback .Endpoint.BodyIsArray}}
 			var body any = []any{}
 {{bodyMapForEndpointVars .Endpoint "\t\t\t" "bodyMap" "body"}}{{else}}
 			bodyMap := map[string]any{}
 			var body any = bodyMap
-{{bodyMapForEndpointVars .Endpoint "\t\t\t" "bodyMap" "body"}}{{end}}{{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}{{if endpointHasRequestParams .Endpoint}}			data, _, err := c.DeleteWithParamsAndBodyAndHeaders(cmd.Context(), path, params, body, headerOverrides)
+{{bodyMapForEndpointVars .Endpoint "\t\t\t" "bodyMap" "body"}}{{end}}{{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}{{if endpointHasRequestParams .Endpoint}}			data, _, err := c.DeleteWithParamsAndBodyAndHeaders(cmd.Context(), path, params, body, headerOverrides)
 {{else}}			data, _, err := c.DeleteWithBodyAndHeaders(cmd.Context(), path, body, headerOverrides)
 {{end}}{{else}}{{if endpointHasRequestParams .Endpoint}}			data, _, err := c.DeleteWithParamsAndBody(cmd.Context(), path, params, body)
 {{else}}			data, _, err := c.DeleteWithBody(cmd.Context(), path, body)
 {{end}}{{end}}
 {{- else}}
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.DeleteWithParamsAndHeaders(cmd.Context(), path, params, headerOverrides)
 {{- else}}
 			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.DeleteWithParams(cmd.Context(), path, params)
@@ -322,12 +327,12 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.{{if .IsReadOnly}}SendRawRead{{else}}SendRaw{{end}}(cmd.Context(), "{{upper .Endpoint.Method}}", path, params, rawBody, rawContentType, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}headerOverrides{{else}}nil{{end}})
+			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.{{if .IsReadOnly}}SendRawRead{{else}}SendRaw{{end}}(cmd.Context(), "{{upper .Endpoint.Method}}", path, params, rawBody, rawContentType, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}})
 {{- else if $isMultipart}}
 			fields := map[string]string{}
 			fileFields := map[string]string{}
 {{multipartBodyMaps .Endpoint.Body "\t\t\t"}}
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 {{- if and .IsReadOnly (eq (upper .Endpoint.Method) "PUT")}}
 			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.PutQueryMultipartWithParamsAndHeaders(cmd.Context(), path, params, fields, fileFields, headerOverrides)
 {{- else if and .IsReadOnly (eq (upper .Endpoint.Method) "PATCH")}}
@@ -347,7 +352,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- else if $isForm}}
 			fields := url.Values{}
 {{formBodyMaps .Endpoint.Body "\t\t\t"}}
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 {{- if and .IsReadOnly (eq (upper .Endpoint.Method) "POST")}}
 			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.PostQueryFormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
 {{- else if and .IsReadOnly (eq (upper .Endpoint.Method) "PUT")}}
@@ -378,9 +383,9 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{bodyMapForEndpointVars .Endpoint "\t\t\t" "bodyMap" "body"}}{{else}}
 			bodyMap := map[string]any{}
 			var body any = bodyMap
-{{bodyMapForEndpointVars .Endpoint "\t\t\t" "bodyMap" "body"}}{{end}}{{if .IsReadOnly}}{{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}			data, _, err := c.{{pascal (lower .Endpoint.Method)}}QueryWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
+{{bodyMapForEndpointVars .Endpoint "\t\t\t" "bodyMap" "body"}}{{end}}{{if .IsReadOnly}}{{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}			data, _, err := c.{{pascal (lower .Endpoint.Method)}}QueryWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
 {{else}}			data, _, err := c.{{pascal (lower .Endpoint.Method)}}QueryWithParams(cmd.Context(), path, params, body)
-{{end}}{{else}}{{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.{{pascal (lower .Endpoint.Method)}}WithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
+{{end}}{{else}}{{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.{{pascal (lower .Endpoint.Method)}}WithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
 {{else}}			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.{{pascal (lower .Endpoint.Method)}}WithParams(cmd.Context(), path, params, body)
 {{end}}{{end}}
 {{- end}}
@@ -388,7 +393,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			// HEAD/OPTIONS and unknown verbs fall back to GET so generation
 			// stays compileable. Spec authors who genuinely need these verbs
 			// should add a typed client method and a dedicated template branch.
-{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 			data, err := c.GetWithHeaders(cmd.Context(), path, params, headerOverrides)
 {{- else}}
 			data, err := c.Get(cmd.Context(), path, params)

--- a/internal/generator/templates/mcp_code_orch.go.tmpl
+++ b/internal/generator/templates/mcp_code_orch.go.tmpl
@@ -77,6 +77,9 @@ type codeOrchEndpoint struct {
 	// string instead of dumping them into the JSON body. Derived from the
 	// same mcpParamBindings location data the per-endpoint tools use.
 	QueryParams []codeOrchParamBinding
+	// Keep declared headers out of query/body routing so execution sends them
+	// through the request-header map.
+	HeaderParams []codeOrchParamBinding
 	// HeaderOverrides carries per-endpoint request headers (e.g. an
 	// Accept override for binary-only response endpoints). Without
 	// threading these through, the code-orchestration execute path
@@ -101,6 +104,7 @@ type codeOrchEndpoint struct {
 type codeOrchParamBinding struct {
 	PublicName string
 	WireName   string
+	Default    string
 {{- if hasArrayQueryParams .APISpec}}
 	QueryArray bool
 	QueryStyle string
@@ -130,6 +134,7 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 		Positional: []string{ {{- range $endpoint.Params}}{{if .Positional}}"{{.Name}}",{{end}}{{end}} },
 		TemplateParams: []codeOrchParamBinding{ {{- range mcpGlobalTemplateBindings $endpoint $path $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}},{{end}} },
 		QueryParams: []codeOrchParamBinding{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "query"}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}},{{end}}{{end}} },
+		HeaderParams: []codeOrchParamBinding{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "header"}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{end}} },
 {{- if $endpoint.BodyIsArray}}
 		BodyIsArray: true,
 {{- end}}
@@ -164,6 +169,7 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 		Positional: []string{ {{- range $endpoint.Params}}{{if .Positional}}"{{.Name}}",{{end}}{{end}} },
 		TemplateParams: []codeOrchParamBinding{ {{- range mcpGlobalTemplateBindings $endpoint $path $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}},{{end}} },
 		QueryParams: []codeOrchParamBinding{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "query"}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}{{if .QueryArray}}, QueryArray: true, QueryStyle: {{printf "%q" .QueryStyle}}, QueryExplode: {{.QueryExplode}}{{end}}},{{end}}{{end}} },
+		HeaderParams: []codeOrchParamBinding{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "header"}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{end}} },
 {{- if $endpoint.BodyIsArray}}
 		BodyIsArray: true,
 {{- end}}
@@ -364,7 +370,7 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 
 	path := ep.Path
 	for _, p := range ep.Positional {
-		if v, ok := params[p]; ok {
+		if v, ok := params[p]; ok && strings.Contains(path, "{"+p+"}") {
 			path = strings.ReplaceAll(path, "{"+p+"}", mcpPathValue(v))
 			delete(params, p)
 		}
@@ -391,6 +397,26 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 		delete(params, "content_type")
 	}
 {{- end}}
+
+	hdrs := make(map[string]string, len(ep.HeaderOverrides)+len(ep.HeaderParams))
+	for k, v := range ep.HeaderOverrides {
+		hdrs[k] = v
+	}
+	for _, binding := range ep.HeaderParams {
+		if binding.Default != "" {
+			hdrs[binding.WireName] = binding.Default
+		}
+		for _, key := range []string{binding.PublicName, binding.WireName} {
+			if v, ok := params[key]; ok {
+				hdrs[binding.WireName] = formatMCPParamValue(v)
+				delete(params, key)
+				break
+			}
+		}
+	}
+	if len(hdrs) == 0 {
+		hdrs = nil
+	}
 
 	// Route params to their runtime slots. GET/DELETE params are query
 	// strings; write methods split spec-declared query params from the
@@ -422,7 +448,6 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 {{- end}}
 	}
 
-	hdrs := ep.HeaderOverrides
 	writeBody := func() any {
 		if ep.BodyIsArray {
 			return codeOrchArrayBody(params)

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -571,6 +571,11 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 				}
 				c.Config.TemplateVars[binding.WireName] = formatMCPParamValue(v)
 {{- end}}
+			case "header":
+				if headers == nil {
+					headers = map[string]string{}
+				}
+				headers[binding.WireName] = formatMCPParamValue(v)
 			case "body":
 {{- if $hasMCPJSONOrScalar}}
 				bodyValue, err := coerceMCPBodyValue(binding, v)

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -4278,7 +4278,7 @@ func classifyGlobalParams(resources map[string]spec.Resource) {
 
 		seen := map[string]struct{}{}
 		for _, param := range endpoint.Params {
-			if isPathSubstitutionParam(param) {
+			if isPathSubstitutionParam(param) || !isQueryParamLocation(param) {
 				continue
 			}
 			key := strings.ToLower(param.Name)
@@ -4412,7 +4412,12 @@ func isGlobalFilterCandidate(param spec.Param) bool {
 	// access scope that defaults true) is not silently stripped, while plain
 	// high-frequency boilerplate (prettyPrint, quotaUser) with no default is
 	// still dropped.
-	return !isPathSubstitutionParam(param) && !param.Required && param.Default == nil
+	return isQueryParamLocation(param) && !isPathSubstitutionParam(param) && !param.Required && param.Default == nil
+}
+
+func isQueryParamLocation(param spec.Param) bool {
+	loc := strings.TrimSpace(param.In)
+	return loc == "" || strings.EqualFold(loc, "query")
 }
 
 func isRetainableSoleGlobalInputParam(param spec.Param) bool {
@@ -4613,7 +4618,7 @@ func mapParameters(pathItem *openapi3.PathItem, op *openapi3.Operation) ([]spec.
 		if parameter == nil {
 			continue
 		}
-		if parameter.In != openapi3.ParameterInPath && parameter.In != openapi3.ParameterInQuery {
+		if parameter.In != openapi3.ParameterInPath && parameter.In != openapi3.ParameterInQuery && parameter.In != openapi3.ParameterInHeader {
 			continue
 		}
 
@@ -4635,6 +4640,7 @@ func mapParameters(pathItem *openapi3.PathItem, op *openapi3.Operation) ([]spec.
 		}
 		param := spec.Param{
 			Name:        paramName,
+			In:          string(parameter.In),
 			Type:        mapSchemaType(schema),
 			Required:    parameter.Required,
 			Positional:  parameter.In == openapi3.ParameterInPath,
@@ -8244,6 +8250,9 @@ func detectPagination(params []spec.Param, op *openapi3.Operation) *spec.Paginat
 	originalCase := map[string]string{}
 	paramsByLowerName := map[string]spec.Param{}
 	for _, p := range params {
+		if !isQueryParamLocation(p) || isPathSubstitutionParam(p) {
+			continue
+		}
 		lowerName := strings.ToLower(p.Name)
 		originalCase[lowerName] = p.Name
 		paramsByLowerName[lowerName] = p

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -52,6 +52,134 @@ func TestParsePetstore(t *testing.T) {
 	assert.Contains(t, parsed.Types, "Pet")
 }
 
+func TestParseOperationPreservesHeaderAndWriteOnlyRequestFields(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := Parse([]byte(`
+openapi: 3.0.3
+info:
+  title: Parameter Pipeline API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /users/{id}:
+    patch:
+      operationId: resetUserPassword
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: X-Request-ID
+          in: header
+          required: false
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [currentPassword, password]
+              properties:
+                currentPassword:
+                  type: string
+                  writeOnly: true
+                password:
+                  type: string
+                  writeOnly: true
+      responses:
+        "200":
+          description: ok
+`))
+	require.NoError(t, err)
+
+	var endpoint spec.Endpoint
+	for _, resource := range parsed.Resources {
+		for _, candidate := range resource.Endpoints {
+			if candidate.Method == "PATCH" {
+				endpoint = candidate
+			}
+		}
+	}
+	require.Equal(t, "PATCH", endpoint.Method)
+
+	var header spec.Param
+	for _, param := range endpoint.Params {
+		if param.Name == "X-Request-ID" {
+			header = param
+		}
+	}
+	require.Equal(t, "header", header.In)
+
+	bodyNames := make(map[string]bool, len(endpoint.Body))
+	for _, param := range endpoint.Body {
+		bodyNames[param.Name] = true
+	}
+	assert.True(t, bodyNames["currentPassword"])
+	assert.True(t, bodyNames["password"])
+}
+
+func TestGlobalParameterFilteringDoesNotDropRepeatedHeaders(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := Parse([]byte(`
+openapi: 3.0.3
+info:
+  title: Repeated Header API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /one:
+    get:
+      parameters:
+        - name: X-Request-ID
+          in: header
+          schema: {type: string}
+        - name: filter_one
+          in: query
+          schema: {type: string}
+      responses: {"200": {description: ok}}
+  /two:
+    get:
+      parameters:
+        - name: X-Request-ID
+          in: header
+          schema: {type: string}
+        - name: filter_two
+          in: query
+          schema: {type: string}
+      responses: {"200": {description: ok}}
+  /three:
+    get:
+      parameters:
+        - name: X-Request-ID
+          in: header
+          schema: {type: string}
+        - name: filter_three
+          in: query
+          schema: {type: string}
+      responses: {"200": {description: ok}}
+`))
+	require.NoError(t, err)
+	for _, resource := range parsed.Resources {
+		for _, endpoint := range resource.Endpoints {
+			var found bool
+			for _, param := range endpoint.Params {
+				if param.Name == "X-Request-ID" {
+					found = true
+					assert.Equal(t, "header", param.In)
+				}
+			}
+			assert.True(t, found, "repeated header should remain on %s", endpoint.Path)
+		}
+	}
+}
+
 func TestParseStreamingExtension(t *testing.T) {
 	t.Parallel()
 

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -1072,6 +1072,12 @@ func hasRequiredScopeParamsForSync(endpoint spec.Endpoint, allowEnumExpansion bo
 		"key": true, "format": true,
 	}
 	for _, param := range endpoint.Params {
+		// Headers are transport inputs, not caller-supplied resource scope.
+		// They were historically absent from parsed endpoint params; preserve
+		// that sync classification now that OpenAPI header params are retained.
+		if loc := strings.TrimSpace(param.In); loc != "" && !strings.EqualFold(loc, "query") {
+			continue
+		}
 		if param.Required && !param.Positional && !param.PathParam {
 			if param.GlobalScope && strings.EqualFold(param.Type, "string") {
 				continue

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -1249,7 +1249,17 @@ func TestProfileRequiredParamResourcesStayExplicitOnlyByDefault(t *testing.T) {
 		Resources: map[string]spec.Resource{
 			"items": {
 				Endpoints: map[string]spec.Endpoint{
-					"list": {Method: "GET", Path: "/items", Response: spec.ResponseDef{Type: "array"}},
+					"list": {
+						Method:   "GET",
+						Path:     "/items",
+						Response: spec.ResponseDef{Type: "array"},
+						Params: []spec.Param{{
+							Name:     "api_version",
+							In:       "header",
+							Type:     "string",
+							Required: true,
+						}},
+					},
 				},
 			},
 			"batch_prices": {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -2550,6 +2550,7 @@ func (h *HTMLExtract) EffectiveScriptSelector() string {
 
 type Param struct {
 	Name         string   `yaml:"name" json:"name"`
+	In           string   `yaml:"in,omitempty" json:"in,omitempty"` // parameter location: path, query, or header
 	FlagName     string   `yaml:"flag_name,omitempty" json:"flag_name,omitempty"`
 	URLName      string   `yaml:"url_name,omitempty" json:"url_name,omitempty"`   // optional override for URL query-key emission (e.g., "$limit" for Socrata while keeping --limit flag)
 	BodyName     string   `yaml:"body_name,omitempty" json:"body_name,omitempty"` // optional override for request-body field emission while keeping the public name
@@ -4080,7 +4081,7 @@ func promoteEndpointParamsToBody(e *Endpoint) {
 	keep := make([]Param, 0, len(e.Params))
 	promote := make([]Param, 0, len(e.Params))
 	for _, p := range e.Params {
-		if p.PathParam || p.Positional {
+		if p.PathParam || p.Positional || strings.EqualFold(p.In, "query") || strings.EqualFold(p.In, "header") {
 			keep = append(keep, p)
 			continue
 		}

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -7212,6 +7212,42 @@ resources:
 		assert.Equal(t, "name", ep.Body[0].Name)
 	})
 
+	t.Run("POST endpoint keeps explicit query and header params", func(t *testing.T) {
+		t.Parallel()
+		input := header + `  messages:
+    description: Message endpoints
+    endpoints:
+      create:
+        method: POST
+        path: /messages
+        description: Create message
+        params:
+          - name: mode
+            in: query
+            type: string
+          - name: X-Request-ID
+            in: header
+            type: string
+          - name: text
+            type: string
+`
+		s, err := ParseBytes([]byte(input))
+		require.NoError(t, err)
+		ep := s.Resources["messages"].Endpoints["create"]
+		require.Len(t, ep.Params, 2)
+		assert.ElementsMatch(t, []string{"mode", "X-Request-ID"}, []string{ep.Params[0].Name, ep.Params[1].Name})
+		require.Len(t, ep.Body, 1)
+		assert.Equal(t, "text", ep.Body[0].Name)
+		for _, param := range ep.Params {
+			if param.Name == "mode" {
+				assert.Equal(t, "query", param.In)
+			}
+			if param.Name == "X-Request-ID" {
+				assert.Equal(t, "header", param.In)
+			}
+		}
+	})
+
 	t.Run("GET endpoint params are not promoted", func(t *testing.T) {
 		t.Parallel()
 		input := header + `  lookup:

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
@@ -267,6 +267,11 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 				placeholder := "{" + binding.WireName + "}"
 				pathParams[binding.PublicName] = true
 				path = strings.Replace(path, placeholder, mcpPathValue(v), 1)
+			case "header":
+				if headers == nil {
+					headers = map[string]string{}
+				}
+				headers[binding.WireName] = formatMCPParamValue(v)
 			case "body":
 				bodyArgs[binding.WireName] = v
 			default:

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -900,7 +900,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		if params != nil {
 			q := req.URL.Query()
 			for k, v := range params {
-				if v != "" {
+				if v != "" || method != "GET" {
 					q.Set(k, v)
 				}
 			}
@@ -1110,7 +1110,7 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 	if params != nil {
 		keys := make([]string, 0, len(params))
 		for k := range params {
-			if params[k] != "" {
+			if params[k] != "" || method != "GET" {
 				keys = append(keys, k)
 			}
 		}

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -904,7 +904,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		if params != nil {
 			q := req.URL.Query()
 			for k, v := range params {
-				if v != "" {
+				if v != "" || method != "GET" {
 					q.Set(k, v)
 				}
 			}
@@ -1115,7 +1115,7 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 	if params != nil {
 		keys := make([]string, 0, len(params))
 		for k := range params {
-			if params[k] != "" {
+			if params[k] != "" || method != "GET" {
 				keys = append(keys, k)
 			}
 		}

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -913,7 +913,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		if params != nil {
 			q := req.URL.Query()
 			for k, v := range params {
-				if v != "" {
+				if v != "" || method != "GET" {
 					q.Set(k, v)
 				}
 			}
@@ -1124,7 +1124,7 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 	if params != nil {
 		keys := make([]string, 0, len(params))
 		for k := range params {
-			if params[k] != "" {
+			if params[k] != "" || method != "GET" {
 				keys = append(keys, k)
 			}
 		}

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -904,7 +904,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		if params != nil {
 			q := req.URL.Query()
 			for k, v := range params {
-				if v != "" {
+				if v != "" || method != "GET" {
 					q.Set(k, v)
 				}
 			}
@@ -1115,7 +1115,7 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 	if params != nil {
 		keys := make([]string, 0, len(params))
 		for k := range params {
-			if params[k] != "" {
+			if params[k] != "" || method != "GET" {
 				keys = append(keys, k)
 			}
 		}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
@@ -205,6 +205,11 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 				placeholder := "{" + binding.WireName + "}"
 				pathParams[binding.PublicName] = true
 				path = strings.Replace(path, placeholder, mcpPathValue(v), 1)
+			case "header":
+				if headers == nil {
+					headers = map[string]string{}
+				}
+				headers[binding.WireName] = formatMCPParamValue(v)
 			case "body":
 				bodyArgs[binding.WireName] = v
 			default:

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
@@ -137,7 +137,7 @@ This checks your configuration and credentials.
 ### 4. Try Your First Command
 
 ```bash
-printing-press-golden-pp-cli currencies
+printing-press-golden-pp-cli currencies --x-api-version example-value
 ```
 
 ## Usage
@@ -242,19 +242,19 @@ The local store's schema version stamp is one-way: once this version of `printin
 
 ```bash
 # Human-readable table (default in terminal, JSON when piped)
-printing-press-golden-pp-cli currencies
+printing-press-golden-pp-cli currencies --x-api-version example-value
 
 # JSON for scripting and agents
-printing-press-golden-pp-cli currencies --json
+printing-press-golden-pp-cli currencies --x-api-version example-value --json
 
 # Filter to specific fields
-printing-press-golden-pp-cli currencies --json --select id,name,status
+printing-press-golden-pp-cli currencies --x-api-version example-value --json --select id,name,status
 
 # Dry run — show the request without sending
-printing-press-golden-pp-cli currencies --dry-run
+printing-press-golden-pp-cli currencies --x-api-version example-value --dry-run
 
 # Agent mode — JSON + compact + no prompts in one flag
-printing-press-golden-pp-cli currencies --agent
+printing-press-golden-pp-cli currencies --x-api-version example-value --agent
 ```
 
 ## Agent Usage

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
@@ -97,7 +97,7 @@ Add `--agent` to any command. Expands to: `--json --compact --no-input --no-colo
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
 
   ```bash
-  printing-press-golden-pp-cli currencies --agent --select id,name,status
+  printing-press-golden-pp-cli currencies --x-api-version example-value --agent --select id,name,status
   ```
 - **Previewable** — `--dry-run` shows the request without sending
 - **Offline-friendly** — sync/search commands can use the local SQLite store when available
@@ -368,7 +368,7 @@ A profile is a saved set of flag values, reused across invocations. Use it when 
 
 ```
 printing-press-golden-pp-cli profile save briefing --json
-printing-press-golden-pp-cli --profile briefing currencies
+printing-press-golden-pp-cli --profile briefing currencies --x-api-version example-value
 printing-press-golden-pp-cli profile list --json
 printing-press-golden-pp-cli profile show briefing
 printing-press-golden-pp-cli profile delete briefing --yes

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
@@ -12,15 +12,17 @@ import (
 )
 
 func newProjectsAvatarUploadProjectCmd(flags *rootFlags) *cobra.Command {
+	var flagXApiVersion string
 	var flagOverwrite bool
 	var bodyCaption string
 	var bodyFile string
 
 	cmd := &cobra.Command{
-		Use:         "upload-project <projectId>",
-		Aliases:     []string{"update"},
-		Short:       "Upload project avatar",
-		Example:     "  printing-press-golden-pp-cli projects avatar upload-project 550e8400-e29b-41d4-a716-446655440000",
+		Use:     "upload-project <projectId>",
+		Aliases: []string{"update"},
+		Short:   "Upload project avatar",
+		// TODO: replace placeholder example values before relying on this for live dogfood.
+		Example:     "  printing-press-golden-pp-cli projects avatar upload-project 550e8400-e29b-41d4-a716-446655440000 --x-api-version example-value",
 		Annotations: map[string]string{"pp:endpoint": "avatar.upload-project", "pp:method": "PUT", "pp:path": "/projects/{projectId}/avatar"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -47,20 +49,26 @@ func newProjectsAvatarUploadProjectCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			headerOverrides := map[string]string{}
+
+			if cmd.Flags().Changed("x-api-version") || flagXApiVersion != "" {
+				headerOverrides["X-Api-Version"] = formatCLIParamValue(flagXApiVersion)
+			}
+
 			params := map[string]string{}
-			if flagOverwrite != false {
+			if cmd.Flags().Changed("overwrite") || flagOverwrite != false {
 				params["overwrite"] = formatCLIParamValue(flagOverwrite)
 			}
 			fields := map[string]string{}
 			fileFields := map[string]string{}
-			if bodyCaption != "" {
+			if cmd.Flags().Changed("caption") || bodyCaption != "" {
 				fields["caption"] = bodyCaption
 			}
-			if bodyFile != "" {
+			if cmd.Flags().Changed("file") || bodyFile != "" {
 				fileFields["file"] = bodyFile
 			}
 
-			data, statusCode, err := c.PutMultipartWithParams(cmd.Context(), path, params, fields, fileFields)
+			data, statusCode, err := c.PutMultipartWithParamsAndHeaders(cmd.Context(), path, params, fields, fileFields, headerOverrides)
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
@@ -211,6 +219,7 @@ func newProjectsAvatarUploadProjectCmd(flags *rootFlags) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&flagXApiVersion, "x-api-version", "2026-04-01", "Required API version header.")
 	cmd.Flags().BoolVar(&flagOverwrite, "overwrite", false, "Overwrite")
 	cmd.Flags().StringVar(&bodyCaption, "caption", "", "Caption")
 	cmd.Flags().StringVar(&bodyFile, "file", "", "File")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
@@ -13,15 +13,18 @@ import (
 )
 
 func newProjectsCreateCmd(flags *rootFlags) *cobra.Command {
+	var flagXApiVersion string
+	var flagXRequestId string
 	var bodyName string
 	var bodyOwnerEmail string
 	var bodyVisibility string
 	var stdinBody bool
 
 	cmd := &cobra.Command{
-		Use:         "create",
-		Short:       "Create project",
-		Example:     "  printing-press-golden-pp-cli projects create --name example-resource",
+		Use:   "create",
+		Short: "Create project",
+		// TODO: replace placeholder example values before relying on this for live dogfood.
+		Example:     "  printing-press-golden-pp-cli projects create --x-api-version example-value --name example-resource",
 		Annotations: map[string]string{"pp:endpoint": "projects.create", "pp:method": "POST", "pp:path": "/projects"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Bare invocation of a command with required input prints help
@@ -55,6 +58,16 @@ func newProjectsCreateCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			headerOverrides := map[string]string{}
+
+			if cmd.Flags().Changed("x-api-version") || flagXApiVersion != "" {
+				headerOverrides["X-Api-Version"] = formatCLIParamValue(flagXApiVersion)
+			}
+
+			if cmd.Flags().Changed("x-request-id") || flagXRequestId != "" {
+				headerOverrides["X-Request-Id"] = formatCLIParamValue(flagXRequestId)
+			}
+
 			params := map[string]string{}
 			var body any
 			if stdinBody {
@@ -70,17 +83,17 @@ func newProjectsCreateCmd(flags *rootFlags) *cobra.Command {
 			} else {
 				bodyMap := map[string]any{}
 				body = bodyMap
-				if bodyName != "" {
+				if cmd.Flags().Changed("name") || bodyName != "" {
 					bodyMap["name"] = bodyName
 				}
-				if bodyOwnerEmail != "" {
+				if cmd.Flags().Changed("owner-email") || bodyOwnerEmail != "" {
 					bodyMap["owner_email"] = bodyOwnerEmail
 				}
-				if bodyVisibility != "" {
+				if cmd.Flags().Changed("visibility") || bodyVisibility != "" {
 					bodyMap["visibility"] = bodyVisibility
 				}
 			}
-			data, statusCode, err := c.PostWithParams(cmd.Context(), path, params, body)
+			data, statusCode, err := c.PostWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
@@ -231,6 +244,8 @@ func newProjectsCreateCmd(flags *rootFlags) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&flagXApiVersion, "x-api-version", "2026-04-01", "Required API version header.")
+	cmd.Flags().StringVar(&flagXRequestId, "x-request-id", "", "Optional per-request correlation ID.")
 	cmd.Flags().StringVar(&bodyName, "name", "", "Name")
 	cmd.Flags().StringVar(&bodyOwnerEmail, "owner-email", "", "Owner email")
 	cmd.Flags().StringVar(&bodyVisibility, "visibility", "", "Visibility")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
@@ -12,15 +12,17 @@ import (
 )
 
 func newProjectsListCmd(flags *rootFlags) *cobra.Command {
+	var flagXApiVersion string
 	var flagStatus string
 	var flagLimit int
 	var flagCursor string
 	var flagAll bool
 
 	cmd := &cobra.Command{
-		Use:         "list",
-		Short:       "List projects",
-		Example:     "  printing-press-golden-pp-cli projects list",
+		Use:   "list",
+		Short: "List projects",
+		// TODO: replace placeholder example values before relying on this for live dogfood.
+		Example:     "  printing-press-golden-pp-cli projects list --x-api-version example-value",
 		Annotations: map[string]string{"pp:endpoint": "projects.list", "pp:method": "GET", "pp:path": "/projects", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Flags().Changed("status") {
@@ -41,11 +43,17 @@ func newProjectsListCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			headerOverrides := map[string]string{}
+
+			if cmd.Flags().Changed("x-api-version") || flagXApiVersion != "" {
+				headerOverrides["X-Api-Version"] = formatCLIParamValue(flagXApiVersion)
+			}
+
 			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "auto", "projects", path, map[string]string{
 				"status": formatCLIParamValue(flagStatus),
 				"limit":  formatCLIParamValue(flagLimit),
 				"cursor": formatCLIParamValue(flagCursor),
-			}, nil, flagAll, "cursor", "cursor", "limit", 25, "", "", cmd.ErrOrStderr())
+			}, headerOverrides, flagAll, "cursor", "cursor", "limit", 25, "", "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
@@ -97,6 +105,7 @@ func newProjectsListCmd(flags *rootFlags) *cobra.Command {
 			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
+	cmd.Flags().StringVar(&flagXApiVersion, "x-api-version", "2026-04-01", "Required API version header.")
 	cmd.Flags().StringVar(&flagStatus, "status", "", "Status (one of: draft, active, archived)")
 	cmd.Flags().IntVar(&flagLimit, "limit", 25, "Limit")
 	cmd.Flags().StringVar(&flagCursor, "cursor", "", "Cursor")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
@@ -12,16 +12,18 @@ import (
 )
 
 func newProjectsTasksListProjectCmd(flags *rootFlags) *cobra.Command {
+	var flagXApiVersion string
 	var flagPriority string
 	var flagLimit int
 	var flagCursor string
 	var flagAll bool
 
 	cmd := &cobra.Command{
-		Use:         "list-project <projectId>",
-		Aliases:     []string{"get"},
-		Short:       "List project tasks",
-		Example:     "  printing-press-golden-pp-cli projects tasks list-project 550e8400-e29b-41d4-a716-446655440000",
+		Use:     "list-project <projectId>",
+		Aliases: []string{"get"},
+		Short:   "List project tasks",
+		// TODO: replace placeholder example values before relying on this for live dogfood.
+		Example:     "  printing-press-golden-pp-cli projects tasks list-project 550e8400-e29b-41d4-a716-446655440000 --x-api-version example-value",
 		Annotations: map[string]string{"pp:endpoint": "tasks.list-project", "pp:method": "GET", "pp:path": "/projects/{projectId}/tasks", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -61,11 +63,17 @@ func newProjectsTasksListProjectCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			headerOverrides := map[string]string{}
+
+			if cmd.Flags().Changed("x-api-version") || flagXApiVersion != "" {
+				headerOverrides["X-Api-Version"] = formatCLIParamValue(flagXApiVersion)
+			}
+
 			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "live", "tasks", path, map[string]string{
 				"priority": formatCLIParamValue(flagPriority),
 				"limit":    formatCLIParamValue(flagLimit),
 				"cursor":   formatCLIParamValue(flagCursor),
-			}, nil, flagAll, "cursor", "cursor", "limit", 50, "", "", cmd.ErrOrStderr())
+			}, headerOverrides, flagAll, "cursor", "cursor", "limit", 50, "", "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
@@ -117,6 +125,7 @@ func newProjectsTasksListProjectCmd(flags *rootFlags) *cobra.Command {
 			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
+	cmd.Flags().StringVar(&flagXApiVersion, "x-api-version", "2026-04-01", "Required API version header.")
 	cmd.Flags().StringVar(&flagPriority, "priority", "", "Priority (one of: low, normal, high)")
 	cmd.Flags().IntVar(&flagLimit, "limit", 50, "Limit")
 	cmd.Flags().StringVar(&flagCursor, "cursor", "", "Cursor")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
@@ -13,6 +13,7 @@ import (
 )
 
 func newProjectsTasksUpdateProjectCmd(flags *rootFlags) *cobra.Command {
+	var flagXApiVersion string
 	var flagNotify bool
 	var bodyCompleted bool
 	var bodyPriority string
@@ -20,10 +21,11 @@ func newProjectsTasksUpdateProjectCmd(flags *rootFlags) *cobra.Command {
 	var stdinBody bool
 
 	cmd := &cobra.Command{
-		Use:         "update-project <projectId> <taskId>",
-		Aliases:     []string{"update"},
-		Short:       "Update project task",
-		Example:     "  printing-press-golden-pp-cli projects tasks update-project 550e8400-e29b-41d4-a716-446655440000 550e8400-e29b-41d4-a716-446655440000",
+		Use:     "update-project <projectId> <taskId>",
+		Aliases: []string{"update"},
+		Short:   "Update project task",
+		// TODO: replace placeholder example values before relying on this for live dogfood.
+		Example:     "  printing-press-golden-pp-cli projects tasks update-project 550e8400-e29b-41d4-a716-446655440000 550e8400-e29b-41d4-a716-446655440000 --x-api-version example-value",
 		Annotations: map[string]string{"pp:endpoint": "tasks.update-project", "pp:method": "PATCH", "pp:path": "/projects/{projectId}/tasks/{taskId}"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -56,8 +58,14 @@ func newProjectsTasksUpdateProjectCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			headerOverrides := map[string]string{}
+
+			if cmd.Flags().Changed("x-api-version") || flagXApiVersion != "" {
+				headerOverrides["X-Api-Version"] = formatCLIParamValue(flagXApiVersion)
+			}
+
 			params := map[string]string{}
-			if flagNotify != false {
+			if cmd.Flags().Changed("notify") || flagNotify != false {
 				params["notify"] = formatCLIParamValue(flagNotify)
 			}
 			var body any
@@ -77,14 +85,14 @@ func newProjectsTasksUpdateProjectCmd(flags *rootFlags) *cobra.Command {
 				if cmd.Flags().Changed("completed") {
 					bodyMap["completed"] = bodyCompleted
 				}
-				if bodyPriority != "" {
+				if cmd.Flags().Changed("priority") || bodyPriority != "" {
 					bodyMap["priority"] = bodyPriority
 				}
-				if bodyTitle != "" {
+				if cmd.Flags().Changed("title") || bodyTitle != "" {
 					bodyMap["title"] = bodyTitle
 				}
 			}
-			data, statusCode, err := c.PatchWithParams(cmd.Context(), path, params, body)
+			data, statusCode, err := c.PatchWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
@@ -235,6 +243,7 @@ func newProjectsTasksUpdateProjectCmd(flags *rootFlags) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&flagXApiVersion, "x-api-version", "2026-04-01", "Required API version header.")
 	cmd.Flags().BoolVar(&flagNotify, "notify", false, "Notify")
 	cmd.Flags().BoolVar(&bodyCompleted, "completed", false, "Completed")
 	cmd.Flags().StringVar(&bodyPriority, "priority", "", "Priority")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
@@ -12,13 +12,15 @@ import (
 )
 
 func newReportsExportReportYearCmd(flags *rootFlags) *cobra.Command {
+	var flagXApiVersion string
 	var flagYear int
 
 	cmd := &cobra.Command{
-		Use:         "report-year",
-		Aliases:     []string{"get"},
-		Short:       "Download the annual report as a binary file",
-		Example:     "  printing-press-golden-pp-cli reports export report-year --year 42",
+		Use:     "report-year",
+		Aliases: []string{"get"},
+		Short:   "Download the annual report as a binary file",
+		// TODO: replace placeholder example values before relying on this for live dogfood.
+		Example:     "  printing-press-golden-pp-cli reports export report-year --x-api-version example-value --year 42",
 		Annotations: map[string]string{"pp:endpoint": "export.report-year", "pp:method": "GET", "pp:path": "/reports/{year}/export", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Bare invocation of a command with required input prints help
@@ -52,6 +54,11 @@ func newReportsExportReportYearCmd(flags *rootFlags) *cobra.Command {
 				"Accept":                           "application/octet-stream",
 				"X-Printing-Press-Binary-Response": "true",
 			}
+
+			if cmd.Flags().Changed("x-api-version") || flagXApiVersion != "" {
+				headerOverrides["X-Api-Version"] = formatCLIParamValue(flagXApiVersion)
+			}
+
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "live", "export", false, path, params, headerOverrides, "", cmd.ErrOrStderr())
 			if err != nil {
@@ -70,6 +77,7 @@ func newReportsExportReportYearCmd(flags *rootFlags) *cobra.Command {
 			return err
 		},
 	}
+	cmd.Flags().StringVar(&flagXApiVersion, "x-api-version", "2026-04-01", "Required API version header.")
 	cmd.Flags().IntVar(&flagYear, "year", 0, "Year")
 
 	return cmd

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -1018,7 +1018,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		if params != nil {
 			q := req.URL.Query()
 			for k, v := range params {
-				if v != "" {
+				if v != "" || method != "GET" {
 					q.Set(k, v)
 				}
 			}
@@ -1213,7 +1213,7 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 	if params != nil {
 		keys := make([]string, 0, len(params))
 		for k := range params {
-			if params[k] != "" {
+			if params[k] != "" || method != "GET" {
 				keys = append(keys, k)
 			}
 		}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
@@ -40,37 +40,42 @@ func RegisterTools(s *server.MCPServer) {
 	installFreshTenantGate(s)
 	s.AddTool(
 		mcplib.NewTool("currencies_list",
-			mcplib.WithDescription("List supported currencies. Returns array of Currency."),
+			mcplib.WithDescription("List supported currencies. Required: X-Api-Version (default: 2026-04-01). Returns array of Currency."),
+			mcplib.WithString("X-Api-Version", mcplib.Required(), mcplib.Description("Required API version header.")),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/currencies", true, false, nil, mcpPageConfig{}, []mcpParamBinding{}, []string{}),
+		makeAPIHandler("GET", "/currencies", true, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "X-Api-Version", WireName: "X-Api-Version", Location: "header", Default: "2026-04-01"}}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_create",
-			mcplib.WithDescription("Create project. Required: name, visibility. Optional: owner_email. Returns the new Project."),
+			mcplib.WithDescription("Create project. Required: X-Api-Version (default: 2026-04-01), name, visibility. Optional: X-Request-Id, owner_email. Returns the new Project."),
+			mcplib.WithString("X-Api-Version", mcplib.Required(), mcplib.Description("Required API version header.")),
+			mcplib.WithString("X-Request-Id", mcplib.Description("Optional per-request correlation ID.")),
 			mcplib.WithString("name", mcplib.Required(), mcplib.Description("Name")),
 			mcplib.WithString("owner_email", mcplib.Description("Owner email")),
 			mcplib.WithString("visibility", mcplib.Required(), mcplib.Description("Visibility")),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("POST", "/projects", false, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "name", WireName: "name", Location: "body"}, {PublicName: "owner_email", WireName: "owner_email", Location: "body"}, {PublicName: "visibility", WireName: "visibility", Location: "body"}}, []string{}),
+		makeAPIHandler("POST", "/projects", false, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "X-Api-Version", WireName: "X-Api-Version", Location: "header", Default: "2026-04-01"}, {PublicName: "X-Request-Id", WireName: "X-Request-Id", Location: "header"}, {PublicName: "name", WireName: "name", Location: "body"}, {PublicName: "owner_email", WireName: "owner_email", Location: "body"}, {PublicName: "visibility", WireName: "visibility", Location: "body"}}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_get",
-			mcplib.WithDescription("Get project. Required: projectId."),
+			mcplib.WithDescription("Get project. Required: X-Api-Version (default: 2026-04-01), projectId."),
+			mcplib.WithString("X-Api-Version", mcplib.Required(), mcplib.Description("Required API version header.")),
 			mcplib.WithString("projectId", mcplib.Required(), mcplib.Description("Project id")),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/projects/{projectId}", true, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "projectId", WireName: "projectId", Location: "path"}}, []string{"projectId"}),
+		makeAPIHandler("GET", "/projects/{projectId}", true, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "X-Api-Version", WireName: "X-Api-Version", Location: "header", Default: "2026-04-01"}, {PublicName: "projectId", WireName: "projectId", Location: "path"}}, []string{"projectId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_list",
-			mcplib.WithDescription("List projects. Optional: status, limit (default: 25), cursor. Returns array of Project."),
+			mcplib.WithDescription("List projects. Required: X-Api-Version (default: 2026-04-01). Optional: status, limit (default: 25), cursor. Returns array of Project."),
+			mcplib.WithString("X-Api-Version", mcplib.Required(), mcplib.Description("Required API version header.")),
 			mcplib.WithString("status", mcplib.Description("Status")),
 			mcplib.WithNumber("limit", mcplib.Description("Limit")),
 			mcplib.WithString("cursor", mcplib.Description("Opaque pagination cursor returned by a previous MCP response")),
@@ -78,22 +83,24 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/projects", true, false, nil, mcpPageConfig{CursorParam: "cursor", NextCursorPath: "cursor"}, []mcpParamBinding{{PublicName: "status", WireName: "status", Location: "query"}, {PublicName: "limit", WireName: "limit", Location: "query", Default: "25"}}, []string{}),
+		makeAPIHandler("GET", "/projects", true, false, nil, mcpPageConfig{CursorParam: "cursor", NextCursorPath: "cursor"}, []mcpParamBinding{{PublicName: "X-Api-Version", WireName: "X-Api-Version", Location: "header", Default: "2026-04-01"}, {PublicName: "status", WireName: "status", Location: "query"}, {PublicName: "limit", WireName: "limit", Location: "query", Default: "25"}}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_avatar_upload-project",
-			mcplib.WithDescription("Upload project avatar. Required: projectId. Optional: overwrite, caption, file."),
+			mcplib.WithDescription("Upload project avatar. Required: X-Api-Version (default: 2026-04-01), projectId. Optional: overwrite, caption, file."),
+			mcplib.WithString("X-Api-Version", mcplib.Required(), mcplib.Description("Required API version header.")),
 			mcplib.WithString("projectId", mcplib.Required(), mcplib.Description("Project id")),
 			mcplib.WithBoolean("overwrite", mcplib.Description("Overwrite")),
 			mcplib.WithString("caption", mcplib.Description("Caption")),
 			mcplib.WithString("file", mcplib.Description("File")),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("PUT", "/projects/{projectId}/avatar", false, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "projectId", WireName: "projectId", Location: "path", RequestContentType: "multipart/form-data"}, {PublicName: "overwrite", WireName: "overwrite", Location: "query", RequestContentType: "multipart/form-data"}, {PublicName: "caption", WireName: "caption", Location: "body", RequestContentType: "multipart/form-data"}, {PublicName: "file", WireName: "file", Location: "body", Format: "binary", RequestContentType: "multipart/form-data"}}, []string{"projectId"}),
+		makeAPIHandler("PUT", "/projects/{projectId}/avatar", false, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "X-Api-Version", WireName: "X-Api-Version", Location: "header", RequestContentType: "multipart/form-data", Default: "2026-04-01"}, {PublicName: "projectId", WireName: "projectId", Location: "path", RequestContentType: "multipart/form-data"}, {PublicName: "overwrite", WireName: "overwrite", Location: "query", RequestContentType: "multipart/form-data"}, {PublicName: "caption", WireName: "caption", Location: "body", RequestContentType: "multipart/form-data"}, {PublicName: "file", WireName: "file", Location: "body", Format: "binary", RequestContentType: "multipart/form-data"}}, []string{"projectId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_tasks_list-project",
-			mcplib.WithDescription("List project tasks. Required: projectId. Optional: priority, limit (default: 50), cursor. Returns array of Task."),
+			mcplib.WithDescription("List project tasks. Required: X-Api-Version (default: 2026-04-01), projectId. Optional: priority, limit (default: 50), cursor. Returns array of Task."),
+			mcplib.WithString("X-Api-Version", mcplib.Required(), mcplib.Description("Required API version header.")),
 			mcplib.WithString("projectId", mcplib.Required(), mcplib.Description("Project id")),
 			mcplib.WithString("priority", mcplib.Description("Priority")),
 			mcplib.WithNumber("limit", mcplib.Description("Limit")),
@@ -102,11 +109,12 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/projects/{projectId}/tasks", true, false, nil, mcpPageConfig{CursorParam: "cursor", NextCursorPath: "cursor"}, []mcpParamBinding{{PublicName: "projectId", WireName: "projectId", Location: "path"}, {PublicName: "priority", WireName: "priority", Location: "query"}, {PublicName: "limit", WireName: "limit", Location: "query", Default: "50"}}, []string{"projectId"}),
+		makeAPIHandler("GET", "/projects/{projectId}/tasks", true, false, nil, mcpPageConfig{CursorParam: "cursor", NextCursorPath: "cursor"}, []mcpParamBinding{{PublicName: "X-Api-Version", WireName: "X-Api-Version", Location: "header", Default: "2026-04-01"}, {PublicName: "projectId", WireName: "projectId", Location: "path"}, {PublicName: "priority", WireName: "priority", Location: "query"}, {PublicName: "limit", WireName: "limit", Location: "query", Default: "50"}}, []string{"projectId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_tasks_update-project",
-			mcplib.WithDescription("Update project task. Required: projectId, taskId. Optional: notify, completed, priority (plus 1 more). Partial update."),
+			mcplib.WithDescription("Update project task. Required: X-Api-Version (default: 2026-04-01), projectId, taskId. Optional: notify, completed, priority (plus 1 more). Partial update."),
+			mcplib.WithString("X-Api-Version", mcplib.Required(), mcplib.Description("Required API version header.")),
 			mcplib.WithString("projectId", mcplib.Required(), mcplib.Description("Project id")),
 			mcplib.WithString("taskId", mcplib.Required(), mcplib.Description("Task id")),
 			mcplib.WithBoolean("notify", mcplib.Description("Notify")),
@@ -115,7 +123,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString("title", mcplib.Description("Title")),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("PATCH", "/projects/{projectId}/tasks/{taskId}", false, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "projectId", WireName: "projectId", Location: "path"}, {PublicName: "taskId", WireName: "taskId", Location: "path"}, {PublicName: "notify", WireName: "notify", Location: "query"}, {PublicName: "completed", WireName: "completed", Location: "body"}, {PublicName: "priority", WireName: "priority", Location: "body"}, {PublicName: "title", WireName: "title", Location: "body"}}, []string{"projectId", "taskId"}),
+		makeAPIHandler("PATCH", "/projects/{projectId}/tasks/{taskId}", false, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "X-Api-Version", WireName: "X-Api-Version", Location: "header", Default: "2026-04-01"}, {PublicName: "projectId", WireName: "projectId", Location: "path"}, {PublicName: "taskId", WireName: "taskId", Location: "path"}, {PublicName: "notify", WireName: "notify", Location: "query"}, {PublicName: "completed", WireName: "completed", Location: "body"}, {PublicName: "priority", WireName: "priority", Location: "body"}, {PublicName: "title", WireName: "title", Location: "body"}}, []string{"projectId", "taskId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("public_get-status",
@@ -128,23 +136,25 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("reports_export_report-year",
-			mcplib.WithDescription("Download the annual report as a binary file. Required: year."),
+			mcplib.WithDescription("Download the annual report as a binary file. Required: X-Api-Version (default: 2026-04-01), year."),
+			mcplib.WithString("X-Api-Version", mcplib.Required(), mcplib.Description("Required API version header.")),
 			mcplib.WithNumber("year", mcplib.Required(), mcplib.Description("Year")),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/reports/{year}/export", true, true, map[string]string{"Accept": "application/octet-stream"}, mcpPageConfig{}, []mcpParamBinding{{PublicName: "year", WireName: "year", Location: "path"}}, []string{"year"}),
+		makeAPIHandler("GET", "/reports/{year}/export", true, true, map[string]string{"Accept": "application/octet-stream"}, mcpPageConfig{}, []mcpParamBinding{{PublicName: "X-Api-Version", WireName: "X-Api-Version", Location: "header", Default: "2026-04-01"}, {PublicName: "year", WireName: "year", Location: "path"}}, []string{"year"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("reports_summary_get-report-year",
-			mcplib.WithDescription("Get a report summary for a year. Required: year."),
+			mcplib.WithDescription("Get a report summary for a year. Required: X-Api-Version (default: 2026-04-01), year."),
+			mcplib.WithString("X-Api-Version", mcplib.Required(), mcplib.Description("Required API version header.")),
 			mcplib.WithNumber("year", mcplib.Required(), mcplib.Description("Year")),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/reports/{year}/summary", true, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "year", WireName: "year", Location: "path"}}, []string{"year"}),
+		makeAPIHandler("GET", "/reports/{year}/summary", true, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "X-Api-Version", WireName: "X-Api-Version", Location: "header", Default: "2026-04-01"}, {PublicName: "year", WireName: "year", Location: "path"}}, []string{"year"}),
 	)
 	// Search tool — faster than iterating list endpoints for finding specific items
 	s.AddTool(
@@ -326,6 +336,11 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 				placeholder := "{" + binding.WireName + "}"
 				pathParams[binding.PublicName] = true
 				path = strings.Replace(path, placeholder, mcpPathValue(v), 1)
+			case "header":
+				if headers == nil {
+					headers = map[string]string{}
+				}
+				headers[binding.WireName] = formatMCPParamValue(v)
 			case "body":
 				bodyArgs[binding.WireName] = v
 				if multipart {
@@ -989,6 +1004,7 @@ func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToo
 				"description": "Manage currencies",
 				"endpoints":   []string{"list"},
 				"syncable":    true,
+				"searchable":  true,
 			},
 			{
 				"name":        "projects",

--- a/testdata/golden/expected/generate-golden-api/scorecard.json
+++ b/testdata/golden/expected/generate-golden-api/scorecard.json
@@ -3,7 +3,6 @@
     "api_name": "printing-press-golden",
     "competitor_scores": null,
     "gap_report": [
-      "mcp_description_quality scored 3/10 - needs improvement",
       "MCP: 10 tools (1 public, 9 auth-required) — readiness: full"
     ],
     "overall_grade": "A",
@@ -21,7 +20,7 @@
       "insight": 9,
       "live_api_verification": 0,
       "local_cache": 10,
-      "mcp_description_quality": 3,
+      "mcp_description_quality": 7,
       "mcp_quality": 10,
       "mcp_remote_transport": 10,
       "mcp_surface_strategy": 0,
@@ -29,11 +28,11 @@
       "mcp_tool_design": 0,
       "output_modes": 10,
       "path_validity": 0,
-      "percentage": 95,
+      "percentage": 96,
       "readme": 8,
       "sync_correctness": 10,
       "terminal_ux": 9,
-      "total": 95,
+      "total": 96,
       "type_fidelity": 5,
       "vision": 9,
       "workflows": 10

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/code_orch.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/code_orch.go
@@ -71,6 +71,9 @@ type codeOrchEndpoint struct {
 	// string instead of dumping them into the JSON body. Derived from the
 	// same mcpParamBindings location data the per-endpoint tools use.
 	QueryParams []codeOrchParamBinding
+	// Keep declared headers out of query/body routing so execution sends them
+	// through the request-header map.
+	HeaderParams []codeOrchParamBinding
 	// HeaderOverrides carries per-endpoint request headers (e.g. an
 	// Accept override for binary-only response endpoints). Without
 	// threading these through, the code-orchestration execute path
@@ -88,6 +91,7 @@ type codeOrchEndpoint struct {
 type codeOrchParamBinding struct {
 	PublicName string
 	WireName   string
+	Default    string
 }
 
 // codeOrchEndpoints is the generator-populated registry covering every
@@ -102,6 +106,7 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 		Positional:     []string{},
 		TemplateParams: []codeOrchParamBinding{},
 		QueryParams:    []codeOrchParamBinding{},
+		HeaderParams:   []codeOrchParamBinding{},
 		keywords:       codeOrchKeywords("items", "list", "List items", "/items"),
 	},
 }
@@ -236,10 +241,30 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 
 	path := ep.Path
 	for _, p := range ep.Positional {
-		if v, ok := params[p]; ok {
+		if v, ok := params[p]; ok && strings.Contains(path, "{"+p+"}") {
 			path = strings.ReplaceAll(path, "{"+p+"}", mcpPathValue(v))
 			delete(params, p)
 		}
+	}
+
+	hdrs := make(map[string]string, len(ep.HeaderOverrides)+len(ep.HeaderParams))
+	for k, v := range ep.HeaderOverrides {
+		hdrs[k] = v
+	}
+	for _, binding := range ep.HeaderParams {
+		if binding.Default != "" {
+			hdrs[binding.WireName] = binding.Default
+		}
+		for _, key := range []string{binding.PublicName, binding.WireName} {
+			if v, ok := params[key]; ok {
+				hdrs[binding.WireName] = formatMCPParamValue(v)
+				delete(params, key)
+				break
+			}
+		}
+	}
+	if len(hdrs) == 0 {
+		hdrs = nil
 	}
 
 	// Route params to their runtime slots. GET/DELETE params are query
@@ -265,7 +290,6 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 		}
 	}
 
-	hdrs := ep.HeaderOverrides
 	writeBody := func() any {
 		if ep.BodyIsArray {
 			return codeOrchArrayBody(params)

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
@@ -199,6 +199,11 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 				placeholder := "{" + binding.WireName + "}"
 				pathParams[binding.PublicName] = true
 				path = strings.Replace(path, placeholder, mcpPathValue(v), 1)
+			case "header":
+				if headers == nil {
+					headers = map[string]string{}
+				}
+				headers[binding.WireName] = formatMCPParamValue(v)
 			case "body":
 				bodyArgs[binding.WireName] = v
 			default:

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
@@ -53,7 +53,7 @@ func newStoresCreateCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			params := map[string]string{}
-			if flagDryRun != false {
+			if cmd.Flags().Changed("dry-run") || flagDryRun != false {
 				params["$dry_run"] = formatCLIParamValue(flagDryRun)
 			}
 			var body any
@@ -70,7 +70,7 @@ func newStoresCreateCmd(flags *rootFlags) *cobra.Command {
 			} else {
 				bodyMap := map[string]any{}
 				body = bodyMap
-				if bodyStoreCode != "" {
+				if (cmd.Flags().Changed("store-code") || cmd.Flags().Changed("code")) || bodyStoreCode != "" {
 					bodyMap["store_code"] = bodyStoreCode
 				}
 			}

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
@@ -218,6 +218,11 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 				placeholder := "{" + binding.WireName + "}"
 				pathParams[binding.PublicName] = true
 				path = strings.Replace(path, placeholder, mcpPathValue(v), 1)
+			case "header":
+				if headers == nil {
+					headers = map[string]string{}
+				}
+				headers[binding.WireName] = formatMCPParamValue(v)
 			case "body":
 				bodyArgs[binding.WireName] = v
 			default:

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -1007,7 +1007,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		if params != nil {
 			q := req.URL.Query()
 			for k, v := range params {
-				if v != "" {
+				if v != "" || method != "GET" {
 					q.Set(k, v)
 				}
 			}
@@ -1209,7 +1209,7 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 	if params != nil {
 		keys := make([]string, 0, len(params))
 		for k := range params {
-			if params[k] != "" {
+			if params[k] != "" || method != "GET" {
 				keys = append(keys, k)
 			}
 		}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
@@ -225,6 +225,11 @@ func makeAPIHandler(method, pathTemplate, tier string, readOnly bool, binaryResp
 				placeholder := "{" + binding.WireName + "}"
 				pathParams[binding.PublicName] = true
 				path = strings.Replace(path, placeholder, mcpPathValue(v), 1)
+			case "header":
+				if headers == nil {
+					headers = map[string]string{}
+				}
+				headers[binding.WireName] = formatMCPParamValue(v)
 			case "body":
 				bodyArgs[binding.WireName] = v
 			default:


### PR DESCRIPTION
## Intent

Generated CLIs now preserve declared request parameters across endpoint commands, promoted commands, typed MCP tools, and code-orchestration calls. Previously, write-only body fields and OpenAPI headers could disappear, numeric body fields could be coerced by query-pagination heuristics, and explicitly supplied empty mutation values could be omitted.

The final correction also keeps resources syncable when their only required non-path inputs are transport headers; those headers no longer masquerade as caller-supplied resource scope.

Closes #3487
Closes #3483
Closes #2607

## Approach

- Carry declared parameter location and body type through parsing, promotion, CLI generation, MCP generation, and client request assembly.
- Route headers separately from query parameters, preserve explicitly changed empty mutation values, and limit cursor coercion to query parameters.
- Exclude required transport headers from sync-scope classification while retaining the existing treatment of required query scope.

## Scope

Primary area: OpenAPI/spec parameter modeling, generator templates, profiler sync classification, and generated-output fixtures.

This is a systemic Printing Press fix for future printed CLIs, not an API-specific patch.

## Risk

Affected generated request schemas and payloads change intentionally: declared headers are exposed, native body types are retained, and explicitly supplied empty mutation values are transmitted. The profiler correction is limited to non-query transport inputs so required query scope continues to block unsafe automatic sync.

## Output Contract

CLI, promoted-command, typed MCP, and code-orchestration surfaces now agree on header/query separation, body types, and presence semantics. Required headers no longer remove otherwise syncable resources; generated compile fixtures and the scorecard golden cover that final behavior.

## Verification

Passed on current head `45d6a11ec260106b9107579754ebb7ce1d51cd47`:

- `go-lint`, `golden`, and `full-golden`
- `generated-output-compile`, `generated-test`, and `test`
- `full-test (generator-3)`, `full-test (pipeline)`, `full-test (cli)`, and `full-test (rest)`
- `Greptile Review` and `All conversations resolved`, with zero unresolved review threads

Still pending when this description was updated: `full-test (generator-0)`, `full-test (generator-1)`, `full-test (generator-2)`, and `Mergify Merge Protections`.
