### PR TITLE
fix(skills): correct secret-scrubbing link in retro artifact-packaging

### DIFF
--- a/skills/printing-press-retro/references/artifact-packaging.md
+++ b/skills/printing-press-retro/references/artifact-packaging.md
@@ -57,7 +57,7 @@ fi
 
 ## Step 3: Scrub secrets
 
-Read and apply [references/secret-scrubbing.md](references/secret-scrubbing.md) on
+Read and apply [references/secret-scrubbing.md](secret-scrubbing.md) on
 the staging copies. The scrub file expects `$STAGING_MANUSCRIPTS` and
 `$STAGING_CLI_SOURCE` to be set.
 


### PR DESCRIPTION
## Intent

`skills/printing-press-retro/references/artifact-packaging.md` line 60 has a broken relative markdown link.

The Step 3 link is written as `[references/secret-scrubbing.md](references/secret-scrubbing.md)`, but the link lives *inside* `references/`, so the target resolves to:

```
skills/printing-press-retro/references/references/secret-scrubbing.md   # does not exist
```

The real file is a sibling:

```
skills/printing-press-retro/references/secret-scrubbing.md             # exists
```

Step 3 is the pre-upload **secret scrub**. An agent that follows this link, gets nothing back, and continues anyway can upload retro artifacts without applying the scrub patterns. That is the reason this is filed as `fix` rather than `docs`.

Found by a `lychee` link-check sweep over an installed skills tree.

Issue: N/A (no existing issue found; searched open/closed issues and open PRs for `link` / `scrub` / `artifact-packaging` / `broken`)

## Approach

Point the link target at the sibling filename, `secret-scrubbing.md`.

The link **text** is deliberately left as `references/secret-scrubbing.md` so the rendered prose still names the file by its skill-relative path, which is how the other skills refer to their reference files. Only the target changed.

```diff
-Read and apply [references/secret-scrubbing.md](references/secret-scrubbing.md) on
+Read and apply [references/secret-scrubbing.md](secret-scrubbing.md) on
```

## Scope

Primary area: `skills` — one line in one skill reference file.

Why this belongs in this repo: `skills/printing-press-retro/**` is machine-level content that ships from this repo and is installed into agent skill trees. It is not printed-CLI output, so there is nowhere downstream to fix it durably — a local edit to an installed skills tree is overwritten on the next Printing Press update.

Deliberately **not** included in this PR:
- No other files touched.
- I scanned every `*/references/*.md` in the repo for the same self-prefixing pattern (`](references/` appearing inside a `references/` directory). This is the **only** occurrence, so there is no companion sweep to do.

## Risk

Very low. Documentation-only, single link target, no code, no templates, no generated output, no manifests, no MCP surface, no auth, no publish/verifier/scorer/release behavior.

Worst case if wrong: the link still does not resolve, which is the status quo.

### Overlap with open PRs

- **#3776** (`feat(skills): split retro skill into router and phase files`) restructures `SKILL.md` into `phases/*.md`. Its file list does not include `references/artifact-packaging.md`, so this should not conflict. The broken link persists under either structure, so this fix stays correct whichever lands first.
- **#3705** (`fix(retro): harden catbox upload — scrub gate + strict response validation`) hardens the same Step 3 scrub gate. Complementary rather than overlapping: that PR strengthens the gate's enforcement, this one repairs the pointer to the scrub instructions the gate depends on.

## Output Contract

N/A — no templates, generated files, manifests, command output, MCP schemas, scorecard output, or pipeline artifacts are affected.

## Verification

Checks actually run:

- Confirmed the current target 404s: `GET /repos/mvanhorn/cli-printing-press/contents/skills/printing-press-retro/references/references` → `404 Not Found`.
- Confirmed the corrected target exists: `skills/printing-press-retro/references/` contains `artifact-packaging.md`, `issue-template.md`, `secret-scrubbing.md`.
- Repo-wide scan for the same defect across all `*/references/*.md` files — exactly one hit, the line fixed here.
- Reviewed the diff: 1 file changed, 1 insertion, 1 deletion; link text unchanged.

- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates

`scripts/golden.sh verify` — **not run**. This change touches no generator, template, or generated-artifact surface, so golden coverage is not applicable per `AGENTS.md` / `docs/GOLDEN.md`.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change

The reporter independently found this with a `lychee` link-check, verified the correct target, and had already applied this identical one-line fix by hand to their local skills tree before asking for it to be sent upstream. The PR was prepared by an AI agent working from that direction.
