### PR TITLE
fix(cli): stabilize live-check binary lifecycle

### DIFF
--- a/internal/cli/shipcheck.go
+++ b/internal/cli/shipcheck.go
@@ -185,10 +185,16 @@ func shipcheckBinaryName(dir string) string {
 }
 
 func shipcheckCLIPath(o *shipcheckOpts) string {
+	if path, err := pipeline.ResolveScorerBinaryPath(o.dir, ""); err == nil {
+		return path
+	}
 	return platform.ExecutablePath(filepath.Join(o.dir, shipcheckBinaryName(o.dir)))
 }
 
 func shipcheckCLIPathForGOOS(o *shipcheckOpts, goos string) string {
+	if path, err := pipeline.ResolveScorerBinaryPathForGOOS(o.dir, "", goos); err == nil {
+		return path
+	}
 	return platform.ExecutablePathForGOOS(filepath.Join(o.dir, shipcheckBinaryName(o.dir)), goos)
 }
 

--- a/internal/cli/shipcheck_test.go
+++ b/internal/cli/shipcheck_test.go
@@ -107,6 +107,48 @@ func TestShipcheckCLIPath_ManifestOverridesBasename(t *testing.T) {
 	}
 }
 
+func TestShipcheckCLIPath_UsesManifestBinaryInStage(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "wt-phase-4-pp-cli")
+	stagedDir := filepath.Join(dir, "build", "stage", "bin")
+	if err := os.MkdirAll(stagedDir, 0o755); err != nil {
+		t.Fatalf("creating staged binary dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".printing-press.json"), []byte(`{"cli_name":"notion-pp-cli"}`), 0o644); err != nil {
+		t.Fatalf("writing manifest: %v", err)
+	}
+	manifestBinary := filepath.Join(stagedDir, "notion-pp-cli")
+	if err := os.WriteFile(manifestBinary, []byte("staged binary"), 0o755); err != nil {
+		t.Fatalf("writing staged binary: %v", err)
+	}
+
+	if got := shipcheckCLIPath(&shipcheckOpts{dir: dir}); got != manifestBinary {
+		t.Fatalf("shipcheck binary path = %q, want manifest-named staged binary %q", got, manifestBinary)
+	}
+}
+
+func TestShipcheckCLIPath_UsesExistingWorktreeBinaryWhenManifestNameDiffers(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "wt-phase-4-pp-cli")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("creating worktree dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".printing-press.json"), []byte(`{"cli_name":"notion-pp-cli"}`), 0o644); err != nil {
+		t.Fatalf("writing manifest: %v", err)
+	}
+	worktreeBinary := filepath.Join(dir, filepath.Base(dir))
+	if err := os.WriteFile(worktreeBinary, []byte("worktree binary"), 0o755); err != nil {
+		t.Fatalf("writing worktree binary: %v", err)
+	}
+
+	opts := &shipcheckOpts{dir: dir}
+	if got := shipcheckCLIPath(opts); got != worktreeBinary {
+		t.Fatalf("shipcheck binary path = %q, want existing worktree binary %q", got, worktreeBinary)
+	}
+}
+
 // TestShipcheckCLIPath_FallsBackToBasename covers the manifest-less case:
 // when .printing-press.json is missing or unparseable, the binary name
 // falls back to the directory basename (preserves legacy behavior).

--- a/internal/narrativecheck/narrativecheck.go
+++ b/internal/narrativecheck/narrativecheck.go
@@ -733,7 +733,7 @@ type templateVarEnvEntry struct {
 }
 
 func discoverTemplateVarEnv(binaryPath string) []templateVarEnvEntry {
-	manifest, err := pipeline.ReadCLIManifest(filepath.Dir(binaryPath))
+	manifest, err := readCLIManifestNearBinary(binaryPath)
 	if err != nil {
 		return nil
 	}
@@ -762,6 +762,26 @@ func discoverTemplateVarEnv(binaryPath string) []templateVarEnvEntry {
 		})
 	}
 	return envs
+}
+
+func readCLIManifestNearBinary(binaryPath string) (pipeline.CLIManifest, error) {
+	dir := filepath.Dir(binaryPath)
+	var lastErr error
+	// Cover a direct binary, bin/, and build/stage/bin/ without inheriting a
+	// manifest from an unrelated parent directory.
+	for depth := 0; depth < 4; depth++ {
+		manifest, err := pipeline.ReadCLIManifest(dir)
+		if err == nil {
+			return manifest, nil
+		}
+		lastErr = err
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return pipeline.CLIManifest{}, lastErr
+		}
+		dir = parent
+	}
+	return pipeline.CLIManifest{}, lastErr
 }
 
 func missingTemplateVarEnvAssignments(templateVars []templateVarEnvEntry) []string {

--- a/internal/narrativecheck/narrativecheck.go
+++ b/internal/narrativecheck/narrativecheck.go
@@ -769,7 +769,7 @@ func readCLIManifestNearBinary(binaryPath string) (pipeline.CLIManifest, error) 
 	var lastErr error
 	// Cover a direct binary, bin/, and build/stage/bin/ without inheriting a
 	// manifest from an unrelated parent directory.
-	for depth := 0; depth < 4; depth++ {
+	for range 4 {
 		manifest, err := pipeline.ReadCLIManifest(dir)
 		if err == nil {
 			return manifest, nil

--- a/internal/narrativecheck/narrativecheck_test.go
+++ b/internal/narrativecheck/narrativecheck_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline"
 )
 
 // TestExtractSubcommandWords pins the wordlist rule against the bash
@@ -502,6 +504,23 @@ func TestValidateWithOptions_FullExamplesUsesTemplateVarEnvOverrides(t *testing.
 
 	if report.HasFailures() {
 		t.Fatalf("full example should seed manifest override env names, got %+v", report)
+	}
+}
+
+func TestDiscoverTemplateVarEnvFindsManifestAboveStagedBinary(t *testing.T) {
+	root := t.TempDir()
+	binary := filepath.Join(root, "build", "stage", "bin", "notion-pp-cli")
+	if err := os.MkdirAll(filepath.Dir(binary), 0o755); err != nil {
+		t.Fatalf("creating staged binary directory: %v", err)
+	}
+	manifest := `{"api_name":"notion","endpoint_template_vars":["workspace"],"endpoint_template_env_overrides":{"workspace":"NOTION_WORKSPACE"}}`
+	if err := os.WriteFile(filepath.Join(root, pipeline.CLIManifestFilename), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("writing root manifest: %v", err)
+	}
+
+	got := discoverTemplateVarEnv(binary)
+	if want := []templateVarEnvEntry{{Name: "NOTION_WORKSPACE", Value: "workspace_placeholder"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("discoverTemplateVarEnv() = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -237,16 +237,25 @@ type NovelFeatureManifest struct {
 }
 
 // ReadCLIBinaryName reads .printing-press.json from dir and returns the
-// cli_name field. Returns empty string when the file is missing or
-// unparseable so callers can fall back to convention. Used by the MCPB
-// bundle builder, which can't store the CLI binary name in manifest.json
-// (Claude Desktop's MCPB v0.3 validator rejects unknown top-level keys).
+// cli_name field when it is a safe single path component. Returns empty string
+// when the file is missing, unparseable, or names a path so callers can fall
+// back to convention. Used by the MCPB bundle builder, which can't store the
+// CLI binary name in manifest.json (Claude Desktop's MCPB v0.3 validator
+// rejects unknown top-level keys).
 func ReadCLIBinaryName(dir string) string {
 	m, err := ReadCLIManifest(dir)
 	if err != nil {
 		return ""
 	}
-	return m.CLIName
+	name := strings.TrimSpace(m.CLIName)
+	if !isSafeCLIBinaryName(name) {
+		return ""
+	}
+	return name
+}
+
+func isSafeCLIBinaryName(name string) bool {
+	return name != "" && name != "." && name != ".." && !filepath.IsAbs(name) && !strings.ContainsAny(name, `/\\`)
 }
 
 // ReadCLIManifest decodes dir/.printing-press.json.

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -69,6 +69,34 @@ func TestWriteCLIManifest(t *testing.T) {
 	assert.Contains(t, string(changelog), "printing-press-library release automation")
 }
 
+func TestReadCLIBinaryNameRejectsPathComponents(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		cliName  string
+		wantName string
+	}{
+		{name: "valid", cliName: "notion-pp-cli", wantName: "notion-pp-cli"},
+		{name: "trims whitespace", cliName: " notion-pp-cli ", wantName: "notion-pp-cli"},
+		{name: "parent traversal", cliName: "../notion-pp-cli"},
+		{name: "absolute path", cliName: "/tmp/notion-pp-cli"},
+		{name: "backslash path", cliName: `..\\notion-pp-cli`},
+		{name: "dot", cliName: "."},
+		{name: "empty", cliName: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			data, err := json.Marshal(CLIManifest{CLIName: tc.cliName})
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(filepath.Join(dir, CLIManifestFilename), data, 0o644))
+
+			assert.Equal(t, tc.wantName, ReadCLIBinaryName(dir))
+		})
+	}
+}
+
 func TestWriteCLIManifestUsesOnlyClientProfileForPlatformRuntime(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "platform"), 0o755))

--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -149,8 +149,8 @@ type LiveCheckOptions struct {
 	// override.
 	ResearchDir string
 	// BinaryName, when non-empty, names the executable to run. Leave blank
-	// to let RunLiveCheck derive it from CLIDir (tries `<base>-pp-cli`,
-	// falls back to `<base>`).
+	// to let RunLiveCheck derive it from CLIDir (tries the manifest name,
+	// then `<base>-pp-cli`, and finally `<base>`).
 	BinaryName string
 	// Timeout bounds each feature invocation. Zero uses DefaultLiveCheckTimeout.
 	Timeout time.Duration
@@ -236,6 +236,13 @@ func RunLiveCheck(opts LiveCheckOptions) *LiveCheckResult {
 			return out
 		}
 	}
+	probeBinaryPath, cleanupProbeBinary, snapshotErr := snapshotLiveCheckBinary(binaryPath)
+	if snapshotErr != nil {
+		out.Unable = true
+		out.Reason = "snapshotting live-check binary: " + snapshotErr.Error()
+		return out
+	}
+	defer cleanupProbeBinary()
 
 	timeout := opts.Timeout
 	if timeout <= 0 {
@@ -249,7 +256,7 @@ func RunLiveCheck(opts LiveCheckOptions) *LiveCheckResult {
 		concurrency = len(features)
 	}
 
-	results := runFeaturesConcurrent(opts.CLIDir, binaryPath, annotateLiveCheckFeatures(opts.CLIDir, features), timeout, concurrency)
+	results := runFeaturesConcurrent(opts.CLIDir, probeBinaryPath, annotateLiveCheckFeatures(opts.CLIDir, features), timeout, concurrency)
 	out.Features = results
 	for _, r := range results {
 		switch r.Status {
@@ -341,6 +348,35 @@ func rebuildLiveCheckBinary(cliDir, binaryPath string) error {
 		return fmt.Errorf("replacing binary: %w", err)
 	}
 	return nil
+}
+
+func snapshotLiveCheckBinary(binaryPath string) (string, func(), error) {
+	// Keep probes on an immutable copy so a later staged refresh cannot replace
+	// the executable backing an in-flight probe.
+	info, err := os.Stat(binaryPath)
+	if err != nil {
+		return "", func() {}, fmt.Errorf("statting resolved binary: %w", err)
+	}
+	data, err := os.ReadFile(binaryPath)
+	if err != nil {
+		return "", func() {}, fmt.Errorf("reading resolved binary: %w", err)
+	}
+
+	tempDir, err := os.MkdirTemp(filepath.Dir(binaryPath), ".printing-press-live-check-")
+	if err != nil {
+		tempDir, err = os.MkdirTemp("", "printing-press-live-check-")
+	}
+	if err != nil {
+		return "", func() {}, fmt.Errorf("creating probe directory: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(tempDir) }
+
+	dstPath := filepath.Join(tempDir, filepath.Base(binaryPath))
+	if err := os.WriteFile(dstPath, data, info.Mode().Perm()); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("writing probe binary: %w", err)
+	}
+	return dstPath, cleanup, nil
 }
 
 func replaceLiveCheckBinary(src, dst string) error {
@@ -578,10 +614,24 @@ func newestLiveCheckBuildGraphModTime(cmdDir string) (time.Time, bool, error) {
 }
 
 // resolveBinaryPath returns the absolute path to the CLI binary. When name
-// is non-empty it's used verbatim; otherwise RunLiveCheck tries the common
-// `<base>-pp-cli` naming convention and falls back to `<base>`.
+// is non-empty it's used verbatim; otherwise the manifest name is tried before
+// the common `<base>-pp-cli` naming convention and `<base>` fallback.
 func resolveBinaryPath(cliDir, name string) (string, error) {
 	return resolveBinaryPathForGOOS(cliDir, name, runtime.GOOS)
+}
+
+// ResolveScorerBinaryPath returns the freshest runnable CLI binary found in
+// the layouts used by scorer and shipcheck. An explicit name wins; otherwise
+// the manifest name is tried before worktree-derived legacy names.
+func ResolveScorerBinaryPath(cliDir, name string) (string, error) {
+	return resolveBinaryPath(cliDir, name)
+}
+
+// ResolveScorerBinaryPathForGOOS is the platform-explicit form used by tests
+// and path-building callers that need to model another host executable
+// suffix.
+func ResolveScorerBinaryPathForGOOS(cliDir, name, goos string) (string, error) {
+	return resolveBinaryPathForGOOS(cliDir, name, goos)
 }
 
 func resolveBinaryPathForGOOS(cliDir, name, goos string) (string, error) {
@@ -646,11 +696,27 @@ func liveCheckBinaryCandidatesForGOOS(cliDir, name, goos string) []string {
 }
 
 func liveCheckBinaryNames(cliDir, name string) []string {
-	names := []string{name}
-	if name == "" {
-		base := filepath.Base(cliDir)
-		names = []string{base + "-pp-cli", base}
+	if strings.TrimSpace(name) != "" {
+		return []string{name}
 	}
+
+	names := make([]string, 0, 3)
+	seen := make(map[string]struct{})
+	add := func(candidate string) {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			return
+		}
+		if _, ok := seen[candidate]; ok {
+			return
+		}
+		seen[candidate] = struct{}{}
+		names = append(names, candidate)
+	}
+	add(ReadCLIBinaryName(cliDir))
+	base := filepath.Base(cliDir)
+	add(base + "-pp-cli")
+	add(base)
 	return names
 }
 

--- a/internal/pipeline/live_check_test.go
+++ b/internal/pipeline/live_check_test.go
@@ -715,8 +715,8 @@ func TestLiveCheck_OutputSampleRedactsSplitJWTAcrossTruncationBoundary(t *testin
 	require.Contains(t, got, artifacts.PIIRedactedSentinel)
 }
 
-// TestLiveCheck_BinaryAutoDerivation verifies RunLiveCheck finds the binary
-// when BinaryName is empty by trying <base>-pp-cli then <base>.
+// TestLiveCheck_BinaryAutoDerivation verifies the legacy fallback after no
+// manifest name is available: <base>-pp-cli is tried before <base>.
 func TestLiveCheck_BinaryAutoDerivation(t *testing.T) {
 	dir := t.TempDir()
 	// CLIDir basename is the last path segment. Build a stub named that way
@@ -736,6 +736,96 @@ func TestLiveCheck_BinaryAutoDerivation(t *testing.T) {
 	require.Equal(t, 1, result.Passed)
 	require.Contains(t, result.Features[0].Example, "stub x matched")
 	require.Contains(t, result.Features[0].OutputSample, "matched via -pp-cli")
+}
+
+func TestLiveCheck_BinaryAutoDerivationUsesManifestName(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub not supported on Windows")
+	}
+
+	dir := filepath.Join(t.TempDir(), "worktree-x")
+	stagedDir := filepath.Join(dir, "build", "stage", "bin")
+	require.NoError(t, os.MkdirAll(stagedDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, CLIManifestFilename), []byte(`{"api_name":"notion","cli_name":"notion-pp-cli"}`), 0o644))
+	writeStubBinary(t, stagedDir, "notion-pp-cli", `echo '{"data":[{"source":"manifest"}]}'`)
+	writeTestResearchJSON(t, dir, []NovelFeature{
+		{Name: "X", Command: "x", Example: "notion-pp-cli x --json"},
+	})
+
+	result := RunLiveCheck(LiveCheckOptions{
+		CLIDir:      dir,
+		ResearchDir: dir,
+		Timeout:     liveCheckIntegrationTimeout,
+	})
+	require.False(t, result.Unable, "manifest-named binary should be found: %s", result.Reason)
+	require.Equal(t, 1, result.Passed)
+	require.Contains(t, result.Features[0].OutputSample, "manifest")
+}
+
+func TestLiveCheck_UsesSnapshotBinaryForProbes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub not supported on Windows")
+	}
+
+	dir := filepath.Join(t.TempDir(), "worktree-x")
+	stagedDir := filepath.Join(dir, "build", "stage", "bin")
+	require.NoError(t, os.MkdirAll(stagedDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, CLIManifestFilename), []byte(`{"api_name":"notion","cli_name":"notion-pp-cli"}`), 0o644))
+	writeStubBinary(t, stagedDir, "notion-pp-cli", `printf '{"data":[{"source":"%s"}]}\n' "$0"`)
+	writeTestResearchJSON(t, dir, []NovelFeature{
+		{Name: "X", Command: "x", Example: "notion-pp-cli x --json"},
+	})
+
+	result := RunLiveCheck(LiveCheckOptions{
+		CLIDir:      dir,
+		ResearchDir: dir,
+		Timeout:     liveCheckIntegrationTimeout,
+	})
+	require.False(t, result.Unable, "snapshot probe should run: %s", result.Reason)
+	require.Equal(t, 1, result.Passed)
+	require.Contains(t, result.Features[0].OutputSample, ".printing-press-live-check-")
+}
+
+func TestResolveBinaryPathForGOOSUsesManifestExe(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "worktree-x")
+	stagedDir := filepath.Join(dir, "build", "stage", "bin")
+	require.NoError(t, os.MkdirAll(stagedDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, CLIManifestFilename), []byte(`{"cli_name":"notion-pp-cli"}`), 0o644))
+	windowsBinary := filepath.Join(stagedDir, "notion-pp-cli.exe")
+	require.NoError(t, os.WriteFile(windowsBinary, []byte("windows binary"), 0o644))
+
+	got, err := ResolveScorerBinaryPathForGOOS(dir, "", "windows")
+	require.NoError(t, err)
+	absWindowsBinary, err := filepath.Abs(windowsBinary)
+	require.NoError(t, err)
+	require.Equal(t, absWindowsBinary, got)
+}
+
+func TestSnapshotLiveCheckBinarySurvivesReplacement(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub not supported on Windows")
+	}
+
+	dir := t.TempDir()
+	original := writeStubBinary(t, dir, "sample-pp-cli", `echo '{"data":[{"source":"old"}]}'`)
+	snapshot, cleanup, err := snapshotLiveCheckBinary(original)
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	replacement := writeStubBinary(t, dir, "replacement", `echo '{"data":[{"source":"new"}]}'`)
+	require.NoError(t, replaceLiveCheckBinary(replacement, original))
+
+	oldResult := runOneFeatureCheck(t.TempDir(), snapshot, NovelFeature{
+		Name: "X", Command: "x", Example: "sample-pp-cli x --json",
+	}, liveCheckIntegrationTimeout)
+	require.Equal(t, StatusPass, oldResult.Status, "snapshot should remain runnable: %s", oldResult.Reason)
+	require.Contains(t, oldResult.OutputSample, "old")
+
+	newResult := runOneFeatureCheck(t.TempDir(), original, NovelFeature{
+		Name: "X", Command: "x", Example: "sample-pp-cli x --json",
+	}, liveCheckIntegrationTimeout)
+	require.Equal(t, StatusPass, newResult.Status, "replacement should be runnable: %s", newResult.Reason)
+	require.Contains(t, newResult.OutputSample, "new")
 }
 
 func TestLiveCheckBinaryCandidatesPreferBuildStageBin(t *testing.T) {


### PR DESCRIPTION
## Intent

Scorecard live checks could select the wrong binary in worktrees, and a stale staged rebuild could replace the executable while probes were still running. This makes binary identity and probe execution stable across scorecard and shipcheck.

Closes #3834
Closes #3745

## Approach

Resolve blank binary names from `.printing-press.json` before legacy basename fallbacks, while rejecting manifest names that are not single path components. Snapshot the resolved executable before starting probes so later atomic refreshes cannot affect an in-flight run. Shipcheck uses the same resolver, and narrative full-example validation finds the root manifest from supported staged binary layouts.

## Scope

Primary area: live-check binary resolution and probe lifecycle in the Printing Press pipeline, plus the shipcheck and narrative validation callers.

Why this belongs in this repo: this is generator-side runtime behavior shared by future printed CLIs, not a repair to one generated CLI.

## Risk

Binary selection and temporary probe execution change for scorecard and shipcheck. Legacy basename and manifest-less layouts retain their fallback behavior; no generated templates, MCP surface, or release metadata changed.

## Output Contract

Scorecard and shipcheck runtime outcomes can now reflect the correct binary, but no serialized schema, generated artifact, or golden output contract changed. Golden coverage is not applicable to this runtime-only path fix.

## Verification

- `go fmt ./...`
- `go test ./internal/pipeline ./internal/cli ./internal/narrativecheck -count=1`
- Focused `go test -race` runs for pipeline, shipcheck, and narrativecheck regressions
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./internal/pipeline ./internal/cli ./internal/narrativecheck`
- Decoy-profile generator regression checks passed for the three affected generator tests
- `go test ./... -count=1` reached the full suite; three unrelated generator tests fail when the shared local learn store is schema version 10 while the test binary supports version 9
- Full `golangci-lint run ./...` is blocked by the pre-existing `modernize` finding in `../issues-3800-3777/internal/googlediscovery/parser.go:455`
