### PR TITLE
fix(cli): isolate generated tests from real home paths

### DIFF
--- a/internal/generator/creds_read_perms_test.go
+++ b/internal/generator/creds_read_perms_test.go
@@ -4,6 +4,7 @@ package generator
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -54,6 +55,9 @@ func TestGenerate_EmitsCredsPermsForTokenSpec(t *testing.T) {
 
 	_, err = os.Stat(filepath.Join(outputDir, "internal", "config", "config_perms_test.go"))
 	require.NoError(t, err, "config.Load read-time perms behavioral test must be emitted")
+	configPermsSrc := readGeneratedFile(t, outputDir, "internal", "config", "config_perms_test.go")
+	require.Contains(t, configPermsSrc, "internal/cliutil/testenv", "config permission tests must use the shared path sandbox")
+	require.Contains(t, configPermsSrc, "testenv.Isolate(t, cliutil.DataDir)", "config permission tests must isolate the credentials store")
 
 	// A4: cliutil.LoadCredentials reads a SEPARATE credentials file that also
 	// holds a live token, so it must apply the same read-time guard. Because
@@ -84,6 +88,55 @@ func TestGenerate_EmitsCredsPermsForTokenSpec(t *testing.T) {
 	require.NotEmpty(t, sysLine, "go.mod must require golang.org/x/sys for a token-bearing spec")
 	require.NotContains(t, sysLine, "// indirect",
 		"golang.org/x/sys must be a DIRECT require for a token-bearing spec (creds_perms_windows.go imports golang.org/x/sys/windows)")
+}
+
+func TestGeneratedConfigPermissionTestsIgnoreSeededCredentialsStore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("generated CLI compile tests run in the full generated-test CI lane")
+	}
+	t.Parallel()
+
+	apiSpec, err := openapi.ParseFile(filepath.Join("..", "..", "testdata", "golden", "fixtures", "golden-api-oauth2-cc.yaml"))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	envPrefix := naming.EnvPrefix(apiSpec.Name)
+	operatorHome := t.TempDir()
+	credentialsPath := filepath.Join(operatorHome, ".local", "share", naming.CLI(apiSpec.Name), "credentials.toml")
+	ambientDataDir := filepath.Dir(credentialsPath)
+	ambientXDGDataHome := filepath.Dir(ambientDataDir)
+	require.NoError(t, os.MkdirAll(filepath.Dir(credentialsPath), 0o700))
+	require.NoError(t, os.WriteFile(credentialsPath, []byte("access_token = \"AMBIENT-CREDENTIAL\"\n"), 0o600))
+
+	cacheDir, err := goBuildCacheDir(outputDir)
+	require.NoError(t, err)
+	cmd := exec.Command("go", "test", "-mod=mod", "./internal/config", "-run", "TestLoad_RefusesOverPermissiveConfigOnRead|TestLoad_ReseedsFromEnvAfterOverPermissiveRefusal|TestLoad_RefusesSymlinkToLoosePermsTarget|TestLoad_DanglingSymlinkIsMiss", "-count=1")
+	cmd.Dir = outputDir
+	cmd.Env = append(os.Environ(),
+		"HOME="+operatorHome,
+		"USERPROFILE="+operatorHome,
+		envPrefix+"_HOME=",
+		envPrefix+"_CONFIG=",
+		envPrefix+"_DATA_DIR="+ambientDataDir,
+		envPrefix+"_CONFIG_DIR="+filepath.Join(operatorHome, ".config"),
+		envPrefix+"_STATE_DIR="+filepath.Join(operatorHome, ".local", "state"),
+		envPrefix+"_CACHE_DIR="+filepath.Join(operatorHome, ".cache"),
+		"XDG_CONFIG_HOME="+filepath.Join(operatorHome, ".config"),
+		"XDG_DATA_HOME="+ambientXDGDataHome,
+		"XDG_STATE_HOME="+filepath.Join(operatorHome, ".local", "state"),
+		"XDG_CACHE_HOME="+filepath.Join(operatorHome, ".cache"),
+		"GOCACHE="+cacheDir,
+	)
+	for _, name := range []string{"GOPATH", "GOMODCACHE"} {
+		if value := goEnvValue(t, name); value != "" {
+			cmd.Env = append(cmd.Env, name+"="+value)
+		}
+	}
+
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "generated config permission tests must ignore ambient credentials:\n%s", output)
 }
 
 // TestGenerate_NoCredsPermsForNonAuthSpec proves the guard is gated on

--- a/internal/generator/paths_emission_test.go
+++ b/internal/generator/paths_emission_test.go
@@ -22,6 +22,8 @@ func TestPathsResolverEmitsAndGeneratedCLIBuilds(t *testing.T) {
 	require.Contains(t, pathsSrc, `const envPrefix = "PATHS_EMISSION"`)
 	require.Contains(t, pathsSrc, `return envPrefix + "_" + suffix`)
 	require.Contains(t, pathsSrc, `envPrefix + "_HOME"`)
+	require.Contains(t, pathsSrc, "func resolvedHomeDir() (string, error)")
+	require.Contains(t, pathsSrc, "if override := homeOverride(); override != \"\" {")
 	for _, suffix := range naming.PathKindEnvSuffixes()[1:] {
 		require.Contains(t, pathsSrc, `return "`+suffix+`"`)
 	}
@@ -41,6 +43,7 @@ func TestPathsResolverEmitsAndGeneratedCLIBuilds(t *testing.T) {
 	require.Contains(t, rootSrc, "if err := hook(c); err != nil {")
 
 	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/cliutil", "-run", "TestHomeOverrideWinsForDefaultBaseAndTildeExpansion", "-count=1")
 }
 
 func TestPathEnvPrefixDerivationCoversEdgeNames(t *testing.T) {

--- a/internal/generator/templates/cliutil_paths.go.tmpl
+++ b/internal/generator/templates/cliutil_paths.go.tmpl
@@ -286,17 +286,24 @@ func CleanPathOverride(raw string) (string, bool) {
 
 func expandTilde(path string) string {
 	if path == "~" {
-		if home, err := os.UserHomeDir(); err == nil {
+		if home, err := resolvedHomeDir(); err == nil {
 			return home
 		}
 		return path
 	}
 	if strings.HasPrefix(path, "~/") {
-		if home, err := os.UserHomeDir(); err == nil {
+		if home, err := resolvedHomeDir(); err == nil {
 			return filepath.Join(home, strings.TrimPrefix(path, "~/"))
 		}
 	}
 	return path
+}
+
+func resolvedHomeDir() (string, error) {
+	if override := homeOverride(); override != "" {
+		return override, nil
+	}
+	return os.UserHomeDir()
 }
 
 func warnSkippedPathOverride(name, raw string) {
@@ -311,7 +318,7 @@ func warnSkippedPathOverride(name, raw string) {
 }
 
 func defaultBase(kind PathKind) (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := resolvedHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve user home dir: %w", err)
 	}

--- a/internal/generator/templates/cliutil_paths_test.go.tmpl
+++ b/internal/generator/templates/cliutil_paths_test.go.tmpl
@@ -187,6 +187,25 @@ func TestSetHomeOverrideExpandsTildeAndCleans(t *testing.T) {
 	}
 }
 
+func TestHomeOverrideWinsForDefaultBaseAndTildeExpansion(t *testing.T) {
+	resetPathEnv(t)
+	override := t.TempDir()
+	restore, err := SetHomeOverride(override)
+	if err != nil {
+		t.Fatalf("SetHomeOverride() error = %v", err)
+	}
+	defer restore()
+
+	if got, want := expandTilde("~/nested"), filepath.Join(override, "nested"); got != want {
+		t.Fatalf("expandTilde() = %q, want %q", got, want)
+	}
+	if got, err := defaultBase(PathKindData); err != nil {
+		t.Fatalf("defaultBase() error = %v", err)
+	} else if want := filepath.Join(override, ".local", "share"); got != want {
+		t.Fatalf("defaultBase() = %q, want %q", got, want)
+	}
+}
+
 func assertDataDir(t *testing.T, want string) {
 	t.Helper()
 	got, err := DataDir()

--- a/internal/generator/templates/config_perms_test.go.tmpl
+++ b/internal/generator/templates/config_perms_test.go.tmpl
@@ -19,6 +19,9 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"{{modulePath}}/internal/cliutil"
+	"{{modulePath}}/internal/cliutil/testenv"
 )
 
 // sampleReadPermsSecret is an exposed on-disk token value. It is written into
@@ -26,12 +29,13 @@ import (
 // refusal assertions never depend on a spec-specific field name.
 const sampleReadPermsSecret = "RT-LIVE-90DAY-SECRET-DO-NOT-LEAK"
 
-// clearCredEnv unsets every credential env var Load reads AFTER the file, so
-// the silent-miss / hit assertions are deterministic regardless of the
-// developer's or CI's ambient environment (an ambient PAT would otherwise
-// re-seed a "miss" and make hasCredentialFields() true).
+// clearCredEnv isolates every path Load can use before unsetting credential
+// values. LoadCredentials can fall through from config.Load to the separate
+// credentials store, so clearing auth variables alone would still allow an
+// ambient credentials file to re-seed a supposed miss.
 func clearCredEnv(t *testing.T) {
 	t.Helper()
+	testenv.Isolate(t, cliutil.DataDir)
 {{- if .Auth.EnvVarSpecs}}
 {{- range .Auth.EnvVarSpecs}}
 	t.Setenv("{{.Name}}", "")
@@ -182,6 +186,7 @@ func TestLoad_RefusesOverPermissiveConfigOnRead(t *testing.T) {
 // operator is left with a working tool, never using the exposed on-disk token.
 func TestLoad_ReseedsFromEnvAfterOverPermissiveRefusal(t *testing.T) {
 	const envValue = "PAT-FROM-ENV-BOOTSTRAP"
+	clearCredEnv(t)
 	t.Setenv("{{if .Auth.EnvVarSpecs}}{{(index .Auth.EnvVarSpecs 0).Name}}{{else}}{{index .Auth.EnvVars 0}}{{end}}", envValue)
 	dir := t.TempDir()
 	p := filepath.Join(dir, configFileName())


### PR DESCRIPTION
## Intent

Issue: Closes #3858
Issue: Closes #3669

Generated test suites could bypass their test home sandbox through direct `os.UserHomeDir` calls and could read an ambient credentials store during config permission tests. This PR closes both escapes at the shared Printing Press generator boundary.

## Approach

The generated path resolver now routes tilde expansion and default directory fallback through the existing home override. Generated config permission tests use the canonical `testenv.Isolate` helper for credential-store resolution, including per-kind and XDG overrides, and the reseeding test now uses the same setup. Generator tests run the emitted cases against a seeded ambient credentials store, including a Windows-compatible case.

## Scope

Primary area: generator path templates and generated config permission test isolation.

Why this belongs in this repo: this is a systemic generated-test defect affecting every printed CLI with these surfaces, not an API-specific printed-CLI repair.

## Risk

The generated `--home` path boundary now consistently honors the existing override for fallback paths and tilde expansion. The remaining changes affect generated tests only. No MCP surface, endpoint contract, or publish behavior changes.

## Output Contract

Generated source assertions verify the home-resolution helper and config test sandbox. A generated CLI is compiled and its emitted path test runs. The generated config permission suite is exercised with seeded per-kind and XDG credential paths, and the golden suite remains unchanged.

## Verification

- [x] Generator/template change: verified emitted source assertions and compiled generated CLI output
- [x] Generator/template change: covered home-override fallback and ambient credential-store variants, including Windows-compatible permission coverage
- [x] Generator/template change: checked emitted definitions and call sites through generated runtime tests
- `go test ./internal/generator -run 'TestPathsResolverEmitsAndGeneratedCLIBuilds|TestGenerate_EmitsCredsPermsForTokenSpec|TestGeneratedConfigPermissionTestsIgnoreSeededCredentialsStore' -count=1`
- `scripts/golden.sh verify` passed 32 cases
- `scripts/verify-generator-output.sh` passed 10 default generated cases
- Decoy-profile proof passed generated Stytch `go test ./...`, `govulncheck ./...`, `go vet ./...`, build, help, version, and doctor with an unchanged `.config` and `.local` snapshot
- `go fmt ./...`
- `golangci-lint run ./internal/generator/...`
- `go test ./...` was attempted; existing unrelated HTML extraction, paginated response-format, and generated dogfood acceptance tests still fail with their pre-existing invalid-JSON and learn-store-schema warnings. The touched focused tests and generated proofs pass.
