### PR TITLE
fix(cli): classify DNS failures and expose typed rate-limit errors

### DIFF
--- a/internal/generator/client_retry_safety_test.go
+++ b/internal/generator/client_retry_safety_test.go
@@ -26,12 +26,14 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"retry-safety-pp-cli/internal/cliutil"
 	"retry-safety-pp-cli/internal/config"
 	"retry-safety-pp-cli/internal/platform"
 )
@@ -109,16 +111,35 @@ func TestRetrySafety_POSTDoesNotRetryRateLimitWithoutIdempotencyKey(t *testing.T
 	var calls int
 	c := newRetrySafetyClient(t, retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		calls++
-		return retryResponse(req, http.StatusTooManyRequests), nil
+		resp := retryResponse(req, http.StatusTooManyRequests)
+		resp.Header.Set("Retry-After", "5")
+		return resp, nil
 	}))
 
 	_, status, err := c.Post(context.Background(), "/items", map[string]string{"name": "one"})
 	var rateErr *platform.RateLimitedError
-	if !errors.As(err, &rateErr) || status != http.StatusTooManyRequests {
+	var cliRateErr *cliutil.RateLimitError
+	var apiErr *APIError
+	if !errors.As(err, &rateErr) || !errors.As(err, &cliRateErr) || !errors.As(err, &apiErr) || status != http.StatusTooManyRequests {
 		t.Fatalf("Post() = status %d, error %v; want typed HTTP 429", status, err)
+	}
+	if cliRateErr.RetryAfter != 5*time.Second {
+		t.Fatalf("cliutil.RateLimitError.RetryAfter = %s, want 5s", cliRateErr.RetryAfter)
 	}
 	if calls != 1 {
 		t.Fatalf("POST calls = %d, want 1", calls)
+	}
+}
+
+func TestRetrySafety_ServerErrorDoesNotMatchRateLimit(t *testing.T) {
+	c := newRetrySafetyClient(t, retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return retryResponse(req, http.StatusInternalServerError), nil
+	}))
+
+	_, status, err := c.Post(context.Background(), "/items", map[string]string{"name": "one"})
+	var cliRateErr *cliutil.RateLimitError
+	if err == nil || status != http.StatusInternalServerError || errors.As(err, &cliRateErr) {
+		t.Fatalf("Post() = status %d, error %v; want untyped HTTP 500 error", status, err)
 	}
 }
 
@@ -180,6 +201,89 @@ func TestRetrySafety_TransportErrorsRespectMethodSafety(t *testing.T) {
 			}
 			if calls != 1 {
 				t.Fatalf("%s calls = %d, want 1", method, calls)
+			}
+		})
+	}
+}
+
+func TestRetrySafety_DNSFailureClassification(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        *net.DNSError
+		wantCalls  int
+		wantResult int
+	}{
+		{
+			name: "NXDOMAIN is terminal",
+			err: &net.DNSError{
+				Err:        "no such host",
+				Name:       "api.example.invalid",
+				IsNotFound: true,
+			},
+			wantCalls:  1,
+		},
+		{
+			name: "REFUSED is terminal",
+			err: &net.DNSError{
+				Err:  "server misbehaving",
+				Name: "api.example.invalid",
+			},
+			wantCalls: 1,
+		},
+		{
+			name: "unclassified DNS retries",
+			err: &net.DNSError{
+				Err:  "unclassified resolver failure",
+				Name: "api.example.invalid",
+			},
+			wantCalls:  2,
+			wantResult: http.StatusOK,
+		},
+		{
+			name: "temporary DNS retries",
+			err: &net.DNSError{
+				Err:         "temporary failure",
+				Name:        "api.example.invalid",
+				IsTemporary: true,
+			},
+			wantCalls:  2,
+			wantResult: http.StatusOK,
+		},
+		{
+			name: "DNS timeout retries",
+			err: &net.DNSError{
+				Err:       "i/o timeout",
+				Name:      "api.example.invalid",
+				IsTimeout: true,
+			},
+			wantCalls:  2,
+			wantResult: http.StatusOK,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls int
+			c := newRetrySafetyClient(t, retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				if calls == 1 {
+					return nil, tc.err
+				}
+				return retryResponse(req, tc.wantResult), nil
+			}))
+
+			_, status, err := c.do(context.Background(), http.MethodGet, "/items", nil, nil, nil)
+			if calls != tc.wantCalls {
+				t.Fatalf("calls = %d, want %d; error = %v", calls, tc.wantCalls, err)
+			}
+			if tc.wantResult == 0 {
+				if err == nil || status != 0 {
+					t.Fatalf("terminal DNS result = status %d, error %v; want immediate transport error", status, err)
+				}
+				return
+			}
+			if err != nil || status != tc.wantResult {
+				t.Fatalf("retryable DNS result = status %d, error %v; want HTTP %d", status, err, tc.wantResult)
 			}
 		})
 	}

--- a/internal/generator/client_retry_safety_test.go
+++ b/internal/generator/client_retry_safety_test.go
@@ -223,9 +223,18 @@ func TestRetrySafety_DNSFailureClassification(t *testing.T) {
 			wantCalls:  1,
 		},
 		{
-			name: "REFUSED is terminal",
+			name: "SERVFAIL retries",
 			err: &net.DNSError{
 				Err:  "server misbehaving",
+				Name: "api.example.invalid",
+			},
+			wantCalls:  2,
+			wantResult: http.StatusOK,
+		},
+		{
+			name: "explicit REFUSED is terminal",
+			err: &net.DNSError{
+				Err:  "query refused",
 				Name: "api.example.invalid",
 			},
 			wantCalls: 1,

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -3183,7 +3183,7 @@ func isPermanentDNSError(err error) bool {
 		return false
 	}
 	reason := strings.ToLower(strings.TrimSpace(dnsErr.Err))
-	// The standard resolver reports DNS RCODE_REFUSED as "server misbehaving";
-	// other platforms may include "refused" in the reason string.
-	return reason == "server misbehaving" || strings.Contains(reason, "refused")
+	// The generic "server misbehaving" text is also used for transient
+	// SERVFAIL responses, so only explicit refusal text is terminal here.
+	return strings.Contains(reason, "refused")
 }

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -20,6 +20,7 @@ import (
 {{- if .HasMultipartRequest}}
 	"mime/multipart"
 {{- end}}
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -2009,7 +2010,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			// timeout). Back off before retrying — same exponential schedule as
 			// the 5xx path below — so a brief outage does not burn every attempt
 			// in a tight loop. ctx cancellation breaks out of the wait at once.
-			if attempt < maxRetries && canRetryAmbiguousFailure {
+			if attempt < maxRetries && canRetryAmbiguousFailure && !isPermanentDNSError(err) {
 				wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 				if !retryWithinBudget(wait) {
 					return nil, 0, lastErr
@@ -2149,6 +2150,12 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			return nil, resp.StatusCode, &platform.RateLimitedError{
 				EndpointClass: endpointClass, Attempts: attempt + 1,
 				RetryAfter: wait, RequestID: requestID,
+				Cause: &cliutil.RateLimitError{
+					URL:        apiErr.Path,
+					RetryAfter: wait,
+					Body:       apiErr.Body,
+					Cause:      apiErr,
+				},
 			}
 		}
 {{- if eq .Auth.Type "session_handshake"}}
@@ -3159,4 +3166,24 @@ func clientMaxRetries() int {
 		return 0
 	}
 	return 3
+}
+
+// isPermanentDNSError identifies known resolver failures that cannot succeed
+// by replaying the request. Timeouts, explicitly temporary failures, and
+// otherwise unclassified DNS errors remain retryable.
+func isPermanentDNSError(err error) bool {
+	var dnsErr *net.DNSError
+	if !errors.As(err, &dnsErr) {
+		return false
+	}
+	if dnsErr.IsNotFound {
+		return true
+	}
+	if dnsErr.IsTimeout || dnsErr.IsTemporary {
+		return false
+	}
+	reason := strings.ToLower(strings.TrimSpace(dnsErr.Err))
+	// The standard resolver reports DNS RCODE_REFUSED as "server misbehaving";
+	// other platforms may include "refused" in the reason string.
+	return reason == "server misbehaving" || strings.Contains(reason, "refused")
 }

--- a/internal/generator/templates/client_platform_rate_limit_test.go.tmpl
+++ b/internal/generator/templates/client_platform_rate_limit_test.go.tmpl
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"{{modulePath}}/internal/cliutil"
 	"{{modulePath}}/internal/config"
 	"{{modulePath}}/internal/platform"
 )
@@ -53,7 +54,9 @@ func TestPlatformRateLimitDoesNotReplayUnsafeWrite(t *testing.T) {
 	client, session := platformRateLimitTestClient(t, server)
 	_, _, err := client.Post(context.Background(), "/mutation", map[string]any{"synthetic": true})
 	var limited *platform.RateLimitedError
-	if !errors.As(err, &limited) || limited.Attempts != 1 || limited.RequestID != "safe-request-id" {
+	var cliLimited *cliutil.RateLimitError
+	var apiErr *APIError
+	if !errors.As(err, &limited) || !errors.As(err, &cliLimited) || !errors.As(err, &apiErr) || limited.Attempts != 1 || limited.RequestID != "safe-request-id" {
 		t.Fatalf("rate-limit error = %#v (%v)", limited, err)
 	}
 	if calls.Load() != 1 {
@@ -61,6 +64,32 @@ func TestPlatformRateLimitDoesNotReplayUnsafeWrite(t *testing.T) {
 	}
 	if !session.RateLimitMetadata().Exhausted {
 		t.Fatal("exhausted rate-limit metadata was not recorded")
+	}
+}
+
+func TestPlatformRateLimitRetryBudgetReturnsTypedError(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	client, _ := platformRateLimitTestClient(t, server)
+	if err := client.SetPlatformEndpointBudget(platform.EndpointBudget{
+		Class: "*", Steady: 60, Interval: time.Minute, Burst: 1,
+		MaxAttempts: 3, RetryBudget: time.Nanosecond,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := client.Get(context.Background(), "/budget", nil)
+	var cliLimited *cliutil.RateLimitError
+	if !errors.As(err, &cliLimited) || cliLimited.RetryAfter != 5*time.Second {
+		t.Fatalf("rate-limit error = %#v (%v); want cliutil error with 5s retry-after", cliLimited, err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("calls = %d, want retry budget to stop after first response", calls.Load())
 	}
 }
 

--- a/internal/generator/templates/cliutil_ratelimit.go.tmpl
+++ b/internal/generator/templates/cliutil_ratelimit.go.tmpl
@@ -221,6 +221,7 @@ type RateLimitError struct {
 	URL        string
 	RetryAfter time.Duration
 	Body       string
+	Cause      error
 }
 
 func (e *RateLimitError) Error() string {
@@ -233,6 +234,8 @@ func (e *RateLimitError) Error() string {
 	}
 	return msg
 }
+
+func (e *RateLimitError) Unwrap() error { return e.Cause }
 
 // ParseRateLimitHeaders reads the X-Ratelimit-Remaining and X-Ratelimit-Reset
 // headers many APIs (Plane among them) emit on every response. Remaining is the

--- a/internal/generator/templates/cliutil_test.go.tmpl
+++ b/internal/generator/templates/cliutil_test.go.tmpl
@@ -792,13 +792,17 @@ func TestRateLimitError_ErrorMessage(t *testing.T) {
 }
 
 func TestRateLimitError_ErrorsAs(t *testing.T) {
-	var err error = &RateLimitError{URL: "https://x", RetryAfter: time.Second}
+	cause := errors.New("underlying API error")
+	var err error = &RateLimitError{URL: "https://x", RetryAfter: time.Second, Cause: cause}
 	var target *RateLimitError
 	if !errors.As(err, &target) {
 		t.Fatal("errors.As should match *RateLimitError")
 	}
 	if target.URL != "https://x" {
 		t.Errorf("target.URL = %q, want %q", target.URL, "https://x")
+	}
+	if !errors.Is(err, cause) {
+		t.Fatal("errors.Is should reach the wrapped cause")
 	}
 }
 

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -1429,7 +1429,7 @@ func isPermanentDNSError(err error) bool {
 		return false
 	}
 	reason := strings.ToLower(strings.TrimSpace(dnsErr.Err))
-	// The standard resolver reports DNS RCODE_REFUSED as "server misbehaving";
-	// other platforms may include "refused" in the reason string.
-	return reason == "server misbehaving" || strings.Contains(reason, "refused")
+	// The generic "server misbehaving" text is also used for transient
+	// SERVFAIL responses, so only explicit refusal text is terminal here.
+	return strings.Contains(reason, "refused")
 }

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -17,6 +17,7 @@ import (
 	"golden-api-cookie-auth-pp-cli/internal/platform"
 	"io"
 	"math"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -974,7 +975,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			// timeout). Back off before retrying — same exponential schedule as
 			// the 5xx path below — so a brief outage does not burn every attempt
 			// in a tight loop. ctx cancellation breaks out of the wait at once.
-			if attempt < maxRetries && canRetryAmbiguousFailure {
+			if attempt < maxRetries && canRetryAmbiguousFailure && !isPermanentDNSError(err) {
 				wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 				if !retryWithinBudget(wait) {
 					return nil, 0, lastErr
@@ -1059,6 +1060,12 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			return nil, resp.StatusCode, &platform.RateLimitedError{
 				EndpointClass: endpointClass, Attempts: attempt + 1,
 				RetryAfter: wait, RequestID: requestID,
+				Cause: &cliutil.RateLimitError{
+					URL:        apiErr.Path,
+					RetryAfter: wait,
+					Body:       apiErr.Body,
+					Cause:      apiErr,
+				},
 			}
 		}
 
@@ -1405,4 +1412,24 @@ func clientMaxRetries() int {
 		return 0
 	}
 	return 3
+}
+
+// isPermanentDNSError identifies known resolver failures that cannot succeed
+// by replaying the request. Timeouts, explicitly temporary failures, and
+// otherwise unclassified DNS errors remain retryable.
+func isPermanentDNSError(err error) bool {
+	var dnsErr *net.DNSError
+	if !errors.As(err, &dnsErr) {
+		return false
+	}
+	if dnsErr.IsNotFound {
+		return true
+	}
+	if dnsErr.IsTimeout || dnsErr.IsTemporary {
+		return false
+	}
+	reason := strings.ToLower(strings.TrimSpace(dnsErr.Err))
+	// The standard resolver reports DNS RCODE_REFUSED as "server misbehaving";
+	// other platforms may include "refused" in the reason string.
+	return reason == "server misbehaving" || strings.Contains(reason, "refused")
 }

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -962,7 +963,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			// timeout). Back off before retrying — same exponential schedule as
 			// the 5xx path below — so a brief outage does not burn every attempt
 			// in a tight loop. ctx cancellation breaks out of the wait at once.
-			if attempt < maxRetries && canRetryAmbiguousFailure {
+			if attempt < maxRetries && canRetryAmbiguousFailure && !isPermanentDNSError(err) {
 				wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 				if !retryWithinBudget(wait) {
 					return nil, 0, lastErr
@@ -1064,6 +1065,12 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			return nil, resp.StatusCode, &platform.RateLimitedError{
 				EndpointClass: endpointClass, Attempts: attempt + 1,
 				RetryAfter: wait, RequestID: requestID,
+				Cause: &cliutil.RateLimitError{
+					URL:        apiErr.Path,
+					RetryAfter: wait,
+					Body:       apiErr.Body,
+					Cause:      apiErr,
+				},
 			}
 		}
 
@@ -1489,4 +1496,24 @@ func clientMaxRetries() int {
 		return 0
 	}
 	return 3
+}
+
+// isPermanentDNSError identifies known resolver failures that cannot succeed
+// by replaying the request. Timeouts, explicitly temporary failures, and
+// otherwise unclassified DNS errors remain retryable.
+func isPermanentDNSError(err error) bool {
+	var dnsErr *net.DNSError
+	if !errors.As(err, &dnsErr) {
+		return false
+	}
+	if dnsErr.IsNotFound {
+		return true
+	}
+	if dnsErr.IsTimeout || dnsErr.IsTemporary {
+		return false
+	}
+	reason := strings.ToLower(strings.TrimSpace(dnsErr.Err))
+	// The standard resolver reports DNS RCODE_REFUSED as "server misbehaving";
+	// other platforms may include "refused" in the reason string.
+	return reason == "server misbehaving" || strings.Contains(reason, "refused")
 }

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -1513,7 +1513,7 @@ func isPermanentDNSError(err error) bool {
 		return false
 	}
 	reason := strings.ToLower(strings.TrimSpace(dnsErr.Err))
-	// The standard resolver reports DNS RCODE_REFUSED as "server misbehaving";
-	// other platforms may include "refused" in the reason string.
-	return reason == "server misbehaving" || strings.Contains(reason, "refused")
+	// The generic "server misbehaving" text is also used for transient
+	// SERVFAIL responses, so only explicit refusal text is terminal here.
+	return strings.Contains(reason, "refused")
 }

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -971,7 +972,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			// timeout). Back off before retrying — same exponential schedule as
 			// the 5xx path below — so a brief outage does not burn every attempt
 			// in a tight loop. ctx cancellation breaks out of the wait at once.
-			if attempt < maxRetries && canRetryAmbiguousFailure {
+			if attempt < maxRetries && canRetryAmbiguousFailure && !isPermanentDNSError(err) {
 				wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 				if !retryWithinBudget(wait) {
 					return nil, 0, lastErr
@@ -1073,6 +1074,12 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			return nil, resp.StatusCode, &platform.RateLimitedError{
 				EndpointClass: endpointClass, Attempts: attempt + 1,
 				RetryAfter: wait, RequestID: requestID,
+				Cause: &cliutil.RateLimitError{
+					URL:        apiErr.Path,
+					RetryAfter: wait,
+					Body:       apiErr.Body,
+					Cause:      apiErr,
+				},
 			}
 		}
 
@@ -1612,4 +1619,24 @@ func clientMaxRetries() int {
 		return 0
 	}
 	return 3
+}
+
+// isPermanentDNSError identifies known resolver failures that cannot succeed
+// by replaying the request. Timeouts, explicitly temporary failures, and
+// otherwise unclassified DNS errors remain retryable.
+func isPermanentDNSError(err error) bool {
+	var dnsErr *net.DNSError
+	if !errors.As(err, &dnsErr) {
+		return false
+	}
+	if dnsErr.IsNotFound {
+		return true
+	}
+	if dnsErr.IsTimeout || dnsErr.IsTemporary {
+		return false
+	}
+	reason := strings.ToLower(strings.TrimSpace(dnsErr.Err))
+	// The standard resolver reports DNS RCODE_REFUSED as "server misbehaving";
+	// other platforms may include "refused" in the reason string.
+	return reason == "server misbehaving" || strings.Contains(reason, "refused")
 }

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -1636,7 +1636,7 @@ func isPermanentDNSError(err error) bool {
 		return false
 	}
 	reason := strings.ToLower(strings.TrimSpace(dnsErr.Err))
-	// The standard resolver reports DNS RCODE_REFUSED as "server misbehaving";
-	// other platforms may include "refused" in the reason string.
-	return reason == "server misbehaving" || strings.Contains(reason, "refused")
+	// The generic "server misbehaving" text is also used for transient
+	// SERVFAIL responses, so only explicit refusal text is terminal here.
+	return strings.Contains(reason, "refused")
 }

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -1512,7 +1512,7 @@ func isPermanentDNSError(err error) bool {
 		return false
 	}
 	reason := strings.ToLower(strings.TrimSpace(dnsErr.Err))
-	// The standard resolver reports DNS RCODE_REFUSED as "server misbehaving";
-	// other platforms may include "refused" in the reason string.
-	return reason == "server misbehaving" || strings.Contains(reason, "refused")
+	// The generic "server misbehaving" text is also used for transient
+	// SERVFAIL responses, so only explicit refusal text is terminal here.
+	return strings.Contains(reason, "refused")
 }

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -962,7 +963,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			// timeout). Back off before retrying — same exponential schedule as
 			// the 5xx path below — so a brief outage does not burn every attempt
 			// in a tight loop. ctx cancellation breaks out of the wait at once.
-			if attempt < maxRetries && canRetryAmbiguousFailure {
+			if attempt < maxRetries && canRetryAmbiguousFailure && !isPermanentDNSError(err) {
 				wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 				if !retryWithinBudget(wait) {
 					return nil, 0, lastErr
@@ -1064,6 +1065,12 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			return nil, resp.StatusCode, &platform.RateLimitedError{
 				EndpointClass: endpointClass, Attempts: attempt + 1,
 				RetryAfter: wait, RequestID: requestID,
+				Cause: &cliutil.RateLimitError{
+					URL:        apiErr.Path,
+					RetryAfter: wait,
+					Body:       apiErr.Body,
+					Cause:      apiErr,
+				},
 			}
 		}
 
@@ -1488,4 +1495,24 @@ func clientMaxRetries() int {
 		return 0
 	}
 	return 3
+}
+
+// isPermanentDNSError identifies known resolver failures that cannot succeed
+// by replaying the request. Timeouts, explicitly temporary failures, and
+// otherwise unclassified DNS errors remain retryable.
+func isPermanentDNSError(err error) bool {
+	var dnsErr *net.DNSError
+	if !errors.As(err, &dnsErr) {
+		return false
+	}
+	if dnsErr.IsNotFound {
+		return true
+	}
+	if dnsErr.IsTimeout || dnsErr.IsTemporary {
+		return false
+	}
+	reason := strings.ToLower(strings.TrimSpace(dnsErr.Err))
+	// The standard resolver reports DNS RCODE_REFUSED as "server misbehaving";
+	// other platforms may include "refused" in the reason string.
+	return reason == "server misbehaving" || strings.Contains(reason, "refused")
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"math"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -1077,7 +1078,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			// timeout). Back off before retrying — same exponential schedule as
 			// the 5xx path below — so a brief outage does not burn every attempt
 			// in a tight loop. ctx cancellation breaks out of the wait at once.
-			if attempt < maxRetries && canRetryAmbiguousFailure {
+			if attempt < maxRetries && canRetryAmbiguousFailure && !isPermanentDNSError(err) {
 				wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 				if !retryWithinBudget(wait) {
 					return nil, 0, lastErr
@@ -1162,6 +1163,12 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			return nil, resp.StatusCode, &platform.RateLimitedError{
 				EndpointClass: endpointClass, Attempts: attempt + 1,
 				RetryAfter: wait, RequestID: requestID,
+				Cause: &cliutil.RateLimitError{
+					URL:        apiErr.Path,
+					RetryAfter: wait,
+					Body:       apiErr.Body,
+					Cause:      apiErr,
+				},
 			}
 		}
 
@@ -1508,4 +1515,24 @@ func clientMaxRetries() int {
 		return 0
 	}
 	return 3
+}
+
+// isPermanentDNSError identifies known resolver failures that cannot succeed
+// by replaying the request. Timeouts, explicitly temporary failures, and
+// otherwise unclassified DNS errors remain retryable.
+func isPermanentDNSError(err error) bool {
+	var dnsErr *net.DNSError
+	if !errors.As(err, &dnsErr) {
+		return false
+	}
+	if dnsErr.IsNotFound {
+		return true
+	}
+	if dnsErr.IsTimeout || dnsErr.IsTemporary {
+		return false
+	}
+	reason := strings.ToLower(strings.TrimSpace(dnsErr.Err))
+	// The standard resolver reports DNS RCODE_REFUSED as "server misbehaving";
+	// other platforms may include "refused" in the reason string.
+	return reason == "server misbehaving" || strings.Contains(reason, "refused")
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -1532,7 +1532,7 @@ func isPermanentDNSError(err error) bool {
 		return false
 	}
 	reason := strings.ToLower(strings.TrimSpace(dnsErr.Err))
-	// The standard resolver reports DNS RCODE_REFUSED as "server misbehaving";
-	// other platforms may include "refused" in the reason string.
-	return reason == "server misbehaving" || strings.Contains(reason, "refused")
+	// The generic "server misbehaving" text is also used for transient
+	// SERVFAIL responses, so only explicit refusal text is terminal here.
+	return strings.Contains(reason, "refused")
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/ratelimit.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/ratelimit.go
@@ -221,6 +221,7 @@ type RateLimitError struct {
 	URL        string
 	RetryAfter time.Duration
 	Body       string
+	Cause      error
 }
 
 func (e *RateLimitError) Error() string {
@@ -233,6 +234,8 @@ func (e *RateLimitError) Error() string {
 	}
 	return msg
 }
+
+func (e *RateLimitError) Unwrap() error { return e.Cause }
 
 // ParseRateLimitHeaders reads the X-Ratelimit-Remaining and X-Ratelimit-Reset
 // headers many APIs (Plane among them) emit on every response. Remaining is the

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -1071,7 +1072,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			// timeout). Back off before retrying — same exponential schedule as
 			// the 5xx path below — so a brief outage does not burn every attempt
 			// in a tight loop. ctx cancellation breaks out of the wait at once.
-			if attempt < maxRetries && canRetryAmbiguousFailure {
+			if attempt < maxRetries && canRetryAmbiguousFailure && !isPermanentDNSError(err) {
 				wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 				if !retryWithinBudget(wait) {
 					return nil, 0, lastErr
@@ -1156,6 +1157,12 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			return nil, resp.StatusCode, &platform.RateLimitedError{
 				EndpointClass: endpointClass, Attempts: attempt + 1,
 				RetryAfter: wait, RequestID: requestID,
+				Cause: &cliutil.RateLimitError{
+					URL:        apiErr.Path,
+					RetryAfter: wait,
+					Body:       apiErr.Body,
+					Cause:      apiErr,
+				},
 			}
 		}
 
@@ -1512,4 +1519,24 @@ func clientMaxRetries() int {
 		return 0
 	}
 	return 3
+}
+
+// isPermanentDNSError identifies known resolver failures that cannot succeed
+// by replaying the request. Timeouts, explicitly temporary failures, and
+// otherwise unclassified DNS errors remain retryable.
+func isPermanentDNSError(err error) bool {
+	var dnsErr *net.DNSError
+	if !errors.As(err, &dnsErr) {
+		return false
+	}
+	if dnsErr.IsNotFound {
+		return true
+	}
+	if dnsErr.IsTimeout || dnsErr.IsTemporary {
+		return false
+	}
+	reason := strings.ToLower(strings.TrimSpace(dnsErr.Err))
+	// The standard resolver reports DNS RCODE_REFUSED as "server misbehaving";
+	// other platforms may include "refused" in the reason string.
+	return reason == "server misbehaving" || strings.Contains(reason, "refused")
 }

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -1536,7 +1536,7 @@ func isPermanentDNSError(err error) bool {
 		return false
 	}
 	reason := strings.ToLower(strings.TrimSpace(dnsErr.Err))
-	// The standard resolver reports DNS RCODE_REFUSED as "server misbehaving";
-	// other platforms may include "refused" in the reason string.
-	return reason == "server misbehaving" || strings.Contains(reason, "refused")
+	// The generic "server misbehaving" text is also used for transient
+	// SERVFAIL responses, so only explicit refusal text is terminal here.
+	return strings.Contains(reason, "refused")
 }


### PR DESCRIPTION
## Intent

Exhausted 429 responses from generated clients now remain visible as typed rate-limit errors, and permanent DNS resolver failures stop immediately instead of masquerading as API outages or burning retry time.

Issue:
Closes #3840
Closes #3796

## Approach

The existing platform rate-limit error now unwraps a `cliutil.RateLimitError`, preserving `Retry-After` and the parsed API error for `errors.As` and `errors.Is` callers. The generated transport treats NXDOMAIN and resolver REFUSED as terminal, while temporary, timeout, and unknown DNS failures retain bounded backoff retries.

## Scope

Primary area: generated client retry transport and the generated `cliutil` error contract.

Why this belongs in this repo: the behavior is emitted by the Printing Press and should be corrected at the source for future printed CLIs, with representative generated goldens updated.

## Risk

Generated client output changes in the retry helper and rate-limit error chain. The DNS predicate is limited to `net.DNSError` and known permanent signals; temporary, timeout, and unclassified resolver failures remain retryable. No endpoint, auth, or MCP command surface changes.

## Output Contract

The generated client exposes an `errors.As`-compatible `cliutil.RateLimitError` for exhausted 429 handling, with `Retry-After`, response body, and API error context preserved. Representative generated client and cliutil goldens were updated, and generated runtime tests cover the affected branches.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates
- `go test ./internal/generator -run 'TestGeneratedClientRetrySafety|TestGeneratedPlatformRateLimit' -count=1`
- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify` (32 cases)
- `golangci-lint run ./internal/generator` (0 issues)
- `go test ./...` attempted; the run is not green because `internal/generator` HTML extraction and paginated subprocess tests fail with `invalid character 'w' looking for beginning of value`, and generated govulncheck lanes also fail. The focused retry tests and other packages pass.
- `golangci-lint run ./...` attempted; it reports a pre-existing `slicesbackward` issue in unmodified `internal/googlediscovery/parser.go:455`. The changed generator package is clean.
