### PR TITLE
fix(cli): remove generated 1Password resolver coupling

### DIFF
--- a/internal/generator/platform_credential_resolver_test.go
+++ b/internal/generator/platform_credential_resolver_test.go
@@ -1,0 +1,313 @@
+package generator
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedPlatformCredentialResolverContract(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("provider-neutral-resolver")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	generatedFiles := []string{
+		"internal/platform/profile.go",
+		"internal/platform/conformance_test.go",
+		"internal/cli/platform_client.go",
+		"internal/cli/platform_cli_test.go",
+		"AGENTS.md",
+	}
+	for _, relativePath := range generatedFiles {
+		generated := readGeneratedFile(t, outputDir, relativePath)
+		for _, forbidden := range []string{
+			"OnePasswordResolver",
+			"1password-pp-cli",
+			"PRINTING_PRESS_ONEPASSWORD_CLI",
+			"platformResolverFactory",
+			"auth.credential_resolvers",
+			"CredentialResolverRegistry",
+		} {
+			assert.NotContains(t, generated, forbidden, relativePath)
+		}
+	}
+
+	profile := readGeneratedFile(t, outputDir, "internal", "platform", "profile.go")
+	assert.NotContains(t, profile, "op://")
+
+	client := readGeneratedFile(t, outputDir, "internal", "cli", "platform_client.go")
+	assert.Contains(t, client, "CredentialResolverFactory")
+	assert.Contains(t, client, "ValidateSourceProfile")
+
+	agents := readGeneratedFile(t, outputDir, "AGENTS.md")
+	assert.Contains(t, agents, "CredentialResolverFactory")
+	assert.Contains(t, agents, "ValidateSourceProfile")
+	assert.Contains(t, agents, "preserved hand-authored file")
+	assert.NotContains(t, agents, "OnePassword")
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestGeneratedPlatformCredentialResolverSupportsPreservedDownstreamAdapter(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+	specPath := filepath.Join(repoRoot, "testdata", "stytch.yaml")
+	apiSpec, err := spec.Parse(specPath)
+	require.NoError(t, err)
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	modulePath := generatedModulePath(t, outputDir)
+	adapterPath := filepath.Join(outputDir, "internal", "cli", "fixture_platform_source.go")
+	require.NoError(t, os.WriteFile(adapterPath, []byte(fixturePlatformAdapterSource(modulePath)), 0o644))
+
+	customAdapterBeforeReprint, err := os.ReadFile(adapterPath)
+	require.NoError(t, err)
+	profilePath := filepath.Join(outputDir, "internal", "platform", "profile.go")
+	profileBeforeReprint, err := os.ReadFile(profilePath)
+	require.NoError(t, err)
+	legacyProfile := append([]byte("// legacy OnePasswordResolver marker\n"), profileBeforeReprint...)
+	require.NoError(t, os.WriteFile(profilePath, legacyProfile, 0o644))
+
+	command := exec.Command("go", "run", "./cmd/cli-printing-press", "generate", "--spec", specPath, "--output", outputDir, "--force", "--validate=false")
+	command.Dir = repoRoot
+	home := t.TempDir()
+	command.Env = append(os.Environ(),
+		"HOME="+home,
+		"USERPROFILE="+home,
+		"XDG_CONFIG_HOME="+filepath.Join(home, ".config"),
+		"XDG_DATA_HOME="+filepath.Join(home, ".local", "share"),
+		"XDG_STATE_HOME="+filepath.Join(home, ".local", "state"),
+		"XDG_CACHE_HOME="+filepath.Join(home, ".cache"),
+		"GOMODCACHE="+goEnvValue(t, "GOMODCACHE"),
+		"GOCACHE="+goEnvValue(t, "GOCACHE"),
+	)
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	customAdapterAfterReprint, err := os.ReadFile(adapterPath)
+	require.NoError(t, err)
+	assert.Equal(t, customAdapterBeforeReprint, customAdapterAfterReprint, "reprint must retain the downstream adapter file")
+	refreshedProfile, err := os.ReadFile(profilePath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(refreshedProfile), "OnePasswordResolver")
+	requireGeneratedCompiles(t, outputDir)
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "fixture_platform_source_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(fixturePlatformAdapterTestSource(modulePath)), 0o644))
+	mcpTestPath := filepath.Join(outputDir, "internal", "mcp", "fixture_platform_source_test.go")
+	require.NoError(t, os.WriteFile(mcpTestPath, []byte(fixturePlatformMCPTestSource(modulePath)), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "./internal/mcp", "-run", "TestFixturePlatform", "-count=1")
+}
+
+func generatedModulePath(t *testing.T, outputDir string) string {
+	t.Helper()
+
+	goMod := readGeneratedFile(t, outputDir, "go.mod")
+	line := strings.SplitN(goMod, "\n", 2)[0]
+	modulePath := strings.TrimSpace(strings.TrimPrefix(line, "module "))
+	require.NotEmpty(t, modulePath)
+	return modulePath
+}
+
+func fixturePlatformAdapterSource(modulePath string) string {
+	return strings.ReplaceAll(`package cli
+
+import (
+	"context"
+	"fmt"
+
+	"__MODULE_PATH__/internal/platform"
+)
+
+var fixturePlatformCredential []byte
+
+type fixturePlatformResolver struct{}
+
+func (fixturePlatformResolver) Resolve(_ context.Context, reference string) ([]byte, error) {
+	if reference != "op://fixture/opaque/token" {
+		return nil, fmt.Errorf("unexpected fixture reference %q", reference)
+	}
+	return []byte("fixture-secret"), nil
+}
+
+type fixturePlatformAdapter struct{}
+
+func (fixturePlatformAdapter) ProbeIdentity(_ context.Context, credentials platform.ResolvedCredentials, source platform.SourceProfile) (platform.ObservedIdentity, error) {
+	fixturePlatformCredential = credentials["credential"]
+	if string(fixturePlatformCredential) != "fixture-secret" {
+		return platform.ObservedIdentity{}, fmt.Errorf("fixture resolver was not used")
+	}
+	if source.CredentialRef != "op://fixture/opaque/token" {
+		return platform.ObservedIdentity{}, fmt.Errorf("selected reference was changed")
+	}
+	return platform.ObservedIdentity{BaseURL: "https://fixture.tenant.example"}, nil
+}
+
+func (fixturePlatformAdapter) EndpointClass() string { return "GET /fixture/identity" }
+
+func registerFixturePlatformSource() {
+	registerPlatformSource(platformSourceRegistration{
+		Source:  "fixture",
+		Adapter: fixturePlatformAdapter{},
+		CredentialResolverFactory: func() platform.CredentialResolver {
+			return fixturePlatformResolver{}
+		},
+		ValidateSourceProfile: func(source platform.SourceProfile) error {
+			if source.CredentialRef != "op://fixture/opaque/token" {
+				return fmt.Errorf("fixture validator received a changed reference")
+			}
+			return nil
+		},
+	})
+}
+
+func RegisterFixturePlatformSourceForTest() { registerFixturePlatformSource() }
+
+func FixturePlatformCredentialsZero() bool {
+	if fixturePlatformCredential == nil {
+		return false
+	}
+	for _, value := range fixturePlatformCredential {
+		if value != 0 {
+			return false
+		}
+	}
+	return true
+}
+`, "__MODULE_PATH__", modulePath)
+}
+
+func fixturePlatformAdapterTestSource(modulePath string) string {
+	return strings.ReplaceAll(`package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"__MODULE_PATH__/internal/platform"
+)
+
+func TestFixturePlatformSourceResolvesThroughCLIAndMCP(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRINTING_PRESS_CLIENT_PROFILE", "tenant-a")
+
+	err := platform.SaveProfile(&platform.Profile{
+		SchemaVersion: platform.ProfileSchemaVersion,
+		Name:          "tenant-a",
+		Sources: map[string]platform.SourceProfile{
+			"fixture": {
+				CredentialRef:   "op://fixture/opaque/token",
+				ExpectedBaseURL: "https://fixture.tenant.example",
+			},
+			"sibling": {
+				CredentialRef:   "opaque://sibling/value",
+				ExpectedBaseURL: "https://sibling.tenant.example",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	previousRegistration := registeredPlatformSource
+	t.Cleanup(func() { registeredPlatformSource = previousRegistration })
+	registerFixturePlatformSource()
+
+	previousArgs := os.Args
+	t.Cleanup(func() { os.Args = previousArgs })
+	os.Args = []string{"preserved-platform-adapter-pp-cli", "whoami", "--client-profile", "tenant-a", "--json"}
+	if err := Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !FixturePlatformCredentialsZero() {
+		t.Fatal("CLI execution did not zero the resolver-returned credential buffer")
+	}
+
+	if err := BindMCPServerProfile(); err != nil {
+		t.Fatal(err)
+	}
+	session, err := VerifyMCPInvocation(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.GateOutcome != platform.GateVerified {
+		t.Fatalf("MCP gate outcome = %q, want %q", session.GateOutcome, platform.GateVerified)
+	}
+	if got := string(session.Credentials["credential"]); got != "fixture-secret" {
+		t.Fatalf("MCP resolver value = %q, want fixture-secret", got)
+	}
+	session.ZeroCredentials()
+	if !bytes.Equal(fixturePlatformCredential, make([]byte, len(fixturePlatformCredential))) {
+		t.Fatal("MCP verification did not zero the resolver-returned credential buffer")
+	}
+}
+`, "__MODULE_PATH__", modulePath)
+}
+
+func fixturePlatformMCPTestSource(modulePath string) string {
+	return strings.ReplaceAll(`package mcp
+
+import (
+	"context"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"__MODULE_PATH__/internal/cli"
+	"__MODULE_PATH__/internal/platform"
+)
+
+func TestFixturePlatformMCPWrapperZeroesCredentials(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRINTING_PRESS_CLIENT_PROFILE", "tenant-a")
+
+	if err := platform.SaveProfile(&platform.Profile{
+		SchemaVersion: platform.ProfileSchemaVersion,
+		Name:          "tenant-a",
+		Sources: map[string]platform.SourceProfile{
+			"fixture": {CredentialRef: "op://fixture/opaque/token", ExpectedBaseURL: "https://fixture.tenant.example"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cli.RegisterFixturePlatformSourceForTest()
+	if err := cli.BindMCPServerProfile(); err != nil {
+		t.Fatal(err)
+	}
+
+	mcpServer := server.NewMCPServer("fixture", "test")
+	result, err := requireFreshTenantGate(mcpServer, func(ctx context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+		session := platform.SessionFromContext(ctx)
+		if session == nil || string(session.Credentials["credential"]) != "fixture-secret" {
+			return mcplib.NewToolResultError("fixture credential was not available to the MCP handler"), nil
+		}
+		return mcplib.NewToolResultText("ok"), nil
+	})(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{Name: "fixture"}})
+	if err != nil || result == nil || result.IsError {
+		t.Fatalf("MCP wrapper result=%#v err=%v", result, err)
+	}
+	if !cli.FixturePlatformCredentialsZero() {
+		t.Fatal("MCP wrapper did not zero the resolver-returned credential buffer")
+	}
+}
+`, "__MODULE_PATH__", modulePath)
+}

--- a/internal/generator/templates/agents.md.tmpl
+++ b/internal/generator/templates/agents.md.tmpl
@@ -65,6 +65,20 @@ The store's schema stamp is one-way: once this binary opens the database, an old
 Disable the loop with `--no-learn` per-invocation or `{{envPrefix .Name}}_NO_LEARN=true` for the whole session - useful for deterministic agent flows that don't want a learning row to silently change subsequent query results.
 {{- end}}
 
+## Platform Credential References
+
+Normal API authentication is separate from optional platform-source credential
+resolution. If this CLI uses indirect references for a tenant-gated platform
+source, add the downstream registration in a preserved hand-authored file
+under `internal/cli/` and provide both `CredentialResolverFactory` and
+`ValidateSourceProfile` on `platformSourceRegistration` for any selected source
+that has references. A source with no references may omit both hooks and receives
+an empty credential map. Keep reference values opaque to shared profile code,
+validate only the selected source in the downstream hook, and never persist
+resolved credential bytes. Do not edit generator-owned `internal/platform`
+packages; a reprint refreshes those files while retaining the downstream
+registration file.
+
 For install, auth, examples, and longer product guidance, read `README.md` and `SKILL.md`. This file intentionally stays small so repo-local agents get invariant local guidance without duplicating the generated docs.
 
 ## Release Ledger

--- a/internal/generator/templates/client_platform_rate_limit_test.go.tmpl
+++ b/internal/generator/templates/client_platform_rate_limit_test.go.tmpl
@@ -74,7 +74,7 @@ func platformRateLimitTestClient(t *testing.T, server *httptest.Server) (*Client
 		SchemaVersion: platform.ProfileSchemaVersion,
 		Name:          "tenant-a",
 		Sources: map[string]platform.SourceProfile{
-			"{{.Name}}": {CredentialRef: "op://Test Vault/Synthetic/token", ExpectedAccountID: "acct-a", ExpectedOrgName: "Tenant A", ExpectedStoreID: "store-a", ExpectedStoreDomain: "tenant-a.example.test", ExpectedPropertyID: "123", ExpectedBaseURL: "https://tenant-a.example.test"},
+			"{{.Name}}": {CredentialRef: "fixture://Test/Synthetic/token", ExpectedAccountID: "acct-a", ExpectedOrgName: "Tenant A", ExpectedStoreID: "store-a", ExpectedStoreDomain: "tenant-a.example.test", ExpectedPropertyID: "123", ExpectedBaseURL: "https://tenant-a.example.test"},
 		},
 	}, "{{.Name}}-pp-cli", "{{.Name}}")
 	if err != nil {

--- a/internal/generator/templates/platform_cli.go.tmpl
+++ b/internal/generator/templates/platform_cli.go.tmpl
@@ -20,9 +20,12 @@ import (
 // platformSourceRegistration is intentionally package-local: a preserved
 // provider adapter registers one source without exposing credential-bearing
 // hooks outside the CLI process.
+type CredentialResolverFactory func() platform.CredentialResolver
+
 type platformSourceRegistration struct {
 	Source               string
 	Adapter              platform.IdentityAdapter
+	CredentialResolverFactory CredentialResolverFactory
 	Credentialless       bool
 	BindClient           func(*client.Client, *platform.Session) error
 	ResourceHealth       func(context.Context, *platform.Session) ([]platform.ResourceHealth, error)
@@ -47,10 +50,6 @@ func registerPlatformSource(registration platformSourceRegistration) {
 	registeredPlatformSource = &registration
 }
 
-var platformResolverFactory = func() platform.CredentialResolver {
-	return platform.OnePasswordResolver{Binary: strings.TrimSpace(os.Getenv("PRINTING_PRESS_ONEPASSWORD_CLI"))}
-}
-
 func preparePlatformSession(flags *rootFlags) error {
 	if registeredPlatformSource == nil || flags.platformSession != nil {
 		return nil
@@ -59,24 +58,79 @@ func preparePlatformSession(flags *rootFlags) error {
 	if err != nil {
 		return err
 	}
-	if err := validateRegisteredPlatformSourceProfile(session.SourceProfile); err != nil {
+	resolver, err := platformCredentialResolver(session.SourceProfile)
+	if err != nil {
 		return err
 	}
 	flags.platformSession = session
+	flags.platformResolver = resolver
+	flags.platformResolverReady = true
 	return nil
 }
 
 func validateRegisteredPlatformSourceProfile(source platform.SourceProfile) error {
+	references := source.References()
+	if err := validateRegisteredPlatformSourceProfileWithReferences(source, references); err != nil {
+		return err
+	}
+	if len(references) == 0 {
+		return nil
+	}
+	return requirePlatformCredentialResolverFactory()
+}
+
+func validateRegisteredPlatformSourceProfileWithReferences(source platform.SourceProfile, references map[string]string) error {
 	if registeredPlatformSource == nil {
 		return nil
 	}
-	if !registeredPlatformSource.Credentialless && len(source.References()) == 0 {
-		return fmt.Errorf("source %q requires at least one exact credential reference", registeredPlatformSource.Source)
+	if len(references) == 0 {
+		return nil
 	}
-	if registeredPlatformSource.ValidateSourceProfile != nil {
-		return registeredPlatformSource.ValidateSourceProfile(source)
+	if registeredPlatformSource.ValidateSourceProfile == nil {
+		return fmt.Errorf("source %q has credential references but no ValidateSourceProfile hook in platformSourceRegistration", registeredPlatformSource.Source)
 	}
-	return nil
+	return registeredPlatformSource.ValidateSourceProfile(source)
+}
+
+func requirePlatformCredentialResolverFactory() error {
+	if registeredPlatformSource == nil || registeredPlatformSource.CredentialResolverFactory != nil {
+		return nil
+	}
+	return fmt.Errorf("source %q has credential references but no CredentialResolverFactory in platformSourceRegistration", registeredPlatformSource.Source)
+}
+
+func isNilCredentialResolver(resolver platform.CredentialResolver) bool {
+	if resolver == nil {
+		return true
+	}
+	value := reflect.ValueOf(resolver)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func platformCredentialResolver(source platform.SourceProfile) (platform.CredentialResolver, error) {
+	if registeredPlatformSource == nil {
+		return nil, nil
+	}
+	references := source.References()
+	if err := validateRegisteredPlatformSourceProfileWithReferences(source, references); err != nil {
+		return nil, err
+	}
+	if len(references) == 0 {
+		return nil, nil
+	}
+	if err := requirePlatformCredentialResolverFactory(); err != nil {
+		return nil, err
+	}
+	resolver := registeredPlatformSource.CredentialResolverFactory()
+	if isNilCredentialResolver(resolver) {
+		return nil, fmt.Errorf("source %q has credential references but CredentialResolverFactory returned nil", registeredPlatformSource.Source)
+	}
+	return resolver, nil
 }
 
 func verifyPlatformSession(ctx context.Context, flags *rootFlags) error {
@@ -92,7 +146,17 @@ func verifyPlatformSession(ctx context.Context, flags *rootFlags) error {
 	if flags.platformSession.GateOutcome == platform.GateVerified {
 		return nil
 	}
-	return platform.VerifyPreparedProfileSource(ctx, flags.platformSession, platformResolverFactory(), registeredPlatformSource.Adapter)
+	resolver := flags.platformResolver
+	if !flags.platformResolverReady {
+		var err error
+		resolver, err = platformCredentialResolver(flags.platformSession.SourceProfile)
+		if err != nil {
+			return err
+		}
+	}
+	flags.platformResolver = nil
+	flags.platformResolverReady = false
+	return platform.VerifyPreparedProfileSource(ctx, flags.platformSession, resolver, registeredPlatformSource.Adapter)
 }
 
 func validatePlatformLegacyInputs(cmd *cobra.Command, flags *rootFlags) error {
@@ -188,8 +252,9 @@ func bindPlatformClient(c *client.Client, flags *rootFlags) error {
 	return nil
 }
 
-// BindMCPServerProfile resolves and validates the non-secret profile at server
-// startup. Each tool invocation still performs a fresh live identity gate.
+// BindMCPServerProfile validates the non-secret profile and registration at
+// server startup. Each tool invocation constructs a fresh resolver and runs a
+// live identity gate.
 func BindMCPServerProfile() error {
 	if registeredPlatformSource == nil {
 		return nil
@@ -227,10 +292,11 @@ func VerifyMCPInvocation(ctx context.Context) (*platform.Session, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := validateRegisteredPlatformSourceProfile(session.SourceProfile); err != nil {
+	resolver, err := platformCredentialResolver(session.SourceProfile)
+	if err != nil {
 		return nil, err
 	}
-	if err := platform.VerifyPreparedProfileSource(ctx, session, platformResolverFactory(), registeredPlatformSource.Adapter); err != nil {
+	if err := platform.VerifyPreparedProfileSource(ctx, session, resolver, registeredPlatformSource.Adapter); err != nil {
 		return nil, err
 	}
 	return session, nil
@@ -363,9 +429,9 @@ type platformSourceFlags struct {
 }
 
 func (values *platformSourceFlags) addFlags(command *cobra.Command) {
-	command.Flags().StringVar(&values.credentialRef, "credential-ref", "", "Exact op:// credential reference")
-	command.Flags().StringVar(&values.usernameRef, "username-ref", "", "Exact op:// username reference")
-	command.Flags().StringToStringVar(&values.additionalCredentialRef, "additional-credential-ref", nil, "Named exact op:// credential references (name=reference)")
+	command.Flags().StringVar(&values.credentialRef, "credential-ref", "", "Credential reference")
+	command.Flags().StringVar(&values.usernameRef, "username-ref", "", "Username reference")
+	command.Flags().StringToStringVar(&values.additionalCredentialRef, "additional-credential-ref", nil, "Named credential references (name=reference)")
 	command.Flags().StringVar(&values.expectedAccountID, "expected-account-id", "", "Trusted immutable provider account ID")
 	command.Flags().StringVar(&values.expectedOrgName, "expected-org-name", "", "Exact expected organization name")
 	command.Flags().StringVar(&values.expectedStoreID, "expected-store-id", "", "Trusted immutable Shopify store ID")
@@ -404,7 +470,7 @@ func newPlatformClientAddCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			sourceProfile := values.sourceProfile()
-			if err := validateRegisteredPlatformSourceProfile(sourceProfile); err != nil {
+			if _, err := platformCredentialResolver(sourceProfile); err != nil {
 				return err
 			}
 			profile := &platform.Profile{SchemaVersion: platform.ProfileSchemaVersion, Name: args[0], Sources: map[string]platform.SourceProfile{registeredPlatformSource.Source: sourceProfile}}
@@ -432,7 +498,7 @@ func newPlatformClientSourceSetCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			sourceProfile := values.sourceProfile()
-			if err := validateRegisteredPlatformSourceProfile(sourceProfile); err != nil {
+			if _, err := platformCredentialResolver(sourceProfile); err != nil {
 				return err
 			}
 			profile.Sources[registeredPlatformSource.Source] = sourceProfile
@@ -499,10 +565,11 @@ func newPlatformClientValidateCmd(flags *rootFlags) *cobra.Command {
 		if err != nil {
 			return err
 		}
-		if err := validateRegisteredPlatformSourceProfile(session.SourceProfile); err != nil {
+		resolver, err := platformCredentialResolver(session.SourceProfile)
+		if err != nil {
 			return err
 		}
-		if err := platform.VerifyPreparedProfileSource(cmd.Context(), session, platformResolverFactory(), registeredPlatformSource.Adapter); err != nil {
+		if err := platform.VerifyPreparedProfileSource(cmd.Context(), session, resolver, registeredPlatformSource.Adapter); err != nil {
 			return err
 		}
 		defer session.ZeroCredentials()
@@ -528,9 +595,6 @@ func newPlatformClientMigrateCmd(flags *rootFlags) *cobra.Command {
 			return errors.New("this CLI has no registered tenant identity adapter")
 		}
 		candidate := values.sourceProfile()
-		if err := validateRegisteredPlatformSourceProfile(candidate); err != nil {
-			return err
-		}
 		profile, err := platform.LoadProfile(args[0])
 		alreadyMigrated := false
 		switch {
@@ -548,6 +612,10 @@ func newPlatformClientMigrateCmd(flags *rootFlags) *cobra.Command {
 		default:
 			return err
 		}
+		resolver, err := platformCredentialResolver(candidate)
+		if err != nil {
+			return err
+		}
 		legacy, err := platform.InspectLegacyMigrationPaths(legacyConfig, legacyDB)
 		if err != nil {
 			return err
@@ -561,7 +629,7 @@ func newPlatformClientMigrateCmd(flags *rootFlags) *cobra.Command {
 			return err
 		}
 		defer finalizePlatformInvocation(flags, &retErr)
-		if err := platform.VerifyPreparedProfileSource(cmd.Context(), session, platformResolverFactory(), registeredPlatformSource.Adapter); err != nil {
+		if err := platform.VerifyPreparedProfileSource(cmd.Context(), session, resolver, registeredPlatformSource.Adapter); err != nil {
 			return err
 		}
 		if !alreadyMigrated {

--- a/internal/generator/templates/platform_cli_test.go.tmpl
+++ b/internal/generator/templates/platform_cli_test.go.tmpl
@@ -8,6 +8,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,17 +64,347 @@ func TestPlatformArtifactOverridesCannotEscapeSelectedProfile(t *testing.T) {
 	}
 }
 
-func TestPlatformCredentiallessRegistrationIsExplicit(t *testing.T) {
+func TestPlatformCredentiallessRegistrationAllowsEmptyReferences(t *testing.T) {
 	previousRegistration := registeredPlatformSource
 	t.Cleanup(func() { registeredPlatformSource = previousRegistration })
 	source := platform.SourceProfile{ExpectedBaseURL: "https://tenant.example"}
 	registeredPlatformSource = &platformSourceRegistration{Source: "credentialed", Adapter: conformanceIdentityAdapter{}}
-	if err := validateRegisteredPlatformSourceProfile(source); err == nil || !strings.Contains(err.Error(), "requires at least one exact credential reference") {
-		t.Fatalf("credentialed source accepted an empty reference set: %v", err)
-	}
-	registeredPlatformSource = &platformSourceRegistration{Source: "public-site", Adapter: conformanceIdentityAdapter{}, Credentialless: true}
 	if err := validateRegisteredPlatformSourceProfile(source); err != nil {
-		t.Fatalf("explicit credentialless source rejected: %v", err)
+		t.Fatalf("source without references rejected: %v", err)
+	}
+
+	registeredPlatformSource = &platformSourceRegistration{Source: "public-site", Adapter: conformanceIdentityAdapter{}, Credentialless: true}
+	withReference := platform.SourceProfile{CredentialRef: "fixture://selected/token", ExpectedBaseURL: "https://tenant.example"}
+	if _, err := platformCredentialResolver(withReference); err == nil || !strings.Contains(err.Error(), "ValidateSourceProfile") {
+		t.Fatalf("credentialless source bypassed selected-source hooks: %v", err)
+	}
+}
+
+func TestPlatformReferencedSourceRequiresResolverAndValidatorPair(t *testing.T) {
+	previousRegistration := registeredPlatformSource
+	t.Cleanup(func() { registeredPlatformSource = previousRegistration })
+	source := platform.SourceProfile{CredentialRef: "fixture://selected/token", ExpectedBaseURL: "https://tenant.example"}
+	validator := func(platform.SourceProfile) error { return nil }
+	factory := func() platform.CredentialResolver { return conformanceResolver{value: []byte("fixture-secret")} }
+	var typedNilResolver *conformanceResolver
+
+	tests := []struct {
+		name       string
+		registration platformSourceRegistration
+		want       string
+	}{
+		{
+			name: "missing both",
+			registration: platformSourceRegistration{Source: "selected", Adapter: conformanceIdentityAdapter{}},
+			want: "ValidateSourceProfile",
+		},
+		{
+			name: "missing validator",
+			registration: platformSourceRegistration{Source: "selected", Adapter: conformanceIdentityAdapter{}, CredentialResolverFactory: factory},
+			want: "ValidateSourceProfile",
+		},
+		{
+			name: "missing resolver factory",
+			registration: platformSourceRegistration{Source: "selected", Adapter: conformanceIdentityAdapter{}, ValidateSourceProfile: validator},
+			want: "CredentialResolverFactory",
+		},
+		{
+			name: "nil resolver",
+			registration: platformSourceRegistration{
+				Source: "selected", Adapter: conformanceIdentityAdapter{}, CredentialResolverFactory: func() platform.CredentialResolver { return nil }, ValidateSourceProfile: validator,
+			},
+			want: "CredentialResolverFactory returned nil",
+		},
+		{
+			name: "typed nil resolver",
+			registration: platformSourceRegistration{
+				Source: "selected", Adapter: conformanceIdentityAdapter{}, CredentialResolverFactory: func() platform.CredentialResolver { return typedNilResolver }, ValidateSourceProfile: validator,
+			},
+			want: "CredentialResolverFactory returned nil",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registeredPlatformSource = &tt.registration
+			if _, err := platformCredentialResolver(source); err == nil || !strings.Contains(err.Error(), tt.want) || !strings.Contains(err.Error(), "selected") {
+				t.Fatalf("resolver configuration error = %v", err)
+			}
+		})
+	}
+
+	registeredPlatformSource = &platformSourceRegistration{
+		Source: "selected", Adapter: conformanceIdentityAdapter{}, CredentialResolverFactory: factory, ValidateSourceProfile: validator,
+	}
+	resolver, err := platformCredentialResolver(source)
+	if err != nil || resolver == nil {
+		t.Fatalf("complete resolver registration = %v resolver=%T", err, resolver)
+	}
+	validatorCalled := false
+	resolverCalled := false
+	registeredPlatformSource = &platformSourceRegistration{
+		Source: "selected", Adapter: conformanceIdentityAdapter{},
+		CredentialResolverFactory: func() platform.CredentialResolver {
+			resolverCalled = true
+			return factory()
+		},
+		ValidateSourceProfile: func(platform.SourceProfile) error {
+			validatorCalled = true
+			return errors.New("synthetic selected-source validation failure")
+		},
+	}
+	if _, err := platformCredentialResolver(source); err == nil || !strings.Contains(err.Error(), "selected-source validation failure") || !validatorCalled || resolverCalled {
+		t.Fatalf("selected-source validation ordering error=%v validator_called=%v resolver_called=%v", err, validatorCalled, resolverCalled)
+	}
+}
+
+type recordingIdentityAdapter struct {
+	observed    platform.ObservedIdentity
+	calls       int
+	credentials platform.ResolvedCredentials
+}
+
+func (a *recordingIdentityAdapter) ProbeIdentity(_ context.Context, credentials platform.ResolvedCredentials, _ platform.SourceProfile) (platform.ObservedIdentity, error) {
+	a.calls++
+	a.credentials = credentials
+	return a.observed, nil
+}
+
+func (*recordingIdentityAdapter) EndpointClass() string { return "GET /identity" }
+
+func TestPlatformCredentiallessCLIAndMCPUseEmptyCredentials(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRINTING_PRESS_CLIENT_PROFILE", "tenant-a")
+	t.Setenv(mcpBoundProfileEnv, "")
+	if err := platform.SaveProfile(&platform.Profile{
+		SchemaVersion: platform.ProfileSchemaVersion,
+		Name:          "tenant-a",
+		Sources:       map[string]platform.SourceProfile{"public-site": {ExpectedBaseURL: "https://tenant.example"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	adapter := &recordingIdentityAdapter{observed: platform.ObservedIdentity{BaseURL: "https://tenant.example"}}
+	previousRegistration := registeredPlatformSource
+	t.Cleanup(func() { registeredPlatformSource = previousRegistration })
+	registeredPlatformSource = &platformSourceRegistration{Source: "public-site", Adapter: adapter, Credentialless: true}
+
+	root := RootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"whoami", "--client-profile", "tenant-a", "--json"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if adapter.calls != 1 || adapter.credentials == nil || len(adapter.credentials) != 0 {
+		t.Fatalf("CLI credentialless gate calls=%d credentials=%#v", adapter.calls, adapter.credentials)
+	}
+
+	if err := BindMCPServerProfile(); err != nil {
+		t.Fatal(err)
+	}
+	session, err := VerifyMCPInvocation(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.ZeroCredentials()
+	if adapter.calls != 2 || session.Credentials == nil || len(session.Credentials) != 0 {
+		t.Fatalf("MCP credentialless gate calls=%d credentials=%#v", adapter.calls, session.Credentials)
+	}
+}
+
+func TestPlatformReferencedSourceWithoutResolverFailsBeforeProbe(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRINTING_PRESS_CLIENT_PROFILE", "")
+	t.Setenv(mcpBoundProfileEnv, "")
+	if err := platform.SaveProfile(&platform.Profile{
+		SchemaVersion: platform.ProfileSchemaVersion,
+		Name:          "tenant-a",
+		Sources:       map[string]platform.SourceProfile{"selected": {CredentialRef: "fixture://selected/token", ExpectedBaseURL: "https://tenant.example"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	adapter := &recordingIdentityAdapter{observed: platform.ObservedIdentity{BaseURL: "https://tenant.example"}}
+	previousRegistration := registeredPlatformSource
+	t.Cleanup(func() { registeredPlatformSource = previousRegistration })
+	registeredPlatformSource = &platformSourceRegistration{
+		Source: "selected", Adapter: adapter, ValidateSourceProfile: func(platform.SourceProfile) error { return nil },
+	}
+
+	root := RootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	receiptPath := filepath.Join(t.TempDir(), "missing-resolver-receipt.json")
+	root.SetArgs([]string{"whoami", "--client-profile", "tenant-a", "--receipt-file", receiptPath, "--json"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "CredentialResolverFactory") || !strings.Contains(err.Error(), "selected") || adapter.calls != 0 {
+		t.Fatalf("missing resolver error=%v adapter_calls=%d", err, adapter.calls)
+	}
+	if _, err := os.Stat(receiptPath); !os.IsNotExist(err) {
+		t.Fatalf("normal CLI wrote a receipt after resolver failure: %v", err)
+	}
+	validateRoot := RootCmd()
+	validateRoot.SetOut(&bytes.Buffer{})
+	validateRoot.SetErr(&bytes.Buffer{})
+	validateRoot.SetArgs([]string{"client", "validate", "tenant-a", "--json"})
+	err = validateRoot.Execute()
+	if err == nil || !strings.Contains(err.Error(), "CredentialResolverFactory") || adapter.calls != 0 {
+		t.Fatalf("client validate missing resolver error=%v adapter_calls=%d", err, adapter.calls)
+	}
+
+	t.Setenv("PRINTING_PRESS_CLIENT_PROFILE", "tenant-a")
+	if err := BindMCPServerProfile(); err == nil || !strings.Contains(err.Error(), "CredentialResolverFactory") || adapter.calls != 0 {
+		t.Fatalf("MCP missing resolver error=%v adapter_calls=%d", err, adapter.calls)
+	}
+}
+
+func TestPlatformMCPBindingDoesNotConsumeResolverFactory(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRINTING_PRESS_CLIENT_PROFILE", "tenant-a")
+	t.Setenv(mcpBoundProfileEnv, "")
+	if err := platform.SaveProfile(&platform.Profile{
+		SchemaVersion: platform.ProfileSchemaVersion,
+		Name:          "tenant-a",
+		Sources:       map[string]platform.SourceProfile{"selected": {CredentialRef: "fixture://selected/token", ExpectedBaseURL: "https://tenant.example"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	adapter := &recordingIdentityAdapter{observed: platform.ObservedIdentity{BaseURL: "https://tenant.example"}}
+	factoryCalls := 0
+	previousRegistration := registeredPlatformSource
+	t.Cleanup(func() { registeredPlatformSource = previousRegistration })
+	registeredPlatformSource = &platformSourceRegistration{
+		Source: "selected", Adapter: adapter,
+		CredentialResolverFactory: func() platform.CredentialResolver {
+			factoryCalls++
+			return conformanceResolver{value: []byte("fixture-secret")}
+		},
+		ValidateSourceProfile: func(platform.SourceProfile) error { return nil },
+	}
+	if err := BindMCPServerProfile(); err != nil {
+		t.Fatal(err)
+	}
+	if factoryCalls != 0 {
+		t.Fatalf("MCP binding consumed the resolver factory %d times", factoryCalls)
+	}
+	first, err := VerifyMCPInvocation(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.ZeroCredentials()
+	second, err := VerifyMCPInvocation(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.ZeroCredentials()
+	if factoryCalls != 2 || adapter.calls != 2 {
+		t.Fatalf("MCP verification factory_calls=%d adapter_calls=%d", factoryCalls, adapter.calls)
+	}
+}
+
+func TestPlatformMCPNilResolverFailsBeforeProbe(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRINTING_PRESS_CLIENT_PROFILE", "tenant-a")
+	t.Setenv(mcpBoundProfileEnv, "")
+	if err := platform.SaveProfile(&platform.Profile{
+		SchemaVersion: platform.ProfileSchemaVersion,
+		Name:          "tenant-a",
+		Sources:       map[string]platform.SourceProfile{"selected": {CredentialRef: "fixture://selected/token", ExpectedBaseURL: "https://tenant.example"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	adapter := &recordingIdentityAdapter{observed: platform.ObservedIdentity{BaseURL: "https://tenant.example"}}
+	previousRegistration := registeredPlatformSource
+	t.Cleanup(func() { registeredPlatformSource = previousRegistration })
+	registeredPlatformSource = &platformSourceRegistration{
+		Source: "selected", Adapter: adapter,
+		CredentialResolverFactory: func() platform.CredentialResolver { return nil },
+		ValidateSourceProfile:     func(platform.SourceProfile) error { return nil },
+	}
+	if err := BindMCPServerProfile(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := VerifyMCPInvocation(context.Background()); err == nil || !strings.Contains(err.Error(), "CredentialResolverFactory returned nil") || adapter.calls != 0 {
+		t.Fatalf("MCP nil resolver error=%v adapter_calls=%d", err, adapter.calls)
+	}
+}
+
+func TestPlatformReferencedProfileWritesFailBeforePersistence(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRINTING_PRESS_CLIENT_PROFILE", "")
+	adapter := &recordingIdentityAdapter{observed: platform.ObservedIdentity{BaseURL: "https://tenant.example"}}
+	previousRegistration := registeredPlatformSource
+	t.Cleanup(func() { registeredPlatformSource = previousRegistration })
+	registeredPlatformSource = &platformSourceRegistration{
+		Source: "selected", Adapter: adapter, ValidateSourceProfile: func(platform.SourceProfile) error { return nil },
+	}
+
+	newProfile := func(commandArgs []string) error {
+		root := RootCmd()
+		root.SetOut(&bytes.Buffer{})
+		root.SetErr(&bytes.Buffer{})
+		root.SetArgs(commandArgs)
+		return root.Execute()
+	}
+	credentialArgs := []string{"--credential-ref", "fixture://selected/token", "--expected-base-url", "https://tenant.example", "--json"}
+	if err := newProfile(append([]string{"client", "add", "new-profile"}, credentialArgs...)); err == nil || !strings.Contains(err.Error(), "CredentialResolverFactory") {
+		t.Fatalf("client add missing resolver error = %v", err)
+	}
+	if _, err := platform.LoadProfile("new-profile"); !os.IsNotExist(err) {
+		t.Fatalf("client add persisted a profile after resolver failure: %v", err)
+	}
+
+	registeredPlatformSource.CredentialResolverFactory = func() platform.CredentialResolver { return nil }
+	if err := newProfile(append([]string{"client", "add", "nil-factory-profile"}, credentialArgs...)); err == nil || !strings.Contains(err.Error(), "CredentialResolverFactory returned nil") {
+		t.Fatalf("client add nil resolver error = %v", err)
+	}
+	if _, err := platform.LoadProfile("nil-factory-profile"); !os.IsNotExist(err) {
+		t.Fatalf("client add persisted a profile after nil resolver failure: %v", err)
+	}
+	registeredPlatformSource.CredentialResolverFactory = nil
+
+	if err := platform.SaveProfile(&platform.Profile{
+		SchemaVersion: platform.ProfileSchemaVersion,
+		Name:          "existing",
+		Sources:       map[string]platform.SourceProfile{"selected": {CredentialRef: "fixture://selected/old", ExpectedBaseURL: "https://tenant.example"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := newProfile(append([]string{"client", "source", "set", "existing"}, credentialArgs...)); err == nil || !strings.Contains(err.Error(), "CredentialResolverFactory") {
+		t.Fatalf("client source set missing resolver error = %v", err)
+	}
+	existing, err := platform.LoadProfile("existing")
+	if err != nil || existing.Sources["selected"].CredentialRef != "fixture://selected/old" {
+		t.Fatalf("client source set changed profile after resolver failure: profile=%#v err=%v", existing, err)
+	}
+
+	receiptPath := filepath.Join(t.TempDir(), "missing-receipt.json")
+	migrateArgs := append([]string{"client", "migrate", "migrated"}, credentialArgs...)
+	migrateArgs = append(migrateArgs, "--receipt-file", receiptPath)
+	if err := newProfile(migrateArgs); err == nil || !strings.Contains(err.Error(), "CredentialResolverFactory") {
+		t.Fatalf("client migrate missing resolver error = %v", err)
+	}
+	if _, err := platform.LoadProfile("migrated"); !os.IsNotExist(err) {
+		t.Fatalf("client migrate persisted a profile after resolver failure: %v", err)
+	}
+	if _, err := os.Stat(receiptPath); !os.IsNotExist(err) {
+		t.Fatalf("client migrate wrote a receipt after resolver failure: %v", err)
+	}
+	if adapter.calls != 0 {
+		t.Fatalf("resolver configuration failure reached identity adapter %d times", adapter.calls)
 	}
 }
 
@@ -82,10 +413,10 @@ func TestPlatformSourceFlagsPreserveNamedExactReferences(t *testing.T) {
 		t.Fatalf("empty named references must stay nil for migration idempotence: %#v", source.AdditionalCredentialRefs)
 	}
 	values := platformSourceFlags{
-		credentialRef: "op://Test Vault/Test Item/token",
+		credentialRef: "fixture://Test/sample/token",
 		additionalCredentialRef: map[string]string{
-			"client_id": "op://Test Vault/Test Item/client-id",
-			"secret":    "op://Test Vault/Test Item/secret",
+			"client_id": "fixture://Test/sample/client-id",
+			"secret":    "fixture://Test/sample/secret",
 		},
 	}
 	source := values.sourceProfile()
@@ -136,7 +467,7 @@ func TestPlatformCLIConformanceSurfaceAndGate(t *testing.T) {
 		SchemaVersion: platform.ProfileSchemaVersion,
 		Name:          "tenant-a",
 		Sources: map[string]platform.SourceProfile{
-			"test-source": {CredentialRef: "op://Test Vault/Test Item/token", ExpectedAccountID: "acct-a"},
+			"test-source": {CredentialRef: "fixture://Test/sample/token", ExpectedAccountID: "acct-a"},
 		},
 	}
 	if err := platform.SaveProfile(profile); err != nil {
@@ -144,17 +475,15 @@ func TestPlatformCLIConformanceSurfaceAndGate(t *testing.T) {
 	}
 
 	previousRegistration := registeredPlatformSource
-	previousResolver := platformResolverFactory
 	t.Cleanup(func() {
 		registeredPlatformSource = previousRegistration
-		platformResolverFactory = previousResolver
 	})
 	registeredPlatformSource = &platformSourceRegistration{
-		Source:  "test-source",
-		Adapter: conformanceIdentityAdapter{observed: platform.ObservedIdentity{AccountID: "acct-a"}},
-	}
-	platformResolverFactory = func() platform.CredentialResolver {
-		return conformanceResolver{value: []byte("credential-bytes-never-print")}
+		Source: "test-source", Adapter: conformanceIdentityAdapter{observed: platform.ObservedIdentity{AccountID: "acct-a"}},
+		CredentialResolverFactory: func() platform.CredentialResolver {
+			return conformanceResolver{value: []byte("credential-bytes-never-print")}
+		},
+		ValidateSourceProfile: func(platform.SourceProfile) error { return nil },
 	}
 
 	root := RootCmd()
@@ -210,7 +539,7 @@ func TestPlatformCLIConformanceOutputMetadataAndAnalytics(t *testing.T) {
 		SchemaVersion: platform.ProfileSchemaVersion,
 		Name:          "tenant-a",
 		Sources: map[string]platform.SourceProfile{
-			"test-source": {CredentialRef: "op://Test Vault/Test Item/token", ExpectedAccountID: "acct-a"},
+			"test-source": {CredentialRef: "fixture://Test/sample/token", ExpectedAccountID: "acct-a"},
 		},
 	}
 	session, err := platform.PrepareProfileSourceFromConfig(profile, "sample-pp-cli", "test-source")
@@ -365,16 +694,18 @@ func TestPlatformCLIConformanceMismatchFailsBeforeCommand(t *testing.T) {
 	t.Setenv("PRINTING_PRESS_CLIENT_PROFILE", "")
 	if err := platform.SaveProfile(&platform.Profile{
 		SchemaVersion: platform.ProfileSchemaVersion, Name: "tenant-a",
-		Sources: map[string]platform.SourceProfile{"test-source": {CredentialRef: "op://Test Vault/Test Item/token", ExpectedAccountID: "acct-a"}},
+		Sources: map[string]platform.SourceProfile{"test-source": {CredentialRef: "fixture://Test/sample/token", ExpectedAccountID: "acct-a"}},
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	previousRegistration := registeredPlatformSource
-	previousResolver := platformResolverFactory
-	t.Cleanup(func() { registeredPlatformSource = previousRegistration; platformResolverFactory = previousResolver })
-	registeredPlatformSource = &platformSourceRegistration{Source: "test-source", Adapter: conformanceIdentityAdapter{observed: platform.ObservedIdentity{AccountID: "acct-b"}}}
-	platformResolverFactory = func() platform.CredentialResolver { return conformanceResolver{value: []byte("secret")} }
+	t.Cleanup(func() { registeredPlatformSource = previousRegistration })
+	registeredPlatformSource = &platformSourceRegistration{
+		Source: "test-source", Adapter: conformanceIdentityAdapter{observed: platform.ObservedIdentity{AccountID: "acct-b"}},
+		CredentialResolverFactory: func() platform.CredentialResolver { return conformanceResolver{value: []byte("secret")} },
+		ValidateSourceProfile:     func(platform.SourceProfile) error { return nil },
+	}
 
 	root := RootCmd()
 	var output bytes.Buffer
@@ -404,14 +735,16 @@ func TestPlatformMigrationIsVerifiedIdempotentAndQuarantinesLegacyState(t *testi
 	receiptPath := filepath.Join(t.TempDir(), "migration-receipt.json")
 
 	previousRegistration := registeredPlatformSource
-	previousResolver := platformResolverFactory
-	t.Cleanup(func() { registeredPlatformSource = previousRegistration; platformResolverFactory = previousResolver })
-	registeredPlatformSource = &platformSourceRegistration{Source: "test-source", Adapter: conformanceIdentityAdapter{observed: platform.ObservedIdentity{AccountID: "acct-a"}}}
-	platformResolverFactory = func() platform.CredentialResolver {
-		return conformanceResolver{value: []byte("migration-secret-never-print")}
+	t.Cleanup(func() { registeredPlatformSource = previousRegistration })
+	registeredPlatformSource = &platformSourceRegistration{
+		Source: "test-source", Adapter: conformanceIdentityAdapter{observed: platform.ObservedIdentity{AccountID: "acct-a"}},
+		CredentialResolverFactory: func() platform.CredentialResolver {
+			return conformanceResolver{value: []byte("migration-secret-never-print")}
+		},
+		ValidateSourceProfile: func(platform.SourceProfile) error { return nil },
 	}
 
-	args := []string{"client", "migrate", "tenant-a", "--credential-ref", "op://Test Vault/Test Item/token", "--expected-account-id", "acct-a", "--legacy-db", legacyDB, "--receipt-file", receiptPath, "--json"}
+	args := []string{"client", "migrate", "tenant-a", "--credential-ref", "fixture://Test/sample/token", "--expected-account-id", "acct-a", "--legacy-db", legacyDB, "--receipt-file", receiptPath, "--json"}
 	root := RootCmd()
 	var output bytes.Buffer
 	root.SetOut(&output)
@@ -458,7 +791,7 @@ func TestPlatformMigrationIsVerifiedIdempotentAndQuarantinesLegacyState(t *testi
 	}
 
 	conflict := RootCmd()
-	conflict.SetArgs([]string{"client", "migrate", "tenant-a", "--credential-ref", "op://Test Vault/Test Item/token", "--expected-account-id", "acct-b"})
+	conflict.SetArgs([]string{"client", "migrate", "tenant-a", "--credential-ref", "fixture://Test/sample/token", "--expected-account-id", "acct-b"})
 	if err := conflict.Execute(); err == nil || !strings.Contains(err.Error(), "refusing to overwrite") {
 		t.Fatalf("conflicting migration error = %v", err)
 	}
@@ -492,16 +825,19 @@ func TestPlatformMigrationAdoptsOnlyVerifiedTenantDatabase(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	previousRegistration, previousResolver := registeredPlatformSource, platformResolverFactory
-	t.Cleanup(func() { registeredPlatformSource, platformResolverFactory = previousRegistration, previousResolver })
-	registeredPlatformSource = &platformSourceRegistration{Source: "test-source", Adapter: conformanceIdentityAdapter{observed: platform.ObservedIdentity{AccountID: "acct-a"}}}
-	platformResolverFactory = func() platform.CredentialResolver { return conformanceResolver{value: []byte("new-credential")} }
+	previousRegistration := registeredPlatformSource
+	t.Cleanup(func() { registeredPlatformSource = previousRegistration })
+	registeredPlatformSource = &platformSourceRegistration{
+		Source: "test-source", Adapter: conformanceIdentityAdapter{observed: platform.ObservedIdentity{AccountID: "acct-a"}},
+		CredentialResolverFactory: func() platform.CredentialResolver { return conformanceResolver{value: []byte("new-credential")} },
+		ValidateSourceProfile:     func(platform.SourceProfile) error { return nil },
+	}
 
 	root := RootCmd()
 	var output bytes.Buffer
 	root.SetOut(&output)
 	root.SetErr(&output)
-	migrationArgs := []string{"client", "migrate", "tenant-adopt", "--credential-ref", "op://Test Vault/Test Item/token", "--expected-account-id", "acct-a", "--legacy-db", legacyDB, "--json"}
+	migrationArgs := []string{"client", "migrate", "tenant-adopt", "--credential-ref", "fixture://Test/sample/token", "--expected-account-id", "acct-a", "--legacy-db", legacyDB, "--json"}
 	root.SetArgs(migrationArgs)
 	if err := root.Execute(); err != nil {
 		t.Fatal(err)
@@ -564,17 +900,20 @@ func TestPlatformMigrationWrongTenantCannotCreateProfile(t *testing.T) {
 	t.Setenv("PRINTING_PRESS_CLIENT_PROFILE", "")
 	t.Setenv(mcpBoundProfileEnv, "")
 
-	previousRegistration, previousResolver := registeredPlatformSource, platformResolverFactory
-	t.Cleanup(func() { registeredPlatformSource, platformResolverFactory = previousRegistration, previousResolver })
-	registeredPlatformSource = &platformSourceRegistration{Source: "test-source", Adapter: conformanceIdentityAdapter{observed: platform.ObservedIdentity{AccountID: "acct-b"}}}
-	platformResolverFactory = func() platform.CredentialResolver {
-		return conformanceResolver{value: []byte("wrong-tenant-credential")}
+	previousRegistration := registeredPlatformSource
+	t.Cleanup(func() { registeredPlatformSource = previousRegistration })
+	registeredPlatformSource = &platformSourceRegistration{
+		Source: "test-source", Adapter: conformanceIdentityAdapter{observed: platform.ObservedIdentity{AccountID: "acct-b"}},
+		CredentialResolverFactory: func() platform.CredentialResolver {
+			return conformanceResolver{value: []byte("wrong-tenant-credential")}
+		},
+		ValidateSourceProfile: func(platform.SourceProfile) error { return nil },
 	}
 
 	root := RootCmd()
 	root.SetOut(&bytes.Buffer{})
 	root.SetErr(&bytes.Buffer{})
-	root.SetArgs([]string{"client", "migrate", "tenant-rejected", "--credential-ref", "op://Test Vault/Test Item/token", "--expected-account-id", "acct-a", "--json"})
+	root.SetArgs([]string{"client", "migrate", "tenant-rejected", "--credential-ref", "fixture://Test/sample/token", "--expected-account-id", "acct-a", "--json"})
 	if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "tenant gate mismatch") {
 		t.Fatalf("wrong-tenant migration error = %v", err)
 	}

--- a/internal/generator/templates/platform_conformance_test.go.tmpl
+++ b/internal/generator/templates/platform_conformance_test.go.tmpl
@@ -32,14 +32,31 @@ func (r fixtureResolver) Resolve(_ context.Context, ref string) ([]byte, error) 
 	return bytes.Clone(value), nil
 }
 
+type zeroOnFailureResolver struct {
+	values  map[string][]byte
+	failRef string
+	returned [][]byte
+}
+
+func (r *zeroOnFailureResolver) Resolve(_ context.Context, ref string) ([]byte, error) {
+	if ref == r.failRef {
+		return nil, errors.New("synthetic resolver failure")
+	}
+	value := bytes.Clone(r.values[ref])
+	r.returned = append(r.returned, value)
+	return value, nil
+}
+
 type fixtureAdapter struct {
 	observed ObservedIdentity
 	err      error
 	calls    int
+	credentials ResolvedCredentials
 }
 
-func (a *fixtureAdapter) ProbeIdentity(_ context.Context, _ ResolvedCredentials, _ SourceProfile) (ObservedIdentity, error) {
+func (a *fixtureAdapter) ProbeIdentity(_ context.Context, credentials ResolvedCredentials, _ SourceProfile) (ObservedIdentity, error) {
 	a.calls++
+	a.credentials = credentials
 	return a.observed, a.err
 }
 
@@ -55,13 +72,13 @@ func setPlatformRoots(t *testing.T) string {
 	return root
 }
 
-func validKlaviyoProfile(name string) *Profile {
+func validSyntheticProfile(name string) *Profile {
 	return &Profile{
 		SchemaVersion: 1,
 		Name:          name,
 		Sources: map[string]SourceProfile{
-			"klaviyo": {
-				CredentialRef:     "op://Synthetic/Klaviyo/private-api-key",
+			"sample": {
+				CredentialRef:     "fixture://Synthetic/sample/private-api-key",
 				ExpectedAccountID: "account-one",
 				ExpectedOrgName:   "Synthetic Org",
 			},
@@ -71,7 +88,7 @@ func validKlaviyoProfile(name string) *Profile {
 
 func TestProfileParserAndSelectionConformance(t *testing.T) {
 	setPlatformRoots(t)
-	profile := validKlaviyoProfile("synthetic")
+	profile := validSyntheticProfile("synthetic")
 	if err := SaveProfile(profile); err != nil {
 		t.Fatal(err)
 	}
@@ -87,9 +104,10 @@ func TestProfileParserAndSelectionConformance(t *testing.T) {
 		t.Fatalf("profile mode = %v, err = %v", info.Mode().Perm(), err)
 	}
 
-	for _, bad := range []string{"literal-secret", "$TOKEN", "${TOKEN}", "file:///tmp/key", "op://vault/item", "op://vault//field"} {
-		if err := ValidateCredentialReference(bad); err == nil {
-			t.Fatalf("unsafe credential reference accepted: %q", bad)
+	for _, reference := range []string{"literal-secret", "$TOKEN", "${TOKEN}", "file:///tmp/key", "opaque://vault/item", "opaque://vault//field"} {
+		profile := SourceProfile{CredentialRef: reference, ExpectedBaseURL: "https://tenant.example"}
+		if err := profile.Validate(); err != nil {
+			t.Fatalf("opaque credential reference rejected: %q: %v", reference, err)
 		}
 	}
 	for _, bad := range []string{"../escape", "UPPER", "", strings.Repeat("a", 64)} {
@@ -118,15 +136,15 @@ func TestProfileRejectsUnknownAndDuplicateNormalizedSources(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	unknown := []byte("schema_version = 1\nname = \"synthetic\"\nunknown = true\n[sources.klaviyo]\ncredential_ref = \"op://Synthetic/Klaviyo/key\"\nexpected_account_id = \"a\"\n")
+	unknown := []byte("schema_version = 1\nname = \"synthetic\"\nunknown = true\n[sources.sample]\ncredential_ref = \"fixture://Synthetic/sample/key\"\nexpected_account_id = \"a\"\n")
 	if err := os.WriteFile(path, unknown, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := LoadProfile("synthetic"); err == nil {
 		t.Fatal("unknown profile field was accepted")
 	}
-	profile := validKlaviyoProfile("synthetic")
-	profile.Sources["KLAVIYO"] = profile.Sources["klaviyo"]
+	profile := validSyntheticProfile("synthetic")
+	profile.Sources["SAMPLE"] = profile.Sources["sample"]
 	if err := profile.Validate(); err == nil {
 		t.Fatal("duplicate normalized source was accepted")
 	}
@@ -142,17 +160,126 @@ func TestCredentiallessSourceProfileRequiresIdentityButNotDummySecret(t *testing
 	}
 }
 
-func TestTenantGateAndIsolationConformance(t *testing.T) {
+func TestSourceProfileValidatesOnlyStructuralReferenceRules(t *testing.T) {
+	for name, source := range map[string]SourceProfile{
+		"empty additional name": {
+			AdditionalCredentialRefs: map[string]string{"": "fixture://opaque/value"},
+			ExpectedBaseURL:           "https://tenant.example",
+		},
+		"whitespace additional name": {
+			AdditionalCredentialRefs: map[string]string{"  ": "fixture://opaque/value"},
+			ExpectedBaseURL:           "https://tenant.example",
+		},
+		"empty additional value": {
+			AdditionalCredentialRefs: map[string]string{"token": ""},
+			ExpectedBaseURL:           "https://tenant.example",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := source.Validate(); err == nil {
+				t.Fatal("malformed additional reference was accepted")
+			}
+		})
+	}
+}
+
+func TestProfilePreservesOpaqueSiblingReferences(t *testing.T) {
 	setPlatformRoots(t)
-	profile := validKlaviyoProfile("client-one")
+	profile := &Profile{
+		SchemaVersion: ProfileSchemaVersion,
+		Name:          "shared",
+		Sources: map[string]SourceProfile{
+			"selected": {CredentialRef: "fixture://selected/value", ExpectedBaseURL: "https://selected.example"},
+			"sibling":  {CredentialRef: "opaque://sibling/opaque/value", UsernameRef: "file:///tmp/sibling-user", ExpectedBaseURL: "https://sibling.example"},
+		},
+	}
 	if err := SaveProfile(profile); err != nil {
 		t.Fatal(err)
 	}
-	ref := profile.Sources["klaviyo"].CredentialRef
+	loaded, err := LoadProfile(profile.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := loaded.Sources["sibling"]; got.CredentialRef != profile.Sources["sibling"].CredentialRef || got.UsernameRef != profile.Sources["sibling"].UsernameRef {
+		t.Fatalf("opaque sibling references changed: %#v", got)
+	}
+}
+
+func TestCredentialResolutionAllowsEmptyReferencesWithoutResolver(t *testing.T) {
+	setPlatformRoots(t)
+	if err := SaveProfile(&Profile{
+		SchemaVersion: ProfileSchemaVersion,
+		Name:          "synthetic",
+		Sources:       map[string]SourceProfile{"sample": {ExpectedBaseURL: "https://tenant.example"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	credentials, err := resolveCredentials(context.Background(), nil, SourceProfile{ExpectedBaseURL: "https://tenant.example"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if credentials == nil || len(credentials) != 0 {
+		t.Fatalf("empty credential map = %#v", credentials)
+	}
+
+	adapter := &fixtureAdapter{observed: ObservedIdentity{BaseURL: "https://tenant.example"}}
+	session, err := VerifyProfileSource(context.Background(), "synthetic", "sample-pp-cli", "sample", nil, adapter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.ZeroCredentials()
+	if adapter.calls != 1 || adapter.credentials == nil || len(adapter.credentials) != 0 {
+		t.Fatalf("credentialless gate adapter input = calls:%d credentials:%#v", adapter.calls, adapter.credentials)
+	}
+}
+
+func TestCredentialResolutionFailsBeforeProbeWithoutResolver(t *testing.T) {
+	setPlatformRoots(t)
+	profile := &Profile{
+		SchemaVersion: ProfileSchemaVersion,
+		Name:          "synthetic",
+		Sources: map[string]SourceProfile{
+			"sample": {CredentialRef: "fixture://selected/value", ExpectedBaseURL: "https://tenant.example"},
+		},
+	}
+	if err := SaveProfile(profile); err != nil {
+		t.Fatal(err)
+	}
+	adapter := &fixtureAdapter{observed: ObservedIdentity{BaseURL: "https://tenant.example"}}
+	_, err := VerifyProfileSource(context.Background(), profile.Name, "sample-pp-cli", "sample", nil, adapter)
+	var gateErr *GateError
+	if !errors.As(err, &gateErr) || !strings.Contains(err.Error(), "credential resolver is required") || adapter.calls != 0 {
+		t.Fatalf("missing resolver error=%v gate=%#v adapter_calls=%d", err, gateErr, adapter.calls)
+	}
+}
+
+func TestCredentialResolutionZerosPriorValuesOnFailure(t *testing.T) {
+	resolver := &zeroOnFailureResolver{
+		values:  map[string][]byte{"fixture://first": []byte("first-secret")},
+		failRef: "fixture://second",
+	}
+	_, err := resolveCredentials(context.Background(), resolver, SourceProfile{AdditionalCredentialRefs: map[string]string{
+		"first": "fixture://first", "second": "fixture://second",
+	}})
+	if err == nil || !strings.Contains(err.Error(), "resolve second reference") {
+		t.Fatalf("resolver failure = %v", err)
+	}
+	if len(resolver.returned) != 1 || !bytes.Equal(resolver.returned[0], make([]byte, len("first-secret"))) {
+		t.Fatalf("resolved credential was not zeroed: %q", resolver.returned)
+	}
+}
+
+func TestTenantGateAndIsolationConformance(t *testing.T) {
+	setPlatformRoots(t)
+	profile := validSyntheticProfile("client-one")
+	if err := SaveProfile(profile); err != nil {
+		t.Fatal(err)
+	}
+	ref := profile.Sources["sample"].CredentialRef
 	resolver := fixtureResolver{ref: []byte("synthetic-credential-one")}
 	adapter := &fixtureAdapter{observed: ObservedIdentity{AccountID: "account-one", OrgName: "Synthetic Org"}}
 	gateCtx, cancelGate := context.WithCancel(context.Background())
-	session, err := VerifyProfileSource(gateCtx, "client-one", "sample-pp-cli", "klaviyo", resolver, adapter)
+	session, err := VerifyProfileSource(gateCtx, "client-one", "sample-pp-cli", "sample", resolver, adapter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +296,7 @@ func TestTenantGateAndIsolationConformance(t *testing.T) {
 	if strings.Contains(session.CredentialFingerprint, "synthetic-credential") {
 		t.Fatal("credential fingerprint exposed credential bytes")
 	}
-	repeated, err := VerifyProfileSource(context.Background(), "client-one", "sample-pp-cli", "klaviyo", resolver, adapter)
+	repeated, err := VerifyProfileSource(context.Background(), "client-one", "sample-pp-cli", "sample", resolver, adapter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,7 +316,7 @@ func TestTenantGateAndIsolationConformance(t *testing.T) {
 		t.Fatalf("cache fingerprint key mode = %v", info.Mode().Perm())
 	}
 
-	otherPaths, err := PathsFor("client-two", "sample-pp-cli", "klaviyo")
+	otherPaths, err := PathsFor("client-two", "sample-pp-cli", "sample")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,13 +325,13 @@ func TestTenantGateAndIsolationConformance(t *testing.T) {
 	}
 
 	wrong := &fixtureAdapter{observed: ObservedIdentity{AccountID: "account-two", OrgName: "Synthetic Org"}}
-	_, err = VerifyProfileSource(context.Background(), "client-one", "sample-pp-cli", "klaviyo", resolver, wrong)
+	_, err = VerifyProfileSource(context.Background(), "client-one", "sample-pp-cli", "sample", resolver, wrong)
 	var gateErr *GateError
 	if !errors.As(err, &gateErr) || gateErr.Outcome != GateMismatch {
 		t.Fatalf("same-name wrong account error = %#v", err)
 	}
 
-	rotated, err := VerifyProfileSource(context.Background(), "client-one", "sample-pp-cli", "klaviyo", fixtureResolver{ref: []byte("synthetic-credential-two")}, adapter)
+	rotated, err := VerifyProfileSource(context.Background(), "client-one", "sample-pp-cli", "sample", fixtureResolver{ref: []byte("synthetic-credential-two")}, adapter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,14 +343,14 @@ func TestTenantGateAndIsolationConformance(t *testing.T) {
 
 func TestGateTypedFailuresConformance(t *testing.T) {
 	setPlatformRoots(t)
-	profile := validKlaviyoProfile("synthetic")
+	profile := validSyntheticProfile("synthetic")
 	if err := SaveProfile(profile); err != nil {
 		t.Fatal(err)
 	}
-	ref := profile.Sources["klaviyo"].CredentialRef
+	ref := profile.Sources["sample"].CredentialRef
 	for _, outcome := range []GateOutcome{GateInvalidCredentials, GateInsufficientScope, GateRateLimited, GateUnavailable, GateIndeterminate} {
 		adapter := &fixtureAdapter{err: &ProbeFailure{Outcome: outcome, Err: errors.New("synthetic probe failure")}}
-		_, err := VerifyProfileSource(context.Background(), "synthetic", "sample-pp-cli", "klaviyo", fixtureResolver{ref: []byte("synthetic")}, adapter)
+		_, err := VerifyProfileSource(context.Background(), "synthetic", "sample-pp-cli", "sample", fixtureResolver{ref: []byte("synthetic")}, adapter)
 		var gateErr *GateError
 		if !errors.As(err, &gateErr) || gateErr.Outcome != outcome {
 			t.Fatalf("outcome %s classified as %#v", outcome, err)
@@ -244,8 +371,8 @@ func TestGorgiasUsesDocumentedBaseURLIdentityOnly(t *testing.T) {
 func TestProviderMismatchAndDatabaseOwnershipConformance(t *testing.T) {
 	setPlatformRoots(t)
 	profile := &Profile{SchemaVersion: ProfileSchemaVersion, Name: "tenant-a", Sources: map[string]SourceProfile{
-		"shopify": {CredentialRef: "op://Synthetic/Shopify/token", ExpectedStoreID: "gid://shopify/Shop/1", ExpectedStoreDomain: "tenant-a.myshopify.com"},
-		"gorgias": {CredentialRef: "op://Synthetic/Gorgias/key", UsernameRef: "op://Synthetic/Gorgias/user", ExpectedBaseURL: "https://tenant-a.gorgias.com/api"},
+		"shopify": {CredentialRef: "fixture://Synthetic/Shopify/token", ExpectedStoreID: "gid://shopify/Shop/1", ExpectedStoreDomain: "tenant-a.myshopify.com"},
+		"gorgias": {CredentialRef: "fixture://Synthetic/Gorgias/key", UsernameRef: "fixture://Synthetic/Gorgias/user", ExpectedBaseURL: "https://tenant-a.gorgias.com/api"},
 	}}
 	if err := SaveProfile(profile); err != nil {
 		t.Fatal(err)
@@ -288,8 +415,8 @@ func TestCrossSourceDatabaseRequiresSelectedProfileOwnership(t *testing.T) {
 		SchemaVersion: ProfileSchemaVersion,
 		Name:          "tenant-a",
 		Sources: map[string]SourceProfile{
-			"meta-ads": {CredentialRef: "op://Synthetic/Meta/token", ExpectedAccountID: "meta-one"},
-			"shopify":  {CredentialRef: "op://Synthetic/Shopify/token", ExpectedStoreID: "shop-one", ExpectedStoreDomain: "tenant-a.myshopify.com"},
+			"meta-ads": {CredentialRef: "fixture://Synthetic/Meta/token", ExpectedAccountID: "meta-one"},
+			"shopify":  {CredentialRef: "fixture://Synthetic/Shopify/token", ExpectedStoreID: "shop-one", ExpectedStoreDomain: "tenant-a.myshopify.com"},
 		},
 	}
 	primary, err := PrepareProfileSourceFromConfig(profile, "meta-ads-pp-cli", "meta-ads")
@@ -331,7 +458,7 @@ func TestCrossSourceDatabaseRequiresSelectedProfileOwnership(t *testing.T) {
 	tamperedProfile := *profile
 	tamperedProfile.Sources = map[string]SourceProfile{
 		"meta-ads": profile.Sources["meta-ads"],
-		"shopify":  {CredentialRef: "op://Synthetic/Shopify/token", ExpectedStoreID: "shop-two", ExpectedStoreDomain: "tenant-b.myshopify.com"},
+			"shopify":  {CredentialRef: "fixture://Synthetic/Shopify/token", ExpectedStoreID: "shop-two", ExpectedStoreDomain: "tenant-b.myshopify.com"},
 	}
 	tampered.Profile = &tamperedProfile
 	if err := VerifyCrossSourceTenantMetadataReadOnly(context.Background(), db, &tampered, "shopify"); err == nil {
@@ -496,7 +623,7 @@ func TestContextCarriesOutputMetadataRecorder(t *testing.T) {
 		SchemaVersion: ProfileSchemaVersion,
 		Name:          "synthetic",
 		Sources: map[string]SourceProfile{
-			"sample": {CredentialRef: "op://Test Vault/Test Item/token", ExpectedAccountID: "one"},
+			"sample": {CredentialRef: "fixture://Test/sample/token", ExpectedAccountID: "one"},
 		},
 	}
 	session, err := PrepareProfileSourceFromConfig(profile, "sample-pp-cli", "sample")

--- a/internal/generator/templates/platform_profile.go.tmpl
+++ b/internal/generator/templates/platform_profile.go.tmpl
@@ -4,7 +4,6 @@
 package platform
 
 import (
-	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/rand"
@@ -14,7 +13,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -64,35 +62,6 @@ type CredentialResolver interface {
 	Resolve(context.Context, string) ([]byte, error)
 }
 
-// OnePasswordResolver delegates exact-reference reads to the existing
-// 1password-pp-cli policy surface. Only the non-secret reference enters argv.
-type OnePasswordResolver struct {
-	Binary string
-}
-
-func (r OnePasswordResolver) Resolve(ctx context.Context, ref string) ([]byte, error) {
-	if err := ValidateCredentialReference(ref); err != nil {
-		return nil, err
-	}
-	binary := strings.TrimSpace(r.Binary)
-	if binary == "" {
-		binary = "1password-pp-cli"
-	}
-	cmd := exec.CommandContext(ctx, binary, "secrets", "read", ref, "--reveal") // #nosec G204 -- binary is operator-selected; credential value is never an argument.
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		// Provider stderr is intentionally suppressed: an external resolver may
-		// echo the resolved field while reporting an error.
-		return nil, fmt.Errorf("resolve exact 1Password reference: %w", err)
-	}
-	if stdout.Len() == 0 {
-		return nil, errors.New("resolve exact 1Password reference: empty value")
-	}
-	return bytes.Clone(stdout.Bytes()), nil
-}
-
 // ResolvedCredentials holds credential bytes only for the current process.
 type ResolvedCredentials map[string][]byte
 
@@ -109,26 +78,6 @@ func (r ResolvedCredentials) Zero() {
 func ValidateProfileName(name string) error {
 	if !profileNamePattern.MatchString(name) || strings.Contains(name, "..") {
 		return fmt.Errorf("invalid client profile name %q", name)
-	}
-	return nil
-}
-
-// ValidateCredentialReference accepts only complete exact op:// references.
-func ValidateCredentialReference(ref string) error {
-	if strings.TrimSpace(ref) != ref || !strings.HasPrefix(ref, "op://") {
-		return errors.New("credential reference must be an exact op://vault/item/field-or-document reference")
-	}
-	if strings.ContainsAny(ref, "$\n\r\t") {
-		return errors.New("credential reference may not contain interpolation or control characters")
-	}
-	parts := strings.Split(strings.TrimPrefix(ref, "op://"), "/")
-	if len(parts) != 3 {
-		return errors.New("credential reference must contain vault, item, and field or document")
-	}
-	for _, part := range parts {
-		if strings.TrimSpace(part) == "" || part == "." || part == ".." {
-			return errors.New("credential reference contains an empty or unsafe component")
-		}
 	}
 	return nil
 }
@@ -167,10 +116,12 @@ func (p *Profile) Validate() error {
 }
 
 func (s SourceProfile) Validate() error {
-	refs := s.References()
-	for name, ref := range refs {
-		if err := ValidateCredentialReference(ref); err != nil {
-			return fmt.Errorf("%s: %w", name, err)
+	for name, ref := range s.AdditionalCredentialRefs {
+		if strings.TrimSpace(name) == "" {
+			return errors.New("additional credential reference name may not be empty")
+		}
+		if ref == "" {
+			return fmt.Errorf("additional credential reference %q may not be empty", name)
 		}
 	}
 	if len(s.ExpectedIdentity()) == 0 {
@@ -496,16 +447,19 @@ func kindRoot(envName string, platformDefault func() (string, error), homeFallba
 }
 
 func resolveCredentials(ctx context.Context, resolver CredentialResolver, source SourceProfile) (ResolvedCredentials, error) {
-	if resolver == nil {
-		return nil, errors.New("credential resolver is required")
-	}
 	refs := source.References()
+	resolved := make(ResolvedCredentials, len(refs))
+	if len(refs) == 0 {
+		return resolved, nil
+	}
+	if resolver == nil {
+		return nil, errors.New("credential resolver is required for credential references")
+	}
 	keys := make([]string, 0, len(refs))
 	for key := range refs {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	resolved := make(ResolvedCredentials, len(keys))
 	for _, key := range keys {
 		value, err := resolver.Resolve(ctx, refs[key])
 		if err != nil {

--- a/internal/generator/templates/platform_window_test.go.tmpl
+++ b/internal/generator/templates/platform_window_test.go.tmpl
@@ -63,7 +63,7 @@ func TestPlatformCommandWindowPreservesCalendarInputs(t *testing.T) {
 }
 
 func TestPlatformMCPWindowPreservesCalendarMonthInput(t *testing.T) {
-	profile := &platform.Profile{SchemaVersion: platform.ProfileSchemaVersion, Name: "tenant-a", Sources: map[string]platform.SourceProfile{"test-source": {CredentialRef: "op://Test Vault/Test Item/token", ExpectedAccountID: "acct-a"}}}
+	profile := &platform.Profile{SchemaVersion: platform.ProfileSchemaVersion, Name: "tenant-a", Sources: map[string]platform.SourceProfile{"test-source": {CredentialRef: "fixture://Test/sample/token", ExpectedAccountID: "acct-a"}}}
 	session, err := platform.PrepareProfileSourceFromConfig(profile, "fixture-pp-cli", "test-source")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -63,6 +63,8 @@ type rootFlags struct {
 	runProfileName string
 	clientProfileName string
 	platformSession *platform.Session
+	platformResolver platform.CredentialResolver
+	platformResolverReady bool
 	platformAnalytics *platform.AnalyticsDeclaration
 	platformGateError error
 	platformMetadataWriter io.Writer

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -4036,6 +4036,8 @@ var reservedRootFlagFieldNames = map[string]struct{}{
 	"clientProfileName":       {},
 	"platformGateError":       {},
 	"platformSession":         {},
+	"platformResolver":        {},
+	"platformResolverReady":   {},
 	"platformAnalytics":       {},
 	"platformMetadataWriter":  {},
 	"platformMetadataEmitted": {},

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/root.go
@@ -50,6 +50,8 @@ type rootFlags struct {
 	runProfileName          string
 	clientProfileName       string
 	platformSession         *platform.Session
+	platformResolver        platform.CredentialResolver
+	platformResolverReady   bool
 	platformAnalytics       *platform.AnalyticsDeclaration
 	platformGateError       error
 	platformMetadataWriter  io.Writer

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/AGENTS.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/AGENTS.md
@@ -63,6 +63,20 @@ The store's schema stamp is one-way: once this binary opens the database, an old
 
 Disable the loop with `--no-learn` per-invocation or `PRINTING_PRESS_RICH_NO_LEARN=true` for the whole session - useful for deterministic agent flows that don't want a learning row to silently change subsequent query results.
 
+## Platform Credential References
+
+Normal API authentication is separate from optional platform-source credential
+resolution. If this CLI uses indirect references for a tenant-gated platform
+source, add the downstream registration in a preserved hand-authored file
+under `internal/cli/` and provide both `CredentialResolverFactory` and
+`ValidateSourceProfile` on `platformSourceRegistration` for any selected source
+that has references. A source with no references may omit both hooks and receives
+an empty credential map. Keep reference values opaque to shared profile code,
+validate only the selected source in the downstream hook, and never persist
+resolved credential bytes. Do not edit generator-owned `internal/platform`
+packages; a reprint refreshes those files while retaining the downstream
+registration file.
+
 For install, auth, examples, and longer product guidance, read `README.md` and `SKILL.md`. This file intentionally stays small so repo-local agents get invariant local guidance without duplicating the generated docs.
 
 ## Release Ledger

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/AGENTS.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/AGENTS.md
@@ -63,6 +63,20 @@ The store's schema stamp is one-way: once this binary opens the database, an old
 
 Disable the loop with `--no-learn` per-invocation or `PRINTING_PRESS_GOLDEN_NO_LEARN=true` for the whole session - useful for deterministic agent flows that don't want a learning row to silently change subsequent query results.
 
+## Platform Credential References
+
+Normal API authentication is separate from optional platform-source credential
+resolution. If this CLI uses indirect references for a tenant-gated platform
+source, add the downstream registration in a preserved hand-authored file
+under `internal/cli/` and provide both `CredentialResolverFactory` and
+`ValidateSourceProfile` on `platformSourceRegistration` for any selected source
+that has references. A source with no references may omit both hooks and receives
+an empty credential map. Keep reference values opaque to shared profile code,
+validate only the selected source in the downstream hook, and never persist
+resolved credential bytes. Do not edit generator-owned `internal/platform`
+packages; a reprint refreshes those files while retaining the downstream
+registration file.
+
 For install, auth, examples, and longer product guidance, read `README.md` and `SKILL.md`. This file intentionally stays small so repo-local agents get invariant local guidance without duplicating the generated docs.
 
 ## Release Ledger

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
@@ -49,6 +49,8 @@ type rootFlags struct {
 	runProfileName          string
 	clientProfileName       string
 	platformSession         *platform.Session
+	platformResolver        platform.CredentialResolver
+	platformResolverReady   bool
 	platformAnalytics       *platform.AnalyticsDeclaration
 	platformGateError       error
 	platformMetadataWriter  io.Writer

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/AGENTS.md
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/AGENTS.md
@@ -43,6 +43,20 @@ Every hand-written novel command must declare its strategy in a Go line comment:
 
 Use exactly one of `auto`, `local`, `live`, or `computed`. Keep `auto` when the command honors `--data-source auto|local|live` by preferring live data with a local fallback; use `local` for local-only reads, `live` for remote-only reads, and `computed` for pure computation from embedded rules. Change a generated scaffold's `auto` default deliberately when its implementation has a narrower source, and reject incompatible `--data-source` requests with a clear error. TODO stubs still fail dogfood even when annotated.
 
+## Platform Credential References
+
+Normal API authentication is separate from optional platform-source credential
+resolution. If this CLI uses indirect references for a tenant-gated platform
+source, add the downstream registration in a preserved hand-authored file
+under `internal/cli/` and provide both `CredentialResolverFactory` and
+`ValidateSourceProfile` on `platformSourceRegistration` for any selected source
+that has references. A source with no references may omit both hooks and receives
+an empty credential map. Keep reference values opaque to shared profile code,
+validate only the selected source in the downstream hook, and never persist
+resolved credential bytes. Do not edit generator-owned `internal/platform`
+packages; a reprint refreshes those files while retaining the downstream
+registration file.
+
 For install, auth, examples, and longer product guidance, read `README.md` and `SKILL.md`. This file intentionally stays small so repo-local agents get invariant local guidance without duplicating the generated docs.
 
 ## Release Ledger

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/cli/root.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/cli/root.go
@@ -38,6 +38,8 @@ type rootFlags struct {
 	runProfileName          string
 	clientProfileName       string
 	platformSession         *platform.Session
+	platformResolver        platform.CredentialResolver
+	platformResolverReady   bool
 	platformAnalytics       *platform.AnalyticsDeclaration
 	platformGateError       error
 	platformMetadataWriter  io.Writer

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/AGENTS.md
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/AGENTS.md
@@ -63,6 +63,20 @@ The store's schema stamp is one-way: once this binary opens the database, an old
 
 Disable the loop with `--no-learn` per-invocation or `LEARN_LOOP_EXAMPLE_NO_LEARN=true` for the whole session - useful for deterministic agent flows that don't want a learning row to silently change subsequent query results.
 
+## Platform Credential References
+
+Normal API authentication is separate from optional platform-source credential
+resolution. If this CLI uses indirect references for a tenant-gated platform
+source, add the downstream registration in a preserved hand-authored file
+under `internal/cli/` and provide both `CredentialResolverFactory` and
+`ValidateSourceProfile` on `platformSourceRegistration` for any selected source
+that has references. A source with no references may omit both hooks and receives
+an empty credential map. Keep reference values opaque to shared profile code,
+validate only the selected source in the downstream hook, and never persist
+resolved credential bytes. Do not edit generator-owned `internal/platform`
+packages; a reprint refreshes those files while retaining the downstream
+registration file.
+
 For install, auth, examples, and longer product guidance, read `README.md` and `SKILL.md`. This file intentionally stays small so repo-local agents get invariant local guidance without duplicating the generated docs.
 
 ## Release Ledger

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/root.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/root.go
@@ -43,6 +43,8 @@ type rootFlags struct {
 	runProfileName          string
 	clientProfileName       string
 	platformSession         *platform.Session
+	platformResolver        platform.CredentialResolver
+	platformResolverReady   bool
 	platformAnalytics       *platform.AnalyticsDeclaration
 	platformGateError       error
 	platformMetadataWriter  io.Writer


### PR DESCRIPTION
## Intent

Issue: Fixes #3914

Generated platform CLIs no longer assume that 1Password is the credential provider. Before this change, generated core owned a provider-specific resolver and reference grammar; now zero-reference sources work without a resolver, while credential-bearing sources require an explicitly registered resolver/validator pair owned by the downstream CLI.

This supersedes closed PR #3841: its provider-catalog direction is intentionally replaced by the narrower provider-neutral registration seam required by this issue.

Related: #3841

## Approach

The existing `CredentialResolver` abstraction remains intact. The generated package-local `platformSourceRegistration` gains an optional `CredentialResolverFactory`; selected-source validation stays in its existing downstream hook. Shared profile validation only enforces structural invariants, preserves nonempty opaque reference values byte-for-byte, and leaves provider syntax and scheme semantics to the selected source.

Resolver creation is per verification call, with a cached instance for each CLI invocation so configuration errors occur before probes, receipts, or profile writes. Empty reference sets receive an initialized empty credential map and do not require a resolver; nonempty sets fail clearly when either hook is missing or the factory returns nil. CLI, MCP, migration, reprint, and credential-zeroization paths are covered without adding a provider catalog, provider config field, default provider, or built-in adapter.

Session-settled decisions carried from planning: resolver ownership moves to downstream registration (user-approved); provider-neutral selected-source validation with opaque nonempty references (user-approved); zero references return an initialized empty map while nonempty references require the resolver/validator pair (user-approved); schema v1 and downstream seam discoverability remain unchanged (user-approved).

## Scope

Primary area: generated platform profile, CLI, MCP, migration, agent-guidance, and conformance-test templates.

Why this belongs in this repo: this is a generator-level behavior and output-contract fix that must apply to future printed CLIs, rather than an API-specific repair in the public library.

## Risk

Generated profile validation and platform lifecycle behavior change. Provider-specific reference rules now belong to the selected downstream validator, and MCP creates a fresh resolver per invocation. Stored profile schema and normal API authentication remain unchanged; resolved credential bytes are still zeroized and never persisted.

## Output Contract

Generated contract assertions reject the removed OnePassword executable/env/resolver coupling and provider-specific `op://` grammar. Generated adapter fixtures compile and exercise CLI and MCP resolution, zero-reference behavior, nil-factory failures, persistence ordering, reprint preservation, and credential zeroization. Golden output was intentionally updated only for the new agent guidance and cached resolver fields; no provider catalog or schema field was added.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions and compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

- `go fmt ./...` — passed
- Focused generated resolver/runtime tests — 4 passed
- `scripts/golden.sh verify` — 32 cases passed
- `scripts/verify-generator-output.sh generate-golden-api generate-golden-api-rich-auth generate-learn-disabled-api generate-learn-loop-api generate-fastapi-operationids` — 5 cases passed
- `go build -o ./cli-printing-press ./cmd/cli-printing-press` — passed
- `golangci-lint run ./internal/generator/...` and `golangci-lint run ./... --new-from-rev origin/main` — passed
- `golangci-lint run ./...` — one pre-existing `modernize` finding in untouched `internal/googlediscovery/parser.go`
- `git diff --check` — passed
- Decoy-home generated-module proof and force reprint proof — passed; the decoy profile snapshot remained byte-identical and the generated module's direct `go test ./...` passed
- `go test ./...` — not a clean result in this macOS worktree: one run reached 6,660 passes and 8 unrelated generated-output failures after local database-version warnings; a rerun hung in the local credential/browser integration lane and was interrupted

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
