### PR TITLE
fix(skills): guard preflights from argument substitution

### DIFF
--- a/.github/scripts/validate-skill-docs.sh
+++ b/.github/scripts/validate-skill-docs.sh
@@ -42,6 +42,19 @@ for skill in skills/*/SKILL.md; do
     echo "::error file=$skill::SKILL.md frontmatter must be valid YAML with name and description"
     status=1
   fi
+
+  if ! awk '
+    BEGIN { inside_bash = 0; found = 0 }
+    /^[[:space:]]*```(bash|sh|shell)[[:space:]]*$/ { inside_bash = 1; next }
+    /^[[:space:]]*```[[:space:]]*$/ { inside_bash = 0; next }
+    inside_bash && (/\$[[:digit:]]/ || /\$\{[[:digit:]]/) {
+      printf "::error file=%s,line=%d::bash fence contains a dollar-digit token: %s\n", FILENAME, FNR, $0
+      found = 1
+    }
+    END { exit found }
+  ' "$skill"; then
+    status=1
+  fi
 done
 
 node .github/scripts/validate-printing-press-skill-list.mjs || status=1

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -141,7 +141,8 @@ func TestSkillsEnforceCurrencyFloor(t *testing.T) {
 	assert.Contains(t, ppBlock, "PRESS_REQUIRED_INSTALLED=")
 	assert.Contains(t, ppBlock, "PRESS_REQUIRED_REASON=")
 	assert.Contains(t, ppBlock, `[ "$_press_repo" != "true" ] && [ -f "$PRESS_VERCHECK_FILE" ]`)
-	assert.Contains(t, ppBlock, `! _semver_lt "$_floor_latest" "$_floor_min"`)
+	assert.Contains(t, ppBlock, `PP_SEMVER_A="$_floor_installed" PP_SEMVER_B="$_floor_min" _semver_lt`)
+	assert.Contains(t, ppBlock, `! PP_SEMVER_A="$_floor_latest" PP_SEMVER_B="$_floor_min" _semver_lt`)
 
 	// setup-checks.md documents the hard gate as upgrade-or-abort, distinct from
 	// the soft [upgrade-available] advisory.
@@ -161,7 +162,8 @@ func TestSkillsEnforceCurrencyFloor(t *testing.T) {
 	assert.Contains(t, amendBlock, "PRESS_REQUIRED_MIN=")
 	assert.Contains(t, amendBlock, "PRESS_REQUIRED_INSTALLED=")
 	assert.Contains(t, amendBlock, "PRESS_REQUIRED_REASON=")
-	assert.Contains(t, amendBlock, `! _semver_lt "$_floor_latest" "$_floor_min"`)
+	assert.Contains(t, amendBlock, `PP_SEMVER_A="$_floor_installed" PP_SEMVER_B="$_floor_min" _semver_lt`)
+	assert.Contains(t, amendBlock, `! PP_SEMVER_A="$_floor_latest" PP_SEMVER_B="$_floor_min" _semver_lt`)
 	assert.Contains(t, amend, "no skip-and-continue")
 }
 

--- a/skills/printing-press-amend/SKILL.md
+++ b/skills/printing-press-amend/SKILL.md
@@ -97,7 +97,11 @@ fi
 echo "PRINTING_PRESS_BIN=$PRINTING_PRESS_BIN"
 
 _pp_semver_lt() {
-  awk -v a="$1" -v b="$2" 'BEGIN {
+  if [ -z "${PP_SEMVER_A:-}" ] || [ -z "${PP_SEMVER_B:-}" ]; then
+    echo "[setup-error] semver comparison inputs are missing." >&2
+    return 2
+  fi
+  awk -v a="${PP_SEMVER_A:-}" -v b="${PP_SEMVER_B:-}" 'BEGIN {
     split(a, x, "."); split(b, y, ".")
     for (i = 1; i <= 3; i++) {
       if ((x[i] + 0) < (y[i] + 0)) exit 0
@@ -108,13 +112,15 @@ _pp_semver_lt() {
 }
 
 _pp_go_version_norm() {
-  printf '%s\n' "$1" | sed -nE 's/.*go([0-9]+)\.([0-9]+)(\.([0-9]+))?.*/\1.\2.\4/p' | awk -F. 'NF >= 2 { printf "%d.%d.%d\n", $1, $2, ($3 == "" ? 0 : $3) }'
+  printf '%s\n' "${PP_GO_VERSION_INPUT:-}" | sed -nE 's/.*go([0-9]+)\.([0-9]+)(\.([0-9]+))?.*/\1.\2.\4/p' | sed -E 's/\.$/.0/'
 }
 
 _pp_check_go_currency() {
-  _pp_go_installed="$(_pp_go_version_norm "$(go env GOVERSION 2>/dev/null)")"
-  _pp_go_required="$(_pp_go_version_norm "$(go version "$PRINTING_PRESS_BIN" 2>/dev/null)")"
-  if [ -z "$_pp_go_installed" ] || [ -z "$_pp_go_required" ] || ! _pp_semver_lt "$_pp_go_installed" "$_pp_go_required"; then
+  _pp_go_installed="$(PP_GO_VERSION_INPUT="$(go env GOVERSION 2>/dev/null)" _pp_go_version_norm)"
+  _pp_go_required="$(PP_GO_VERSION_INPUT="$(go version "$PRINTING_PRESS_BIN" 2>/dev/null)" _pp_go_version_norm)"
+  PP_SEMVER_A="$_pp_go_installed"
+  PP_SEMVER_B="$_pp_go_required"
+  if [ -z "$_pp_go_installed" ] || [ -z "$_pp_go_required" ] || ! _pp_semver_lt; then
     return 0
   fi
 
@@ -160,7 +166,11 @@ _pp_check_disk_space() {
     _pp_disk_path="$(dirname "$_pp_disk_path")"
   done
 
-  _pp_disk_avail_kb="$(df -Pk "$_pp_disk_path" 2>/dev/null | awk 'NR == 2 { print $4; exit }')"
+  _pp_disk_avail_kb="$(df -Pk "$_pp_disk_path" 2>/dev/null | awk 'BEGIN {
+    if ((getline header) <= 0 || (getline record) <= 0) exit
+    field_count = split(record, fields)
+    if (field_count >= 4) print fields[4]
+  }')"
   case "$_pp_disk_avail_kb" in
     ""|*[!0-9]*) return 0 ;;
   esac
@@ -199,7 +209,11 @@ mkdir -p "$PRESS_RUNSTATE" "$PRESS_LIBRARY" "$PRESS_MANUSCRIPTS" "$PRESS_CURRENT
 # cost is not worth its own cache here.
 if [ "$_press_repo" != "true" ] && command -v curl >/dev/null 2>&1; then
   _semver_lt() {
-    awk -v a="$1" -v b="$2" 'BEGIN {
+    if [ -z "${PP_SEMVER_A:-}" ] || [ -z "${PP_SEMVER_B:-}" ]; then
+      echo "[setup-error] semver comparison inputs are missing." >&2
+      return 2
+    fi
+    awk -v a="${PP_SEMVER_A:-}" -v b="${PP_SEMVER_B:-}" 'BEGIN {
       split(a, x, "."); split(b, y, ".")
       for (i = 1; i <= 3; i++) {
         if ((x[i] + 0) < (y[i] + 0)) exit 0
@@ -211,15 +225,15 @@ if [ "$_press_repo" != "true" ] && command -v curl >/dev/null 2>&1; then
   _floor_installed=$("$PRINTING_PRESS_BIN" version --json 2>/dev/null | sed -nE 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p')
   _floor_doc=$(curl -fsSL --max-time 5 \
     https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/supported-versions.txt 2>/dev/null || true)
-  _floor_min=$(printf '%s\n' "$_floor_doc" | awk -F= '/^min_supported=/{print $2; exit}')
+  _floor_min=$(printf '%s\n' "$_floor_doc" | sed -nE 's/^min_supported=//p' | head -n 1)
   _floor_reason=$(printf '%s\n' "$_floor_doc" | sed -nE 's/^reason=//p' | head -n 1)
   _floor_latest=""
   if command -v go >/dev/null 2>&1; then
-    _floor_latest=$(go list -m -json github.com/mvanhorn/cli-printing-press/v4@latest 2>/dev/null | awk '/"Version":/{v=$2; gsub(/[",]/,"",v); sub(/^v/,"",v); print v; exit}')
+    _floor_latest=$(go list -m -json github.com/mvanhorn/cli-printing-press/v4@latest 2>/dev/null | sed -nE 's/^[[:space:]]*"Version":[[:space:]]*"v?([^"]+)".*/\1/p' | head -n 1)
   fi
   if [ -n "$_floor_min" ] && [ -n "$_floor_installed" ] && [ -n "$_floor_latest" ] &&
-     _semver_lt "$_floor_installed" "$_floor_min" &&
-     ! _semver_lt "$_floor_latest" "$_floor_min"; then
+     PP_SEMVER_A="$_floor_installed" PP_SEMVER_B="$_floor_min" _semver_lt &&
+     ! PP_SEMVER_A="$_floor_latest" PP_SEMVER_B="$_floor_min" _semver_lt; then
     echo ""
     echo "[upgrade-required] printing-press v$_floor_min is the minimum supported version (you have v$_floor_installed)"
     echo "PRESS_REQUIRED_MIN=$_floor_min"

--- a/skills/printing-press-import/SKILL.md
+++ b/skills/printing-press-import/SKILL.md
@@ -49,7 +49,7 @@ library" or "from the repo", suggest running this skill first.
 PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
 PRESS_LIBRARY="$PRESS_HOME/library"
 PRESS_MANUSCRIPTS="$PRESS_HOME/manuscripts"
-SCRIPTS_DIR="$(dirname "${BASH_SOURCE[0]:-$0}")/references"
+SCRIPTS_DIR="$(dirname "${BASH_SOURCE[0]:-.}")/references"
 
 if ! command -v go >/dev/null 2>&1; then
   echo ""
@@ -75,7 +75,11 @@ _pp_check_disk_space() {
     _pp_disk_path="$(dirname "$_pp_disk_path")"
   done
 
-  _pp_disk_avail_kb="$(df -Pk "$_pp_disk_path" 2>/dev/null | awk 'NR == 2 { print $4; exit }')"
+  _pp_disk_avail_kb="$(df -Pk "$_pp_disk_path" 2>/dev/null | awk 'BEGIN {
+    if ((getline header) <= 0 || (getline record) <= 0) exit
+    field_count = split(record, fields)
+    if (field_count >= 4) print fields[4]
+  }')"
   case "$_pp_disk_avail_kb" in
     ""|*[!0-9]*) return 0 ;;
   esac

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -63,7 +63,11 @@ _pp_check_disk_space() {
     _pp_disk_path="$(dirname "$_pp_disk_path")"
   done
 
-  _pp_disk_avail_kb="$(df -Pk "$_pp_disk_path" 2>/dev/null | awk 'NR == 2 { print $4; exit }')"
+  _pp_disk_avail_kb="$(df -Pk "$_pp_disk_path" 2>/dev/null | awk 'BEGIN {
+    if ((getline header) <= 0 || (getline record) <= 0) exit
+    field_count = split(record, fields)
+    if (field_count >= 4) print fields[4]
+  }')"
   case "$_pp_disk_avail_kb" in
     ""|*[!0-9]*) return 0 ;;
   esac
@@ -121,7 +125,11 @@ fi
 echo "PRINTING_PRESS_BIN=$PRINTING_PRESS_BIN"
 
 _pp_semver_lt() {
-  awk -v a="$1" -v b="$2" 'BEGIN {
+  if [ -z "${PP_SEMVER_A:-}" ] || [ -z "${PP_SEMVER_B:-}" ]; then
+    echo "[setup-error] semver comparison inputs are missing." >&2
+    return 2
+  fi
+  awk -v a="${PP_SEMVER_A:-}" -v b="${PP_SEMVER_B:-}" 'BEGIN {
     split(a, x, "."); split(b, y, ".")
     for (i = 1; i <= 3; i++) {
       if ((x[i] + 0) < (y[i] + 0)) exit 0
@@ -132,13 +140,15 @@ _pp_semver_lt() {
 }
 
 _pp_go_version_norm() {
-  printf '%s\n' "$1" | sed -nE 's/.*go([0-9]+)\.([0-9]+)(\.([0-9]+))?.*/\1.\2.\4/p' | awk -F. 'NF >= 2 { printf "%d.%d.%d\n", $1, $2, ($3 == "" ? 0 : $3) }'
+  printf '%s\n' "${PP_GO_VERSION_INPUT:-}" | sed -nE 's/.*go([0-9]+)\.([0-9]+)(\.([0-9]+))?.*/\1.\2.\4/p' | sed -E 's/\.$/.0/'
 }
 
 _pp_check_go_currency() {
-  _pp_go_installed="$(_pp_go_version_norm "$(go env GOVERSION 2>/dev/null)")"
-  _pp_go_required="$(_pp_go_version_norm "$(go version "$PRINTING_PRESS_BIN" 2>/dev/null)")"
-  if [ -z "$_pp_go_installed" ] || [ -z "$_pp_go_required" ] || ! _pp_semver_lt "$_pp_go_installed" "$_pp_go_required"; then
+  _pp_go_installed="$(PP_GO_VERSION_INPUT="$(go env GOVERSION 2>/dev/null)" _pp_go_version_norm)"
+  _pp_go_required="$(PP_GO_VERSION_INPUT="$(go version "$PRINTING_PRESS_BIN" 2>/dev/null)" _pp_go_version_norm)"
+  PP_SEMVER_A="$_pp_go_installed"
+  PP_SEMVER_B="$_pp_go_required"
+  if [ -z "$_pp_go_installed" ] || [ -z "$_pp_go_required" ] || ! _pp_semver_lt; then
     return 0
   fi
 

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -225,7 +225,11 @@ fi
 echo "PRINTING_PRESS_BIN=$PRINTING_PRESS_BIN"
 
 _pp_semver_lt() {
-  awk -v a="$1" -v b="$2" 'BEGIN {
+  if [ -z "${PP_SEMVER_A:-}" ] || [ -z "${PP_SEMVER_B:-}" ]; then
+    echo "[setup-error] semver comparison inputs are missing." >&2
+    return 2
+  fi
+  awk -v a="${PP_SEMVER_A:-}" -v b="${PP_SEMVER_B:-}" 'BEGIN {
     split(a, x, "."); split(b, y, ".")
     for (i = 1; i <= 3; i++) {
       if ((x[i] + 0) < (y[i] + 0)) exit 0
@@ -236,13 +240,15 @@ _pp_semver_lt() {
 }
 
 _pp_go_version_norm() {
-  printf '%s\n' "$1" | sed -nE 's/.*go([0-9]+)\.([0-9]+)(\.([0-9]+))?.*/\1.\2.\4/p' | awk -F. 'NF >= 2 { printf "%d.%d.%d\n", $1, $2, ($3 == "" ? 0 : $3) }'
+  printf '%s\n' "${PP_GO_VERSION_INPUT:-}" | sed -nE 's/.*go([0-9]+)\.([0-9]+)(\.([0-9]+))?.*/\1.\2.\4/p' | sed -E 's/\.$/.0/'
 }
 
 _pp_check_go_currency() {
-  _pp_go_installed="$(_pp_go_version_norm "$(go env GOVERSION 2>/dev/null)")"
-  _pp_go_required="$(_pp_go_version_norm "$(go version "$PRINTING_PRESS_BIN" 2>/dev/null)")"
-  if [ -z "$_pp_go_installed" ] || [ -z "$_pp_go_required" ] || ! _pp_semver_lt "$_pp_go_installed" "$_pp_go_required"; then
+  _pp_go_installed="$(PP_GO_VERSION_INPUT="$(go env GOVERSION 2>/dev/null)" _pp_go_version_norm)"
+  _pp_go_required="$(PP_GO_VERSION_INPUT="$(go version "$PRINTING_PRESS_BIN" 2>/dev/null)" _pp_go_version_norm)"
+  PP_SEMVER_A="$_pp_go_installed"
+  PP_SEMVER_B="$_pp_go_required"
+  if [ -z "$_pp_go_installed" ] || [ -z "$_pp_go_required" ] || ! _pp_semver_lt; then
     return 0
   fi
 
@@ -288,7 +294,11 @@ _pp_check_disk_space() {
     _pp_disk_path="$(dirname "$_pp_disk_path")"
   done
 
-  _pp_disk_avail_kb="$(df -Pk "$_pp_disk_path" 2>/dev/null | awk 'NR == 2 { print $4; exit }')"
+  _pp_disk_avail_kb="$(df -Pk "$_pp_disk_path" 2>/dev/null | awk 'BEGIN {
+    if ((getline header) <= 0 || (getline record) <= 0) exit
+    field_count = split(record, fields)
+    if (field_count >= 4) print fields[4]
+  }')"
   case "$_pp_disk_avail_kb" in
     ""|*[!0-9]*) return 0 ;;
   esac
@@ -1420,16 +1430,18 @@ git add -f "library/<category>/<api-slug>/"
 # fragments from previous publish branches before they leak into the wrong PR.
 EXPECTED_STAGE_PREFIXES=$(printf '%s\n' "library/<category>/<api-slug>/" "$PREEXISTING_MERGED_PATHS" | sed '/^$/d; s#/*$#/#' | sort -u)
 UNEXPECTED_STAGED=$(git diff --cached --name-only | awk -v prefixes="$EXPECTED_STAGE_PREFIXES" '
-BEGIN { n = split(prefixes, p, "\n") }
-{
-  matched = 0
-  for (i = 1; i <= n; i++) {
-    if (p[i] != "" && ($0 == p[i] || index($0, p[i]) == 1)) {
-      matched = 1
-      break
+BEGIN {
+  n = split(prefixes, p, "\n")
+  while ((getline line) > 0) {
+    matched = 0
+    for (i = 1; i <= n; i++) {
+      if (p[i] != "" && (line == p[i] || index(line, p[i]) == 1)) {
+        matched = 1
+        break
+      }
     }
+    if (!matched) print line
   }
-  if (!matched) print
 }')
 if [ -n "$UNEXPECTED_STAGED" ]; then
   echo "ERROR: publish staged paths outside the expected CLI scope:" >&2

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -146,7 +146,11 @@ _resolve_press_bin() {
 # suffixes collapse to their GA counterpart (acceptable: we ship no pre-release
 # tags).
 _semver_lt() {
-  awk -v a="$1" -v b="$2" 'BEGIN {
+  if [ -z "${PP_SEMVER_A:-}" ] || [ -z "${PP_SEMVER_B:-}" ]; then
+    echo "[setup-error] semver comparison inputs are missing." >&2
+    return 2
+  fi
+  awk -v a="${PP_SEMVER_A:-}" -v b="${PP_SEMVER_B:-}" 'BEGIN {
     split(a, x, ".")
     split(b, y, ".")
     for (i = 1; i <= 3; i++) {
@@ -169,7 +173,12 @@ _rebuild_local_press_bin_if_stale() {
 
   _local_v="$("$_scope_dir/cli-printing-press" version --json 2>/dev/null | sed -nE 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p')"
   _source_v="$(_source_press_version)"
-  if [ -z "$_local_v" ] || [ -z "$_source_v" ] || ! _semver_lt "$_local_v" "$_source_v"; then
+  if [ -z "$_local_v" ] || [ -z "$_source_v" ]; then
+    return 0
+  fi
+  PP_SEMVER_A="$_local_v"
+  PP_SEMVER_B="$_source_v"
+  if ! _semver_lt; then
     return 0
   fi
 
@@ -326,7 +335,7 @@ echo "PRINTING_PRESS_BIN=$PRINTING_PRESS_BIN"
 echo "PRESS_REPO_MODE=$_press_repo"
 
 _pp_go_version_norm() {
-  printf '%s\n' "$1" | sed -nE 's/.*go([0-9]+)\.([0-9]+)(\.([0-9]+))?.*/\1.\2.\4/p' | awk -F. 'NF >= 2 { printf "%d.%d.%d\n", $1, $2, ($3 == "" ? 0 : $3) }'
+  printf '%s\n' "${PP_GO_VERSION_INPUT:-}" | sed -nE 's/.*go([0-9]+)\.([0-9]+)(\.([0-9]+))?.*/\1.\2.\4/p' | sed -E 's/\.$/.0/'
 }
 
 _pp_check_go_currency() {
@@ -334,9 +343,11 @@ _pp_check_go_currency() {
     return 0
   fi
 
-  _pp_go_installed="$(_pp_go_version_norm "$(go env GOVERSION 2>/dev/null)")"
-  _pp_go_required="$(_pp_go_version_norm "$(go version "$PRINTING_PRESS_BIN" 2>/dev/null)")"
-  if [ -z "$_pp_go_installed" ] || [ -z "$_pp_go_required" ] || ! _semver_lt "$_pp_go_installed" "$_pp_go_required"; then
+  _pp_go_installed="$(PP_GO_VERSION_INPUT="$(go env GOVERSION 2>/dev/null)" _pp_go_version_norm)"
+  _pp_go_required="$(PP_GO_VERSION_INPUT="$(go version "$PRINTING_PRESS_BIN" 2>/dev/null)" _pp_go_version_norm)"
+  PP_SEMVER_A="$_pp_go_installed"
+  PP_SEMVER_B="$_pp_go_required"
+  if [ -z "$_pp_go_installed" ] || [ -z "$_pp_go_required" ] || ! _semver_lt; then
     return 0
   fi
 
@@ -408,7 +419,11 @@ _pp_check_disk_space() {
     _pp_disk_path="$(dirname "$_pp_disk_path")"
   done
 
-  _pp_disk_avail_kb="$(df -Pk "$_pp_disk_path" 2>/dev/null | awk 'NR == 2 { print $4; exit }')"
+  _pp_disk_avail_kb="$(df -Pk "$_pp_disk_path" 2>/dev/null | awk 'BEGIN {
+    if ((getline header) <= 0 || (getline record) <= 0) exit
+    field_count = split(record, fields)
+    if (field_count >= 4) print fields[4]
+  }')"
   case "$_pp_disk_avail_kb" in
     ""|*[!0-9]*) return 0 ;;
   esac
@@ -447,7 +462,7 @@ _now_ts=$(date +%s)
 
 _should_check=true
 if [ -f "$PRESS_VERCHECK_FILE" ] && [ -z "$PRESS_VERCHECK_FORCE" ]; then
-  _last_ts=$(awk -F= '/^last_check=/{print $2}' "$PRESS_VERCHECK_FILE" 2>/dev/null)
+  _last_ts=$(sed -nE 's/^last_check=//p' "$PRESS_VERCHECK_FILE" 2>/dev/null | head -n 1)
   if [ -n "$_last_ts" ] && [ "$((_now_ts - _last_ts))" -lt "$PRESS_VERCHECK_TTL" ]; then
     _should_check=false
   fi
@@ -462,7 +477,7 @@ if [ "$_press_repo" = "true" ]; then
     _main_rev=$(git -C "$_scope_dir" rev-parse origin/main 2>/dev/null || true)
     _skipped_repo_main=""
     if [ -f "$PRESS_VERCHECK_FILE" ] && [ -z "$PRESS_VERCHECK_FORCE" ]; then
-      _skipped_repo_main=$(awk -F= '/^skipped_repo_main=/{value=$2} END{print value}' "$PRESS_VERCHECK_FILE" 2>/dev/null)
+      _skipped_repo_main=$(sed -nE 's/^skipped_repo_main=//p' "$PRESS_VERCHECK_FILE" 2>/dev/null | tail -n 1)
     fi
     if [ -n "$_head_rev" ] && [ -n "$_main_rev" ] &&
        [ "$_head_rev" != "$_main_rev" ] &&
@@ -483,15 +498,7 @@ elif [ "$_should_check" = "true" ] && command -v go >/dev/null 2>&1; then
   _latest=""
 
   if [ -n "$_installed" ]; then
-    _latest=$(go list -m -json github.com/mvanhorn/cli-printing-press/v4@latest 2>/dev/null | awk '
-      /"Version":/ {
-        version=$2
-        gsub(/[",]/, "", version)
-        sub(/^v/, "", version)
-        print version
-        exit
-      }
-    ')
+    _latest=$(go list -m -json github.com/mvanhorn/cli-printing-press/v4@latest 2>/dev/null | sed -nE 's/^[[:space:]]*"Version":[[:space:]]*"v?([^"]+)".*/\1/p' | head -n 1)
   fi
 
   # Currency floor: the lowest release still considered safe to generate with,
@@ -504,12 +511,14 @@ elif [ "$_should_check" = "true" ] && command -v go >/dev/null 2>&1; then
     _floor_doc=$(curl -fsSL --max-time 5 \
       https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/supported-versions.txt 2>/dev/null || true)
     if [ -n "$_floor_doc" ]; then
-      _min_supported=$(printf '%s\n' "$_floor_doc" | awk -F= '/^min_supported=/{print $2; exit}')
+      _min_supported=$(printf '%s\n' "$_floor_doc" | sed -nE 's/^min_supported=//p' | head -n 1)
       _min_reason=$(printf '%s\n' "$_floor_doc" | sed -nE 's/^reason=//p' | head -n 1)
     fi
   fi
 
-  if [ -n "$_installed" ] && [ -n "$_latest" ] && _semver_lt "$_installed" "$_latest"; then
+  PP_SEMVER_A="$_installed"
+  PP_SEMVER_B="$_latest"
+  if [ -n "$_installed" ] && [ -n "$_latest" ] && _semver_lt; then
     # Marker for the skill prose below to detect and offer an interactive upgrade.
     # The skill reads PRESS_UPGRADE_AVAILABLE / PRESS_UPGRADE_INSTALLED from this output.
     echo ""
@@ -531,13 +540,13 @@ fi
 # is itself <= latest, so a typo'd or tampered floor above the newest release
 # cannot brick every install.
 if [ "$_press_repo" != "true" ] && [ -f "$PRESS_VERCHECK_FILE" ]; then
-  _floor_min=$(awk -F= '/^min_supported=/{print $2; exit}' "$PRESS_VERCHECK_FILE" 2>/dev/null)
-  _floor_latest=$(awk -F= '/^latest=/{print $2; exit}' "$PRESS_VERCHECK_FILE" 2>/dev/null)
+  _floor_min=$(sed -nE 's/^min_supported=//p' "$PRESS_VERCHECK_FILE" 2>/dev/null | head -n 1)
+  _floor_latest=$(sed -nE 's/^latest=//p' "$PRESS_VERCHECK_FILE" 2>/dev/null | head -n 1)
   _floor_reason=$(sed -nE 's/^reason=//p' "$PRESS_VERCHECK_FILE" 2>/dev/null | head -n 1)
   _floor_installed=$("$PRINTING_PRESS_BIN" version --json 2>/dev/null | sed -nE 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p')
   if [ -n "$_floor_min" ] && [ -n "$_floor_installed" ] && [ -n "$_floor_latest" ] &&
-     _semver_lt "$_floor_installed" "$_floor_min" &&
-     ! _semver_lt "$_floor_latest" "$_floor_min"; then
+     PP_SEMVER_A="$_floor_installed" PP_SEMVER_B="$_floor_min" _semver_lt &&
+     ! PP_SEMVER_A="$_floor_latest" PP_SEMVER_B="$_floor_min" _semver_lt; then
     echo ""
     echo "[upgrade-required] printing-press v$_floor_min is the minimum supported version (you have v$_floor_installed)"
     echo "PRESS_REQUIRED_MIN=$_floor_min"


### PR DESCRIPTION

## Intent

Skill invocations with arguments no longer corrupt setup values through slash-command substitution. `Closes #3860`.

## Approach

Preflight helpers now consume named environment inputs, and shell parsing avoids positional awk fields. The skill-doc validator rejects `$N` and `${N}` tokens inside bash/sh/shell fences, while the currency-floor contract test tracks the named-input form.

## Scope

Primary area: `skills/*/SKILL.md` setup contracts and the shared skill-doc validator.

Why this belongs in this repo: the defect is in reusable Printing Press skill instructions and affects future invocations across printed CLI workflows, not one generated CLI.

## Risk

The change preserves semver, Go-version, disk-space, cache, import-path, and publish-scope behavior while removing reliance on positional shell parameters. The full repository suite still reports unrelated generated-runtime and live-dogfood timeouts in `internal/generator` and `internal/pipeline`; issue-specific checks pass.

## Output Contract

No generated CLI output, MCP surface, or published artifact changes.

## Verification

- `bash .github/scripts/validate-skill-docs.sh`
- `go test ./internal/pipeline -run 'TestSkillsEnforceCurrencyFloor|TestPrintingPressSetupContract' -count=1`
- Manual shell probes for Go normalization, cache parsing, disk parsing, publish scope filtering, and `$N`/`${N}` lint rejection
- `go fmt ./...`
- `git diff --check`
- `go test ./...` (fails on unrelated generated-runtime and live-dogfood timeout tests)

Closes #3860
