### PR TITLE
docs(cli): document x-pp-default-rate-limit and x-pp-membership-field extensions

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -20,6 +20,7 @@ in the same change as any new `Extensions["x-*"]` lookup in that file.
 | `x-roles` | root or `info` | `APISpec.Roles` | No |
 | `x-tier-routing` | root or `info` | `APISpec.TierRouting` | No |
 | `x-rate-class` | root or `info` | `APISpec.RateClass` | No |
+| `x-pp-default-rate-limit` | root or `info` | `APISpec.DefaultRateLimit` | No |
 | `x-mcp` | root or `info` | `APISpec.MCP` | No |
 | `x-cache` | root or `info` | `APISpec.Cache` | No |
 | `x-learn` | root or `info` | `APISpec.Learn` | No |
@@ -56,6 +57,7 @@ in the same change as any new `Extensions["x-*"]` lookup in that file.
 | `x-pp-sync-walker` | operation | `Endpoint.Walker` | No |
 | `x-pp-dispatch-param` | parameter | `Param.DispatchParam` | No |
 | `x-pp-tenant-scope-column` | path item | *reserved for follow-up tenant-scoped reconcile; not parsed yet* | No |
+| `x-pp-membership-field` | path item | `Endpoint.MembershipField` | No |
 
 ## `info` Extensions
 
@@ -254,6 +256,36 @@ info:
   title: Low Quota API
   version: "1.0"
   x-rate-class: monthly
+```
+
+### `x-pp-default-rate-limit`
+
+Sets the built-in default for the generated CLI's `--rate-limit` flag from an
+OpenAPI spec, mirroring the internal YAML `default_rate_limit` field.
+
+Parsed field: `APISpec.DefaultRateLimit`
+
+Rules:
+- Optional.
+- May be declared at the OpenAPI root or under `info`. Root takes precedence
+  when both are present.
+- The value is either the string `"auto"` (case-insensitive) or a non-negative
+  number (a JSON number or a numeric string). Any other shape is rejected with
+  a validation error.
+- `"auto"` selects the header-driven adaptive limiter so the CLI paces itself
+  to the server's `X-Ratelimit-*` headers with no hardcoded ceiling. A numeric
+  value (e.g. `2`) pins a fixed requests-per-second ceiling.
+- When absent, the legacy provenance default applies (2 for sniffed specs, else
+  0 = disabled). This only sets the default; the generated `--rate-limit` flag
+  still overrides it at runtime.
+
+Example:
+
+```yaml
+info:
+  title: Throttled API
+  version: "1.0"
+  x-pp-default-rate-limit: auto
 ```
 
 ### `x-mcp`
@@ -575,6 +607,36 @@ paths:
     get:
       operationId: list_projects
       summary: List or retrieve projects
+```
+
+### `x-pp-membership-field`
+
+Declares, on a parent collection's list path-item, the boolean field in that
+collection's own row payload that indicates whether the authenticated user is a
+member of the resource (e.g. `is_member`). Dependent fan-out over the parent
+table skips rows whose field is false — their sub-resources would 403 — so a
+sync reports one clear "not a member" summary instead of a 403 per
+(sub-resource, parent).
+
+Parsed field: `Endpoint.MembershipField`
+
+Rules:
+- Optional. Absence means no membership filtering is recorded.
+- Placed on the list path-item object (same level as `get:`, `post:`, etc.),
+  not on an individual operation.
+- Must be a string naming a boolean field in the row payload; non-string
+  values are ignored with a warning.
+- Consumed by the profiler when building dependent-sync resource metadata.
+
+Example:
+
+```yaml
+paths:
+  /workspaces/:
+    x-pp-membership-field: is_member
+    get:
+      operationId: list_workspaces
+      summary: List workspaces
 ```
 
 ### `x-path-template-env-vars`

--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -626,6 +626,10 @@ Rules:
   not on an individual operation.
 - Must be a string naming a boolean field in the row payload; non-string
   values are ignored with a warning.
+- The field name must be a simple identifier (`^[a-zA-Z_][a-zA-Z0-9_]*$`). It
+  is interpolated into the generated store's non-member query, so dotted or
+  nested-path field names are rejected at runtime and the membership skip
+  becomes a no-op rather than filtering rows.
 - Consumed by the profiler when building dependent-sync resource metadata.
 
 Example:


### PR DESCRIPTION
## Intent

`docs/SPEC-EXTENSIONS.md` opens with an explicit completeness contract — *"the Printing Press only reads the extensions listed here"*, with `internal/openapi/parser.go` as the source of truth. Two extensions are parsed and mapped onto real spec fields today but were absent from the reference, so the doc under-described its own contract.

Issue: #3944

## Approach

Adds one Summary-table row and one section for each extension, following the existing `x-rate-class` (root/info rate extension) and `x-pp-tenant-scope-column` (path-item field extension) entry styles. No new behavior is proposed — every rule line is transcribed from the parser code and the struct doc-comments:

- **`x-pp-default-rate-limit`** → `APISpec.DefaultRateLimit`. Root/info; value is `"auto"` or a non-negative number (`parser.go:939-984`); sets the generated `--rate-limit` default (`spec.go:304-312`).
- **`x-pp-membership-field`** → `Endpoint.MembershipField`. Path-item string naming the boolean membership field in a parent collection row payload (`parser.go:5765-5783`, `spec.go:2356-2363`); consumed by the profiler for dependent fan-out (`profiler.go:890-895`).

## Scope

Primary area: `docs/` (OpenAPI extension reference).

Why this belongs in this repo: `docs/SPEC-EXTENSIONS.md` is the canonical Printing Press extension reference and its own header mandates it stay in sync with `internal/openapi/parser.go`. This PR closes that gap for two extensions already parsed by the generator (machine) — it documents existing machine behavior, not a printed-CLI fix.

## Risk

N/A — documentation-only. No template, generator code, parser, manifest, MCP schema, command output, scorecard, or pipeline artifact is touched, so there is no generated-output or output-contract impact.

## Output Contract

N/A — docs-only change; does not affect templates, generated files, manifests, command output, MCP schemas, scorecard output, or pipeline artifacts.

## Verification

- [ ] Not applicable — this is a docs-only edit to `docs/SPEC-EXTENSIONS.md`; no generator/template/parser code changed.
- `go build -o ./cli-printing-press ./cmd/cli-printing-press` — passes.
- `scripts/golden.sh verify` — the only diffs are the pre-existing Windows CRLF / `spec_checksum` platform artifacts (identical 32-case failure count with this branch stashed vs. applied; tracked by #3689 / #3918). None of the golden diffs touch any extension, rate-limit, or membership field. CI runs on Linux where these pass.

Not run: full `go test ./...` on Windows reports only the pre-existing POSIX-0600 permission failures (#3918); not caused by this change (no Go files touched).

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only
- [ ] Fully automated