### PR TITLE
fix(cli): count helper-registered novel commands

### DIFF
--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -1915,11 +1915,28 @@ func addCommandConstructorCalls(content string) map[string]bool {
 		if !ok {
 			return true
 		}
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || sel.Sel == nil || sel.Sel.Name != "AddCommand" {
+		helperCall := false
+		switch fun := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			if fun.Sel == nil || fun.Sel.Name != "AddCommand" {
+				return true
+			}
+		case *ast.Ident:
+			if fun.Name != "addNovelCommandIfAbsent" {
+				return true
+			}
+			helperCall = true
+		default:
 			return true
 		}
-		for _, arg := range call.Args {
+		args := call.Args
+		if helperCall {
+			if len(args) != 2 {
+				return true
+			}
+			args = args[1:]
+		}
+		for _, arg := range args {
 			if ctor := commandConstructorName(arg); ctor != "" {
 				ctors[ctor] = true
 			}

--- a/internal/pipeline/scorecard_registered_test.go
+++ b/internal/pipeline/scorecard_registered_test.go
@@ -111,6 +111,56 @@ func newAvailabilitySweepCmd(flags any) *cobra.Command {
 	}
 }
 
+func TestRegisteredCommandFiles_FollowsNovelHelperCalls(t *testing.T) {
+	dir := t.TempDir()
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+func newRootCmd() {
+	addNovelCommandIfAbsent(rootCmd, newAvailabilityCmd(nil))
+}`)
+
+	writeFile(t, filepath.Join(cliDir, "availability.go"), `package cli
+import "github.com/spf13/cobra"
+func newAvailabilityCmd(flags any) *cobra.Command {
+	cmd := &cobra.Command{Use: "availability"}
+	addNovelCommandIfAbsent(newParentDeadCmd(), newAvailabilitySweepCmd(flags))
+	return cmd
+}`)
+
+	writeFile(t, filepath.Join(cliDir, "availability_sweep.go"), `package cli
+import "github.com/spf13/cobra"
+func newAvailabilitySweepCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "sweep"}
+}`)
+
+	writeFile(t, filepath.Join(cliDir, "dead.go"), `package cli
+import "github.com/spf13/cobra"
+func newDeadCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "dead"}
+}`)
+
+	writeFile(t, filepath.Join(cliDir, "parent_dead.go"), `package cli
+import "github.com/spf13/cobra"
+func newParentDeadCmd() *cobra.Command {
+	return &cobra.Command{Use: "parent-dead"}
+}`)
+
+	registered := registeredCommandFiles(cliDir)
+	if !registered["availability.go"] || !registered["availability_sweep.go"] {
+		t.Errorf("expected novel helper registrations to be reachable, got %v", registered)
+	}
+	if registered["dead.go"] {
+		t.Errorf("expected unregistered constructor to stay orphaned, got %v", registered)
+	}
+	if registered["parent_dead.go"] {
+		t.Errorf("expected helper parent constructor to stay orphaned, got %v", registered)
+	}
+}
+
 func TestRegisteredCommandFiles_IgnoresConstructorCallsOutsideAddCommand(t *testing.T) {
 	dir := t.TempDir()
 	cliDir := filepath.Join(dir, "internal", "cli")


### PR DESCRIPTION
## Summary

The scorecard now follows both Cobra `.AddCommand()` calls and the Printing Press `addNovelCommandIfAbsent(parent, candidate)` helper when determining registered command files. For the helper form, only the candidate constructor is traced, preserving orphan-command exclusion even when the parent is an expression.

## Validation

- `go test ./internal/pipeline -run TestRegisteredCommandFiles -count=1`
- `go test ./internal/pipeline -run TestScoreInsightCountsNovelCommandsRegisteredThroughParentGroupers -count=1`
- `go vet ./internal/pipeline`
- `go build ./...`
- `git diff --check`

The full repository test and lint runs still expose unrelated existing failures in generator HTML/pagination tests, side-effect help classification, and a `modernize` finding in another worktree's `internal/googlediscovery/parser.go`.

Closes #3961

Not included: #3984 was verified already fixed on `main` and was closed during triage.
