### PR TITLE
fix(cli): protect auth-destructive GET dogfood probes

### DIFF
--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -1949,26 +1949,38 @@ var destructiveAuthResources = map[string]bool{
 	"tokens":   true,
 }
 
+var destructiveAuthScopes = map[string]bool{
+	"auth":     true,
+	"oauth":    true,
+	"api-keys": true,
+	"api_keys": true,
+	"sessions": true,
+	"tokens":   true,
+}
+
 // isDestructiveAtAuth reports whether a command can invalidate the bearer
 // the live-dogfood runner is using. Reads pp:endpoint
 // (authoritative for endpoint-mirror commands) and falls back to
 // path-segment matching across the command path for novel commands.
-// Read-only commands are exempt regardless of name.
+// Auth-scoped destructive endpoint names take precedence over inferred
+// read-only metadata; ordinary read endpoints named refresh remain probeable.
 func isDestructiveAtAuth(annotations map[string]string, commandPath []string) bool {
 	if v, ok := annotations[destructiveAuthAnnotation]; ok {
 		return annotationIsTrueValue(v)
 	}
-	if annotationIsTrueValue(annotations[mcpReadOnlyAnnotation]) {
-		return false
-	}
 	if endpoint := annotations[endpointAnnotation]; endpoint != "" {
-		if containsDestructiveAuthTerm(endpoint) {
+		readOnly := annotationIsTrueValue(annotations[mcpReadOnlyAnnotation])
+		if containsDestructiveAuthTerm(endpoint) &&
+			(!readOnly || endpointTargetsAuthScope(endpoint, annotations[endpointPathAnnotation])) {
 			return true
 		}
 		if strings.EqualFold(strings.TrimSpace(annotations[endpointMethodAnnotation]), "DELETE") &&
 			endpointTargetsAuthResource(endpoint, annotations[endpointPathAnnotation]) {
 			return true
 		}
+		return false
+	}
+	if annotationIsTrueValue(annotations[mcpReadOnlyAnnotation]) {
 		return false
 	}
 	return slices.ContainsFunc(commandPath, containsDestructiveAuthTerm)
@@ -1989,6 +2001,18 @@ func endpointTargetsAuthResource(endpoint, path string) bool {
 	}
 	return slices.ContainsFunc(strings.Split(strings.ToLower(endpoint), "."), func(segment string) bool {
 		return destructiveAuthResources[segment]
+	})
+}
+
+func endpointTargetsAuthScope(endpoint, path string) bool {
+	if slices.ContainsFunc(splitPath(path), func(segment string) bool {
+		segment = strings.ToLower(strings.Trim(segment, "{}:"))
+		return destructiveAuthScopes[segment]
+	}) {
+		return true
+	}
+	return slices.ContainsFunc(strings.Split(strings.ToLower(endpoint), "."), func(segment string) bool {
+		return destructiveAuthScopes[strings.Trim(segment, "{}:")]
 	})
 }
 

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -1949,13 +1949,24 @@ var destructiveAuthResources = map[string]bool{
 	"tokens":   true,
 }
 
-var destructiveAuthScopes = map[string]bool{
-	"auth":     true,
-	"oauth":    true,
-	"api-keys": true,
-	"api_keys": true,
-	"sessions": true,
-	"tokens":   true,
+type destructiveAuthScope string
+
+const (
+	destructiveAuthScopeAuth              destructiveAuthScope = "auth"
+	destructiveAuthScopeOAuth             destructiveAuthScope = "oauth"
+	destructiveAuthScopeAPIKeys           destructiveAuthScope = "api-keys"
+	destructiveAuthScopeAPIKeysUnderscore destructiveAuthScope = "api_keys"
+	destructiveAuthScopeSessions          destructiveAuthScope = "sessions"
+	destructiveAuthScopeTokens            destructiveAuthScope = "tokens"
+)
+
+var destructiveAuthScopes = map[destructiveAuthScope]bool{
+	destructiveAuthScopeAuth:              true,
+	destructiveAuthScopeOAuth:             true,
+	destructiveAuthScopeAPIKeys:           true,
+	destructiveAuthScopeAPIKeysUnderscore: true,
+	destructiveAuthScopeSessions:          true,
+	destructiveAuthScopeTokens:            true,
 }
 
 // isDestructiveAtAuth reports whether a command can invalidate the bearer
@@ -2007,12 +2018,12 @@ func endpointTargetsAuthResource(endpoint, path string) bool {
 func endpointTargetsAuthScope(endpoint, path string) bool {
 	if slices.ContainsFunc(splitPath(path), func(segment string) bool {
 		segment = strings.ToLower(strings.Trim(segment, "{}:"))
-		return destructiveAuthScopes[segment]
+		return destructiveAuthScopes[destructiveAuthScope(segment)]
 	}) {
 		return true
 	}
 	return slices.ContainsFunc(strings.Split(strings.ToLower(endpoint), "."), func(segment string) bool {
-		return destructiveAuthScopes[strings.Trim(segment, "{}:")]
+		return destructiveAuthScopes[destructiveAuthScope(strings.Trim(segment, "{}:"))]
 	})
 }
 

--- a/internal/pipeline/live_dogfood_destructive_test.go
+++ b/internal/pipeline/live_dogfood_destructive_test.go
@@ -129,10 +129,39 @@ func TestIsDestructiveAtAuth(t *testing.T) {
 		{
 			name: "read-only exempt with pp:endpoint",
 			annotations: map[string]string{
-				"mcp:read-only": "true",
-				"pp:endpoint":   "catalog.catalog-refresh",
+				mcpReadOnlyAnnotation: "true",
+				endpointAnnotation:    "catalog.catalog-refresh",
 			},
 			path: []string{"craigslist-pp-cli", "catalog", "refresh"},
+			want: false,
+		},
+		{
+			name: "read-only conversations history remains probeable",
+			annotations: map[string]string{
+				mcpReadOnlyAnnotation: "true",
+				endpointAnnotation:    "conversations.history",
+			},
+			path: []string{"slack-pp-cli", "conversations", "history"},
+			want: false,
+		},
+		{
+			name: "destructive endpoint outranks read-only annotation",
+			annotations: map[string]string{
+				mcpReadOnlyAnnotation:    "true",
+				endpointAnnotation:       "auth.revoke",
+				endpointMethodAnnotation: "GET",
+			},
+			path: []string{"slack-pp-cli", "auth-api", "revoke"},
+			want: true,
+		},
+		{
+			name: "explicit destructive-auth false overrides destructive endpoint",
+			annotations: map[string]string{
+				destructiveAuthAnnotation: "false",
+				mcpReadOnlyAnnotation:     "true",
+				endpointAnnotation:        "auth.revoke",
+			},
+			path: []string{"slack-pp-cli", "auth-api", "revoke"},
 			want: false,
 		},
 		{


### PR DESCRIPTION
## Intent

Issue: Closes #3952

Live dogfood no longer treats inferred `mcp:read-only` metadata as sufficient to probe an auth-scoped destructive GET such as Slack `auth.revoke`. Ordinary read endpoints such as `catalog.catalog-refresh` and `conversations.history` remain probeable.

## Approach

Keep the explicit `pp:destructive-auth` override first. For endpoint mirrors, let destructive terms override inferred read-only metadata only when the endpoint or path is auth-scoped, including `auth`, `oauth`, API keys, sessions, and tokens.

## Scope

Primary area: live dogfood safety classification and regression tests.

Why this belongs in this repo: this changes reusable Printing Press verifier behavior for future printed CLIs, not a Slack-specific generated CLI.

## Risk

This changes skip classification for auth-scoped GET endpoint mirrors. The behavior is conservative: a false positive skips a probe, while the reported credential-revocation path is prevented. Explicit `pp:destructive-auth` overrides remain authoritative. Generated GET mutation classification already landed separately in #3929, so this PR does not change generated output or MCP annotations.

## Output Contract

N/A. No generated files, templates, manifests, command output, MCP schemas, scorecard output, or pipeline artifact schemas changed.

## Verification

- `go test ./internal/pipeline -run '^TestIsDestructiveAtAuth$' -count=1` passed after the final change.
- `go test ./internal/pipeline ./internal/generator` passed after the initial implementation.
- `go test ./...` passed before the final auth-scope refinement; the final refinement is covered by the focused pipeline regression suite.
- `golangci-lint run ./internal/pipeline ./internal/generator` passed with 0 issues after the final change.
- `git diff --check` passed.
- Repository-wide `golangci-lint run ./...` remains blocked by an unrelated pre-existing `modernize` warning in `internal/googlediscovery/parser.go` from another worktree.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
