### PR TITLE
fix(cli): annotate generated MCP safety metadata

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -17618,13 +17618,13 @@ func assertMCPMainUsesVersionVar(t *testing.T, body string) {
 	assert.NotContains(t, body, "\n\t\t\"1.0.0\",\n\t\tserver.WithToolCapabilities(false),")
 }
 
-// TestGenerateMCPCodeOrchestrationEmitsSearchExecute proves that when the
-// spec opts into code-orchestration, the generator emits only
-// <api>_search and <api>_execute as MCP tools, covering every endpoint via
-// a single registry. This is the thin surface pattern referenced by
+// TestGenerateMCPCodeOrchestrationEmitsRegistryTools proves that when the
+// spec opts into code-orchestration, the generator emits only the registry
+// tools <api>_search, <api>_get, and <api>_execute as MCP tools, covering every
+// endpoint via a single registry. This is the thin surface pattern referenced by
 // Anthropic's 2026-04-22 post (Cloudflare's ~2,500-endpoint server in ~1K
 // tokens).
-func TestGenerateMCPCodeOrchestrationEmitsSearchExecute(t *testing.T) {
+func TestGenerateMCPCodeOrchestrationEmitsRegistryTools(t *testing.T) {
 	t.Parallel()
 
 	apiSpec, err := spec.Parse(filepath.Join("..", "..", "testdata", "loops.yaml"))
@@ -17643,6 +17643,7 @@ func TestGenerateMCPCodeOrchestrationEmitsSearchExecute(t *testing.T) {
 	for _, want := range []string{
 		`func RegisterCodeOrchestrationTools(`,
 		`mcplib.NewTool("loops_search"`,
+		`mcplib.NewTool("loops_get"`,
 		`mcplib.NewTool("loops_execute"`,
 		`codeOrchEndpoints = []codeOrchEndpoint`,
 		`func handleCodeOrchSearch(`,

--- a/internal/generator/learn_mcp_parity_test.go
+++ b/internal/generator/learn_mcp_parity_test.go
@@ -238,7 +238,7 @@ func TestGenerateTeachPlaybookInlineJSON(t *testing.T) {
 // TestGenerateLearnMCPParity_CodeOrchestrationExposesLearnTools is the U12
 // empirical check: a spec with mcp.orchestration="code" must still expose
 // the learn loop (teach/recall/learnings) as MCP tools alongside the
-// search/execute pair. The registration is runtime (the cobratree walker
+// registry tools. The registration is runtime (the cobratree walker
 // mirrors the Cobra tree at server start), so the static contract pinned
 // here is that the emitted RegisterTools calls BOTH the code-orchestration
 // pair AND the unconditional cobratree walker + context tool, and that the
@@ -256,7 +256,7 @@ func TestGenerateLearnMCPParity_CodeOrchestrationExposesLearnTools(t *testing.T)
 
 	mcpSrc := readEmitted(t, outputDir, "internal", "mcp", "tools.go")
 	require.Contains(t, mcpSrc, "RegisterCodeOrchestrationTools(s)",
-		"code orchestration must register the search/execute pair")
+		"code orchestration must register its registry tools")
 	require.Contains(t, mcpSrc, "cobratree.RegisterAll(s, cli.RootCmd(), cobratree.SiblingCLIPath)",
 		"the runtime Cobra-tree mirror must still run under code orchestration so learn commands surface as MCP tools")
 	require.Contains(t, mcpSrc, "learn.RecallFirstProtocol",

--- a/internal/generator/mcp_safety_annotations_test.go
+++ b/internal/generator/mcp_safety_annotations_test.go
@@ -1,0 +1,172 @@
+package generator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateMCPCodeOrchestrationSafetyAnnotations(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("mcp-safety")
+	apiSpec.Resources = map[string]spec.Resource{
+		"items": {
+			Description: "Items",
+			Endpoints: map[string]spec.Endpoint{
+				"list":   {Method: "GET", Path: "/items", Description: "List items"},
+				"create": {Method: "POST", Path: "/items", Description: "Create an item"},
+			},
+		},
+	}
+	apiSpec.MCP = spec.MCPConfig{Orchestration: "code"}
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	runtimeTest := `package mcp
+
+import (
+	"context"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func TestCodeOrchestrationSafetyMetadata(t *testing.T) {
+	s := server.NewMCPServer("mcp-safety", "test")
+	RegisterCodeOrchestrationTools(s)
+	tools := s.ListTools()
+
+	tests := map[string]struct {
+		readOnly   bool
+		destructive bool
+		openWorld   bool
+	}{
+		"mcp-safety_search":  {readOnly: true, destructive: false, openWorld: false},
+		"mcp-safety_get":     {readOnly: true, destructive: false, openWorld: false},
+		"mcp-safety_execute": {readOnly: false, destructive: true, openWorld: true},
+	}
+	for name, want := range tests {
+		entry, ok := tools[name]
+		if !ok {
+			t.Fatalf("tool %q missing from tools/list: %#v", name, tools)
+		}
+		if entry.Tool.Annotations.ReadOnlyHint == nil || *entry.Tool.Annotations.ReadOnlyHint != want.readOnly {
+			t.Fatalf("%s readOnlyHint = %v, want %v", name, entry.Tool.Annotations.ReadOnlyHint, want.readOnly)
+		}
+		if entry.Tool.Annotations.DestructiveHint == nil || *entry.Tool.Annotations.DestructiveHint != want.destructive {
+			t.Fatalf("%s destructiveHint = %v, want %v", name, entry.Tool.Annotations.DestructiveHint, want.destructive)
+		}
+		if entry.Tool.Annotations.OpenWorldHint == nil || *entry.Tool.Annotations.OpenWorldHint != want.openWorld {
+			t.Fatalf("%s openWorldHint = %v, want %v", name, entry.Tool.Annotations.OpenWorldHint, want.openWorld)
+		}
+	}
+}
+
+func TestCodeOrchestrationGetRejectsWrites(t *testing.T) {
+	tests := map[string]struct {
+		args map[string]any
+	}{
+		"missing endpoint_id": {args: map[string]any{}},
+		"non-string endpoint_id": {args: map[string]any{"endpoint_id": 42}},
+		"unknown endpoint_id": {args: map[string]any{"endpoint_id": "items.unknown"}},
+		"write endpoint":      {args: map[string]any{"endpoint_id": "items.create"}},
+	}
+	for name, test := range tests {
+		result, err := handleCodeOrchGet(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{Arguments: test.args}})
+		if err != nil {
+			t.Fatalf("handleCodeOrchGet(%s) returned transport error: %v", name, err)
+		}
+		if result == nil || !result.IsError {
+			t.Fatalf("handleCodeOrchGet(%s) IsError = %v, want true", name, result != nil && result.IsError)
+		}
+	}
+
+	result, err := handleCodeOrchGet(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"endpoint_id": "items.list"},
+	}})
+	if err != nil {
+		t.Fatalf("handleCodeOrchGet(GET) returned transport error: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("handleCodeOrchGet(GET) failed: %#v", result)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "mcp", "mcp_safety_annotations_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/mcp", "-run", "TestCodeOrchestration(SafetyMetadata|GetRejectsWrites)", "-count=1")
+}
+
+func TestGeneratePlatformClientMCPAnnotations(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("platform-mcp-safety")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	goMod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
+	require.NoError(t, err)
+	modulePath := strings.TrimSpace(strings.TrimPrefix(strings.SplitN(string(goMod), "\n", 2)[0], "module "))
+
+	runtimeTest := fmt.Sprintf(`package cli
+
+import (
+	"testing"
+
+	"%s/internal/mcp/cobratree"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func TestPlatformClientMCPAnnotations(t *testing.T) {
+	previousRegistration := registeredPlatformSource
+	t.Cleanup(func() { registeredPlatformSource = previousRegistration })
+	registeredPlatformSource = &platformSourceRegistration{Source: "test-source", Adapter: conformanceIdentityAdapter{}}
+
+	s := server.NewMCPServer("platform-mcp-safety", "test")
+	cobratree.RegisterAll(s, RootCmd(), func() (string, error) { return "fixture", nil })
+	tools := s.ListTools()
+
+	tests := map[string]struct {
+		readOnly   bool
+		destructive bool
+		openWorld   bool
+	}{
+		"client_list":        {readOnly: true, destructive: false, openWorld: true},
+		"client_show":        {readOnly: true, destructive: false, openWorld: true},
+		"client_add":         {readOnly: false, destructive: true, openWorld: true},
+		"client_source_set":  {readOnly: false, destructive: true, openWorld: true},
+		"client_set_default": {readOnly: false, destructive: true, openWorld: true},
+		"client_cache_clear": {readOnly: false, destructive: true, openWorld: true},
+		"client_validate":    {readOnly: false, destructive: true, openWorld: true},
+		"client_migrate":     {readOnly: false, destructive: true, openWorld: true},
+		"client_delete":      {readOnly: false, destructive: true, openWorld: true},
+		"whoami":             {readOnly: false, destructive: true, openWorld: true},
+	}
+	for name, want := range tests {
+		entry, ok := tools[name]
+		if !ok {
+			t.Fatalf("tool %%q missing from tools/list: %%#v", name, tools)
+		}
+		annotations := entry.Tool.Annotations
+		if annotations.ReadOnlyHint == nil || *annotations.ReadOnlyHint != want.readOnly {
+			t.Fatalf("%%s readOnlyHint = %%v, want %%v", name, annotations.ReadOnlyHint, want.readOnly)
+		}
+		if annotations.DestructiveHint == nil || *annotations.DestructiveHint != want.destructive {
+			t.Fatalf("%%s destructiveHint = %%v, want %%v", name, annotations.DestructiveHint, want.destructive)
+		}
+		if annotations.OpenWorldHint == nil || *annotations.OpenWorldHint != want.openWorld {
+			t.Fatalf("%%s openWorldHint = %%v, want %%v", name, annotations.OpenWorldHint, want.openWorld)
+		}
+	}
+}
+`, modulePath)
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "platform_mcp_annotations_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "^TestPlatformClientMCPAnnotations$", "-count=1")
+}

--- a/internal/generator/non_json_media_test.go
+++ b/internal/generator/non_json_media_test.go
@@ -109,7 +109,7 @@ func TestGeneratedCommandsHonorNonJSONRequestAndResponseMediaTypes(t *testing.T)
 	assert.Contains(t, codeOrchSource, `rawBody, err = base64.StdEncoding.DecodeString(encoded)`)
 	assert.Contains(t, codeOrchSource, `data, _, err = c.SendRaw(ctx, ep.Method, path, query, rawBody, rawContentType, hdrs)`)
 	assert.Contains(t, codeOrchSource, `"request_body"] = map[string]any`)
-	assert.Contains(t, codeOrchSource, `"default_content_type":   r.ep.RequestContentType`)
+	assert.Contains(t, codeOrchSource, `"default_content_type":   ep.RequestContentType`)
 	assert.Contains(t, codeOrchSource, `"X-Printing-Press-Text-Response": "true"`)
 
 	codeOrchRuntimeTest := `package mcp

--- a/internal/generator/templates/mcp_code_orch.go.tmpl
+++ b/internal/generator/templates/mcp_code_orch.go.tmpl
@@ -3,14 +3,15 @@
 
 // Package mcp — code-orchestration thin surface.
 //
-// Two tools cover the entire API: <api>_search to discover endpoints, and
-// <api>_execute to invoke one. This collapses a large API (50+ endpoints)
+// Three tools cover the entire API: <api>_search to discover endpoints,
+// <api>_get to inspect one GET endpoint, and <api>_execute to invoke one.
+// This collapses a large API (50+ endpoints)
 // to ~1K tokens of tool definitions while preserving full coverage — the
 // agent writes the composition logic in its own sandbox.
 //
 // Pattern source: Anthropic 2026-04-22 "Building agents that reach
 // production systems with MCP" — Cloudflare's MCP server covers ~2,500
-// endpoints in roughly 1K tokens via the same search+execute shape.
+// endpoints in roughly 1K tokens via the same search, get, and execute shape.
 
 package mcp
 
@@ -31,17 +32,31 @@ import (
 	"{{modulePath}}/internal/mcp/bound"
 )
 
-// RegisterCodeOrchestrationTools registers the two agent-facing tools that
-// cover the whole API surface. Called from RegisterTools in place of the
-// per-endpoint registrations when MCP.Orchestration is "code".
+// RegisterCodeOrchestrationTools registers the agent-facing tools that cover
+// the whole API surface. Called from RegisterTools in place of the per-endpoint
+// registrations when MCP.Orchestration is "code".
 func RegisterCodeOrchestrationTools(s *server.MCPServer) {
 	s.AddTool(
 		mcplib.NewTool("{{snake .Name}}_search",
 			mcplib.WithDescription("Search the {{.Name}} API for endpoints matching a natural-language query. Returns a ranked list of {{if hasRawRequest .APISpec}}endpoint metadata, including request_body instructions for raw uploads{{else}}{endpoint_id, method, path, summary} entries{{end}}. Call this first to find the endpoint to execute."),
 			mcplib.WithString("query", mcplib.Required(), mcplib.Description("Natural-language description of what you want to do.")),
 			mcplib.WithNumber("limit", mcplib.Description("Max endpoints to return (default 10).")),
+			mcplib.WithReadOnlyHintAnnotation(true),
+			mcplib.WithDestructiveHintAnnotation(false),
+			mcplib.WithOpenWorldHintAnnotation(false),
 		),
 		handleCodeOrchSearch,
+	)
+
+	s.AddTool(
+		mcplib.NewTool("{{snake .Name}}_get",
+			mcplib.WithDescription("Get metadata for one GET endpoint by its endpoint_id (from {{snake .Name}}_search). This registry-only lookup never calls the API."),
+			mcplib.WithString("endpoint_id", mcplib.Required(), mcplib.Description("GET endpoint identifier returned by {{snake .Name}}_search (e.g., \"users.list\").")),
+			mcplib.WithReadOnlyHintAnnotation(true),
+			mcplib.WithDestructiveHintAnnotation(false),
+			mcplib.WithOpenWorldHintAnnotation(false),
+		),
+		handleCodeOrchGet,
 	)
 
 	s.AddTool(
@@ -55,7 +70,7 @@ func RegisterCodeOrchestrationTools(s *server.MCPServer) {
 }
 
 // codeOrchEndpoint captures the small slice of endpoint metadata the
-// search+execute pair needs at runtime. `keywords` is a precomputed
+// registry tools need at runtime. `keywords` is a precomputed
 // lowercase stream of description + path tokens used for naive ranking;
 // anything more sophisticated belongs on the agent side.
 type codeOrchEndpoint struct {
@@ -228,6 +243,39 @@ func codeOrchKeywords(resource, endpoint, summary, path string) []string {
 	return out
 }
 
+func codeOrchEndpointMetadata(ep *codeOrchEndpoint) map[string]any {
+	out := map[string]any{
+		"endpoint_id": ep.ID,
+		"method":      ep.Method,
+		"path":        ep.Path,
+		"summary":     ep.Summary,
+	}
+{{- if .HasTierRouting}}
+	out["tier"] = ep.Tier
+{{- end}}
+{{- if hasRawRequest .APISpec}}
+	if ep.RequestContentType != "" {
+		out["request_body"] = map[string]any{
+			"encoding":               "base64",
+			"parameter":              "body_base64",
+			"required":               ep.BodyRequired,
+			"default_content_type":   ep.RequestContentType,
+			"content_type_parameter": "content_type",
+		}
+	}
+{{- end}}
+	return out
+}
+
+func findCodeOrchEndpoint(id string) *codeOrchEndpoint {
+	for i := range codeOrchEndpoints {
+		if codeOrchEndpoints[i].ID == id {
+			return &codeOrchEndpoints[i]
+		}
+	}
+	return nil
+}
+
 func handleCodeOrchSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	args := req.GetArguments()
 	query, ok := args["query"].(string)
@@ -268,38 +316,33 @@ func handleCodeOrchSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcp
 
 	out := make([]map[string]any, 0, len(results))
 	for _, r := range results {
-{{- if hasRawRequest .APISpec}}
-		item := map[string]any{
-{{- else}}
-		out = append(out, map[string]any{
-{{- end}}
-			"endpoint_id": r.ep.ID,
-			"method":      r.ep.Method,
-			"path":        r.ep.Path,
-			"summary":     r.ep.Summary,
-{{- if .HasTierRouting}}
-			"tier":        r.ep.Tier,
-{{- end}}
-			"score":       r.score,
-{{- if hasRawRequest .APISpec}}
-		}
-		if r.ep.RequestContentType != "" {
-			item["request_body"] = map[string]any{
-				"encoding":               "base64",
-				"parameter":              "body_base64",
-				"required":               r.ep.BodyRequired,
-				"default_content_type":   r.ep.RequestContentType,
-				"content_type_parameter": "content_type",
-			}
-		}
+		item := codeOrchEndpointMetadata(r.ep)
+		item["score"] = r.score
 		out = append(out, item)
-{{- else}}
-		})
-{{- end}}
 	}
 	text, err := bound.JSON(map[string]any{"count": len(out), "results": out})
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("encoding search results: %v", err)), nil
+	}
+	return mcplib.NewToolResultText(text), nil
+}
+
+func handleCodeOrchGet(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	args := req.GetArguments()
+	id, ok := args["endpoint_id"].(string)
+	if !ok || id == "" {
+		return mcplib.NewToolResultError("endpoint_id is required (call {{snake .Name}}_search first)"), nil
+	}
+	ep := findCodeOrchEndpoint(id)
+	if ep == nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("unknown endpoint_id %q — call {{snake .Name}}_search to discover valid ids", id)), nil
+	}
+	if ep.Method != "GET" {
+		return mcplib.NewToolResultError(fmt.Sprintf("endpoint_id %q is %s, but {{snake .Name}}_get only permits GET endpoints", id, ep.Method)), nil
+	}
+	text, err := bound.JSON(codeOrchEndpointMetadata(ep))
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("encoding endpoint metadata: %v", err)), nil
 	}
 	return mcplib.NewToolResultText(text), nil
 }
@@ -311,13 +354,7 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 		return mcplib.NewToolResultError("endpoint_id is required (call {{snake .Name}}_search first)"), nil
 	}
 
-	var ep *codeOrchEndpoint
-	for i := range codeOrchEndpoints {
-		if codeOrchEndpoints[i].ID == id {
-			ep = &codeOrchEndpoints[i]
-			break
-		}
-	}
+	ep := findCodeOrchEndpoint(id)
 	if ep == nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("unknown endpoint_id %q — call {{snake .Name}}_search to discover valid ids", id)), nil
 	}

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -62,8 +62,8 @@ const (
 func RegisterTools(s *server.MCPServer) {
 	installFreshTenantGate(s)
 {{- if .MCP.IsCodeOrchestration}}
-	// Code-orchestration mode — the full surface is covered by two tools
-	// (<api>_search + <api>_execute). Endpoint-mirror tools are suppressed.
+	// Code-orchestration mode — the full surface is covered by registry tools
+	// (<api>_search, <api>_get, and <api>_execute). Endpoint-mirror tools are suppressed.
 	RegisterCodeOrchestrationTools(s)
 {{- else}}
 {{- if and (ne .MCP.EndpointTools "hidden") (not .APISpec.IsLocalSQLiteSource)}}

--- a/internal/generator/templates/platform_cli.go.tmpl
+++ b/internal/generator/templates/platform_cli.go.tmpl
@@ -448,7 +448,7 @@ func newPlatformClientSourceSetCmd(flags *rootFlags) *cobra.Command {
 }
 
 func newPlatformClientListCmd(flags *rootFlags) *cobra.Command {
-	return &cobra.Command{Use: "list", Short: "List client profiles", Args: cobra.NoArgs, RunE: func(cmd *cobra.Command, args []string) error {
+	return &cobra.Command{Use: "list", Short: "List client profiles", Args: cobra.NoArgs, Annotations: map[string]string{"mcp:read-only": "true"}, RunE: func(cmd *cobra.Command, args []string) error {
 		names, err := platform.ListProfiles()
 		if err != nil {
 			return err
@@ -459,7 +459,7 @@ func newPlatformClientListCmd(flags *rootFlags) *cobra.Command {
 
 func newPlatformClientShowCmd(flags *rootFlags) *cobra.Command {
 	var refs string
-	command := &cobra.Command{Use: "show <name>", Short: "Show non-secret client profile configuration", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+	command := &cobra.Command{Use: "show <name>", Short: "Show non-secret client profile configuration", Args: cobra.ExactArgs(1), Annotations: map[string]string{"mcp:read-only": "true"}, RunE: func(cmd *cobra.Command, args []string) error {
 		profile, err := platform.LoadProfile(args[0])
 		if err != nil {
 			return err

--- a/internal/generator/tier_routing_test.go
+++ b/internal/generator/tier_routing_test.go
@@ -161,7 +161,7 @@ func TestTierRoutingEmitsTierAwareClientAndCommands(t *testing.T) {
 	codeOrchSrc := readGeneratedFile(t, codeOutputDir, "internal", "mcp", "code_orch.go")
 	require.Regexp(t, `\bTier\s+string\b`, codeOrchSrc)
 	require.Regexp(t, `Tier:\s+"paid"`, codeOrchSrc)
-	require.Regexp(t, `"tier":\s+r\.ep\.Tier`, codeOrchSrc)
+	require.Regexp(t, `out\["tier"\]\s*=\s*ep\.Tier`, codeOrchSrc)
 	require.Contains(t, codeOrchSrc, `c = c.WithTier(ep.Tier)`)
 }
 

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/code_orch.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/code_orch.go
@@ -3,14 +3,15 @@
 
 // Package mcp — code-orchestration thin surface.
 //
-// Two tools cover the entire API: <api>_search to discover endpoints, and
-// <api>_execute to invoke one. This collapses a large API (50+ endpoints)
+// Three tools cover the entire API: <api>_search to discover endpoints,
+// <api>_get to inspect one GET endpoint, and <api>_execute to invoke one.
+// This collapses a large API (50+ endpoints)
 // to ~1K tokens of tool definitions while preserving full coverage — the
 // agent writes the composition logic in its own sandbox.
 //
 // Pattern source: Anthropic 2026-04-22 "Building agents that reach
 // production systems with MCP" — Cloudflare's MCP server covers ~2,500
-// endpoints in roughly 1K tokens via the same search+execute shape.
+// endpoints in roughly 1K tokens via the same search, get, and execute shape.
 
 package mcp
 
@@ -28,17 +29,31 @@ import (
 	"mcp-cloudflare-pp-cli/internal/mcp/bound"
 )
 
-// RegisterCodeOrchestrationTools registers the two agent-facing tools that
-// cover the whole API surface. Called from RegisterTools in place of the
-// per-endpoint registrations when MCP.Orchestration is "code".
+// RegisterCodeOrchestrationTools registers the agent-facing tools that cover
+// the whole API surface. Called from RegisterTools in place of the per-endpoint
+// registrations when MCP.Orchestration is "code".
 func RegisterCodeOrchestrationTools(s *server.MCPServer) {
 	s.AddTool(
 		mcplib.NewTool("mcp-cloudflare_search",
 			mcplib.WithDescription("Search the mcp-cloudflare API for endpoints matching a natural-language query. Returns a ranked list of {endpoint_id, method, path, summary} entries. Call this first to find the endpoint to execute."),
 			mcplib.WithString("query", mcplib.Required(), mcplib.Description("Natural-language description of what you want to do.")),
 			mcplib.WithNumber("limit", mcplib.Description("Max endpoints to return (default 10).")),
+			mcplib.WithReadOnlyHintAnnotation(true),
+			mcplib.WithDestructiveHintAnnotation(false),
+			mcplib.WithOpenWorldHintAnnotation(false),
 		),
 		handleCodeOrchSearch,
+	)
+
+	s.AddTool(
+		mcplib.NewTool("mcp-cloudflare_get",
+			mcplib.WithDescription("Get metadata for one GET endpoint by its endpoint_id (from mcp-cloudflare_search). This registry-only lookup never calls the API."),
+			mcplib.WithString("endpoint_id", mcplib.Required(), mcplib.Description("GET endpoint identifier returned by mcp-cloudflare_search (e.g., \"users.list\").")),
+			mcplib.WithReadOnlyHintAnnotation(true),
+			mcplib.WithDestructiveHintAnnotation(false),
+			mcplib.WithOpenWorldHintAnnotation(false),
+		),
+		handleCodeOrchGet,
 	)
 
 	s.AddTool(
@@ -52,7 +67,7 @@ func RegisterCodeOrchestrationTools(s *server.MCPServer) {
 }
 
 // codeOrchEndpoint captures the small slice of endpoint metadata the
-// search+execute pair needs at runtime. `keywords` is a precomputed
+// registry tools need at runtime. `keywords` is a precomputed
 // lowercase stream of description + path tokens used for naive ranking;
 // anything more sophisticated belongs on the agent side.
 type codeOrchEndpoint struct {
@@ -149,6 +164,25 @@ func codeOrchKeywords(resource, endpoint, summary, path string) []string {
 	return out
 }
 
+func codeOrchEndpointMetadata(ep *codeOrchEndpoint) map[string]any {
+	out := map[string]any{
+		"endpoint_id": ep.ID,
+		"method":      ep.Method,
+		"path":        ep.Path,
+		"summary":     ep.Summary,
+	}
+	return out
+}
+
+func findCodeOrchEndpoint(id string) *codeOrchEndpoint {
+	for i := range codeOrchEndpoints {
+		if codeOrchEndpoints[i].ID == id {
+			return &codeOrchEndpoints[i]
+		}
+	}
+	return nil
+}
+
 func handleCodeOrchSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	args := req.GetArguments()
 	query, ok := args["query"].(string)
@@ -189,17 +223,33 @@ func handleCodeOrchSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcp
 
 	out := make([]map[string]any, 0, len(results))
 	for _, r := range results {
-		out = append(out, map[string]any{
-			"endpoint_id": r.ep.ID,
-			"method":      r.ep.Method,
-			"path":        r.ep.Path,
-			"summary":     r.ep.Summary,
-			"score":       r.score,
-		})
+		item := codeOrchEndpointMetadata(r.ep)
+		item["score"] = r.score
+		out = append(out, item)
 	}
 	text, err := bound.JSON(map[string]any{"count": len(out), "results": out})
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("encoding search results: %v", err)), nil
+	}
+	return mcplib.NewToolResultText(text), nil
+}
+
+func handleCodeOrchGet(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	args := req.GetArguments()
+	id, ok := args["endpoint_id"].(string)
+	if !ok || id == "" {
+		return mcplib.NewToolResultError("endpoint_id is required (call mcp-cloudflare_search first)"), nil
+	}
+	ep := findCodeOrchEndpoint(id)
+	if ep == nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("unknown endpoint_id %q — call mcp-cloudflare_search to discover valid ids", id)), nil
+	}
+	if ep.Method != "GET" {
+		return mcplib.NewToolResultError(fmt.Sprintf("endpoint_id %q is %s, but mcp-cloudflare_get only permits GET endpoints", id, ep.Method)), nil
+	}
+	text, err := bound.JSON(codeOrchEndpointMetadata(ep))
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("encoding endpoint metadata: %v", err)), nil
 	}
 	return mcplib.NewToolResultText(text), nil
 }
@@ -211,13 +261,7 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 		return mcplib.NewToolResultError("endpoint_id is required (call mcp-cloudflare_search first)"), nil
 	}
 
-	var ep *codeOrchEndpoint
-	for i := range codeOrchEndpoints {
-		if codeOrchEndpoints[i].ID == id {
-			ep = &codeOrchEndpoints[i]
-			break
-		}
-	}
+	ep := findCodeOrchEndpoint(id)
 	if ep == nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("unknown endpoint_id %q — call mcp-cloudflare_search to discover valid ids", id)), nil
 	}

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
@@ -38,8 +38,8 @@ const (
 // RegisterTools registers all API operations as MCP tools.
 func RegisterTools(s *server.MCPServer) {
 	installFreshTenantGate(s)
-	// Code-orchestration mode — the full surface is covered by two tools
-	// (<api>_search + <api>_execute). Endpoint-mirror tools are suppressed.
+	// Code-orchestration mode — the full surface is covered by registry tools
+	// (<api>_search, <api>_get, and <api>_execute). Endpoint-mirror tools are suppressed.
 	RegisterCodeOrchestrationTools(s)
 	// Search tool — faster than iterating list endpoints for finding specific items
 	s.AddTool(


### PR DESCRIPTION
## Summary

Generated MCP safety metadata now matches the behavior of the generated tools. Registry-only code orchestration search and GET metadata tools are read-only, non-destructive, and local-only, while endpoint execution keeps its write-capable defaults.

## Approach

- Added a registry-only `<api>_get` tool that returns metadata for GET endpoints and rejects non-GET endpoint IDs before any client call.
- Annotated generated platform client list/show commands as read-only and left profile, default-profile, migration, deletion, and cache mutations with the default destructive/open-world metadata.
- Added generated-CLI `tools/list` coverage for positive and negative metadata cases, input validation, generated compilation, and updated the affected MCP golden fixture.

## Verification

- `go test ./internal/generator -run 'TestGenerateMCPCodeOrchestrationEmitsRegistryTools|TestGenerateMCPCodeOrchestrationSafetyAnnotations|TestGeneratePlatformClientMCPAnnotations|TestGenerateMCPSharedBoundPackageAndConsumers|TestGeneratedMCPEveryToolUsesExactlyOneFreshTenantGate|TestMCPReadOnlyAnnotationEmission' -count=1`
- `go vet ./internal/generator`
- `golangci-lint run ./internal/generator/...`
- `scripts/golden.sh verify` (32 cases)
- `scripts/verify-generator-output.sh` (10 generated cases)

`go test ./...` was also run, but the shared batch environment produced unrelated HTML extraction and live-dogfood failures involving generated test profile state. The changed generator tests and generated-output gates pass independently.

Closes #3843
Closes #3837
