### PR TITLE
fix(dogfood): parse backslash-continuation example blocks as one command

### DIFF
--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -2165,39 +2165,35 @@ func liveDogfoodHappyArgsParsed(command liveDogfoodCommand) ([]string, bool, hap
 
 func liveDogfoodExampleArgs(command liveDogfoodCommand) ([]string, bool) {
 	examples := extractExamplesSection(command.Help)
-	// Parse the example block as a single shell command instead of one line
-	// at a time. Generated examples use backslash-newline continuations:
-	// shellargs.Split folds them, but a per-line parse of the first
+	// Split the example section into logical commands: backslash-newline
+	// continuations fold into the command they belong to; any other line
+	// boundary starts a new candidate. Generated examples use
+	// backslash-newline continuations, so a per-line parse of the first
 	// continuation line yields a stray "\" token as a positional and drops
-	// the real example flags, failing commands that require flags (e.g.
-	// teach-pattern --query-template).
-	var sb strings.Builder
+	// the real example flags (e.g. teach-pattern --query-template). Parsing
+	// the whole block as one command is wrong the other way: shellargs
+	// treats a bare newline as whitespace, so a target-first example
+	// swallows every later example's tokens into its argument list.
+	var blocks []string
+	var cur strings.Builder
 	for line := range strings.SplitSeq(examples, "\n") {
 		t := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "$"))
 		if t == "" || strings.HasPrefix(t, "#") {
 			continue
 		}
-		sb.WriteString(t)
+		cur.WriteString(t)
 		if strings.HasSuffix(t, "\\") {
-			sb.WriteString("\n") // backslash continuation: newline folds like the real help text
-		} else {
-			sb.WriteString("\n") // distinct example command boundary
-		}
-	}
-	block := strings.TrimSpace(sb.String())
-	if block != "" {
-		args, err := parseExampleArgs(block)
-		if err == nil && len(args) > 0 && slices.Equal(args[:min(len(command.Path), len(args))], command.Path) {
-			return args, true
-		}
-	}
-	// Per-line fallback for help text with multiple distinct examples.
-	for line := range strings.SplitSeq(examples, "\n") {
-		candidate := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "$"))
-		if candidate == "" || strings.HasPrefix(candidate, "#") {
+			cur.WriteString("\n") // backslash continuation: newline folds like the real help text
 			continue
 		}
-		args, err := parseExampleArgs(candidate)
+		blocks = append(blocks, cur.String()) // distinct example command boundary
+		cur.Reset()
+	}
+	if cur.Len() > 0 {
+		blocks = append(blocks, cur.String())
+	}
+	for _, block := range blocks {
+		args, err := parseExampleArgs(block)
 		if err == nil && len(args) > 0 && slices.Equal(args[:min(len(command.Path), len(args))], command.Path) {
 			return args, true
 		}

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -2165,6 +2165,33 @@ func liveDogfoodHappyArgsParsed(command liveDogfoodCommand) ([]string, bool, hap
 
 func liveDogfoodExampleArgs(command liveDogfoodCommand) ([]string, bool) {
 	examples := extractExamplesSection(command.Help)
+	// Parse the example block as a single shell command instead of one line
+	// at a time. Generated examples use backslash-newline continuations:
+	// shellargs.Split folds them, but a per-line parse of the first
+	// continuation line yields a stray "\" token as a positional and drops
+	// the real example flags, failing commands that require flags (e.g.
+	// teach-pattern --query-template).
+	var sb strings.Builder
+	for line := range strings.SplitSeq(examples, "\n") {
+		t := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "$"))
+		if t == "" || strings.HasPrefix(t, "#") {
+			continue
+		}
+		sb.WriteString(t)
+		if strings.HasSuffix(t, "\\") {
+			sb.WriteString("\n") // backslash continuation: newline folds like the real help text
+		} else {
+			sb.WriteString("\n") // distinct example command boundary
+		}
+	}
+	block := strings.TrimSpace(sb.String())
+	if block != "" {
+		args, err := parseExampleArgs(block)
+		if err == nil && len(args) > 0 && slices.Equal(args[:min(len(command.Path), len(args))], command.Path) {
+			return args, true
+		}
+	}
+	// Per-line fallback for help text with multiple distinct examples.
 	for line := range strings.SplitSeq(examples, "\n") {
 		candidate := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "$"))
 		if candidate == "" || strings.HasPrefix(candidate, "#") {

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -6638,3 +6638,44 @@ exit 99
 	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755))
 	return dir, binaryName
 }
+
+func TestLiveDogfoodExampleArgsJoinsBackslashContinuations(t *testing.T) {
+	cmd := liveDogfoodCommand{
+		Path: []string{"teach-pattern"},
+		Help: `Usage:
+  cli teach-pattern [flags]
+
+Examples:
+  cli teach-pattern \
+    --query-template "items in {entity}" \
+    --resource-template "GROUP-{entity:category}" \
+    --resource-type items \
+    --entity-kind category \
+    --strategy substitute
+`,
+	}
+	args, ok := liveDogfoodExampleArgs(cmd)
+	require.True(t, ok)
+	assert.Equal(t, []string{
+		"teach-pattern", "--query-template", "items in {entity}",
+		"--resource-template", "GROUP-{entity:category}",
+		"--resource-type", "items", "--entity-kind", "category",
+		"--strategy", "substitute",
+	}, args)
+}
+
+func TestLiveDogfoodExampleArgsSeparatesDistinctExamples(t *testing.T) {
+	cmd := liveDogfoodCommand{
+		Path: []string{"widgets", "get"},
+		Help: `Usage:
+  cli widgets get <id> [flags]
+
+Examples:
+  cli widgets list --verbose
+  cli widgets get widget-1 --format=summary
+`,
+	}
+	args, ok := liveDogfoodExampleArgs(cmd)
+	require.True(t, ok)
+	assert.Equal(t, []string{"widgets", "get", "widget-1", "--format=summary"}, args)
+}

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -6679,3 +6679,19 @@ Examples:
 	require.True(t, ok)
 	assert.Equal(t, []string{"widgets", "get", "widget-1", "--format=summary"}, args)
 }
+
+func TestLiveDogfoodExampleArgsDoesNotMergeDistinctExamplesWhenTargetFirst(t *testing.T) {
+	cmd := liveDogfoodCommand{
+		Path: []string{"widgets", "list"},
+		Help: `Usage:
+  cli widgets list [flags]
+
+Examples:
+  cli widgets list --verbose
+  cli widgets get widget-1 --format=summary
+`,
+	}
+	args, ok := liveDogfoodExampleArgs(cmd)
+	require.True(t, ok)
+	assert.Equal(t, []string{"widgets", "list", "--verbose"}, args)
+}


### PR DESCRIPTION
## Fix live dogfood happy-arg derivation for backslash-continuation examples

### Problem

`liveDogfoodExampleArgs` in `internal/pipeline/live_dogfood.go` parses the
help Examples section **one line at a time**. Generated printed CLIs emit
examples with backslash-newline continuations:

```text
Examples:
  cli teach-pattern \
    --query-template "items in {entity}" \
    --resource-template "GROUP-{entity:category}" \
    --strategy substitute
```

Parsing only the first line yields `["teach-pattern", "\\"]` — a stray
backslash token and none of the real flags. Commands that require flags
then fail the live dogfood happy path with a misleading "flag is required"
error, and the full matrix can never certify acceptance for any CLI whose
example is continuation-shaped.

Observed in the field: `teach-pattern` failed `dogfood --live` on freshly
printed CLIs with `Error: --query-template is required` even though the
example clearly carries the flag.

### Change

Parse the example block as a single shell command before falling back to
per-line parsing:

- Join example lines into one command string. Lines ending in a backslash
  are joined with a newline (shellargs folds `\` + newline exactly like
  the real help text; a space would be treated as an escaped literal and
  stick to the next token).
- Non-continuation lines stay separated so help text with multiple
  distinct example commands still resolves each one.
- The per-line loop remains as a fallback for multi-example help blocks.

### Tests

- `TestLiveDogfoodExampleArgsJoinsBackslashContinuations` — a
  continuation-shaped example resolves to the full flag set.
- `TestLiveDogfoodExampleArgsSeparatesDistinctExamples` — two distinct
  example commands in one block still resolve to the matching one.

### Validation

- `go test ./internal/pipeline/ -run 'TestLiveDogfoodExampleArgs'` passes.
- The full package suite on this machine has pre-existing environment
  failures unrelated to this change (verified by running the suite on the
  unmodified tree); the live-dogfood tests themselves pass.
- The fix was exercised end to end: freshly printed CLIs whose
  teach-family examples were continuation-shaped passed `dogfood --live`
  after applying this change.

### Notes

No API-specific names in the fix; applies to every generated CLI. No
behavioral change for examples that are already single-line.
