### PR TITLE
fix(cli): preserve sync watermarks across pagination caps

### DIFF
--- a/internal/generator/export_sync_persistence_test.go
+++ b/internal/generator/export_sync_persistence_test.go
@@ -40,8 +40,16 @@ func TestSyncTemplates_DoNotDiscardSaveSyncStateErrors(t *testing.T) {
 				"%s must propagate SaveSyncState errors", tmpl)
 			require.NotContains(t, content, "warning: failed to save sync state",
 				"%s must not downgrade checkpoint failures to warnings", tmpl)
-			require.Equal(t, 4, strings.Count(content, "if err := db.SaveSyncState(resource"),
-				"%s must check reset, latest-only, per-page, and final checkpoints", tmpl)
+			if tmpl == "sync.go.tmpl" {
+				require.Equal(t, 0, strings.Count(content, "if err := db.SaveSyncState(resource"),
+					"REST sync should keep cursor progress separate from watermark writes")
+				require.Equal(t, 1, strings.Count(content, "if err := db.SaveSyncProgress(resource"),
+					"%s must check the per-page progress checkpoint", tmpl)
+				require.Contains(t, content, "SaveSyncStateAt(resource, finalCursor, cachedCount, watermark)")
+			} else {
+				require.Equal(t, 4, strings.Count(content, "if err := db.SaveSyncState(resource"),
+					"%s must check reset, latest-only, per-page, and final checkpoints", tmpl)
+			}
 			require.True(t, strings.Contains(content, "saving sync state for"),
 				"%s should wrap final SaveSyncState failures", tmpl)
 		})
@@ -94,6 +102,8 @@ func TestGeneratedSync_PropagatesEveryResourceCheckpoint(t *testing.T) {
 	content := string(syncGo)
 
 	require.NotContains(t, content, "warning: failed to save sync state")
-	require.Equal(t, 4, strings.Count(content, "if err := db.SaveSyncState(resource"))
-	require.Contains(t, content, `return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err)`)
+	require.Equal(t, 0, strings.Count(content, "if err := db.SaveSyncState(resource"))
+	require.Equal(t, 1, strings.Count(content, "if err := db.SaveSyncProgress(resource"))
+	require.Contains(t, content, "SaveSyncStateAt(resource, finalCursor, cachedCount, watermark)")
+	require.Contains(t, content, `Err: fmt.Errorf("saving sync state for %s: %w", resource, stateErr)`)
 }

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -444,6 +444,410 @@ func TestSyncResourceDoesNotAdvancePastNullItems(t *testing.T) {
 	requireGeneratedCompiles(t, outputDir)
 }
 
+func TestGeneratedSyncNormalizesPagePaginationProfile(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		page spec.Pagination
+		want string
+	}{
+		{name: "missing type", page: spec.Pagination{CursorParam: "page", LimitParam: "per_page"}, want: "page"},
+		{name: "offset type on page parameter", page: spec.Pagination{Type: "offset", CursorParam: "page", LimitParam: "per_page"}, want: "page"},
+		{name: "page type on offset parameter", page: spec.Pagination{Type: "page", CursorParam: "offset", LimitParam: "limit"}, want: "offset"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			apiSpec := minimalSpec("page-profile-" + strings.ReplaceAll(tc.name, " ", "-"))
+			apiSpec.Resources = map[string]spec.Resource{
+				"items": {
+					Description: "Manage items",
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method:      "GET",
+							Path:        "/items",
+							Description: "List items",
+							Params:      []spec.Param{{Name: "page", Type: "integer"}, {Name: "per_page", Type: "integer"}},
+							Pagination:  &tc.page,
+							Response:    spec.ResponseDef{Type: "array"},
+						},
+					},
+				},
+			}
+
+			outputDir := filepath.Join(t.TempDir(), "page-profile-pp-cli")
+			require.NoError(t, New(apiSpec, outputDir).Generate())
+			syncSrc := readGeneratedCLIFileContaining(t, outputDir, "func determinePaginationDefaults")
+			require.Contains(t, syncSrc, fmt.Sprintf(`cursorType:  %q`, tc.want), "generated sync must use the normalized pagination strategy")
+			requireGeneratedCompiles(t, outputDir)
+		})
+	}
+}
+
+func TestGeneratedSyncPreservesWatermarkAcrossPaginationCaps(t *testing.T) {
+	apiSpec := minimalSpec("sync-watermark")
+	apiSpec.Resources = map[string]spec.Resource{
+		"items": {
+			Description: "Manage items",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/items",
+					Description: "List items updated after a timestamp, sorted by updated_at ascending.",
+					Params: []spec.Param{
+						{Name: "after", Type: "string"},
+						{Name: "limit", Type: "integer", Default: 2},
+						{Name: "updated_after", Type: "string"},
+						{Name: "sort", Type: "string", Default: "updated_at:asc", Description: "Sort by updated_at ascending."},
+					},
+					Pagination: &spec.Pagination{
+						Type:           "cursor",
+						CursorParam:    "after",
+						LimitParam:     "limit",
+						NextCursorPath: "next_cursor",
+						HasMoreField:   "has_more",
+					},
+					Response: spec.ResponseDef{Type: "array"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "sync-watermark-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	syncSrc := readGeneratedCLIFileContaining(t, outputDir, "func syncResourceSortParam")
+	require.Contains(t, syncSrc, "func syncResourceSortParam(resource string) string")
+	require.Contains(t, syncSrc, "db.SaveSyncStateAt(resource, finalCursor, cachedCount, watermark)")
+	require.Contains(t, syncSrc, "db.SaveSyncProgress(resource, nextCursor, totalCount)")
+	requireGeneratedCompiles(t, outputDir)
+
+	goMod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
+	require.NoError(t, err)
+	modulePath := strings.TrimPrefix(strings.SplitN(string(goMod), "\n", 2)[0], "module ")
+	behaviorTest := `package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	` + fmt.Sprintf("%q", modulePath+"/internal/store") + `
+)
+
+type watermarkPagerClient struct {
+	responses []json.RawMessage
+	params    []map[string]string
+}
+
+func (c *watermarkPagerClient) Get(_ context.Context, _ string, params map[string]string) (json.RawMessage, error) {
+	copied := make(map[string]string, len(params))
+	for key, value := range params {
+		copied[key] = value
+	}
+	c.params = append(c.params, copied)
+	response := c.responses[0]
+	c.responses = c.responses[1:]
+	return response, nil
+}
+
+func (c *watermarkPagerClient) RateLimit() float64 { return 0 }
+
+func seedWatermark(t *testing.T, db *store.Store, at time.Time) {
+	t.Helper()
+	if err := db.Upsert("items", "existing", []byte("{\"id\":\"existing\",\"updated_at\":\"2025-12-31T00:00:00Z\"}")); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+	if err := db.SaveSyncStateAt("items", "", 1, at); err != nil {
+		t.Fatalf("seed sync state: %v", err)
+	}
+}
+
+func readWatermark(t *testing.T, db *store.Store) (string, time.Time, int) {
+	t.Helper()
+	cursor, synced, count, err := db.GetSyncState("items")
+	if err != nil {
+		t.Fatalf("read sync state: %v", err)
+	}
+	return cursor, synced, count
+}
+
+func TestCappedOrderedPageAdvancesToNewestStored(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	old := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
+	seedWatermark(t, db, old)
+	client := &watermarkPagerClient{responses: []json.RawMessage{
+		json.RawMessage("{\"items\":[{\"id\":\"one\",\"updated_at\":\"2026-01-02T00:00:00Z\"},{\"id\":\"two\",\"updated_at\":\"2026-01-03T00:00:00Z\"}],\"next_cursor\":\"page-2\",\"has_more\":true}"),
+	}}
+	result := syncResource(context.Background(), client, db, "items", old.Format(time.RFC3339), false, 1, false, false, &syncUserParams{}, io.Discard)
+	if result.Err != nil || result.Warn != nil {
+		t.Fatalf("sync result error=%v warning=%v", result.Err, result.Warn)
+	}
+	if client.params[0]["sort"] != "updated_at:asc" {
+		t.Fatalf("sort param = %q, want updated_at:asc", client.params[0]["sort"])
+	}
+	cursor, synced, count := readWatermark(t, db)
+	want := time.Date(2026, 1, 2, 23, 59, 59, 0, time.UTC)
+	if cursor != "" || !synced.Equal(want) || count != 3 {
+		t.Fatalf("sync state = cursor %q, synced %s, count %d; want empty cursor, %s, 3", cursor, synced, count, want)
+	}
+}
+
+func TestCappedNestedTimestampUsesRecordTimestamp(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	old := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
+	seedWatermark(t, db, old)
+	client := &watermarkPagerClient{responses: []json.RawMessage{
+		json.RawMessage("{\"items\":[{\"id\":\"first\",\"updated_at\":\"2026-01-01T00:00:00Z\"},{\"id\":\"nested\",\"updated_at\":\"2026-01-02T00:00:00Z\",\"children\":[{\"updated_at\":\"2026-06-01T00:00:00Z\"}]}],\"next_cursor\":\"page-2\",\"has_more\":true}"),
+	}}
+	if timestamp, ok := restSyncTimestamp(json.RawMessage("{\"id\":\"nested\",\"updated_at\":\"2026-01-02T00:00:00Z\",\"children\":[{\"updated_at\":\"2026-06-01T00:00:00Z\"}]}")); !ok || !timestamp.Equal(time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("record timestamp = %s, ok=%v; want 2026-01-02, true", timestamp, ok)
+	}
+	var events bytes.Buffer
+	result := syncResource(context.Background(), client, db, "items", old.Format(time.RFC3339), false, 1, false, false, &syncUserParams{}, &events)
+	if result.Err != nil || result.Warn != nil {
+		t.Fatalf("sync result error=%v warning=%v", result.Err, result.Warn)
+	}
+	cursor, synced, count := readWatermark(t, db)
+	want := time.Date(2026, 1, 1, 23, 59, 59, 0, time.UTC)
+	if cursor != "" || !synced.Equal(want) || count != 3 {
+		t.Fatalf("sync state = cursor %q, synced %s, count %d; want empty cursor, %s, 3; events=%s", cursor, synced, count, want, events.String())
+	}
+}
+
+func TestCappedPageWithUnstoredItemRetainsWatermark(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	old := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
+	seedWatermark(t, db, old)
+	client := &watermarkPagerClient{responses: []json.RawMessage{
+		json.RawMessage("{\"items\":[{\"id\":\"stored\",\"updated_at\":\"2026-01-02T00:00:00Z\"},{\"updated_at\":\"2026-01-03T00:00:00Z\"}],\"next_cursor\":\"page-2\",\"has_more\":true}"),
+	}}
+	result := syncResource(context.Background(), client, db, "items", old.Format(time.RFC3339), false, 1, false, false, &syncUserParams{}, io.Discard)
+	if result.Err != nil || result.Warn != nil {
+		t.Fatalf("sync result error=%v warning=%v", result.Err, result.Warn)
+	}
+	cursor, synced, count := readWatermark(t, db)
+	if cursor != "page-2" || !synced.Equal(old) || count != 2 {
+		t.Fatalf("sync state = cursor %q, synced %s, count %d; want page-2, %s, 2", cursor, synced, count, old)
+	}
+}
+
+func TestCappedUnorderedPageRetainsWatermark(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	old := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
+	seedWatermark(t, db, old)
+	client := &watermarkPagerClient{responses: []json.RawMessage{
+		json.RawMessage("{\"items\":[{\"id\":\"two\",\"updated_at\":\"2026-01-03T00:00:00Z\"},{\"id\":\"one\",\"updated_at\":\"2026-01-02T00:00:00Z\"}],\"next_cursor\":\"page-2\",\"has_more\":true}"),
+	}}
+	result := syncResource(context.Background(), client, db, "items", old.Format(time.RFC3339), false, 1, false, false, &syncUserParams{}, io.Discard)
+	if result.Err != nil || result.Warn != nil {
+		t.Fatalf("sync result error=%v warning=%v", result.Err, result.Warn)
+	}
+	cursor, synced, count := readWatermark(t, db)
+	if cursor != "page-2" || !synced.Equal(old) || count != 3 {
+		t.Fatalf("sync state = cursor %q, synced %s, count %d; want page-2, %s, 3", cursor, synced, count, old)
+	}
+}
+
+func TestDrainedSyncUsesRequestWatermark(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	old := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
+	seedWatermark(t, db, old)
+	before := time.Now().UTC().Add(-2 * time.Second)
+	client := &watermarkPagerClient{responses: []json.RawMessage{
+		json.RawMessage("{\"items\":[{\"id\":\"one\",\"updated_at\":\"2026-01-02T00:00:00Z\"},{\"id\":\"two\",\"updated_at\":\"2026-01-03T00:00:00Z\"}],\"next_cursor\":\"page-2\",\"has_more\":true}"),
+		json.RawMessage("{\"items\":[{\"id\":\"three\",\"updated_at\":\"2026-01-04T00:00:00Z\"}],\"has_more\":false}"),
+	}}
+	result := syncResource(context.Background(), client, db, "items", old.Format(time.RFC3339), false, 0, false, false, &syncUserParams{}, io.Discard)
+	if result.Err != nil || result.Warn != nil {
+		t.Fatalf("sync result error=%v warning=%v", result.Err, result.Warn)
+	}
+	cursor, synced, count := readWatermark(t, db)
+	if cursor != "" || !synced.After(before) || !synced.Before(time.Now().UTC().Add(time.Second)) || count != 4 {
+		t.Fatalf("sync state = cursor %q, synced %s, count %d; want drained request watermark and count 4", cursor, synced, count)
+	}
+}
+
+func TestLatestOnlySinglePageIsNaturalEnd(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	old := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
+	seedWatermark(t, db, old)
+	if err := db.SaveSyncStateAt("items", "", 0, time.Time{}); err != nil {
+		t.Fatalf("clear latest-only state: %v", err)
+	}
+	var events bytes.Buffer
+	client := &watermarkPagerClient{responses: []json.RawMessage{
+		json.RawMessage("{\"items\":[{\"id\":\"head\",\"updated_at\":\"2026-01-05T00:00:00Z\"}],\"has_more\":false}"),
+	}}
+	result := syncResource(context.Background(), client, db, "items", "", false, 1, true, false, &syncUserParams{}, &events)
+	if result.Err != nil || result.Warn != nil {
+		t.Fatalf("sync result error=%v warning=%v", result.Err, result.Warn)
+	}
+	if strings.Contains(events.String(), "max_pages_cap_hit") {
+		t.Fatalf("latest-only natural end emitted a cap warning: %s", events.String())
+	}
+	if _, ok := client.params[0]["sort"]; ok {
+		t.Fatalf("latest-only unexpectedly sent sort=%q", client.params[0]["sort"])
+	}
+	if _, ok := client.params[0]["updated_after"]; ok {
+		t.Fatalf("latest-only unexpectedly sent updated_after=%q", client.params[0]["updated_after"])
+	}
+	_, synced, _ := readWatermark(t, db)
+	if !synced.After(old) {
+		t.Fatalf("latest-only watermark = %s, want it advanced past %s", synced, old)
+	}
+}
+
+func TestFullSyncOmitsIncrementalSort(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	client := &watermarkPagerClient{responses: []json.RawMessage{
+		json.RawMessage("{\"items\":[{\"id\":\"one\",\"updated_at\":\"2026-01-02T00:00:00Z\"}],\"has_more\":false}"),
+	}}
+	result := syncResource(context.Background(), client, db, "items", "", true, 0, false, false, &syncUserParams{}, io.Discard)
+	if result.Err != nil || result.Warn != nil {
+		t.Fatalf("sync result error=%v warning=%v", result.Err, result.Warn)
+	}
+	if _, ok := client.params[0]["sort"]; ok {
+		t.Fatalf("full sync unexpectedly sent sort=%q", client.params[0]["sort"])
+	}
+	if _, ok := client.params[0]["updated_after"]; ok {
+		t.Fatalf("full sync unexpectedly sent updated_after=%q", client.params[0]["updated_after"])
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "sync_watermark_test.go"), []byte(behaviorTest), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "Test(Capped|Drained|LatestOnly|FullSync)", "-count=1")
+}
+
+func TestGeneratedSyncClearsOffsetCursorWhenWatermarkMoves(t *testing.T) {
+	apiSpec := minimalSpec("sync-watermark-offset")
+	apiSpec.Resources = map[string]spec.Resource{
+		"items": {
+			Description: "Manage items",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/items",
+					Description: "List items updated after a timestamp, sorted by updated_at ascending.",
+					Params: []spec.Param{
+						{Name: "offset", Type: "integer"},
+						{Name: "limit", Type: "integer", Default: 2},
+						{Name: "updated_after", Type: "string"},
+						{Name: "sort", Type: "string", Default: "updated_at:asc", Description: "Sort by updated_at ascending."},
+					},
+					Pagination: &spec.Pagination{
+						Type:           "offset",
+						CursorParam:    "offset",
+						LimitParam:     "limit",
+						HasMoreField:   "has_more",
+						NextCursorPath: "",
+					},
+					Response: spec.ResponseDef{Type: "array"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "sync-watermark-offset-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	requireGeneratedCompiles(t, outputDir)
+
+	goMod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
+	require.NoError(t, err)
+	modulePath := strings.TrimPrefix(strings.SplitN(string(goMod), "\n", 2)[0], "module ")
+	behaviorTest := `package cli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"testing"
+	"time"
+
+	` + fmt.Sprintf("%q", modulePath+"/internal/store") + `
+)
+
+type offsetWatermarkClient struct {
+	response json.RawMessage
+	params   []map[string]string
+}
+
+func (c *offsetWatermarkClient) Get(_ context.Context, _ string, params map[string]string) (json.RawMessage, error) {
+	copied := make(map[string]string, len(params))
+	for key, value := range params {
+		copied[key] = value
+	}
+	c.params = append(c.params, copied)
+	return c.response, nil
+}
+
+func (c *offsetWatermarkClient) RateLimit() float64 { return 0 }
+
+func TestOffsetWatermarkDoesNotKeepOldPosition(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	old := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
+	if err := db.Upsert("items", "existing", []byte("{\"id\":\"existing\"}")); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+	if err := db.SaveSyncStateAt("items", "", 1, old); err != nil {
+		t.Fatalf("seed sync state: %v", err)
+	}
+	client := &offsetWatermarkClient{response: json.RawMessage("{\"items\":[{\"id\":\"one\",\"updated_at\":\"2026-01-02T00:00:00Z\"},{\"id\":\"two\",\"updated_at\":\"2026-01-03T00:00:00Z\"}],\"has_more\":true}")}
+	result := syncResource(context.Background(), client, db, "items", old.Format(time.RFC3339), false, 1, false, false, &syncUserParams{}, io.Discard)
+	if result.Err != nil || result.Warn != nil {
+		t.Fatalf("sync result error=%v warning=%v", result.Err, result.Warn)
+	}
+	cursor, synced, count, err := db.GetSyncState("items")
+	if err != nil {
+		t.Fatalf("read sync state: %v", err)
+	}
+	want := time.Date(2026, 1, 2, 23, 59, 59, 0, time.UTC)
+	if cursor != "" || !synced.Equal(want) || count != 3 {
+		t.Fatalf("sync state = cursor %q, synced %s, count %d; want empty cursor, %s, 3", cursor, synced, count, want)
+	}
+	if offset, ok := client.params[0]["offset"]; ok && offset != "0" {
+		t.Fatalf("first offset = %q, want absent or 0", offset)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "sync_watermark_offset_test.go"), []byte(behaviorTest), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "TestOffsetWatermarkDoesNotKeepOldPosition", "-count=1")
+}
+
 func TestPaginatedGetHandlesNumericCursorAndMissingAllSignal(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -172,7 +172,7 @@ func TestGeneratedSyncShortPageTerminationRespectsPaginationType(t *testing.T) {
 
 	templateSrc, err := os.ReadFile(filepath.Join("templates", "sync.go.tmpl"))
 	require.NoError(t, err)
-	require.Equal(t, 11, strings.Count(string(templateSrc), "shortPageEndsPagination("),
+	require.Equal(t, 13, strings.Count(string(templateSrc), "shortPageEndsPagination("),
 		"the helper definition and every termination and cap-classification variant must stay cursor-aware")
 	require.Equal(t, 3, strings.Count(string(templateSrc), "cursorPageHasContinuation("),
 		"the helper definition and both flat and dependent empty-page branches must preserve cursor continuation")
@@ -663,6 +663,41 @@ func TestCappedUnorderedPageRetainsWatermark(t *testing.T) {
 	cursor, synced, count := readWatermark(t, db)
 	if cursor != "page-2" || !synced.Equal(old) || count != 3 {
 		t.Fatalf("sync state = cursor %q, synced %s, count %d; want page-2, %s, 3", cursor, synced, count, old)
+	}
+}
+
+func TestCappedSortOverrideRetainsWatermark(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		userParams *syncUserParams
+	}{
+		{name: "param", userParams: &syncUserParams{flatGlobal: map[string]string{"sort": "name:asc"}}},
+		{name: "global-param", userParams: &syncUserParams{trueGlobal: map[string]string{"sort": "name:asc"}}},
+		{name: "resource-param", userParams: &syncUserParams{perResource: map[string]map[string]string{"items": {"sort": "name:asc"}}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+			if err != nil {
+				t.Fatalf("open store: %v", err)
+			}
+			defer db.Close()
+			old := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
+			seedWatermark(t, db, old)
+			client := &watermarkPagerClient{responses: []json.RawMessage{
+				json.RawMessage("{\"items\":[{\"id\":\"one\",\"updated_at\":\"2026-01-02T00:00:00Z\"},{\"id\":\"two\",\"updated_at\":\"2026-01-03T00:00:00Z\"}],\"next_cursor\":\"page-2\",\"has_more\":true}"),
+			}}
+			result := syncResource(context.Background(), client, db, "items", old.Format(time.RFC3339), false, 1, false, false, tc.userParams, io.Discard)
+			if result.Err != nil || result.Warn != nil {
+				t.Fatalf("sync result error=%v warning=%v", result.Err, result.Warn)
+			}
+			if client.params[0]["sort"] != "name:asc" {
+				t.Fatalf("sort param = %q, want name:asc", client.params[0]["sort"])
+			}
+			cursor, synced, count := readWatermark(t, db)
+			if cursor != "page-2" || !synced.Equal(old) || count != 3 {
+				t.Fatalf("sync state = cursor %q, synced %s, count %d; want page-2, %s, 3", cursor, synced, count, old)
+			}
+		})
 	}
 }
 

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -514,6 +514,8 @@ func TestGeneratedSyncPreservesWatermarkAcrossPaginationCaps(t *testing.T) {
 	require.NoError(t, New(apiSpec, outputDir).Generate())
 	syncSrc := readGeneratedCLIFileContaining(t, outputDir, "func syncResourceSortParam")
 	require.Contains(t, syncSrc, "func syncResourceSortParam(resource string) string")
+	require.Contains(t, syncSrc, "func syncResourceSortField(resource string) string")
+	require.Contains(t, syncSrc, "restSyncTimestamp(item, sortField)")
 	require.Contains(t, syncSrc, "db.SaveSyncStateAt(resource, finalCursor, cachedCount, watermark)")
 	require.Contains(t, syncSrc, "db.SaveSyncProgress(resource, nextCursor, totalCount)")
 	requireGeneratedCompiles(t, outputDir)
@@ -609,7 +611,7 @@ func TestCappedNestedTimestampUsesRecordTimestamp(t *testing.T) {
 	client := &watermarkPagerClient{responses: []json.RawMessage{
 		json.RawMessage("{\"items\":[{\"id\":\"first\",\"updated_at\":\"2026-01-01T00:00:00Z\"},{\"id\":\"nested\",\"updated_at\":\"2026-01-02T00:00:00Z\",\"children\":[{\"updated_at\":\"2026-06-01T00:00:00Z\"}]}],\"next_cursor\":\"page-2\",\"has_more\":true}"),
 	}}
-	if timestamp, ok := restSyncTimestamp(json.RawMessage("{\"id\":\"nested\",\"updated_at\":\"2026-01-02T00:00:00Z\",\"children\":[{\"updated_at\":\"2026-06-01T00:00:00Z\"}]}")); !ok || !timestamp.Equal(time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)) {
+	if timestamp, ok := restSyncTimestamp(json.RawMessage("{\"id\":\"nested\",\"updated_at\":\"2026-01-02T00:00:00Z\",\"children\":[{\"updated_at\":\"2026-06-01T00:00:00Z\"}]}"), "updated_at"); !ok || !timestamp.Equal(time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)) {
 		t.Fatalf("record timestamp = %s, ok=%v; want 2026-01-02, true", timestamp, ok)
 	}
 	var events bytes.Buffer
@@ -621,6 +623,58 @@ func TestCappedNestedTimestampUsesRecordTimestamp(t *testing.T) {
 	want := time.Date(2026, 1, 1, 23, 59, 59, 0, time.UTC)
 	if cursor != "" || !synced.Equal(want) || count != 3 {
 		t.Fatalf("sync state = cursor %q, synced %s, count %d; want empty cursor, %s, 3; events=%s", cursor, synced, count, want, events.String())
+	}
+}
+
+func TestCappedMismatchedTimestampRetainsWatermark(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	old := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
+	seedWatermark(t, db, old)
+	client := &watermarkPagerClient{responses: []json.RawMessage{
+		json.RawMessage("{\"items\":[{\"id\":\"one\",\"modified_at\":\"2026-06-01T00:00:00Z\"},{\"id\":\"two\",\"modified_at\":\"2026-06-02T00:00:00Z\"}],\"next_cursor\":\"page-2\",\"has_more\":true}"),
+	}}
+	result := syncResource(context.Background(), client, db, "items", old.Format(time.RFC3339), false, 1, false, false, &syncUserParams{}, io.Discard)
+	if result.Err != nil || result.Warn != nil {
+		t.Fatalf("sync result error=%v warning=%v", result.Err, result.Warn)
+	}
+	cursor, synced, count := readWatermark(t, db)
+	if cursor != "page-2" || !synced.Equal(old) || count != 3 {
+		t.Fatalf("sync state = cursor %q, synced %s, count %d; want page-2, %s, 3", cursor, synced, count, old)
+	}
+}
+
+func TestCappedTimestampUsesExpectedFieldWithUnrelatedTimestamp(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	old := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
+	seedWatermark(t, db, old)
+	client := &watermarkPagerClient{responses: []json.RawMessage{
+		json.RawMessage("{\"items\":[{\"id\":\"one\",\"updated_at\":\"2026-01-02T00:00:00Z\",\"modified_at\":\"2026-06-01T00:00:00Z\"},{\"id\":\"two\",\"updated_at\":\"2026-01-03T00:00:00Z\",\"modified_at\":\"2026-06-02T00:00:00Z\"}],\"next_cursor\":\"page-2\",\"has_more\":true}"),
+	}}
+	result := syncResource(context.Background(), client, db, "items", old.Format(time.RFC3339), false, 1, false, false, &syncUserParams{}, io.Discard)
+	if result.Err != nil || result.Warn != nil {
+		t.Fatalf("sync result error=%v warning=%v", result.Err, result.Warn)
+	}
+	cursor, synced, count := readWatermark(t, db)
+	want := time.Date(2026, 1, 2, 23, 59, 59, 0, time.UTC)
+	if cursor != "" || !synced.Equal(want) || count != 3 {
+		t.Fatalf("sync state = cursor %q, synced %s, count %d; want empty cursor, %s, 3", cursor, synced, count, want)
+	}
+}
+
+func TestRestSyncTimestampRequiresExpectedField(t *testing.T) {
+	if timestamp, ok := restSyncTimestamp(json.RawMessage("{\"modified_at\":\"2026-06-01T00:00:00Z\"}"), "updated_at"); ok || !timestamp.IsZero() {
+		t.Fatalf("mismatched timestamp = %s, ok=%v; want zero, false", timestamp, ok)
+	}
+	if timestamp, ok := restSyncTimestamp(json.RawMessage("{\"updatedAt\":\"2026-01-02T00:00:00Z\",\"modified_at\":\"2026-06-01T00:00:00Z\"}"), "updated_at"); !ok || !timestamp.Equal(time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("normalized timestamp = %s, ok=%v; want 2026-01-02, true", timestamp, ok)
 	}
 }
 
@@ -780,7 +834,7 @@ func TestFullSyncOmitsIncrementalSort(t *testing.T) {
 }
 `
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "sync_watermark_test.go"), []byte(behaviorTest), 0o644))
-	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "Test(Capped|Drained|LatestOnly|FullSync)", "-count=1")
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "Test(Capped|Drained|LatestOnly|FullSync|RestSync)", "-count=1")
 }
 
 func TestGeneratedSyncClearsOffsetCursorWhenWatermarkMoves(t *testing.T) {

--- a/internal/generator/store_synced_at_rfc3339_test.go
+++ b/internal/generator/store_synced_at_rfc3339_test.go
@@ -89,6 +89,35 @@ func TestSyncedAtIsSQLiteStrftimeParseable(t *testing.T) {
 		t.Fatalf("GetSyncState count = %d, want 5", count)
 	}
 
+	watermark := time.Date(2026, 5, 17, 2, 24, 0, 0, time.UTC)
+	if err := s.SaveSyncStateAt("items", "cursor-watermark", 6, watermark); err != nil {
+		t.Fatalf("SaveSyncStateAt error: %v", err)
+	}
+	if err := s.SaveSyncProgress("items", "cursor-progress", 7); err != nil {
+		t.Fatalf("SaveSyncProgress error: %v", err)
+	}
+	cursor, progressSyncedAt, progressCount, err := s.GetSyncState("items")
+	if err != nil {
+		t.Fatalf("GetSyncState after SaveSyncProgress error: %v", err)
+	}
+	if cursor != "cursor-progress" || progressCount != 7 {
+		t.Fatalf("progress state = cursor %q, count %d; want cursor-progress, 7", cursor, progressCount)
+	}
+	if !progressSyncedAt.Equal(watermark) {
+		t.Fatalf("SaveSyncProgress rewrote watermark to %v, want %v", progressSyncedAt, watermark)
+	}
+
+	if err := s.SaveSyncProgress("new-items", "cursor-new", 1); err != nil {
+		t.Fatalf("SaveSyncProgress new resource error: %v", err)
+	}
+	_, newSyncedAt, _, err := s.GetSyncState("new-items")
+	if err != nil {
+		t.Fatalf("GetSyncState new resource error: %v", err)
+	}
+	if !newSyncedAt.IsZero() {
+		t.Fatalf("new resource progress watermark = %v, want zero time", newSyncedAt)
+	}
+
 	if err := s.SaveSyncCursor("items", "cursor-next"); err != nil {
 		t.Fatalf("SaveSyncCursor error: %v", err)
 	}

--- a/internal/generator/sync_flat_reconcile_test.go
+++ b/internal/generator/sync_flat_reconcile_test.go
@@ -85,14 +85,23 @@ import (
 // When fullPage is true the first page is treated as "exactly the limit" so a
 // maxPages cap can hit with outcome.complete still false.
 type stubFlatClient struct {
-	items []json.RawMessage
-	calls int
+	items           []json.RawMessage
+	calls           int
+	hasMore         bool
 }
 
 func (s *stubFlatClient) Get(_ context.Context, _ string, _ map[string]string) (json.RawMessage, error) {
 	s.calls++
 	if s.calls > 1 {
 		return json.RawMessage("[]"), nil
+	}
+	if s.hasMore {
+		payload, _ := json.Marshal(map[string]any{
+			"items":       s.items,
+			"next_cursor": "page-2",
+			"has_more":    true,
+		})
+		return json.RawMessage(payload), nil
 	}
 	payload, _ := json.Marshal(s.items)
 	return json.RawMessage(payload), nil
@@ -214,7 +223,7 @@ func TestFlatReconcile_CapHitPrunesNothing(t *testing.T) {
 		raw, _ := json.Marshal(map[string]any{"id": "p1", "workspace": "ws-A", "name": "proj-p1"})
 		page = append(page, json.RawMessage(raw))
 	}
-	client := &stubFlatClient{items: page}
+	client := &stubFlatClient{items: page, hasMore: true}
 
 	prev := resolveTenantID
 	resolveTenantID = func() string { return "ws-A" }

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1959,6 +1959,13 @@ func (s *Store) Search{{pascal .Name}}(query string, limit int) ([]json.RawMessa
 {{- end}}
 
 func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
+	return s.SaveSyncStateAt(resourceType, cursor, count, time.Now().UTC())
+}
+
+// SaveSyncStateAt stores both pagination progress and the incremental
+// watermark represented by at. Callers use this when the watermark belongs to
+// the data just fetched rather than to the instant the checkpoint is written.
+func (s *Store) SaveSyncStateAt(resourceType, cursor string, count int, at time.Time) error {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
 	_, err := s.db.Exec(
@@ -1966,7 +1973,23 @@ func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT(resource_type) DO UPDATE SET last_cursor = excluded.last_cursor,
 		 last_synced_at = excluded.last_synced_at, total_count = excluded.total_count`,
-		resourceType, cursor, time.Now().UTC().Format(time.RFC3339), count,
+		resourceType, cursor, at.UTC().Format(time.RFC3339), count,
+	)
+	return err
+}
+
+// SaveSyncProgress stores pagination progress without changing the
+// incremental watermark. A new row gets a parseable zero timestamp so
+// GetSyncState can scan it into time.Time without a NULL conversion error.
+func (s *Store) SaveSyncProgress(resourceType, cursor string, count int) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	_, err := s.db.Exec(
+		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(resource_type) DO UPDATE SET last_cursor = excluded.last_cursor,
+		 total_count = excluded.total_count`,
+		resourceType, cursor, time.Time{}.UTC().Format(time.RFC3339), count,
 	)
 	return err
 }

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -85,6 +85,8 @@ type syncResult struct {
 	Duration time.Duration
 }
 
+const syncWatermarkOverlap = time.Second
+
 {{- if globalScopeParams .Resources}}
 func applySyncGlobalScopeEnvDefaults(userParams *syncUserParams) {
 {{- range globalScopeParams .Resources}}
@@ -278,7 +280,7 @@ Resource scoping:
 			// Skip under --dry-run: a preview must not mutate sync-state (issue #2935).
 			if full && !c.DryRun {
 				for _, resource := range resources {
-					if err := db.SaveSyncState(resource, "", 0); err != nil {
+					if err := db.SaveSyncStateAt(resource, "", 0, time.Time{}); err != nil {
 						return fmt.Errorf("clearing sync state for %s: %w", resource, err)
 					}
 				}
@@ -299,15 +301,14 @@ Resource scoping:
 					maxPages = 1
 					// Clear the cursor so we start from the head each time;
 					// the goal of --latest-only is "refresh the top" not
-					// "resume from wherever I left off". Skip under --dry-run:
+					// "resume from wherever I left off". Clear the watermark too,
+					// so the head request does not inherit an old incremental window.
+					// Skip under --dry-run:
 					// a preview must not mutate sync-state (issue #2935).
 					if !c.DryRun {
 						for _, resource := range resources {
-							existing, _, _, _ := db.GetSyncState(resource)
-							if existing != "" {
-								if err := db.SaveSyncState(resource, "", 0); err != nil {
-									return fmt.Errorf("clearing sync state for %s: %w", resource, err)
-								}
+							if err := db.SaveSyncStateAt(resource, "", 0, time.Time{}); err != nil {
+								return fmt.Errorf("clearing sync state for %s: %w", resource, err)
 							}
 						}
 					}
@@ -655,6 +656,7 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	var totalCount int
+	requestedAt := started.UTC()
 
 	// Resume cursor from sync_state (unless --full cleared it)
 	existingCursor, lastSynced, _, _ := db.GetSyncState(resource)
@@ -705,6 +707,11 @@ func syncResource(ctx context.Context, c interface {
 	lastNextCursor := ""
 	capExitHit := false
 	capExitCursor := ""
+	capTruncated := false
+	var previousStoredAt time.Time
+	var newestStoredAt time.Time
+	timestampOrderSafe := true
+	timestampEvidence := false
 	// extractFailureTotal accumulates per-item primary-key extraction
 	// misses across pages within this resource sync. Resource-level
 	// concurrency is 1 (one goroutine per resource via the work channel)
@@ -746,6 +753,9 @@ func syncResource(ctx context.Context, c interface {
 	// Set since filter
 	if effectiveSince != "" {
 		params[sinceParam] = effectiveSince
+		if sortParam := syncResourceSortParam(resource); sortParam != "" {
+			params[sortParam] = syncResourceSortValue(resource)
+		}
 	}
 {{- if .Pagination.DateRangeParam}}
 
@@ -842,6 +852,23 @@ func syncResource(ctx context.Context, c interface {
 	// Try to extract items from the response.
 	// Strategy: try array first, then common wrapper keys.
 	items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
+	if effectiveSince != "" && syncResourceSortParam(resource) != "" && maxPages > 0 {
+		for _, item := range items {
+			itemTimestamp, ok := restSyncTimestamp(item)
+			if !ok {
+				timestampOrderSafe = false
+				continue
+			}
+			timestampEvidence = true
+			if !previousStoredAt.IsZero() && itemTimestamp.Before(previousStoredAt) {
+				timestampOrderSafe = false
+			}
+			previousStoredAt = itemTimestamp
+			if newestStoredAt.IsZero() || itemTimestamp.After(newestStoredAt) {
+				newestStoredAt = itemTimestamp
+			}
+		}
+	}
 
 	// Page-int paginator fallback: when the API paginates by integer
 	// ?page=N and emits no body cursor, treat a full page as a signal
@@ -950,6 +977,11 @@ func syncResource(ctx context.Context, c interface {
 		extractFailureTotal += extractFailures + hydrateFailures
 		hydrateFailureTotal += hydrateFailures
 		pageFailureCount := extractFailures + hydrateFailures
+		if pageFailureCount > 0 {
+			// A timestamp from an item that did not reach the store cannot safely
+			// advance the incremental watermark past that item.
+			timestampOrderSafe = false
+		}
 
 		if fetchedThisPage > 0 && stored == 0 {
 			reason := "all_items_failed_id_extraction"
@@ -1052,6 +1084,7 @@ func syncResource(ctx context.Context, c interface {
 			truncatedByCap = truncatedByCap && !shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit)
 {{- end}}
 {{- end}}
+			capResumed := false
 			if truncatedByCap {
 				capExitCursor = nextCursor
 			}
@@ -1063,7 +1096,24 @@ func syncResource(ctx context.Context, c interface {
 					truncatedByCap = false
 				}
 			}
-			if truncatedByCap && capExitCursor != cursor {
+			capResumed = truncatedByCap && capExitCursor != cursor
+			capPageLimit := pageSize.limit
+{{- if $hasIDWalk}}
+			if usesIDWalk {
+				capPageLimit = activePageLimit
+			}
+{{- end}}
+{{- if .QuerySync}}
+			if _, ok := queryEntity[resource]; ok && path == queryPath {
+				capPageLimit = queryPageSize
+			}
+{{- end}}
+			// A resume cursor alone does not prove that the page window was
+			// truncated. Only a full page with a real continuation advances a
+			// watermark; short cursor pages retain the cursor but leave the
+			// watermark unchanged.
+			capTruncated = capResumed && fetchedThisPage >= capPageLimit
+			if capResumed {
 				if !latestOnly {
 					capExitHit = true
 					if humanFriendly {
@@ -1073,10 +1123,21 @@ func syncResource(ctx context.Context, c interface {
 					}
 				}
 			}
-			// A cap break ends enumeration before exhausting the partition; mirror
-			// the dependent loop and treat it as incomplete (reconcile SKIPS). Safe
-			// default: when the cap may have truncated, never prune.
-			outcome.reason = "max_pages_cap"
+			// A cap break is incomplete when it has a continuation. A short
+			// page for page/offset pagination is a proven natural end even when
+			// the operator's page ceiling fired on that same request.
+			if capResumed {
+				outcome.reason = "max_pages_cap"
+			} else if !hasMore ||
+{{- if .QuerySync}}
+				(path != queryPath && shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, capPageLimit)) {
+{{- else}}
+				shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, capPageLimit) {
+{{- end}}
+				outcome.complete = true
+			} else {
+				outcome.reason = "max_pages_cap"
+			}
 			break
 		}
 
@@ -1151,8 +1212,8 @@ func syncResource(ctx context.Context, c interface {
 		}
 
 		// Save cursor after each page for resumability
-		if err := db.SaveSyncState(resource, nextCursor, totalCount); err != nil {
-			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
+		if err := db.SaveSyncProgress(resource, nextCursor, totalCount); err != nil {
+			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync progress for %s: %w", resource, err), Duration: time.Since(started)}
 		}
 
 		cursor = nextCursor
@@ -1191,15 +1252,38 @@ func syncResource(ctx context.Context, c interface {
 		fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unsupported-resource-shape"}`+"\n", resource)
 	}
 
-	// Final sync state: clear cursor on natural completion, but preserve the
-	// resume cursor when an operator intentionally capped the page budget.
-	finalCursor := ""
-	if capExitHit {
-		finalCursor = capExitCursor
-	}
-	if err := db.SaveSyncState(resource, finalCursor, totalCount); err != nil {
-		return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
-	}
+		// Final sync state separates pagination progress from the incremental
+		// watermark. A checkpoint after a capped page may retain a resume cursor
+		// without claiming that records on pages we did not fetch were observed.
+		finalCursor := ""
+		if capExitHit {
+			finalCursor = capExitCursor
+		}
+		cachedCount, countErr := db.Count(resource)
+		if countErr != nil {
+			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("counting stored %s rows: %w", resource, countErr), Duration: time.Since(started)}
+		}
+		watermark := time.Time{}
+		if outcome.complete {
+			watermark = requestedAt.Add(-syncWatermarkOverlap)
+		} else if capTruncated && effectiveSince != "" && syncResourceSortParam(resource) != "" && timestampOrderSafe && timestampEvidence && !newestStoredAt.IsZero() {
+			watermark = newestStoredAt.Add(-syncWatermarkOverlap)
+		}
+		if !watermark.IsZero() {
+			// A positional or opaque cursor was issued for the old since window.
+			// Restart from the new watermark instead of combining two incompatible
+			// result windows on the next run.
+			finalCursor = ""
+		}
+		var stateErr error
+		if watermark.IsZero() {
+			stateErr = db.SaveSyncProgress(resource, finalCursor, cachedCount)
+		} else {
+			stateErr = db.SaveSyncStateAt(resource, finalCursor, cachedCount, watermark)
+		}
+		if stateErr != nil {
+			return syncResult{Resource: resource, Count: cachedCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, stateErr), Duration: time.Since(started)}
+		}
 
 	// F4b symptom probe: if items were consumed and successfully
 	// extracted (extractFailures < consumed) but nothing landed in
@@ -1217,7 +1301,7 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	if !humanFriendly {
-		fmt.Fprintf(syncEvents, `{"event":"sync_complete","resource":"%s","total":%d,"duration_ms":%d}`+"\n", resource, totalCount, time.Since(started).Milliseconds())
+		fmt.Fprintf(syncEvents, `{"event":"sync_complete","resource":"%s","total":%d,"duration_ms":%d}`+"\n", resource, cachedCount, time.Since(started).Milliseconds())
 	}
 
 	if consumedTotal > 0 && totalCount == 0 && extractFailureTotal >= consumedTotal {
@@ -1233,7 +1317,7 @@ func syncResource(ctx context.Context, c interface {
 		}
 	}
 
-	return syncResult{Resource: resource, Count: totalCount, Duration: time.Since(started)}
+		return syncResult{Resource: resource, Count: cachedCount, Duration: time.Since(started)}
 }
 
 // paginationDefaults holds the resolved pagination parameter names and page size.
@@ -1558,6 +1642,34 @@ func syncResourceSinceParam(resource string) string {
 {{- if .SinceParam}}
 	case "{{.Name}}":
 		return "{{.SinceParam}}"
+{{- end}}
+{{- end}}
+	}
+	return ""
+}
+
+// syncResourceSortParam and syncResourceSortValue describe a spec-declared
+// ascending last-modified ordering. Sync adds them only when it sends a since
+// filter, because applying a sort to a full sync can change API behavior and
+// does not improve the watermark proof.
+func syncResourceSortParam(resource string) string {
+	switch resource {
+{{- range .SyncableResources}}
+{{- if .PaginationSortParam}}
+	case "{{.Name}}":
+		return "{{.PaginationSortParam}}"
+{{- end}}
+{{- end}}
+	}
+	return ""
+}
+
+func syncResourceSortValue(resource string) string {
+	switch resource {
+{{- range .SyncableResources}}
+{{- if .PaginationSortValue}}
+	case "{{.Name}}":
+		return "{{.PaginationSortValue}}"
 {{- end}}
 {{- end}}
 	}
@@ -2496,6 +2608,64 @@ func parseSinceDuration(s string) (time.Time, error) {
 	default:
 		return time.Time{}, fmt.Errorf("unknown unit %q", matches[2])
 	}
+}
+
+// restSyncTimestamp extracts a record-level last-modified timestamp from one
+// REST item. Nested child or metadata timestamps are deliberately ignored:
+// the incremental filter applies to the resource record, not its embedded
+// objects. Multiple candidate top-level timestamps are also rejected because
+// the generator cannot prove which one the endpoint sorts and filters on.
+func restSyncTimestamp(data json.RawMessage) (time.Time, bool) {
+		var value map[string]any
+		if err := json.Unmarshal(data, &value); err != nil {
+			return time.Time{}, false
+		}
+		var newest time.Time
+		var found bool
+		matches := 0
+		for fieldName, child := range value {
+			if !restSyncTimestampField(fieldName) {
+				continue
+			}
+			text, ok := child.(string)
+			if !ok {
+				continue
+			}
+			ts, ok := parseRestSyncTimestamp(text)
+			if !ok {
+				continue
+			}
+			matches++
+			if !found || ts.After(newest) {
+				newest = ts
+				found = true
+			}
+		}
+		if matches != 1 {
+			return time.Time{}, false
+		}
+		return newest, true
+	}
+
+func restSyncTimestampField(name string) bool {
+	normalized := strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(name))
+	return strings.Contains(normalized, "updated") ||
+		strings.Contains(normalized, "modified") ||
+		strings.Contains(normalized, "lastchanged") ||
+		strings.Contains(normalized, "lastmodified")
+}
+
+func parseRestSyncTimestamp(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
+		if ts, err := time.Parse(layout, value); err == nil {
+			return ts, true
+		}
+	}
+	return time.Time{}, false
 }
 
 func defaultSyncResources() []string {

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -695,6 +695,9 @@ func syncResource(ctx context.Context, c interface {
 
 	cursor := existingCursor
 	pageSize := determinePaginationDefaults(resource)
+	sortParam := syncResourceSortParam(resource)
+	sortValue := syncResourceSortValue(resource)
+	sortEffective := false
 {{- if $hasIDWalk}}
 	idWalk, usesIDWalk := syncResourceIDWalkConfig(resource)
 	pageLimit := pageSize.limit
@@ -753,8 +756,8 @@ func syncResource(ctx context.Context, c interface {
 	// Set since filter
 	if effectiveSince != "" {
 		params[sinceParam] = effectiveSince
-		if sortParam := syncResourceSortParam(resource); sortParam != "" {
-			params[sortParam] = syncResourceSortValue(resource)
+		if sortParam != "" {
+			params[sortParam] = sortValue
 		}
 	}
 {{- if .Pagination.DateRangeParam}}
@@ -768,6 +771,7 @@ func syncResource(ctx context.Context, c interface {
 	// win over spec-derived defaults (e.g. forcing mine=true on a list
 	// endpoint whose OpenAPI spec marks the filter optional).
 	userParams.applyTo(resource, params, false)
+	sortEffective = effectiveSince != "" && sortParam != "" && sortValue != "" && params[sortParam] == sortValue
 {{- if $hasIDWalk}}
 	activePageLimit := pageLimit
 	if usesIDWalk {
@@ -852,7 +856,7 @@ func syncResource(ctx context.Context, c interface {
 	// Try to extract items from the response.
 	// Strategy: try array first, then common wrapper keys.
 	items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
-	if effectiveSince != "" && syncResourceSortParam(resource) != "" && maxPages > 0 {
+	if sortEffective && maxPages > 0 {
 		for _, item := range items {
 			itemTimestamp, ok := restSyncTimestamp(item)
 			if !ok {
@@ -1266,7 +1270,7 @@ func syncResource(ctx context.Context, c interface {
 		watermark := time.Time{}
 		if outcome.complete {
 			watermark = requestedAt.Add(-syncWatermarkOverlap)
-		} else if capTruncated && effectiveSince != "" && syncResourceSortParam(resource) != "" && timestampOrderSafe && timestampEvidence && !newestStoredAt.IsZero() {
+		} else if capTruncated && sortEffective && timestampOrderSafe && timestampEvidence && !newestStoredAt.IsZero() {
 			watermark = newestStoredAt.Add(-syncWatermarkOverlap)
 		}
 		if !watermark.IsZero() {

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -697,6 +697,7 @@ func syncResource(ctx context.Context, c interface {
 	pageSize := determinePaginationDefaults(resource)
 	sortParam := syncResourceSortParam(resource)
 	sortValue := syncResourceSortValue(resource)
+	sortField := syncResourceSortField(resource)
 	sortEffective := false
 {{- if $hasIDWalk}}
 	idWalk, usesIDWalk := syncResourceIDWalkConfig(resource)
@@ -771,7 +772,7 @@ func syncResource(ctx context.Context, c interface {
 	// win over spec-derived defaults (e.g. forcing mine=true on a list
 	// endpoint whose OpenAPI spec marks the filter optional).
 	userParams.applyTo(resource, params, false)
-	sortEffective = effectiveSince != "" && sortParam != "" && sortValue != "" && params[sortParam] == sortValue
+	sortEffective = effectiveSince != "" && sortParam != "" && sortValue != "" && sortField != "" && params[sortParam] == sortValue
 {{- if $hasIDWalk}}
 	activePageLimit := pageLimit
 	if usesIDWalk {
@@ -858,7 +859,7 @@ func syncResource(ctx context.Context, c interface {
 	items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
 	if sortEffective && maxPages > 0 {
 		for _, item := range items {
-			itemTimestamp, ok := restSyncTimestamp(item)
+			itemTimestamp, ok := restSyncTimestamp(item, sortField)
 			if !ok {
 				timestampOrderSafe = false
 				continue
@@ -1674,6 +1675,18 @@ func syncResourceSortValue(resource string) string {
 {{- if .PaginationSortValue}}
 	case "{{.Name}}":
 		return "{{.PaginationSortValue}}"
+{{- end}}
+{{- end}}
+	}
+	return ""
+}
+
+func syncResourceSortField(resource string) string {
+	switch resource {
+{{- range .SyncableResources}}
+{{- if .PaginationSortField}}
+	case "{{.Name}}":
+		return "{{.PaginationSortField}}"
 {{- end}}
 {{- end}}
 	}
@@ -2614,45 +2627,49 @@ func parseSinceDuration(s string) (time.Time, error) {
 	}
 }
 
-// restSyncTimestamp extracts a record-level last-modified timestamp from one
-// REST item. Nested child or metadata timestamps are deliberately ignored:
-// the incremental filter applies to the resource record, not its embedded
-// objects. Multiple candidate top-level timestamps are also rejected because
-// the generator cannot prove which one the endpoint sorts and filters on.
-func restSyncTimestamp(data json.RawMessage) (time.Time, bool) {
-		var value map[string]any
-		if err := json.Unmarshal(data, &value); err != nil {
-			return time.Time{}, false
-		}
-		var newest time.Time
-		var found bool
-		matches := 0
-		for fieldName, child := range value {
-			if !restSyncTimestampField(fieldName) {
-				continue
-			}
-			text, ok := child.(string)
-			if !ok {
-				continue
-			}
-			ts, ok := parseRestSyncTimestamp(text)
-			if !ok {
-				continue
-			}
-			matches++
-			if !found || ts.After(newest) {
-				newest = ts
-				found = true
-			}
-		}
-		if matches != 1 {
-			return time.Time{}, false
-		}
-		return newest, true
+// restSyncTimestamp extracts the record-level timestamp for the exact field
+// used by the endpoint's incremental sort. Nested child or metadata timestamps
+// are deliberately ignored: the incremental filter applies to the resource
+// record, not its embedded objects. A missing or unparseable expected field is
+// unsafe, so this helper never falls back to another recognized timestamp.
+func restSyncTimestamp(data json.RawMessage, expectedField string) (time.Time, bool) {
+	var value map[string]any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return time.Time{}, false
 	}
+	expectedField = normalizeRestSyncTimestampField(expectedField)
+	if expectedField == "" || !restSyncTimestampField(expectedField) {
+		return time.Time{}, false
+	}
+	var timestamp time.Time
+	matches := 0
+	for fieldName, child := range value {
+		if normalizeRestSyncTimestampField(fieldName) != expectedField {
+			continue
+		}
+		text, ok := child.(string)
+		if !ok {
+			continue
+		}
+		ts, ok := parseRestSyncTimestamp(text)
+		if !ok {
+			continue
+		}
+		matches++
+		timestamp = ts
+	}
+	if matches != 1 {
+		return time.Time{}, false
+	}
+	return timestamp, true
+}
+
+func normalizeRestSyncTimestampField(name string) string {
+	return strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(name))
+}
 
 func restSyncTimestampField(name string) bool {
-	normalized := strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(name))
+	normalized := normalizeRestSyncTimestampField(name)
 	return strings.Contains(normalized, "updated") ||
 		strings.Contains(normalized, "modified") ||
 		strings.Contains(normalized, "lastchanged") ||

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -2829,9 +2829,11 @@ func inferPaginationType(cursorParam string) string {
 // sort parameter is not enough to prove that a capped sync has a monotonic
 // watermark.
 func detectEndpointSyncSort(endpoint spec.Endpoint) (string, string) {
-	if sinceParam, _ := detectEndpointSinceParamAndFormat(endpoint, nil); sinceParam == "" {
+	sinceParam, _ := detectEndpointSinceParamAndFormat(endpoint, nil)
+	if sinceParam == "" {
 		return "", ""
 	}
+	sinceField := temporalSinceField(sinceParam)
 	for _, param := range endpoint.Params {
 		if param.PathParam || param.Positional || !isSyncSortParamName(param.Name) {
 			continue
@@ -2850,13 +2852,54 @@ func detectEndpointSyncSort(endpoint spec.Endpoint) (string, string) {
 			// The wire value must name the temporal field itself. Prose on the
 			// endpoint or sort parameter cannot prove that a generic value such
 			// as name:asc orders by the field used by the since filter.
-			if !describesLastModifiedSort(strings.ToLower(value)) || !isAscendingSortValue(value) {
+			sortField := temporalSortField(value)
+			if sortField == "" || !describesLastModifiedSort(sortField) || !isAscendingSortValue(value) {
+				continue
+			}
+			if sinceField != "" && !temporalFieldsMatch(sortField, sinceField) {
 				continue
 			}
 			return param.WireName(), value
 		}
 	}
 	return "", ""
+}
+
+func temporalSinceField(name string) string {
+	normalized := normalizeTemporalFieldName(name)
+	for _, suffix := range []string{"after", "since", "gte", "gt", "lte", "lt"} {
+		if strings.HasSuffix(normalized, suffix) {
+			return strings.TrimSuffix(normalized, suffix)
+		}
+	}
+	if normalized == "since" {
+		return ""
+	}
+	return normalized
+}
+
+func temporalSortField(value string) string {
+	parts := strings.FieldsFunc(strings.ToLower(strings.TrimSpace(value)), func(r rune) bool {
+		return r == ':' || r == ',' || r == ' ' || r == '\t'
+	})
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.TrimLeft(parts[0], "+-")
+}
+
+func temporalFieldsMatch(a, b string) bool {
+	a = normalizeTemporalFieldName(a)
+	b = normalizeTemporalFieldName(b)
+	if a == b {
+		return true
+	}
+	for _, suffix := range []string{"at", "date", "time"} {
+		if strings.TrimSuffix(a, suffix) == b || strings.TrimSuffix(b, suffix) == a {
+			return true
+		}
+	}
+	return false
 }
 
 func isSyncSortParamName(name string) bool {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -2856,7 +2856,7 @@ func detectEndpointSyncSort(endpoint spec.Endpoint) (string, string) {
 			if sortField == "" || !describesLastModifiedSort(sortField) || !isAscendingSortValue(value) {
 				continue
 			}
-			if sinceField != "" && !temporalFieldsMatch(sortField, sinceField) {
+			if !temporalFieldsMatch(sortField, sinceField) {
 				continue
 			}
 			return param.WireName(), value

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -2836,7 +2836,6 @@ func detectEndpointSyncSort(endpoint spec.Endpoint) (string, string) {
 		if param.PathParam || param.Positional || !isSyncSortParamName(param.Name) {
 			continue
 		}
-		description := strings.ToLower(strings.TrimSpace(param.Description + " " + endpoint.Description))
 		defaultValue, hasDefault := stringParamDefault(param.Default)
 		values := make([]string, 0, len(param.Enum)+1)
 		if hasDefault {
@@ -2848,13 +2847,13 @@ func detectEndpointSyncSort(endpoint spec.Endpoint) (string, string) {
 			if value == "" {
 				continue
 			}
-			evidence := description + " " + strings.ToLower(value)
-			if !describesLastModifiedSort(evidence) || !describesAscendingSort(evidence) {
+			// The wire value must name the temporal field itself. Prose on the
+			// endpoint or sort parameter cannot prove that a generic value such
+			// as name:asc orders by the field used by the since filter.
+			if !describesLastModifiedSort(strings.ToLower(value)) || !isAscendingSortValue(value) {
 				continue
 			}
-			if isAscendingSortValue(value) {
-				return param.WireName(), value
-			}
+			return param.WireName(), value
 		}
 	}
 	return "", ""
@@ -2881,13 +2880,6 @@ func describesLastModifiedSort(text string) bool {
 	return containsAny(text, []string{
 		"updated", "modified", "last changed", "lastchanged", "last_modified", "lastmodified",
 	})
-}
-
-func describesAscendingSort(text string) bool {
-	if containsAny(text, []string{"descending", "newest first", "most recent first"}) {
-		return false
-	}
-	return containsAny(text, []string{"ascending", "oldest first", "chronological order"})
 }
 
 func isAscendingSortValue(value string) bool {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -146,6 +146,10 @@ type SyncableResource struct {
 	// that is safe to send alongside an incremental temporal filter.
 	PaginationSortParam string
 	PaginationSortValue string
+	// PaginationSortField is the temporal response field named by
+	// PaginationSortValue. It is the only field the generated sync may use for
+	// a capped watermark; another recognized timestamp is not an equivalent.
+	PaginationSortField string
 
 	// UsesHTMLResponse and HTMLExtract mirror the chosen list endpoint's
 	// response_format/html_extract contract so sync can normalize HTML into
@@ -2312,6 +2316,7 @@ type syncableMeta struct {
 	PaginationPageSize    int
 	PaginationSortParam   string
 	PaginationSortValue   string
+	PaginationSortField   string
 	UsesHTMLResponse      bool
 	HTMLExtract           *spec.HTMLExtract
 	BodyFields            []SyncBodyField
@@ -2351,6 +2356,7 @@ func metaFromEndpoint(s *spec.APISpec, resourceName string, resource spec.Resour
 	sinceParam, sinceParamFormat := detectEndpointSinceParamAndFormat(e, types)
 	paginationCursorParam, paginationCursorType, paginationLimitParam, paginationPageSize := syncPaginationDefaultsFromEndpoint(e)
 	paginationSortParam, paginationSortValue := detectEndpointSyncSort(e)
+	paginationSortField := temporalSortField(paginationSortValue)
 	hydratePath, hydrateIDParam := scalarIDHydrationTarget(s, resourceName, e, types)
 	return syncableMeta{
 		Path:                  e.Path,
@@ -2368,6 +2374,7 @@ func metaFromEndpoint(s *spec.APISpec, resourceName string, resource spec.Resour
 		PaginationPageSize:    paginationPageSize,
 		PaginationSortParam:   paginationSortParam,
 		PaginationSortValue:   paginationSortValue,
+		PaginationSortField:   paginationSortField,
 		UsesHTMLResponse:      e.UsesHTMLResponse(),
 		HTMLExtract:           e.HTMLExtract,
 		BodyFields:            syncBodyFieldsFromEndpoint(e),
@@ -3356,6 +3363,7 @@ func sortedSyncableResources(m map[string]syncableMeta) []SyncableResource {
 			PaginationPageSize:    meta.PaginationPageSize,
 			PaginationSortParam:   meta.PaginationSortParam,
 			PaginationSortValue:   meta.PaginationSortValue,
+			PaginationSortField:   meta.PaginationSortField,
 			UsesHTMLResponse:      meta.UsesHTMLResponse,
 			HTMLExtract:           meta.HTMLExtract,
 			BodyFields:            meta.BodyFields,

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -2868,8 +2868,8 @@ func detectEndpointSyncSort(endpoint spec.Endpoint) (string, string) {
 func temporalSinceField(name string) string {
 	normalized := normalizeTemporalFieldName(name)
 	for _, suffix := range []string{"after", "since", "gte", "gt", "lte", "lt"} {
-		if strings.HasSuffix(normalized, suffix) {
-			return strings.TrimSuffix(normalized, suffix)
+		if prefix, ok := strings.CutSuffix(normalized, suffix); ok {
+			return prefix
 		}
 	}
 	if normalized == "since" {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -43,13 +43,15 @@ type DomainSignals struct {
 
 // PaginationProfile describes the detected pagination patterns across the API.
 type PaginationProfile struct {
-	CursorParam     string `json:"cursor_param"`      // most common cursor param name (after, cursor, page_token, offset)
-	CursorType      string `json:"cursor_type"`       // most common paginator class (cursor, page_token, offset, page, id_walk); drives runtime iteration strategy
-	PageSizeParam   string `json:"page_size_param"`   // most common page size param (limit, per_page, page_size, first)
-	SinceParam      string `json:"since_param"`       // temporal filter param (since, updated_after, modified_since)
-	DateRangeParam  string `json:"date_range_param"`  // date-range filter param (dates, date_range, dateRange)
-	ItemsKey        string `json:"items_key"`         // response array key (data, results, items, or "" for root array)
-	DefaultPageSize int    `json:"default_page_size"` // detected or default 100
+	CursorParam     string `json:"cursor_param"`         // most common cursor param name (after, cursor, page_token, offset)
+	CursorType      string `json:"cursor_type"`          // most common paginator class (cursor, page_token, offset, page, id_walk); drives runtime iteration strategy
+	PageSizeParam   string `json:"page_size_param"`      // most common page size param (limit, per_page, page_size, first)
+	SinceParam      string `json:"since_param"`          // temporal filter param (since, updated_after, modified_since)
+	SortParam       string `json:"sort_param,omitempty"` // sort parameter used to request ascending last-modified order
+	SortValue       string `json:"sort_value,omitempty"` // value that requests ascending last-modified order
+	DateRangeParam  string `json:"date_range_param"`     // date-range filter param (dates, date_range, dateRange)
+	ItemsKey        string `json:"items_key"`            // response array key (data, results, items, or "" for root array)
+	DefaultPageSize int    `json:"default_page_size"`    // detected or default 100
 }
 
 // SearchBodyField describes an additional body field needed for POST search endpoints.
@@ -140,6 +142,10 @@ type SyncableResource struct {
 	PaginationCursorType  string
 	PaginationLimitParam  string
 	PaginationPageSize    int
+	// PaginationSort* describe an explicit ascending last-modified ordering
+	// that is safe to send alongside an incremental temporal filter.
+	PaginationSortParam string
+	PaginationSortValue string
 
 	// UsesHTMLResponse and HTMLExtract mirror the chosen list endpoint's
 	// response_format/html_extract contract so sync can normalize HTML into
@@ -364,6 +370,7 @@ func Profile(s *spec.APISpec) *APIProfile {
 	cursorTypes := make(map[string]int)
 	pageSizeParams := make(map[string]int)
 	sinceParams := make(map[string]int)
+	sortSpecs := make(map[string]int)
 	dateRangeParams := make(map[string]int)
 	responsePaths := make(map[string]int)
 
@@ -577,8 +584,11 @@ func Profile(s *spec.APISpec) *APIProfile {
 				if isRuntimePagination(endpoint.Pagination) && endpoint.Pagination.CursorParam != "" {
 					cursorParams[endpoint.Pagination.CursorParam]++
 				}
-				if isRuntimePagination(endpoint.Pagination) && endpoint.Pagination.Type != "" {
-					cursorTypes[endpoint.Pagination.Type]++
+				if isRuntimePagination(endpoint.Pagination) {
+					_, cursorType, _, _ := syncPaginationDefaultsFromEndpoint(endpoint)
+					if cursorType != "" {
+						cursorTypes[cursorType]++
+					}
 				}
 				if isRuntimePagination(endpoint.Pagination) && endpoint.Pagination.LimitParam != "" {
 					pageSizeParams[endpoint.Pagination.LimitParam]++
@@ -604,6 +614,9 @@ func Profile(s *spec.APISpec) *APIProfile {
 			}
 			if sinceParam, _ := detectEndpointSinceParamAndFormat(endpoint, s.Types); sinceParam != "" {
 				sinceParams[sinceParam]++
+			}
+			if sortParam, sortValue := detectEndpointSyncSort(endpoint); sortParam != "" && sortValue != "" {
+				sortSpecs[sortParam+"\x00"+sortValue]++
 			}
 			for _, param := range endpoint.Params {
 				name := strings.ToLower(param.Name)
@@ -711,11 +724,14 @@ func Profile(s *spec.APISpec) *APIProfile {
 
 	p.Domain = detectDomainSignals(s)
 
+	sortParam, sortValue := mostCommonSort(sortSpecs)
 	p.Pagination = PaginationProfile{
 		CursorParam:     mostCommon(cursorParams, "after"),
 		CursorType:      mostCommon(cursorTypes, ""),
 		PageSizeParam:   mostCommon(pageSizeParams, "limit"),
 		SinceParam:      mostCommon(sinceParams, ""),
+		SortParam:       sortParam,
+		SortValue:       sortValue,
 		DateRangeParam:  mostCommon(dateRangeParams, ""),
 		ItemsKey:        mostCommon(responsePaths, ""),
 		DefaultPageSize: 100,
@@ -2294,6 +2310,8 @@ type syncableMeta struct {
 	PaginationCursorType  string
 	PaginationLimitParam  string
 	PaginationPageSize    int
+	PaginationSortParam   string
+	PaginationSortValue   string
 	UsesHTMLResponse      bool
 	HTMLExtract           *spec.HTMLExtract
 	BodyFields            []SyncBodyField
@@ -2332,6 +2350,7 @@ func metaFromEndpoint(s *spec.APISpec, resourceName string, resource spec.Resour
 	idWalkFilterParam, idWalkLimitParam, idWalkPageSize := detectIDWalkParams(e)
 	sinceParam, sinceParamFormat := detectEndpointSinceParamAndFormat(e, types)
 	paginationCursorParam, paginationCursorType, paginationLimitParam, paginationPageSize := syncPaginationDefaultsFromEndpoint(e)
+	paginationSortParam, paginationSortValue := detectEndpointSyncSort(e)
 	hydratePath, hydrateIDParam := scalarIDHydrationTarget(s, resourceName, e, types)
 	return syncableMeta{
 		Path:                  e.Path,
@@ -2347,6 +2366,8 @@ func metaFromEndpoint(s *spec.APISpec, resourceName string, resource spec.Resour
 		PaginationCursorType:  paginationCursorType,
 		PaginationLimitParam:  paginationLimitParam,
 		PaginationPageSize:    paginationPageSize,
+		PaginationSortParam:   paginationSortParam,
+		PaginationSortValue:   paginationSortValue,
 		UsesHTMLResponse:      e.UsesHTMLResponse(),
 		HTMLExtract:           e.HTMLExtract,
 		BodyFields:            syncBodyFieldsFromEndpoint(e),
@@ -2746,6 +2767,15 @@ func syncPaginationDefaultsFromEndpoint(endpoint spec.Endpoint) (string, string,
 	if cursorType == "" {
 		cursorType = inferPaginationType(cursorParam)
 	}
+	// Canonical page and offset parameter names are stronger evidence than an
+	// inconsistent explicit type. Letting a page-named cursor reach offset
+	// arithmetic silently repeats page one or skips pages, and the inverse
+	// mismatch makes offset APIs advance with the wrong strategy.
+	inferredType := inferPaginationType(cursorParam)
+	if (inferredType == "page" || inferredType == "offset") &&
+		(cursorType == "page" || cursorType == "offset") {
+		cursorType = inferredType
+	}
 	pageSize := 100
 	if defaultSize, ok := paginationLimitDefault(endpoint, limitParam); ok {
 		pageSize = defaultSize
@@ -2782,7 +2812,7 @@ func inferPaginationType(cursorParam string) string {
 	switch strings.ToLower(strings.TrimSpace(cursorParam)) {
 	case "":
 		return ""
-	case "page", "page_number", "pagenumber":
+	case "page", "page_number", "pagenumber", "page[number]":
 		return "page"
 	case "offset", "skip":
 		return "offset"
@@ -2791,6 +2821,80 @@ func inferPaginationType(cursorParam string) string {
 	default:
 		return "cursor"
 	}
+}
+
+// detectEndpointSyncSort finds a spec-declared ordering that makes an
+// incremental page walk safe to checkpoint at the newest stored record. It
+// intentionally requires both temporal and ascending-order evidence; a plain
+// sort parameter is not enough to prove that a capped sync has a monotonic
+// watermark.
+func detectEndpointSyncSort(endpoint spec.Endpoint) (string, string) {
+	if sinceParam, _ := detectEndpointSinceParamAndFormat(endpoint, nil); sinceParam == "" {
+		return "", ""
+	}
+	for _, param := range endpoint.Params {
+		if param.PathParam || param.Positional || !isSyncSortParamName(param.Name) {
+			continue
+		}
+		description := strings.ToLower(strings.TrimSpace(param.Description + " " + endpoint.Description))
+		defaultValue, hasDefault := stringParamDefault(param.Default)
+		values := make([]string, 0, len(param.Enum)+1)
+		if hasDefault {
+			values = append(values, defaultValue)
+		}
+		values = append(values, param.Enum...)
+		for _, value := range values {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				continue
+			}
+			evidence := description + " " + strings.ToLower(value)
+			if !describesLastModifiedSort(evidence) || !describesAscendingSort(evidence) {
+				continue
+			}
+			if isAscendingSortValue(value) {
+				return param.WireName(), value
+			}
+		}
+	}
+	return "", ""
+}
+
+func isSyncSortParamName(name string) bool {
+	switch normalizeTemporalFieldName(name) {
+	case "sort", "sortby", "order", "orderby", "ordering":
+		return true
+	default:
+		return false
+	}
+}
+
+func stringParamDefault(value any) (string, bool) {
+	if value == nil {
+		return "", false
+	}
+	text, ok := value.(string)
+	return text, ok && strings.TrimSpace(text) != ""
+}
+
+func describesLastModifiedSort(text string) bool {
+	return containsAny(text, []string{
+		"updated", "modified", "last changed", "lastchanged", "last_modified", "lastmodified",
+	})
+}
+
+func describesAscendingSort(text string) bool {
+	if containsAny(text, []string{"descending", "newest first", "most recent first"}) {
+		return false
+	}
+	return containsAny(text, []string{"ascending", "oldest first", "chronological order"})
+}
+
+func isAscendingSortValue(value string) bool {
+	lower := strings.ToLower(strings.TrimSpace(value))
+	return lower == "asc" || strings.Contains(lower, "ascending") ||
+		strings.Contains(lower, ":asc") || strings.HasSuffix(lower, "_asc") ||
+		strings.HasPrefix(lower, "+") || strings.Contains(lower, "oldest")
 }
 
 func detectEndpointSinceParamAndFormat(endpoint spec.Endpoint, types map[string]spec.TypeDef) (string, string) {
@@ -3215,6 +3319,8 @@ func sortedSyncableResources(m map[string]syncableMeta) []SyncableResource {
 			PaginationCursorType:  meta.PaginationCursorType,
 			PaginationLimitParam:  meta.PaginationLimitParam,
 			PaginationPageSize:    meta.PaginationPageSize,
+			PaginationSortParam:   meta.PaginationSortParam,
+			PaginationSortValue:   meta.PaginationSortValue,
 			UsesHTMLResponse:      meta.UsesHTMLResponse,
 			HTMLExtract:           meta.HTMLExtract,
 			BodyFields:            meta.BodyFields,
@@ -3362,4 +3468,23 @@ func mostCommon(counts map[string]int, fallback string) string {
 		}
 	}
 	return best
+}
+
+func mostCommonSort(counts map[string]int) (string, string) {
+	best := ""
+	bestCount := 0
+	for key, count := range counts {
+		if count > bestCount || (count == bestCount && count > 0 && (best == "" || key < best)) {
+			best = key
+			bestCount = count
+		}
+	}
+	if best == "" {
+		return "", ""
+	}
+	param, value, ok := strings.Cut(best, "\x00")
+	if !ok {
+		return "", ""
+	}
+	return param, value
 }

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -3426,6 +3426,7 @@ func TestProfilePaginationDetectsAscendingLastModifiedSort(t *testing.T) {
 	require.Len(t, profile.SyncableResources, 1)
 	assert.Equal(t, "sort", profile.SyncableResources[0].PaginationSortParam)
 	assert.Equal(t, "updated_at:asc", profile.SyncableResources[0].PaginationSortValue)
+	assert.Equal(t, "updated_at", profile.SyncableResources[0].PaginationSortField)
 }
 
 func TestDetectEndpointSyncSortRejectsDescendingDefault(t *testing.T) {

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -3442,6 +3442,20 @@ func TestDetectEndpointSyncSortRejectsDescendingDefault(t *testing.T) {
 	assert.Empty(t, value)
 }
 
+func TestDetectEndpointSyncSortDoesNotConflateEndpointDescription(t *testing.T) {
+	endpoint := spec.Endpoint{
+		Description: "List items updated after a timestamp.",
+		Params: []spec.Param{
+			{Name: "updated_after", Type: "string"},
+			{Name: "sort", Type: "string", Default: "name:asc", Description: "Sort by any field in ascending order."},
+		},
+	}
+
+	param, value := detectEndpointSyncSort(endpoint)
+	assert.Empty(t, param, "an unrelated ascending field must not become watermark-safe")
+	assert.Empty(t, value)
+}
+
 func TestProfileSyncableResourcePaginationDefaultsPreserveEndpointParams(t *testing.T) {
 	s := &spec.APISpec{
 		Name: "mixed-pagination",

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -3456,6 +3456,19 @@ func TestDetectEndpointSyncSortDoesNotConflateEndpointDescription(t *testing.T) 
 	assert.Empty(t, value)
 }
 
+func TestDetectEndpointSyncSortRequiresMatchingSinceField(t *testing.T) {
+	endpoint := spec.Endpoint{
+		Params: []spec.Param{
+			{Name: "updated_after", Type: "string"},
+			{Name: "sort", Type: "string", Default: "modified_at:asc"},
+		},
+	}
+
+	param, value := detectEndpointSyncSort(endpoint)
+	assert.Empty(t, param, "a different temporal field must not become watermark-safe")
+	assert.Empty(t, value)
+}
+
 func TestProfileSyncableResourcePaginationDefaultsPreserveEndpointParams(t *testing.T) {
 	s := &spec.APISpec{
 		Name: "mixed-pagination",

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -3469,6 +3469,19 @@ func TestDetectEndpointSyncSortRequiresMatchingSinceField(t *testing.T) {
 	assert.Empty(t, value)
 }
 
+func TestDetectEndpointSyncSortRequiresKnownSinceField(t *testing.T) {
+	endpoint := spec.Endpoint{
+		Params: []spec.Param{
+			{Name: "since", Type: "string"},
+			{Name: "sort", Type: "string", Default: "updated_at:asc"},
+		},
+	}
+
+	param, value := detectEndpointSyncSort(endpoint)
+	assert.Empty(t, param, "a generic since filter cannot prove which temporal field is sorted")
+	assert.Empty(t, value)
+}
+
 func TestProfileSyncableResourcePaginationDefaultsPreserveEndpointParams(t *testing.T) {
 	s := &spec.APISpec{
 		Name: "mixed-pagination",

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -3349,6 +3349,99 @@ func TestProfilePagination_ExplicitBlockWinsOverInference(t *testing.T) {
 	assert.Equal(t, "bar", profile.Pagination.PageSizeParam, "explicit limit_param must win")
 }
 
+func TestProfilePaginationKeepsPageProfilesInternallyConsistent(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		page spec.Pagination
+		want string
+	}{
+		{
+			name: "missing type",
+			page: spec.Pagination{CursorParam: "page", LimitParam: "per_page"},
+			want: "page",
+		},
+		{
+			name: "offset type on page parameter",
+			page: spec.Pagination{Type: "offset", CursorParam: "page", LimitParam: "per_page"},
+			want: "page",
+		},
+		{
+			name: "page type on offset parameter",
+			page: spec.Pagination{Type: "page", CursorParam: "offset", LimitParam: "limit"},
+			want: "offset",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &spec.APISpec{
+				Name: "consistent-page-profile",
+				Resources: map[string]spec.Resource{
+					"items": {
+						Endpoints: map[string]spec.Endpoint{
+							"list": {
+								Method:     "GET",
+								Path:       "/items",
+								Params:     []spec.Param{{Name: "page", Type: "integer"}, {Name: "per_page", Type: "integer"}},
+								Pagination: &tc.page,
+								Response:   spec.ResponseDef{Type: "array"},
+							},
+						},
+					},
+				},
+			}
+
+			profile := Profile(s)
+			assert.Equal(t, tc.want, profile.Pagination.CursorType)
+			require.Len(t, profile.SyncableResources, 1)
+			assert.Equal(t, tc.want, profile.SyncableResources[0].PaginationCursorType)
+		})
+	}
+}
+
+func TestProfilePaginationDetectsAscendingLastModifiedSort(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "sorted-incremental",
+		Resources: map[string]spec.Resource{
+			"items": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method: "GET",
+						Path:   "/items",
+						Params: []spec.Param{
+							{Name: "after", Type: "string"},
+							{Name: "limit", Type: "integer"},
+							{Name: "updated_after", Type: "string"},
+							{Name: "sort", Type: "string", Default: "updated_at:asc", Description: "Sort by updated_at ascending."},
+						},
+						Pagination: &spec.Pagination{Type: "cursor", CursorParam: "after", LimitParam: "limit"},
+						Response:   spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+	assert.Equal(t, "sort", profile.Pagination.SortParam)
+	assert.Equal(t, "updated_at:asc", profile.Pagination.SortValue)
+	require.Len(t, profile.SyncableResources, 1)
+	assert.Equal(t, "sort", profile.SyncableResources[0].PaginationSortParam)
+	assert.Equal(t, "updated_at:asc", profile.SyncableResources[0].PaginationSortValue)
+}
+
+func TestDetectEndpointSyncSortRejectsDescendingDefault(t *testing.T) {
+	endpoint := spec.Endpoint{
+		Description: "List items updated after a timestamp; ascending unless prefixed with -.",
+		Params: []spec.Param{
+			{Name: "updated_after", Type: "string"},
+			{Name: "sort", Type: "string", Default: "-updated_at", Description: "Sort by updated_at; ascending unless prefixed with -."},
+		},
+	}
+
+	param, value := detectEndpointSyncSort(endpoint)
+	assert.Empty(t, param)
+	assert.Empty(t, value)
+}
+
 func TestProfileSyncableResourcePaginationDefaultsPreserveEndpointParams(t *testing.T) {
 	s := &spec.APISpec{
 		Name: "mixed-pagination",

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -513,6 +513,7 @@ func syncResource(ctx context.Context, c interface {
 	pageSize := determinePaginationDefaults(resource)
 	sortParam := syncResourceSortParam(resource)
 	sortValue := syncResourceSortValue(resource)
+	sortField := syncResourceSortField(resource)
 	sortEffective := false
 	var progressCount int64
 	pagesFetched := 0
@@ -567,7 +568,7 @@ func syncResource(ctx context.Context, c interface {
 		// win over spec-derived defaults (e.g. forcing mine=true on a list
 		// endpoint whose OpenAPI spec marks the filter optional).
 		userParams.applyTo(resource, params, false)
-		sortEffective = effectiveSince != "" && sortParam != "" && sortValue != "" && params[sortParam] == sortValue
+		sortEffective = effectiveSince != "" && sortParam != "" && sortValue != "" && sortField != "" && params[sortParam] == sortValue
 
 		data, err := c.Get(ctx, path, params)
 		if err != nil {
@@ -601,7 +602,7 @@ func syncResource(ctx context.Context, c interface {
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
 		if sortEffective && maxPages > 0 {
 			for _, item := range items {
-				itemTimestamp, ok := restSyncTimestamp(item)
+				itemTimestamp, ok := restSyncTimestamp(item, sortField)
 				if !ok {
 					timestampOrderSafe = false
 					continue
@@ -1044,6 +1045,12 @@ func syncResourceSortParam(resource string) string {
 }
 
 func syncResourceSortValue(resource string) string {
+	switch resource {
+	}
+	return ""
+}
+
+func syncResourceSortField(resource string) string {
 	switch resource {
 	}
 	return ""
@@ -1792,21 +1799,24 @@ func parseSinceDuration(s string) (time.Time, error) {
 	}
 }
 
-// restSyncTimestamp extracts a record-level last-modified timestamp from one
-// REST item. Nested child or metadata timestamps are deliberately ignored:
-// the incremental filter applies to the resource record, not its embedded
-// objects. Multiple candidate top-level timestamps are also rejected because
-// the generator cannot prove which one the endpoint sorts and filters on.
-func restSyncTimestamp(data json.RawMessage) (time.Time, bool) {
+// restSyncTimestamp extracts the record-level timestamp for the exact field
+// used by the endpoint's incremental sort. Nested child or metadata timestamps
+// are deliberately ignored: the incremental filter applies to the resource
+// record, not its embedded objects. A missing or unparseable expected field is
+// unsafe, so this helper never falls back to another recognized timestamp.
+func restSyncTimestamp(data json.RawMessage, expectedField string) (time.Time, bool) {
 	var value map[string]any
 	if err := json.Unmarshal(data, &value); err != nil {
 		return time.Time{}, false
 	}
-	var newest time.Time
-	var found bool
+	expectedField = normalizeRestSyncTimestampField(expectedField)
+	if expectedField == "" || !restSyncTimestampField(expectedField) {
+		return time.Time{}, false
+	}
+	var timestamp time.Time
 	matches := 0
 	for fieldName, child := range value {
-		if !restSyncTimestampField(fieldName) {
+		if normalizeRestSyncTimestampField(fieldName) != expectedField {
 			continue
 		}
 		text, ok := child.(string)
@@ -1818,19 +1828,20 @@ func restSyncTimestamp(data json.RawMessage) (time.Time, bool) {
 			continue
 		}
 		matches++
-		if !found || ts.After(newest) {
-			newest = ts
-			found = true
-		}
+		timestamp = ts
 	}
 	if matches != 1 {
 		return time.Time{}, false
 	}
-	return newest, true
+	return timestamp, true
+}
+
+func normalizeRestSyncTimestampField(name string) string {
+	return strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(name))
 }
 
 func restSyncTimestampField(name string) bool {
-	normalized := strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(name))
+	normalized := normalizeRestSyncTimestampField(name)
 	return strings.Contains(normalized, "updated") ||
 		strings.Contains(normalized, "modified") ||
 		strings.Contains(normalized, "lastchanged") ||

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -511,6 +511,9 @@ func syncResource(ctx context.Context, c interface {
 
 	cursor := existingCursor
 	pageSize := determinePaginationDefaults(resource)
+	sortParam := syncResourceSortParam(resource)
+	sortValue := syncResourceSortValue(resource)
+	sortEffective := false
 	var progressCount int64
 	pagesFetched := 0
 	lastNextCursor := ""
@@ -556,14 +559,15 @@ func syncResource(ctx context.Context, c interface {
 		// Set since filter
 		if effectiveSince != "" {
 			params[sinceParam] = effectiveSince
-			if sortParam := syncResourceSortParam(resource); sortParam != "" {
-				params[sortParam] = syncResourceSortValue(resource)
+			if sortParam != "" {
+				params[sortParam] = sortValue
 			}
 		}
 		// Apply user-supplied --param / --resource-param overrides last so they
 		// win over spec-derived defaults (e.g. forcing mine=true on a list
 		// endpoint whose OpenAPI spec marks the filter optional).
 		userParams.applyTo(resource, params, false)
+		sortEffective = effectiveSince != "" && sortParam != "" && sortValue != "" && params[sortParam] == sortValue
 
 		data, err := c.Get(ctx, path, params)
 		if err != nil {
@@ -595,7 +599,7 @@ func syncResource(ctx context.Context, c interface {
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
-		if effectiveSince != "" && syncResourceSortParam(resource) != "" && maxPages > 0 {
+		if sortEffective && maxPages > 0 {
 			for _, item := range items {
 				itemTimestamp, ok := restSyncTimestamp(item)
 				if !ok {
@@ -912,7 +916,7 @@ func syncResource(ctx context.Context, c interface {
 	watermark := time.Time{}
 	if outcome.complete {
 		watermark = requestedAt.Add(-syncWatermarkOverlap)
-	} else if capTruncated && effectiveSince != "" && syncResourceSortParam(resource) != "" && timestampOrderSafe && timestampEvidence && !newestStoredAt.IsZero() {
+	} else if capTruncated && sortEffective && timestampOrderSafe && timestampEvidence && !newestStoredAt.IsZero() {
 		watermark = newestStoredAt.Add(-syncWatermarkOverlap)
 	}
 	if !watermark.IsZero() {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -47,6 +47,8 @@ type syncResult struct {
 	Duration time.Duration
 }
 
+const syncWatermarkOverlap = time.Second
+
 func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var resources []string
 	var full bool
@@ -155,7 +157,7 @@ Resource scoping:
 			// Skip under --dry-run: a preview must not mutate sync-state (issue #2935).
 			if full && !c.DryRun {
 				for _, resource := range resources {
-					if err := db.SaveSyncState(resource, "", 0); err != nil {
+					if err := db.SaveSyncStateAt(resource, "", 0, time.Time{}); err != nil {
 						return fmt.Errorf("clearing sync state for %s: %w", resource, err)
 					}
 				}
@@ -176,15 +178,14 @@ Resource scoping:
 					maxPages = 1
 					// Clear the cursor so we start from the head each time;
 					// the goal of --latest-only is "refresh the top" not
-					// "resume from wherever I left off". Skip under --dry-run:
+					// "resume from wherever I left off". Clear the watermark too,
+					// so the head request does not inherit an old incremental window.
+					// Skip under --dry-run:
 					// a preview must not mutate sync-state (issue #2935).
 					if !c.DryRun {
 						for _, resource := range resources {
-							existing, _, _, _ := db.GetSyncState(resource)
-							if existing != "" {
-								if err := db.SaveSyncState(resource, "", 0); err != nil {
-									return fmt.Errorf("clearing sync state for %s: %w", resource, err)
-								}
+							if err := db.SaveSyncStateAt(resource, "", 0, time.Time{}); err != nil {
+								return fmt.Errorf("clearing sync state for %s: %w", resource, err)
 							}
 						}
 					}
@@ -471,6 +472,7 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	var totalCount int
+	requestedAt := started.UTC()
 
 	// Resume cursor from sync_state (unless --full cleared it)
 	existingCursor, lastSynced, _, _ := db.GetSyncState(resource)
@@ -514,6 +516,11 @@ func syncResource(ctx context.Context, c interface {
 	lastNextCursor := ""
 	capExitHit := false
 	capExitCursor := ""
+	capTruncated := false
+	var previousStoredAt time.Time
+	var newestStoredAt time.Time
+	timestampOrderSafe := true
+	timestampEvidence := false
 	// extractFailureTotal accumulates per-item primary-key extraction
 	// misses across pages within this resource sync. Resource-level
 	// concurrency is 1 (one goroutine per resource via the work channel)
@@ -549,6 +556,9 @@ func syncResource(ctx context.Context, c interface {
 		// Set since filter
 		if effectiveSince != "" {
 			params[sinceParam] = effectiveSince
+			if sortParam := syncResourceSortParam(resource); sortParam != "" {
+				params[sortParam] = syncResourceSortValue(resource)
+			}
 		}
 		// Apply user-supplied --param / --resource-param overrides last so they
 		// win over spec-derived defaults (e.g. forcing mine=true on a list
@@ -585,6 +595,23 @@ func syncResource(ctx context.Context, c interface {
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
+		if effectiveSince != "" && syncResourceSortParam(resource) != "" && maxPages > 0 {
+			for _, item := range items {
+				itemTimestamp, ok := restSyncTimestamp(item)
+				if !ok {
+					timestampOrderSafe = false
+					continue
+				}
+				timestampEvidence = true
+				if !previousStoredAt.IsZero() && itemTimestamp.Before(previousStoredAt) {
+					timestampOrderSafe = false
+				}
+				previousStoredAt = itemTimestamp
+				if newestStoredAt.IsZero() || itemTimestamp.After(newestStoredAt) {
+					newestStoredAt = itemTimestamp
+				}
+			}
+		}
 
 		// Page-int paginator fallback: when the API paginates by integer
 		// ?page=N and emits no body cursor, treat a full page as a signal
@@ -666,6 +693,11 @@ func syncResource(ctx context.Context, c interface {
 		extractFailureTotal += extractFailures + hydrateFailures
 		hydrateFailureTotal += hydrateFailures
 		pageFailureCount := extractFailures + hydrateFailures
+		if pageFailureCount > 0 {
+			// A timestamp from an item that did not reach the store cannot safely
+			// advance the incremental watermark past that item.
+			timestampOrderSafe = false
+		}
 
 		if fetchedThisPage > 0 && stored == 0 {
 			reason := "all_items_failed_id_extraction"
@@ -740,6 +772,7 @@ func syncResource(ctx context.Context, c interface {
 		if maxPages > 0 && pagesFetched >= maxPages {
 			truncatedByCap := resourceSupportsPagination(resource) && hasMore
 			truncatedByCap = truncatedByCap && !shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit)
+			capResumed := false
 			if truncatedByCap {
 				capExitCursor = nextCursor
 			}
@@ -751,7 +784,14 @@ func syncResource(ctx context.Context, c interface {
 					truncatedByCap = false
 				}
 			}
-			if truncatedByCap && capExitCursor != cursor {
+			capResumed = truncatedByCap && capExitCursor != cursor
+			capPageLimit := pageSize.limit
+			// A resume cursor alone does not prove that the page window was
+			// truncated. Only a full page with a real continuation advances a
+			// watermark; short cursor pages retain the cursor but leave the
+			// watermark unchanged.
+			capTruncated = capResumed && fetchedThisPage >= capPageLimit
+			if capResumed {
 				if !latestOnly {
 					capExitHit = true
 					if humanFriendly {
@@ -761,10 +801,17 @@ func syncResource(ctx context.Context, c interface {
 					}
 				}
 			}
-			// A cap break ends enumeration before exhausting the partition; mirror
-			// the dependent loop and treat it as incomplete (reconcile SKIPS). Safe
-			// default: when the cap may have truncated, never prune.
-			outcome.reason = "max_pages_cap"
+			// A cap break is incomplete when it has a continuation. A short
+			// page for page/offset pagination is a proven natural end even when
+			// the operator's page ceiling fired on that same request.
+			if capResumed {
+				outcome.reason = "max_pages_cap"
+			} else if !hasMore ||
+				shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, capPageLimit) {
+				outcome.complete = true
+			} else {
+				outcome.reason = "max_pages_cap"
+			}
 			break
 		}
 
@@ -811,8 +858,8 @@ func syncResource(ctx context.Context, c interface {
 		}
 
 		// Save cursor after each page for resumability
-		if err := db.SaveSyncState(resource, nextCursor, totalCount); err != nil {
-			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
+		if err := db.SaveSyncProgress(resource, nextCursor, totalCount); err != nil {
+			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync progress for %s: %w", resource, err), Duration: time.Since(started)}
 		}
 
 		cursor = nextCursor
@@ -851,14 +898,37 @@ func syncResource(ctx context.Context, c interface {
 		fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unsupported-resource-shape"}`+"\n", resource)
 	}
 
-	// Final sync state: clear cursor on natural completion, but preserve the
-	// resume cursor when an operator intentionally capped the page budget.
+	// Final sync state separates pagination progress from the incremental
+	// watermark. A checkpoint after a capped page may retain a resume cursor
+	// without claiming that records on pages we did not fetch were observed.
 	finalCursor := ""
 	if capExitHit {
 		finalCursor = capExitCursor
 	}
-	if err := db.SaveSyncState(resource, finalCursor, totalCount); err != nil {
-		return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
+	cachedCount, countErr := db.Count(resource)
+	if countErr != nil {
+		return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("counting stored %s rows: %w", resource, countErr), Duration: time.Since(started)}
+	}
+	watermark := time.Time{}
+	if outcome.complete {
+		watermark = requestedAt.Add(-syncWatermarkOverlap)
+	} else if capTruncated && effectiveSince != "" && syncResourceSortParam(resource) != "" && timestampOrderSafe && timestampEvidence && !newestStoredAt.IsZero() {
+		watermark = newestStoredAt.Add(-syncWatermarkOverlap)
+	}
+	if !watermark.IsZero() {
+		// A positional or opaque cursor was issued for the old since window.
+		// Restart from the new watermark instead of combining two incompatible
+		// result windows on the next run.
+		finalCursor = ""
+	}
+	var stateErr error
+	if watermark.IsZero() {
+		stateErr = db.SaveSyncProgress(resource, finalCursor, cachedCount)
+	} else {
+		stateErr = db.SaveSyncStateAt(resource, finalCursor, cachedCount, watermark)
+	}
+	if stateErr != nil {
+		return syncResult{Resource: resource, Count: cachedCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, stateErr), Duration: time.Since(started)}
 	}
 
 	// F4b symptom probe: if items were consumed and successfully
@@ -877,7 +947,7 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	if !humanFriendly {
-		fmt.Fprintf(syncEvents, `{"event":"sync_complete","resource":"%s","total":%d,"duration_ms":%d}`+"\n", resource, totalCount, time.Since(started).Milliseconds())
+		fmt.Fprintf(syncEvents, `{"event":"sync_complete","resource":"%s","total":%d,"duration_ms":%d}`+"\n", resource, cachedCount, time.Since(started).Milliseconds())
 	}
 
 	if consumedTotal > 0 && totalCount == 0 && extractFailureTotal >= consumedTotal {
@@ -893,7 +963,7 @@ func syncResource(ctx context.Context, c interface {
 		}
 	}
 
-	return syncResult{Resource: resource, Count: totalCount, Duration: time.Since(started)}
+	return syncResult{Resource: resource, Count: cachedCount, Duration: time.Since(started)}
 }
 
 // paginationDefaults holds the resolved pagination parameter names and page size.
@@ -954,6 +1024,22 @@ func resourceSupportsPagination(resource string) bool {
 // endpoint declares none. Skipping the param for "" resources avoids
 // validation-error 400s on APIs that reject unknown query keys.
 func syncResourceSinceParam(resource string) string {
+	switch resource {
+	}
+	return ""
+}
+
+// syncResourceSortParam and syncResourceSortValue describe a spec-declared
+// ascending last-modified ordering. Sync adds them only when it sends a since
+// filter, because applying a sort to a full sync can change API behavior and
+// does not improve the watermark proof.
+func syncResourceSortParam(resource string) string {
+	switch resource {
+	}
+	return ""
+}
+
+func syncResourceSortValue(resource string) string {
 	switch resource {
 	}
 	return ""
@@ -1700,6 +1786,64 @@ func parseSinceDuration(s string) (time.Time, error) {
 	default:
 		return time.Time{}, fmt.Errorf("unknown unit %q", matches[2])
 	}
+}
+
+// restSyncTimestamp extracts a record-level last-modified timestamp from one
+// REST item. Nested child or metadata timestamps are deliberately ignored:
+// the incremental filter applies to the resource record, not its embedded
+// objects. Multiple candidate top-level timestamps are also rejected because
+// the generator cannot prove which one the endpoint sorts and filters on.
+func restSyncTimestamp(data json.RawMessage) (time.Time, bool) {
+	var value map[string]any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return time.Time{}, false
+	}
+	var newest time.Time
+	var found bool
+	matches := 0
+	for fieldName, child := range value {
+		if !restSyncTimestampField(fieldName) {
+			continue
+		}
+		text, ok := child.(string)
+		if !ok {
+			continue
+		}
+		ts, ok := parseRestSyncTimestamp(text)
+		if !ok {
+			continue
+		}
+		matches++
+		if !found || ts.After(newest) {
+			newest = ts
+			found = true
+		}
+	}
+	if matches != 1 {
+		return time.Time{}, false
+	}
+	return newest, true
+}
+
+func restSyncTimestampField(name string) bool {
+	normalized := strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(name))
+	return strings.Contains(normalized, "updated") ||
+		strings.Contains(normalized, "modified") ||
+		strings.Contains(normalized, "lastchanged") ||
+		strings.Contains(normalized, "lastmodified")
+}
+
+func parseRestSyncTimestamp(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
+		if ts, err := time.Parse(layout, value); err == nil {
+			return ts, true
+		}
+	}
+	return time.Time{}, false
 }
 
 func defaultSyncResources() []string {

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -1503,6 +1503,13 @@ func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj 
 }
 
 func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
+	return s.SaveSyncStateAt(resourceType, cursor, count, time.Now().UTC())
+}
+
+// SaveSyncStateAt stores both pagination progress and the incremental
+// watermark represented by at. Callers use this when the watermark belongs to
+// the data just fetched rather than to the instant the checkpoint is written.
+func (s *Store) SaveSyncStateAt(resourceType, cursor string, count int, at time.Time) error {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
 	_, err := s.db.Exec(
@@ -1510,7 +1517,23 @@ func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT(resource_type) DO UPDATE SET last_cursor = excluded.last_cursor,
 		 last_synced_at = excluded.last_synced_at, total_count = excluded.total_count`,
-		resourceType, cursor, time.Now().UTC().Format(time.RFC3339), count,
+		resourceType, cursor, at.UTC().Format(time.RFC3339), count,
+	)
+	return err
+}
+
+// SaveSyncProgress stores pagination progress without changing the
+// incremental watermark. A new row gets a parseable zero timestamp so
+// GetSyncState can scan it into time.Time without a NULL conversion error.
+func (s *Store) SaveSyncProgress(resourceType, cursor string, count int) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	_, err := s.db.Exec(
+		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(resource_type) DO UPDATE SET last_cursor = excluded.last_cursor,
+		 total_count = excluded.total_count`,
+		resourceType, cursor, time.Time{}.UTC().Format(time.RFC3339), count,
 	)
 	return err
 }

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1758,6 +1758,13 @@ func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj 
 }
 
 func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
+	return s.SaveSyncStateAt(resourceType, cursor, count, time.Now().UTC())
+}
+
+// SaveSyncStateAt stores both pagination progress and the incremental
+// watermark represented by at. Callers use this when the watermark belongs to
+// the data just fetched rather than to the instant the checkpoint is written.
+func (s *Store) SaveSyncStateAt(resourceType, cursor string, count int, at time.Time) error {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
 	_, err := s.db.Exec(
@@ -1765,7 +1772,23 @@ func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT(resource_type) DO UPDATE SET last_cursor = excluded.last_cursor,
 		 last_synced_at = excluded.last_synced_at, total_count = excluded.total_count`,
-		resourceType, cursor, time.Now().UTC().Format(time.RFC3339), count,
+		resourceType, cursor, at.UTC().Format(time.RFC3339), count,
+	)
+	return err
+}
+
+// SaveSyncProgress stores pagination progress without changing the
+// incremental watermark. A new row gets a parseable zero timestamp so
+// GetSyncState can scan it into time.Time without a NULL conversion error.
+func (s *Store) SaveSyncProgress(resourceType, cursor string, count int) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	_, err := s.db.Exec(
+		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(resource_type) DO UPDATE SET last_cursor = excluded.last_cursor,
+		 total_count = excluded.total_count`,
+		resourceType, cursor, time.Time{}.UTC().Format(time.RFC3339), count,
 	)
 	return err
 }

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -45,6 +45,8 @@ type syncResult struct {
 	Duration time.Duration
 }
 
+const syncWatermarkOverlap = time.Second
+
 func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var resources []string
 	var full bool
@@ -149,7 +151,7 @@ Resource scoping:
 			// Skip under --dry-run: a preview must not mutate sync-state (issue #2935).
 			if full && !c.DryRun {
 				for _, resource := range resources {
-					if err := db.SaveSyncState(resource, "", 0); err != nil {
+					if err := db.SaveSyncStateAt(resource, "", 0, time.Time{}); err != nil {
 						return fmt.Errorf("clearing sync state for %s: %w", resource, err)
 					}
 				}
@@ -170,15 +172,14 @@ Resource scoping:
 					maxPages = 1
 					// Clear the cursor so we start from the head each time;
 					// the goal of --latest-only is "refresh the top" not
-					// "resume from wherever I left off". Skip under --dry-run:
+					// "resume from wherever I left off". Clear the watermark too,
+					// so the head request does not inherit an old incremental window.
+					// Skip under --dry-run:
 					// a preview must not mutate sync-state (issue #2935).
 					if !c.DryRun {
 						for _, resource := range resources {
-							existing, _, _, _ := db.GetSyncState(resource)
-							if existing != "" {
-								if err := db.SaveSyncState(resource, "", 0); err != nil {
-									return fmt.Errorf("clearing sync state for %s: %w", resource, err)
-								}
+							if err := db.SaveSyncStateAt(resource, "", 0, time.Time{}); err != nil {
+								return fmt.Errorf("clearing sync state for %s: %w", resource, err)
 							}
 						}
 					}
@@ -432,6 +433,7 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	var totalCount int
+	requestedAt := started.UTC()
 
 	// Resume cursor from sync_state (unless --full cleared it)
 	existingCursor, lastSynced, _, _ := db.GetSyncState(resource)
@@ -475,6 +477,11 @@ func syncResource(ctx context.Context, c interface {
 	lastNextCursor := ""
 	capExitHit := false
 	capExitCursor := ""
+	capTruncated := false
+	var previousStoredAt time.Time
+	var newestStoredAt time.Time
+	timestampOrderSafe := true
+	timestampEvidence := false
 	// extractFailureTotal accumulates per-item primary-key extraction
 	// misses across pages within this resource sync. Resource-level
 	// concurrency is 1 (one goroutine per resource via the work channel)
@@ -510,6 +517,9 @@ func syncResource(ctx context.Context, c interface {
 		// Set since filter
 		if effectiveSince != "" {
 			params[sinceParam] = effectiveSince
+			if sortParam := syncResourceSortParam(resource); sortParam != "" {
+				params[sortParam] = syncResourceSortValue(resource)
+			}
 		}
 		// Apply user-supplied --param / --resource-param overrides last so they
 		// win over spec-derived defaults (e.g. forcing mine=true on a list
@@ -569,6 +579,23 @@ func syncResource(ctx context.Context, c interface {
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
+		if effectiveSince != "" && syncResourceSortParam(resource) != "" && maxPages > 0 {
+			for _, item := range items {
+				itemTimestamp, ok := restSyncTimestamp(item)
+				if !ok {
+					timestampOrderSafe = false
+					continue
+				}
+				timestampEvidence = true
+				if !previousStoredAt.IsZero() && itemTimestamp.Before(previousStoredAt) {
+					timestampOrderSafe = false
+				}
+				previousStoredAt = itemTimestamp
+				if newestStoredAt.IsZero() || itemTimestamp.After(newestStoredAt) {
+					newestStoredAt = itemTimestamp
+				}
+			}
+		}
 
 		// Page-int paginator fallback: when the API paginates by integer
 		// ?page=N and emits no body cursor, treat a full page as a signal
@@ -670,6 +697,11 @@ func syncResource(ctx context.Context, c interface {
 		extractFailureTotal += extractFailures + hydrateFailures
 		hydrateFailureTotal += hydrateFailures
 		pageFailureCount := extractFailures + hydrateFailures
+		if pageFailureCount > 0 {
+			// A timestamp from an item that did not reach the store cannot safely
+			// advance the incremental watermark past that item.
+			timestampOrderSafe = false
+		}
 
 		if fetchedThisPage > 0 && stored == 0 {
 			reason := "all_items_failed_id_extraction"
@@ -751,6 +783,7 @@ func syncResource(ctx context.Context, c interface {
 			} else {
 				truncatedByCap = truncatedByCap && !shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit)
 			}
+			capResumed := false
 			if truncatedByCap {
 				capExitCursor = nextCursor
 			}
@@ -762,7 +795,17 @@ func syncResource(ctx context.Context, c interface {
 					truncatedByCap = false
 				}
 			}
-			if truncatedByCap && capExitCursor != cursor {
+			capResumed = truncatedByCap && capExitCursor != cursor
+			capPageLimit := pageSize.limit
+			if _, ok := queryEntity[resource]; ok && path == queryPath {
+				capPageLimit = queryPageSize
+			}
+			// A resume cursor alone does not prove that the page window was
+			// truncated. Only a full page with a real continuation advances a
+			// watermark; short cursor pages retain the cursor but leave the
+			// watermark unchanged.
+			capTruncated = capResumed && fetchedThisPage >= capPageLimit
+			if capResumed {
 				if !latestOnly {
 					capExitHit = true
 					if humanFriendly {
@@ -772,10 +815,17 @@ func syncResource(ctx context.Context, c interface {
 					}
 				}
 			}
-			// A cap break ends enumeration before exhausting the partition; mirror
-			// the dependent loop and treat it as incomplete (reconcile SKIPS). Safe
-			// default: when the cap may have truncated, never prune.
-			outcome.reason = "max_pages_cap"
+			// A cap break is incomplete when it has a continuation. A short
+			// page for page/offset pagination is a proven natural end even when
+			// the operator's page ceiling fired on that same request.
+			if capResumed {
+				outcome.reason = "max_pages_cap"
+			} else if !hasMore ||
+				(path != queryPath && shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, capPageLimit)) {
+				outcome.complete = true
+			} else {
+				outcome.reason = "max_pages_cap"
+			}
 			break
 		}
 
@@ -831,8 +881,8 @@ func syncResource(ctx context.Context, c interface {
 		}
 
 		// Save cursor after each page for resumability
-		if err := db.SaveSyncState(resource, nextCursor, totalCount); err != nil {
-			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
+		if err := db.SaveSyncProgress(resource, nextCursor, totalCount); err != nil {
+			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync progress for %s: %w", resource, err), Duration: time.Since(started)}
 		}
 
 		cursor = nextCursor
@@ -871,14 +921,37 @@ func syncResource(ctx context.Context, c interface {
 		fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unsupported-resource-shape"}`+"\n", resource)
 	}
 
-	// Final sync state: clear cursor on natural completion, but preserve the
-	// resume cursor when an operator intentionally capped the page budget.
+	// Final sync state separates pagination progress from the incremental
+	// watermark. A checkpoint after a capped page may retain a resume cursor
+	// without claiming that records on pages we did not fetch were observed.
 	finalCursor := ""
 	if capExitHit {
 		finalCursor = capExitCursor
 	}
-	if err := db.SaveSyncState(resource, finalCursor, totalCount); err != nil {
-		return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
+	cachedCount, countErr := db.Count(resource)
+	if countErr != nil {
+		return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("counting stored %s rows: %w", resource, countErr), Duration: time.Since(started)}
+	}
+	watermark := time.Time{}
+	if outcome.complete {
+		watermark = requestedAt.Add(-syncWatermarkOverlap)
+	} else if capTruncated && effectiveSince != "" && syncResourceSortParam(resource) != "" && timestampOrderSafe && timestampEvidence && !newestStoredAt.IsZero() {
+		watermark = newestStoredAt.Add(-syncWatermarkOverlap)
+	}
+	if !watermark.IsZero() {
+		// A positional or opaque cursor was issued for the old since window.
+		// Restart from the new watermark instead of combining two incompatible
+		// result windows on the next run.
+		finalCursor = ""
+	}
+	var stateErr error
+	if watermark.IsZero() {
+		stateErr = db.SaveSyncProgress(resource, finalCursor, cachedCount)
+	} else {
+		stateErr = db.SaveSyncStateAt(resource, finalCursor, cachedCount, watermark)
+	}
+	if stateErr != nil {
+		return syncResult{Resource: resource, Count: cachedCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, stateErr), Duration: time.Since(started)}
 	}
 
 	// F4b symptom probe: if items were consumed and successfully
@@ -897,7 +970,7 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	if !humanFriendly {
-		fmt.Fprintf(syncEvents, `{"event":"sync_complete","resource":"%s","total":%d,"duration_ms":%d}`+"\n", resource, totalCount, time.Since(started).Milliseconds())
+		fmt.Fprintf(syncEvents, `{"event":"sync_complete","resource":"%s","total":%d,"duration_ms":%d}`+"\n", resource, cachedCount, time.Since(started).Milliseconds())
 	}
 
 	if consumedTotal > 0 && totalCount == 0 && extractFailureTotal >= consumedTotal {
@@ -913,7 +986,7 @@ func syncResource(ctx context.Context, c interface {
 		}
 	}
 
-	return syncResult{Resource: resource, Count: totalCount, Duration: time.Since(started)}
+	return syncResult{Resource: resource, Count: cachedCount, Duration: time.Since(started)}
 }
 
 // paginationDefaults holds the resolved pagination parameter names and page size.
@@ -956,6 +1029,22 @@ func resourceSupportsPagination(resource string) bool {
 // endpoint declares none. Skipping the param for "" resources avoids
 // validation-error 400s on APIs that reject unknown query keys.
 func syncResourceSinceParam(resource string) string {
+	switch resource {
+	}
+	return ""
+}
+
+// syncResourceSortParam and syncResourceSortValue describe a spec-declared
+// ascending last-modified ordering. Sync adds them only when it sends a since
+// filter, because applying a sort to a full sync can change API behavior and
+// does not improve the watermark proof.
+func syncResourceSortParam(resource string) string {
+	switch resource {
+	}
+	return ""
+}
+
+func syncResourceSortValue(resource string) string {
 	switch resource {
 	}
 	return ""
@@ -1696,6 +1785,64 @@ func parseSinceDuration(s string) (time.Time, error) {
 	default:
 		return time.Time{}, fmt.Errorf("unknown unit %q", matches[2])
 	}
+}
+
+// restSyncTimestamp extracts a record-level last-modified timestamp from one
+// REST item. Nested child or metadata timestamps are deliberately ignored:
+// the incremental filter applies to the resource record, not its embedded
+// objects. Multiple candidate top-level timestamps are also rejected because
+// the generator cannot prove which one the endpoint sorts and filters on.
+func restSyncTimestamp(data json.RawMessage) (time.Time, bool) {
+	var value map[string]any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return time.Time{}, false
+	}
+	var newest time.Time
+	var found bool
+	matches := 0
+	for fieldName, child := range value {
+		if !restSyncTimestampField(fieldName) {
+			continue
+		}
+		text, ok := child.(string)
+		if !ok {
+			continue
+		}
+		ts, ok := parseRestSyncTimestamp(text)
+		if !ok {
+			continue
+		}
+		matches++
+		if !found || ts.After(newest) {
+			newest = ts
+			found = true
+		}
+	}
+	if matches != 1 {
+		return time.Time{}, false
+	}
+	return newest, true
+}
+
+func restSyncTimestampField(name string) bool {
+	normalized := strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(name))
+	return strings.Contains(normalized, "updated") ||
+		strings.Contains(normalized, "modified") ||
+		strings.Contains(normalized, "lastchanged") ||
+		strings.Contains(normalized, "lastmodified")
+}
+
+func parseRestSyncTimestamp(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
+		if ts, err := time.Parse(layout, value); err == nil {
+			return ts, true
+		}
+	}
+	return time.Time{}, false
 }
 
 func defaultSyncResources() []string {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -472,6 +472,9 @@ func syncResource(ctx context.Context, c interface {
 
 	cursor := existingCursor
 	pageSize := determinePaginationDefaults(resource)
+	sortParam := syncResourceSortParam(resource)
+	sortValue := syncResourceSortValue(resource)
+	sortEffective := false
 	var progressCount int64
 	pagesFetched := 0
 	lastNextCursor := ""
@@ -517,14 +520,15 @@ func syncResource(ctx context.Context, c interface {
 		// Set since filter
 		if effectiveSince != "" {
 			params[sinceParam] = effectiveSince
-			if sortParam := syncResourceSortParam(resource); sortParam != "" {
-				params[sortParam] = syncResourceSortValue(resource)
+			if sortParam != "" {
+				params[sortParam] = sortValue
 			}
 		}
 		// Apply user-supplied --param / --resource-param overrides last so they
 		// win over spec-derived defaults (e.g. forcing mine=true on a list
 		// endpoint whose OpenAPI spec marks the filter optional).
 		userParams.applyTo(resource, params, false)
+		sortEffective = effectiveSince != "" && sortParam != "" && sortValue != "" && params[sortParam] == sortValue
 
 		// SQL-query-endpoint sync: this resource is read through one shared
 		// query endpoint that REQUIRES an injected SELECT (a bare path answers
@@ -579,7 +583,7 @@ func syncResource(ctx context.Context, c interface {
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
-		if effectiveSince != "" && syncResourceSortParam(resource) != "" && maxPages > 0 {
+		if sortEffective && maxPages > 0 {
 			for _, item := range items {
 				itemTimestamp, ok := restSyncTimestamp(item)
 				if !ok {
@@ -935,7 +939,7 @@ func syncResource(ctx context.Context, c interface {
 	watermark := time.Time{}
 	if outcome.complete {
 		watermark = requestedAt.Add(-syncWatermarkOverlap)
-	} else if capTruncated && effectiveSince != "" && syncResourceSortParam(resource) != "" && timestampOrderSafe && timestampEvidence && !newestStoredAt.IsZero() {
+	} else if capTruncated && sortEffective && timestampOrderSafe && timestampEvidence && !newestStoredAt.IsZero() {
 		watermark = newestStoredAt.Add(-syncWatermarkOverlap)
 	}
 	if !watermark.IsZero() {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -474,6 +474,7 @@ func syncResource(ctx context.Context, c interface {
 	pageSize := determinePaginationDefaults(resource)
 	sortParam := syncResourceSortParam(resource)
 	sortValue := syncResourceSortValue(resource)
+	sortField := syncResourceSortField(resource)
 	sortEffective := false
 	var progressCount int64
 	pagesFetched := 0
@@ -528,7 +529,7 @@ func syncResource(ctx context.Context, c interface {
 		// win over spec-derived defaults (e.g. forcing mine=true on a list
 		// endpoint whose OpenAPI spec marks the filter optional).
 		userParams.applyTo(resource, params, false)
-		sortEffective = effectiveSince != "" && sortParam != "" && sortValue != "" && params[sortParam] == sortValue
+		sortEffective = effectiveSince != "" && sortParam != "" && sortValue != "" && sortField != "" && params[sortParam] == sortValue
 
 		// SQL-query-endpoint sync: this resource is read through one shared
 		// query endpoint that REQUIRES an injected SELECT (a bare path answers
@@ -585,7 +586,7 @@ func syncResource(ctx context.Context, c interface {
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
 		if sortEffective && maxPages > 0 {
 			for _, item := range items {
-				itemTimestamp, ok := restSyncTimestamp(item)
+				itemTimestamp, ok := restSyncTimestamp(item, sortField)
 				if !ok {
 					timestampOrderSafe = false
 					continue
@@ -1049,6 +1050,12 @@ func syncResourceSortParam(resource string) string {
 }
 
 func syncResourceSortValue(resource string) string {
+	switch resource {
+	}
+	return ""
+}
+
+func syncResourceSortField(resource string) string {
 	switch resource {
 	}
 	return ""
@@ -1791,21 +1798,24 @@ func parseSinceDuration(s string) (time.Time, error) {
 	}
 }
 
-// restSyncTimestamp extracts a record-level last-modified timestamp from one
-// REST item. Nested child or metadata timestamps are deliberately ignored:
-// the incremental filter applies to the resource record, not its embedded
-// objects. Multiple candidate top-level timestamps are also rejected because
-// the generator cannot prove which one the endpoint sorts and filters on.
-func restSyncTimestamp(data json.RawMessage) (time.Time, bool) {
+// restSyncTimestamp extracts the record-level timestamp for the exact field
+// used by the endpoint's incremental sort. Nested child or metadata timestamps
+// are deliberately ignored: the incremental filter applies to the resource
+// record, not its embedded objects. A missing or unparseable expected field is
+// unsafe, so this helper never falls back to another recognized timestamp.
+func restSyncTimestamp(data json.RawMessage, expectedField string) (time.Time, bool) {
 	var value map[string]any
 	if err := json.Unmarshal(data, &value); err != nil {
 		return time.Time{}, false
 	}
-	var newest time.Time
-	var found bool
+	expectedField = normalizeRestSyncTimestampField(expectedField)
+	if expectedField == "" || !restSyncTimestampField(expectedField) {
+		return time.Time{}, false
+	}
+	var timestamp time.Time
 	matches := 0
 	for fieldName, child := range value {
-		if !restSyncTimestampField(fieldName) {
+		if normalizeRestSyncTimestampField(fieldName) != expectedField {
 			continue
 		}
 		text, ok := child.(string)
@@ -1817,19 +1827,20 @@ func restSyncTimestamp(data json.RawMessage) (time.Time, bool) {
 			continue
 		}
 		matches++
-		if !found || ts.After(newest) {
-			newest = ts
-			found = true
-		}
+		timestamp = ts
 	}
 	if matches != 1 {
 		return time.Time{}, false
 	}
-	return newest, true
+	return timestamp, true
+}
+
+func normalizeRestSyncTimestampField(name string) string {
+	return strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(name))
 }
 
 func restSyncTimestampField(name string) bool {
-	normalized := strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(name))
+	normalized := normalizeRestSyncTimestampField(name)
 	return strings.Contains(normalized, "updated") ||
 		strings.Contains(normalized, "modified") ||
 		strings.Contains(normalized, "lastchanged") ||

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1810,6 +1810,13 @@ func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj 
 }
 
 func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
+	return s.SaveSyncStateAt(resourceType, cursor, count, time.Now().UTC())
+}
+
+// SaveSyncStateAt stores both pagination progress and the incremental
+// watermark represented by at. Callers use this when the watermark belongs to
+// the data just fetched rather than to the instant the checkpoint is written.
+func (s *Store) SaveSyncStateAt(resourceType, cursor string, count int, at time.Time) error {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
 	_, err := s.db.Exec(
@@ -1817,7 +1824,23 @@ func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT(resource_type) DO UPDATE SET last_cursor = excluded.last_cursor,
 		 last_synced_at = excluded.last_synced_at, total_count = excluded.total_count`,
-		resourceType, cursor, time.Now().UTC().Format(time.RFC3339), count,
+		resourceType, cursor, at.UTC().Format(time.RFC3339), count,
+	)
+	return err
+}
+
+// SaveSyncProgress stores pagination progress without changing the
+// incremental watermark. A new row gets a parseable zero timestamp so
+// GetSyncState can scan it into time.Time without a NULL conversion error.
+func (s *Store) SaveSyncProgress(resourceType, cursor string, count int) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	_, err := s.db.Exec(
+		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(resource_type) DO UPDATE SET last_cursor = excluded.last_cursor,
+		 total_count = excluded.total_count`,
+		resourceType, cursor, time.Time{}.UTC().Format(time.RFC3339), count,
 	)
 	return err
 }

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -513,6 +513,7 @@ func syncResource(ctx context.Context, c interface {
 	pageSize := determinePaginationDefaults(resource)
 	sortParam := syncResourceSortParam(resource)
 	sortValue := syncResourceSortValue(resource)
+	sortField := syncResourceSortField(resource)
 	sortEffective := false
 	var progressCount int64
 	pagesFetched := 0
@@ -567,7 +568,7 @@ func syncResource(ctx context.Context, c interface {
 		// win over spec-derived defaults (e.g. forcing mine=true on a list
 		// endpoint whose OpenAPI spec marks the filter optional).
 		userParams.applyTo(resource, params, false)
-		sortEffective = effectiveSince != "" && sortParam != "" && sortValue != "" && params[sortParam] == sortValue
+		sortEffective = effectiveSince != "" && sortParam != "" && sortValue != "" && sortField != "" && params[sortParam] == sortValue
 
 		data, err := c.Get(ctx, path, params)
 		if err != nil {
@@ -601,7 +602,7 @@ func syncResource(ctx context.Context, c interface {
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
 		if sortEffective && maxPages > 0 {
 			for _, item := range items {
-				itemTimestamp, ok := restSyncTimestamp(item)
+				itemTimestamp, ok := restSyncTimestamp(item, sortField)
 				if !ok {
 					timestampOrderSafe = false
 					continue
@@ -1026,6 +1027,12 @@ func syncResourceSortParam(resource string) string {
 }
 
 func syncResourceSortValue(resource string) string {
+	switch resource {
+	}
+	return ""
+}
+
+func syncResourceSortField(resource string) string {
 	switch resource {
 	}
 	return ""
@@ -1766,21 +1773,24 @@ func parseSinceDuration(s string) (time.Time, error) {
 	}
 }
 
-// restSyncTimestamp extracts a record-level last-modified timestamp from one
-// REST item. Nested child or metadata timestamps are deliberately ignored:
-// the incremental filter applies to the resource record, not its embedded
-// objects. Multiple candidate top-level timestamps are also rejected because
-// the generator cannot prove which one the endpoint sorts and filters on.
-func restSyncTimestamp(data json.RawMessage) (time.Time, bool) {
+// restSyncTimestamp extracts the record-level timestamp for the exact field
+// used by the endpoint's incremental sort. Nested child or metadata timestamps
+// are deliberately ignored: the incremental filter applies to the resource
+// record, not its embedded objects. A missing or unparseable expected field is
+// unsafe, so this helper never falls back to another recognized timestamp.
+func restSyncTimestamp(data json.RawMessage, expectedField string) (time.Time, bool) {
 	var value map[string]any
 	if err := json.Unmarshal(data, &value); err != nil {
 		return time.Time{}, false
 	}
-	var newest time.Time
-	var found bool
+	expectedField = normalizeRestSyncTimestampField(expectedField)
+	if expectedField == "" || !restSyncTimestampField(expectedField) {
+		return time.Time{}, false
+	}
+	var timestamp time.Time
 	matches := 0
 	for fieldName, child := range value {
-		if !restSyncTimestampField(fieldName) {
+		if normalizeRestSyncTimestampField(fieldName) != expectedField {
 			continue
 		}
 		text, ok := child.(string)
@@ -1792,19 +1802,20 @@ func restSyncTimestamp(data json.RawMessage) (time.Time, bool) {
 			continue
 		}
 		matches++
-		if !found || ts.After(newest) {
-			newest = ts
-			found = true
-		}
+		timestamp = ts
 	}
 	if matches != 1 {
 		return time.Time{}, false
 	}
-	return newest, true
+	return timestamp, true
+}
+
+func normalizeRestSyncTimestampField(name string) string {
+	return strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(name))
 }
 
 func restSyncTimestampField(name string) bool {
-	normalized := strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(name))
+	normalized := normalizeRestSyncTimestampField(name)
 	return strings.Contains(normalized, "updated") ||
 		strings.Contains(normalized, "modified") ||
 		strings.Contains(normalized, "lastchanged") ||

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -511,6 +511,9 @@ func syncResource(ctx context.Context, c interface {
 
 	cursor := existingCursor
 	pageSize := determinePaginationDefaults(resource)
+	sortParam := syncResourceSortParam(resource)
+	sortValue := syncResourceSortValue(resource)
+	sortEffective := false
 	var progressCount int64
 	pagesFetched := 0
 	lastNextCursor := ""
@@ -556,14 +559,15 @@ func syncResource(ctx context.Context, c interface {
 		// Set since filter
 		if effectiveSince != "" {
 			params[sinceParam] = effectiveSince
-			if sortParam := syncResourceSortParam(resource); sortParam != "" {
-				params[sortParam] = syncResourceSortValue(resource)
+			if sortParam != "" {
+				params[sortParam] = sortValue
 			}
 		}
 		// Apply user-supplied --param / --resource-param overrides last so they
 		// win over spec-derived defaults (e.g. forcing mine=true on a list
 		// endpoint whose OpenAPI spec marks the filter optional).
 		userParams.applyTo(resource, params, false)
+		sortEffective = effectiveSince != "" && sortParam != "" && sortValue != "" && params[sortParam] == sortValue
 
 		data, err := c.Get(ctx, path, params)
 		if err != nil {
@@ -595,7 +599,7 @@ func syncResource(ctx context.Context, c interface {
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
-		if effectiveSince != "" && syncResourceSortParam(resource) != "" && maxPages > 0 {
+		if sortEffective && maxPages > 0 {
 			for _, item := range items {
 				itemTimestamp, ok := restSyncTimestamp(item)
 				if !ok {
@@ -912,7 +916,7 @@ func syncResource(ctx context.Context, c interface {
 	watermark := time.Time{}
 	if outcome.complete {
 		watermark = requestedAt.Add(-syncWatermarkOverlap)
-	} else if capTruncated && effectiveSince != "" && syncResourceSortParam(resource) != "" && timestampOrderSafe && timestampEvidence && !newestStoredAt.IsZero() {
+	} else if capTruncated && sortEffective && timestampOrderSafe && timestampEvidence && !newestStoredAt.IsZero() {
 		watermark = newestStoredAt.Add(-syncWatermarkOverlap)
 	}
 	if !watermark.IsZero() {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -47,6 +47,8 @@ type syncResult struct {
 	Duration time.Duration
 }
 
+const syncWatermarkOverlap = time.Second
+
 func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var resources []string
 	var full bool
@@ -155,7 +157,7 @@ Resource scoping:
 			// Skip under --dry-run: a preview must not mutate sync-state (issue #2935).
 			if full && !c.DryRun {
 				for _, resource := range resources {
-					if err := db.SaveSyncState(resource, "", 0); err != nil {
+					if err := db.SaveSyncStateAt(resource, "", 0, time.Time{}); err != nil {
 						return fmt.Errorf("clearing sync state for %s: %w", resource, err)
 					}
 				}
@@ -176,15 +178,14 @@ Resource scoping:
 					maxPages = 1
 					// Clear the cursor so we start from the head each time;
 					// the goal of --latest-only is "refresh the top" not
-					// "resume from wherever I left off". Skip under --dry-run:
+					// "resume from wherever I left off". Clear the watermark too,
+					// so the head request does not inherit an old incremental window.
+					// Skip under --dry-run:
 					// a preview must not mutate sync-state (issue #2935).
 					if !c.DryRun {
 						for _, resource := range resources {
-							existing, _, _, _ := db.GetSyncState(resource)
-							if existing != "" {
-								if err := db.SaveSyncState(resource, "", 0); err != nil {
-									return fmt.Errorf("clearing sync state for %s: %w", resource, err)
-								}
+							if err := db.SaveSyncStateAt(resource, "", 0, time.Time{}); err != nil {
+								return fmt.Errorf("clearing sync state for %s: %w", resource, err)
 							}
 						}
 					}
@@ -471,6 +472,7 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	var totalCount int
+	requestedAt := started.UTC()
 
 	// Resume cursor from sync_state (unless --full cleared it)
 	existingCursor, lastSynced, _, _ := db.GetSyncState(resource)
@@ -514,6 +516,11 @@ func syncResource(ctx context.Context, c interface {
 	lastNextCursor := ""
 	capExitHit := false
 	capExitCursor := ""
+	capTruncated := false
+	var previousStoredAt time.Time
+	var newestStoredAt time.Time
+	timestampOrderSafe := true
+	timestampEvidence := false
 	// extractFailureTotal accumulates per-item primary-key extraction
 	// misses across pages within this resource sync. Resource-level
 	// concurrency is 1 (one goroutine per resource via the work channel)
@@ -549,6 +556,9 @@ func syncResource(ctx context.Context, c interface {
 		// Set since filter
 		if effectiveSince != "" {
 			params[sinceParam] = effectiveSince
+			if sortParam := syncResourceSortParam(resource); sortParam != "" {
+				params[sortParam] = syncResourceSortValue(resource)
+			}
 		}
 		// Apply user-supplied --param / --resource-param overrides last so they
 		// win over spec-derived defaults (e.g. forcing mine=true on a list
@@ -585,6 +595,23 @@ func syncResource(ctx context.Context, c interface {
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
+		if effectiveSince != "" && syncResourceSortParam(resource) != "" && maxPages > 0 {
+			for _, item := range items {
+				itemTimestamp, ok := restSyncTimestamp(item)
+				if !ok {
+					timestampOrderSafe = false
+					continue
+				}
+				timestampEvidence = true
+				if !previousStoredAt.IsZero() && itemTimestamp.Before(previousStoredAt) {
+					timestampOrderSafe = false
+				}
+				previousStoredAt = itemTimestamp
+				if newestStoredAt.IsZero() || itemTimestamp.After(newestStoredAt) {
+					newestStoredAt = itemTimestamp
+				}
+			}
+		}
 
 		// Page-int paginator fallback: when the API paginates by integer
 		// ?page=N and emits no body cursor, treat a full page as a signal
@@ -666,6 +693,11 @@ func syncResource(ctx context.Context, c interface {
 		extractFailureTotal += extractFailures + hydrateFailures
 		hydrateFailureTotal += hydrateFailures
 		pageFailureCount := extractFailures + hydrateFailures
+		if pageFailureCount > 0 {
+			// A timestamp from an item that did not reach the store cannot safely
+			// advance the incremental watermark past that item.
+			timestampOrderSafe = false
+		}
 
 		if fetchedThisPage > 0 && stored == 0 {
 			reason := "all_items_failed_id_extraction"
@@ -740,6 +772,7 @@ func syncResource(ctx context.Context, c interface {
 		if maxPages > 0 && pagesFetched >= maxPages {
 			truncatedByCap := resourceSupportsPagination(resource) && hasMore
 			truncatedByCap = truncatedByCap && !shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit)
+			capResumed := false
 			if truncatedByCap {
 				capExitCursor = nextCursor
 			}
@@ -751,7 +784,14 @@ func syncResource(ctx context.Context, c interface {
 					truncatedByCap = false
 				}
 			}
-			if truncatedByCap && capExitCursor != cursor {
+			capResumed = truncatedByCap && capExitCursor != cursor
+			capPageLimit := pageSize.limit
+			// A resume cursor alone does not prove that the page window was
+			// truncated. Only a full page with a real continuation advances a
+			// watermark; short cursor pages retain the cursor but leave the
+			// watermark unchanged.
+			capTruncated = capResumed && fetchedThisPage >= capPageLimit
+			if capResumed {
 				if !latestOnly {
 					capExitHit = true
 					if humanFriendly {
@@ -761,10 +801,17 @@ func syncResource(ctx context.Context, c interface {
 					}
 				}
 			}
-			// A cap break ends enumeration before exhausting the partition; mirror
-			// the dependent loop and treat it as incomplete (reconcile SKIPS). Safe
-			// default: when the cap may have truncated, never prune.
-			outcome.reason = "max_pages_cap"
+			// A cap break is incomplete when it has a continuation. A short
+			// page for page/offset pagination is a proven natural end even when
+			// the operator's page ceiling fired on that same request.
+			if capResumed {
+				outcome.reason = "max_pages_cap"
+			} else if !hasMore ||
+				shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, capPageLimit) {
+				outcome.complete = true
+			} else {
+				outcome.reason = "max_pages_cap"
+			}
 			break
 		}
 
@@ -811,8 +858,8 @@ func syncResource(ctx context.Context, c interface {
 		}
 
 		// Save cursor after each page for resumability
-		if err := db.SaveSyncState(resource, nextCursor, totalCount); err != nil {
-			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
+		if err := db.SaveSyncProgress(resource, nextCursor, totalCount); err != nil {
+			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync progress for %s: %w", resource, err), Duration: time.Since(started)}
 		}
 
 		cursor = nextCursor
@@ -851,14 +898,37 @@ func syncResource(ctx context.Context, c interface {
 		fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unsupported-resource-shape"}`+"\n", resource)
 	}
 
-	// Final sync state: clear cursor on natural completion, but preserve the
-	// resume cursor when an operator intentionally capped the page budget.
+	// Final sync state separates pagination progress from the incremental
+	// watermark. A checkpoint after a capped page may retain a resume cursor
+	// without claiming that records on pages we did not fetch were observed.
 	finalCursor := ""
 	if capExitHit {
 		finalCursor = capExitCursor
 	}
-	if err := db.SaveSyncState(resource, finalCursor, totalCount); err != nil {
-		return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
+	cachedCount, countErr := db.Count(resource)
+	if countErr != nil {
+		return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("counting stored %s rows: %w", resource, countErr), Duration: time.Since(started)}
+	}
+	watermark := time.Time{}
+	if outcome.complete {
+		watermark = requestedAt.Add(-syncWatermarkOverlap)
+	} else if capTruncated && effectiveSince != "" && syncResourceSortParam(resource) != "" && timestampOrderSafe && timestampEvidence && !newestStoredAt.IsZero() {
+		watermark = newestStoredAt.Add(-syncWatermarkOverlap)
+	}
+	if !watermark.IsZero() {
+		// A positional or opaque cursor was issued for the old since window.
+		// Restart from the new watermark instead of combining two incompatible
+		// result windows on the next run.
+		finalCursor = ""
+	}
+	var stateErr error
+	if watermark.IsZero() {
+		stateErr = db.SaveSyncProgress(resource, finalCursor, cachedCount)
+	} else {
+		stateErr = db.SaveSyncStateAt(resource, finalCursor, cachedCount, watermark)
+	}
+	if stateErr != nil {
+		return syncResult{Resource: resource, Count: cachedCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, stateErr), Duration: time.Since(started)}
 	}
 
 	// F4b symptom probe: if items were consumed and successfully
@@ -877,7 +947,7 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	if !humanFriendly {
-		fmt.Fprintf(syncEvents, `{"event":"sync_complete","resource":"%s","total":%d,"duration_ms":%d}`+"\n", resource, totalCount, time.Since(started).Milliseconds())
+		fmt.Fprintf(syncEvents, `{"event":"sync_complete","resource":"%s","total":%d,"duration_ms":%d}`+"\n", resource, cachedCount, time.Since(started).Milliseconds())
 	}
 
 	if consumedTotal > 0 && totalCount == 0 && extractFailureTotal >= consumedTotal {
@@ -893,7 +963,7 @@ func syncResource(ctx context.Context, c interface {
 		}
 	}
 
-	return syncResult{Resource: resource, Count: totalCount, Duration: time.Since(started)}
+	return syncResult{Resource: resource, Count: cachedCount, Duration: time.Since(started)}
 }
 
 // paginationDefaults holds the resolved pagination parameter names and page size.
@@ -936,6 +1006,22 @@ func resourceSupportsPagination(resource string) bool {
 // endpoint declares none. Skipping the param for "" resources avoids
 // validation-error 400s on APIs that reject unknown query keys.
 func syncResourceSinceParam(resource string) string {
+	switch resource {
+	}
+	return ""
+}
+
+// syncResourceSortParam and syncResourceSortValue describe a spec-declared
+// ascending last-modified ordering. Sync adds them only when it sends a since
+// filter, because applying a sort to a full sync can change API behavior and
+// does not improve the watermark proof.
+func syncResourceSortParam(resource string) string {
+	switch resource {
+	}
+	return ""
+}
+
+func syncResourceSortValue(resource string) string {
 	switch resource {
 	}
 	return ""
@@ -1674,6 +1760,64 @@ func parseSinceDuration(s string) (time.Time, error) {
 	default:
 		return time.Time{}, fmt.Errorf("unknown unit %q", matches[2])
 	}
+}
+
+// restSyncTimestamp extracts a record-level last-modified timestamp from one
+// REST item. Nested child or metadata timestamps are deliberately ignored:
+// the incremental filter applies to the resource record, not its embedded
+// objects. Multiple candidate top-level timestamps are also rejected because
+// the generator cannot prove which one the endpoint sorts and filters on.
+func restSyncTimestamp(data json.RawMessage) (time.Time, bool) {
+	var value map[string]any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return time.Time{}, false
+	}
+	var newest time.Time
+	var found bool
+	matches := 0
+	for fieldName, child := range value {
+		if !restSyncTimestampField(fieldName) {
+			continue
+		}
+		text, ok := child.(string)
+		if !ok {
+			continue
+		}
+		ts, ok := parseRestSyncTimestamp(text)
+		if !ok {
+			continue
+		}
+		matches++
+		if !found || ts.After(newest) {
+			newest = ts
+			found = true
+		}
+	}
+	if matches != 1 {
+		return time.Time{}, false
+	}
+	return newest, true
+}
+
+func restSyncTimestampField(name string) bool {
+	normalized := strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(name))
+	return strings.Contains(normalized, "updated") ||
+		strings.Contains(normalized, "modified") ||
+		strings.Contains(normalized, "lastchanged") ||
+		strings.Contains(normalized, "lastmodified")
+}
+
+func parseRestSyncTimestamp(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
+		if ts, err := time.Parse(layout, value); err == nil {
+			return ts, true
+		}
+	}
+	return time.Time{}, false
 }
 
 func defaultSyncResources() []string {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1758,6 +1758,13 @@ func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj 
 }
 
 func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
+	return s.SaveSyncStateAt(resourceType, cursor, count, time.Now().UTC())
+}
+
+// SaveSyncStateAt stores both pagination progress and the incremental
+// watermark represented by at. Callers use this when the watermark belongs to
+// the data just fetched rather than to the instant the checkpoint is written.
+func (s *Store) SaveSyncStateAt(resourceType, cursor string, count int, at time.Time) error {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
 	_, err := s.db.Exec(
@@ -1765,7 +1772,23 @@ func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT(resource_type) DO UPDATE SET last_cursor = excluded.last_cursor,
 		 last_synced_at = excluded.last_synced_at, total_count = excluded.total_count`,
-		resourceType, cursor, time.Now().UTC().Format(time.RFC3339), count,
+		resourceType, cursor, at.UTC().Format(time.RFC3339), count,
+	)
+	return err
+}
+
+// SaveSyncProgress stores pagination progress without changing the
+// incremental watermark. A new row gets a parseable zero timestamp so
+// GetSyncState can scan it into time.Time without a NULL conversion error.
+func (s *Store) SaveSyncProgress(resourceType, cursor string, count int) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	_, err := s.db.Exec(
+		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(resource_type) DO UPDATE SET last_cursor = excluded.last_cursor,
+		 total_count = excluded.total_count`,
+		resourceType, cursor, time.Time{}.UTC().Format(time.RFC3339), count,
 	)
 	return err
 }

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -45,6 +45,8 @@ type syncResult struct {
 	Duration time.Duration
 }
 
+const syncWatermarkOverlap = time.Second
+
 func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var resources []string
 	var full bool
@@ -149,7 +151,7 @@ Resource scoping:
 			// Skip under --dry-run: a preview must not mutate sync-state (issue #2935).
 			if full && !c.DryRun {
 				for _, resource := range resources {
-					if err := db.SaveSyncState(resource, "", 0); err != nil {
+					if err := db.SaveSyncStateAt(resource, "", 0, time.Time{}); err != nil {
 						return fmt.Errorf("clearing sync state for %s: %w", resource, err)
 					}
 				}
@@ -170,15 +172,14 @@ Resource scoping:
 					maxPages = 1
 					// Clear the cursor so we start from the head each time;
 					// the goal of --latest-only is "refresh the top" not
-					// "resume from wherever I left off". Skip under --dry-run:
+					// "resume from wherever I left off". Clear the watermark too,
+					// so the head request does not inherit an old incremental window.
+					// Skip under --dry-run:
 					// a preview must not mutate sync-state (issue #2935).
 					if !c.DryRun {
 						for _, resource := range resources {
-							existing, _, _, _ := db.GetSyncState(resource)
-							if existing != "" {
-								if err := db.SaveSyncState(resource, "", 0); err != nil {
-									return fmt.Errorf("clearing sync state for %s: %w", resource, err)
-								}
+							if err := db.SaveSyncStateAt(resource, "", 0, time.Time{}); err != nil {
+								return fmt.Errorf("clearing sync state for %s: %w", resource, err)
 							}
 						}
 					}
@@ -432,6 +433,7 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	var totalCount int
+	requestedAt := started.UTC()
 
 	// Resume cursor from sync_state (unless --full cleared it)
 	existingCursor, lastSynced, _, _ := db.GetSyncState(resource)
@@ -475,6 +477,11 @@ func syncResource(ctx context.Context, c interface {
 	lastNextCursor := ""
 	capExitHit := false
 	capExitCursor := ""
+	capTruncated := false
+	var previousStoredAt time.Time
+	var newestStoredAt time.Time
+	timestampOrderSafe := true
+	timestampEvidence := false
 	// extractFailureTotal accumulates per-item primary-key extraction
 	// misses across pages within this resource sync. Resource-level
 	// concurrency is 1 (one goroutine per resource via the work channel)
@@ -510,6 +517,9 @@ func syncResource(ctx context.Context, c interface {
 		// Set since filter
 		if effectiveSince != "" {
 			params[sinceParam] = effectiveSince
+			if sortParam := syncResourceSortParam(resource); sortParam != "" {
+				params[sortParam] = syncResourceSortValue(resource)
+			}
 		}
 		// Apply user-supplied --param / --resource-param overrides last so they
 		// win over spec-derived defaults (e.g. forcing mine=true on a list
@@ -546,6 +556,23 @@ func syncResource(ctx context.Context, c interface {
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
+		if effectiveSince != "" && syncResourceSortParam(resource) != "" && maxPages > 0 {
+			for _, item := range items {
+				itemTimestamp, ok := restSyncTimestamp(item)
+				if !ok {
+					timestampOrderSafe = false
+					continue
+				}
+				timestampEvidence = true
+				if !previousStoredAt.IsZero() && itemTimestamp.Before(previousStoredAt) {
+					timestampOrderSafe = false
+				}
+				previousStoredAt = itemTimestamp
+				if newestStoredAt.IsZero() || itemTimestamp.After(newestStoredAt) {
+					newestStoredAt = itemTimestamp
+				}
+			}
+		}
 
 		// Page-int paginator fallback: when the API paginates by integer
 		// ?page=N and emits no body cursor, treat a full page as a signal
@@ -627,6 +654,11 @@ func syncResource(ctx context.Context, c interface {
 		extractFailureTotal += extractFailures + hydrateFailures
 		hydrateFailureTotal += hydrateFailures
 		pageFailureCount := extractFailures + hydrateFailures
+		if pageFailureCount > 0 {
+			// A timestamp from an item that did not reach the store cannot safely
+			// advance the incremental watermark past that item.
+			timestampOrderSafe = false
+		}
 
 		if fetchedThisPage > 0 && stored == 0 {
 			reason := "all_items_failed_id_extraction"
@@ -701,6 +733,7 @@ func syncResource(ctx context.Context, c interface {
 		if maxPages > 0 && pagesFetched >= maxPages {
 			truncatedByCap := resourceSupportsPagination(resource) && hasMore
 			truncatedByCap = truncatedByCap && !shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit)
+			capResumed := false
 			if truncatedByCap {
 				capExitCursor = nextCursor
 			}
@@ -712,7 +745,14 @@ func syncResource(ctx context.Context, c interface {
 					truncatedByCap = false
 				}
 			}
-			if truncatedByCap && capExitCursor != cursor {
+			capResumed = truncatedByCap && capExitCursor != cursor
+			capPageLimit := pageSize.limit
+			// A resume cursor alone does not prove that the page window was
+			// truncated. Only a full page with a real continuation advances a
+			// watermark; short cursor pages retain the cursor but leave the
+			// watermark unchanged.
+			capTruncated = capResumed && fetchedThisPage >= capPageLimit
+			if capResumed {
 				if !latestOnly {
 					capExitHit = true
 					if humanFriendly {
@@ -722,10 +762,17 @@ func syncResource(ctx context.Context, c interface {
 					}
 				}
 			}
-			// A cap break ends enumeration before exhausting the partition; mirror
-			// the dependent loop and treat it as incomplete (reconcile SKIPS). Safe
-			// default: when the cap may have truncated, never prune.
-			outcome.reason = "max_pages_cap"
+			// A cap break is incomplete when it has a continuation. A short
+			// page for page/offset pagination is a proven natural end even when
+			// the operator's page ceiling fired on that same request.
+			if capResumed {
+				outcome.reason = "max_pages_cap"
+			} else if !hasMore ||
+				shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, capPageLimit) {
+				outcome.complete = true
+			} else {
+				outcome.reason = "max_pages_cap"
+			}
 			break
 		}
 
@@ -772,8 +819,8 @@ func syncResource(ctx context.Context, c interface {
 		}
 
 		// Save cursor after each page for resumability
-		if err := db.SaveSyncState(resource, nextCursor, totalCount); err != nil {
-			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
+		if err := db.SaveSyncProgress(resource, nextCursor, totalCount); err != nil {
+			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync progress for %s: %w", resource, err), Duration: time.Since(started)}
 		}
 
 		cursor = nextCursor
@@ -812,14 +859,37 @@ func syncResource(ctx context.Context, c interface {
 		fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unsupported-resource-shape"}`+"\n", resource)
 	}
 
-	// Final sync state: clear cursor on natural completion, but preserve the
-	// resume cursor when an operator intentionally capped the page budget.
+	// Final sync state separates pagination progress from the incremental
+	// watermark. A checkpoint after a capped page may retain a resume cursor
+	// without claiming that records on pages we did not fetch were observed.
 	finalCursor := ""
 	if capExitHit {
 		finalCursor = capExitCursor
 	}
-	if err := db.SaveSyncState(resource, finalCursor, totalCount); err != nil {
-		return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, err), Duration: time.Since(started)}
+	cachedCount, countErr := db.Count(resource)
+	if countErr != nil {
+		return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("counting stored %s rows: %w", resource, countErr), Duration: time.Since(started)}
+	}
+	watermark := time.Time{}
+	if outcome.complete {
+		watermark = requestedAt.Add(-syncWatermarkOverlap)
+	} else if capTruncated && effectiveSince != "" && syncResourceSortParam(resource) != "" && timestampOrderSafe && timestampEvidence && !newestStoredAt.IsZero() {
+		watermark = newestStoredAt.Add(-syncWatermarkOverlap)
+	}
+	if !watermark.IsZero() {
+		// A positional or opaque cursor was issued for the old since window.
+		// Restart from the new watermark instead of combining two incompatible
+		// result windows on the next run.
+		finalCursor = ""
+	}
+	var stateErr error
+	if watermark.IsZero() {
+		stateErr = db.SaveSyncProgress(resource, finalCursor, cachedCount)
+	} else {
+		stateErr = db.SaveSyncStateAt(resource, finalCursor, cachedCount, watermark)
+	}
+	if stateErr != nil {
+		return syncResult{Resource: resource, Count: cachedCount, Err: fmt.Errorf("saving sync state for %s: %w", resource, stateErr), Duration: time.Since(started)}
 	}
 
 	// F4b symptom probe: if items were consumed and successfully
@@ -838,7 +908,7 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	if !humanFriendly {
-		fmt.Fprintf(syncEvents, `{"event":"sync_complete","resource":"%s","total":%d,"duration_ms":%d}`+"\n", resource, totalCount, time.Since(started).Milliseconds())
+		fmt.Fprintf(syncEvents, `{"event":"sync_complete","resource":"%s","total":%d,"duration_ms":%d}`+"\n", resource, cachedCount, time.Since(started).Milliseconds())
 	}
 
 	if consumedTotal > 0 && totalCount == 0 && extractFailureTotal >= consumedTotal {
@@ -854,7 +924,7 @@ func syncResource(ctx context.Context, c interface {
 		}
 	}
 
-	return syncResult{Resource: resource, Count: totalCount, Duration: time.Since(started)}
+	return syncResult{Resource: resource, Count: cachedCount, Duration: time.Since(started)}
 }
 
 // paginationDefaults holds the resolved pagination parameter names and page size.
@@ -906,6 +976,22 @@ func resourceSupportsPagination(resource string) bool {
 // endpoint declares none. Skipping the param for "" resources avoids
 // validation-error 400s on APIs that reject unknown query keys.
 func syncResourceSinceParam(resource string) string {
+	switch resource {
+	}
+	return ""
+}
+
+// syncResourceSortParam and syncResourceSortValue describe a spec-declared
+// ascending last-modified ordering. Sync adds them only when it sends a since
+// filter, because applying a sort to a full sync can change API behavior and
+// does not improve the watermark proof.
+func syncResourceSortParam(resource string) string {
+	switch resource {
+	}
+	return ""
+}
+
+func syncResourceSortValue(resource string) string {
 	switch resource {
 	}
 	return ""
@@ -1642,6 +1728,64 @@ func parseSinceDuration(s string) (time.Time, error) {
 	default:
 		return time.Time{}, fmt.Errorf("unknown unit %q", matches[2])
 	}
+}
+
+// restSyncTimestamp extracts a record-level last-modified timestamp from one
+// REST item. Nested child or metadata timestamps are deliberately ignored:
+// the incremental filter applies to the resource record, not its embedded
+// objects. Multiple candidate top-level timestamps are also rejected because
+// the generator cannot prove which one the endpoint sorts and filters on.
+func restSyncTimestamp(data json.RawMessage) (time.Time, bool) {
+	var value map[string]any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return time.Time{}, false
+	}
+	var newest time.Time
+	var found bool
+	matches := 0
+	for fieldName, child := range value {
+		if !restSyncTimestampField(fieldName) {
+			continue
+		}
+		text, ok := child.(string)
+		if !ok {
+			continue
+		}
+		ts, ok := parseRestSyncTimestamp(text)
+		if !ok {
+			continue
+		}
+		matches++
+		if !found || ts.After(newest) {
+			newest = ts
+			found = true
+		}
+	}
+	if matches != 1 {
+		return time.Time{}, false
+	}
+	return newest, true
+}
+
+func restSyncTimestampField(name string) bool {
+	normalized := strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(name))
+	return strings.Contains(normalized, "updated") ||
+		strings.Contains(normalized, "modified") ||
+		strings.Contains(normalized, "lastchanged") ||
+		strings.Contains(normalized, "lastmodified")
+}
+
+func parseRestSyncTimestamp(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
+		if ts, err := time.Parse(layout, value); err == nil {
+			return ts, true
+		}
+	}
+	return time.Time{}, false
 }
 
 func defaultSyncResources() []string {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -472,6 +472,9 @@ func syncResource(ctx context.Context, c interface {
 
 	cursor := existingCursor
 	pageSize := determinePaginationDefaults(resource)
+	sortParam := syncResourceSortParam(resource)
+	sortValue := syncResourceSortValue(resource)
+	sortEffective := false
 	var progressCount int64
 	pagesFetched := 0
 	lastNextCursor := ""
@@ -517,14 +520,15 @@ func syncResource(ctx context.Context, c interface {
 		// Set since filter
 		if effectiveSince != "" {
 			params[sinceParam] = effectiveSince
-			if sortParam := syncResourceSortParam(resource); sortParam != "" {
-				params[sortParam] = syncResourceSortValue(resource)
+			if sortParam != "" {
+				params[sortParam] = sortValue
 			}
 		}
 		// Apply user-supplied --param / --resource-param overrides last so they
 		// win over spec-derived defaults (e.g. forcing mine=true on a list
 		// endpoint whose OpenAPI spec marks the filter optional).
 		userParams.applyTo(resource, params, false)
+		sortEffective = effectiveSince != "" && sortParam != "" && sortValue != "" && params[sortParam] == sortValue
 
 		data, err := c.Get(ctx, path, params)
 		if err != nil {
@@ -556,7 +560,7 @@ func syncResource(ctx context.Context, c interface {
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
-		if effectiveSince != "" && syncResourceSortParam(resource) != "" && maxPages > 0 {
+		if sortEffective && maxPages > 0 {
 			for _, item := range items {
 				itemTimestamp, ok := restSyncTimestamp(item)
 				if !ok {
@@ -873,7 +877,7 @@ func syncResource(ctx context.Context, c interface {
 	watermark := time.Time{}
 	if outcome.complete {
 		watermark = requestedAt.Add(-syncWatermarkOverlap)
-	} else if capTruncated && effectiveSince != "" && syncResourceSortParam(resource) != "" && timestampOrderSafe && timestampEvidence && !newestStoredAt.IsZero() {
+	} else if capTruncated && sortEffective && timestampOrderSafe && timestampEvidence && !newestStoredAt.IsZero() {
 		watermark = newestStoredAt.Add(-syncWatermarkOverlap)
 	}
 	if !watermark.IsZero() {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -474,6 +474,7 @@ func syncResource(ctx context.Context, c interface {
 	pageSize := determinePaginationDefaults(resource)
 	sortParam := syncResourceSortParam(resource)
 	sortValue := syncResourceSortValue(resource)
+	sortField := syncResourceSortField(resource)
 	sortEffective := false
 	var progressCount int64
 	pagesFetched := 0
@@ -528,7 +529,7 @@ func syncResource(ctx context.Context, c interface {
 		// win over spec-derived defaults (e.g. forcing mine=true on a list
 		// endpoint whose OpenAPI spec marks the filter optional).
 		userParams.applyTo(resource, params, false)
-		sortEffective = effectiveSince != "" && sortParam != "" && sortValue != "" && params[sortParam] == sortValue
+		sortEffective = effectiveSince != "" && sortParam != "" && sortValue != "" && sortField != "" && params[sortParam] == sortValue
 
 		data, err := c.Get(ctx, path, params)
 		if err != nil {
@@ -562,7 +563,7 @@ func syncResource(ctx context.Context, c interface {
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
 		if sortEffective && maxPages > 0 {
 			for _, item := range items {
-				itemTimestamp, ok := restSyncTimestamp(item)
+				itemTimestamp, ok := restSyncTimestamp(item, sortField)
 				if !ok {
 					timestampOrderSafe = false
 					continue
@@ -996,6 +997,12 @@ func syncResourceSortParam(resource string) string {
 }
 
 func syncResourceSortValue(resource string) string {
+	switch resource {
+	}
+	return ""
+}
+
+func syncResourceSortField(resource string) string {
 	switch resource {
 	}
 	return ""
@@ -1734,21 +1741,24 @@ func parseSinceDuration(s string) (time.Time, error) {
 	}
 }
 
-// restSyncTimestamp extracts a record-level last-modified timestamp from one
-// REST item. Nested child or metadata timestamps are deliberately ignored:
-// the incremental filter applies to the resource record, not its embedded
-// objects. Multiple candidate top-level timestamps are also rejected because
-// the generator cannot prove which one the endpoint sorts and filters on.
-func restSyncTimestamp(data json.RawMessage) (time.Time, bool) {
+// restSyncTimestamp extracts the record-level timestamp for the exact field
+// used by the endpoint's incremental sort. Nested child or metadata timestamps
+// are deliberately ignored: the incremental filter applies to the resource
+// record, not its embedded objects. A missing or unparseable expected field is
+// unsafe, so this helper never falls back to another recognized timestamp.
+func restSyncTimestamp(data json.RawMessage, expectedField string) (time.Time, bool) {
 	var value map[string]any
 	if err := json.Unmarshal(data, &value); err != nil {
 		return time.Time{}, false
 	}
-	var newest time.Time
-	var found bool
+	expectedField = normalizeRestSyncTimestampField(expectedField)
+	if expectedField == "" || !restSyncTimestampField(expectedField) {
+		return time.Time{}, false
+	}
+	var timestamp time.Time
 	matches := 0
 	for fieldName, child := range value {
-		if !restSyncTimestampField(fieldName) {
+		if normalizeRestSyncTimestampField(fieldName) != expectedField {
 			continue
 		}
 		text, ok := child.(string)
@@ -1760,19 +1770,20 @@ func restSyncTimestamp(data json.RawMessage) (time.Time, bool) {
 			continue
 		}
 		matches++
-		if !found || ts.After(newest) {
-			newest = ts
-			found = true
-		}
+		timestamp = ts
 	}
 	if matches != 1 {
 		return time.Time{}, false
 	}
-	return newest, true
+	return timestamp, true
+}
+
+func normalizeRestSyncTimestampField(name string) string {
+	return strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(name))
 }
 
 func restSyncTimestampField(name string) bool {
-	normalized := strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(name))
+	normalized := normalizeRestSyncTimestampField(name)
 	return strings.Contains(normalized, "updated") ||
 		strings.Contains(normalized, "modified") ||
 		strings.Contains(normalized, "lastchanged") ||


### PR DESCRIPTION
## Summary

Capped incremental syncs could move the persisted watermark to the end of a request even when later pages were never fetched, causing the next run to skip records. Contradictory page profiles could also select the wrong pagination strategy and silently stop after one page. This PR makes cursor progress and incremental watermarks separate, advances a capped watermark only from safe ordered observations, and normalizes page and offset profiles before generation.

## Approach

- Add store writers that preserve the existing watermark during per-page progress and accept an explicit watermark timestamp for final state.
- Clear both cursor and watermark for full and latest-only resets. For capped incremental REST syncs, retain the old watermark when ordering or storage is not provably safe; otherwise use a one-second overlap and restart from the new watermark instead of combining it with an old cursor.
- Normalize missing and contradictory page or offset profile types, and only emit an incremental sort when the profile explicitly proves ascending last-modified order.
- Add generated fake-pager coverage for ordered, unordered, drained, capped, latest-only, nested-timestamp, failed-store, and offset cases, plus golden and generated-output proof.

## Scope

Primary area: generated REST sync, store checkpoint helpers, and pagination profiling.

Why this belongs in the Printing Press: the defect was emitted by shared generator contracts and affected every printed CLI using the affected pagination shapes.

## Risk

Generated REST sync state semantics and generated source output change. GraphQL and dependent-resource checkpoint paths remain unchanged, and no MCP or auth surface changes.

## Verification

- `go test ./internal/profiler -count=1`
- Focused generated sync and persistence tests in `internal/generator`
- `scripts/golden.sh verify` passed 32 cases
- `scripts/verify-generator-output.sh` passed 10 generated cases
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go vet ./...`
- Repository-wide `go test ./...` was attempted locally but hit unrelated macOS Keychain and broad generated-suite timeouts; the changed package suites and generated-output gates passed.
- `golangci-lint run ./...` was attempted and reports one unchanged baseline `modernize` finding at `internal/googlediscovery/parser.go:455`.

Closes #3842
Closes #3538
