### PR TITLE
fix(cli): handle generated collection envelopes consistently

### DIFF
--- a/internal/generator/agent_envelope_test.go
+++ b/internal/generator/agent_envelope_test.go
@@ -244,7 +244,7 @@ func TestGeneratedNoStoreEndpointAgentWrapsFallthroughOutput(t *testing.T) {
 		case "/items":
 			_, _ = w.Write([]byte(`[{"id":"one","name":"Alpha"}]`))
 		case "/widgets":
-			_, _ = w.Write([]byte(`{"meta":{"total":1,"page":1},"results":[{"id":"nested","name":"Nested shape"}]}`))
+			_, _ = w.Write([]byte(`{"meta":{"total":1,"page":1},"results":[{"id":"nested","name":"Nested shape"}],"kind":"widgets"}`))
 		case "/gadgets":
 			_, _ = w.Write([]byte(`{"results":[{"id":"flat","name":"Single-key wrapper"}]}`))
 		default:

--- a/internal/generator/filter_fields_envelope_test.go
+++ b/internal/generator/filter_fields_envelope_test.go
@@ -31,6 +31,7 @@ func TestFilterFieldsEnvelopeDescent_EmittedHelper(t *testing.T) {
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -67,6 +68,12 @@ func TestFilterFieldsEnvelopeDescent(t *testing.T) {
 			`+"`"+`{"items":[{"id":"a"}],"total_count":2}`+"`"+`,
 		},
 		{
+			"nested type-keyed envelope preserves metadata",
+			`+"`"+`{"artists":{"items":[{"id":"a","name":"Radiohead","other":"y"}]},"meta":{"total":1},"links":{"next":"/artists?page=2"}}`+"`"+`,
+			"id,name",
+			`+"`"+`{"artists":{"items":[{"id":"a","name":"Radiohead"}]},"meta":{"total":1},"links":{"next":"/artists?page=2"}}`+"`"+`,
+		},
+		{
 			"envelope preserves null pagination cursor verbatim",
 			`+"`"+`{"items":[{"id":"a"}],"next_cursor":null}`+"`"+`,
 			"id",
@@ -77,6 +84,12 @@ func TestFilterFieldsEnvelopeDescent(t *testing.T) {
 			`+"`"+`{"a":1,"b":2}`+"`"+`,
 			"c",
 			`+"`"+`{"a":1,"b":2}`+"`"+`,
+		},
+		{
+			"nested object without collection preserves input",
+			`+"`"+`{"artist":{"name":"Radiohead"}}`+"`"+`,
+			"id",
+			`+"`"+`{"artist":{"name":"Radiohead"}}`+"`"+`,
 		},
 		{
 			"selector matches envelope key suppresses descent",
@@ -127,6 +140,22 @@ func TestFilterFieldsEnvelopeDescent_UnknownSelector(t *testing.T) {
 	}
 	if !strings.Contains(string(warning), "valid fields: items") {
 		t.Fatalf("warning = %q, want valid top-level fields", warning)
+	}
+}
+
+func TestFilterFieldsEnvelopeDescent_StopsAtDepthBound(t *testing.T) {
+	var input strings.Builder
+	for i := 0; i < 33; i++ {
+		fmt.Fprintf(&input, `+"`"+`{"level%d":`+"`"+`, i)
+	}
+	input.WriteString(`+"`"+`{"items":[{"id":"a","extra":"b"}]}`+"`"+`)
+	for i := 0; i < 33; i++ {
+		input.WriteByte('}')
+	}
+
+	got := filterFields(json.RawMessage(input.String()), "id")
+	if string(got) != input.String() {
+		t.Fatalf("overly deep envelope was unexpectedly traversed: got %s", got)
 	}
 }
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -8443,6 +8443,7 @@ func TestUnwrapSingleKeyArray_KnownWrapperKeysUnwrap(t *testing.T) {
 		{"nodes", ` + "`{\"nodes\":[]}`" + `, ` + "`[]`" + `},
 		{"entries", ` + "`{\"entries\":[\"x\"]}`" + `, ` + "`[\"x\"]`" + `},
 		{"records", ` + "`{\"records\":[null]}`" + `, ` + "`[null]`" + `},
+		{"results with pagination metadata sibling", ` + "`{\"results\":[{\"id\":\"a\"}],\"paging\":{\"next\":{\"after\":\"1\"}}}`" + `, ` + "`[{\"id\":\"a\"}]`" + `},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -8462,6 +8463,10 @@ func TestUnwrapSingleKeyArray_PassThroughs(t *testing.T) {
 	}{
 		{"bare array", ` + "`[{\"id\":\"a\"}]`" + `},
 		{"multi-key object preserves cursor", ` + "`{\"results\":[],\"next_page_token\":\"abc\"}`" + `},
+		{"two collection siblings", ` + "`{\"results\":[],\"items\":[]}`" + `},
+		{"empty key alongside collection", ` + "`{\"\":[],\"results\":[]}`" + `},
+		{"unknown wrapper with pagination metadata", ` + "`{\"payload\":[],\"paging\":{\"next\":{}}}`" + `},
+		{"metadata without collection", ` + "`{\"paging\":{\"next\":{}}}`" + `},
 		{"unknown wrapper key", ` + "`{\"payload\":[1,2]}`" + `},
 		{"single key but not array value", ` + "`{\"data\":{\"issues\":{\"nodes\":[]}}}`" + `},
 		{"single key but value is null", ` + "`{\"results\":null}`" + `},

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1791,6 +1791,22 @@ var envelopeMetadataArrayKeys = map[string]bool{
 	"warnings": true, "Warnings": true,
 }
 
+// envelopeMetadataKeys lists pagination and collection-envelope metadata
+// siblings to ignore when recognizing a wrapped array. Projection helpers
+// preserve these keys while filtering or compacting the collection.
+// Keep this data-driven so the envelope helpers do not depend on one API's
+// response vocabulary.
+var envelopeMetadataKeys = map[string]bool{
+	"paging": true, "pagination": true,
+	"_links": true, "links": true,
+	"meta": true, "metadata": true,
+	"total": true, "totalCount": true, "total_count": true,
+	"hasMore": true, "has_more": true,
+	"offset": true,
+	"nextPage": true, "next_page": true,
+	"cursor": true,
+}
+
 func extractPaginatedObjectArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	var items []json.RawMessage
 	// Empty fallback arrays are deliberately ignored: without an object item,
@@ -2139,9 +2155,10 @@ func wrapAgentOutput(data json.RawMessage, meta map[string]any) (json.RawMessage
 
 // unwrapSingleKeyArray flattens single-key collection envelopes
 // ({"results":[...]}, {"data":[...]}, etc.) so the agent envelope
-// emits a stable .results[] across APIs. Multi-key objects pass
-// through so cursor/pagination fields stay accessible; non-array
-// values pass through so non-collection responses aren't reshaped.
+// emits a stable .results[] across APIs. Known pagination metadata siblings
+// do not prevent a recognized collection wrapper from being flattened;
+// unrelated multi-key objects still pass through so non-collection responses
+// aren't reshaped.
 //
 // The wrapper-key set is intentionally narrower than
 // extractPaginatedItems (which also walks domain-specific keys like
@@ -2157,20 +2174,28 @@ func unwrapSingleKeyArray(data json.RawMessage) json.RawMessage {
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return data
 	}
-	if len(obj) != 1 {
+	var collectionKey string
+	var collectionValue json.RawMessage
+	foundCollection := false
+	for key, val := range obj {
+		if envelopeMetadataKeys[key] {
+			continue
+		}
+		if foundCollection {
+			return data
+		}
+		foundCollection = true
+		collectionKey = key
+		collectionValue = val
+	}
+	if collectionKey != "results" && collectionKey != "data" && collectionKey != "items" && collectionKey != "nodes" && collectionKey != "entries" && collectionKey != "records" {
 		return data
 	}
-	for key, val := range obj {
-		if key != "results" && key != "data" && key != "items" && key != "nodes" && key != "entries" && key != "records" {
-			return data
-		}
-		trimmed := bytes.TrimLeft(val, " \t\r\n")
-		if len(trimmed) == 0 || trimmed[0] != '[' {
-			return data
-		}
-		return val
+	trimmed := bytes.TrimLeft(collectionValue, " \t\r\n")
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		return data
 	}
-	return data
+	return collectionValue
 }
 
 // filterFields keeps only the specified fields (comma-separated) from JSON objects/arrays.
@@ -2250,6 +2275,10 @@ type selectMatchState struct {
 	fallbackIndeterminate bool
 }
 
+// maxListEnvelopeDepth bounds generic object descent so malformed or hostile
+// JSON cannot force unbounded recursion in selector or compact projection.
+const maxListEnvelopeDepth = 32
+
 func (s *selectMatchState) merge(other selectMatchState) {
 	s.matched = s.matched || other.matched
 	s.anchoredIndeterminate = s.anchoredIndeterminate || other.anchoredIndeterminate
@@ -2261,6 +2290,10 @@ func (s *selectMatchState) merge(other selectMatchState) {
 // empty arrays reached through a known selector prefix from empty arrays found
 // only by the list-envelope fallback.
 func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) (json.RawMessage, selectMatchState) {
+	return filterFieldsRecAtDepth(data, paths, pathAnchored, 0)
+}
+
+func filterFieldsRecAtDepth(data json.RawMessage, paths [][]string, pathAnchored bool, envelopeDepth int) (json.RawMessage, selectMatchState) {
 	var arr []json.RawMessage
 	if err := json.Unmarshal(data, &arr); err == nil {
 		out := make([]json.RawMessage, len(arr))
@@ -2270,7 +2303,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 		}
 		for i, el := range arr {
 			var childState selectMatchState
-			out[i], childState = filterFieldsRec(el, paths, pathAnchored)
+			out[i], childState = filterFieldsRecAtDepth(el, paths, pathAnchored, envelopeDepth)
 			state.merge(childState)
 		}
 		result, _ := json.Marshal(out)
@@ -2308,7 +2341,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 			}
 			if subs := subPaths[matched]; subs != nil {
 				var childState selectMatchState
-				filtered[k], childState = filterFieldsRec(v, subs, true)
+				filtered[k], childState = filterFieldsRecAtDepth(v, subs, true, envelopeDepth)
 				state.merge(childState)
 			}
 		}
@@ -2323,7 +2356,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 		// which json.Unmarshal otherwise accepts into a []json.RawMessage
 		// as a nil slice and would coerce to `[]`.
 		if !headMatched {
-			if pending, foundArray, nestedState := filterListEnvelopeFields(obj, paths); foundArray {
+			if pending, foundArray, nestedState := filterListEnvelopeFields(obj, paths, envelopeDepth); foundArray {
 				filtered = pending
 				state.merge(nestedState)
 			}
@@ -2335,29 +2368,37 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 	return data, selectMatchState{}
 }
 
-func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, selectMatchState) {
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string, envelopeDepth int) (map[string]json.RawMessage, bool, selectMatchState) {
 	pending := map[string]json.RawMessage{}
 	foundArray := false
 	state := selectMatchState{}
 	for k, v := range obj {
-		if envelopeMetadataArrayKeys[k] {
+		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
 			pending[k] = v
 			continue
 		}
-		var arr []json.RawMessage
-		if json.Unmarshal(v, &arr) == nil && arr != nil {
-			foundArray = true
-			var childState selectMatchState
-			pending[k], childState = filterFieldsRec(v, paths, false)
-			state.merge(childState)
-			continue
-		}
-		if k == "_embedded" {
-			if nested, ok, nestedState := filterNestedListEnvelopeFields(v, paths); ok {
-				foundArray = true
-				pending[k] = nested
-				state.merge(nestedState)
-				continue
+		trimmed := bytes.TrimLeft(v, " \t\r\n")
+		if len(trimmed) > 0 {
+			switch trimmed[0] {
+			case '[':
+				var arr []json.RawMessage
+				if json.Unmarshal(v, &arr) == nil && arr != nil {
+					foundArray = true
+					var childState selectMatchState
+					pending[k], childState = filterFieldsRecAtDepth(v, paths, false, envelopeDepth)
+					state.merge(childState)
+					continue
+				}
+			case '{':
+				var nestedObj map[string]json.RawMessage
+				if json.Unmarshal(v, &nestedObj) == nil && nestedObj != nil {
+					if nested, ok, nestedState := filterNestedListEnvelopeFields(v, paths, envelopeDepth); ok {
+						foundArray = true
+						pending[k] = nested
+						state.merge(nestedState)
+						continue
+					}
+				}
 			}
 		}
 		pending[k] = v
@@ -2365,12 +2406,15 @@ func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) 
 	return pending, foundArray, state
 }
 
-func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, selectMatchState) {
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string, envelopeDepth int) (json.RawMessage, bool, selectMatchState) {
+	if envelopeDepth >= maxListEnvelopeDepth {
+		return nil, false, selectMatchState{}
+	}
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return nil, false, selectMatchState{}
 	}
-	filtered, found, state := filterListEnvelopeFields(obj, paths)
+	filtered, found, state := filterListEnvelopeFields(obj, paths, envelopeDepth+1)
 	if !found {
 		return nil, false, selectMatchState{}
 	}
@@ -2653,7 +2697,7 @@ func isCompactScalar(v any) bool {
 // under `--agent`/`--compact` is a silent loss; agents who want to omit them
 // can pass `--select` to specify only the fields they need.
 func compactObjectFields(obj map[string]any) json.RawMessage {
-	if compacted, ok := compactListEnvelopeObject(obj); ok {
+	if compacted, ok := compactListEnvelopeObjectAtDepth(obj, 0); ok {
 		result, _ := json.Marshal(compacted)
 		return result
 	}
@@ -2667,14 +2711,14 @@ func compactObjectFields(obj map[string]any) json.RawMessage {
 	return result
 }
 
-func compactListEnvelopeObject(obj map[string]any) (map[string]any, bool) {
+func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int) (map[string]any, bool) {
 	out := map[string]any{}
 	foundArray := false
 	for k, v := range obj {
-		if compactVerboseObjectFields[k] {
+		if envelopeDepth == 0 && compactVerboseObjectFields[k] {
 			continue
 		}
-		if envelopeMetadataArrayKeys[k] {
+		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
 			out[k] = v
 			continue
 		}
@@ -2683,11 +2727,13 @@ func compactListEnvelopeObject(obj map[string]any) (map[string]any, bool) {
 			out[k] = compacted
 			continue
 		}
-		if nested, ok := v.(map[string]any); ok && k == "_embedded" {
-			if compacted, ok := compactListEnvelopeObject(nested); ok {
-				foundArray = true
-				out[k] = compacted
-				continue
+		if nested, ok := v.(map[string]any); ok {
+			if envelopeDepth < maxListEnvelopeDepth {
+				if compacted, ok := compactListEnvelopeObjectAtDepth(nested, envelopeDepth+1); ok {
+					foundArray = true
+					out[k] = compacted
+					continue
+				}
 			}
 		}
 		out[k] = v

--- a/internal/generator/templates/root_test.go.tmpl
+++ b/internal/generator/templates/root_test.go.tmpl
@@ -242,14 +242,13 @@ func TestFilterFields(t *testing.T) {
 			want:   `{"events":[{"id":"e1"}],"speakers":[{"id":"s1"}]}`,
 		},
 		{
-			// Envelope fallback is intentionally one level deep. A nested
-			// object envelope like {"data":{"items":[...]}} surfaces no
-			// array at the outer level, so the fallback does not fire and
-			// an invalid selector preserves the input.
-			name:   "nested object envelope preserves input (one-level only)",
+			// Generic object descent supports type-keyed envelopes such as
+			// {"data":{"items":[...]}} while keeping the fail-closed
+			// behavior for objects with no collection below them.
+			name:   "nested object envelope descends into collection",
 			input:  `{"data":{"items":[{"id":"a","other":"y"}]}}`,
 			fields: "id",
-			want:   `{"data":{"items":[{"id":"a","other":"y"}]}}`,
+			want:   `{"data":{"items":[{"id":"a"}]}}`,
 		},
 	}
 	for _, tc := range cases {

--- a/internal/generator/wrapped_projection_test.go
+++ b/internal/generator/wrapped_projection_test.go
@@ -20,6 +20,8 @@ func TestWrappedArrayProjectionHelpers_EmittedRuntime(t *testing.T) {
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -83,6 +85,86 @@ func TestCompactFieldsProjectsDomainSpecificArrayWrapper(t *testing.T) {
 	}
 	if got["request_id"] != "req-1" {
 		t.Fatalf("compact should preserve scalar envelope metadata, got %#v", got["request_id"])
+	}
+}
+
+func TestCompactFieldsProjectsNestedDomainSpecificArrayWrapper(t *testing.T) {
+	input := json.RawMessage(`+"`"+`{
+		"meta": {"total": 1},
+		"links": {"next": "/artists?page=2"},
+		"artists": {
+			"items": [
+				{"id":"artist-1","name":"Radiohead","description":"verbose"}
+			]
+		}
+	}`+"`"+`)
+
+	got := decodeObject(t, compactFields(input))
+	meta, ok := got["meta"].(map[string]any)
+	if !ok || meta["total"] != float64(1) {
+		t.Fatalf("compact should preserve nested envelope metadata, got %#v", got["meta"])
+	}
+	links, ok := got["links"].(map[string]any)
+	if !ok || links["next"] != "/artists?page=2" {
+		t.Fatalf("compact should preserve links metadata, got %#v", got["links"])
+	}
+	artists, ok := got["artists"].(map[string]any)
+	if !ok {
+		t.Fatalf("artists = %#v, want nested object envelope", got["artists"])
+	}
+	items, ok := artists["items"].([]any)
+	if !ok || len(items) != 1 {
+		t.Fatalf("artists.items = %#v, want one item", artists["items"])
+	}
+	first := items[0].(map[string]any)
+	if first["id"] != "artist-1" || first["name"] != "Radiohead" {
+		t.Fatalf("nested compact row lost identity fields: %#v", first)
+	}
+	if _, ok := first["description"]; ok {
+		t.Fatalf("nested compact row kept verbose description: %#v", first)
+	}
+}
+
+func TestCompactFieldsPreservesNestedDetailPayload(t *testing.T) {
+	input := json.RawMessage(`+"`"+`{
+		"data": {
+			"id": "issue-1",
+			"description": "actual answer",
+			"tags": [{"id": "tag-1", "label": "bug"}]
+		}
+	}`+"`"+`)
+
+	got := decodeObject(t, compactFields(input))
+	data, ok := got["data"].(map[string]any)
+	if !ok || data["description"] != "actual answer" {
+		t.Fatalf("nested detail payload was stripped: %#v", got["data"])
+	}
+}
+
+func TestCompactFieldsStopsAtDepthBound(t *testing.T) {
+	var input strings.Builder
+	for i := 0; i < 33; i++ {
+		fmt.Fprintf(&input, `+"`"+`{"level%d":`+"`"+`, i)
+	}
+	input.WriteString(`+"`"+`{"items":[{"id":"artist-1","description":"verbose"}]}`+"`"+`)
+	for i := 0; i < 33; i++ {
+		input.WriteByte('}')
+	}
+
+	current := decodeObject(t, compactFields(json.RawMessage(input.String())))
+	for i := 0; i < 33; i++ {
+		var ok bool
+		current, ok = current[fmt.Sprintf("level%d", i)].(map[string]any)
+		if !ok {
+			t.Fatalf("level%d was not preserved while depth bound stopped descent", i)
+		}
+	}
+	items, ok := current["items"].([]any)
+	if !ok || len(items) != 1 {
+		t.Fatalf("deep items = %#v, want one unprojected item", current["items"])
+	}
+	if items[0].(map[string]any)["description"] != "verbose" {
+		t.Fatalf("overly deep compact envelope was unexpectedly traversed: %#v", items[0])
 	}
 }
 

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -1187,6 +1187,22 @@ var envelopeMetadataArrayKeys = map[string]bool{
 	"warnings": true, "Warnings": true,
 }
 
+// envelopeMetadataKeys lists pagination and collection-envelope metadata
+// siblings to ignore when recognizing a wrapped array. Projection helpers
+// preserve these keys while filtering or compacting the collection.
+// Keep this data-driven so the envelope helpers do not depend on one API's
+// response vocabulary.
+var envelopeMetadataKeys = map[string]bool{
+	"paging": true, "pagination": true,
+	"_links": true, "links": true,
+	"meta": true, "metadata": true,
+	"total": true, "totalCount": true, "total_count": true,
+	"hasMore": true, "has_more": true,
+	"offset":   true,
+	"nextPage": true, "next_page": true,
+	"cursor": true,
+}
+
 func extractPaginatedObjectArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	var items []json.RawMessage
 	// Empty fallback arrays are deliberately ignored: without an object item,
@@ -1532,9 +1548,10 @@ func wrapAgentOutput(data json.RawMessage, meta map[string]any) (json.RawMessage
 
 // unwrapSingleKeyArray flattens single-key collection envelopes
 // ({"results":[...]}, {"data":[...]}, etc.) so the agent envelope
-// emits a stable .results[] across APIs. Multi-key objects pass
-// through so cursor/pagination fields stay accessible; non-array
-// values pass through so non-collection responses aren't reshaped.
+// emits a stable .results[] across APIs. Known pagination metadata siblings
+// do not prevent a recognized collection wrapper from being flattened;
+// unrelated multi-key objects still pass through so non-collection responses
+// aren't reshaped.
 //
 // The wrapper-key set is intentionally narrower than
 // extractPaginatedItems (which also walks domain-specific keys like
@@ -1550,20 +1567,28 @@ func unwrapSingleKeyArray(data json.RawMessage) json.RawMessage {
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return data
 	}
-	if len(obj) != 1 {
+	var collectionKey string
+	var collectionValue json.RawMessage
+	foundCollection := false
+	for key, val := range obj {
+		if envelopeMetadataKeys[key] {
+			continue
+		}
+		if foundCollection {
+			return data
+		}
+		foundCollection = true
+		collectionKey = key
+		collectionValue = val
+	}
+	if collectionKey != "results" && collectionKey != "data" && collectionKey != "items" && collectionKey != "nodes" && collectionKey != "entries" && collectionKey != "records" {
 		return data
 	}
-	for key, val := range obj {
-		if key != "results" && key != "data" && key != "items" && key != "nodes" && key != "entries" && key != "records" {
-			return data
-		}
-		trimmed := bytes.TrimLeft(val, " \t\r\n")
-		if len(trimmed) == 0 || trimmed[0] != '[' {
-			return data
-		}
-		return val
+	trimmed := bytes.TrimLeft(collectionValue, " \t\r\n")
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		return data
 	}
-	return data
+	return collectionValue
 }
 
 // filterFields keeps only the specified fields (comma-separated) from JSON objects/arrays.
@@ -1643,6 +1668,10 @@ type selectMatchState struct {
 	fallbackIndeterminate bool
 }
 
+// maxListEnvelopeDepth bounds generic object descent so malformed or hostile
+// JSON cannot force unbounded recursion in selector or compact projection.
+const maxListEnvelopeDepth = 32
+
 func (s *selectMatchState) merge(other selectMatchState) {
 	s.matched = s.matched || other.matched
 	s.anchoredIndeterminate = s.anchoredIndeterminate || other.anchoredIndeterminate
@@ -1654,6 +1683,10 @@ func (s *selectMatchState) merge(other selectMatchState) {
 // empty arrays reached through a known selector prefix from empty arrays found
 // only by the list-envelope fallback.
 func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) (json.RawMessage, selectMatchState) {
+	return filterFieldsRecAtDepth(data, paths, pathAnchored, 0)
+}
+
+func filterFieldsRecAtDepth(data json.RawMessage, paths [][]string, pathAnchored bool, envelopeDepth int) (json.RawMessage, selectMatchState) {
 	var arr []json.RawMessage
 	if err := json.Unmarshal(data, &arr); err == nil {
 		out := make([]json.RawMessage, len(arr))
@@ -1663,7 +1696,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 		}
 		for i, el := range arr {
 			var childState selectMatchState
-			out[i], childState = filterFieldsRec(el, paths, pathAnchored)
+			out[i], childState = filterFieldsRecAtDepth(el, paths, pathAnchored, envelopeDepth)
 			state.merge(childState)
 		}
 		result, _ := json.Marshal(out)
@@ -1701,7 +1734,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 			}
 			if subs := subPaths[matched]; subs != nil {
 				var childState selectMatchState
-				filtered[k], childState = filterFieldsRec(v, subs, true)
+				filtered[k], childState = filterFieldsRecAtDepth(v, subs, true, envelopeDepth)
 				state.merge(childState)
 			}
 		}
@@ -1716,7 +1749,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 		// which json.Unmarshal otherwise accepts into a []json.RawMessage
 		// as a nil slice and would coerce to `[]`.
 		if !headMatched {
-			if pending, foundArray, nestedState := filterListEnvelopeFields(obj, paths); foundArray {
+			if pending, foundArray, nestedState := filterListEnvelopeFields(obj, paths, envelopeDepth); foundArray {
 				filtered = pending
 				state.merge(nestedState)
 			}
@@ -1728,29 +1761,37 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 	return data, selectMatchState{}
 }
 
-func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, selectMatchState) {
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string, envelopeDepth int) (map[string]json.RawMessage, bool, selectMatchState) {
 	pending := map[string]json.RawMessage{}
 	foundArray := false
 	state := selectMatchState{}
 	for k, v := range obj {
-		if envelopeMetadataArrayKeys[k] {
+		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
 			pending[k] = v
 			continue
 		}
-		var arr []json.RawMessage
-		if json.Unmarshal(v, &arr) == nil && arr != nil {
-			foundArray = true
-			var childState selectMatchState
-			pending[k], childState = filterFieldsRec(v, paths, false)
-			state.merge(childState)
-			continue
-		}
-		if k == "_embedded" {
-			if nested, ok, nestedState := filterNestedListEnvelopeFields(v, paths); ok {
-				foundArray = true
-				pending[k] = nested
-				state.merge(nestedState)
-				continue
+		trimmed := bytes.TrimLeft(v, " \t\r\n")
+		if len(trimmed) > 0 {
+			switch trimmed[0] {
+			case '[':
+				var arr []json.RawMessage
+				if json.Unmarshal(v, &arr) == nil && arr != nil {
+					foundArray = true
+					var childState selectMatchState
+					pending[k], childState = filterFieldsRecAtDepth(v, paths, false, envelopeDepth)
+					state.merge(childState)
+					continue
+				}
+			case '{':
+				var nestedObj map[string]json.RawMessage
+				if json.Unmarshal(v, &nestedObj) == nil && nestedObj != nil {
+					if nested, ok, nestedState := filterNestedListEnvelopeFields(v, paths, envelopeDepth); ok {
+						foundArray = true
+						pending[k] = nested
+						state.merge(nestedState)
+						continue
+					}
+				}
 			}
 		}
 		pending[k] = v
@@ -1758,12 +1799,15 @@ func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) 
 	return pending, foundArray, state
 }
 
-func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, selectMatchState) {
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string, envelopeDepth int) (json.RawMessage, bool, selectMatchState) {
+	if envelopeDepth >= maxListEnvelopeDepth {
+		return nil, false, selectMatchState{}
+	}
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return nil, false, selectMatchState{}
 	}
-	filtered, found, state := filterListEnvelopeFields(obj, paths)
+	filtered, found, state := filterListEnvelopeFields(obj, paths, envelopeDepth+1)
 	if !found {
 		return nil, false, selectMatchState{}
 	}
@@ -2016,7 +2060,7 @@ func isCompactScalar(v any) bool {
 // under `--agent`/`--compact` is a silent loss; agents who want to omit them
 // can pass `--select` to specify only the fields they need.
 func compactObjectFields(obj map[string]any) json.RawMessage {
-	if compacted, ok := compactListEnvelopeObject(obj); ok {
+	if compacted, ok := compactListEnvelopeObjectAtDepth(obj, 0); ok {
 		result, _ := json.Marshal(compacted)
 		return result
 	}
@@ -2030,14 +2074,14 @@ func compactObjectFields(obj map[string]any) json.RawMessage {
 	return result
 }
 
-func compactListEnvelopeObject(obj map[string]any) (map[string]any, bool) {
+func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int) (map[string]any, bool) {
 	out := map[string]any{}
 	foundArray := false
 	for k, v := range obj {
-		if compactVerboseObjectFields[k] {
+		if envelopeDepth == 0 && compactVerboseObjectFields[k] {
 			continue
 		}
-		if envelopeMetadataArrayKeys[k] {
+		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
 			out[k] = v
 			continue
 		}
@@ -2046,11 +2090,13 @@ func compactListEnvelopeObject(obj map[string]any) (map[string]any, bool) {
 			out[k] = compacted
 			continue
 		}
-		if nested, ok := v.(map[string]any); ok && k == "_embedded" {
-			if compacted, ok := compactListEnvelopeObject(nested); ok {
-				foundArray = true
-				out[k] = compacted
-				continue
+		if nested, ok := v.(map[string]any); ok {
+			if envelopeDepth < maxListEnvelopeDepth {
+				if compacted, ok := compactListEnvelopeObjectAtDepth(nested, envelopeDepth+1); ok {
+					foundArray = true
+					out[k] = compacted
+					continue
+				}
 			}
 		}
 		out[k] = v

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -1180,6 +1180,22 @@ var envelopeMetadataArrayKeys = map[string]bool{
 	"warnings": true, "Warnings": true,
 }
 
+// envelopeMetadataKeys lists pagination and collection-envelope metadata
+// siblings to ignore when recognizing a wrapped array. Projection helpers
+// preserve these keys while filtering or compacting the collection.
+// Keep this data-driven so the envelope helpers do not depend on one API's
+// response vocabulary.
+var envelopeMetadataKeys = map[string]bool{
+	"paging": true, "pagination": true,
+	"_links": true, "links": true,
+	"meta": true, "metadata": true,
+	"total": true, "totalCount": true, "total_count": true,
+	"hasMore": true, "has_more": true,
+	"offset":   true,
+	"nextPage": true, "next_page": true,
+	"cursor": true,
+}
+
 func extractPaginatedObjectArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	var items []json.RawMessage
 	// Empty fallback arrays are deliberately ignored: without an object item,
@@ -1398,9 +1414,10 @@ func wrapAgentOutput(data json.RawMessage, meta map[string]any) (json.RawMessage
 
 // unwrapSingleKeyArray flattens single-key collection envelopes
 // ({"results":[...]}, {"data":[...]}, etc.) so the agent envelope
-// emits a stable .results[] across APIs. Multi-key objects pass
-// through so cursor/pagination fields stay accessible; non-array
-// values pass through so non-collection responses aren't reshaped.
+// emits a stable .results[] across APIs. Known pagination metadata siblings
+// do not prevent a recognized collection wrapper from being flattened;
+// unrelated multi-key objects still pass through so non-collection responses
+// aren't reshaped.
 //
 // The wrapper-key set is intentionally narrower than
 // extractPaginatedItems (which also walks domain-specific keys like
@@ -1416,20 +1433,28 @@ func unwrapSingleKeyArray(data json.RawMessage) json.RawMessage {
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return data
 	}
-	if len(obj) != 1 {
+	var collectionKey string
+	var collectionValue json.RawMessage
+	foundCollection := false
+	for key, val := range obj {
+		if envelopeMetadataKeys[key] {
+			continue
+		}
+		if foundCollection {
+			return data
+		}
+		foundCollection = true
+		collectionKey = key
+		collectionValue = val
+	}
+	if collectionKey != "results" && collectionKey != "data" && collectionKey != "items" && collectionKey != "nodes" && collectionKey != "entries" && collectionKey != "records" {
 		return data
 	}
-	for key, val := range obj {
-		if key != "results" && key != "data" && key != "items" && key != "nodes" && key != "entries" && key != "records" {
-			return data
-		}
-		trimmed := bytes.TrimLeft(val, " \t\r\n")
-		if len(trimmed) == 0 || trimmed[0] != '[' {
-			return data
-		}
-		return val
+	trimmed := bytes.TrimLeft(collectionValue, " \t\r\n")
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		return data
 	}
-	return data
+	return collectionValue
 }
 
 // filterFields keeps only the specified fields (comma-separated) from JSON objects/arrays.
@@ -1509,6 +1534,10 @@ type selectMatchState struct {
 	fallbackIndeterminate bool
 }
 
+// maxListEnvelopeDepth bounds generic object descent so malformed or hostile
+// JSON cannot force unbounded recursion in selector or compact projection.
+const maxListEnvelopeDepth = 32
+
 func (s *selectMatchState) merge(other selectMatchState) {
 	s.matched = s.matched || other.matched
 	s.anchoredIndeterminate = s.anchoredIndeterminate || other.anchoredIndeterminate
@@ -1520,6 +1549,10 @@ func (s *selectMatchState) merge(other selectMatchState) {
 // empty arrays reached through a known selector prefix from empty arrays found
 // only by the list-envelope fallback.
 func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) (json.RawMessage, selectMatchState) {
+	return filterFieldsRecAtDepth(data, paths, pathAnchored, 0)
+}
+
+func filterFieldsRecAtDepth(data json.RawMessage, paths [][]string, pathAnchored bool, envelopeDepth int) (json.RawMessage, selectMatchState) {
 	var arr []json.RawMessage
 	if err := json.Unmarshal(data, &arr); err == nil {
 		out := make([]json.RawMessage, len(arr))
@@ -1529,7 +1562,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 		}
 		for i, el := range arr {
 			var childState selectMatchState
-			out[i], childState = filterFieldsRec(el, paths, pathAnchored)
+			out[i], childState = filterFieldsRecAtDepth(el, paths, pathAnchored, envelopeDepth)
 			state.merge(childState)
 		}
 		result, _ := json.Marshal(out)
@@ -1567,7 +1600,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 			}
 			if subs := subPaths[matched]; subs != nil {
 				var childState selectMatchState
-				filtered[k], childState = filterFieldsRec(v, subs, true)
+				filtered[k], childState = filterFieldsRecAtDepth(v, subs, true, envelopeDepth)
 				state.merge(childState)
 			}
 		}
@@ -1582,7 +1615,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 		// which json.Unmarshal otherwise accepts into a []json.RawMessage
 		// as a nil slice and would coerce to `[]`.
 		if !headMatched {
-			if pending, foundArray, nestedState := filterListEnvelopeFields(obj, paths); foundArray {
+			if pending, foundArray, nestedState := filterListEnvelopeFields(obj, paths, envelopeDepth); foundArray {
 				filtered = pending
 				state.merge(nestedState)
 			}
@@ -1594,29 +1627,37 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 	return data, selectMatchState{}
 }
 
-func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, selectMatchState) {
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string, envelopeDepth int) (map[string]json.RawMessage, bool, selectMatchState) {
 	pending := map[string]json.RawMessage{}
 	foundArray := false
 	state := selectMatchState{}
 	for k, v := range obj {
-		if envelopeMetadataArrayKeys[k] {
+		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
 			pending[k] = v
 			continue
 		}
-		var arr []json.RawMessage
-		if json.Unmarshal(v, &arr) == nil && arr != nil {
-			foundArray = true
-			var childState selectMatchState
-			pending[k], childState = filterFieldsRec(v, paths, false)
-			state.merge(childState)
-			continue
-		}
-		if k == "_embedded" {
-			if nested, ok, nestedState := filterNestedListEnvelopeFields(v, paths); ok {
-				foundArray = true
-				pending[k] = nested
-				state.merge(nestedState)
-				continue
+		trimmed := bytes.TrimLeft(v, " \t\r\n")
+		if len(trimmed) > 0 {
+			switch trimmed[0] {
+			case '[':
+				var arr []json.RawMessage
+				if json.Unmarshal(v, &arr) == nil && arr != nil {
+					foundArray = true
+					var childState selectMatchState
+					pending[k], childState = filterFieldsRecAtDepth(v, paths, false, envelopeDepth)
+					state.merge(childState)
+					continue
+				}
+			case '{':
+				var nestedObj map[string]json.RawMessage
+				if json.Unmarshal(v, &nestedObj) == nil && nestedObj != nil {
+					if nested, ok, nestedState := filterNestedListEnvelopeFields(v, paths, envelopeDepth); ok {
+						foundArray = true
+						pending[k] = nested
+						state.merge(nestedState)
+						continue
+					}
+				}
 			}
 		}
 		pending[k] = v
@@ -1624,12 +1665,15 @@ func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) 
 	return pending, foundArray, state
 }
 
-func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, selectMatchState) {
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string, envelopeDepth int) (json.RawMessage, bool, selectMatchState) {
+	if envelopeDepth >= maxListEnvelopeDepth {
+		return nil, false, selectMatchState{}
+	}
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return nil, false, selectMatchState{}
 	}
-	filtered, found, state := filterListEnvelopeFields(obj, paths)
+	filtered, found, state := filterListEnvelopeFields(obj, paths, envelopeDepth+1)
 	if !found {
 		return nil, false, selectMatchState{}
 	}
@@ -1882,7 +1926,7 @@ func isCompactScalar(v any) bool {
 // under `--agent`/`--compact` is a silent loss; agents who want to omit them
 // can pass `--select` to specify only the fields they need.
 func compactObjectFields(obj map[string]any) json.RawMessage {
-	if compacted, ok := compactListEnvelopeObject(obj); ok {
+	if compacted, ok := compactListEnvelopeObjectAtDepth(obj, 0); ok {
 		result, _ := json.Marshal(compacted)
 		return result
 	}
@@ -1896,14 +1940,14 @@ func compactObjectFields(obj map[string]any) json.RawMessage {
 	return result
 }
 
-func compactListEnvelopeObject(obj map[string]any) (map[string]any, bool) {
+func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int) (map[string]any, bool) {
 	out := map[string]any{}
 	foundArray := false
 	for k, v := range obj {
-		if compactVerboseObjectFields[k] {
+		if envelopeDepth == 0 && compactVerboseObjectFields[k] {
 			continue
 		}
-		if envelopeMetadataArrayKeys[k] {
+		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
 			out[k] = v
 			continue
 		}
@@ -1912,11 +1956,13 @@ func compactListEnvelopeObject(obj map[string]any) (map[string]any, bool) {
 			out[k] = compacted
 			continue
 		}
-		if nested, ok := v.(map[string]any); ok && k == "_embedded" {
-			if compacted, ok := compactListEnvelopeObject(nested); ok {
-				foundArray = true
-				out[k] = compacted
-				continue
+		if nested, ok := v.(map[string]any); ok {
+			if envelopeDepth < maxListEnvelopeDepth {
+				if compacted, ok := compactListEnvelopeObjectAtDepth(nested, envelopeDepth+1); ok {
+					foundArray = true
+					out[k] = compacted
+					continue
+				}
 			}
 		}
 		out[k] = v

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/root_test.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/root_test.go
@@ -240,14 +240,13 @@ func TestFilterFields(t *testing.T) {
 			want:   `{"events":[{"id":"e1"}],"speakers":[{"id":"s1"}]}`,
 		},
 		{
-			// Envelope fallback is intentionally one level deep. A nested
-			// object envelope like {"data":{"items":[...]}} surfaces no
-			// array at the outer level, so the fallback does not fire and
-			// an invalid selector preserves the input.
-			name:   "nested object envelope preserves input (one-level only)",
+			// Generic object descent supports type-keyed envelopes such as
+			// {"data":{"items":[...]}} while keeping the fail-closed
+			// behavior for objects with no collection below them.
+			name:   "nested object envelope descends into collection",
 			input:  `{"data":{"items":[{"id":"a","other":"y"}]}}`,
 			fields: "id",
-			want:   `{"data":{"items":[{"id":"a","other":"y"}]}}`,
+			want:   `{"data":{"items":[{"id":"a"}]}}`,
 		},
 	}
 	for _, tc := range cases {

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 85
+    "total": 86
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -1264,6 +1264,22 @@ var envelopeMetadataArrayKeys = map[string]bool{
 	"warnings": true, "Warnings": true,
 }
 
+// envelopeMetadataKeys lists pagination and collection-envelope metadata
+// siblings to ignore when recognizing a wrapped array. Projection helpers
+// preserve these keys while filtering or compacting the collection.
+// Keep this data-driven so the envelope helpers do not depend on one API's
+// response vocabulary.
+var envelopeMetadataKeys = map[string]bool{
+	"paging": true, "pagination": true,
+	"_links": true, "links": true,
+	"meta": true, "metadata": true,
+	"total": true, "totalCount": true, "total_count": true,
+	"hasMore": true, "has_more": true,
+	"offset":   true,
+	"nextPage": true, "next_page": true,
+	"cursor": true,
+}
+
 func extractPaginatedObjectArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	var items []json.RawMessage
 	// Empty fallback arrays are deliberately ignored: without an object item,
@@ -1482,9 +1498,10 @@ func wrapAgentOutput(data json.RawMessage, meta map[string]any) (json.RawMessage
 
 // unwrapSingleKeyArray flattens single-key collection envelopes
 // ({"results":[...]}, {"data":[...]}, etc.) so the agent envelope
-// emits a stable .results[] across APIs. Multi-key objects pass
-// through so cursor/pagination fields stay accessible; non-array
-// values pass through so non-collection responses aren't reshaped.
+// emits a stable .results[] across APIs. Known pagination metadata siblings
+// do not prevent a recognized collection wrapper from being flattened;
+// unrelated multi-key objects still pass through so non-collection responses
+// aren't reshaped.
 //
 // The wrapper-key set is intentionally narrower than
 // extractPaginatedItems (which also walks domain-specific keys like
@@ -1500,20 +1517,28 @@ func unwrapSingleKeyArray(data json.RawMessage) json.RawMessage {
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return data
 	}
-	if len(obj) != 1 {
+	var collectionKey string
+	var collectionValue json.RawMessage
+	foundCollection := false
+	for key, val := range obj {
+		if envelopeMetadataKeys[key] {
+			continue
+		}
+		if foundCollection {
+			return data
+		}
+		foundCollection = true
+		collectionKey = key
+		collectionValue = val
+	}
+	if collectionKey != "results" && collectionKey != "data" && collectionKey != "items" && collectionKey != "nodes" && collectionKey != "entries" && collectionKey != "records" {
 		return data
 	}
-	for key, val := range obj {
-		if key != "results" && key != "data" && key != "items" && key != "nodes" && key != "entries" && key != "records" {
-			return data
-		}
-		trimmed := bytes.TrimLeft(val, " \t\r\n")
-		if len(trimmed) == 0 || trimmed[0] != '[' {
-			return data
-		}
-		return val
+	trimmed := bytes.TrimLeft(collectionValue, " \t\r\n")
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		return data
 	}
-	return data
+	return collectionValue
 }
 
 // filterFields keeps only the specified fields (comma-separated) from JSON objects/arrays.
@@ -1593,6 +1618,10 @@ type selectMatchState struct {
 	fallbackIndeterminate bool
 }
 
+// maxListEnvelopeDepth bounds generic object descent so malformed or hostile
+// JSON cannot force unbounded recursion in selector or compact projection.
+const maxListEnvelopeDepth = 32
+
 func (s *selectMatchState) merge(other selectMatchState) {
 	s.matched = s.matched || other.matched
 	s.anchoredIndeterminate = s.anchoredIndeterminate || other.anchoredIndeterminate
@@ -1604,6 +1633,10 @@ func (s *selectMatchState) merge(other selectMatchState) {
 // empty arrays reached through a known selector prefix from empty arrays found
 // only by the list-envelope fallback.
 func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) (json.RawMessage, selectMatchState) {
+	return filterFieldsRecAtDepth(data, paths, pathAnchored, 0)
+}
+
+func filterFieldsRecAtDepth(data json.RawMessage, paths [][]string, pathAnchored bool, envelopeDepth int) (json.RawMessage, selectMatchState) {
 	var arr []json.RawMessage
 	if err := json.Unmarshal(data, &arr); err == nil {
 		out := make([]json.RawMessage, len(arr))
@@ -1613,7 +1646,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 		}
 		for i, el := range arr {
 			var childState selectMatchState
-			out[i], childState = filterFieldsRec(el, paths, pathAnchored)
+			out[i], childState = filterFieldsRecAtDepth(el, paths, pathAnchored, envelopeDepth)
 			state.merge(childState)
 		}
 		result, _ := json.Marshal(out)
@@ -1651,7 +1684,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 			}
 			if subs := subPaths[matched]; subs != nil {
 				var childState selectMatchState
-				filtered[k], childState = filterFieldsRec(v, subs, true)
+				filtered[k], childState = filterFieldsRecAtDepth(v, subs, true, envelopeDepth)
 				state.merge(childState)
 			}
 		}
@@ -1666,7 +1699,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 		// which json.Unmarshal otherwise accepts into a []json.RawMessage
 		// as a nil slice and would coerce to `[]`.
 		if !headMatched {
-			if pending, foundArray, nestedState := filterListEnvelopeFields(obj, paths); foundArray {
+			if pending, foundArray, nestedState := filterListEnvelopeFields(obj, paths, envelopeDepth); foundArray {
 				filtered = pending
 				state.merge(nestedState)
 			}
@@ -1678,29 +1711,37 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 	return data, selectMatchState{}
 }
 
-func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, selectMatchState) {
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string, envelopeDepth int) (map[string]json.RawMessage, bool, selectMatchState) {
 	pending := map[string]json.RawMessage{}
 	foundArray := false
 	state := selectMatchState{}
 	for k, v := range obj {
-		if envelopeMetadataArrayKeys[k] {
+		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
 			pending[k] = v
 			continue
 		}
-		var arr []json.RawMessage
-		if json.Unmarshal(v, &arr) == nil && arr != nil {
-			foundArray = true
-			var childState selectMatchState
-			pending[k], childState = filterFieldsRec(v, paths, false)
-			state.merge(childState)
-			continue
-		}
-		if k == "_embedded" {
-			if nested, ok, nestedState := filterNestedListEnvelopeFields(v, paths); ok {
-				foundArray = true
-				pending[k] = nested
-				state.merge(nestedState)
-				continue
+		trimmed := bytes.TrimLeft(v, " \t\r\n")
+		if len(trimmed) > 0 {
+			switch trimmed[0] {
+			case '[':
+				var arr []json.RawMessage
+				if json.Unmarshal(v, &arr) == nil && arr != nil {
+					foundArray = true
+					var childState selectMatchState
+					pending[k], childState = filterFieldsRecAtDepth(v, paths, false, envelopeDepth)
+					state.merge(childState)
+					continue
+				}
+			case '{':
+				var nestedObj map[string]json.RawMessage
+				if json.Unmarshal(v, &nestedObj) == nil && nestedObj != nil {
+					if nested, ok, nestedState := filterNestedListEnvelopeFields(v, paths, envelopeDepth); ok {
+						foundArray = true
+						pending[k] = nested
+						state.merge(nestedState)
+						continue
+					}
+				}
 			}
 		}
 		pending[k] = v
@@ -1708,12 +1749,15 @@ func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) 
 	return pending, foundArray, state
 }
 
-func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, selectMatchState) {
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string, envelopeDepth int) (json.RawMessage, bool, selectMatchState) {
+	if envelopeDepth >= maxListEnvelopeDepth {
+		return nil, false, selectMatchState{}
+	}
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return nil, false, selectMatchState{}
 	}
-	filtered, found, state := filterListEnvelopeFields(obj, paths)
+	filtered, found, state := filterListEnvelopeFields(obj, paths, envelopeDepth+1)
 	if !found {
 		return nil, false, selectMatchState{}
 	}
@@ -1966,7 +2010,7 @@ func isCompactScalar(v any) bool {
 // under `--agent`/`--compact` is a silent loss; agents who want to omit them
 // can pass `--select` to specify only the fields they need.
 func compactObjectFields(obj map[string]any) json.RawMessage {
-	if compacted, ok := compactListEnvelopeObject(obj); ok {
+	if compacted, ok := compactListEnvelopeObjectAtDepth(obj, 0); ok {
 		result, _ := json.Marshal(compacted)
 		return result
 	}
@@ -1980,14 +2024,14 @@ func compactObjectFields(obj map[string]any) json.RawMessage {
 	return result
 }
 
-func compactListEnvelopeObject(obj map[string]any) (map[string]any, bool) {
+func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int) (map[string]any, bool) {
 	out := map[string]any{}
 	foundArray := false
 	for k, v := range obj {
-		if compactVerboseObjectFields[k] {
+		if envelopeDepth == 0 && compactVerboseObjectFields[k] {
 			continue
 		}
-		if envelopeMetadataArrayKeys[k] {
+		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
 			out[k] = v
 			continue
 		}
@@ -1996,11 +2040,13 @@ func compactListEnvelopeObject(obj map[string]any) (map[string]any, bool) {
 			out[k] = compacted
 			continue
 		}
-		if nested, ok := v.(map[string]any); ok && k == "_embedded" {
-			if compacted, ok := compactListEnvelopeObject(nested); ok {
-				foundArray = true
-				out[k] = compacted
-				continue
+		if nested, ok := v.(map[string]any); ok {
+			if envelopeDepth < maxListEnvelopeDepth {
+				if compacted, ok := compactListEnvelopeObjectAtDepth(nested, envelopeDepth+1); ok {
+					foundArray = true
+					out[k] = compacted
+					continue
+				}
 			}
 		}
 		out[k] = v

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root_test.go
@@ -255,14 +255,13 @@ func TestFilterFields(t *testing.T) {
 			want:   `{"events":[{"id":"e1"}],"speakers":[{"id":"s1"}]}`,
 		},
 		{
-			// Envelope fallback is intentionally one level deep. A nested
-			// object envelope like {"data":{"items":[...]}} surfaces no
-			// array at the outer level, so the fallback does not fire and
-			// an invalid selector preserves the input.
-			name:   "nested object envelope preserves input (one-level only)",
+			// Generic object descent supports type-keyed envelopes such as
+			// {"data":{"items":[...]}} while keeping the fail-closed
+			// behavior for objects with no collection below them.
+			name:   "nested object envelope descends into collection",
 			input:  `{"data":{"items":[{"id":"a","other":"y"}]}}`,
 			fields: "id",
-			want:   `{"data":{"items":[{"id":"a","other":"y"}]}}`,
+			want:   `{"data":{"items":[{"id":"a"}]}}`,
 		},
 	}
 	for _, tc := range cases {

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
@@ -1254,6 +1254,22 @@ var envelopeMetadataArrayKeys = map[string]bool{
 	"warnings": true, "Warnings": true,
 }
 
+// envelopeMetadataKeys lists pagination and collection-envelope metadata
+// siblings to ignore when recognizing a wrapped array. Projection helpers
+// preserve these keys while filtering or compacting the collection.
+// Keep this data-driven so the envelope helpers do not depend on one API's
+// response vocabulary.
+var envelopeMetadataKeys = map[string]bool{
+	"paging": true, "pagination": true,
+	"_links": true, "links": true,
+	"meta": true, "metadata": true,
+	"total": true, "totalCount": true, "total_count": true,
+	"hasMore": true, "has_more": true,
+	"offset":   true,
+	"nextPage": true, "next_page": true,
+	"cursor": true,
+}
+
 func extractPaginatedObjectArray(raw json.RawMessage) ([]json.RawMessage, bool) {
 	var items []json.RawMessage
 	// Empty fallback arrays are deliberately ignored: without an object item,
@@ -1472,9 +1488,10 @@ func wrapAgentOutput(data json.RawMessage, meta map[string]any) (json.RawMessage
 
 // unwrapSingleKeyArray flattens single-key collection envelopes
 // ({"results":[...]}, {"data":[...]}, etc.) so the agent envelope
-// emits a stable .results[] across APIs. Multi-key objects pass
-// through so cursor/pagination fields stay accessible; non-array
-// values pass through so non-collection responses aren't reshaped.
+// emits a stable .results[] across APIs. Known pagination metadata siblings
+// do not prevent a recognized collection wrapper from being flattened;
+// unrelated multi-key objects still pass through so non-collection responses
+// aren't reshaped.
 //
 // The wrapper-key set is intentionally narrower than
 // extractPaginatedItems (which also walks domain-specific keys like
@@ -1490,20 +1507,28 @@ func unwrapSingleKeyArray(data json.RawMessage) json.RawMessage {
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return data
 	}
-	if len(obj) != 1 {
+	var collectionKey string
+	var collectionValue json.RawMessage
+	foundCollection := false
+	for key, val := range obj {
+		if envelopeMetadataKeys[key] {
+			continue
+		}
+		if foundCollection {
+			return data
+		}
+		foundCollection = true
+		collectionKey = key
+		collectionValue = val
+	}
+	if collectionKey != "results" && collectionKey != "data" && collectionKey != "items" && collectionKey != "nodes" && collectionKey != "entries" && collectionKey != "records" {
 		return data
 	}
-	for key, val := range obj {
-		if key != "results" && key != "data" && key != "items" && key != "nodes" && key != "entries" && key != "records" {
-			return data
-		}
-		trimmed := bytes.TrimLeft(val, " \t\r\n")
-		if len(trimmed) == 0 || trimmed[0] != '[' {
-			return data
-		}
-		return val
+	trimmed := bytes.TrimLeft(collectionValue, " \t\r\n")
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		return data
 	}
-	return data
+	return collectionValue
 }
 
 // filterFields keeps only the specified fields (comma-separated) from JSON objects/arrays.
@@ -1583,6 +1608,10 @@ type selectMatchState struct {
 	fallbackIndeterminate bool
 }
 
+// maxListEnvelopeDepth bounds generic object descent so malformed or hostile
+// JSON cannot force unbounded recursion in selector or compact projection.
+const maxListEnvelopeDepth = 32
+
 func (s *selectMatchState) merge(other selectMatchState) {
 	s.matched = s.matched || other.matched
 	s.anchoredIndeterminate = s.anchoredIndeterminate || other.anchoredIndeterminate
@@ -1594,6 +1623,10 @@ func (s *selectMatchState) merge(other selectMatchState) {
 // empty arrays reached through a known selector prefix from empty arrays found
 // only by the list-envelope fallback.
 func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) (json.RawMessage, selectMatchState) {
+	return filterFieldsRecAtDepth(data, paths, pathAnchored, 0)
+}
+
+func filterFieldsRecAtDepth(data json.RawMessage, paths [][]string, pathAnchored bool, envelopeDepth int) (json.RawMessage, selectMatchState) {
 	var arr []json.RawMessage
 	if err := json.Unmarshal(data, &arr); err == nil {
 		out := make([]json.RawMessage, len(arr))
@@ -1603,7 +1636,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 		}
 		for i, el := range arr {
 			var childState selectMatchState
-			out[i], childState = filterFieldsRec(el, paths, pathAnchored)
+			out[i], childState = filterFieldsRecAtDepth(el, paths, pathAnchored, envelopeDepth)
 			state.merge(childState)
 		}
 		result, _ := json.Marshal(out)
@@ -1641,7 +1674,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 			}
 			if subs := subPaths[matched]; subs != nil {
 				var childState selectMatchState
-				filtered[k], childState = filterFieldsRec(v, subs, true)
+				filtered[k], childState = filterFieldsRecAtDepth(v, subs, true, envelopeDepth)
 				state.merge(childState)
 			}
 		}
@@ -1656,7 +1689,7 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 		// which json.Unmarshal otherwise accepts into a []json.RawMessage
 		// as a nil slice and would coerce to `[]`.
 		if !headMatched {
-			if pending, foundArray, nestedState := filterListEnvelopeFields(obj, paths); foundArray {
+			if pending, foundArray, nestedState := filterListEnvelopeFields(obj, paths, envelopeDepth); foundArray {
 				filtered = pending
 				state.merge(nestedState)
 			}
@@ -1668,29 +1701,37 @@ func filterFieldsRec(data json.RawMessage, paths [][]string, pathAnchored bool) 
 	return data, selectMatchState{}
 }
 
-func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool, selectMatchState) {
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string, envelopeDepth int) (map[string]json.RawMessage, bool, selectMatchState) {
 	pending := map[string]json.RawMessage{}
 	foundArray := false
 	state := selectMatchState{}
 	for k, v := range obj {
-		if envelopeMetadataArrayKeys[k] {
+		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
 			pending[k] = v
 			continue
 		}
-		var arr []json.RawMessage
-		if json.Unmarshal(v, &arr) == nil && arr != nil {
-			foundArray = true
-			var childState selectMatchState
-			pending[k], childState = filterFieldsRec(v, paths, false)
-			state.merge(childState)
-			continue
-		}
-		if k == "_embedded" {
-			if nested, ok, nestedState := filterNestedListEnvelopeFields(v, paths); ok {
-				foundArray = true
-				pending[k] = nested
-				state.merge(nestedState)
-				continue
+		trimmed := bytes.TrimLeft(v, " \t\r\n")
+		if len(trimmed) > 0 {
+			switch trimmed[0] {
+			case '[':
+				var arr []json.RawMessage
+				if json.Unmarshal(v, &arr) == nil && arr != nil {
+					foundArray = true
+					var childState selectMatchState
+					pending[k], childState = filterFieldsRecAtDepth(v, paths, false, envelopeDepth)
+					state.merge(childState)
+					continue
+				}
+			case '{':
+				var nestedObj map[string]json.RawMessage
+				if json.Unmarshal(v, &nestedObj) == nil && nestedObj != nil {
+					if nested, ok, nestedState := filterNestedListEnvelopeFields(v, paths, envelopeDepth); ok {
+						foundArray = true
+						pending[k] = nested
+						state.merge(nestedState)
+						continue
+					}
+				}
 			}
 		}
 		pending[k] = v
@@ -1698,12 +1739,15 @@ func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) 
 	return pending, foundArray, state
 }
 
-func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool, selectMatchState) {
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string, envelopeDepth int) (json.RawMessage, bool, selectMatchState) {
+	if envelopeDepth >= maxListEnvelopeDepth {
+		return nil, false, selectMatchState{}
+	}
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return nil, false, selectMatchState{}
 	}
-	filtered, found, state := filterListEnvelopeFields(obj, paths)
+	filtered, found, state := filterListEnvelopeFields(obj, paths, envelopeDepth+1)
 	if !found {
 		return nil, false, selectMatchState{}
 	}
@@ -1956,7 +2000,7 @@ func isCompactScalar(v any) bool {
 // under `--agent`/`--compact` is a silent loss; agents who want to omit them
 // can pass `--select` to specify only the fields they need.
 func compactObjectFields(obj map[string]any) json.RawMessage {
-	if compacted, ok := compactListEnvelopeObject(obj); ok {
+	if compacted, ok := compactListEnvelopeObjectAtDepth(obj, 0); ok {
 		result, _ := json.Marshal(compacted)
 		return result
 	}
@@ -1970,14 +2014,14 @@ func compactObjectFields(obj map[string]any) json.RawMessage {
 	return result
 }
 
-func compactListEnvelopeObject(obj map[string]any) (map[string]any, bool) {
+func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int) (map[string]any, bool) {
 	out := map[string]any{}
 	foundArray := false
 	for k, v := range obj {
-		if compactVerboseObjectFields[k] {
+		if envelopeDepth == 0 && compactVerboseObjectFields[k] {
 			continue
 		}
-		if envelopeMetadataArrayKeys[k] {
+		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
 			out[k] = v
 			continue
 		}
@@ -1986,11 +2030,13 @@ func compactListEnvelopeObject(obj map[string]any) (map[string]any, bool) {
 			out[k] = compacted
 			continue
 		}
-		if nested, ok := v.(map[string]any); ok && k == "_embedded" {
-			if compacted, ok := compactListEnvelopeObject(nested); ok {
-				foundArray = true
-				out[k] = compacted
-				continue
+		if nested, ok := v.(map[string]any); ok {
+			if envelopeDepth < maxListEnvelopeDepth {
+				if compacted, ok := compactListEnvelopeObjectAtDepth(nested, envelopeDepth+1); ok {
+					foundArray = true
+					out[k] = compacted
+					continue
+				}
 			}
 		}
 		out[k] = v


### PR DESCRIPTION
## Summary

Generated CLIs now keep the same collection shape when a recognized array wrapper has pagination metadata siblings, and `--select`/`--compact` can project nested type-keyed collections instead of returning `{}` or stripping useful detail.

## Approach

The generated output-envelope helpers now classify the documented metadata keys separately from collection keys, unwrap only one recognized collection with those siblings, and recurse through arbitrary object-valued envelope layers with a shared depth bound. Projection preserves envelope metadata and fail-closed pass-through behavior for unrelated or overly deep objects; compacting avoids applying top-level verbose-field removal to nested detail payloads.

## Scope

This is a generator/template fix in `internal/generator/templates/helpers.go.tmpl`, with generated golden fixtures and runtime tests. It belongs in the Printing Press because these are systemic emitted-helper behaviors, not an API-specific printed-CLI repair.

## Risk

Generated helper output changes for paginated siblings and nested collection envelopes. Unrelated multi-key responses and no-collection objects remain unchanged, and the depth bound prevents unbounded generic descent. No MCP, auth, publish, or release surfaces change.

## Output contract

The generated `helpers.go` and `root_test.go` goldens were intentionally updated. Generated runtime tests cover pagination siblings, nested type-keyed selection and compaction, metadata preservation, empty-key handling, fail-closed no-collection behavior, nested detail payloads, and the depth bound.

## Verification

- `go test ./internal/generator -run 'TestGeneratedHelpers_WrapWithProvenanceUnwrapsSingleKeyEnvelope|TestFilterFieldsEnvelopeDescent_EmittedHelper|TestWrappedArrayProjectionHelpers_EmittedRuntime' -count=1` passed
- Generated `go test ./internal/cli -run '^TestFilterFields$' -count=1` passed
- `scripts/verify-generator-output.sh` passed 10 cases
- `go build -o ./cli-printing-press ./cmd/cli-printing-press` passed
- `go fmt ./...` passed
- `git diff --check` passed
- `scripts/golden.sh verify` passed all affected cases; it still reports an unrelated `generate-golden-api/dogfood.json` drift in `dead_functions.total` from 85 to 86
- `go test ./... -count=1` completed with 6673 passed, 11 skipped, and 7 pre-existing HTML/pagination response-format failures
- `golangci-lint run ./...` reports one pre-existing `modernize` finding in `parser.go`

Closes #3800
Closes #3777
