### PR TITLE
fix(cli): align generated auth diagnostics

### DIFF
--- a/internal/generator/doctor_auth_status_test.go
+++ b/internal/generator/doctor_auth_status_test.go
@@ -2,9 +2,11 @@ package generator
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/require"
 )
@@ -181,4 +183,240 @@ func TestDoctorPreservesConfiguredUserAgentWhenAuthInIsEmpty(t *testing.T) {
 		"doctor probe must assign the configured UA when Auth.In is empty (defaults to header)")
 	require.NotContains(t, doctor, `authHeaders["User-Agent"] = "ua-auth-empty-in-pp-cli"`,
 		"doctor must not emit the hardcoded UA fallback when Auth.Header is User-Agent, even with Auth.In empty")
+}
+
+func TestCookieAuthDiagnosticsUseCredentialPresence(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("cookie-credential-presence")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:         "cookie",
+		Header:       "Cookie",
+		CookieDomain: ".example.com",
+		Cookies:      []string{"session_id"},
+		EnvVars:      []string{"COOKIE_CREDENTIAL_PRESENCE_SESSION"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "cookie-credential-presence-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	configSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	config := string(configSrc)
+	require.Contains(t, config, "func (c *Config) CredentialConfigured() bool")
+	require.Contains(t, funcBody(t, config, "func (c *Config) hasCredentialFields() bool {"),
+		"if c.CookieCredential() != \"\" {")
+	require.Contains(t, funcBody(t, config, "func (c *Config) hasCompleteCredentialFields() bool {"),
+		"if c.CookieCredential() != \"\" {")
+
+	authSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "auth.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(authSrc), "credentialConfigured := cfg.CredentialConfigured()")
+
+	doctorSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "doctor.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(doctorSrc), "credentialConfigured, authSource := doctorAuthConfiguredState(cfg)")
+	require.Contains(t, string(doctorSrc), "if cfg != nil && cfg.CredentialConfigured()")
+	require.Contains(t, string(doctorSrc), "authHeader = cfg.CookieCredential()")
+
+	runtimeTest := `package config
+
+import "testing"
+
+func TestCookieCredentialConfiguredUsesRawCookie(t *testing.T) {
+	cfg := &Config{AccessToken: "session_id=abc123"}
+	if !cfg.CredentialConfigured() {
+		t.Fatal("raw cookie credential should count as configured")
+	}
+
+	if !(&Config{AuthHeaderVal: "Cookie: session_id=abc123"}).CredentialConfigured() {
+		t.Fatal("explicit auth header should count as configured")
+	}
+
+	if (&Config{}).CredentialConfigured() {
+		t.Fatal("empty cookie credential should not count as configured")
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "config", "cookie_credential_presence_test.go"), []byte(runtimeTest), 0o644))
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "^TestCookieCredentialConfiguredUsesRawCookie$", "-count=1")
+}
+
+func TestComposedAuthDiagnosticsUseCredentialPresence(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("composed-credential-presence")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:         "composed",
+		Header:       "Authorization",
+		CookieDomain: ".example.com",
+		Cookies:      []string{"session_id"},
+		EnvVars:      []string{"COMPOSED_CREDENTIAL_PRESENCE_SESSION"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "composed-credential-presence-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	configSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(configSrc), "func (c *Config) CredentialConfigured() bool")
+	require.Contains(t, string(configSrc), `return c.AuthHeader() != "" || c.CookieCredential() != ""`)
+
+	doctorSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "doctor.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(doctorSrc), "credentialConfigured, authSource := doctorAuthConfiguredState(cfg)")
+	require.Contains(t, string(doctorSrc), "authHeader = cfg.CookieCredential()")
+
+	runtimeTest := `package config
+
+import "testing"
+
+func TestComposedCredentialConfiguredUsesRawCookie(t *testing.T) {
+	if !(&Config{AccessToken: "session_id=abc123"}).CredentialConfigured() {
+		t.Fatal("raw composed cookie credential should count as configured")
+	}
+
+	if (&Config{}).CredentialConfigured() {
+		t.Fatal("empty composed cookie credential should not count as configured")
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "config", "composed_credential_presence_test.go"), []byte(runtimeTest), 0o644))
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "^TestComposedCredentialConfiguredUsesRawCookie$", "-count=1")
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	binaryPath := filepath.Join(outputDir, naming.CLI(apiSpec.Name))
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/"+naming.CLI(apiSpec.Name))
+	env := append(doctorEnv(t.TempDir(), naming.EnvPrefix(apiSpec.Name)), "COMPOSED_CREDENTIAL_PRESENCE_SESSION=session_id=abc123")
+	payload, err := runDoctorJSON(t, binaryPath, env)
+	require.NoError(t, err)
+	require.Equal(t, "configured (browser session)", payload["auth"])
+
+	cmd := exec.Command(binaryPath, "auth", "status")
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "auth status output: %s", out)
+	require.Contains(t, string(out), "Authenticated")
+}
+
+func TestGeneratedCookieDiagnosticsReportConfiguredCredentials(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("cookie-diagnostics-runtime")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:         "cookie",
+		Header:       "Cookie",
+		CookieDomain: ".example.com",
+		Cookies:      []string{"session_id"},
+		EnvVars:      []string{"COOKIE_DIAGNOSTICS_RUNTIME_SESSION"},
+	}
+	_, binaryPath := buildGeneratedBinary(t, apiSpec)
+	prefix := naming.EnvPrefix(apiSpec.Name)
+	env := append(doctorEnv(t.TempDir(), prefix), "COOKIE_DIAGNOSTICS_RUNTIME_SESSION=session_id=abc123")
+
+	payload, err := runDoctorJSON(t, binaryPath, env)
+	require.NoError(t, err)
+	require.Equal(t, "configured (browser session)", payload["auth"])
+
+	cmd := exec.Command(binaryPath, "auth", "status")
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "auth status output: %s", out)
+	require.Contains(t, string(out), "Authenticated")
+}
+
+func TestHeaderAuthDiagnosticsKeepAuthHeaderPresence(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("header-credential-presence")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:    "bearer_token",
+		Header:  "Authorization",
+		EnvVars: []string{"HEADER_CREDENTIAL_PRESENCE_TOKEN"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "header-credential-presence-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	runtimeTest := `package config
+
+import "testing"
+
+func TestHeaderCredentialConfiguredUsesAuthHeader(t *testing.T) {
+	cfg := &Config{AuthHeaderVal: "Bearer header-token"}
+	if !cfg.CredentialConfigured() {
+		t.Fatal("header credential should count as configured")
+	}
+
+	if (&Config{}).CredentialConfigured() {
+		t.Fatal("empty header credential should not count as configured")
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "config", "header_credential_presence_test.go"), []byte(runtimeTest), 0o644))
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "^TestHeaderCredentialConfiguredUsesAuthHeader$", "-count=1")
+}
+
+func TestDoctorAuthHookSupportsHandCodedAuthAndSurvivesRegeneration(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("custom-doctor-auth")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:    "bearer_token",
+		Header:  "Authorization",
+		EnvVars: []string{"CUSTOM_DOCTOR_AUTH_TOKEN"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "custom-doctor-auth-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	customAuth := `package cli
+
+func init() {
+	doctorAuthConfiguredHook = func() (bool, string) {
+		return true, "custom auth"
+	}
+}
+`
+	customAuthPath := filepath.Join(outputDir, "internal", "cli", "custom_auth.go")
+	require.NoError(t, os.WriteFile(customAuthPath, []byte(customAuth), 0o644))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	gotCustomAuth, err := os.ReadFile(customAuthPath)
+	require.NoError(t, err)
+	require.Equal(t, customAuth, string(gotCustomAuth), "regeneration must preserve hand-coded auth")
+
+	doctorSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "doctor.go"))
+	require.NoError(t, err)
+	doctor := string(doctorSrc)
+	require.Contains(t, doctor, "var doctorAuthConfiguredHook func() (bool, string)")
+	require.Contains(t, doctor, "func doctorAuthConfiguredState(cfg *config.Config) (bool, string)")
+	require.Contains(t, doctor, "configured, authSource := doctorAuthConfiguredState(cfg)")
+
+	runtimeTest := `package cli
+
+import "testing"
+
+func TestDoctorAuthConfiguredHook(t *testing.T) {
+	configured, source := doctorAuthConfiguredState(nil)
+	if !configured || source != "custom auth" {
+		t.Fatalf("doctor auth hook = (%v, %q), want (true, custom auth)", configured, source)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "custom_auth_test.go"), []byte(runtimeTest), 0o644))
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "^TestDoctorAuthConfiguredHook$", "-count=1")
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	binaryPath := filepath.Join(outputDir, naming.CLI(apiSpec.Name))
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/"+naming.CLI(apiSpec.Name))
+	env := doctorEnv(t.TempDir(), naming.EnvPrefix(apiSpec.Name))
+	payload, err := runDoctorJSON(t, binaryPath, env)
+	require.NoError(t, err)
+	require.Equal(t, "configured", payload["auth"])
+	require.Equal(t, "custom auth", payload["auth_source"])
+	require.Contains(t, payload["env_vars"], "credentials available from custom auth")
 }

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -1308,8 +1308,8 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			w := cmd.OutOrStdout()
-			header := cfg.AuthHeader()
-			if header == "" {
+			credentialConfigured := cfg.CredentialConfigured()
+			if !credentialConfigured {
 {{- if eq .Auth.Type "none"}}
 				// This CLI ships with auth.type:none — no credentials are ever
 				// required. Report ok status so agents don't treat `auth status`

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -905,6 +905,19 @@ func (c *Config) CookieCredential() string {
 }
 {{- end}}
 
+// Raw browser-session values count as credentials even when no header
+// representation exists; hand-coded flows may also preserve a working header.
+func (c *Config) CredentialConfigured() bool {
+	if c == nil {
+		return false
+	}
+{{- if or (eq .Auth.Type "composed") (eq .Auth.Type "cookie")}}
+	return c.AuthHeader() != "" || c.CookieCredential() != ""
+{{- else}}
+	return c.AuthHeader() != ""
+{{- end}}
+}
+
 func applyAuthFormat(format string, replacements map[string]string) string {
 	if format == "" {
 		return ""
@@ -988,6 +1001,11 @@ func (c *Config) hasCredentialFields() bool {
 		c.ClientSecret != "" {
 		return true
 	}
+{{- if or (eq .Auth.Type "composed") (eq .Auth.Type "cookie")}}
+	if c.CookieCredential() != "" {
+		return true
+	}
+{{- end}}
 {{- range .CredentialFields}}
 	if c.{{.GoField}} != "" {
 		return true
@@ -1000,6 +1018,11 @@ func (c *Config) hasCompleteCredentialFields() bool {
 	if c.AuthHeaderVal != "" {
 		return true
 	}
+{{- if or (eq .Auth.Type "composed") (eq .Auth.Type "cookie")}}
+	if c.CookieCredential() != "" {
+		return true
+	}
+{{- end}}
 	{{- if eq .Auth.Type "api_key"}}
 	{{- $basicAuthEnvVars := basicAuthEnvVars .Auth}}
 	{{- if $basicAuthEnvVars}}

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -53,6 +53,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Hand-coded auth flows can report credentials that are intentionally not
+// represented by the generated Config fields. Assign this from a same-package
+// author file after generation. This is a presence signal only; custom flows
+// own their transport and credential-probe validation.
+var doctorAuthConfiguredHook func() (bool, string)
+
+func doctorAuthConfiguredState(cfg *config.Config) (bool, string) {
+	if cfg != nil && cfg.CredentialConfigured() {
+		return true, cfg.AuthSource
+	}
+	if doctorAuthConfiguredHook != nil {
+		return doctorAuthConfiguredHook()
+	}
+	return false, ""
+}
+
 // looksLikeDoctorInterstitial reports whether the response body matches a known
 // bot-detection challenge page (Cloudflare, Akamai, Vercel, AWS WAF, DataDome,
 // PerimeterX). Only fires on the doctor probe — used to distinguish "transport
@@ -261,17 +277,22 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				report["auth"] = "inferred (not configured)"
 			}
 {{- else if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
-			if cfg != nil {
-				header := cfg.AuthHeader()
-				if header == "" {
-					report["auth"] = "not configured"
-					report["auth_hint"] = "{{.Name}}-pp-cli auth login --chrome"
-				} else {
-					authConfigured = true
+			credentialConfigured, authSource := doctorAuthConfiguredState(cfg)
+			if !credentialConfigured {
+				report["auth"] = "not configured"
+				report["auth_hint"] = "{{.Name}}-pp-cli auth login --chrome"
+			} else {
+				authConfigured = true
+				report["auth"] = "configured"
+				report["auth_source"] = authSource
+				if cfg != nil && cfg.CredentialConfigured() {
 					report["auth"] = "configured (browser session)"
-					report["auth_source"] = cfg.AuthSource
 					report["auth_domain"] = "{{.Auth.CookieDomain}}"
 {{- if .Auth.RequiresBrowserSession}}
+					header := cfg.AuthHeader()
+					if header == "" {
+						header = cfg.CookieCredential()
+					}
 					if proofOK, proofDetail := browserSessionProofStatus(cfg, header); proofOK {
 						report["browser_session_proof"] = "valid"
 						report["browser_session_proof_detail"] = proofDetail
@@ -354,8 +375,8 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					}
 				}
 				{{- else}}
-				header := cfg.AuthHeader()
-				if header == "" {
+				configured, authSource := doctorAuthConfiguredState(cfg)
+				if !configured {
 {{- if .Auth.Optional}}
 					report["auth"] = "optional — not configured"
 {{- else}}
@@ -379,7 +400,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				} else {
 					authConfigured = true
 					report["auth"] = "configured"
-					report["auth_source"] = cfg.AuthSource
+					report["auth_source"] = authSource
 				}
 				{{- end}}
 			}
@@ -593,6 +614,11 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 
 					// Step 2: Validate credentials with an authenticated probe.
 					authHeader := cfg.AuthHeader()
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+					if authHeader == "" {
+						authHeader = cfg.CookieCredential()
+					}
+{{- end}}
 					if authHeader == "" {
 						// No auth configured — skip credential validation
 {{- if .Auth.RequiresBrowserSession}}

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
@@ -318,8 +318,8 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			w := cmd.OutOrStdout()
-			header := cfg.AuthHeader()
-			if header == "" {
+			credentialConfigured := cfg.CredentialConfigured()
+			if !credentialConfigured {
 				if v := os.Getenv("COOKIE_AUTH_SESSION"); v != "" {
 					fmt.Fprintln(w, green("Authenticated"))
 					fmt.Fprintf(w, "  Source: %s env var\n", "COOKIE_AUTH_SESSION")

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/config/config.go
@@ -272,6 +272,15 @@ func (c *Config) AuthHeader() string {
 	return ""
 }
 
+// Raw browser-session values count as credentials even when no header
+// representation exists; hand-coded flows may also preserve a working header.
+func (c *Config) CredentialConfigured() bool {
+	if c == nil {
+		return false
+	}
+	return c.AuthHeader() != ""
+}
+
 func applyAuthFormat(format string, replacements map[string]string) string {
 	if format == "" {
 		return ""

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
@@ -264,6 +264,15 @@ func (c *Config) AuthHeader() string {
 	return ""
 }
 
+// Raw browser-session values count as credentials even when no header
+// representation exists; hand-coded flows may also preserve a working header.
+func (c *Config) CredentialConfigured() bool {
+	if c == nil {
+		return false
+	}
+	return c.AuthHeader() != ""
+}
+
 func applyAuthFormat(format string, replacements map[string]string) string {
 	if format == "" {
 		return ""

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/config/config.go
@@ -265,6 +265,15 @@ func (c *Config) AuthHeader() string {
 	return ""
 }
 
+// Raw browser-session values count as credentials even when no header
+// representation exists; hand-coded flows may also preserve a working header.
+func (c *Config) CredentialConfigured() bool {
+	if c == nil {
+		return false
+	}
+	return c.AuthHeader() != ""
+}
+
 func applyAuthFormat(format string, replacements map[string]string) string {
 	if format == "" {
 		return ""

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/doctor.go
@@ -20,6 +20,22 @@ import (
 	"printing-press-rich-pp-cli/internal/store"
 )
 
+// Hand-coded auth flows can report credentials that are intentionally not
+// represented by the generated Config fields. Assign this from a same-package
+// author file after generation. This is a presence signal only; custom flows
+// own their transport and credential-probe validation.
+var doctorAuthConfiguredHook func() (bool, string)
+
+func doctorAuthConfiguredState(cfg *config.Config) (bool, string) {
+	if cfg != nil && cfg.CredentialConfigured() {
+		return true, cfg.AuthSource
+	}
+	if doctorAuthConfiguredHook != nil {
+		return doctorAuthConfiguredHook()
+	}
+	return false, ""
+}
+
 // looksLikeDoctorInterstitial reports whether the response body matches a known
 // bot-detection challenge page (Cloudflare, Akamai, Vercel, AWS WAF, DataDome,
 // PerimeterX). Only fires on the doctor probe — used to distinguish "transport
@@ -188,14 +204,14 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			// Check auth
 			authConfigured := false
 			if cfg != nil {
-				header := cfg.AuthHeader()
-				if header == "" {
+				configured, authSource := doctorAuthConfiguredState(cfg)
+				if !configured {
 					report["auth"] = "not configured"
 					report["auth_hint"] = "Set your API key with: export RICH_AUTH_API_KEY=\"your-token-here\""
 				} else {
 					authConfigured = true
 					report["auth"] = "configured"
-					report["auth_source"] = cfg.AuthSource
+					report["auth_source"] = authSource
 				}
 			}
 

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/config/config.go
@@ -289,6 +289,15 @@ func (c *Config) AuthHeader() string {
 	return token
 }
 
+// Raw browser-session values count as credentials even when no header
+// representation exists; hand-coded flows may also preserve a working header.
+func (c *Config) CredentialConfigured() bool {
+	if c == nil {
+		return false
+	}
+	return c.AuthHeader() != ""
+}
+
 func applyAuthFormat(format string, replacements map[string]string) string {
 	if format == "" {
 		return ""

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/doctor.go
@@ -20,6 +20,22 @@ import (
 	"printing-press-golden-pp-cli/internal/store"
 )
 
+// Hand-coded auth flows can report credentials that are intentionally not
+// represented by the generated Config fields. Assign this from a same-package
+// author file after generation. This is a presence signal only; custom flows
+// own their transport and credential-probe validation.
+var doctorAuthConfiguredHook func() (bool, string)
+
+func doctorAuthConfiguredState(cfg *config.Config) (bool, string) {
+	if cfg != nil && cfg.CredentialConfigured() {
+		return true, cfg.AuthSource
+	}
+	if doctorAuthConfiguredHook != nil {
+		return doctorAuthConfiguredHook()
+	}
+	return false, ""
+}
+
 // looksLikeDoctorInterstitial reports whether the response body matches a known
 // bot-detection challenge page (Cloudflare, Akamai, Vercel, AWS WAF, DataDome,
 // PerimeterX). Only fires on the doctor probe — used to distinguish "transport
@@ -188,14 +204,14 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			// Check auth
 			authConfigured := false
 			if cfg != nil {
-				header := cfg.AuthHeader()
-				if header == "" {
+				configured, authSource := doctorAuthConfiguredState(cfg)
+				if !configured {
 					report["auth"] = "not configured"
 					report["auth_hint"] = "Set your API key with: export PRINTING_PRESS_GOLDEN_API_KEY=\"your-token-here\""
 				} else {
 					authConfigured = true
 					report["auth"] = "configured"
-					report["auth_source"] = cfg.AuthSource
+					report["auth_source"] = authSource
 				}
 			}
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/config/config.go
@@ -247,6 +247,15 @@ func (c *Config) AuthHeader() string {
 	return token
 }
 
+// Raw browser-session values count as credentials even when no header
+// representation exists; hand-coded flows may also preserve a working header.
+func (c *Config) CredentialConfigured() bool {
+	if c == nil {
+		return false
+	}
+	return c.AuthHeader() != ""
+}
+
 func applyAuthFormat(format string, replacements map[string]string) string {
 	if format == "" {
 		return ""

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/doctor.go
@@ -20,6 +20,22 @@ import (
 	"tier-routing-golden-pp-cli/internal/store"
 )
 
+// Hand-coded auth flows can report credentials that are intentionally not
+// represented by the generated Config fields. Assign this from a same-package
+// author file after generation. This is a presence signal only; custom flows
+// own their transport and credential-probe validation.
+var doctorAuthConfiguredHook func() (bool, string)
+
+func doctorAuthConfiguredState(cfg *config.Config) (bool, string) {
+	if cfg != nil && cfg.CredentialConfigured() {
+		return true, cfg.AuthSource
+	}
+	if doctorAuthConfiguredHook != nil {
+		return doctorAuthConfiguredHook()
+	}
+	return false, ""
+}
+
 // looksLikeDoctorInterstitial reports whether the response body matches a known
 // bot-detection challenge page (Cloudflare, Akamai, Vercel, AWS WAF, DataDome,
 // PerimeterX). Only fires on the doctor probe — used to distinguish "transport
@@ -188,14 +204,14 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			// Check auth
 			authConfigured := false
 			if cfg != nil {
-				header := cfg.AuthHeader()
-				if header == "" {
+				configured, authSource := doctorAuthConfiguredState(cfg)
+				if !configured {
 					report["auth"] = "not configured"
 					report["auth_hint"] = "Set it with: tier-routing-golden-pp-cli auth set-token <token> or export TIER_GLOBAL_TOKEN=\"your-token-here\""
 				} else {
 					authConfigured = true
 					report["auth"] = "configured"
-					report["auth_source"] = cfg.AuthSource
+					report["auth_source"] = authSource
 				}
 			}
 


### PR DESCRIPTION
## Intent

Valid cookie-session credentials can be present while generated auth status and doctor report them as missing. Hand-coded auth flows have the same problem in doctor when their credentials are intentionally outside the generated config.

Closes #3925
Closes #3823

## Approach

Generated diagnostics now use one credential-presence contract. Cookie and composed auth recognize raw session credentials as well as explicit headers, while ordinary header auth keeps its existing behavior. Doctor also exposes a regeneration-safe same-package hook for hand-coded auth so Auth and Env Vars report the flow's configured source; the hook is presence-only and leaves custom transport validation to the custom flow.

## Scope

Primary area: Printing Press generator templates and generated-output regression coverage.

Why this belongs in this repo: the false verdict is emitted by the generator and would otherwise recur in every newly printed CLI.

## Risk

This changes generated config, auth status, and doctor diagnostics, plus their golden outputs. The request path remains unchanged, and the raw cookie fallback continues to use the generated cookie jar for live requests.

## Output Contract

The generated `Config` exposes `CredentialConfigured()`. Cookie and composed doctor output can report browser-session credentials from raw cookie storage, and hand-coded auth authors can assign `doctorAuthConfiguredHook` from a preserved same-package file. Generated golden fixtures and compiled runtime cases cover the emitted contract.

## Verification

- [x] Focused generated auth regressions for cookie, composed, header, and custom-auth flows passed in a decoy profile
- [x] `scripts/golden.sh verify` passed all 32 cases
- [x] `scripts/verify-generator-output.sh` passed all 10 cases
- [x] `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- [x] `go vet ./internal/generator`
- [x] `golangci-lint run ./internal/generator`
- Full generator-package execution reached the unrelated existing `TestGeneratedPlatformCredentialResolverSupportsPreservedDownstreamAdapter` timeout after its generated validation legs passed; the changed-surface tests above passed.
