### PR TITLE
fix(generator): scope cursor zero-strip exemption to offset pagination

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -7736,6 +7736,28 @@ func TestPaginatedGetExemptsCursorParamFromZeroStripping(t *testing.T) {
 		`the unconditional v != "" && v != "0" && v != "false" filter incorrectly drops cursor="0" for offset-paginated APIs`)
 }
 
+// The exemption above must stay scoped to offset pagination. Under id-cursor
+// pagination 0 is not a real record id, so sending cursor=0 (what an unset
+// cursor flag produces) makes the API return an empty page — and every list
+// command reports zero rows while the endpoint itself is healthy.
+func TestPaginatedGetScopesCursorZeroExemptionToOffsetPagination(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("templates", "helpers.go.tmpl")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "template must exist: %s", path)
+	body := string(data)
+
+	cleanStart := strings.Index(body, "clean := map[string]string{}")
+	require.GreaterOrEqual(t, cleanStart, 0, "paginatedGet must declare a clean map")
+	loopEnd := strings.Index(body[cleanStart:], "if !fetchAll")
+	require.GreaterOrEqual(t, loopEnd, 0, "expected fetchAll branch after clean loop")
+	cleanBlock := body[cleanStart : cleanStart+loopEnd]
+
+	assert.Contains(t, cleanBlock, `k == cursorParam && paginationType == "offset"`,
+		`the cursor zero-value exemption must be gated on offset pagination; an unconditional exemption sends cursor=0 for id-cursor APIs and silently empties every list command`)
+}
+
 // TestPipedJsonGateRespectsExplicitFormatFlags pins the contract: the
 // piped-output auto-JSON gate must defer to explicit --csv / --quiet /
 // --plain flags so piped consumers that asked for a non-JSON format

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -7743,9 +7743,30 @@ func TestPaginatedGetExemptsCursorParamFromZeroStripping(t *testing.T) {
 func TestPaginatedGetScopesCursorZeroExemptionToOffsetPagination(t *testing.T) {
 	t.Parallel()
 
-	path := filepath.Join("templates", "helpers.go.tmpl")
+	apiSpec := minimalSpec("cursor-zero-scope")
+	apiSpec.Resources = map[string]spec.Resource{
+		"items": {
+			Description: "Manage items",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/items",
+					Description: "List items",
+					Pagination: &spec.Pagination{
+						Type:        "cursor",
+						CursorParam: "after",
+						LimitParam:  "limit",
+					},
+				},
+			},
+		},
+	}
+	outputDir := filepath.Join(t.TempDir(), "cursor-zero-scope-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	path := filepath.Join(outputDir, "internal", "cli", "helpers.go")
 	data, err := os.ReadFile(path)
-	require.NoError(t, err, "template must exist: %s", path)
+	require.NoError(t, err, "generated helper must exist: %s", path)
 	body := string(data)
 
 	cleanStart := strings.Index(body, "clean := map[string]string{}")
@@ -7756,6 +7777,7 @@ func TestPaginatedGetScopesCursorZeroExemptionToOffsetPagination(t *testing.T) {
 
 	assert.Contains(t, cleanBlock, `k == cursorParam && paginationType == "offset"`,
 		`the cursor zero-value exemption must be gated on offset pagination; an unconditional exemption sends cursor=0 for id-cursor APIs and silently empties every list command`)
+	requireGeneratedCompiles(t, outputDir)
 }
 
 // TestPipedJsonGateRespectsExplicitFormatFlags pins the contract: the

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1250,14 +1250,16 @@ func paginatedGetWithResponsePath(ctx context.Context, c interface {
 func paginatedGet(ctx context.Context, c interface {
 	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
-	// Cursor params are exempt from the "0"/"false" strip: offset-paginated
-	// APIs send offset=0 on the first page.
+	// The cursor param is exempt from the "0"/"false" strip only for offset
+	// pagination, where offset=0 is a legitimate first page. Under id-cursor
+	// pagination 0 is not a real record id: APIs answer it with an empty page,
+	// so an unset cursor flag would silently empty every list command.
 	clean := map[string]string{}
 	for k, v := range params {
 		if v == "" {
 			continue
 		}
-		if k == cursorParam || (v != "0" && v != "false") {
+		if (k == cursorParam && paginationType == "offset") || (v != "0" && v != "false") {
 			clean[k] = v
 		}
 	}

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -646,14 +646,16 @@ func paginatedGetWithResponsePath(ctx context.Context, c interface {
 func paginatedGet(ctx context.Context, c interface {
 	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
-	// Cursor params are exempt from the "0"/"false" strip: offset-paginated
-	// APIs send offset=0 on the first page.
+	// The cursor param is exempt from the "0"/"false" strip only for offset
+	// pagination, where offset=0 is a legitimate first page. Under id-cursor
+	// pagination 0 is not a real record id: APIs answer it with an empty page,
+	// so an unset cursor flag would silently empty every list command.
 	clean := map[string]string{}
 	for k, v := range params {
 		if v == "" {
 			continue
 		}
-		if k == cursorParam || (v != "0" && v != "false") {
+		if (k == cursorParam && paginationType == "offset") || (v != "0" && v != "false") {
 			clean[k] = v
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -639,14 +639,16 @@ func paginatedGetWithResponsePath(ctx context.Context, c interface {
 func paginatedGet(ctx context.Context, c interface {
 	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
-	// Cursor params are exempt from the "0"/"false" strip: offset-paginated
-	// APIs send offset=0 on the first page.
+	// The cursor param is exempt from the "0"/"false" strip only for offset
+	// pagination, where offset=0 is a legitimate first page. Under id-cursor
+	// pagination 0 is not a real record id: APIs answer it with an empty page,
+	// so an unset cursor flag would silently empty every list command.
 	clean := map[string]string{}
 	for k, v := range params {
 		if v == "" {
 			continue
 		}
-		if k == cursorParam || (v != "0" && v != "false") {
+		if (k == cursorParam && paginationType == "offset") || (v != "0" && v != "false") {
 			clean[k] = v
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -723,14 +723,16 @@ func paginatedGetWithResponsePath(ctx context.Context, c interface {
 func paginatedGet(ctx context.Context, c interface {
 	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
-	// Cursor params are exempt from the "0"/"false" strip: offset-paginated
-	// APIs send offset=0 on the first page.
+	// The cursor param is exempt from the "0"/"false" strip only for offset
+	// pagination, where offset=0 is a legitimate first page. Under id-cursor
+	// pagination 0 is not a real record id: APIs answer it with an empty page,
+	// so an unset cursor flag would silently empty every list command.
 	clean := map[string]string{}
 	for k, v := range params {
 		if v == "" {
 			continue
 		}
-		if k == cursorParam || (v != "0" && v != "false") {
+		if (k == cursorParam && paginationType == "offset") || (v != "0" && v != "false") {
 			clean[k] = v
 		}
 	}

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
@@ -713,14 +713,16 @@ func paginatedGetWithResponsePath(ctx context.Context, c interface {
 func paginatedGet(ctx context.Context, c interface {
 	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
-	// Cursor params are exempt from the "0"/"false" strip: offset-paginated
-	// APIs send offset=0 on the first page.
+	// The cursor param is exempt from the "0"/"false" strip only for offset
+	// pagination, where offset=0 is a legitimate first page. Under id-cursor
+	// pagination 0 is not a real record id: APIs answer it with an empty page,
+	// so an unset cursor flag would silently empty every list command.
 	clean := map[string]string{}
 	for k, v := range params {
 		if v == "" {
 			continue
 		}
-		if k == cursorParam || (v != "0" && v != "false") {
+		if (k == cursorParam && paginationType == "offset") || (v != "0" && v != "false") {
 			clean[k] = v
 		}
 	}


### PR DESCRIPTION
## Problem

`paginatedGet` exempts the cursor param from the `"0"`/`"false"` param strip unconditionally:

```go
if k == cursorParam || (v != "0" && v != "false") {
```

That exemption is right for **offset** pagination — `offset=0` is a legitimate first page. It is wrong for **id-cursor** pagination: `0` is not a real record id, and APIs answer `cursor=0` with an empty page.

The consequence is quiet and broad: when the user does not pass the cursor flag, its zero value is sent anyway, so **every generated list command returns nothing** while the endpoint is perfectly healthy.

## How it showed up

On a DocuSeal-backed printed CLI, `templates list`, `submissions list` and `submitters list` all returned `count: 0` against an account holding 9 templates, 6 submissions and 12 submitters. Confirmed against the live API:

| request | result |
|---|---|
| `GET /templates` | `count: 9` |
| `GET /templates?after=0` | `count: 0` |

`sync` kept working because it does not go through `paginatedGet` — which is exactly what kept this hidden.

## Fix

Gate the exemption on the pagination type:

```go
if (k == cursorParam && paginationType == "offset") || (v != "0" && v != "false") {
```

`offset=0` still survives on the first page; `cursor=0` is dropped for id-cursor APIs.

## Tests

- `TestPaginatedGetExemptsCursorParamFromZeroStripping` still passes — its stated intent (offset APIs require `offset=0`) is preserved, not reverted.
- New companion test pins the narrowing so the exemption is not widened back. Verified it **fails** against the unpatched template.
- Golden `helpers.go` files updated to match the template.
- Full generator suite: **1889 passed**.