### PR TITLE
fix(openapi): classify array-root multipart bodies so file upload works

### DIFF
--- a/internal/generator/multipart_test.go
+++ b/internal/generator/multipart_test.go
@@ -133,6 +133,24 @@ paths:
       responses:
         "201":
           description: created
+  /attachments:
+    post:
+      operationId: uploadAttachments
+      summary: Upload attachments
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+      responses:
+        "201":
+          description: created
   /notes:
     post:
       operationId: createNote
@@ -165,13 +183,19 @@ paths:
 	assert.NotContains(t, uploadSrc, `body["assetData"] = bodyAssetData`)
 	assert.NotContains(t, uploadSrc, `body["filename"] = bodyFilename`)
 
+	attachmentsSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_attachments.go")
+	assert.Contains(t, attachmentsSrc, `cmd.Flags().StringVar(&bodyFile, "file", "", "Path to the file to upload.")`)
+	assert.Contains(t, attachmentsSrc, `return fmt.Errorf("required flag \"%s\" not set", "file")`)
+	assert.Contains(t, attachmentsSrc, `fileFields["file"] = bodyFile`)
+	assert.Contains(t, attachmentsSrc, `c.PostMultipartWithParams(cmd.Context(), path, params, fields, fileFields)`)
+	assert.NotContains(t, attachmentsSrc, `"stdin"`)
+
 	createSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_notes.go")
 	assert.Contains(t, createSrc, `bodyMap["title"] = bodyTitle`)
 	assert.Contains(t, createSrc, `c.PostWithParams(cmd.Context(), path, params, body)`)
 	assert.NotContains(t, createSrc, `c.PostMultipartWithParams`)
 
-	runGoCommand(t, outputDir, "mod", "tidy")
-	runGoCommand(t, outputDir, "build", "./...")
+	requireGeneratedCompiles(t, outputDir)
 }
 
 func TestGenerateBinaryResponseWritesRawBytes(t *testing.T) {

--- a/internal/openapi/multipart_array_body_test.go
+++ b/internal/openapi/multipart_array_body_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package openapi
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+)
+
+// arrayRootMultipartBody builds the request body shape Atlassian ships for
+// file-upload endpoints: content type multipart/form-data, schema a top-level
+// array. The item schema is an object because their generator dumped the Java
+// MultipartFile type instead of declaring `type: string, format: binary`.
+func arrayRootMultipartBody() *openapi3.RequestBodyRef {
+	item := openapi3.NewObjectSchema()
+	item.Properties = openapi3.Schemas{
+		"name":             openapi3.NewStringSchema().NewRef(),
+		"originalFilename": openapi3.NewStringSchema().NewRef(),
+	}
+	arr := openapi3.NewArraySchema()
+	arr.Items = item.NewRef()
+
+	body := openapi3.NewRequestBody()
+	body.Required = true
+	body.Content = openapi3.Content{
+		"multipart/form-data": openapi3.NewMediaType().WithSchema(arr),
+	}
+	return &openapi3.RequestBodyRef{Value: body}
+}
+
+// TestMapRequestBody_ArrayRootMultipartKeepsContentType pins that a multipart
+// upload endpoint is still recognised as multipart.
+//
+// mapRequestBody dropped the content type entirely for any array-root body
+// whose media type was not JSON. endpointUsesMultipart then saw "" and the
+// generator emitted the generic JSON path: the command took --stdin and POSTed
+// a JSON body with the file *path* as a string. Against an endpoint that
+// requires multipart/form-data that can never succeed, and the command's own
+// help still claimed multipart.
+//
+// The transport was never the gap — the client template already ships
+// PostMultipart / multipartRequestBody{Fields, FileFields}. Only the
+// classification was lost.
+func TestMapRequestBody_ArrayRootMultipartKeepsContentType(t *testing.T) {
+	params, contentType, bodyJSONFallback, required, arrayBody :=
+		mapRequestBody(arrayRootMultipartBody(), "post", "/servicedesk/{id}/attachTemporaryFile")
+
+	require.Equal(t, "multipart/form-data", contentType,
+		"content type must survive so endpointUsesMultipart classifies this endpoint")
+	require.True(t, required)
+	require.False(t, arrayBody,
+		"a multipart upload is not a JSON array body; the --body-json array marker must stay off")
+	require.False(t, bodyJSONFallback,
+		"a multipart upload must not fall back to --body-json")
+
+	require.Len(t, params, 1, "a file param must be synthesized")
+	require.Equal(t, "binary", params[0].Format,
+		"the param must be binary so multipartBodyMaps routes it to fileFields, not fields")
+	require.True(t, params[0].Required)
+	require.NotContains(t, params[0].Description, "Repeatable",
+		"fileFields is map[string]string, so only one file per field is possible; do not promise otherwise")
+}
+
+// TestMapRequestBody_ArrayRootJSONStillUsesBodyJSON guards the neighbouring
+// case: a genuine JSON array body keeps the --body-json fallback and the
+// array-body marker. This is the branch the multipart change sits beside.
+func TestMapRequestBody_ArrayRootJSONStillUsesBodyJSON(t *testing.T) {
+	arr := openapi3.NewArraySchema()
+	arr.Items = openapi3.NewObjectSchema().NewRef()
+	body := openapi3.NewRequestBody()
+	body.Required = true
+	body.Content = openapi3.Content{
+		"application/json": openapi3.NewMediaType().WithSchema(arr),
+	}
+
+	params, contentType, bodyJSONFallback, required, arrayBody :=
+		mapRequestBody(&openapi3.RequestBodyRef{Value: body}, "put", "/postings")
+
+	require.Equal(t, "application/json", contentType)
+	require.True(t, bodyJSONFallback)
+	require.True(t, arrayBody)
+	require.True(t, required)
+	require.Empty(t, params)
+}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -5113,6 +5113,27 @@ func mapRequestBody(requestBodyRef *openapi3.RequestBodyRef, method, path string
 	// with HTTP 422 "Invalid json" (e.g. Tripletex [BETA] PUT
 	// /supplierInvoice/voucher/{id}/postings, body [{"posting":{...}}]).
 	if media.Schema.Value.Type != nil && media.Schema.Value.Type.Is(openapi3.TypeArray) {
+		// An array-root multipart body means "one or more file parts". The item
+		// schema is no help: Atlassian, for one, emits their Java MultipartFile
+		// type here rather than `type: string, format: binary`, so the file-ness
+		// is carried by the content type alone.
+		//
+		// Dropping the content type here left endpointUsesMultipart seeing "",
+		// so the generator emitted its generic JSON path and the command POSTed
+		// a JSON body naming a local file path — which the endpoint can never
+		// accept, while its help text still advertised multipart. Synthesize the
+		// binary param instead; multipartBodyMaps routes a binary
+		// param into fileFields, and the client's PostMultipart already builds a
+		// real multipart body.
+		if isMultipartContentType(requestContentType) {
+			return []spec.Param{{
+				Name:        "file",
+				Type:        "string",
+				Format:      "binary",
+				Required:    requestBody.Required,
+				Description: "Path to the file to upload.",
+			}}, requestContentType, false, requestBody.Required, false
+		}
 		if !isJSONContentType(requestContentType) {
 			warnf("skipping request body for %s %q: array-root body and content type %q is not JSON-shaped", strings.ToUpper(method), path, requestContentType)
 			return nil, "", false, false, false
@@ -5219,6 +5240,12 @@ func isJSONContentType(ct string) bool {
 		return true
 	}
 	return strings.HasPrefix(ct, "application/") && strings.HasSuffix(ct, "+json")
+}
+
+// isMultipartContentType reports whether ct is a multipart request body.
+func isMultipartContentType(ct string) bool {
+	base := strings.ToLower(strings.TrimSpace(strings.SplitN(ct, ";", 2)[0]))
+	return base == "multipart/form-data"
 }
 
 func isRawRequestContentType(ct string) bool {


### PR DESCRIPTION
Fixes #3994.

## The transport was never missing

The client template already ships everything needed: `PostMultipart`,
`PostMultipartWithParams`, `multipartRequestBody{Fields, FileFields}`, and an
`encodeMultipartBody` that opens the path, calls `CreateFormFile` with
`filepath.Base`, and copies the contents. The command template already has a
`$isMultipart` branch that fills `fields`/`fileFields` and calls it.

What broke was **classification**, one branch upstream in the parser.

## Root cause

`mapRequestBody` drops the content type for any array-root body whose media type
is not JSON:

```go
if media.Schema.Value.Type.Is(openapi3.TypeArray) {
    if !isJSONContentType(requestContentType) {
        warnf("skipping request body ... is not JSON-shaped")
        return nil, "", false, false, false     // content type lost
    }
```

`endpointUsesMultipart` then compares `""` against `"multipart/form-data"`,
returns false, and the generator emits the generic JSON path. The command takes
`--stdin` and POSTs a JSON body naming a local file path — which the endpoint can
never accept — while its own help text still says "Attachments are posted as
multipart/form-data".

Array-root multipart is exactly how file-upload endpoints are spelled. Atlassian's
`POST /servicedesk/{id}/attachTemporaryFile` is `type: array` whose items `$ref`
a `MultipartFile` object — their generator dumped the Java type rather than
declaring `type: string, format: binary`. The item schema is no help; the
**content type** is the only reliable signal.

## The fix

When an array-root body carries `multipart/form-data`, preserve the content type
and synthesize a single binary body param:

```go
return []spec.Param{{
    Name: "file", Type: "string", Format: "binary",
    Required: requestBody.Required,
    Description: "Path to the file to upload.",
}}, requestContentType, false, requestBody.Required, false
```

`multipartBodyMaps` routes a `format: binary` param into `fileFields`, and the
rest of the existing chain takes over. Six lines of behaviour, no new machinery.

The neighbouring JSON array-root branch (`--body-json` fallback + array-body
marker) is untouched, and a test pins it.

## Before / after on a real spec

Regenerating a JSM CLI, `servicedeskapi attach-temporary-file`:

| | before | after |
|---|---|---|
| flags | `--stdin` only | `--file string` (+ required-flag guard) |
| call | JSON body with the path as a string | `PostMultipartWithParams(..., fileFields)` |
| help vs behaviour | help claimed multipart, code sent JSON | consistent |

Generated tree builds clean.

## What this does not solve

Endpoint-specific required headers are still the spec's job. Atlassian's
attachment endpoints need `X-Atlassian-Token: no-check`, and their published spec
does not declare it as a parameter (the JSM operation declares only
`serviceDeskId`), so a generated command still will not send it. That is a spec
defect, not a generator one, and adding vendor-specific headers here would be the
wrong place. Flagging it so nobody reads this PR as "Atlassian attachment upload
now works end-to-end" — the body is now correct; the XSRF header is not covered.

## Verification

Two parser tests, written failing first:

- `TestMapRequestBody_ArrayRootMultipartKeepsContentType` — content type
  survives, one `format: binary` param is synthesized, `--body-json` fallback and
  array-body marker both stay off, and the description does not promise
  repeatability (`fileFields` is `map[string]string`, so one file per field).
- `TestMapRequestBody_ArrayRootJSONStillUsesBodyJSON` — the JSON neighbour keeps
  its fallback and marker.

`go vet` clean. Two `internal/openapi` tests fail both before and after on this
host, unrelated.
