### PR TITLE
fix(cli): hide credential suffixes in generated redaction

### DIFF
--- a/internal/generator/client_url_redaction_test.go
+++ b/internal/generator/client_url_redaction_test.go
@@ -85,9 +85,21 @@ func TestCredentialMaskingHandlesPrefixOverlaps(t *testing.T) {
 
 	got := c.maskCredentialText("raw="+long+"&escaped="+url.QueryEscape(long)+"&short="+short, short)
 
-	assertCredentialMasked(t, "prefix-overlap text", got, long, "****ac==", "****6a0d")
+	assertCredentialMasked(t, "prefix-overlap long credential", got, long, "****")
+	assertCredentialMasked(t, "prefix-overlap short credential", got, short, "****")
 	if strings.Contains(got, "/8e81") || strings.Contains(got, "%2F8e81") {
 		t.Fatalf("prefix-overlap text leaked long credential suffix: %s", got)
+	}
+}
+
+func TestCredentialMaskingDoesNotRevealTokenLength(t *testing.T) {
+	for _, secret := range []string{"a", "a2d16a0d", "a2d16a0d/8e81+e7fb9e6437ac=="} {
+		if got := maskToken(secret); got != "****" {
+			t.Errorf("maskToken(%q) = %q, want fixed mask", secret, got)
+		}
+	}
+	if got := maskToken(""); got != "" {
+		t.Errorf("maskToken(\"\") = %q, want empty string", got)
 	}
 }
 
@@ -137,7 +149,7 @@ func TestDryRunMasksCredentialEmbeddedInURLPath(t *testing.T) {
 		}
 	})
 
-	assertCredentialMasked(t, "dry-run stderr", stderr, secret, "/v6/****ac==/codes", "echo=****ac==", "api_key=****ac==")
+	assertCredentialMasked(t, "dry-run stderr", stderr, secret, "/v6/****/codes", "echo=****", "api_key=****")
 }
 
 func TestAPIErrorMasksCredentialEmbeddedInURLPath(t *testing.T) {
@@ -149,7 +161,7 @@ func TestAPIErrorMasksCredentialEmbeddedInURLPath(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected API error")
 	}
-	assertCredentialMasked(t, "APIError", err.Error(), secret, "/v6/****ac==/codes", "forbidden for token ****ac==")
+	assertCredentialMasked(t, "APIError", err.Error(), secret, "/v6/****/codes", "forbidden for token ****")
 }
 
 func TestTransportErrorMasksCredentialInWrappedURLError(t *testing.T) {
@@ -163,7 +175,7 @@ func TestTransportErrorMasksCredentialInWrappedURLError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected transport error")
 	}
-	assertCredentialMasked(t, "transport error", err.Error(), secret, "/v6/****ac==/pair/USD/EUR", "api_key=****ac==")
+	assertCredentialMasked(t, "transport error", err.Error(), secret, "/v6/****/pair/USD/EUR", "api_key=****")
 	var urlErr *url.Error
 	if errors.As(err, &urlErr) {
 		t.Fatalf("transport error exposed unredacted URL error through unwrap chain: %v", urlErr)

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -3035,15 +3035,12 @@ func unwrapResponseEnvelope(body []byte) []byte {
 {{- end}}
 
 
-// maskToken redacts all but the last 4 characters of a token for safe display.
+// maskToken returns a fixed placeholder for a non-empty token.
 func maskToken(token string) string {
 	if token == "" {
 		return ""
 	}
-	if len(token) <= 4 {
-		return "****"
-	}
-	return "****" + token[len(token)-4:]
+	return "****"
 }
 
 type maskedError struct {

--- a/internal/generator/tier_routing_test.go
+++ b/internal/generator/tier_routing_test.go
@@ -143,7 +143,7 @@ func TestTierRoutingEmitsTierAwareClientAndCommands(t *testing.T) {
 	cmd.Env = append(os.Environ(), "TIERED_ENTERPRISE_TOKEN=enterprise-secret")
 	output, err = cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
-	require.Contains(t, string(output), "Authorization: ****cret")
+	require.Contains(t, string(output), "Authorization: ****")
 
 	codeSpec := minimalSpec("tiered-code")
 	codeSpec.TierRouting = apiSpec.TierRouting

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -1298,15 +1298,12 @@ func sanitizeJSONResponse(body []byte) []byte {
 	return body
 }
 
-// maskToken redacts all but the last 4 characters of a token for safe display.
+// maskToken returns a fixed placeholder for a non-empty token.
 func maskToken(token string) string {
 	if token == "" {
 		return ""
 	}
-	if len(token) <= 4 {
-		return "****"
-	}
-	return "****" + token[len(token)-4:]
+	return "****"
 }
 
 type maskedError struct {

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -1382,15 +1382,12 @@ func sanitizeJSONResponse(body []byte) []byte {
 	return body
 }
 
-// maskToken redacts all but the last 4 characters of a token for safe display.
+// maskToken returns a fixed placeholder for a non-empty token.
 func maskToken(token string) string {
 	if token == "" {
 		return ""
 	}
-	if len(token) <= 4 {
-		return "****"
-	}
-	return "****" + token[len(token)-4:]
+	return "****"
 }
 
 type maskedError struct {

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -1505,15 +1505,12 @@ func sanitizeJSONResponse(body []byte) []byte {
 	return body
 }
 
-// maskToken redacts all but the last 4 characters of a token for safe display.
+// maskToken returns a fixed placeholder for a non-empty token.
 func maskToken(token string) string {
 	if token == "" {
 		return ""
 	}
-	if len(token) <= 4 {
-		return "****"
-	}
-	return "****" + token[len(token)-4:]
+	return "****"
 }
 
 type maskedError struct {

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -1382,15 +1382,12 @@ func sanitizeJSONResponse(body []byte) []byte {
 	return body
 }
 
-// maskToken redacts all but the last 4 characters of a token for safe display.
+// maskToken returns a fixed placeholder for a non-empty token.
 func maskToken(token string) string {
 	if token == "" {
 		return ""
 	}
-	if len(token) <= 4 {
-		return "****"
-	}
-	return "****" + token[len(token)-4:]
+	return "****"
 }
 
 type maskedError struct {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -1401,15 +1401,12 @@ func sanitizeJSONResponse(body []byte) []byte {
 	return body
 }
 
-// maskToken redacts all but the last 4 characters of a token for safe display.
+// maskToken returns a fixed placeholder for a non-empty token.
 func maskToken(token string) string {
 	if token == "" {
 		return ""
 	}
-	if len(token) <= 4 {
-		return "****"
-	}
-	return "****" + token[len(token)-4:]
+	return "****"
 }
 
 type maskedError struct {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -1405,15 +1405,12 @@ func sanitizeJSONResponse(body []byte) []byte {
 	return body
 }
 
-// maskToken redacts all but the last 4 characters of a token for safe display.
+// maskToken returns a fixed placeholder for a non-empty token.
 func maskToken(token string) string {
 	if token == "" {
 		return ""
 	}
-	if len(token) <= 4 {
-		return "****"
-	}
-	return "****" + token[len(token)-4:]
+	return "****"
 }
 
 type maskedError struct {


### PR DESCRIPTION
## Intent

Issue: Closes #3797

## Approach

Generated clients now replace every non-empty credential with the fixed placeholder `****`. This removes the real suffix and token-length signal from dry-run output, API errors, transport errors, and other redacted URL surfaces while preserving the existing empty-token behavior.

## Scope

Primary area: generator client templates and their generated-output fixtures.

Why this belongs in this repo: the defect is shared generator behavior that would otherwise be reproduced by every future printed CLI.

## Risk

The redacted display contract changes from suffix-preserving output to a fixed mask. Empty credentials remain hidden as an empty value, and header-auth display behavior is unchanged.

## Output Contract

Generated `internal/client` code uses the fixed mask helper across cookie, OAuth2, and tier-routing golden cases. The regression coverage exercises direct masking plus dry-run, API-error, transport-error, and prefix-overlap paths.

## Verification

- [x] Generator/template change: `scripts/verify-generator-output.sh` passed for 10 cases.
- [x] Generator/template change: focused generated-client redaction tests passed, including query API-key and header API-key paths.
- [x] Generator/template change: affected cookie, OAuth2 auth-code, OAuth2 client-credentials, OAuth2 device-code, base API, and tier-routing golden cases passed.
- `go build -o ./cli-printing-press ./cmd/cli-printing-press` passed.
- `go vet ./...` passed.
- `scripts/golden.sh verify` reached all affected cases successfully; the overall run still reports an unrelated `verify-runtime-matrix` fixture mismatch in this shared worktree.
- `go test ./...` and `golangci-lint run ./...` were attempted; remaining failures are outside this diff, including shared-host HTML extraction and pipeline help-scan tests plus a lint finding in another concurrent worktree.
