### PR TITLE
fix(cli): recognize MongoDB _id as a stable store identifier

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -5606,6 +5606,12 @@ func TestExtractObjectIDPascalCaseIdWinsOverUppercaseID(t *testing.T) {
 		t.Fatalf("PascalCase Id must precede uppercase ID: got %q", got)
 	}
 }
+
+func TestExtractObjectIDMongoID(t *testing.T) {
+	if got := extractObjectID(map[string]any{"_id": "mongo-1", "name": "Jack's"}); got != "mongo-1" {
+		t.Fatalf("MongoDB _id must precede display name: got %q", got)
+	}
+}
 `
 	storeTestPath := filepath.Join(outputDir, "internal", "store", "store_pascalcase_test.go")
 	require.NoError(t, os.WriteFile(storeTestPath, []byte(storeInlineTest), 0o644))
@@ -15591,7 +15597,7 @@ func TestGeneratedSyncIDFieldOverridesAndProbes(t *testing.T) {
 	// Vendor identifiers (gid, sid, uid, uuid, guid) and resource-specific
 	// suffixes precede descriptive fields so APIs do not key rows by names.
 	assert.Contains(t, storeContent,
-		`var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id"}`,
+		`var genericIDFieldFallbacks = []string{"id", "ID", "_id", "gid", "sid", "uid", "uuid", "guid", "api_id"}`,
 		"store.go genericIDFieldFallbacks must include stable vendor identifiers")
 	assert.Contains(t, storeContent,
 		`var genericDescriptiveIDFieldFallbacks = []string{"name", "slug", "key", "code"}`,

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -6433,6 +6433,76 @@ func TestWriteThroughCachePopulatesTypedTable(t *testing.T) {
 	runGoCommandRequired(t, outputDir, "test", "-run", "TestWriteThroughCachePopulatesTypedTable", "./internal/cli")
 }
 
+// TestGeneratedTypedSingleObjectSkipsEmptyIDForMongoFallback guards the
+// typed single-object path: an empty or null canonical id must not prevent a
+// valid MongoDB _id from being normalized and used as the row key.
+func TestGeneratedTypedSingleObjectSkipsEmptyIDForMongoFallback(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := adsCampaignSpec()
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, MCP: true}
+	require.NoError(t, gen.Generate())
+
+	inlineTest := `package cli
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"` + naming.CLI(apiSpec.Name) + `/internal/store"
+)
+
+func TestUpsertSingleObjectSkipsEmptyIDForMongoFallback(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open cache store: %v", err)
+	}
+	defer db.Close()
+
+	cases := []struct {
+		name string
+		data string
+		want string
+	}{
+		{
+			name: "empty id",
+			data: "{\"id\":\"\",\"_id\":{\"$oid\":\"mongo-empty\"},\"name\":\"Empty\"}",
+			want: "mongo-empty",
+		},
+		{
+			name: "null id",
+			data: "{\"id\":null,\"_id\":\"mongo-null\",\"name\":\"Null\"}",
+			want: "mongo-null",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := upsertSingleObject(db, "campaigns", json.RawMessage(tc.data)); err != nil {
+				t.Fatalf("upsertSingleObject: %v", err)
+			}
+
+			var count int
+			if err := db.DB().QueryRow("SELECT COUNT(*) FROM campaigns WHERE id = ?", tc.want).Scan(&count); err != nil {
+				t.Fatalf("query typed campaigns: %v", err)
+			}
+			if count != 1 {
+				t.Fatalf("typed campaigns for %q = %d, want 1", tc.want, count)
+			}
+		})
+	}
+}
+`
+	testPath := filepath.Join(outputDir, "internal", "cli", "typed_single_object_id_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommandRequired(t, outputDir, "test", "-run", "TestUpsertSingleObjectSkipsEmptyIDForMongoFallback", "./internal/cli")
+}
+
 // TestWriteThroughCacheNonIDPrimaryKeyResponse guards #1439: the previous
 // `envelope["id"]` guard silently dropped single-object detail responses
 // whose primary key field was named anything other than "id" (PCGS uses

--- a/internal/generator/sync_store_template_fixes_test.go
+++ b/internal/generator/sync_store_template_fixes_test.go
@@ -96,6 +96,16 @@ import (
 )
 
 func TestCurrencyCodeSuffixExtractsResourceID(t *testing.T) {
+	if got := ExtractResourceID("spots", map[string]any{"_id": "mongo-1"}); got != "mongo-1" {
+		t.Fatalf("MongoDB _id fallback = %q, want mongo-1", got)
+	}
+	if got := ExtractResourceID("spots", map[string]any{"_id": map[string]any{"$oid": "mongo-object-1"}, "name": "Jack's"}); got != "mongo-object-1" {
+		t.Fatalf("MongoDB Extended JSON _id fallback = %q, want mongo-object-1", got)
+	}
+	if got := ExtractResourceID("spots", map[string]any{"id": "canonical-1", "name": "Jack's"}); got != "canonical-1" {
+		t.Fatalf("stable id must win over display name, got %q", got)
+	}
+
 	obj := map[string]any{"currency_code": "USD", "name": "US Dollar"}
 	if got := ExtractResourceID("currencies", obj); got != "USD" {
 		t.Fatalf("resource-specific id must win over display name, got %q", got)
@@ -164,6 +174,26 @@ func TestCurrencyCodeSuffixExtractsResourceID(t *testing.T) {
 	}
 	if len(rows) != 1 {
 		t.Fatalf("stored rows = %d, want 1", len(rows))
+	}
+
+	items = []json.RawMessage{
+		json.RawMessage(` + "`" + `{"_id":"spot-1","name":"Jack's"}` + "`" + `),
+		json.RawMessage(` + "`" + `{"_id":"spot-2","name":"Jack's"}` + "`" + `),
+		json.RawMessage(` + "`" + `{"_id":{"$oid":"spot-3"},"name":"Jack's"}` + "`" + `),
+	}
+	stored, failures, err = db.UpsertBatch("spots", items)
+	if err != nil {
+		t.Fatalf("upsert MongoDB rows: %v", err)
+	}
+	if stored != 3 || failures != 0 {
+		t.Fatalf("MongoDB stored/failures = %d/%d, want 3/0", stored, failures)
+	}
+	rows, err = db.List("spots", 10)
+	if err != nil {
+		t.Fatalf("list spots: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("MongoDB rows = %d, want 3 distinct rows", len(rows))
 	}
 }
 `

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1274,7 +1274,7 @@ func ftsMatchQuery(query string) string {
 }
 
 func extractObjectID(obj map[string]any) string {
-	for _, key := range []string{"id", "Id", "ID", "uuid", "slug", "name"} {
+	for _, key := range []string{"id", "Id", "ID", "_id", "uuid", "slug", "name"} {
 		if v, ok := obj[key]; ok {
 			return ResourceIDString(v)
 		}
@@ -1365,6 +1365,10 @@ func ResourceIDString(v any) string {
 	switch t := v.(type) {
 	case nil:
 		return ""
+	case string:
+		return extendedJSONIDString(t)
+	case map[string]any:
+		return extendedJSONIDMapString(t)
 	case json.Number:
 		return strings.TrimSpace(t.String())
 	case float64:
@@ -1383,6 +1387,30 @@ func ResourceIDString(v any) string {
 		// that sentinel so unresolved IDs do not become stored resource keys.
 		return strings.TrimSpace(fmt.Sprint(t))
 	}
+}
+
+func extendedJSONIDString(value string) string {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "{") {
+		return value
+	}
+	var object map[string]any
+	if err := json.Unmarshal([]byte(value), &object); err != nil {
+		return value
+	}
+	if id := extendedJSONIDMapString(object); id != "" {
+		return id
+	}
+	return value
+}
+
+func extendedJSONIDMapString(object map[string]any) string {
+	for _, key := range []string{"$oid", "$numberLong", "$numberInt"} {
+		if value, ok := object[key]; ok {
+			return ResourceIDString(value)
+		}
+	}
+	return ""
 }
 
 {{- range .Tables}}
@@ -1484,7 +1512,7 @@ var resourceIDFieldOverrides = map[string]string{
 // Stable vendor identifiers win first; then fields derived from the resource
 // name (accountId, workspaceId); descriptive fallbacks are last. Keeping name
 // ahead of the resource-specific probe silently keys rows by display labels.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id"}
+var genericIDFieldFallbacks = []string{"id", "ID", "_id", "gid", "sid", "uid", "uuid", "guid", "api_id"}
 var genericDescriptiveIDFieldFallbacks = []string{"name", "slug", "key", "code"}
 
 // resourceIDBaseOverrides preserves the complete final collection name for

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1276,7 +1276,9 @@ func ftsMatchQuery(query string) string {
 func extractObjectID(obj map[string]any) string {
 	for _, key := range []string{"id", "Id", "ID", "_id", "uuid", "slug", "name"} {
 		if v, ok := obj[key]; ok {
-			return ResourceIDString(v)
+			if id := ResourceIDString(v); id != "" && id != "<nil>" {
+				return id
+			}
 		}
 	}
 	return ""

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -185,7 +185,7 @@ func TestUpsertBatch_GenericFallbackList(t *testing.T) {
 	}
 	defer s.Close()
 
-	for _, key := range []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"} {
+	for _, key := range []string{"id", "ID", "_id", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"} {
 		t.Run(key, func(t *testing.T) {
 			rt := "fallback_" + key
 			items := []json.RawMessage{

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -998,7 +998,9 @@ func ftsMatchQuery(query string) string {
 func extractObjectID(obj map[string]any) string {
 	for _, key := range []string{"id", "Id", "ID", "_id", "uuid", "slug", "name"} {
 		if v, ok := obj[key]; ok {
-			return ResourceIDString(v)
+			if id := ResourceIDString(v); id != "" && id != "<nil>" {
+				return id
+			}
 		}
 	}
 	return ""

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -996,7 +996,7 @@ func ftsMatchQuery(query string) string {
 }
 
 func extractObjectID(obj map[string]any) string {
-	for _, key := range []string{"id", "Id", "ID", "uuid", "slug", "name"} {
+	for _, key := range []string{"id", "Id", "ID", "_id", "uuid", "slug", "name"} {
 		if v, ok := obj[key]; ok {
 			return ResourceIDString(v)
 		}
@@ -1087,6 +1087,10 @@ func ResourceIDString(v any) string {
 	switch t := v.(type) {
 	case nil:
 		return ""
+	case string:
+		return extendedJSONIDString(t)
+	case map[string]any:
+		return extendedJSONIDMapString(t)
 	case json.Number:
 		return strings.TrimSpace(t.String())
 	case float64:
@@ -1107,6 +1111,30 @@ func ResourceIDString(v any) string {
 	}
 }
 
+func extendedJSONIDString(value string) string {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "{") {
+		return value
+	}
+	var object map[string]any
+	if err := json.Unmarshal([]byte(value), &object); err != nil {
+		return value
+	}
+	if id := extendedJSONIDMapString(object); id != "" {
+		return id
+	}
+	return value
+}
+
+func extendedJSONIDMapString(object map[string]any) string {
+	for _, key := range []string{"$oid", "$numberLong", "$numberInt"} {
+		if value, ok := object[key]; ok {
+			return ResourceIDString(value)
+		}
+	}
+	return ""
+}
+
 // resourceIDFieldOverrides projects per-resource IDField (set by the profiler
 // from x-resource-id or response-schema fallback) into a runtime lookup map.
 // UpsertBatch consults this first so the templated path wins over the
@@ -1124,7 +1152,7 @@ var resourceIDFieldOverrides = map[string]string{
 // Stable vendor identifiers win first; then fields derived from the resource
 // name (accountId, workspaceId); descriptive fallbacks are last. Keeping name
 // ahead of the resource-specific probe silently keys rows by display labels.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id"}
+var genericIDFieldFallbacks = []string{"id", "ID", "_id", "gid", "sid", "uid", "uuid", "guid", "api_id"}
 var genericDescriptiveIDFieldFallbacks = []string{"name", "slug", "key", "code"}
 
 // resourceIDBaseOverrides preserves the complete final collection name for

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1160,7 +1160,9 @@ func ftsMatchQuery(query string) string {
 func extractObjectID(obj map[string]any) string {
 	for _, key := range []string{"id", "Id", "ID", "_id", "uuid", "slug", "name"} {
 		if v, ok := obj[key]; ok {
-			return ResourceIDString(v)
+			if id := ResourceIDString(v); id != "" && id != "<nil>" {
+				return id
+			}
 		}
 	}
 	return ""

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1158,7 +1158,7 @@ func ftsMatchQuery(query string) string {
 }
 
 func extractObjectID(obj map[string]any) string {
-	for _, key := range []string{"id", "Id", "ID", "uuid", "slug", "name"} {
+	for _, key := range []string{"id", "Id", "ID", "_id", "uuid", "slug", "name"} {
 		if v, ok := obj[key]; ok {
 			return ResourceIDString(v)
 		}
@@ -1249,6 +1249,10 @@ func ResourceIDString(v any) string {
 	switch t := v.(type) {
 	case nil:
 		return ""
+	case string:
+		return extendedJSONIDString(t)
+	case map[string]any:
+		return extendedJSONIDMapString(t)
 	case json.Number:
 		return strings.TrimSpace(t.String())
 	case float64:
@@ -1267,6 +1271,30 @@ func ResourceIDString(v any) string {
 		// that sentinel so unresolved IDs do not become stored resource keys.
 		return strings.TrimSpace(fmt.Sprint(t))
 	}
+}
+
+func extendedJSONIDString(value string) string {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "{") {
+		return value
+	}
+	var object map[string]any
+	if err := json.Unmarshal([]byte(value), &object); err != nil {
+		return value
+	}
+	if id := extendedJSONIDMapString(object); id != "" {
+		return id
+	}
+	return value
+}
+
+func extendedJSONIDMapString(object map[string]any) string {
+	for _, key := range []string{"$oid", "$numberLong", "$numberInt"} {
+		if value, ok := object[key]; ok {
+			return ResourceIDString(value)
+		}
+	}
+	return ""
 }
 
 // upsertLeaguesTx writes the per-resource domain-table portion of a
@@ -1338,7 +1366,7 @@ var resourceIDFieldOverrides = map[string]string{
 // Stable vendor identifiers win first; then fields derived from the resource
 // name (accountId, workspaceId); descriptive fallbacks are last. Keeping name
 // ahead of the resource-specific probe silently keys rows by display labels.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id"}
+var genericIDFieldFallbacks = []string{"id", "ID", "_id", "gid", "sid", "uid", "uuid", "guid", "api_id"}
 var genericDescriptiveIDFieldFallbacks = []string{"name", "slug", "key", "code"}
 
 // resourceIDBaseOverrides preserves the complete final collection name for

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1164,7 +1164,7 @@ func ftsMatchQuery(query string) string {
 }
 
 func extractObjectID(obj map[string]any) string {
-	for _, key := range []string{"id", "Id", "ID", "uuid", "slug", "name"} {
+	for _, key := range []string{"id", "Id", "ID", "_id", "uuid", "slug", "name"} {
 		if v, ok := obj[key]; ok {
 			return ResourceIDString(v)
 		}
@@ -1255,6 +1255,10 @@ func ResourceIDString(v any) string {
 	switch t := v.(type) {
 	case nil:
 		return ""
+	case string:
+		return extendedJSONIDString(t)
+	case map[string]any:
+		return extendedJSONIDMapString(t)
 	case json.Number:
 		return strings.TrimSpace(t.String())
 	case float64:
@@ -1273,6 +1277,30 @@ func ResourceIDString(v any) string {
 		// that sentinel so unresolved IDs do not become stored resource keys.
 		return strings.TrimSpace(fmt.Sprint(t))
 	}
+}
+
+func extendedJSONIDString(value string) string {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "{") {
+		return value
+	}
+	var object map[string]any
+	if err := json.Unmarshal([]byte(value), &object); err != nil {
+		return value
+	}
+	if id := extendedJSONIDMapString(object); id != "" {
+		return id
+	}
+	return value
+}
+
+func extendedJSONIDMapString(object map[string]any) string {
+	for _, key := range []string{"$oid", "$numberLong", "$numberInt"} {
+		if value, ok := object[key]; ok {
+			return ResourceIDString(value)
+		}
+	}
+	return ""
 }
 
 // upsertGadgetsTx writes the per-resource domain-table portion of a
@@ -1394,7 +1422,7 @@ var resourceIDFieldOverrides = map[string]string{}
 // Stable vendor identifiers win first; then fields derived from the resource
 // name (accountId, workspaceId); descriptive fallbacks are last. Keeping name
 // ahead of the resource-specific probe silently keys rows by display labels.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id"}
+var genericIDFieldFallbacks = []string{"id", "ID", "_id", "gid", "sid", "uid", "uuid", "guid", "api_id"}
 var genericDescriptiveIDFieldFallbacks = []string{"name", "slug", "key", "code"}
 
 // resourceIDBaseOverrides preserves the complete final collection name for

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1166,7 +1166,9 @@ func ftsMatchQuery(query string) string {
 func extractObjectID(obj map[string]any) string {
 	for _, key := range []string{"id", "Id", "ID", "_id", "uuid", "slug", "name"} {
 		if v, ok := obj[key]; ok {
-			return ResourceIDString(v)
+			if id := ResourceIDString(v); id != "" && id != "<nil>" {
+				return id
+			}
 		}
 	}
 	return ""

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1160,7 +1160,9 @@ func ftsMatchQuery(query string) string {
 func extractObjectID(obj map[string]any) string {
 	for _, key := range []string{"id", "Id", "ID", "_id", "uuid", "slug", "name"} {
 		if v, ok := obj[key]; ok {
-			return ResourceIDString(v)
+			if id := ResourceIDString(v); id != "" && id != "<nil>" {
+				return id
+			}
 		}
 	}
 	return ""

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1158,7 +1158,7 @@ func ftsMatchQuery(query string) string {
 }
 
 func extractObjectID(obj map[string]any) string {
-	for _, key := range []string{"id", "Id", "ID", "uuid", "slug", "name"} {
+	for _, key := range []string{"id", "Id", "ID", "_id", "uuid", "slug", "name"} {
 		if v, ok := obj[key]; ok {
 			return ResourceIDString(v)
 		}
@@ -1249,6 +1249,10 @@ func ResourceIDString(v any) string {
 	switch t := v.(type) {
 	case nil:
 		return ""
+	case string:
+		return extendedJSONIDString(t)
+	case map[string]any:
+		return extendedJSONIDMapString(t)
 	case json.Number:
 		return strings.TrimSpace(t.String())
 	case float64:
@@ -1267,6 +1271,30 @@ func ResourceIDString(v any) string {
 		// that sentinel so unresolved IDs do not become stored resource keys.
 		return strings.TrimSpace(fmt.Sprint(t))
 	}
+}
+
+func extendedJSONIDString(value string) string {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "{") {
+		return value
+	}
+	var object map[string]any
+	if err := json.Unmarshal([]byte(value), &object); err != nil {
+		return value
+	}
+	if id := extendedJSONIDMapString(object); id != "" {
+		return id
+	}
+	return value
+}
+
+func extendedJSONIDMapString(object map[string]any) string {
+	for _, key := range []string{"$oid", "$numberLong", "$numberInt"} {
+		if value, ok := object[key]; ok {
+			return ResourceIDString(value)
+		}
+	}
+	return ""
 }
 
 // upsertLeaguesTx writes the per-resource domain-table portion of a
@@ -1338,7 +1366,7 @@ var resourceIDFieldOverrides = map[string]string{
 // Stable vendor identifiers win first; then fields derived from the resource
 // name (accountId, workspaceId); descriptive fallbacks are last. Keeping name
 // ahead of the resource-specific probe silently keys rows by display labels.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id"}
+var genericIDFieldFallbacks = []string{"id", "ID", "_id", "gid", "sid", "uid", "uuid", "guid", "api_id"}
 var genericDescriptiveIDFieldFallbacks = []string{"name", "slug", "key", "code"}
 
 // resourceIDBaseOverrides preserves the complete final collection name for


### PR DESCRIPTION
## Intent

Issue: Closes #3844

Generated CLIs now preserve distinct records when an API exposes MongoDB `_id` instead of `id`, rather than silently keying rows by a non-unique display name.

## Approach

The generated store identity contract ranks `_id` with stable identifiers before descriptive fallbacks, and the typed single-object path recognizes it as well. MongoDB Extended JSON wrappers such as `$oid`, `$numberLong`, and `$numberInt` are unwrapped so encoded IDs do not become JSON-blob keys. Generated fallback tests and runtime fixtures cover `_id`, stable-ID-over-name precedence, duplicate names, and Extended JSON.

## Scope

Primary area: Generator store templates and generated-output tests/goldens

Why this belongs in this repo: The bug is in the Printing Press generator contract and affects every future printed CLI whose API uses MongoDB-style identifiers.

## Risk

The generated key-selection behavior changes for future syncs and single-object writes. Existing local databases are not migrated, so previously name-keyed rows may remain until they are recreated or reconciled. No MCP, auth, publish, or release surface changes.

## Output Contract

The emitted store identity helpers and fallback list change intentionally. The four affected golden store outputs were updated, and generated-output verification compiled ten representative generated CLI cases.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions and compiled generated CLI output
- [x] Generator/template change: covered the affected fallback and Extended JSON variants, not only the scalar happy path
- [x] Generator/template change: checked emitted definitions and call sites for matching gates
- `go test ./internal/generator -run '^TestGenerated(SyncStoreBatch4TemplateFixes|SyncIDFieldOverridesAndProbes)$' -count=1`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go fmt ./...`
- `env GOLANGCI_LINT_CACHE=/tmp/pp-fix-batch-lint-3844 golangci-lint run ./internal/generator/...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`

`go test ./...` still has unrelated baseline failures in HTML extraction and paginated response-format tests (`invalid character 'w' looking for beginning of value`). Whole-repo `golangci-lint run ./...` also still reports the pre-existing `internal/googlediscovery/parser.go:455:6` `slicesbackward` finding; the affected generator package passes targeted lint.

## New concepts

MongoDB Extended JSON represents BSON values as wrapper objects such as `{"$oid":"..."}`. The generated identity normalizer unwraps only known ID wrappers, while preserving ordinary scalar IDs. This handling belongs at the identity boundary because arbitrary object fields should not become primary keys.
