### PR TITLE
fix(skills): migrate retro issue taxonomy labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This repo is **the machine** (generator, templates, binary, skills) that produce
 - **Don't change the machine for one CLI's edge case.** If a fix helps one API but breaks another, guard it with a clear conditional or leave it as a printed-CLI fix.
 - **Don't hardcode API/site names in reusable artifacts.** Skills, templates, generator code, prompts, and shared docs must use placeholders (`<api>`, `<site>`, "the target site") unless the text is explicitly an example or test fixture.
 - **Update dependent verifiers in the same change.** A new generator capability that affects scoring requires a scorer update; one that changes the MCP surface requires an audit update.
-When iterating on a printed CLI to discover issues, label findings as systemic (retro candidate) vs specific (printed-CLI fix).
+When iterating on a printed CLI to discover issues, classify findings as systemic (retro candidate) vs specific (printed-CLI fix).
 
 ### Anti-reimplementation
 A printed CLI wraps an API; it does not replace one. Novel-feature commands must call the real endpoint or read from the local store populated by sync.
@@ -172,6 +172,14 @@ Before implementation, claim the issue: assign it to yourself (or the GitHub use
 If the issue already has an assignee, treat that as active ownership until you can determine otherwise from recent activity or direct confirmation. For a plausibly stale assignment, ask the current assignee by tagging them in an issue comment before taking over or reassigning the issue.
 
 If you stop, abandon, or hand off before opening a PR, unclaim: remove the assignment and comment so the next picker-upper knows it is free. No need to unclaim on success — a merged PR closes the issue.
+
+## Issue Taxonomy and Relationships
+
+For actionable GitHub issues, including retro work-unit issues, apply exactly one `priority:P1|P2|P3` label, exactly one real issue type (`bug` or `enhancement`), and exactly one primary `comp:<slug>` component label. `source:retro` is optional provenance; legacy `retro` is accepted only while the provenance-label cutover is in progress and is never an issue type. Optional surface labels are a closed vocabulary: `surface:cli`, `surface:auth`, `surface:sync`, `surface:store`, `surface:mcp`, `surface:docs`, `surface:verify`, `surface:sniff`, and `surface:publish`; normally apply one, and never more than two, when evidence supports them. Components identify ownership; surfaces identify affected behavior.
+
+Routing outcomes `duplicate`, `invalid`, `wontfix`, and `question` are exempt from the actionable-field requirement. `documentation` and `good first issue` are overlays; they do not replace an actionable issue's priority, type, or primary component. PR queue labels are governed by the separate PR guidance below and are PR-only, outside the issue taxonomy.
+
+Keep retro work units as flat top-level issues. When a work unit declares a real prerequisite, represent it with GitHub's native `blocked-by`/`blocking` relationship; ordinary related-area or prior-retro references remain prose links in `Related issues` and must not be promoted to dependencies merely because they are adjacent. The `pp-fix-batch` queue derives readiness from an open, unassigned issue with the required priority and type labels (and its primary component for actionable work), not from provenance or routing labels; an unresolved native prerequisite remains a dependency, not a substitute label.
 
 ## Commit Style
 Format: `type(scope): description`. Both type and scope are required.

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -573,7 +573,35 @@ func TestRetroIssueTaxonomyAndRelationshipContracts(t *testing.T) {
 	assert.Contains(t, createBlock, "--remove-label enhancement")
 	assert.Contains(t, createBlock, "--add-blocked-by")
 	assert.Contains(t, createBlock, "Related-area references")
+	assert.Contains(t, createBlock, "declare -A OUTCOME_ISSUE_NUM_BY_WU_ID SORTED_WU_ID_SEEN")
+	assert.Contains(t, createBlock, "SORTED_WU_IDS")
+	assert.Contains(t, createBlock, "WU-2|wu:WU-1")
+	assert.Contains(t, createBlock, "OUTCOME_ISSUE_NUM_BY_WU_ID[$dependent_id]")
+	assert.Contains(t, createBlock, "OUTCOME_ISSUE_NUM_BY_WU_ID[$prerequisite_id]")
+	assert.Contains(t, createBlock, "remains correct when a P1 WU-2 sorts before a P2 WU-1")
+	assert.NotContains(t, createBlock, "dependent_wu_index|wu:<prerequisite_wu_index>")
+	assert.NotContains(t, createBlock, "OUTCOME_ISSUE_NUM[$")
 	assert.Contains(t, issueTemplate, "Apply labels: $RETRO_PROVENANCE_LABEL, bug or enhancement")
+	assert.Contains(t, issueTemplate, "stable WU-N identifiers from each")
+	assert.Contains(t, issueTemplate, "Dependency edges use these stable IDs, never sorted array positions")
+}
+
+func TestRetroDependencyStableIDsSurvivePriorityReorder(t *testing.T) {
+	// WU-2 was originally second, but its P1 priority sorts it before WU-1.
+	sortedWUIds := []string{"WU-2", "WU-1"}
+	issueNumbersByWUId := map[string]string{
+		"WU-2": "202",
+		"WU-1": "201",
+	}
+
+	edgeParts := strings.SplitN("WU-2|wu:WU-1", "|", 2)
+	dependentID := edgeParts[0]
+	prerequisiteID := strings.TrimPrefix(edgeParts[1], "wu:")
+
+	assert.Equal(t, "WU-2", sortedWUIds[0])
+	assert.Equal(t, "202", issueNumbersByWUId[dependentID])
+	assert.Equal(t, "201", issueNumbersByWUId[prerequisiteID])
+	assert.NotEqual(t, issueNumbersByWUId[dependentID], issueNumbersByWUId[prerequisiteID])
 }
 
 func TestPrintingPressSkillRunERequiredInputContract(t *testing.T) {

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -494,6 +494,88 @@ func TestSkillsProhibitProposalFallbackForRequestedArtifacts(t *testing.T) {
 	assert.Contains(t, holdBlock, "The only public-library PR this menu may lead to is the explicit `blocked-apis.json` journal option")
 }
 
+func TestRetroIssueTaxonomyAndRelationshipContracts(t *testing.T) {
+	t.Parallel()
+
+	agents := readContractFile(t, filepath.Join("..", "..", "AGENTS.md"))
+	ownershipEnd := strings.Index(agents, "## Commit Style")
+	taxonomyStart := strings.Index(agents, "## Issue Taxonomy and Relationships")
+	require.GreaterOrEqual(t, taxonomyStart, 0, "AGENTS.md must define the issue taxonomy")
+	require.Greater(t, taxonomyStart, strings.Index(agents, "## Issue Work Ownership"))
+	require.Less(t, taxonomyStart, ownershipEnd, "taxonomy must immediately follow Issue Work Ownership")
+	taxonomy := substringBetween(t, agents, "## Issue Taxonomy and Relationships", "## Commit Style")
+	assert.Contains(t, taxonomy, "exactly one `priority:P1|P2|P3`")
+	assert.Contains(t, taxonomy, "exactly one real issue type (`bug` or `enhancement`)")
+	assert.Contains(t, taxonomy, "exactly one primary `comp:<slug>`")
+	assert.Contains(t, taxonomy, "`source:retro` is optional provenance")
+	assert.Contains(t, taxonomy, "`surface:cli`, `surface:auth`, `surface:sync`, `surface:store`, `surface:mcp`, `surface:docs`, `surface:verify`, `surface:sniff`, and `surface:publish`")
+	assert.Contains(t, taxonomy, "normally apply one, and never more than two")
+	assert.Contains(t, taxonomy, "Components identify ownership; surfaces identify affected behavior")
+	assert.Contains(t, taxonomy, "Routing outcomes `duplicate`, `invalid`, `wontfix`, and `question`")
+	assert.Contains(t, taxonomy, "`documentation` and `good first issue` are overlays")
+	assert.Contains(t, taxonomy, "PR-only, outside the issue taxonomy")
+	assert.Contains(t, taxonomy, "native `blocked-by`/`blocking` relationship")
+	assert.Contains(t, taxonomy, "ordinary related-area or prior-retro references remain prose links")
+	assert.Contains(t, taxonomy, "`pp-fix-batch` queue derives readiness")
+	assert.NotContains(t, taxonomy, "ready-to-merge")
+	assert.NotContains(t, taxonomy, "queued")
+	assert.NotContains(t, taxonomy, "dequeued")
+	assert.NotContains(t, taxonomy, "ready-for-maintainer")
+	assert.Contains(t, agents[:taxonomyStart], "classify findings as systemic")
+	assert.NotContains(t, agents[:taxonomyStart], "label findings as systemic")
+
+	claude := strings.TrimSpace(readContractFile(t, filepath.Join("..", "..", "CLAUDE.md")))
+	assert.Equal(t, "@AGENTS.md", claude, "CLAUDE.md must import AGENTS.md instead of duplicating the contract")
+
+	retroSkill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-retro", "SKILL.md"))
+	typeMapping := substringBetween(t, retroSkill, "### Actionable issue type mapping", "**4. Where in the Printing Press does this originate?**")
+	for _, category := range []string{
+		"| Bug | `bug` |",
+		"| Scorer bug | `bug` |",
+		"| Assumption mismatch | `bug` |",
+		"| Default gap | `bug` |",
+		"| Template gap | `enhancement` |",
+		"| Recurring friction | `enhancement` |",
+		"| Missing scaffolding | `enhancement` |",
+		"| Discovered optimization | `enhancement` |",
+		"| Skill instruction gap | `enhancement` |",
+	} {
+		assert.Contains(t, typeMapping, category)
+	}
+	assert.Contains(t, typeMapping, "`bug` wins")
+	assert.Contains(t, retroSkill, "source:retro")
+	assert.Contains(t, retroSkill, "native `blocked-by`/`blocking` relationships")
+	assert.NotContains(t, retroSkill, "Each new issue carries `retro`,")
+
+	issueTemplate := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-retro", "references", "issue-template.md"))
+	labelBlock := substringBetween(t, issueTemplate, "## Step 1: Ensure labels exist", "## Step 2: Sort work units")
+	assert.Contains(t, labelBlock, "all 11 canonical labels")
+	assert.Contains(t, labelBlock, `"bug" "enhancement" "source:retro"`)
+	assert.Contains(t, labelBlock, `ensure_label "source:retro"`)
+	assert.NotContains(t, labelBlock, `ensure_label "retro"`)
+	assert.Contains(t, labelBlock, `ensure_label "priority:P1" "b60205" "High priority: safety, correctness, release, or broad user impact"`)
+	assert.Contains(t, labelBlock, `ensure_label "priority:P2" "d93f0b" "Medium priority: meaningful recurring defect or capability gap"`)
+	assert.Contains(t, labelBlock, `ensure_label "priority:P3" "fbca04" "Low priority: useful systemic improvement"`)
+	assert.Contains(t, labelBlock, `ensure_label "source:retro" "c59c0f" "Issue produced by /printing-press-retro; systemic Printing Press finding"`)
+	assert.Contains(t, labelBlock, "RETRO_PROVENANCE_LABEL=\"source:retro\"")
+	assert.Contains(t, labelBlock, "RETRO_PROVENANCE_LABEL=\"retro\"")
+
+	dedupBlock := substringBetween(t, issueTemplate, "### Fetch open retro issues", "### Classify each WU against the candidate set")
+	assert.Contains(t, dedupBlock, "--label source:retro")
+	assert.Contains(t, dedupBlock, "--label retro")
+	assert.Contains(t, dedupBlock, "unique_by(.number)")
+
+	createBlock := substringBetween(t, issueTemplate, "### Parallel execution", "# Cleanup is conditional on scrub-failed WUs.")
+	assert.Contains(t, createBlock, `--label "$RETRO_PROVENANCE_LABEL"`)
+	assert.Contains(t, createBlock, `--label "$WU_TYPE_LABEL"`)
+	assert.NotContains(t, createBlock, "--label retro")
+	assert.Contains(t, createBlock, "--remove-label bug")
+	assert.Contains(t, createBlock, "--remove-label enhancement")
+	assert.Contains(t, createBlock, "--add-blocked-by")
+	assert.Contains(t, createBlock, "Related-area references")
+	assert.Contains(t, issueTemplate, "Apply labels: $RETRO_PROVENANCE_LABEL, bug or enhancement")
+}
+
 func TestPrintingPressSkillRunERequiredInputContract(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md"))
 	template := substringBetween(t, skill, "#### Verify-friendly RunE template", "If the command reads a file or directory")

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -574,7 +574,9 @@ func TestRetroIssueTaxonomyAndRelationshipContracts(t *testing.T) {
 	assert.Contains(t, createBlock, "--add-blocked-by")
 	assert.Contains(t, createBlock, "Related-area references")
 	assert.Contains(t, createBlock, "declare -A OUTCOME_ISSUE_NUM_BY_WU_ID SORTED_WU_ID_SEEN")
-	assert.Contains(t, createBlock, "SORTED_WU_IDS")
+	assert.Contains(t, createBlock, "extract_wu_id")
+	assert.Contains(t, issueTemplate, "never sort a work-unit array and an ID array independently")
+	assert.NotContains(t, createBlock, "SORTED_WU_IDS")
 	assert.Contains(t, createBlock, "WU-2|wu:WU-1")
 	assert.Contains(t, createBlock, "OUTCOME_ISSUE_NUM_BY_WU_ID[$dependent_id]")
 	assert.Contains(t, createBlock, "OUTCOME_ISSUE_NUM_BY_WU_ID[$prerequisite_id]")
@@ -582,8 +584,8 @@ func TestRetroIssueTaxonomyAndRelationshipContracts(t *testing.T) {
 	assert.NotContains(t, createBlock, "dependent_wu_index|wu:<prerequisite_wu_index>")
 	assert.NotContains(t, createBlock, "OUTCOME_ISSUE_NUM[$")
 	assert.Contains(t, issueTemplate, "Apply labels: $RETRO_PROVENANCE_LABEL, bug or enhancement")
-	assert.Contains(t, issueTemplate, "stable WU-N identifiers from each")
-	assert.Contains(t, issueTemplate, "Dependency edges use these stable IDs, never sorted array positions")
+	assert.Contains(t, issueTemplate, "Each record retains its own `Stable ID: WU-N` field")
+	assert.Contains(t, issueTemplate, "Dependency edges use the stable ID extracted from each sorted record")
 }
 
 func TestRetroDependencyStableIDsSurvivePriorityReorder(t *testing.T) {

--- a/skills/printing-press-retro/SKILL.md
+++ b/skills/printing-press-retro/SKILL.md
@@ -730,6 +730,8 @@ For each "Do" finding or group of related findings:
 
 ```markdown
 ### WU-1: <Title> (from F1, F3, ...)
+- **Stable ID:** WU-1 *(preserve this identifier when sorting; dependency edges
+  use the stable ID rather than a post-sort array position)*
 - **Priority:** P1 / P2 / P3 *(max priority among absorbed findings — P1 if any
   absorbed finding is P1, else P2 if any is P2, else P3)*
 - **Type:** bug / enhancement *(use the deterministic category mapping above;
@@ -745,8 +747,11 @@ For each "Do" finding or group of related findings:
 - **Scope boundary:** What this does NOT include
 - **Dependencies:** None, unless another work unit or issue is a real
   prerequisite. Explicit prerequisites become native GitHub `blocked-by` /
-  `blocking` relationships after issue numbers are known; related-area context
-  stays prose in `Related issues`.
+  `blocking` relationships after issue numbers are known. Encode work-unit
+  edges as `WU-2|wu:WU-1` (dependent stable ID first); existing issues use
+  `WU-2|issue:123`. The executor validates that every WU ID is known and
+  resolves both endpoints by stable ID after priority sorting. Related-area
+  context stays prose in `Related issues`.
 - **Complexity:** small / medium / large
 ```
 

--- a/skills/printing-press-retro/SKILL.md
+++ b/skills/printing-press-retro/SKILL.md
@@ -415,6 +415,28 @@ the Do/Skip tables, they go on the dropped-candidates list with the reason.
 | **Discovered optimization** | Improvement found during use |
 | **Skill instruction gap** | Skill told Claude wrong thing or missed a step |
 
+### Actionable issue type mapping
+
+Every actionable work unit must carry exactly one real GitHub issue type label:
+`bug` or `enhancement`. Derive it deterministically from the absorbed finding
+categories:
+
+| Finding category | Issue type |
+|------------------|------------|
+| Bug | `bug` |
+| Scorer bug | `bug` |
+| Assumption mismatch | `bug` |
+| Default gap | `bug` |
+| Template gap | `enhancement` |
+| Recurring friction | `enhancement` |
+| Missing scaffolding | `enhancement` |
+| Discovered optimization | `enhancement` |
+| Skill instruction gap | `enhancement` |
+
+If a work unit absorbs multiple findings, `bug` wins when any absorbed category
+maps to `bug`; otherwise use `enhancement`. Priority, component, provenance,
+and routing/terminal labels are not substitutes for this type label.
+
 **4. Where in the Printing Press does this originate?**
 
 Pick exactly one component. The `slug` column drives the `comp:<slug>` label
@@ -710,6 +732,8 @@ For each "Do" finding or group of related findings:
 ### WU-1: <Title> (from F1, F3, ...)
 - **Priority:** P1 / P2 / P3 *(max priority among absorbed findings — P1 if any
   absorbed finding is P1, else P2 if any is P2, else P3)*
+- **Type:** bug / enhancement *(use the deterministic category mapping above;
+  `bug` wins for a mixed work unit)*
 - **Component:** generator / openapi-parser / spec-parser / scorer / skill
   *(must match one of the five fixed component slugs; drives the `comp:*` label
   applied to the issue when filed)*
@@ -719,7 +743,10 @@ For each "Do" finding or group of related findings:
   - positive test: ...
   - negative test: ...
 - **Scope boundary:** What this does NOT include
-- **Dependencies:** Other work units that must complete first
+- **Dependencies:** None, unless another work unit or issue is a real
+  prerequisite. Explicit prerequisites become native GitHub `blocked-by` /
+  `blocking` relationships after issue numbers are known; related-area context
+  stays prose in `Related issues`.
 - **Complexity:** small / medium / large
 ```
 
@@ -784,7 +811,7 @@ This is both the review target and the upload source.
 Before showing the confirm prompt, run `references/issue-template.md`
 **Steps 1, 2, and 2.5** to ensure labels exist, sort the work units, and
 compute the per-WU filing plan via the dedup scan against open
-retro-tagged issues. Each WU ends up classified as either:
+`source:retro` or legacy `retro` issues. Each WU ends up classified as either:
 
 - **File new** — no matching open issue
 - **Comment on #N** — Step 2.5 found a `same` match; the new evidence will be added as a comment instead of filing a duplicate
@@ -805,13 +832,16 @@ confirmation via `AskUserQuestion`.
 >
 > | # | Title | Plan | Notes |
 > |---|-------|------|-------|
-> | 1 | <wu-1 title> | File new (P1, comp:<slug>) | No match |
+> | 1 | <wu-1 title> | File new (P1, bug, comp:<slug>) | No match |
 > | 2 | <wu-2 title> | Comment on #234 | Matches "<existing title>" |
 > | 3 | <wu-3 title> | File new + reference #189 | Adjacent open issue |
 >
-> Each new issue carries `retro`, `priority:P<n>`, `comp:<slug>` labels —
-> agents filter related work across retros with `gh issue list --label
-> comp:<slug>` or `gh issue list --label priority:P1`.
+> Each new issue carries `source:retro`, the mapped `bug` or `enhancement` type,
+> `priority:P<n>`, and `comp:<slug>` labels — agents filter related work across
+> retros with `gh issue list --label source:retro`, `gh issue list --label
+> comp:<slug>`, or `gh issue list --label priority:P1`. During the label cutover,
+> legacy `retro` issues remain discoverable and a write may use `retro` only when
+> the canonical `source:retro` label is not available.
 >
 > Scrubbed artifact zips uploaded to catbox.moe and linked from each new issue:
 >   - **Retro document** — full triage rationale, drops, skips, what went right
@@ -844,8 +874,9 @@ Run artifact-packaging.md Step 5 (the catbox upload) using the zips already in
 ### Step 4: Execute the filing plan
 
 Steps 1, 2, and 2.5 of [references/issue-template.md](references/issue-template.md)
-already ran during Step 2 (filing plan + confirm), so labels exist, WUs are
-sorted, and `$WU_DEDUP` and `$WU_RELATED` are populated. This step runs
+already ran during Step 2 (filing plan + confirm), so labels exist, the safe
+provenance marker is selected, WUs are sorted, and `$WU_DEDUP`, `$WU_RELATED`,
+and `$WU_DEPENDENCY_EDGES` are populated. This step runs
 **Step 3** of the reference: build bodies and execute the plan in parallel.
 
 The "Execution principles" block at the top of `issue-template.md` is
@@ -857,10 +888,14 @@ round trip's worth of network time, not a serialized stack of them.
 
 Each WU is independent: WUs marked `comment:#N` get a comment on the
 existing issue; WUs marked file-new create a new flat top-level issue. No
-parent, no sub-issue REST linking — every new issue stands alone in
-GitHub's issue list with its own open/close lifecycle.
+parent or sub-issue hierarchy — every new issue stands alone in GitHub's issue
+list with its own open/close lifecycle. Explicit prerequisites are applied as
+native `blocked-by`/`blocking` relationships after issue numbers are known;
+ordinary related-area references remain prose.
 
-Each new issue carries its own `priority:P<n>` and `comp:<slug>` labels.
+Each new issue carries its own provenance marker (`source:retro`, or legacy
+`retro` only when the canonical label is unavailable), exactly one mapped
+`bug`/`enhancement` type, `priority:P<n>`, and `comp:<slug>` labels.
 This is what enables `gh issue list --label comp:openapi-parser` to surface
 every retro WU in that area across every retro — labels are the cross-retro
 discovery surface, not auto-cross-links inside issue bodies.
@@ -872,8 +907,9 @@ Each new issue body's **Related issues** block combines:
 
 Both reach across separate filed work where the `#N` auto-cross-link is
 real signal. The body does *not* auto-cross-link to sibling WUs in the
-same retro; that linkage is noise unless one is genuinely a prerequisite
-(captured as free-text `Dependencies:` instead).
+same retro; that linkage is noise unless one is genuinely a prerequisite,
+which is captured in `Dependencies:` and applied natively rather than left as
+prose alone.
 
 If `gh` is not authenticated or every per-WU action fails, follow the
 graceful degradation path in the issue-template reference: save locally and
@@ -911,9 +947,11 @@ filed work, but the shape differs.
 >   - [P1] <title> → comment on #234 — <comment URL>
 >   - ...
 >
-> <N> findings across <M> work units. New issues are tagged with `comp:<slug>`
-> and `priority:P<n>` labels — agents can filter related work across retros
-> with `gh issue list --label comp:<slug>` or `gh issue list --label priority:P1`.
+> <N> findings across <M> work units. New issues are tagged with `source:retro`,
+> their mapped `bug` or `enhancement` type, `comp:<slug>`, and `priority:P<n>`
+> labels — agents can filter related work across retros with `gh issue list
+> --label source:retro`, `gh issue list --label comp:<slug>`, or `gh issue list
+> --label priority:P1`.
 > *(if artifacts uploaded)* Artifacts: [retro doc](<URL>) · [manuscripts](<URL>) · [CLI source](<URL>)
 > Local copy: <$RETRO_SCRATCH_PATH>
 

--- a/skills/printing-press-retro/references/issue-template.md
+++ b/skills/printing-press-retro/references/issue-template.md
@@ -176,6 +176,9 @@ that).
 
 ```bash
 # SORTED_WORK_UNITS is populated from $WORK_UNITS sorted P1 → P3.
+# SORTED_WU_IDS is the parallel list of stable WU-N identifiers from each
+# record before sorting; each entry stays paired with SORTED_WORK_UNITS.
+# Dependency edges use these stable IDs, never sorted array positions.
 ```
 
 ## Step 2.5: Dedup against open issues
@@ -440,19 +443,34 @@ trail for anyone who wants more context.
 ### Parallel execution
 
 ```bash
-declare -a OUTCOME_KIND OUTCOME_URL OUTCOME_TITLE OUTCOME_PRIORITY OUTCOME_COMP OUTCOME_COMPLEXITY OUTCOME_ISSUE_NUM
+declare -a OUTCOME_KIND OUTCOME_URL OUTCOME_TITLE OUTCOME_PRIORITY OUTCOME_COMP OUTCOME_COMPLEXITY
 declare -a WU_DEPENDENCY_EDGES
 declare -a FAILED_ISSUES
+declare -A OUTCOME_ISSUE_NUM_BY_WU_ID SORTED_WU_ID_SEEN
 
 ISSUE_TMPDIR=$(mktemp -d)
 ISSUE_RUN_START_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 for wu_idx in "${!SORTED_WORK_UNITS[@]}"; do
+  WU_ID="${SORTED_WU_IDS[$wu_idx]-}"
+  if [[ ! "$WU_ID" =~ ^WU-[1-9][0-9]*$ ]]; then
+    echo "ERROR: sorted WU $wu_idx has missing or duplicate stable ID: ${WU_ID:-<empty>}" >&2
+    exit 1
+  fi
+  if [[ -n "${SORTED_WU_ID_SEEN[$WU_ID]+x}" ]]; then
+    echo "ERROR: sorted WU $wu_idx has duplicate stable ID: $WU_ID" >&2
+    exit 1
+  fi
+  SORTED_WU_ID_SEEN["$WU_ID"]=1
+done
+
+for wu_idx in "${!SORTED_WORK_UNITS[@]}"; do
   (
     WU="${SORTED_WORK_UNITS[$wu_idx]}"
+    WU_ID="${SORTED_WU_IDS[$wu_idx]}"
     DEDUP="${WU_DEDUP[$wu_idx]}"  # "comment:NN" or empty
 
-    # Each WU contributes: $WU_TITLE, $WU_BODY, $WU_COMMENT_BODY,
+    # Each WU contributes: $WU_ID, $WU_TITLE, $WU_BODY, $WU_COMMENT_BODY,
     # $WU_PRIORITY_NUM, $WU_PRIORITY_LABEL, $WU_TYPE_LABEL, $WU_COMP_SLUG,
     # $WU_COMPLEXITY.
 
@@ -524,6 +542,7 @@ for wu_idx in "${!SORTED_WORK_UNITS[@]}"; do
     fi
 
     {
+      printf '%s\n' "$WU_ID"
       printf '%s\n' "$KIND"
       printf '%s\n' "$URL"
       printf '%s\n' "$WU_TITLE"
@@ -548,6 +567,7 @@ EXPECTED_ISSUE_NUMBERS=$(
   for wu_idx in "${!SORTED_WORK_UNITS[@]}"; do
     if [ -f "$ISSUE_TMPDIR/issue-$wu_idx" ]; then
       {
+        IFS= read -r WU_ID_TMP
         IFS= read -r KIND_TMP
         IFS= read -r URL_TMP
       } < "$ISSUE_TMPDIR/issue-$wu_idx"
@@ -593,6 +613,7 @@ fi
 
 for wu_idx in "${!SORTED_WORK_UNITS[@]}"; do
   {
+    IFS= read -r WU_ID
     IFS= read -r KIND
     IFS= read -r URL
     IFS= read -r TITLE
@@ -602,6 +623,12 @@ for wu_idx in "${!SORTED_WORK_UNITS[@]}"; do
     IFS= read -r FAIL_MSG
   } < "$ISSUE_TMPDIR/issue-$wu_idx"
 
+  EXPECTED_WU_ID="${SORTED_WU_IDS[$wu_idx]-}"
+  if [[ "$WU_ID" != "$EXPECTED_WU_ID" ]]; then
+    FAILED_ISSUES+=("sorted WU $wu_idx returned stable ID ${WU_ID:-<empty>}, expected ${EXPECTED_WU_ID:-<empty>}")
+    continue
+  fi
+
   OUTCOME_KIND+=("$KIND")
   OUTCOME_URL+=("$URL")
   OUTCOME_TITLE+=("$TITLE")
@@ -609,11 +636,11 @@ for wu_idx in "${!SORTED_WORK_UNITS[@]}"; do
   OUTCOME_COMP+=("$COMP")
   OUTCOME_COMPLEXITY+=("$COMPLEXITY")
   if [[ "$URL" =~ /issues/([0-9]+) ]]; then
-    OUTCOME_ISSUE_NUM[$wu_idx]="${BASH_REMATCH[1]}"
+    OUTCOME_ISSUE_NUM_BY_WU_ID["$WU_ID"]="${BASH_REMATCH[1]}"
   elif [[ "${WU_DEDUP[$wu_idx]}" == comment:* ]]; then
-    OUTCOME_ISSUE_NUM[$wu_idx]="${WU_DEDUP[$wu_idx]#comment:}"
+    OUTCOME_ISSUE_NUM_BY_WU_ID["$WU_ID"]="${WU_DEDUP[$wu_idx]#comment:}"
   else
-    OUTCOME_ISSUE_NUM[$wu_idx]=""
+    OUTCOME_ISSUE_NUM_BY_WU_ID["$WU_ID"]=""
   fi
 
   case "$KIND" in
@@ -629,19 +656,40 @@ done
 
 # Apply only explicitly declared prerequisite edges, after all creates and
 # dedup decisions have produced issue numbers. Each edge is
-# `dependent_wu_index|wu:<prerequisite_wu_index>` or
-# `dependent_wu_index|issue:<existing_issue_number>`. Related-area references
-# never enter this array.
+# `WU-2|wu:WU-1` or `WU-2|issue:123`. IDs are stable WU-N values, so this
+# remains correct when a P1 WU-2 sorts before a P2 WU-1. Resolve both endpoints
+# through the associative outcome map; never use sorted array positions.
+# Related-area references never enter this array; they remain prose links.
 for edge in "${WU_DEPENDENCY_EDGES[@]}"; do
-  IFS='|' read -r dependent_idx prerequisite_ref <<< "$edge"
-  dependent_issue="${OUTCOME_ISSUE_NUM[$dependent_idx]-}"
+  IFS='|' read -r dependent_id prerequisite_ref <<< "$edge"
+  if [[ ! "$dependent_id" =~ ^WU-[1-9][0-9]*$ ]]; then
+    FAILED_ISSUES+=("dependency edge $edge — unknown or malformed dependent stable WU ID")
+    continue
+  fi
+  if [[ -z "${SORTED_WU_ID_SEEN[$dependent_id]+x}" ]]; then
+    FAILED_ISSUES+=("dependency edge $edge — unknown dependent stable WU ID")
+    continue
+  fi
+  dependent_issue="${OUTCOME_ISSUE_NUM_BY_WU_ID[$dependent_id]-}"
   case "$prerequisite_ref" in
     wu:*)
-      prerequisite_idx="${prerequisite_ref#wu:}"
-      prerequisite_issue="${OUTCOME_ISSUE_NUM[$prerequisite_idx]-}"
+      prerequisite_id="${prerequisite_ref#wu:}"
+      if [[ ! "$prerequisite_id" =~ ^WU-[1-9][0-9]*$ ]]; then
+        FAILED_ISSUES+=("dependency edge $edge — unknown or malformed prerequisite stable WU ID")
+        continue
+      fi
+      if [[ -z "${SORTED_WU_ID_SEEN[$prerequisite_id]+x}" ]]; then
+        FAILED_ISSUES+=("dependency edge $edge — unknown prerequisite stable WU ID")
+        continue
+      fi
+      prerequisite_issue="${OUTCOME_ISSUE_NUM_BY_WU_ID[$prerequisite_id]-}"
       ;;
     issue:*)
       prerequisite_issue="${prerequisite_ref#issue:}"
+      if [[ ! "$prerequisite_issue" =~ ^[1-9][0-9]*$ ]]; then
+        FAILED_ISSUES+=("dependency edge $edge — malformed existing issue number")
+        continue
+      fi
       ;;
     *)
       prerequisite_issue=""
@@ -696,10 +744,12 @@ Failure modes:
 | `$RETRO_PROVENANCE_LABEL` | This file Step 1 | Available write marker: canonical `source:retro`, or legacy `retro` only during cutover fallback |
 | `$WORK_UNITS` | SKILL.md Phase 5.5 | Array of WU records |
 | `$SORTED_WORK_UNITS` | This file Step 2 | `$WORK_UNITS` sorted P1 → P3 |
+| `$SORTED_WU_IDS` | This file Step 2 | Stable WU-N identifiers kept parallel with `$SORTED_WORK_UNITS` after priority sorting |
 | `$EXISTING_OPEN_RETROS` | This file Step 2.5 | De-duplicated JSON of open issues carrying `source:retro` or legacy `retro` |
 | `$WU_DEDUP` | This file Step 2.5 | Per-WU dedup decision: `comment:NN` or empty |
 | `$WU_RELATED` | This file Step 2.5 + Phase 3 Step D | Per-WU comma-separated related-issue numbers (annotated for the body) |
-| `$WU_DEPENDENCY_EDGES` | SKILL.md Phase 5.5 + this file Step 3 | Explicit prerequisite edges applied with native `--add-blocked-by`; related-area references are excluded |
+| `$WU_DEPENDENCY_EDGES` | SKILL.md Phase 5.5 + this file Step 3 | Explicit stable-ID prerequisite edges such as `WU-2|wu:WU-1` applied with native `--add-blocked-by`; related-area references are excluded |
+| `$OUTCOME_ISSUE_NUM_BY_WU_ID` | This file Step 3 | Issue numbers keyed by stable WU-N, independent of sorted array positions |
 | `$WU_TYPE_LABEL` | Each sorted WU record | Exactly one mapped real issue type: `bug` or `enhancement` |
 | All retro findings | SKILL.md Phase 4 | Used to populate each issue's "Findings absorbed" section |
 

--- a/skills/printing-press-retro/references/issue-template.md
+++ b/skills/printing-press-retro/references/issue-template.md
@@ -175,10 +175,11 @@ but the skill may have intentionally ordered them by dependency — preserve
 that).
 
 ```bash
-# SORTED_WORK_UNITS is populated from $WORK_UNITS sorted P1 → P3.
-# SORTED_WU_IDS is the parallel list of stable WU-N identifiers from each
-# record before sorting; each entry stays paired with SORTED_WORK_UNITS.
-# Dependency edges use these stable IDs, never sorted array positions.
+# SORTED_WORK_UNITS is populated by sorting the complete WU records from
+# $WORK_UNITS P1 → P3. Each record retains its own `Stable ID: WU-N` field;
+# never sort a work-unit array and an ID array independently.
+# Dependency edges use the stable ID extracted from each sorted record, never
+# a sorted array position.
 ```
 
 ## Step 2.5: Dedup against open issues
@@ -448,11 +449,17 @@ declare -a WU_DEPENDENCY_EDGES
 declare -a FAILED_ISSUES
 declare -A OUTCOME_ISSUE_NUM_BY_WU_ID SORTED_WU_ID_SEEN
 
+extract_wu_id() {
+  printf '%s\n' "$1" \
+    | sed -nE 's/^- \*\*Stable ID:\*\* (WU-[1-9][0-9]*)([[:space:]].*)?$/\1/p' \
+    | head -1
+}
+
 ISSUE_TMPDIR=$(mktemp -d)
 ISSUE_RUN_START_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 for wu_idx in "${!SORTED_WORK_UNITS[@]}"; do
-  WU_ID="${SORTED_WU_IDS[$wu_idx]-}"
+  WU_ID="$(extract_wu_id "${SORTED_WORK_UNITS[$wu_idx]}")"
   if [[ ! "$WU_ID" =~ ^WU-[1-9][0-9]*$ ]]; then
     echo "ERROR: sorted WU $wu_idx has missing or duplicate stable ID: ${WU_ID:-<empty>}" >&2
     exit 1
@@ -467,7 +474,7 @@ done
 for wu_idx in "${!SORTED_WORK_UNITS[@]}"; do
   (
     WU="${SORTED_WORK_UNITS[$wu_idx]}"
-    WU_ID="${SORTED_WU_IDS[$wu_idx]}"
+    WU_ID="$(extract_wu_id "$WU")"
     DEDUP="${WU_DEDUP[$wu_idx]}"  # "comment:NN" or empty
 
     # Each WU contributes: $WU_ID, $WU_TITLE, $WU_BODY, $WU_COMMENT_BODY,
@@ -623,7 +630,7 @@ for wu_idx in "${!SORTED_WORK_UNITS[@]}"; do
     IFS= read -r FAIL_MSG
   } < "$ISSUE_TMPDIR/issue-$wu_idx"
 
-  EXPECTED_WU_ID="${SORTED_WU_IDS[$wu_idx]-}"
+  EXPECTED_WU_ID="$(extract_wu_id "${SORTED_WORK_UNITS[$wu_idx]}")"
   if [[ "$WU_ID" != "$EXPECTED_WU_ID" ]]; then
     FAILED_ISSUES+=("sorted WU $wu_idx returned stable ID ${WU_ID:-<empty>}, expected ${EXPECTED_WU_ID:-<empty>}")
     continue
@@ -743,8 +750,7 @@ Failure modes:
 | `$RETRO_SCRATCH_PATH` | SKILL.md Phase 5 | Path to temp retro copy under `/tmp/printing-press/retro/` |
 | `$RETRO_PROVENANCE_LABEL` | This file Step 1 | Available write marker: canonical `source:retro`, or legacy `retro` only during cutover fallback |
 | `$WORK_UNITS` | SKILL.md Phase 5.5 | Array of WU records |
-| `$SORTED_WORK_UNITS` | This file Step 2 | `$WORK_UNITS` sorted P1 → P3 |
-| `$SORTED_WU_IDS` | This file Step 2 | Stable WU-N identifiers kept parallel with `$SORTED_WORK_UNITS` after priority sorting |
+| `$SORTED_WORK_UNITS` | This file Step 2 | Complete `$WORK_UNITS` records sorted P1 → P3; each record retains its own stable WU-N identifier |
 | `$EXISTING_OPEN_RETROS` | This file Step 2.5 | De-duplicated JSON of open issues carrying `source:retro` or legacy `retro` |
 | `$WU_DEDUP` | This file Step 2.5 | Per-WU dedup decision: `comment:NN` or empty |
 | `$WU_RELATED` | This file Step 2.5 + Phase 3 Step D | Per-WU comma-separated related-issue numbers (annotated for the body) |

--- a/skills/printing-press-retro/references/issue-template.md
+++ b/skills/printing-press-retro/references/issue-template.md
@@ -13,9 +13,10 @@ This shape was chosen deliberately:
 - The default GitHub issue list is not duplicated; there is no parent to
   mirror children, no progress bar to drift, no parent-not-auto-closing
   bookkeeping.
-- Cross-retro discovery still works through labels: `comp:<slug>` surfaces
-  every retro WU touching one component; `priority:P1` surfaces high-priority
-  work across retros.
+- Cross-retro discovery still works through labels: `source:retro` marks
+  provenance, `comp:<slug>` surfaces every retro WU touching one component,
+  `priority:P1` surfaces high-priority work, and `bug`/`enhancement` carry the
+  real issue type.
 - Inter-issue links inside the same retro are not auto-generated. They appear
   only when an issue genuinely relates to another (a contradicting prior
   retro, or a `related-area` open issue surfaced by the dedup scan).
@@ -76,8 +77,8 @@ clobber them).
 ```bash
 REPO="mvanhorn/cli-printing-press"
 
-# Fast-path: list existing labels once. If all 10 canonical labels are already
-# present, skip the create loop entirely — saves up to 10 gh API calls per
+# Fast-path: list existing labels once. If all 11 canonical labels are already
+# present, skip the create loop entirely — saves up to 11 gh API calls per
 # retro on a repo where prior retros already provisioned the set.
 EXISTING_LABELS=$(gh label list --repo "$REPO" --limit 200 --json name --jq '.[].name' 2>/dev/null || echo "")
 NEED_CREATE=false
@@ -85,7 +86,7 @@ for required in \
   "comp:generator" "comp:openapi-parser" "comp:spec-parser" \
   "comp:scorer" "comp:skill" \
   "priority:P1" "priority:P2" "priority:P3" \
-  "retro"; do
+  "bug" "enhancement" "source:retro"; do
   if ! printf '%s\n' "$EXISTING_LABELS" | grep -qFx "$required"; then
     NEED_CREATE=true
     break
@@ -107,18 +108,64 @@ if [ "$NEED_CREATE" = true ]; then
 
   # Priority labels (3) — drive priority-based filtering. The label is the
   # primary carrier; titles do not duplicate the priority prefix.
-  ensure_label "priority:P1" "b60205" "Retro priority P1 (high)"
-  ensure_label "priority:P2" "d93f0b" "Retro priority P2 (medium)"
-  ensure_label "priority:P3" "fbca04" "Retro priority P3 (low)"
+  ensure_label "priority:P1" "b60205" "High priority: safety, correctness, release, or broad user impact"
+  ensure_label "priority:P2" "d93f0b" "Medium priority: meaningful recurring defect or capability gap"
+  ensure_label "priority:P3" "fbca04" "Low priority: useful systemic improvement"
 
-  # Marker label
-  ensure_label "retro" "0e8a16" "Issue produced by /printing-press-retro"
+  # Real issue types. These are actionable taxonomy, not routing or provenance.
+  ensure_label "bug"         "d73a4a" "Something isn't working"
+  ensure_label "enhancement" "a2eeef" "New feature or request"
+
+  # Canonical provenance marker. Do not create the legacy `retro` label.
+  ensure_label "source:retro" "c59c0f" "Issue produced by /printing-press-retro; systemic Printing Press finding"
+fi
+
+REFRESHED_LABELS=$(gh label list --repo "$REPO" --limit 200 --json name --jq '.[].name' 2>/dev/null || true)
+if [ -n "$REFRESHED_LABELS" ]; then
+  EXISTING_LABELS="$REFRESHED_LABELS"
 fi
 ```
 
 The `retro-parent` label is intentionally omitted — there are no parent
-issues. If the label exists from prior retros, leave it; the skill never
-creates new issues with it.
+issues. If the legacy `retro` label exists from prior retros, leave it for
+discovery during the cutover; the skill never creates new issues with it.
+
+### Resolve the provenance marker for writes
+
+`source:retro` is the canonical provenance label. Before creating an issue,
+choose a marker from labels that are actually available, preferring
+`source:retro` and falling back to legacy `retro` only when the canonical label
+cannot be created or is not available. Never pass a guessed label to `gh issue
+create`:
+
+```bash
+has_label() {
+  printf '%s\n' "$EXISTING_LABELS" | grep -qFx "$1"
+}
+
+RETRO_PROVENANCE_LABEL=""
+if has_label "source:retro"; then
+  RETRO_PROVENANCE_LABEL="source:retro"
+elif has_label "retro"; then
+  RETRO_PROVENANCE_LABEL="retro"
+else
+  gh label create "source:retro" --repo "$REPO" --color "c59c0f" \
+    --description "Issue produced by /printing-press-retro; systemic Printing Press finding" 2>/dev/null || true
+  EXISTING_LABELS=$(gh label list --repo "$REPO" --limit 200 --json name --jq '.[].name' 2>/dev/null || echo "")
+  if has_label "source:retro"; then
+    RETRO_PROVENANCE_LABEL="source:retro"
+  elif has_label "retro"; then
+    RETRO_PROVENANCE_LABEL="retro"
+  else
+    echo "ERROR: neither source:retro nor legacy retro is available; cannot file a provenance-marked issue." >&2
+    exit 1
+  fi
+fi
+```
+
+The initial label pass provisions `source:retro` on a fresh fork. The
+post-create re-list makes the fallback safe when label creation races or is
+denied. Existing issues are not relabeled solely to rename provenance.
 
 ## Step 2: Sort work units
 
@@ -137,26 +184,40 @@ Before filing, check whether any WUs match an issue that's already open.
 If they do, comment on the existing issue with new evidence rather than
 file a duplicate.
 
-This is a single `gh` call followed by per-WU agent reasoning over titles.
-**It does not need to be bulletproof** — false negatives (filing new when
+This is two label-filtered `gh` calls followed by per-WU agent reasoning over
+the de-duplicated result set. **It does not need to be bulletproof** — false negatives (filing new when
 one exists) are recoverable; false positives (commenting on the wrong
 issue) are uglier. **Bias toward `file-new` when uncertain.**
 
 ### Fetch open retro issues
 
 ```bash
-EXISTING_OPEN_RETROS=$(gh issue list \
+EXISTING_OPEN_RETROS_SOURCE=$(gh issue list \
+  --repo "$REPO" \
+  --label source:retro \
+  --state open \
+  --limit 200 \
+  --json number,title,url,labels 2>/dev/null \
+  || echo "[]")
+
+EXISTING_OPEN_RETROS_LEGACY=$(gh issue list \
   --repo "$REPO" \
   --label retro \
   --state open \
   --limit 200 \
-  --json number,title,url 2>/dev/null \
+  --json number,title,url,labels 2>/dev/null \
   || echo "[]")
+
+EXISTING_OPEN_RETROS=$(jq -s 'add | unique_by(.number)' \
+  <(printf '%s\n' "$EXISTING_OPEN_RETROS_SOURCE") \
+  <(printf '%s\n' "$EXISTING_OPEN_RETROS_LEGACY"))
 ```
 
-A single call. No per-WU label filtering — the agent reasons over titles
+The two results are merged by issue number so an issue carrying both labels is
+considered once. No per-WU component filtering — the agent reasons over titles
 across the whole open-retro set so a related-area issue under a different
-component still surfaces.
+component still surfaces. The `labels` field lets the executor preserve the
+one-type invariant when commenting on an existing match.
 
 ### Classify each WU against the candidate set
 
@@ -231,6 +292,7 @@ should understand what they're being asked to address.>
 ## Where to look
 
 - **Component:** <comp-slug>
+- **Issue type:** `bug` or `enhancement` from the deterministic finding-category mapping
 - **Likely area:** <path or files in the printing-press repo, e.g. `internal/generator/templates/`>
 - **Triggered when:** <spec shape, API behavior, or runtime context that surfaces this>
 
@@ -298,7 +360,12 @@ small / medium / large
 
 ## Dependencies
 
-<Free text — only if there's a real prerequisite. Most issues say "None.">
+<"None." unless this work unit has a real prerequisite. For an explicit
+prerequisite, name the blocking issue or work unit here. After issue numbers are
+known, the filing pass applies GitHub's native relationship with
+`gh issue edit <dependent> --repo "$REPO" --add-blocked-by <prerequisite>`.
+Related-area references do not belong here and must remain prose in
+`Related issues`.
 
 ## Findings absorbed
 
@@ -316,7 +383,8 @@ small / medium / large
 <Combined output from Phase 3 Step D (prior-retro doc archaeology) and
 Step 2.5 (open-issue dedup `related-area` classification). Auto-cross-links
 via `#N`. Sibling WUs in this same retro do NOT appear here unless one is
-genuinely a prerequisite.>
+genuinely a prerequisite; a real prerequisite is also represented by a native
+`blocked-by`/`blocking` relationship, not only by this prose link.>
 
 - #<num> — prior retro (`aligned`/`contradicts`/`extends`): <one-sentence note>
 - #<num> — open issue (`related-area`): <one-sentence note on the adjacency>
@@ -343,7 +411,8 @@ What's *not* in the body, by design:
 - **Skipped table** — retro-wide triage record; lives in the retro doc.
 - **Auto-cross-references to sibling WUs in this same retro** — these are
   noise unless one WU is genuinely a prerequisite for another (and that
-  goes in `Dependencies:` as free text, not as an auto-linked `#N`).
+  goes in `Dependencies:` and becomes a native `blocked-by` relationship after
+  issue numbers are known).
 
 ### Comment body (for `comment:#N` decisions)
 
@@ -371,7 +440,8 @@ trail for anyone who wants more context.
 ### Parallel execution
 
 ```bash
-declare -a OUTCOME_KIND OUTCOME_URL OUTCOME_TITLE OUTCOME_PRIORITY OUTCOME_COMP OUTCOME_COMPLEXITY
+declare -a OUTCOME_KIND OUTCOME_URL OUTCOME_TITLE OUTCOME_PRIORITY OUTCOME_COMP OUTCOME_COMPLEXITY OUTCOME_ISSUE_NUM
+declare -a WU_DEPENDENCY_EDGES
 declare -a FAILED_ISSUES
 
 ISSUE_TMPDIR=$(mktemp -d)
@@ -383,7 +453,8 @@ for wu_idx in "${!SORTED_WORK_UNITS[@]}"; do
     DEDUP="${WU_DEDUP[$wu_idx]}"  # "comment:NN" or empty
 
     # Each WU contributes: $WU_TITLE, $WU_BODY, $WU_COMMENT_BODY,
-    # $WU_PRIORITY_NUM, $WU_PRIORITY_LABEL, $WU_COMP_SLUG, $WU_COMPLEXITY.
+    # $WU_PRIORITY_NUM, $WU_PRIORITY_LABEL, $WU_TYPE_LABEL, $WU_COMP_SLUG,
+    # $WU_COMPLEXITY.
 
     KIND=""
     URL=""
@@ -413,7 +484,18 @@ for wu_idx in "${!SORTED_WORK_UNITS[@]}"; do
       URL=""
     elif [[ "$DEDUP" == comment:* ]]; then
       ISSUE_NUM="${DEDUP#comment:}"
-      if URL=$(gh issue comment "$ISSUE_NUM" \
+      # A recurrence may target a legacy issue that predates real type labels.
+      # Normalize the two actionable type labels before adding evidence so the
+      # existing issue still satisfies the one-type taxonomy invariant.
+      if ! gh issue edit "$ISSUE_NUM" \
+            --repo "$REPO" \
+            --remove-label bug \
+            --remove-label enhancement \
+            --add-label "$WU_TYPE_LABEL" >/dev/null 2>&1; then
+        KIND="type-normalization-failed"
+        FAIL_MSG="$WU_TITLE — could not normalize #$ISSUE_NUM to exactly one type label ($WU_TYPE_LABEL); comment not posted."
+        URL=""
+      elif URL=$(gh issue comment "$ISSUE_NUM" \
             --repo "$REPO" \
             --body-file "$BODY_TMP_SCRUBBED" 2>&1) \
             && [[ "$URL" == https://* ]]; then
@@ -428,7 +510,8 @@ for wu_idx in "${!SORTED_WORK_UNITS[@]}"; do
             --repo "$REPO" \
             --title "$WU_TITLE" \
             --body-file "$BODY_TMP_SCRUBBED" \
-            --label retro \
+            --label "$RETRO_PROVENANCE_LABEL" \
+            --label "$WU_TYPE_LABEL" \
             --label "priority:P${WU_PRIORITY_NUM}" \
             --label "comp:${WU_COMP_SLUG}" 2>&1) \
             && [[ "$URL" == https://* ]]; then
@@ -525,16 +608,51 @@ for wu_idx in "${!SORTED_WORK_UNITS[@]}"; do
   OUTCOME_PRIORITY+=("$PRIORITY")
   OUTCOME_COMP+=("$COMP")
   OUTCOME_COMPLEXITY+=("$COMPLEXITY")
+  if [[ "$URL" =~ /issues/([0-9]+) ]]; then
+    OUTCOME_ISSUE_NUM[$wu_idx]="${BASH_REMATCH[1]}"
+  elif [[ "${WU_DEDUP[$wu_idx]}" == comment:* ]]; then
+    OUTCOME_ISSUE_NUM[$wu_idx]="${WU_DEDUP[$wu_idx]#comment:}"
+  else
+    OUTCOME_ISSUE_NUM[$wu_idx]=""
+  fi
 
   case "$KIND" in
     created|commented)
       echo "${KIND^}: $URL"
       ;;
-    create-failed|comment-failed|scrub-failed)
+    create-failed|comment-failed|type-normalization-failed|scrub-failed)
       echo "WARNING: $FAIL_MSG"
       FAILED_ISSUES+=("$FAIL_MSG")
       ;;
   esac
+done
+
+# Apply only explicitly declared prerequisite edges, after all creates and
+# dedup decisions have produced issue numbers. Each edge is
+# `dependent_wu_index|wu:<prerequisite_wu_index>` or
+# `dependent_wu_index|issue:<existing_issue_number>`. Related-area references
+# never enter this array.
+for edge in "${WU_DEPENDENCY_EDGES[@]}"; do
+  IFS='|' read -r dependent_idx prerequisite_ref <<< "$edge"
+  dependent_issue="${OUTCOME_ISSUE_NUM[$dependent_idx]-}"
+  case "$prerequisite_ref" in
+    wu:*)
+      prerequisite_idx="${prerequisite_ref#wu:}"
+      prerequisite_issue="${OUTCOME_ISSUE_NUM[$prerequisite_idx]-}"
+      ;;
+    issue:*)
+      prerequisite_issue="${prerequisite_ref#issue:}"
+      ;;
+    *)
+      prerequisite_issue=""
+      ;;
+  esac
+  if [[ -z "$dependent_issue" || -z "$prerequisite_issue" ]]; then
+    FAILED_ISSUES+=("dependency edge $edge — issue number unavailable; native relationship not applied")
+  elif ! gh issue edit "$dependent_issue" --repo "$REPO" \
+      --add-blocked-by "$prerequisite_issue" >/dev/null 2>&1; then
+    FAILED_ISSUES+=("dependency edge #$dependent_issue blocked by #$prerequisite_issue — native relationship failed")
+  fi
 done
 
 # Cleanup is conditional on scrub-failed WUs. Those WUs' body files are the
@@ -562,6 +680,7 @@ Failure modes:
 | `commented` | Comment added to existing issue | Listed as "commented on #N" |
 | `create-failed` | `gh issue create` returned no usable URL | `$FAILED_ISSUES` summary; manual filing instructions |
 | `comment-failed` | `gh issue comment` failed | `$FAILED_ISSUES` summary; manual comment instructions |
+| `type-normalization-failed` | Existing matched issue could not be normalized to exactly one real type label | `$FAILED_ISSUES` summary; manual label repair instructions |
 | `scrub-failed` | Body contained an unredacted vendor-prefix secret; `scrub_body` refused to write the scrubbed copy. Body file left at `$BODY_TMP` for hand-redaction | `$FAILED_ISSUES` summary; agent must hand-redact per `secret-scrubbing.md` Layer 0 and retry the WU |
 
 ## Variables expected
@@ -574,11 +693,14 @@ Failure modes:
 | `$CLI_SOURCE_URL` | artifact-packaging.md | catbox URL or empty |
 | `$RETRO_PROOF_PATH` | SKILL.md Phase 5 | Path to saved retro in manuscript proofs |
 | `$RETRO_SCRATCH_PATH` | SKILL.md Phase 5 | Path to temp retro copy under `/tmp/printing-press/retro/` |
+| `$RETRO_PROVENANCE_LABEL` | This file Step 1 | Available write marker: canonical `source:retro`, or legacy `retro` only during cutover fallback |
 | `$WORK_UNITS` | SKILL.md Phase 5.5 | Array of WU records |
 | `$SORTED_WORK_UNITS` | This file Step 2 | `$WORK_UNITS` sorted P1 → P3 |
-| `$EXISTING_OPEN_RETROS` | This file Step 2.5 | JSON of open retro-tagged issues |
+| `$EXISTING_OPEN_RETROS` | This file Step 2.5 | De-duplicated JSON of open issues carrying `source:retro` or legacy `retro` |
 | `$WU_DEDUP` | This file Step 2.5 | Per-WU dedup decision: `comment:NN` or empty |
 | `$WU_RELATED` | This file Step 2.5 + Phase 3 Step D | Per-WU comma-separated related-issue numbers (annotated for the body) |
+| `$WU_DEPENDENCY_EDGES` | SKILL.md Phase 5.5 + this file Step 3 | Explicit prerequisite edges applied with native `--add-blocked-by`; related-area references are excluded |
+| `$WU_TYPE_LABEL` | Each sorted WU record | Exactly one mapped real issue type: `bug` or `enhancement` |
 | All retro findings | SKILL.md Phase 4 | Used to populate each issue's "Findings absorbed" section |
 
 ## Variables produced
@@ -617,7 +739,7 @@ if [ "$GH_AVAILABLE" = false ] || [ "${#FAILED_ISSUES[@]}" -eq "${#SORTED_WORK_U
   if [ -n "$RETRO_SCRATCH_PATH" ] && [ -f "$RETRO_SCRATCH_PATH" ]; then
     echo "       $RETRO_SCRATCH_PATH"
   fi
-  echo "  3. File one issue per work unit. Apply labels: retro, priority:P<n>, comp:<slug>."
+  echo "  3. File one issue per work unit. Apply labels: $RETRO_PROVENANCE_LABEL, bug or enhancement, priority:P<n>, comp:<slug>. Use native --add-blocked-by only for explicit prerequisites; keep related-area references in prose."
   if [ -n "$MANUSCRIPTS_URL" ]; then
     echo "  4. Manuscripts: $MANUSCRIPTS_URL"
   fi


### PR DESCRIPTION
## Intent

Actionable work filed by `/printing-press-retro` now keeps provenance separate from issue type, so the `retro` label cutover does not weaken cross-retro discovery or batch eligibility.

Issue: Fixes #3931

## Approach

The skill provisions canonical `source:retro` metadata on fresh forks, reads both `source:retro` and legacy `retro` during cutover, and selects a safe write marker with canonical-first preference. Every retro work unit now carries a deterministic `bug` or `enhancement` label mapping, while priority, component, provenance, surfaces, and routing labels remain separate concerns. The flat work-unit model is preserved; only explicit prerequisites become native GitHub `blocked-by`/`blocking` relationships, while related-area references stay prose.

`AGENTS.md` now makes the same taxonomy contract executable, including the exact nine-surface vocabulary and the distinction between component ownership and affected behavior.

## Scope

Primary area: `/printing-press-retro` skill/reference contracts and repository issue-taxonomy guidance.

Why this belongs in this repo: the Printing Press owns the retro skill that creates these issues and the repo guidance that governs their interpretation.

## Risk

Low. Existing legacy `retro` issues remain discoverable and remain a write fallback only when `source:retro` is unavailable. Native dependency edges are applied only for explicitly declared prerequisites; no PR queue labels or generated CLI surfaces change.

## Output Contract

N/A — this changes skill and policy contracts, not generator templates, generated files, manifests, command output, MCP schemas, scorecard output, or pipeline artifacts.

## Verification

- `go fmt ./...`
- `go test ./internal/pipeline -run '^TestRetroIssueTaxonomyAndRelationshipContracts$' -count=1` — passed
- `go run ./cmd/cli-printing-press verify-internal-skill --dir skills/printing-press-retro` — passed
- Extracted Bash blocks from `skills/printing-press-retro/references/issue-template.md` with `bash -n` — passed
- `git diff --check` — passed
- `go test ./...` — attempted; the inherited profile failed existing generator HTML-extraction tests after a schema-version warning polluted JSON output. A decoy-profile rerun passed the affected generator tests but the full suite still hit unrelated generator integration failures and macOS keychain `-60006` failures in `internal/pressauth`.
- Golden suite — not run: no generator templates, generated outputs, naming, manifests, or other golden-governed artifacts changed.

The generator/template checklist below is not applicable to this skill/policy-only change.

- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates

## New concepts

The contract separates durable issue facets from derived workflow state: labels carry priority, type, and ownership, while provenance and bounded surfaces add context and `pp-fix-batch` readiness remains derived. A declared prerequisite has a directed native dependency edge; a related-area mention does not, because prose alone does not establish dependency direction.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
