### PR TITLE
fix(cli): preserve pagination response declarations

### DIFF
--- a/internal/generator/binary_paginated_promoted_test.go
+++ b/internal/generator/binary_paginated_promoted_test.go
@@ -51,7 +51,7 @@ func TestGenerateBinaryPaginatedPromotedThreadsHeader(t *testing.T) {
 
 	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
 	gen := New(apiSpec, outputDir)
-	// Force no-store so the paginatedGet branch is exercised; resolvePaginatedRead
+	// Force no-store so the direct paginated response-path helper branch is exercised; resolvePaginatedRead
 	// would be wired the same way (both accept the headers map). Export keeps
 	// VisionSet.IsZero() false so the generator doesn't recompute from profile.
 	gen.VisionSet = VisionTemplateSet{Export: true}
@@ -62,12 +62,12 @@ func TestGenerateBinaryPaginatedPromotedThreadsHeader(t *testing.T) {
 		"binary paginated promoted must declare headerOverrides")
 	assert.Contains(t, endpointSrc, `"X-Printing-Press-Binary-Response": "true",`,
 		"binary paginated promoted must include the binary sentinel")
-	assert.Contains(t, endpointSrc, `paginatedGet(cmd.Context(), c, path, map[string]string{`,
-		"non-HasStore pagination must use paginatedGet")
+	assert.Contains(t, endpointSrc, `paginatedGetWithResponsePath(cmd.Context(), c, path, map[string]string{`,
+		"non-HasStore pagination must use paginatedGetWithResponsePath")
 	assert.NotContains(t, endpointSrc, `}, nil, flagAll,`,
 		"paginated binary endpoint must pass headerOverrides, not nil")
 	assert.Contains(t, endpointSrc, `}, headerOverrides, flagAll && !flags.dryRun,`,
-		"paginated binary endpoint must thread headerOverrides into paginatedGet")
+		"paginated binary endpoint must thread headerOverrides into paginatedGetWithResponsePath")
 }
 
 // Regression: store-backed binary GET previously passed nil to resolveRead,

--- a/internal/generator/pagination_declarations_test.go
+++ b/internal/generator/pagination_declarations_test.go
@@ -100,9 +100,10 @@ func TestGeneratedPaginatedCommandsEmitResponsePath(t *testing.T) {
 	behaviorTest := `package cli
 
 import (
-    "context"
-    "encoding/json"
-    "testing"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
 )
 
 type responsePathPaginationClient struct {
@@ -159,8 +160,40 @@ func TestPaginatedResponsePathAggregatesPages(t *testing.T) {
         t.Fatalf("single page = %#v, want response_path projection", page)
     }
 }
+
+func TestPaginatedResponsePathRejectsInvalidDeclarations(t *testing.T) {
+    tests := []struct {
+        name     string
+        response string
+        path     string
+        want     string
+    }{
+        {
+            name:     "missing path",
+            response: "{\"items\":[{\"id\":\"item-1\"}]}",
+            path:     "results",
+            want:     "response_path \"results\" not found in response",
+        },
+        {
+            name:     "non-array path",
+            response: "{\"results\":{\"id\":\"item-1\"}}",
+            path:     "results",
+            want:     "response_path \"results\" must resolve to an array",
+        },
+    }
+
+    for _, test := range tests {
+        t.Run(test.name, func(t *testing.T) {
+            client := &responsePathPaginationClient{responses: []json.RawMessage{json.RawMessage(test.response)}}
+            _, err := paginatedGetWithResponsePath(context.Background(), client, "/items", nil, nil, false, "after", "cursor", "limit", 100, "", "", test.path)
+            if err == nil || !strings.Contains(err.Error(), test.want) {
+                t.Fatalf("error = %v, want substring %q", err, test.want)
+            }
+        })
+    }
+}
 `
 	testPath := filepath.Join(outputDir, "internal", "cli", "pagination_declarations_runtime_test.go")
 	require.NoError(t, os.WriteFile(testPath, []byte(behaviorTest), 0o644))
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPaginatedResponsePathAggregatesPages", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPaginatedResponsePath", "-count=1")
 }

--- a/internal/generator/pagination_declarations_test.go
+++ b/internal/generator/pagination_declarations_test.go
@@ -1,0 +1,137 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedPaginatedCommandsEmitResponsePath(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("paginated-response-path")
+	apiSpec.Resources = map[string]spec.Resource{
+		"items": {
+			Description: "Manage items",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:       "GET",
+					Path:         "/items",
+					Description:  "List items",
+					Response:     spec.ResponseDef{Type: "array", Item: "Item"},
+					ResponsePath: "results",
+					Pagination: &spec.Pagination{
+						Type:           "cursor",
+						CursorParam:    "after",
+						LimitParam:     "limit",
+						NextCursorPath: "paging.next.after",
+						HasMoreField:   "paging.has_more",
+					},
+					Params: []spec.Param{
+						{Name: "after", Type: "string", Description: "Cursor"},
+						{Name: "limit", Type: "integer", Description: "Page size"},
+					},
+				},
+			},
+		},
+		"catalog": {
+			Description: "Manage catalog",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/catalog",
+					Description: "List catalog",
+					Response:    spec.ResponseDef{Type: "array", Item: "Item"},
+				},
+				"lookup": {
+					Method:       "GET",
+					Path:         "/catalog/lookup",
+					Description:  "Look up items",
+					Response:     spec.ResponseDef{Type: "array", Item: "Item"},
+					ResponsePath: "payload.records",
+					Pagination: &spec.Pagination{
+						Type:         "offset",
+						CursorParam:  "offset",
+						LimitParam:   "limit",
+						HasMoreField: "payload.has_more",
+					},
+					Params: []spec.Param{
+						{Name: "offset", Type: "integer", Description: "Offset"},
+						{Name: "limit", Type: "integer", Description: "Page size"},
+					},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Item": {Fields: []spec.TypeField{{Name: "id", Type: "string"}}},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{MCP: true, Store: true}
+	require.NoError(t, gen.Generate())
+
+	promotedSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_items.go")
+	assert.Contains(t, promotedSrc, `"paging.next.after", "paging.has_more", "results", cmd.ErrOrStderr())`)
+
+	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "catalog_lookup.go")
+	assert.Contains(t, endpointSrc, `"", "payload.has_more", "payload.records", cmd.ErrOrStderr())`)
+	requireGeneratedCompiles(t, outputDir)
+
+	behaviorTest := `package cli
+
+import (
+    "context"
+    "encoding/json"
+    "testing"
+)
+
+type responsePathPaginationClient struct {
+    responses []json.RawMessage
+    params []map[string]string
+}
+
+func (c *responsePathPaginationClient) IsDryRun() bool { return false }
+
+func (c *responsePathPaginationClient) GetWithHeaders(_ context.Context, _ string, params map[string]string, _ map[string]string) (json.RawMessage, error) {
+    copied := map[string]string{}
+    for key, value := range params {
+        copied[key] = value
+    }
+    c.params = append(c.params, copied)
+    response := c.responses[0]
+    c.responses = c.responses[1:]
+    return response, nil
+}
+
+func TestPaginatedResponsePathAggregatesPages(t *testing.T) {
+    client := &responsePathPaginationClient{responses: []json.RawMessage{
+        json.RawMessage("{\"results\":[{\"id\":\"item-1\"}],\"paging\":{\"next\":{\"after\":\"token-2\"}}}"),
+        json.RawMessage("{\"results\":[{\"id\":\"item-2\"}],\"paging\":{\"next\":{\"after\":\"\"}}}"),
+    }}
+    data, err := paginatedGetWithResponsePath(context.Background(), client, "/items", map[string]string{"limit":"1"}, nil, true, "after", "cursor", "limit", 100, "paging.next.after", "", "results")
+    if err != nil {
+        t.Fatalf("paginatedGetWithResponsePath: %v", err)
+    }
+    var items []map[string]string
+    if err := json.Unmarshal(data, &items); err != nil {
+        t.Fatalf("decode aggregated items: %v; data=%s", err, data)
+    }
+    if len(items) != 2 || items[0]["id"] != "item-1" || items[1]["id"] != "item-2" {
+        t.Fatalf("items = %#v, want both projected pages", items)
+    }
+    if len(client.params) != 2 || client.params[1]["after"] != "token-2" {
+        t.Fatalf("params = %#v, want the declared nested cursor on page two", client.params)
+    }
+}
+`
+	testPath := filepath.Join(outputDir, "internal", "cli", "pagination_declarations_runtime_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(behaviorTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPaginatedResponsePathAggregatesPages", "-count=1")
+}

--- a/internal/generator/pagination_declarations_test.go
+++ b/internal/generator/pagination_declarations_test.go
@@ -84,6 +84,19 @@ func TestGeneratedPaginatedCommandsEmitResponsePath(t *testing.T) {
 	assert.Contains(t, endpointSrc, `"", "payload.has_more", "payload.records", cmd.ErrOrStderr())`)
 	requireGeneratedCompiles(t, outputDir)
 
+	apiSpec.Learn.Disabled = true
+	apiSpec.Learn.Enabled = false
+	apiSpec.Learn.EnabledSet = false
+	noStoreOutputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	noStoreGen := New(apiSpec, noStoreOutputDir)
+	noStoreGen.VisionSet = VisionTemplateSet{MCP: true}
+	require.NoError(t, noStoreGen.Generate())
+	noStorePromotedSrc := readGeneratedFile(t, noStoreOutputDir, "internal", "cli", "promoted_items.go")
+	assert.Contains(t, noStorePromotedSrc, `paginatedGetWithResponsePath(cmd.Context(), c, path`)
+	noStoreEndpointSrc := readGeneratedFile(t, noStoreOutputDir, "internal", "cli", "catalog_lookup.go")
+	assert.Contains(t, noStoreEndpointSrc, `paginatedGetWithResponsePath(cmd.Context(), c, path`)
+	requireGeneratedCompiles(t, noStoreOutputDir)
+
 	behaviorTest := `package cli
 
 import (
@@ -128,6 +141,22 @@ func TestPaginatedResponsePathAggregatesPages(t *testing.T) {
     }
     if len(client.params) != 2 || client.params[1]["after"] != "token-2" {
         t.Fatalf("params = %#v, want the declared nested cursor on page two", client.params)
+    }
+
+    client.responses = []json.RawMessage{
+        json.RawMessage("{\"results\":[{\"id\":\"item-single\"}],\"paging\":{\"next\":{\"after\":\"token-ignored\"}}}"),
+    }
+    client.params = nil
+    data, err = paginatedGetWithResponsePath(context.Background(), client, "/items", nil, nil, false, "after", "cursor", "limit", 100, "paging.next.after", "", "results")
+    if err != nil {
+        t.Fatalf("single-page paginatedGetWithResponsePath: %v", err)
+    }
+    var page []map[string]string
+    if err := json.Unmarshal(data, &page); err != nil {
+        t.Fatalf("decode single projected page: %v; data=%s", err, data)
+    }
+    if len(page) != 1 || page[0]["id"] != "item-single" {
+        t.Fatalf("single page = %#v, want response_path projection", page)
     }
 }
 `

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -390,7 +390,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				return fmt.Errorf("no local data source for this command; use --data-source live or --data-source auto")
 			}
 {{- end}}
-			data, err := paginatedGet(cmd.Context(), c, path, map[string]string{
+			data, err := paginatedGetWithResponsePath(cmd.Context(), c, path, map[string]string{
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -381,7 +381,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{if eq .Endpoint.ResponseFormat "html"}}false, {{end}}cmd.ErrOrStderr())
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{printf "%q" .Endpoint.ResponsePath}}, {{if eq .Endpoint.ResponseFormat "html"}}false, {{end}}cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")
@@ -399,7 +399,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll && !flags.dryRun, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll && !flags.dryRun, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{printf "%q" .Endpoint.ResponsePath}})
 {{- end}}
 {{- else}}
 			params := map[string]string{}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -252,7 +252,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				return fmt.Errorf("no local data source for this command; use --data-source live or --data-source auto")
 			}
 {{- end}}
-			data, err := paginatedGet(cmd.Context(), c, path, map[string]string{
+			data, err := paginatedGetWithResponsePath(cmd.Context(), c, path, map[string]string{
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -243,7 +243,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{if eq .Endpoint.ResponseFormat "html"}}false, {{end}}cmd.ErrOrStderr())
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{printf "%q" .Endpoint.ResponsePath}}, {{if eq .Endpoint.ResponseFormat "html"}}false, {{end}}cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")
@@ -261,7 +261,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll && !flags.dryRun, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll && !flags.dryRun, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{printf "%q" .Endpoint.ResponsePath}})
 {{- end}}
 {{- else}}
 {{- if not $deleteBodyWithoutParams}}

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -224,14 +224,14 @@ func resolveReadWithStrategyResponsePathAndJSONGuard(ctx context.Context, c *cli
 // headers argument carries per-endpoint required headers; pass nil when the
 // endpoint declares no overrides.
 func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
-	return resolvePaginatedReadWithStrategy(ctx, c, flags, "auto", resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, hintWriter)
+	return resolvePaginatedReadWithStrategy(ctx, c, flags, "auto", resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, "", hintWriter)
 }
 
-func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
-	return resolvePaginatedReadWithStrategyAndJSONGuard(ctx, c, flags, strategy, resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, true, hintWriter)
+func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+	return resolvePaginatedReadWithStrategyAndJSONGuard(ctx, c, flags, strategy, resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath, true, hintWriter)
 }
 
-func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string, guardLiveJSON bool, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string, guardLiveJSON bool, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
 	if err := validateDataSourceStrategy(flags, strategy); err != nil {
 		return nil, DataProvenance{}, err
 	}
@@ -246,7 +246,7 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		if !guardLiveJSON && fetchAll {
 			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
 		}
-		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
+		data, err := paginatedGetWithResponsePath(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath)
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
@@ -269,7 +269,7 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		if !guardLiveJSON && fetchAll {
 			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
 		}
-		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
+		data, err := paginatedGetWithResponsePath(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath)
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
@@ -287,7 +287,7 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		if !guardLiveJSON && fetchAll {
 			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all or use --data-source local")
 		}
-		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
+		data, err := paginatedGetWithResponsePath(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath)
 		if err == nil {
 			if isDryRunResponse(c.IsDryRun(), data) {
 				return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1111,6 +1111,55 @@ func replacePathParam(path, name, value string) string {
 }
 {{- end}}
 
+const responsePathItemsKey = "__printing_press_response_path_items"
+
+type responsePathPaginatedClient struct {
+	client interface {
+		GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+	}
+	responsePath string
+}
+
+func (c responsePathPaginatedClient) IsDryRun() bool {
+	dryRunClient, ok := c.client.(interface{ IsDryRun() bool })
+	return ok && dryRunClient.IsDryRun()
+}
+
+func (c responsePathPaginatedClient) GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	data, err := c.client.GetWithHeaders(ctx, path, params, headers)
+	if err != nil || isDryRunResponseForClient(c.client, data) {
+		return data, err
+	}
+	selected, ok := responsePayloadAtPath(data, c.responsePath)
+	if !ok {
+		return data, nil
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		return data, nil
+	}
+	root[responsePathItemsKey] = selected
+	transformed, err := json.Marshal(root)
+	if err != nil {
+		return data, nil
+	}
+	return transformed, nil
+}
+
+func paginatedGetWithResponsePath(ctx context.Context, c interface {
+	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+}, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string) (json.RawMessage, error) {
+	if responsePath == "" {
+		return paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
+	}
+	wrapped := responsePathPaginatedClient{client: c, responsePath: responsePath}
+	data, err := paginatedGet(ctx, wrapped, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
+	if err != nil || fetchAll {
+		return data, err
+	}
+	return applyResponsePath(data, responsePath), nil
+}
+
 // paginatedGet fetches pages and concatenates array results. The headers
 // argument carries per-endpoint required headers (e.g. cal-api-version) that
 // must be sent on every page request, including the first; pass nil when the
@@ -1378,6 +1427,7 @@ func isJSONArray(raw json.RawMessage) bool {
 }
 
 var canonicalPaginationCollectionKeys = map[string]bool{
+	responsePathItemsKey: true,
 	"data": true, "items": true, "results": true, "messages": true, "members": true, "values": true,
 }
 
@@ -1583,7 +1633,7 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath
 	}
 
 	if allowEmbedded {
-		for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
+		for _, field := range []string{responsePathItemsKey, "data", "items", "results", "messages", "members", "values"} {
 			if arr, ok := obj[field]; ok {
 				var nested []json.RawMessage
 				if json.Unmarshal(arr, &nested) == nil {

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1132,16 +1132,19 @@ func (c responsePathPaginatedClient) GetWithHeaders(ctx context.Context, path st
 	}
 	selected, ok := responsePayloadAtPath(data, c.responsePath)
 	if !ok {
-		return data, nil
+		return nil, fmt.Errorf("response_path %q not found in response", c.responsePath)
+	}
+	if !isJSONArray(selected) {
+		return nil, fmt.Errorf("response_path %q must resolve to an array", c.responsePath)
 	}
 	var root map[string]json.RawMessage
 	if err := json.Unmarshal(data, &root); err != nil {
-		return data, nil
+		return nil, fmt.Errorf("response_path %q requires an object response envelope: %w", c.responsePath, err)
 	}
 	root[responsePathItemsKey] = selected
 	transformed, err := json.Marshal(root)
 	if err != nil {
-		return data, nil
+		return nil, fmt.Errorf("wrap response_path %q: %w", c.responsePath, err)
 	}
 	return transformed, nil
 }

--- a/internal/pipeline/fixloop.go
+++ b/internal/pipeline/fixloop.go
@@ -176,7 +176,9 @@ func applyFix(fix Fix, dir string) error {
 	var target string
 	switch method {
 	case "GET":
-		if strings.Contains(src, "data, err := paginatedGet(") {
+		if strings.Contains(src, "data, err := paginatedGetWithResponsePath(") {
+			target = "data, err := paginatedGetWithResponsePath("
+		} else if strings.Contains(src, "data, err := paginatedGet(") {
 			target = "data, err := paginatedGet("
 		} else {
 			target = "data, err := c.Get("
@@ -278,7 +280,7 @@ func detectHTTPMethod(src string) string {
 			return strings.ToUpper(candidate)
 		}
 	}
-	if strings.Contains(src, "paginatedGet(") {
+	if strings.Contains(src, "paginatedGetWithResponsePath(") || strings.Contains(src, "paginatedGet(") {
 		return "GET"
 	}
 	return ""

--- a/internal/pipeline/fixloop_test.go
+++ b/internal/pipeline/fixloop_test.go
@@ -1,0 +1,35 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyFixRecognizesResponsePathPagination(t *testing.T) {
+	t.Parallel()
+
+	cliDir := filepath.Join(t.TempDir(), "internal", "cli")
+	require.NoError(t, os.MkdirAll(cliDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "helpers.go"), []byte("func printDryRun() {}\n"), 0o644))
+	commandPath := filepath.Join(cliDir, "items.go")
+	require.NoError(t, os.WriteFile(commandPath, []byte(`package cli
+
+func run() error {
+	data, err := paginatedGetWithResponsePath(cmd.Context(), c, path, map[string]string{}, nil, flagAll, "cursor", "cursor", "limit", 100, "", "", "results")
+	return data, err
+}
+`), 0o644))
+
+	require.NoError(t, applyFix(Fix{Issue: "dryrun_fail", File: commandPath}, filepath.Dir(filepath.Dir(cliDir))))
+	updated, err := os.ReadFile(commandPath)
+	require.NoError(t, err)
+	require.Contains(t, string(updated), `if flags.dryRun {
+			method := "GET"
+			return printDryRun(cmd, method, path)
+		}
+
+			data, err := paginatedGetWithResponsePath(`)
+}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -3002,6 +3002,44 @@ type Pagination struct {
 	HasMoreField   string `yaml:"has_more_field" json:"has_more_field"`     // response field indicating more pages (has_more)
 }
 
+type paginationWire struct {
+	Type           string `yaml:"type" json:"type"`
+	LimitParam     string `yaml:"limit_param" json:"limit_param"`
+	CursorParam    string `yaml:"cursor_param" json:"cursor_param"`
+	NextCursorPath string `yaml:"next_cursor_path" json:"next_cursor_path"`
+	CursorField    string `yaml:"cursor_field" json:"cursor_field"`
+	HasMoreField   string `yaml:"has_more_field" json:"has_more_field"`
+}
+
+func (p *Pagination) UnmarshalYAML(value *yaml.Node) error {
+	var wire paginationWire
+	if err := value.Decode(&wire); err != nil {
+		return err
+	}
+	p.assignPaginationWire(wire)
+	return nil
+}
+
+func (p *Pagination) UnmarshalJSON(data []byte) error {
+	var wire paginationWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	p.assignPaginationWire(wire)
+	return nil
+}
+
+func (p *Pagination) assignPaginationWire(wire paginationWire) {
+	p.Type = wire.Type
+	p.LimitParam = wire.LimitParam
+	p.CursorParam = wire.CursorParam
+	p.NextCursorPath = wire.NextCursorPath
+	if p.NextCursorPath == "" {
+		p.NextCursorPath = wire.CursorField
+	}
+	p.HasMoreField = wire.HasMoreField
+}
+
 // QuerySyncConfig declares the SQL-query-endpoint sync shape: an API where every
 // list resource is read through one shared endpoint with an injected SELECT-style
 // query, results wrapped in an entity-named envelope, and paging carried inside

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -190,6 +190,39 @@ resources:
 	assert.Equal(t, "per_page", list.Pagination.LimitParam)
 }
 
+func TestParsePaginationCursorFieldAlias(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`
+name: cursor-pagination
+base_url: https://api.example.com
+auth:
+  type: none
+resources:
+  contacts:
+    endpoints:
+      list:
+        method: GET
+        path: /contacts
+        response:
+          type: array
+          item: Contact
+        response_path: results
+        pagination:
+          type: cursor
+          cursor_param: after
+          cursor_field: paging.next.after
+          limit_param: limit
+`)
+	s, err := ParseBytes(yamlSpec)
+	require.NoError(t, err)
+
+	list := s.Resources["contacts"].Endpoints["list"]
+	require.NotNil(t, list.Pagination)
+	assert.Equal(t, "paging.next.after", list.Pagination.NextCursorPath)
+	assert.Equal(t, "results", list.ResponsePath)
+}
+
 func TestParseEndpointExampleAndHappyArgs(t *testing.T) {
 	t.Parallel()
 

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -557,6 +557,55 @@ func replacePathParam(path, name, value string) string {
 	return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(value))
 }
 
+const responsePathItemsKey = "__printing_press_response_path_items"
+
+type responsePathPaginatedClient struct {
+	client interface {
+		GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+	}
+	responsePath string
+}
+
+func (c responsePathPaginatedClient) IsDryRun() bool {
+	dryRunClient, ok := c.client.(interface{ IsDryRun() bool })
+	return ok && dryRunClient.IsDryRun()
+}
+
+func (c responsePathPaginatedClient) GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	data, err := c.client.GetWithHeaders(ctx, path, params, headers)
+	if err != nil || isDryRunResponseForClient(c.client, data) {
+		return data, err
+	}
+	selected, ok := responsePayloadAtPath(data, c.responsePath)
+	if !ok {
+		return data, nil
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		return data, nil
+	}
+	root[responsePathItemsKey] = selected
+	transformed, err := json.Marshal(root)
+	if err != nil {
+		return data, nil
+	}
+	return transformed, nil
+}
+
+func paginatedGetWithResponsePath(ctx context.Context, c interface {
+	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+}, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string) (json.RawMessage, error) {
+	if responsePath == "" {
+		return paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
+	}
+	wrapped := responsePathPaginatedClient{client: c, responsePath: responsePath}
+	data, err := paginatedGet(ctx, wrapped, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
+	if err != nil || fetchAll {
+		return data, err
+	}
+	return applyResponsePath(data, responsePath), nil
+}
+
 // paginatedGet fetches pages and concatenates array results. The headers
 // argument carries per-endpoint required headers (e.g. cal-api-version) that
 // must be sent on every page request, including the first; pass nil when the
@@ -824,7 +873,8 @@ func isJSONArray(raw json.RawMessage) bool {
 }
 
 var canonicalPaginationCollectionKeys = map[string]bool{
-	"data": true, "items": true, "results": true, "messages": true, "members": true, "values": true,
+	responsePathItemsKey: true,
+	"data":               true, "items": true, "results": true, "messages": true, "members": true, "values": true,
 }
 
 func deleteRawPath(obj map[string]json.RawMessage, path string) {
@@ -1029,7 +1079,7 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath
 	}
 
 	if allowEmbedded {
-		for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
+		for _, field := range []string{responsePathItemsKey, "data", "items", "results", "messages", "members", "values"} {
 			if arr, ok := obj[field]; ok {
 				var nested []json.RawMessage
 				if json.Unmarshal(arr, &nested) == nil {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -578,16 +578,19 @@ func (c responsePathPaginatedClient) GetWithHeaders(ctx context.Context, path st
 	}
 	selected, ok := responsePayloadAtPath(data, c.responsePath)
 	if !ok {
-		return data, nil
+		return nil, fmt.Errorf("response_path %q not found in response", c.responsePath)
+	}
+	if !isJSONArray(selected) {
+		return nil, fmt.Errorf("response_path %q must resolve to an array", c.responsePath)
 	}
 	var root map[string]json.RawMessage
 	if err := json.Unmarshal(data, &root); err != nil {
-		return data, nil
+		return nil, fmt.Errorf("response_path %q requires an object response envelope: %w", c.responsePath, err)
 	}
 	root[responsePathItemsKey] = selected
 	transformed, err := json.Marshal(root)
 	if err != nil {
-		return data, nil
+		return nil, fmt.Errorf("wrap response_path %q: %w", c.responsePath, err)
 	}
 	return transformed, nil
 }

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -571,16 +571,19 @@ func (c responsePathPaginatedClient) GetWithHeaders(ctx context.Context, path st
 	}
 	selected, ok := responsePayloadAtPath(data, c.responsePath)
 	if !ok {
-		return data, nil
+		return nil, fmt.Errorf("response_path %q not found in response", c.responsePath)
+	}
+	if !isJSONArray(selected) {
+		return nil, fmt.Errorf("response_path %q must resolve to an array", c.responsePath)
 	}
 	var root map[string]json.RawMessage
 	if err := json.Unmarshal(data, &root); err != nil {
-		return data, nil
+		return nil, fmt.Errorf("response_path %q requires an object response envelope: %w", c.responsePath, err)
 	}
 	root[responsePathItemsKey] = selected
 	transformed, err := json.Marshal(root)
 	if err != nil {
-		return data, nil
+		return nil, fmt.Errorf("wrap response_path %q: %w", c.responsePath, err)
 	}
 	return transformed, nil
 }

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -550,6 +550,55 @@ func newTabWriter(w io.Writer) *tabwriter.Writer {
 	return tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
 }
 
+const responsePathItemsKey = "__printing_press_response_path_items"
+
+type responsePathPaginatedClient struct {
+	client interface {
+		GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+	}
+	responsePath string
+}
+
+func (c responsePathPaginatedClient) IsDryRun() bool {
+	dryRunClient, ok := c.client.(interface{ IsDryRun() bool })
+	return ok && dryRunClient.IsDryRun()
+}
+
+func (c responsePathPaginatedClient) GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	data, err := c.client.GetWithHeaders(ctx, path, params, headers)
+	if err != nil || isDryRunResponseForClient(c.client, data) {
+		return data, err
+	}
+	selected, ok := responsePayloadAtPath(data, c.responsePath)
+	if !ok {
+		return data, nil
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		return data, nil
+	}
+	root[responsePathItemsKey] = selected
+	transformed, err := json.Marshal(root)
+	if err != nil {
+		return data, nil
+	}
+	return transformed, nil
+}
+
+func paginatedGetWithResponsePath(ctx context.Context, c interface {
+	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+}, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string) (json.RawMessage, error) {
+	if responsePath == "" {
+		return paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
+	}
+	wrapped := responsePathPaginatedClient{client: c, responsePath: responsePath}
+	data, err := paginatedGet(ctx, wrapped, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
+	if err != nil || fetchAll {
+		return data, err
+	}
+	return applyResponsePath(data, responsePath), nil
+}
+
 // paginatedGet fetches pages and concatenates array results. The headers
 // argument carries per-endpoint required headers (e.g. cal-api-version) that
 // must be sent on every page request, including the first; pass nil when the
@@ -817,7 +866,8 @@ func isJSONArray(raw json.RawMessage) bool {
 }
 
 var canonicalPaginationCollectionKeys = map[string]bool{
-	"data": true, "items": true, "results": true, "messages": true, "members": true, "values": true,
+	responsePathItemsKey: true,
+	"data":               true, "items": true, "results": true, "messages": true, "members": true, "values": true,
 }
 
 func deleteRawPath(obj map[string]json.RawMessage, path string) {
@@ -1022,7 +1072,7 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath
 	}
 
 	if allowEmbedded {
-		for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
+		for _, field := range []string{responsePathItemsKey, "data", "items", "results", "messages", "members", "values"} {
 			if arr, ok := obj[field]; ok {
 				var nested []json.RawMessage
 				if json.Unmarshal(arr, &nested) == nil {

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 83
+    "total": 84
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -224,14 +224,14 @@ func resolveReadWithStrategyResponsePathAndJSONGuard(ctx context.Context, c *cli
 // headers argument carries per-endpoint required headers; pass nil when the
 // endpoint declares no overrides.
 func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
-	return resolvePaginatedReadWithStrategy(ctx, c, flags, "auto", resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, hintWriter)
+	return resolvePaginatedReadWithStrategy(ctx, c, flags, "auto", resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, "", hintWriter)
 }
 
-func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
-	return resolvePaginatedReadWithStrategyAndJSONGuard(ctx, c, flags, strategy, resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, true, hintWriter)
+func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+	return resolvePaginatedReadWithStrategyAndJSONGuard(ctx, c, flags, strategy, resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath, true, hintWriter)
 }
 
-func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string, guardLiveJSON bool, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string, guardLiveJSON bool, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
 	if err := validateDataSourceStrategy(flags, strategy); err != nil {
 		return nil, DataProvenance{}, err
 	}
@@ -246,7 +246,7 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		if !guardLiveJSON && fetchAll {
 			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
 		}
-		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
+		data, err := paginatedGetWithResponsePath(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath)
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
@@ -269,7 +269,7 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		if !guardLiveJSON && fetchAll {
 			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
 		}
-		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
+		data, err := paginatedGetWithResponsePath(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath)
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
@@ -287,7 +287,7 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		if !guardLiveJSON && fetchAll {
 			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all or use --data-source local")
 		}
-		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
+		data, err := paginatedGetWithResponsePath(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath)
 		if err == nil {
 			if isDryRunResponse(c.IsDryRun(), data) {
 				return data, attachFreshness(DataProvenance{Source: "dry-run"}, flags), nil

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -634,6 +634,55 @@ func replacePathParam(path, name, value string) string {
 	return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(value))
 }
 
+const responsePathItemsKey = "__printing_press_response_path_items"
+
+type responsePathPaginatedClient struct {
+	client interface {
+		GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+	}
+	responsePath string
+}
+
+func (c responsePathPaginatedClient) IsDryRun() bool {
+	dryRunClient, ok := c.client.(interface{ IsDryRun() bool })
+	return ok && dryRunClient.IsDryRun()
+}
+
+func (c responsePathPaginatedClient) GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	data, err := c.client.GetWithHeaders(ctx, path, params, headers)
+	if err != nil || isDryRunResponseForClient(c.client, data) {
+		return data, err
+	}
+	selected, ok := responsePayloadAtPath(data, c.responsePath)
+	if !ok {
+		return data, nil
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		return data, nil
+	}
+	root[responsePathItemsKey] = selected
+	transformed, err := json.Marshal(root)
+	if err != nil {
+		return data, nil
+	}
+	return transformed, nil
+}
+
+func paginatedGetWithResponsePath(ctx context.Context, c interface {
+	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+}, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string) (json.RawMessage, error) {
+	if responsePath == "" {
+		return paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
+	}
+	wrapped := responsePathPaginatedClient{client: c, responsePath: responsePath}
+	data, err := paginatedGet(ctx, wrapped, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField)
+	if err != nil || fetchAll {
+		return data, err
+	}
+	return applyResponsePath(data, responsePath), nil
+}
+
 // paginatedGet fetches pages and concatenates array results. The headers
 // argument carries per-endpoint required headers (e.g. cal-api-version) that
 // must be sent on every page request, including the first; pass nil when the
@@ -901,7 +950,8 @@ func isJSONArray(raw json.RawMessage) bool {
 }
 
 var canonicalPaginationCollectionKeys = map[string]bool{
-	"data": true, "items": true, "results": true, "messages": true, "members": true, "values": true,
+	responsePathItemsKey: true,
+	"data":               true, "items": true, "results": true, "messages": true, "members": true, "values": true,
 }
 
 func deleteRawPath(obj map[string]json.RawMessage, path string) {
@@ -1106,7 +1156,7 @@ func extractPaginatedItemsFromObject(obj map[string]json.RawMessage, requestPath
 	}
 
 	if allowEmbedded {
-		for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
+		for _, field := range []string{responsePathItemsKey, "data", "items", "results", "messages", "members", "values"} {
 			if arr, ok := obj[field]; ok {
 				var nested []json.RawMessage
 				if json.Unmarshal(arr, &nested) == nil {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -655,16 +655,19 @@ func (c responsePathPaginatedClient) GetWithHeaders(ctx context.Context, path st
 	}
 	selected, ok := responsePayloadAtPath(data, c.responsePath)
 	if !ok {
-		return data, nil
+		return nil, fmt.Errorf("response_path %q not found in response", c.responsePath)
+	}
+	if !isJSONArray(selected) {
+		return nil, fmt.Errorf("response_path %q must resolve to an array", c.responsePath)
 	}
 	var root map[string]json.RawMessage
 	if err := json.Unmarshal(data, &root); err != nil {
-		return data, nil
+		return nil, fmt.Errorf("response_path %q requires an object response envelope: %w", c.responsePath, err)
 	}
 	root[responsePathItemsKey] = selected
 	transformed, err := json.Marshal(root)
 	if err != nil {
-		return data, nil
+		return nil, fmt.Errorf("wrap response_path %q: %w", c.responsePath, err)
 	}
 	return transformed, nil
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
@@ -53,7 +53,7 @@ func newProjectsListCmd(flags *rootFlags) *cobra.Command {
 				"status": formatCLIParamValue(flagStatus),
 				"limit":  formatCLIParamValue(flagLimit),
 				"cursor": formatCLIParamValue(flagCursor),
-			}, headerOverrides, flagAll, "cursor", "cursor", "limit", 25, "", "", cmd.ErrOrStderr())
+			}, headerOverrides, flagAll, "cursor", "cursor", "limit", 25, "", "", "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
@@ -73,7 +73,7 @@ func newProjectsTasksListProjectCmd(flags *rootFlags) *cobra.Command {
 				"priority": formatCLIParamValue(flagPriority),
 				"limit":    formatCLIParamValue(flagLimit),
 				"cursor":   formatCLIParamValue(flagCursor),
-			}, headerOverrides, flagAll, "cursor", "cursor", "limit", 50, "", "", cmd.ErrOrStderr())
+			}, headerOverrides, flagAll, "cursor", "cursor", "limit", 50, "", "", "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_list.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_list.go
@@ -26,7 +26,7 @@ func newItemsListCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			c = c.WithTier("free")
-			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "auto", "items", path, map[string]string{}, nil, flagAll, "cursor", "cursor", "limit", 100, "", "", cmd.ErrOrStderr())
+			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "auto", "items", path, map[string]string{}, nil, flagAll, "cursor", "cursor", "limit", 100, "", "", "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}


### PR DESCRIPTION
## Intent

Issue:
- Closes #3782
- Closes #3801

Paginated list reads now preserve declared response paths and cursor fields, so wrapped responses advance across pages and return the declared collection instead of falling back to heuristic extraction.

## Approach

The internal spec parser normalizes `pagination.cursor_field` into the existing cursor-path representation while preserving an explicit `next_cursor_path`. Generated promoted and endpoint commands thread `response_path` through store-backed and direct paginated reads. The generated helper projects each page for aggregation while resolving cursor and has-more metadata from the original response envelope.

## Scope

Primary area: generator templates, internal spec pagination parsing, generated pagination helpers, pipeline fix-loop detection, and their tests and golden fixtures.

Why this belongs in this repo: this is a Printing Press generator contract issue affecting future printed CLIs, not an API-specific printed-CLI repair.

## Risk

This changes generated paginated reads for endpoints with response envelopes. Empty response paths continue to use the existing pagination behavior, and the generated runtime test covers nested cursor metadata across multiple pages plus single-page response-path extraction. The change does not intentionally alter auth, MCP, publish, or release behavior.

## Output Contract

Generated paginated helper call sites now carry `response_path`, including promoted and endpoint-specific store and no-store paths. Coverage includes parser assertions, emitted-code assertions, compiled generated CLIs, runtime aggregation and single-page tests, fix-loop detection, and updated golden output.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions and compiled generated CLI output
- [x] Generator/template change: covered the affected fallback and variant shapes, including store and no-store promoted and endpoint paths
- [x] Generator/template change: checked emitted definitions and call sites for matching gates
- `go test ./internal/generator -run 'TestGenerateBinaryPaginatedPromoted|TestGeneratedPaginatedCommandsEmitResponsePath' -count=1`
- `go test ./internal/pipeline -run TestApplyFixRecognizesResponsePathPagination -count=1`
- isolated `go test ./internal/pipeline -count=1 -p=1`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...` was attempted; the relevant package tests pass under isolated profiles, while the shared workspace run was affected by home-directory database schema output and concurrent pipeline contract state
- `golangci-lint run ./...` was attempted; it reported one pre-existing `modernize` warning in `internal/googlediscovery/parser.go:455`, outside this change
