### PR TITLE
fix(polish): count _test.go references and compile test binaries before verifying

### DIFF
--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -3297,9 +3297,8 @@ func listGoFiles(dir string) []string {
 	return files
 }
 
-// listGoTestFiles returns the _test.go files in dir. It is the complement of
-// listGoFiles, which skips them. Dead-code analysis needs both: definitions
-// come from non-test files, usage must be counted across everything.
+// Dead-code analysis needs non-test files for definitions while counting usage
+// across both production and test files.
 func listGoTestFiles(dir string) []string {
 	entries, err := os.ReadDir(dir)
 	if err != nil {

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -3297,6 +3297,26 @@ func listGoFiles(dir string) []string {
 	return files
 }
 
+// listGoTestFiles returns the _test.go files in dir. It is the complement of
+// listGoFiles, which skips them. Dead-code analysis needs both: definitions
+// come from non-test files, usage must be counted across everything.
+func listGoTestFiles(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	var files []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		files = append(files, filepath.Join(dir, entry.Name()))
+	}
+	sort.Strings(files)
+	return files
+}
+
 func countDomainTables(storeSource string) int {
 	if storeSource == "" {
 		return 0

--- a/internal/pipeline/polish.go
+++ b/internal/pipeline/polish.go
@@ -106,16 +106,14 @@ func RemoveDeadCode(dir string, dryRun bool) (*PolishResult, error) {
 		buildCmd.Dir = dir
 		buildOutput, buildErr := buildCmd.CombinedOutput()
 
-		// `go build` never compiles _test.go, so on its own it cannot notice
-		// that a removal broke the test suite. `go test -run ^$` builds every
-		// test binary and runs no test: it is the compile-only check, and it is
-		// as fast as a build. Actually running the suite here would be slow and
-		// would fail for reasons unrelated to the removal (network, live API).
+		// Test binaries must compile after removal, but they must not execute:
+		// generated suites can require live credentials or other runtime setup.
 		if buildErr == nil {
-			testCmd := exec.Command("go", "test", "-run", "^$", "./...")
-			testCmd.Dir = dir
-			if out, err := testCmd.CombinedOutput(); err != nil {
+			if out, err := compileTestBinaries(dir); err != nil {
 				buildErr = err
+				if len(out) == 0 {
+					out = []byte(err.Error())
+				}
 				buildOutput = out
 			}
 		}
@@ -138,6 +136,18 @@ func RemoveDeadCode(dir string, dryRun bool) (*PolishResult, error) {
 
 	result.BuildVerified = true
 	return result, nil
+}
+
+func compileTestBinaries(dir string) ([]byte, error) {
+	outputDir, err := os.MkdirTemp("", "printing-press-polish-tests-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating test build directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(outputDir) }()
+
+	testCmd := exec.Command("go", "test", "-c", "-o", outputDir, "./...")
+	testCmd.Dir = dir
+	return testCmd.CombinedOutput()
 }
 
 // findAllDeadFunctions scans ALL .go files in a CLI's internal/cli/ directory

--- a/internal/pipeline/polish.go
+++ b/internal/pipeline/polish.go
@@ -101,10 +101,24 @@ func RemoveDeadCode(dir string, dryRun bool) (*PolishResult, error) {
 			}
 		}
 
-		// Verify build after each pass
+		// Verify build after each pass.
 		buildCmd := exec.Command("go", "build", "./...")
 		buildCmd.Dir = dir
 		buildOutput, buildErr := buildCmd.CombinedOutput()
+
+		// `go build` never compiles _test.go, so on its own it cannot notice
+		// that a removal broke the test suite. `go test -run ^$` builds every
+		// test binary and runs no test: it is the compile-only check, and it is
+		// as fast as a build. Actually running the suite here would be slow and
+		// would fail for reasons unrelated to the removal (network, live API).
+		if buildErr == nil {
+			testCmd := exec.Command("go", "test", "-run", "^$", "./...")
+			testCmd.Dir = dir
+			if out, err := testCmd.CombinedOutput(); err != nil {
+				buildErr = err
+				buildOutput = out
+			}
+		}
 
 		if buildErr != nil {
 			result.BuildVerified = false
@@ -157,6 +171,17 @@ func findAllDeadFunctions(cliDir string, extraSearchDirs ...string) []string {
 		matches := funcRe.FindAllStringSubmatch(content, -1)
 		for _, match := range matches {
 			allDefs = append(allDefs, funcDef{name: match[1], file: file})
+		}
+	}
+
+	// Usage detection must see _test.go too. listGoFiles deliberately skips
+	// test files so their helpers never become removal candidates, but a
+	// function whose only callers are tests is still live: deleting it leaves a
+	// tree that passes `go build` and fails `go test`. Read them for usage
+	// only — no definitions are harvested here.
+	for _, file := range listGoTestFiles(cliDir) {
+		if data, err := os.ReadFile(file); err == nil {
+			allContent = append(allContent, string(data))
 		}
 	}
 

--- a/internal/pipeline/polish_testrefs_test.go
+++ b/internal/pipeline/polish_testrefs_test.go
@@ -1,0 +1,77 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFindAllDeadFunctions_CountsTestFileReferences pins that a function whose
+// only callers live in _test.go files is NOT reported dead.
+//
+// listGoFiles skips *_test.go, and findAllDeadFunctions built both its
+// definition set and its usage corpus from that same list, so test-only callers
+// were invisible. On a real printed CLI that made RootCmd — the entry point the
+// generator's own scaffold tests call, 25 times in one case — look unreferenced.
+// Removing it leaves a tree that still passes `go build` and fails `go test`.
+func TestFindAllDeadFunctions_CountsTestFileReferences(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "root.go"), []byte(`package cli
+
+// RootCmd is constructed by main and by every scaffold test.
+func RootCmd() string {
+	return "root"
+}
+
+func trulyDead() string {
+	return "nobody calls me, not even a test"
+}
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "root_test.go"), []byte(`package cli
+
+import "testing"
+
+func TestRootWires(t *testing.T) {
+	if RootCmd() != "root" {
+		t.Fatal("boom")
+	}
+}
+`), 0o644))
+
+	dead := findAllDeadFunctions(dir)
+
+	require.NotContains(t, dead, "RootCmd",
+		"RootCmd is called from root_test.go; deleting it would break the suite while still passing go build")
+	require.Contains(t, dead, "trulyDead",
+		"a function with no caller anywhere must still be reported dead")
+}
+
+// TestFindAllDeadFunctions_TestOnlyHelperIsLive covers the same rule for an
+// unexported helper used only by a table test.
+func TestFindAllDeadFunctions_TestOnlyHelperIsLive(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "helpers.go"), []byte(`package cli
+
+func normalizeKey(s string) string {
+	return s
+}
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "helpers_test.go"), []byte(`package cli
+
+import "testing"
+
+func TestNormalizeKey(t *testing.T) {
+	if normalizeKey("a") != "a" {
+		t.Fatal("boom")
+	}
+}
+`), 0o644))
+
+	require.NotContains(t, findAllDeadFunctions(dir), "normalizeKey")
+}

--- a/internal/pipeline/polish_verify_test.go
+++ b/internal/pipeline/polish_verify_test.go
@@ -1,0 +1,67 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoveDeadCode_KeepsTheSuiteCompiling is the end-to-end guard for
+// --remove-dead-code: after a pass, the tree must still build AND its test
+// binaries must still compile.
+//
+// `go build` never compiles _test.go, so verification on build alone cannot
+// notice that a removal broke the suite — the command would report
+// build_verified:true over a red tree. Verification now also runs
+// `go test -run ^$ ./...`, which builds every test binary and runs no test.
+func TestRemoveDeadCode_KeepsTheSuiteCompiling(t *testing.T) {
+	dir := t.TempDir()
+	cliDir := filepath.Join(dir, "internal", "cli")
+	require.NoError(t, os.MkdirAll(cliDir, 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "probe"), 0o755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module probe-pp-cli\n\ngo 1.22\n"), 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "root.go"), []byte(`package cli
+
+// RootCmd is referenced only from root_test.go.
+func RootCmd() string {
+	return "root"
+}
+
+func trulyDead() string {
+	return "no caller anywhere"
+}
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "root_test.go"), []byte(`package cli
+
+import "testing"
+
+func TestRootWires(t *testing.T) {
+	if RootCmd() != "root" {
+		t.Fatal("boom")
+	}
+}
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd", "probe", "main.go"),
+		[]byte("package main\n\nfunc main() {}\n"), 0o644))
+
+	result, err := RemoveDeadCode(dir, false)
+	require.NoError(t, err)
+
+	require.True(t, result.BuildVerified,
+		"tree must verify clean; build_error=%q", result.BuildError)
+	require.NotContains(t, result.Removed, "RootCmd",
+		"RootCmd is referenced from a _test.go and must survive")
+
+	// The surviving source must still contain RootCmd, and the test binary must
+	// still compile — the whole point of the verification change.
+	src, err := os.ReadFile(filepath.Join(cliDir, "root.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(src), "func RootCmd(")
+}

--- a/internal/pipeline/polish_verify_test.go
+++ b/internal/pipeline/polish_verify_test.go
@@ -13,9 +13,8 @@ import (
 // binaries must still compile.
 //
 // `go build` never compiles _test.go, so verification on build alone cannot
-// notice that a removal broke the suite — the command would report
-// build_verified:true over a red tree. Verification now also runs
-// `go test -run ^$ ./...`, which builds every test binary and runs no test.
+// notice that a removal broke the suite. Verification must compile test
+// binaries without executing package initialization or TestMain setup.
 func TestRemoveDeadCode_KeepsTheSuiteCompiling(t *testing.T) {
 	dir := t.TempDir()
 	cliDir := filepath.Join(dir, "internal", "cli")
@@ -39,7 +38,14 @@ func trulyDead() string {
 
 	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "root_test.go"), []byte(`package cli
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(*testing.M) {
+	os.Exit(23)
+}
 
 func TestRootWires(t *testing.T) {
 	if RootCmd() != "root" {
@@ -55,7 +61,7 @@ func TestRootWires(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, result.BuildVerified,
-		"tree must verify clean; build_error=%q", result.BuildError)
+		"test binaries must compile without executing TestMain; build_error=%q", result.BuildError)
 	require.NotContains(t, result.Removed, "RootCmd",
 		"RootCmd is referenced from a _test.go and must survive")
 


### PR DESCRIPTION
Fixes #3992.

## The bug

`findAllDeadFunctions` built **both** its definition set and its usage corpus from
`listGoFiles`, which deliberately skips `*_test.go`. Test-only callers were
therefore invisible, and any function called only from tests was reported dead.

`go build` never compiles `_test.go`, so the post-removal verification could not
notice the breakage either. The command would delete a live function, report
`build_verified: true`, and leave a red suite behind.

## Real-world impact

On a 4.30.1-generated CLI, `--dry-run` proposed deleting **`RootCmd`** — the entry
point the generator's own scaffold tests call, 25 times in that tree. It is
reached during the documented Phase 5.5 polish step, where an operator may well
run it without a dry run first.

## The fix

**1. Usage detection now reads `_test.go`.** Definitions still come from non-test
files only, so test helpers never become removal candidates — the asymmetry is
deliberate and commented. New `listGoTestFiles`, the complement of `listGoFiles`.

(`extraSearchDirs` already walked every `.go` including tests, so only the
`internal/cli` corpus had the blind spot.)

**2. Verification now compiles the test binaries.** After `go build ./...`,
verification runs `go test -run ^$ ./...` — builds every test binary, runs no
test. Fast, deterministic, and it catches exactly what `go build` cannot.

Deliberately *not* running the real suite: it is slow and would fail for reasons
unrelated to the removal (network, live API), which would make the gate flaky and
train people to ignore it.

## Verification

Three tests, all written failing first:

- `TestFindAllDeadFunctions_CountsTestFileReferences` — a function called only
  from `_test.go` is not dead; one with no caller anywhere still is.
- `TestFindAllDeadFunctions_TestOnlyHelperIsLive` — same rule for an unexported
  helper used by a table test.
- `TestRemoveDeadCode_KeepsTheSuiteCompiling` — end-to-end against a real temp
  module: after a pass the tree builds, the test binaries compile, and `RootCmd`
  survives.

Real CLI, before → after: `dead_functions_found` drops from **14 to 10**, and
`RootCmd` is no longer among them. The 10 that remain are genuinely unreferenced.

`go vet` clean. Six `internal/pipeline` tests fail both before and after on this
host (skill-file/currency-floor tests, unrelated to this change).
