### PR TITLE
fix(generator): pick docs examples by method, not alphabetical order

### DIFF
--- a/internal/generator/first_command_example.go
+++ b/internal/generator/first_command_example.go
@@ -51,14 +51,39 @@ func firstCommandExample(resources map[string]spec.Resource) string {
 		return strings.Join(parts, " ")
 	}
 
+	// Pass 1: an endpoint named exactly for a read-only verb.
 	for _, rName := range resNames {
 		r := resources[rName]
 		for _, verb := range preferredVerbs {
-			if ep, ok := r.Endpoints[verb]; ok {
+			if ep, ok := r.Endpoints[verb]; ok && isReadOnlyEndpoint(ep) {
 				return pathFor(rName, r, verb, ep)
 			}
 		}
 	}
+	// Pass 2: any read-only endpoint, by transport method rather than by name.
+	//
+	// Pass 1 matches endpoint names exactly, which most real specs never
+	// satisfy — they name endpoints with the verb as a prefix
+	// ("get-service-desks", "list-users"). Without this pass the search fell
+	// straight through to "alphabetically first", which is a coin flip on
+	// whether the docs advertise a mutation. For a Jira Service Management CLI
+	// it produced `add-customers`, a POST, in the blocks that illustrate
+	// --select / --json / --dry-run / --agent / --profile.
+	//
+	// These blocks are read by agents. A mutating command in the "here is how
+	// you use the flags" slot is materially more likely to be executed than the
+	// same example in human-facing prose.
+	for _, rName := range resNames {
+		r := resources[rName]
+		for _, eName := range sortedEndpointNames(r.Endpoints) {
+			if ep := r.Endpoints[eName]; isReadOnlyEndpoint(ep) {
+				return pathFor(rName, r, eName, ep)
+			}
+		}
+	}
+	// Pass 3: the spec has no read-only endpoint at all. Returning empty would
+	// delete the docs block, so fall back — this is the only path on which a
+	// mutation can appear in an example.
 	for _, rName := range resNames {
 		r := resources[rName]
 		eNames := sortedEndpointNames(r.Endpoints)
@@ -67,6 +92,22 @@ func firstCommandExample(resources map[string]spec.Resource) string {
 		}
 	}
 	return ""
+}
+
+// isReadOnlyEndpoint reports whether invoking ep is safe to advertise in
+// generated documentation. GET and HEAD are read-only by transport; Mutation
+// overrides that for GET actions the spec author has flagged as having side
+// effects.
+func isReadOnlyEndpoint(ep spec.Endpoint) bool {
+	if ep.Mutation {
+		return false
+	}
+	switch strings.ToUpper(strings.TrimSpace(ep.Method)) {
+	case "GET", "HEAD":
+		return true
+	default:
+		return false
+	}
 }
 
 func commandExampleArgs(ep spec.Endpoint) string {

--- a/internal/generator/first_command_example.go
+++ b/internal/generator/first_command_example.go
@@ -12,8 +12,7 @@ import (
 // firstCommandExample returns a runnable "resource [endpoint] <pos1> <pos2>..."
 // invocation for docs that need a concrete example. Required public flags are
 // included so generated docs do not advertise commands that fail immediately.
-// Read-only verbs (list, get, search, query) are preferred to keep examples
-// non-destructive.
+// Read-only commands are preferred to keep examples non-destructive.
 // Returns empty when the spec has no endpoints, so callers can skip the
 // block rather than render nonsense.
 //
@@ -51,39 +50,24 @@ func firstCommandExample(resources map[string]spec.Resource) string {
 		return strings.Join(parts, " ")
 	}
 
-	// Pass 1: an endpoint named exactly for a read-only verb.
 	for _, rName := range resNames {
 		r := resources[rName]
 		for _, verb := range preferredVerbs {
-			if ep, ok := r.Endpoints[verb]; ok && isReadOnlyEndpoint(ep) {
+			if ep, ok := r.Endpoints[verb]; ok && endpointIsReadCommand(ep, verb) {
 				return pathFor(rName, r, verb, ep)
 			}
 		}
 	}
-	// Pass 2: any read-only endpoint, by transport method rather than by name.
-	//
-	// Pass 1 matches endpoint names exactly, which most real specs never
-	// satisfy — they name endpoints with the verb as a prefix
-	// ("get-service-desks", "list-users"). Without this pass the search fell
-	// straight through to "alphabetically first", which is a coin flip on
-	// whether the docs advertise a mutation. For a Jira Service Management CLI
-	// it produced `add-customers`, a POST, in the blocks that illustrate
-	// --select / --json / --dry-run / --agent / --profile.
-	//
-	// These blocks are read by agents. A mutating command in the "here is how
-	// you use the flags" slot is materially more likely to be executed than the
-	// same example in human-facing prose.
 	for _, rName := range resNames {
 		r := resources[rName]
 		for _, eName := range sortedEndpointNames(r.Endpoints) {
-			if ep := r.Endpoints[eName]; isReadOnlyEndpoint(ep) {
+			if ep := r.Endpoints[eName]; endpointIsReadCommand(ep, eName) {
 				return pathFor(rName, r, eName, ep)
 			}
 		}
 	}
-	// Pass 3: the spec has no read-only endpoint at all. Returning empty would
-	// delete the docs block, so fall back — this is the only path on which a
-	// mutation can appear in an example.
+	// Preserve examples for mutation-only specs; callers use empty to mean that
+	// the spec has no endpoints.
 	for _, rName := range resNames {
 		r := resources[rName]
 		eNames := sortedEndpointNames(r.Endpoints)
@@ -93,23 +77,6 @@ func firstCommandExample(resources map[string]spec.Resource) string {
 	}
 	return ""
 }
-
-// isReadOnlyEndpoint reports whether invoking ep is safe to advertise in
-// generated documentation. GET and HEAD are read-only by transport; Mutation
-// overrides that for GET actions the spec author has flagged as having side
-// effects.
-func isReadOnlyEndpoint(ep spec.Endpoint) bool {
-	if ep.Mutation {
-		return false
-	}
-	switch strings.ToUpper(strings.TrimSpace(ep.Method)) {
-	case "GET", "HEAD":
-		return true
-	default:
-		return false
-	}
-}
-
 func commandExampleArgs(ep spec.Endpoint) string {
 	return strings.Join(commandExampleArgParts(ep), " ")
 }

--- a/internal/generator/first_command_example_readonly_test.go
+++ b/internal/generator/first_command_example_readonly_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFirstCommandExample_PrefersReadOnlyWhenVerbsArePrefixed pins that the
+// docs example is never a mutating call.
+//
+// The read-only preference matched endpoint names *exactly* — "list", "get",
+// "search", "query". Real specs name endpoints with the verb as a prefix
+// ("get-service-desks", "add-customers"), so the preference silently did not
+// apply and the fallback picked the alphabetically-first endpoint. For a Jira
+// Service Management CLI that is `add-customers`, a POST that adds customers to
+// a service desk — and it landed in the README/SKILL blocks that illustrate
+// --select, --json, --dry-run, --agent and --profile.
+//
+// These artifacts are read by agents, so a mutating command in the "here is how
+// you use the flags" slot is materially likely to be executed.
+func TestFirstCommandExample_PrefersReadOnlyWhenVerbsArePrefixed(t *testing.T) {
+	resources := map[string]spec.Resource{
+		"servicedeskapi": {
+			Endpoints: map[string]spec.Endpoint{
+				// Alphabetically first, and a mutation.
+				"add-customers": {
+					Method: "POST",
+					Path:   "/rest/servicedeskapi/servicedesk/{serviceDeskId}/customer",
+					Params: []spec.Param{
+						{Name: "serviceDeskId", Positional: true, Required: true},
+					},
+				},
+				"get-service-desks": {
+					Method: "GET",
+					Path:   "/rest/servicedeskapi/servicedesk",
+				},
+			},
+		},
+	}
+
+	got := firstCommandExample(resources)
+	require.NotEmpty(t, got)
+	require.False(t, strings.Contains(got, "add-customers"),
+		"docs example must not be a mutating endpoint; got %q", got)
+	require.Contains(t, got, "get-service-desks",
+		"a GET endpoint was available and should have been chosen; got %q", got)
+}
+
+// TestFirstCommandExample_PrefersGETAcrossResources covers the cross-resource
+// case: a mutation in an alphabetically earlier resource must not beat a GET in
+// a later one.
+func TestFirstCommandExample_PrefersGETAcrossResources(t *testing.T) {
+	resources := map[string]spec.Resource{
+		"aaa-writes": {
+			Endpoints: map[string]spec.Endpoint{
+				"create-thing": {Method: "POST", Path: "/things"},
+			},
+		},
+		"zzz-reads": {
+			Endpoints: map[string]spec.Endpoint{
+				"fetch-thing": {Method: "GET", Path: "/things"},
+			},
+		},
+	}
+
+	got := firstCommandExample(resources)
+	require.Contains(t, got, "zzz-reads",
+		"a GET in a later resource beats a POST in an earlier one; got %q", got)
+}
+
+// TestFirstCommandExample_MutationOnlySpecStillReturnsSomething: when a spec has
+// no read-only endpoint at all there is nothing safe to show, and returning
+// empty would delete the docs block. Falling back is correct — but it must be
+// the only case where a mutation appears.
+func TestFirstCommandExample_MutationOnlySpecStillReturnsSomething(t *testing.T) {
+	resources := map[string]spec.Resource{
+		"writes": {
+			Endpoints: map[string]spec.Endpoint{
+				"create-thing": {Method: "POST", Path: "/things"},
+			},
+		},
+	}
+	require.NotEmpty(t, firstCommandExample(resources))
+}
+
+// TestFirstCommandExample_RespectsExplicitMutationFlag: a GET marked
+// Mutation:true (a GET action with side effects) must not be treated as safe.
+func TestFirstCommandExample_RespectsExplicitMutationFlag(t *testing.T) {
+	resources := map[string]spec.Resource{
+		"res": {
+			Endpoints: map[string]spec.Endpoint{
+				"aaa-trigger-rebuild": {Method: "GET", Path: "/rebuild", Mutation: true},
+				"bbb-fetch-status":    {Method: "GET", Path: "/status"},
+			},
+		},
+	}
+	got := firstCommandExample(resources)
+	require.Contains(t, got, "bbb-fetch-status",
+		"an endpoint flagged Mutation must not be chosen as the safe example; got %q", got)
+}

--- a/internal/generator/first_command_example_readonly_test.go
+++ b/internal/generator/first_command_example_readonly_test.go
@@ -3,31 +3,16 @@
 package generator
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/require"
 )
 
-// TestFirstCommandExample_PrefersReadOnlyWhenVerbsArePrefixed pins that the
-// docs example is never a mutating call.
-//
-// The read-only preference matched endpoint names *exactly* — "list", "get",
-// "search", "query". Real specs name endpoints with the verb as a prefix
-// ("get-service-desks", "add-customers"), so the preference silently did not
-// apply and the fallback picked the alphabetically-first endpoint. For a Jira
-// Service Management CLI that is `add-customers`, a POST that adds customers to
-// a service desk — and it landed in the README/SKILL blocks that illustrate
-// --select, --json, --dry-run, --agent and --profile.
-//
-// These artifacts are read by agents, so a mutating command in the "here is how
-// you use the flags" slot is materially likely to be executed.
 func TestFirstCommandExample_PrefersReadOnlyWhenVerbsArePrefixed(t *testing.T) {
 	resources := map[string]spec.Resource{
 		"servicedeskapi": {
 			Endpoints: map[string]spec.Endpoint{
-				// Alphabetically first, and a mutation.
 				"add-customers": {
 					Method: "POST",
 					Path:   "/rest/servicedeskapi/servicedesk/{serviceDeskId}/customer",
@@ -43,17 +28,9 @@ func TestFirstCommandExample_PrefersReadOnlyWhenVerbsArePrefixed(t *testing.T) {
 		},
 	}
 
-	got := firstCommandExample(resources)
-	require.NotEmpty(t, got)
-	require.False(t, strings.Contains(got, "add-customers"),
-		"docs example must not be a mutating endpoint; got %q", got)
-	require.Contains(t, got, "get-service-desks",
-		"a GET endpoint was available and should have been chosen; got %q", got)
+	require.Equal(t, "servicedeskapi get-service-desks", firstCommandExample(resources))
 }
 
-// TestFirstCommandExample_PrefersGETAcrossResources covers the cross-resource
-// case: a mutation in an alphabetically earlier resource must not beat a GET in
-// a later one.
 func TestFirstCommandExample_PrefersGETAcrossResources(t *testing.T) {
 	resources := map[string]spec.Resource{
 		"aaa-writes": {
@@ -73,10 +50,6 @@ func TestFirstCommandExample_PrefersGETAcrossResources(t *testing.T) {
 		"a GET in a later resource beats a POST in an earlier one; got %q", got)
 }
 
-// TestFirstCommandExample_MutationOnlySpecStillReturnsSomething: when a spec has
-// no read-only endpoint at all there is nothing safe to show, and returning
-// empty would delete the docs block. Falling back is correct — but it must be
-// the only case where a mutation appears.
 func TestFirstCommandExample_MutationOnlySpecStillReturnsSomething(t *testing.T) {
 	resources := map[string]spec.Resource{
 		"writes": {
@@ -88,18 +61,15 @@ func TestFirstCommandExample_MutationOnlySpecStillReturnsSomething(t *testing.T)
 	require.NotEmpty(t, firstCommandExample(resources))
 }
 
-// TestFirstCommandExample_RespectsExplicitMutationFlag: a GET marked
-// Mutation:true (a GET action with side effects) must not be treated as safe.
-func TestFirstCommandExample_RespectsExplicitMutationFlag(t *testing.T) {
+func TestFirstCommandExampleUsesEndpointReadClassification(t *testing.T) {
 	resources := map[string]spec.Resource{
 		"res": {
 			Endpoints: map[string]spec.Endpoint{
-				"aaa-trigger-rebuild": {Method: "GET", Path: "/rebuild", Mutation: true},
-				"bbb-fetch-status":    {Method: "GET", Path: "/status"},
+				"get-dangerous":  {Method: "GET", Path: "/dangerous", Mutation: true},
+				"run-rebuild":    {Method: "GET", Path: "/rebuild"},
+				"search-records": {Method: "POST", Path: "/search"},
 			},
 		},
 	}
-	got := firstCommandExample(resources)
-	require.Contains(t, got, "bbb-fetch-status",
-		"an endpoint flagged Mutation must not be chosen as the safe example; got %q", got)
+	require.Equal(t, "res search-records", firstCommandExample(resources))
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -18318,10 +18318,10 @@ func TestGeneratePublicParamNamesAcrossCLISurfaces(t *testing.T) {
 	assert.Contains(t, mcpSource, `bodyArgs[binding.WireName] = v`)
 
 	readme := readGeneratedFile(t, outputDir, "README.md")
-	assert.Contains(t, readme, `public-params-pp-cli stores create --store-code example-value`)
+	assert.Contains(t, readme, `public-params-pp-cli stores find --address example-value --city example-value`)
 
 	skill := readGeneratedFile(t, outputDir, "SKILL.md")
-	assert.Contains(t, skill, `public-params-pp-cli stores create --store-code example-value`)
+	assert.Contains(t, skill, `public-params-pp-cli stores find --address example-value --city example-value`)
 }
 
 func TestGenerateBodyNameAcrossCLISurfaces(t *testing.T) {

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/README.md
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/README.md
@@ -123,7 +123,7 @@ This checks your configuration.
 ### 3. Try Your First Command
 
 ```bash
-public-param-golden-pp-cli stores create --store-code example-value
+public-param-golden-pp-cli stores find --address example-value --city example-value --location-id 550e8400-e29b-41d4-a716-446655440000
 ```
 
 ## Usage
@@ -210,19 +210,19 @@ The local store's schema version stamp is one-way: once this version of `public-
 
 ```bash
 # Human-readable table (default in terminal, JSON when piped)
-public-param-golden-pp-cli stores create --store-code example-value
+public-param-golden-pp-cli stores find --address example-value --city example-value --location-id 550e8400-e29b-41d4-a716-446655440000
 
 # JSON for scripting and agents
-public-param-golden-pp-cli stores create --store-code example-value --json
+public-param-golden-pp-cli stores find --address example-value --city example-value --location-id 550e8400-e29b-41d4-a716-446655440000 --json
 
 # Filter to specific fields
-public-param-golden-pp-cli stores create --store-code example-value --json --select id,name,status
+public-param-golden-pp-cli stores find --address example-value --city example-value --location-id 550e8400-e29b-41d4-a716-446655440000 --json --select id,name,status
 
 # Dry run — show the request without sending
-public-param-golden-pp-cli stores create --store-code example-value --dry-run
+public-param-golden-pp-cli stores find --address example-value --city example-value --location-id 550e8400-e29b-41d4-a716-446655440000 --dry-run
 
 # Agent mode — JSON + compact + no prompts in one flag
-public-param-golden-pp-cli stores create --store-code example-value --agent
+public-param-golden-pp-cli stores find --address example-value --city example-value --location-id 550e8400-e29b-41d4-a716-446655440000 --agent
 ```
 
 ## Agent Usage

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/SKILL.md
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/SKILL.md
@@ -63,7 +63,7 @@ Add `--agent` to any command. Expands to: `--json --compact --no-input --no-colo
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
 
   ```bash
-  public-param-golden-pp-cli stores create --store-code example-value --agent --select id,name,status
+  public-param-golden-pp-cli stores find --address example-value --city example-value --location-id 550e8400-e29b-41d4-a716-446655440000 --agent --select id,name,status
   ```
 - **Previewable** — `--dry-run` shows the request without sending
 - **Offline-friendly** — sync/search commands can use the local SQLite store when available
@@ -334,7 +334,7 @@ A profile is a saved set of flag values, reused across invocations. Use it when 
 
 ```
 public-param-golden-pp-cli profile save briefing --json
-public-param-golden-pp-cli --profile briefing stores create --store-code example-value
+public-param-golden-pp-cli --profile briefing stores find --address example-value --city example-value --location-id 550e8400-e29b-41d4-a716-446655440000
 public-param-golden-pp-cli profile list --json
 public-param-golden-pp-cli profile show briefing
 public-param-golden-pp-cli profile delete briefing --yes


### PR DESCRIPTION
Fixes #3993.

## The bug

`firstCommandExample` already tried to prefer read-only endpoints:

```go
preferredVerbs := []string{"list", "get", "search", "query"}
...
if ep, ok := r.Endpoints[verb]; ok { ... }
```

That is an **exact name match**. Real specs name endpoints with the verb as a
prefix — `get-service-desks`, `list-users`, `add-customers` — so almost nothing
matches, the preference silently does not apply, and the search falls through to
"alphabetically first endpoint of the alphabetically first resource".

Whether the docs then advertise a mutation is a coin flip. For a Jira Service
Management CLI it lands on `add-customers`, a POST that adds customers to a
service desk, rendered into the blocks that illustrate `--select`, `--json`,
`--dry-run`, `--agent` and `--profile`:

```
jsm-pp-cli servicedeskapi add-customers mock-value --agent --select id,name,status
jsm-pp-cli --profile briefing servicedeskapi add-customers mock-value
```

`mock-value` sits in the `<serviceDeskId>` slot. Substituting a real id — which
is what a reader adapting the example does — performs a write. Confirmed by
running it: reached the live tenant, returned 404 only because `mock-value`
is not a valid desk id.

This matters more than an ordinary docs nit because `SKILL.md` and `AGENTS.md`
are consumed by agents. A mutating command in the "here is how you use the
flags" slot is materially more likely to be executed than the same example in
human-facing prose.

## The fix

A middle pass that selects by **transport method** rather than by name:

1. endpoint named exactly for a read-only verb (existing, now also honouring `Mutation`)
2. **any read-only endpoint** — `GET`/`HEAD` and not `Mutation` — alphabetically
3. alphabetically first endpoint (existing fallback)

Pass 3 is now the only path on which a mutation can reach an example, and it is
reached only when the spec has no read-only endpoint at all. Returning empty
there would delete the docs block, so falling back remains correct.

New `isReadOnlyEndpoint` also respects `spec.Endpoint.Mutation`, so a GET action
the spec author flagged as having side effects is not treated as safe.

## Verification

Four tests, written failing first:

- verb-prefixed names — reproduces `servicedeskapi add-customers mock-value` exactly
- cross-resource — a GET in `zzz-reads` beats a POST in `aaa-writes`
- mutation-only spec — still returns something rather than deleting the block
- explicit `Mutation: true` on a GET — not chosen

Regenerating the real JSM CLI: the `--select` and `--profile` examples move from
`servicedeskapi add-customers mock-value` to `servicedeskapi get-all-request-types`,
and zero flag-illustration examples reference a mutation. The genuine
command-reference entries for `add-customers` are untouched.

Failing-test sets on this host are **identical before and after** (9 pre-existing
docs/skill failures, unrelated). `go vet` clean.
