### PR TITLE
fix(cli): preserve lock promote artifacts

### DIFF
--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -238,14 +238,16 @@ func newLockPromoteCmd() *cobra.Command {
 				state = pipeline.NewMinimalState(cliName, dir)
 			}
 
-			if err := pipeline.PromoteWorkingCLI(cliName, dir, state); err != nil {
+			promotion, err := pipeline.PromoteWorkingCLIWithResult(cliName, dir, state)
+			if err != nil {
 				return &ExitError{Code: ExitGenerationError, Err: fmt.Errorf("promoting CLI: %w", err)}
 			}
 
 			result := map[string]any{
-				"promoted":    true,
-				"cli":         cliName,
-				"library_dir": state.PublishedDir,
+				"promoted":          true,
+				"cli":               cliName,
+				"library_dir":       state.PublishedDir,
+				"preserved_patches": promotion.PreservedPatches,
 			}
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")

--- a/internal/cli/lock_test.go
+++ b/internal/cli/lock_test.go
@@ -177,11 +177,35 @@ func TestLockPromote_Success(t *testing.T) {
 	var result map[string]any
 	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
 	assert.Equal(t, true, result["promoted"])
+	assert.Equal(t, []any{}, result["preserved_patches"])
 
 	// Verify library dir exists (slug-keyed).
 	libDir := filepath.Join(pipeline.PublishedLibraryRoot(), "test")
 	_, err := os.Stat(filepath.Join(libDir, "go.mod"))
 	assert.NoError(t, err)
+}
+
+func TestLockPromote_ReportsPreservedPatches(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	workDir := filepath.Join(tmp, "working", "test-pp-cli")
+	workPatches := filepath.Join(workDir, pipeline.PatchesDirName)
+	libPatches := filepath.Join(pipeline.PublishedLibraryRoot(), "test", pipeline.PatchesDirName)
+	require.NoError(t, os.MkdirAll(workPatches, 0o755))
+	require.NoError(t, os.MkdirAll(libPatches, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module test-pp-cli\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package main\nfunc main() {}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workPatches, "staged.json"), []byte("staged\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(libPatches, "library-only.json"), []byte("library\n"), 0o644))
+
+	stdout, code := runLockCmd("promote", "--cli", "test-pp-cli", "--dir", workDir)
+	assert.Equal(t, 0, code)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	assert.Equal(t, []any{"library-only.json"}, result["preserved_patches"])
 }
 
 func writeLockPhase5Pass(t *testing.T, state *pipeline.PipelineState) {

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -55,6 +55,10 @@ const PatchesDirName = ".printing-press-patches"
 // tracked by git (which does not track empty directories).
 const PatchesGitKeepName = ".gitkeep"
 
+// PatchesMetadataFilename stores directory-level patch metadata and is not an
+// individual applied patch record.
+const PatchesMetadataFilename = "_meta.json"
+
 // CurrentPatchesIndexSchemaVersion is the schema version stamped into per-patch
 // files authored against the directory layout. Matches the shape documented in
 // internal/generator/templates/agents.md.tmpl.
@@ -301,6 +305,21 @@ func RefreshCLIManifestFromSpec(dir string, parsed *spec.APISpec) error {
 // dir/.printing-press.json. It preserves existing release-ledger files because
 // the public library workflow owns updating them after merge.
 func WriteCLIManifest(dir string, m CLIManifest) error {
+	m = normalizeCLIManifestForWrite(dir, m)
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling CLI manifest: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, CLIManifestFilename), data, 0o644); err != nil {
+		return fmt.Errorf("writing CLI manifest: %w", err)
+	}
+	if err := WriteReleaseLedgerSkeleton(dir, m); err != nil {
+		return err
+	}
+	return nil
+}
+
+func normalizeCLIManifestForWrite(dir string, m CLIManifest) CLIManifest {
 	if usesPlatformClientProfiles(dir) {
 		m.AuthEnvVars = []string{"PRINTING_PRESS_CLIENT_PROFILE"}
 		m.AuthEnvVarSpecs = []spec.AuthEnvVar{{
@@ -309,11 +328,28 @@ func WriteCLIManifest(dir string, m CLIManifest) error {
 		}}
 		m.AuthAdditionalHeaders = nil
 	}
-	data, err := json.MarshalIndent(m, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshaling CLI manifest: %w", err)
+	return m
+}
+
+func writeCLIManifestPreservingRaw(dir string, m CLIManifest, existingRaw map[string]json.RawMessage) error {
+	return writeCLIManifestPreservingRawFields(dir, m, existingRaw, nil)
+}
+
+func writeCLIManifestPreservingRawFields(dir string, m CLIManifest, existingRaw map[string]json.RawMessage, clearFields map[string]struct{}) error {
+	if len(existingRaw) == 0 {
+		return WriteCLIManifest(dir, m)
 	}
-	if err := os.WriteFile(filepath.Join(dir, CLIManifestFilename), data, 0o644); err != nil {
+
+	m = normalizeCLIManifestForWrite(dir, m)
+	merged, err := mergeRawCLIManifestFields(existingRaw, m, clearFields)
+	if err != nil {
+		return err
+	}
+	data, err := marshalCLIManifestObject(merged)
+	if err != nil {
+		return err
+	}
+	if err := writeFileAtomic(filepath.Join(dir, CLIManifestFilename), data, 0o644); err != nil {
 		return fmt.Errorf("writing CLI manifest: %w", err)
 	}
 	if err := WriteReleaseLedgerSkeleton(dir, m); err != nil {
@@ -646,6 +682,20 @@ func marshalCLIManifestFields(m CLIManifest) (map[string]json.RawMessage, error)
 		return nil, fmt.Errorf("parsing CLI manifest fields: %w", err)
 	}
 	return raw, nil
+}
+
+func mergeRawCLIManifestFields(existingRaw map[string]json.RawMessage, m CLIManifest, clearFields map[string]struct{}) (map[string]json.RawMessage, error) {
+	generatedFields, err := marshalCLIManifestFields(m)
+	if err != nil {
+		return nil, err
+	}
+	merged := maps.Clone(existingRaw)
+	for key := range clearFields {
+		delete(merged, key)
+	}
+	delete(merged, "catalog_entry")
+	maps.Copy(merged, generatedFields)
+	return merged, nil
 }
 
 func marshalCLIManifestObject(raw map[string]json.RawMessage) ([]byte, error) {
@@ -1240,16 +1290,10 @@ func writeCLIManifestForGenerate(dir string, m CLIManifest, existingRaw map[stri
 	if len(existingRaw) == 0 {
 		return WriteCLIManifest(dir, m)
 	}
-	generatedFields, err := marshalCLIManifestFields(m)
+	merged, err := mergeRawCLIManifestFields(existingRaw, m, clearFields)
 	if err != nil {
 		return err
 	}
-	merged := maps.Clone(existingRaw)
-	for key := range clearFields {
-		delete(merged, key)
-	}
-	delete(merged, "catalog_entry")
-	maps.Copy(merged, generatedFields)
 	data, err := marshalCLIManifestObject(merged)
 	if err != nil {
 		return err

--- a/internal/pipeline/lock.go
+++ b/internal/pipeline/lock.go
@@ -3,8 +3,10 @@ package pipeline
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -213,29 +215,34 @@ func ReleaseLock(cliName string) error {
 // Uses a staging directory with atomic swap so the previous library copy
 // survives if any step fails.
 func PromoteWorkingCLI(cliName, workingDir string, state *PipelineState) error {
+	_, err := promoteWorkingCLI(cliName, workingDir, state)
+	return err
+}
+
+func promoteWorkingCLI(cliName, workingDir string, state *PipelineState) (*PromoteResult, error) {
 	if err := validateCLIName(cliName); err != nil {
-		return err
+		return nil, err
 	}
 	if workingDir == "" {
-		return fmt.Errorf("working directory is empty")
+		return nil, fmt.Errorf("working directory is empty")
 	}
 
 	// Verify working dir has content.
 	entries, err := os.ReadDir(workingDir)
 	if err != nil {
-		return fmt.Errorf("reading working directory: %w", err)
+		return nil, fmt.Errorf("reading working directory: %w", err)
 	}
 	if len(entries) == 0 {
-		return fmt.Errorf("working directory is empty: %s", workingDir)
+		return nil, fmt.Errorf("working directory is empty: %s", workingDir)
 	}
 	if err := validatePhase5GateForPromote(workingDir, state); err != nil {
-		return err
+		return nil, err
 	}
 	if err := validatePIIGateForPromote(workingDir, state); err != nil {
-		return err
+		return nil, err
 	}
 	if _, err := refreshPromoteArtifacts(workingDir, cliName); err != nil {
-		return fmt.Errorf("refreshing staged artifacts: %w", err)
+		return nil, fmt.Errorf("refreshing staged artifacts: %w", err)
 	}
 
 	slug := naming.TrimCLISuffix(cliName)
@@ -245,7 +252,7 @@ func PromoteWorkingCLI(cliName, workingDir string, state *PipelineState) error {
 
 	// Ensure parent exists.
 	if err := os.MkdirAll(filepath.Dir(libraryDir), 0o755); err != nil {
-		return fmt.Errorf("creating library parent directory: %w", err)
+		return nil, fmt.Errorf("creating library parent directory: %w", err)
 	}
 
 	// If a previous promote died after moving the live library to backup but
@@ -253,10 +260,10 @@ func PromoteWorkingCLI(cliName, workingDir string, state *PipelineState) error {
 	if _, err := os.Stat(backupDir); err == nil {
 		if _, libErr := os.Stat(libraryDir); os.IsNotExist(libErr) {
 			if err := os.Rename(backupDir, libraryDir); err != nil {
-				return fmt.Errorf("restoring library from backup: %w", err)
+				return nil, fmt.Errorf("restoring library from backup: %w", err)
 			}
 		} else if libErr != nil {
-			return fmt.Errorf("checking existing library directory: %w", libErr)
+			return nil, fmt.Errorf("checking existing library directory: %w", libErr)
 		}
 	}
 
@@ -266,14 +273,23 @@ func PromoteWorkingCLI(cliName, workingDir string, state *PipelineState) error {
 	// Copy working dir to staging.
 	if err := CopyDir(workingDir, stagingDir); err != nil {
 		_ = os.RemoveAll(stagingDir)
-		return fmt.Errorf("copying to staging directory: %w", err)
+		return nil, fmt.Errorf("copying to staging directory: %w", err)
+	}
+
+	// The library may contain hand-authored patch records that were created
+	// after the working copy was generated. Keep those records in the atomic
+	// replacement while letting the staged copy win on filename conflicts.
+	preservedPatches, err := preserveLibraryOnlyPatches(libraryDir, stagingDir)
+	if err != nil {
+		_ = os.RemoveAll(stagingDir)
+		return nil, fmt.Errorf("preserving library-only patches: %w", err)
 	}
 
 	// Phase 5 writes acceptance markers to the runstate, but the published
 	// copy is the path downstream consumers see — embed them before the swap.
 	if err := stageRunstateManuscripts(stagingDir, state); err != nil {
 		_ = os.RemoveAll(stagingDir)
-		return fmt.Errorf("staging runstate manuscripts: %w", err)
+		return nil, fmt.Errorf("staging runstate manuscripts: %w", err)
 	}
 
 	// Update state to reflect promotion.
@@ -282,11 +298,11 @@ func PromoteWorkingCLI(cliName, workingDir string, state *PipelineState) error {
 	// Write CLI manifest into the staging copy.
 	if err := writeCLIManifestForPublish(state, stagingDir); err != nil {
 		_ = os.RemoveAll(stagingDir)
-		return fmt.Errorf("writing CLI manifest: %w", err)
+		return nil, fmt.Errorf("writing CLI manifest: %w", err)
 	}
 	if err := restorePermanentCreatorForPromote(stagingDir, libraryDir, state.APIName); err != nil {
 		_ = os.RemoveAll(stagingDir)
-		return fmt.Errorf("restoring permanent creator: %w", err)
+		return nil, fmt.Errorf("restoring permanent creator: %w", err)
 	}
 
 	// Refresh the MCPB manifest.json in the staging dir so the lock-and-promote
@@ -298,11 +314,11 @@ func PromoteWorkingCLI(cliName, workingDir string, state *PipelineState) error {
 	// fields, which is the exact bug class this writer chain exists to prevent.
 	if err := WriteMCPBManifest(stagingDir); err != nil {
 		_ = os.RemoveAll(stagingDir)
-		return fmt.Errorf("writing MCPB manifest to staging: %w", err)
+		return nil, fmt.Errorf("writing MCPB manifest to staging: %w", err)
 	}
 	if _, err := syncPromoteBundle(stagingDir, cliName); err != nil {
 		_ = os.RemoveAll(stagingDir)
-		return fmt.Errorf("syncing MCPB bundle in staging: %w", err)
+		return nil, fmt.Errorf("syncing MCPB bundle in staging: %w", err)
 	}
 
 	// Remove any stale backup from a prior successful swap before we create a
@@ -310,7 +326,7 @@ func PromoteWorkingCLI(cliName, workingDir string, state *PipelineState) error {
 	if _, err := os.Stat(backupDir); err == nil {
 		if err := os.RemoveAll(backupDir); err != nil {
 			_ = os.RemoveAll(stagingDir)
-			return fmt.Errorf("removing stale backup directory: %w", err)
+			return nil, fmt.Errorf("removing stale backup directory: %w", err)
 		}
 	}
 
@@ -318,11 +334,11 @@ func PromoteWorkingCLI(cliName, workingDir string, state *PipelineState) error {
 	if _, err := os.Stat(libraryDir); err == nil {
 		if err := os.Rename(libraryDir, backupDir); err != nil {
 			_ = os.RemoveAll(stagingDir)
-			return fmt.Errorf("backing up existing library directory: %w", err)
+			return nil, fmt.Errorf("backing up existing library directory: %w", err)
 		}
 	} else if !os.IsNotExist(err) {
 		_ = os.RemoveAll(stagingDir)
-		return fmt.Errorf("checking library directory before promote: %w", err)
+		return nil, fmt.Errorf("checking library directory before promote: %w", err)
 	}
 
 	if err := os.Rename(stagingDir, libraryDir); err != nil {
@@ -330,7 +346,7 @@ func PromoteWorkingCLI(cliName, workingDir string, state *PipelineState) error {
 		if _, statErr := os.Stat(backupDir); statErr == nil {
 			_ = os.Rename(backupDir, libraryDir)
 		}
-		return fmt.Errorf("promoting staging to library: %w", err)
+		return nil, fmt.Errorf("promoting staging to library: %w", err)
 	}
 
 	// Swap succeeded — remove the backup.
@@ -343,14 +359,74 @@ func PromoteWorkingCLI(cliName, workingDir string, state *PipelineState) error {
 
 	switch {
 	case saveErr != nil && releaseErr != nil:
-		return fmt.Errorf("cli promoted to %s, but state update failed: %v; lock release also failed: %w", libraryDir, saveErr, releaseErr)
+		return nil, fmt.Errorf("cli promoted to %s, but state update failed: %v; lock release also failed: %w", libraryDir, saveErr, releaseErr)
 	case saveErr != nil:
-		return fmt.Errorf("cli promoted to %s, but state update failed: %w", libraryDir, saveErr)
+		return nil, fmt.Errorf("cli promoted to %s, but state update failed: %w", libraryDir, saveErr)
 	case releaseErr != nil:
-		return fmt.Errorf("cli promoted to %s, but lock release failed: %w", libraryDir, releaseErr)
+		return nil, fmt.Errorf("cli promoted to %s, but lock release failed: %w", libraryDir, releaseErr)
 	default:
-		return nil
+		return &PromoteResult{PreservedPatches: preservedPatches}, nil
 	}
+}
+
+// PromoteResult contains operator-visible details from a successful promote.
+type PromoteResult struct {
+	PreservedPatches []string
+}
+
+// PromoteWorkingCLIWithResult is the reporting form of PromoteWorkingCLI used
+// by the lock CLI. The existing error-only function remains for callers that
+// do not need promote details.
+func PromoteWorkingCLIWithResult(cliName, workingDir string, state *PipelineState) (*PromoteResult, error) {
+	return promoteWorkingCLI(cliName, workingDir, state)
+}
+
+func preserveLibraryOnlyPatches(libraryDir, stagingDir string) ([]string, error) {
+	libraryPatches := filepath.Join(libraryDir, PatchesDirName)
+	entries, err := os.ReadDir(libraryPatches)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, nil
+		}
+		return nil, err
+	}
+	stagingPatches := filepath.Join(stagingDir, PatchesDirName)
+	if info, err := os.Stat(stagingPatches); err == nil {
+		if !info.IsDir() {
+			return nil, fmt.Errorf("staged patches path is not a directory: %s", stagingPatches)
+		}
+	} else if os.IsNotExist(err) {
+		if err := os.MkdirAll(stagingPatches, 0o755); err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, err
+	}
+
+	preserved := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Name() == PatchesGitKeepName || entry.Name() == PatchesMetadataFilename {
+			continue
+		}
+		if _, err := os.Lstat(filepath.Join(stagingPatches, entry.Name())); os.IsNotExist(err) {
+			preserved = append(preserved, entry.Name())
+		} else if err != nil {
+			return nil, err
+		}
+	}
+	sort.Strings(preserved)
+
+	if err := copyDirFiltered(libraryPatches, stagingPatches, func(path string, _ fs.FileInfo) bool {
+		rel, err := filepath.Rel(libraryPatches, path)
+		if err != nil {
+			return false
+		}
+		_, err = os.Lstat(filepath.Join(stagingPatches, rel))
+		return err == nil
+	}); err != nil {
+		return nil, err
+	}
+	return preserved, nil
 }
 
 // A pre-existing subtree in the staging copy wins so artifacts that generate

--- a/internal/pipeline/lock_test.go
+++ b/internal/pipeline/lock_test.go
@@ -427,6 +427,185 @@ func TestPromoteWorkingCLI_ReplacesExistingLibrary(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestPromoteWorkingCLI_PreservesPatchAndManifestUnion(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	workDir := filepath.Join(tmp, "working", "test-pp-cli")
+	libDir := filepath.Join(PublishedLibraryRoot(), "test")
+	workPatches := filepath.Join(workDir, PatchesDirName)
+	libPatches := filepath.Join(libDir, PatchesDirName)
+	require.NoError(t, os.MkdirAll(workPatches, 0o755))
+	require.NoError(t, os.MkdirAll(libPatches, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module test-pp-cli\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package main\nfunc main() {}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workPatches, "staged.json"), []byte("staged\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workPatches, "shared.json"), []byte("staged wins\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(libPatches, "library-only.json"), []byte("library\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(libPatches, "shared.json"), []byte("library loses\n"), 0o644))
+	require.NoError(t, WriteCLIManifest(libDir, CLIManifest{
+		SchemaVersion: CurrentCLIManifestSchemaVersion,
+		APIName:       "test",
+		CLIName:       "test-pp-cli",
+		Creator:       &spec.Person{Handle: "mvanhorn", Name: "Matt Van Horn"},
+	}))
+	stagedManifest := []byte(`{
+  "schema_version": 2,
+  "api_name": "test",
+  "cli_name": "test-pp-cli",
+  "creator": {"handle": "tmchow", "name": "Trevin Chow"},
+  "spec_url": "https://example.com/staged.yaml",
+  "spec_source": "remote",
+  "novel_features_built": [{"name": "Health", "command": "health"}],
+  "verify": {"mode": "live", "pass_rate": 1, "passed": 2, "total": 2},
+  "scorecard": {"steinberger": {"percentage": 92, "grade": "A"}}
+}
+`)
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, CLIManifestFilename), stagedManifest, 0o644))
+
+	state := NewMinimalState("test-pp-cli", workDir)
+	result, err := PromoteWorkingCLIWithResult("test-pp-cli", workDir, state)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, []string{"library-only.json"}, result.PreservedPatches)
+
+	data, err := os.ReadFile(filepath.Join(libDir, CLIManifestFilename))
+	require.NoError(t, err)
+	var manifest map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &manifest))
+	assert.JSONEq(t, `"https://example.com/staged.yaml"`, string(manifest["spec_url"]))
+	assert.JSONEq(t, `"remote"`, string(manifest["spec_source"]))
+	assert.JSONEq(t, `[{"name":"Health","command":"health"}]`, string(manifest["novel_features_built"]))
+	assert.JSONEq(t, `{"mode":"live","pass_rate":1,"passed":2,"total":2}`, string(manifest["verify"]))
+	assert.JSONEq(t, `{"steinberger":{"percentage":92,"grade":"A"}}`, string(manifest["scorecard"]))
+	assert.JSONEq(t, `{"handle":"mvanhorn","name":"Matt Van Horn"}`, string(manifest["creator"]))
+
+	data, err = os.ReadFile(filepath.Join(libPatches, "library-only.json"))
+	require.NoError(t, err)
+	assert.Equal(t, "library\n", string(data))
+	data, err = os.ReadFile(filepath.Join(libPatches, "shared.json"))
+	require.NoError(t, err)
+	assert.Equal(t, "staged wins\n", string(data))
+
+	// A second union over the promoted tree is a no-op: all library-only
+	// entries are now present in the staged round-trip copy.
+	roundTripDir := filepath.Join(tmp, "round-trip")
+	require.NoError(t, CopyDir(libDir, roundTripDir))
+	preserved, err := preserveLibraryOnlyPatches(libDir, roundTripDir)
+	require.NoError(t, err)
+	assert.Empty(t, preserved)
+}
+
+func TestPromoteWorkingCLI_CreatesMissingPatchDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	workDir := filepath.Join(tmp, "working", "test-pp-cli")
+	libDir := filepath.Join(PublishedLibraryRoot(), "test")
+	libPatches := filepath.Join(libDir, PatchesDirName)
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+	require.NoError(t, os.MkdirAll(libPatches, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module test-pp-cli\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package main\nfunc main() {}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(libPatches, PatchesGitKeepName), nil, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(libPatches, PatchesMetadataFilename), []byte(`{"schema_version":2}\n`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(libPatches, "library-only.json"), []byte("library\n"), 0o644))
+
+	result, err := PromoteWorkingCLIWithResult("test-pp-cli", workDir, NewMinimalState("test-pp-cli", workDir))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"library-only.json"}, result.PreservedPatches)
+	assert.FileExists(t, filepath.Join(libPatches, PatchesGitKeepName))
+	assert.FileExists(t, filepath.Join(libPatches, PatchesMetadataFilename))
+	assert.FileExists(t, filepath.Join(libPatches, "library-only.json"))
+}
+
+func TestPromoteWorkingCLI_PreservesBackupPatchesOnRetry(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	libDir := filepath.Join(PublishedLibraryRoot(), "test")
+	backupDir := libDir + ".old"
+	backupPatches := filepath.Join(backupDir, PatchesDirName)
+	require.NoError(t, os.MkdirAll(backupPatches, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(backupDir, "go.mod"), []byte("module old\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(backupPatches, "recovered.json"), []byte("recovered\n"), 0o644))
+
+	workDir := filepath.Join(tmp, "working", "test-pp-cli")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module test-pp-cli\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package main\nfunc main() {}\n"), 0o644))
+
+	result, err := PromoteWorkingCLIWithResult("test-pp-cli", workDir, NewMinimalState("test-pp-cli", workDir))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"recovered.json"}, result.PreservedPatches)
+	assert.FileExists(t, filepath.Join(libDir, PatchesDirName, "recovered.json"))
+}
+
+func TestPromoteWorkingCLI_PatchUnionFailureLeavesLibraryUntouched(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	libDir := filepath.Join(PublishedLibraryRoot(), "test")
+	libPatches := filepath.Join(libDir, PatchesDirName)
+	require.NoError(t, os.MkdirAll(libPatches, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(libDir, "sentinel.txt"), []byte("keep\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(libPatches, "library-only.json"), []byte("library\n"), 0o644))
+
+	workDir := filepath.Join(tmp, "working", "test-pp-cli")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module test-pp-cli\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package main\nfunc main() {}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, PatchesDirName), []byte("not a directory\n"), 0o644))
+
+	_, err := PromoteWorkingCLIWithResult("test-pp-cli", workDir, NewMinimalState("test-pp-cli", workDir))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "preserving library-only patches")
+	assert.FileExists(t, filepath.Join(libDir, "sentinel.txt"))
+	_, statErr := os.Stat(libDir + ".promoting")
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestPromoteWorkingCLI_ClearsStaleSpecURLForPathSource(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	workDir := filepath.Join(tmp, "working", "test-pp-cli")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module test-pp-cli\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package main\nfunc main() {}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, CLIManifestFilename), []byte(`{
+  "schema_version": 2,
+  "api_name": "test",
+  "cli_name": "test-pp-cli",
+  "spec_url": "https://example.com/old.yaml"
+}
+`), 0o644))
+	specPath := filepath.Join(tmp, "openapi.yaml")
+	require.NoError(t, os.WriteFile(specPath, []byte("openapi: 3.0.0\n"), 0o644))
+	state := NewMinimalState("test-pp-cli", workDir)
+	state.SpecURL = specPath
+
+	_, err := PromoteWorkingCLIWithResult("test-pp-cli", workDir, state)
+	require.NoError(t, err)
+	data, err := os.ReadFile(filepath.Join(PublishedLibraryRoot(), "test", CLIManifestFilename))
+	require.NoError(t, err)
+	var manifest map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &manifest))
+	assert.NotContains(t, manifest, "spec_url")
+	assert.JSONEq(t, `"openapi.yaml"`, string(manifest["spec_path"]))
+}
+
 func TestPromoteWorkingCLI_RestoresPermanentCreatorFromExistingLibrary(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("PRINTING_PRESS_HOME", tmp)

--- a/internal/pipeline/promote_attribution.go
+++ b/internal/pipeline/promote_attribution.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -29,6 +30,14 @@ func restorePermanentCreatorForPromote(stagingDir, libraryDir, apiName string) e
 	if err != nil {
 		return fmt.Errorf("reading staged manifest: %w", err)
 	}
+	stagedData, err := os.ReadFile(filepath.Join(stagingDir, CLIManifestFilename))
+	if err != nil {
+		return fmt.Errorf("reading staged manifest fields: %w", err)
+	}
+	var stagedRaw map[string]json.RawMessage
+	if err := json.Unmarshal(stagedData, &stagedRaw); err != nil {
+		return fmt.Errorf("parsing staged manifest fields: %w", err)
+	}
 	if staged.Creator == nil || staged.Creator.IsZero() || spec.SamePerson(*staged.Creator, *existing.Creator) {
 		return nil
 	}
@@ -54,7 +63,7 @@ func restorePermanentCreatorForPromote(stagingDir, libraryDir, apiName string) e
 	if err := rewriteGeneratedAttribution(stagingDir, priorCreator, restoredCreator, priorContributors, staged.Contributors); err != nil {
 		return err
 	}
-	if err := WriteCLIManifest(stagingDir, staged); err != nil {
+	if err := writeCLIManifestPreservingRaw(stagingDir, staged, stagedRaw); err != nil {
 		return err
 	}
 	return nil

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -209,7 +209,9 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 	// parsing is unavailable or lossy for the original spec format. NovelFeatures
 	// is carried forward as a defensive fallback in case research.json is absent;
 	// when both are available, research.json wins as the post-dogfood source of truth.
+	var existingRaw map[string]json.RawMessage
 	if existingData, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename)); err == nil {
+		_ = json.Unmarshal(existingData, &existingRaw)
 		var existing CLIManifest
 		if json.Unmarshal(existingData, &existing) == nil {
 			if state.RunID == "" && existing.RunID != "" {
@@ -399,7 +401,14 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 		}
 	}
 
-	return WriteCLIManifest(dir, m)
+	clearFields := map[string]struct{}{}
+	if m.SpecURL != "" && m.SpecPath == "" {
+		clearFields["spec_path"] = struct{}{}
+	}
+	if m.SpecPath != "" && m.SpecURL == "" {
+		clearFields["spec_url"] = struct{}{}
+	}
+	return writeCLIManifestPreservingRawFields(dir, m, existingRaw, clearFields)
 }
 
 func archivedSpecDescription(data []byte) string {


### PR DESCRIPTION
## Summary

Lock promote now retains the complete staged manifest payload, including fields not modeled by `CLIManifest`, while still removing the intentional `catalog_entry` field. Atomic promotion unions library-only `.printing-press-patches/` records into staging, keeps staged same-name records authoritative, and reports preserved patch names as a stable JSON array.

## Scope

Primary area: the lock promote transaction and manifest serialization in the Printing Press.

## Verification

- `go test ./internal/pipeline`
- `go test ./internal/cli`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go vet ./...`
- `golangci-lint run ./internal/pipeline ./internal/cli`
- `scripts/golden.sh verify` (32 cases)
- `go test ./...` reached the affected packages successfully; the repository-wide run remains environment-blocked by a macOS keychain timeout in `pressauth` and an unrelated flaky help-scan case. The exact generator HTML extraction tests pass with an isolated decoy profile.

Closes #3839
Closes #3815
