### PR TITLE
docs(cli): correct stale x-pp-tenant-scope-column reference

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -56,7 +56,7 @@ in the same change as any new `Extensions["x-*"]` lookup in that file.
 | `x-pp-safe-probe` | operation | *skill guidance only; not parsed in parser.go* | No |
 | `x-pp-sync-walker` | operation | `Endpoint.Walker` | No |
 | `x-pp-dispatch-param` | parameter | `Param.DispatchParam` | No |
-| `x-pp-tenant-scope-column` | path item | *reserved for follow-up tenant-scoped reconcile; not parsed yet* | No |
+| `x-pp-tenant-scope-column` | path item | `Endpoint.TenantScopeColumn` | No |
 | `x-pp-membership-field` | path item | `Endpoint.MembershipField` | No |
 
 ## `info` Extensions
@@ -573,30 +573,33 @@ info:
 
 ### `x-pp-tenant-scope-column`
 
-Declares, on a parent collection's list path-item, the column or field name
-that identifies the tenant (e.g. workspace) scope for each row returned by
-that collection. Use it on list path-items whose synced rows are partitioned
-by a workspace or organization identifier, so that a future deletion-
-reconciliation pass can target only the rows belonging to the active tenant
-rather than pruning the entire table.
+Declares, on a collection's list path-item, the column or field name that
+identifies the tenant (e.g. workspace) scope for each row returned by that
+collection. It is self-declaring: the annotated collection's own rows carry
+this column. Use it on list path-items whose synced rows are partitioned by a
+workspace or organization identifier.
 
-This extension is **reserved and forward-looking**. It is consumed by the
-upcoming tenant-scoped deletion-reconciliation and flat fan-out work; the
-follow-up parser will map it to a `tenantScopeColumn` field on the profiled
-resource. The extension is **not parsed in the current release** and has no
-effect on generated output today. Specs without it are unaffected.
+Parsed field: `Endpoint.TenantScopeColumn`
+
+The value flows into the resource profile and is consumed in two places:
+- **Tenant-scoped dependent fan-out** (parent tables): a parent collection
+  carrying a tenant column is surfaced via `APIProfile.TenantScopedParents()`
+  into the generated `parentTenantScopeColumns` map, so dependent fan-out
+  targets only rows belonging to the active tenant.
+- **Flat tenant-scoped reconcile**: a flat resource becomes reconcilable
+  (`ReconcileMode = "flat"`) only when it carries a tenant column, has a
+  stable primary key, and is not routed through a discriminator dispatcher;
+  otherwise it stays `"none"`.
 
 Rules:
-- Optional. Absence means no tenant scoping is recorded; the current release
-  behavior is unchanged.
+- Optional. Absence means no tenant scoping is recorded for the collection.
 - Placed on the list path-item object (same level as `get:`, `post:`, etc.),
   not on an individual operation.
-- Value must be a non-empty string naming the response field that holds the
-  tenant scope (e.g. `workspace`, `workspace_slug`, `org_id`).
-- Only one column per path-item is meaningful; the field names the foreign-key
-  column whose values identify tenant boundaries in the synced rows.
-- Has no effect this round; the parser will begin reading it in the follow-up
-  tenant-scoped reconcile task.
+- Must be a string naming the response field that holds the tenant scope
+  (e.g. `workspace`, `workspace_slug`, `org_id`); non-string values are
+  ignored with a warning.
+- The field names the foreign-key column whose values identify tenant
+  boundaries in the synced rows.
 
 Example:
 


### PR DESCRIPTION
## Intent

`docs/SPEC-EXTENSIONS.md` documented `x-pp-tenant-scope-column` as reserved / forward-looking, stating it is *"not parsed in the current release"* and *"has no effect on generated output today."* That is no longer accurate — the follow-up it described has landed, but the doc was never updated, so it now contradicts the source of truth (`internal/openapi/parser.go`).

Issue: #3945

## Approach

Two changes to the `x-pp-tenant-scope-column` entry, both transcribed from the current code:

1. **Summary-table row** — replace *"reserved for follow-up tenant-scoped reconcile; not parsed yet"* with `Endpoint.TenantScopeColumn` (parsed), matching every other parsed extension row.
2. **Section body** — drop the "reserved / not parsed / no effect" claims and describe the actual behavior sourced from the parser and profiler:
   - Parsed from the path-item (`parser.go:5748-5762`) → `Endpoint.TenantScopeColumn` (`spec.go:2350-2355`); self-declaring (the annotated collection's own rows carry the column).
   - Consumed by the profiler in two places: tenant-scoped dependent fan-out (`APIProfile.TenantScopedParents()` → `parentTenantScopeColumns`, `profiler.go:854-872`) and flat tenant-scoped reconcile gating (`ReconcileMode = "flat"`, `profiler.go:707-711`).
   - Non-string values are ignored with a warning (`parser.go:5760`).

The existing YAML example is kept unchanged. No new behavior is proposed.

## Scope

Primary area: `docs/` (OpenAPI extension reference).

Why this belongs in this repo: `docs/SPEC-EXTENSIONS.md` is the canonical Printing Press extension reference and its header names `internal/openapi/parser.go` as the source of truth. This PR fixes a factual error in that reference — documenting existing machine behavior, not a printed-CLI fix.

## Risk

N/A — documentation-only. No template, generator code, parser, manifest, MCP schema, command output, scorecard, or pipeline artifact is touched, so there is no generated-output or output-contract impact.

## Output Contract

N/A — docs-only change; does not affect templates, generated files, manifests, command output, MCP schemas, scorecard output, or pipeline artifacts.

## Verification

- [ ] Not applicable — this is a docs-only edit to `docs/SPEC-EXTENSIONS.md`; no generator/template/parser code changed.
- `go build -o ./cli-printing-press ./cmd/cli-printing-press` — passes.
- `scripts/golden.sh verify` — the only diffs are the pre-existing Windows CRLF / `spec_checksum` platform artifacts (identical 32-case failure count on clean `main` and on this branch; tracked by #3689 / #3918). None of the golden diffs touch tenant-scope-column. CI runs on Linux where these pass.

Not run: full `go test ./...` on Windows reports only the pre-existing POSIX-0600 permission failures (#3918); not caused by this change (no Go files touched).

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only
- [ ] Fully automated
