### PR TITLE
fix(cli): prevent silent pagination truncation

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -5081,30 +5081,22 @@ func (g *Generator) renderPromotedCommandFiles(promotedCommands []PromotedComman
 	return nil
 }
 
-func (g *Generator) paginationDefaultPageSize() int {
-	if g != nil && g.profile != nil && g.profile.Pagination.DefaultPageSize > 0 {
-		return g.profile.Pagination.DefaultPageSize
-	}
-	return 100
-}
-
 func (g *Generator) paginationPageSizeForEndpoint(endpoint spec.Endpoint) int {
-	pageSize := g.paginationDefaultPageSize()
+	// Only an endpoint-declared default is safe as short-page evidence. Zero
+	// tells the generated helper that the server's page size is unknown.
 	if endpoint.Pagination == nil || endpoint.Pagination.LimitParam == "" {
-		return pageSize
+		return 0
 	}
 	limitParam, ok := endpointParamByName(endpoint, endpoint.Pagination.LimitParam)
 	if !ok {
-		return pageSize
+		return 0
 	}
+	pageSize := 0
 	if defaultPageSize, ok := positiveIntValue(limitParam.Default); ok {
 		pageSize = defaultPageSize
 	}
-	if maxPageSize, ok := paramMaxInt(limitParam); ok && maxPageSize < pageSize {
+	if maxPageSize, ok := paramMaxInt(limitParam); ok && pageSize > 0 && maxPageSize < pageSize {
 		pageSize = maxPageSize
-	}
-	if pageSize <= 0 {
-		return g.paginationDefaultPageSize()
 	}
 	return pageSize
 }

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/openapi"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -967,7 +968,7 @@ func TestPaginatedGetHandlesNumericCursorAndMissingAllSignal(t *testing.T) {
 	outputDir := filepath.Join(t.TempDir(), "paginate-edge-pp-cli")
 	require.NoError(t, New(apiSpec, outputDir).Generate())
 	endpointSrc := readGeneratedCLIFileContaining(t, outputDir, `flagAll, "cursor", "cursor", "limit"`)
-	require.Contains(t, endpointSrc, `flagAll, "cursor", "cursor", "limit", 100, "", ""`,
+	require.Contains(t, endpointSrc, `flagAll, "cursor", "cursor", "limit", 0, "", ""`,
 		"generated list command must preserve an empty next-cursor path for the runtime fallback")
 
 	behaviorTest := `package cli
@@ -1741,16 +1742,19 @@ func TestIssue3497BareAllOffsetUsesEndpointPageSize(t *testing.T) {
 
 	capped := 2.0
 	for _, tc := range []struct {
-		name       string
-		limitParam spec.Param
+		name         string
+		limitParam   spec.Param
+		wantPageSize int
 	}{
 		{
-			name:       "default",
-			limitParam: spec.Param{Name: "limit", Type: "integer", Default: 2},
+			name:         "default",
+			limitParam:   spec.Param{Name: "limit", Type: "integer", Default: 2},
+			wantPageSize: 2,
 		},
 		{
-			name:       "maximum",
-			limitParam: spec.Param{Name: "limit", Type: "integer", Maximum: &capped},
+			name:         "maximum",
+			limitParam:   spec.Param{Name: "limit", Type: "integer", Maximum: &capped},
+			wantPageSize: 0,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1793,7 +1797,7 @@ func TestIssue3497BareAllOffsetUsesEndpointPageSize(t *testing.T) {
 			}
 			require.NoError(t, gen.Generate())
 
-			generatedCLISourceContaining(t, outputDir, `flagAll && !flags.dryRun, "offset", "offset", "limit", 2, "", ""`)
+			generatedCLISourceContaining(t, outputDir, fmt.Sprintf(`flagAll && !flags.dryRun, "offset", "offset", "limit", %d, "", ""`, tc.wantPageSize))
 
 			behaviorTest := `package cli
 
@@ -1863,6 +1867,134 @@ func TestIssue3497BareAllOffsetUsesDefaultPageSize(t *testing.T) {
 	}
 }
 
+func TestIssue3989UnknownPageSizeDoesNotStopOnShortPage(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("unknown-page-size")
+	apiSpec.Resources = map[string]spec.Resource{
+		"records": {
+			Description: "Records",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/records",
+					Description: "List records",
+					Response:    spec.ResponseDef{Type: "array", Item: "Record"},
+					Pagination:  &spec.Pagination{Type: "page", CursorParam: "page"},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Record": {Fields: []spec.TypeField{{Name: "id", Type: "string"}}},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "unknown-page-size-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	commandSrc := generatedCLISourceContaining(t, outputDir, `"page", "page", "", `)
+	assert.Contains(t, commandSrc, `"page", "page", "", 0, "", ""`,
+		"generated page pagination must not pass fabricated page size 100 when the spec has no page-size parameter")
+	requireGeneratedCompiles(t, outputDir)
+
+	behaviorTest := `package cli
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+type unknownPageSizeClient struct {
+	responses []json.RawMessage
+	params    []map[string]string
+}
+
+func (c *unknownPageSizeClient) GetWithHeaders(_ context.Context, _ string, params map[string]string, _ map[string]string) (json.RawMessage, error) {
+	copied := map[string]string{}
+	for key, value := range params {
+		copied[key] = value
+	}
+	c.params = append(c.params, copied)
+	response := c.responses[0]
+	c.responses = c.responses[1:]
+	return response, nil
+}
+
+func TestPaginatedGetKeepsFetchingWithUnknownPageSize(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		cursorParam string
+		pagination  string
+		wantFirst   string
+		wantSecond  string
+		wantThird   string
+	}{
+		{name: "page", cursorParam: "page", pagination: "page", wantSecond: "2", wantThird: "3"},
+		{name: "offset", cursorParam: "offset", pagination: "offset", wantFirst: "0", wantSecond: "2", wantThird: "3"},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+			client := &unknownPageSizeClient{responses: []json.RawMessage{
+				json.RawMessage("[{\"id\":\"one\"},{\"id\":\"two\"}]"),
+				json.RawMessage("[{\"id\":\"three\"}]"),
+				json.RawMessage("[]"),
+			}}
+			params := map[string]string{}
+			if test.wantFirst != "" {
+				params[test.cursorParam] = test.wantFirst
+			}
+			data, err := paginatedGet(context.Background(), client, "/records", params, nil, true, test.cursorParam, test.pagination, "", 0, "", "")
+			if err != nil {
+				t.Fatalf("paginatedGet returned error: %v", err)
+			}
+			var got []map[string]string
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("unmarshal data: %v", err)
+			}
+			if len(got) != 3 {
+				t.Fatalf("got %d items, want 3; data=%s", len(got), data)
+			}
+			if len(client.params) != 3 {
+				t.Fatalf("got %d requests, want 3", len(client.params))
+			}
+			if client.params[0][test.cursorParam] != test.wantFirst || client.params[1][test.cursorParam] != test.wantSecond || client.params[2][test.cursorParam] != test.wantThird {
+				t.Fatalf("%s params = %#v, want %s, %s, %s", test.cursorParam, client.params, test.wantFirst, test.wantSecond, test.wantThird)
+			}
+		})
+	}
+	}
+
+func TestPaginatedGetKeepsFetchingWithUnknownOffsetSizeAndHasMore(t *testing.T) {
+	client := &unknownPageSizeClient{responses: []json.RawMessage{
+		json.RawMessage("{\"items\":[{\"id\":\"one\"},{\"id\":\"two\"}],\"meta\":{\"has_more\":true}}"),
+		json.RawMessage("{\"items\":[{\"id\":\"three\"}],\"meta\":{\"has_more\":true}}"),
+		json.RawMessage("{\"items\":[],\"meta\":{\"has_more\":false}}"),
+	}}
+	data, err := paginatedGet(context.Background(), client, "/records", map[string]string{"offset":"0"}, nil, true, "offset", "offset", "", 0, "", "meta.has_more")
+	if err != nil {
+		t.Fatalf("paginatedGet returned error: %v", err)
+	}
+	var got []map[string]string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d items, want 3; data=%s", len(got), data)
+	}
+	if len(client.params) != 3 {
+		t.Fatalf("got %d requests, want 3", len(client.params))
+	}
+	for i, want := range []string{"0", "2", "3"} {
+		if got := client.params[i]["offset"]; got != want {
+			t.Fatalf("request %d offset = %q, want %q", i+1, got, want)
+		}
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "unknown_page_size_test.go"), []byte(behaviorTest), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "^TestPaginatedGetKeepsFetchingWithUnknown", "-count=1")
+}
+
 func TestOpenAPINestedNextPageGeneratesPaginatedCommandSignal(t *testing.T) {
 	t.Parallel()
 
@@ -1920,7 +2052,7 @@ paths:
 		commandSrc.Write(src)
 		commandSrc.WriteByte('\n')
 	}
-	require.Contains(t, commandSrc.String(), `flagAll, "page", "page", "limit", 100, "meta.nextPage", ""`,
+	require.Contains(t, commandSrc.String(), `flagAll, "page", "page", "limit", 0, "meta.nextPage", ""`,
 		"generated command must pass parser-detected nested nextPage to resolvePaginatedRead")
 }
 
@@ -1978,6 +2110,6 @@ paths:
 		commandSrc.Write(src)
 		commandSrc.WriteByte('\n')
 	}
-	require.Contains(t, commandSrc.String(), `flagAll, "page", "page", "limit", 100, "", "has_more"`,
+	require.Contains(t, commandSrc.String(), `flagAll, "page", "page", "limit", 0, "", "has_more"`,
 		"generated command must pass has-more-only page pagination metadata to resolvePaginatedRead")
 }

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -2014,6 +2014,33 @@ func TestPaginatedGetKeepsFetchingWithUnknownOffsetAfterEmptyHasMorePage(t *test
 		t.Fatalf("second request offset = %q, want 1", got)
 	}
 }
+
+func TestPaginatedGetKeepsFetchingWithUnknownOffsetAfterPopulatedEmptyHasMorePage(t *testing.T) {
+	client := &unknownPageSizeClient{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `{"items":[{"id":"one"},{"id":"two"}],"meta":{"has_more":true}}` + "`" + `),
+		json.RawMessage(` + "`" + `{"items":[],"meta":{"has_more":true}}` + "`" + `),
+		json.RawMessage(` + "`" + `{"items":[{"id":"three"}],"meta":{"has_more":false}}` + "`" + `),
+	}}
+	data, err := paginatedGet(context.Background(), client, "/records", map[string]string{"offset":"0"}, nil, true, "offset", "offset", "", 0, "", "meta.has_more")
+	if err != nil {
+		t.Fatalf("paginatedGet returned error: %v", err)
+	}
+	var got []map[string]string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d items, want 3; data=%s", len(got), data)
+	}
+	if len(client.params) != 3 {
+		t.Fatalf("got %d requests, want 3", len(client.params))
+	}
+	for i, want := range []string{"0", "2", "3"} {
+		if got := client.params[i]["offset"]; got != want {
+			t.Fatalf("request %d offset = %q, want %q", i+1, got, want)
+		}
+	}
+}
 `
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "unknown_page_size_test.go"), []byte(behaviorTest), 0o644))
 	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "^TestPaginatedGetKeepsFetchingWithUnknown", "-count=1")

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -1990,6 +1990,30 @@ func TestPaginatedGetKeepsFetchingWithUnknownOffsetSizeAndHasMore(t *testing.T) 
 		}
 	}
 }
+
+func TestPaginatedGetKeepsFetchingWithUnknownOffsetAfterEmptyHasMorePage(t *testing.T) {
+	client := &unknownPageSizeClient{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `{"items":[],"meta":{"has_more":true}}` + "`" + `),
+		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"meta":{"has_more":false}}` + "`" + `),
+	}}
+	data, err := paginatedGet(context.Background(), client, "/records", map[string]string{"offset":"0"}, nil, true, "offset", "offset", "", 0, "", "meta.has_more")
+	if err != nil {
+		t.Fatalf("paginatedGet returned error: %v", err)
+	}
+	var got []map[string]string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d items, want 1; data=%s", len(got), data)
+	}
+	if len(client.params) != 2 {
+		t.Fatalf("got %d requests, want 2", len(client.params))
+	}
+	if got := client.params[1]["offset"]; got != "1" {
+		t.Fatalf("second request offset = %q, want 1", got)
+	}
+}
 `
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "unknown_page_size_test.go"), []byte(behaviorTest), 0o644))
 	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "^TestPaginatedGetKeepsFetchingWithUnknown", "-count=1")

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1282,6 +1282,8 @@ func paginatedGet(ctx context.Context, c interface {
 	pageSize := 0
 	if paginationType == "offset" || paginationType == "page" {
 		pageSize = defaultPageSize
+		// A zero page size means the server controls the page size. Do not
+		// invent a limit or treat a short observed page as terminal.
 		hasPositiveLimit := false
 		if limitParam != "" {
 			if limit, err := strconv.Atoi(clean[limitParam]); err == nil && limit > 0 {
@@ -1289,10 +1291,7 @@ func paginatedGet(ctx context.Context, c interface {
 				hasPositiveLimit = true
 			}
 		}
-		if pageSize <= 0 {
-			pageSize = 100
-		}
-		if limitParam != "" && !hasPositiveLimit {
+		if limitParam != "" && !hasPositiveLimit && pageSize > 0 {
 			clean[limitParam] = strconv.Itoa(pageSize)
 		}
 	}
@@ -1400,7 +1399,11 @@ func paginatedGet(ctx context.Context, c interface {
 						var more bool
 						if json.Unmarshal(moreRaw, &more) == nil {
 							if more {
-								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, pageSize); ok {
+								nextPageSize := pageSize
+								if nextPageSize <= 0 && paginationType == "offset" {
+									nextPageSize = itemCount
+								}
+								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, nextPageSize); ok {
 									if page >= paginatedGetMaxPages {
 										emitPaginatedGetMaxPagesWarning(ctx)
 										break
@@ -1546,8 +1549,11 @@ func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationT
 	if (paginationType != "offset" && paginationType != "page") || itemCount == 0 {
 		return "", false
 	}
-	if pageSize <= 0 || itemCount < pageSize {
+	if pageSize > 0 && itemCount < pageSize {
 		return "", false
+	}
+	if pageSize <= 0 && paginationType == "offset" {
+		pageSize = itemCount
 	}
 	return nextClientSidePaginationCursor(params, cursorParam, paginationType, pageSize)
 }

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1306,7 +1306,6 @@ func paginatedGet(ctx context.Context, c interface {
 		seenCursorTokens[sentCursor] = struct{}{}
 	}
 	foundCursorField := false
-	observedOffsetPageSize := 0
 	page := 0
 	for {
 		page++
@@ -1365,9 +1364,6 @@ func paginatedGet(ctx context.Context, c interface {
 					}
 					allItems = append(allItems, nested...)
 					itemCount = len(nested)
-					if paginationType == "offset" && itemCount > 0 {
-						observedOffsetPageSize = itemCount
-					}
 				}
 
 				// Check for next cursor
@@ -1406,9 +1402,6 @@ func paginatedGet(ctx context.Context, c interface {
 								nextPageSize := pageSize
 								if nextPageSize <= 0 && paginationType == "offset" {
 									nextPageSize = itemCount
-									if nextPageSize <= 0 {
-										nextPageSize = observedOffsetPageSize
-									}
 									if nextPageSize <= 0 {
 										// A server can truthfully report more data after an
 										// empty page. Advance by one so --all does not stall

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1306,6 +1306,7 @@ func paginatedGet(ctx context.Context, c interface {
 		seenCursorTokens[sentCursor] = struct{}{}
 	}
 	foundCursorField := false
+	observedOffsetPageSize := 0
 	page := 0
 	for {
 		page++
@@ -1364,6 +1365,9 @@ func paginatedGet(ctx context.Context, c interface {
 					}
 					allItems = append(allItems, nested...)
 					itemCount = len(nested)
+					if paginationType == "offset" && itemCount > 0 {
+						observedOffsetPageSize = itemCount
+					}
 				}
 
 				// Check for next cursor
@@ -1402,6 +1406,15 @@ func paginatedGet(ctx context.Context, c interface {
 								nextPageSize := pageSize
 								if nextPageSize <= 0 && paginationType == "offset" {
 									nextPageSize = itemCount
+									if nextPageSize <= 0 {
+										nextPageSize = observedOffsetPageSize
+									}
+									if nextPageSize <= 0 {
+										// A server can truthfully report more data after an
+										// empty page. Advance by one so --all does not stall
+										// forever when no page size has been observed yet.
+										nextPageSize = 1
+									}
 								}
 								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, nextPageSize); ok {
 									if page >= paginatedGetMaxPages {

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -8553,6 +8553,13 @@ func detectPaginationResponseFields(schema *openapi3.Schema, prefix string, pag 
 			if pag.Type == "" {
 				pag.Type = "page"
 			}
+		case lower == "next" && isNumericPaginationField(propRef):
+			if pag.NextCursorPath == "" && pag.CursorParam != "" {
+				pag.NextCursorPath = path
+			}
+			if pag.Type == "" {
+				pag.Type = "cursor"
+			}
 		case stringInSlice(lower, nextFieldCursorNames):
 			if pag.NextCursorPath == "" && pag.CursorParam != "" {
 				pag.NextCursorPath = path
@@ -8574,6 +8581,14 @@ func detectPaginationResponseFields(schema *openapi3.Schema, prefix string, pag 
 		}
 		detectPaginationResponseFields(propRef.Value, path, pag)
 	}
+}
+
+func isNumericPaginationField(ref *openapi3.SchemaRef) bool {
+	schema := schemaRefValue(ref)
+	if schema == nil || schema.Type == nil {
+		return false
+	}
+	return schema.Type.Includes(openapi3.TypeInteger)
 }
 
 func isPaginationWrapperField(lower string) bool {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -12467,6 +12467,42 @@ func TestDetectPaginationRecognizesNestedNumericNextPage(t *testing.T) {
 	assert.Equal(t, "meta.nextPage", pag.NextCursorPath)
 }
 
+func TestDetectPaginationRecognizesNestedNumericNextCursor(t *testing.T) {
+	t.Parallel()
+
+	description := "OK"
+	responses := openapi3.NewResponses()
+	responses.Set("200", &openapi3.ResponseRef{Value: &openapi3.Response{
+		Description: &description,
+		Content: openapi3.Content{
+			"application/json": &openapi3.MediaType{
+				Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{
+					Type: &openapi3.Types{"object"},
+					Properties: openapi3.Schemas{
+						"data": &openapi3.SchemaRef{Value: &openapi3.Schema{
+							Type:  &openapi3.Types{"array"},
+							Items: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"object"}}},
+						}},
+						"pagination": &openapi3.SchemaRef{Value: &openapi3.Schema{
+							Type: &openapi3.Types{"object"},
+							Properties: openapi3.Schemas{
+								"next": &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"integer"}}},
+							},
+						}},
+					},
+				}},
+			},
+		},
+	}})
+	op := &openapi3.Operation{Responses: responses}
+
+	pag := detectPagination([]spec.Param{{Name: "after"}, {Name: "limit"}}, op)
+	require.NotNil(t, pag)
+	assert.Equal(t, "after", pag.CursorParam)
+	assert.Equal(t, "cursor", pag.Type)
+	assert.Equal(t, "pagination.next", pag.NextCursorPath)
+}
+
 func TestDetectPaginationDoesNotWireNestedNextPageWithoutRequestCursor(t *testing.T) {
 	t.Parallel()
 

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -702,7 +702,6 @@ func paginatedGet(ctx context.Context, c interface {
 		seenCursorTokens[sentCursor] = struct{}{}
 	}
 	foundCursorField := false
-	observedOffsetPageSize := 0
 	page := 0
 	for {
 		page++
@@ -761,9 +760,6 @@ func paginatedGet(ctx context.Context, c interface {
 					}
 					allItems = append(allItems, nested...)
 					itemCount = len(nested)
-					if paginationType == "offset" && itemCount > 0 {
-						observedOffsetPageSize = itemCount
-					}
 				}
 
 				// Check for next cursor
@@ -802,9 +798,6 @@ func paginatedGet(ctx context.Context, c interface {
 								nextPageSize := pageSize
 								if nextPageSize <= 0 && paginationType == "offset" {
 									nextPageSize = itemCount
-									if nextPageSize <= 0 {
-										nextPageSize = observedOffsetPageSize
-									}
 									if nextPageSize <= 0 {
 										// A server can truthfully report more data after an
 										// empty page. Advance by one so --all does not stall

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -678,6 +678,8 @@ func paginatedGet(ctx context.Context, c interface {
 	pageSize := 0
 	if paginationType == "offset" || paginationType == "page" {
 		pageSize = defaultPageSize
+		// A zero page size means the server controls the page size. Do not
+		// invent a limit or treat a short observed page as terminal.
 		hasPositiveLimit := false
 		if limitParam != "" {
 			if limit, err := strconv.Atoi(clean[limitParam]); err == nil && limit > 0 {
@@ -685,10 +687,7 @@ func paginatedGet(ctx context.Context, c interface {
 				hasPositiveLimit = true
 			}
 		}
-		if pageSize <= 0 {
-			pageSize = 100
-		}
-		if limitParam != "" && !hasPositiveLimit {
+		if limitParam != "" && !hasPositiveLimit && pageSize > 0 {
 			clean[limitParam] = strconv.Itoa(pageSize)
 		}
 	}
@@ -796,7 +795,11 @@ func paginatedGet(ctx context.Context, c interface {
 						var more bool
 						if json.Unmarshal(moreRaw, &more) == nil {
 							if more {
-								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, pageSize); ok {
+								nextPageSize := pageSize
+								if nextPageSize <= 0 && paginationType == "offset" {
+									nextPageSize = itemCount
+								}
+								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, nextPageSize); ok {
 									if page >= paginatedGetMaxPages {
 										emitPaginatedGetMaxPagesWarning(ctx)
 										break
@@ -942,8 +945,11 @@ func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationT
 	if (paginationType != "offset" && paginationType != "page") || itemCount == 0 {
 		return "", false
 	}
-	if pageSize <= 0 || itemCount < pageSize {
+	if pageSize > 0 && itemCount < pageSize {
 		return "", false
+	}
+	if pageSize <= 0 && paginationType == "offset" {
+		pageSize = itemCount
 	}
 	return nextClientSidePaginationCursor(params, cursorParam, paginationType, pageSize)
 }

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -702,6 +702,7 @@ func paginatedGet(ctx context.Context, c interface {
 		seenCursorTokens[sentCursor] = struct{}{}
 	}
 	foundCursorField := false
+	observedOffsetPageSize := 0
 	page := 0
 	for {
 		page++
@@ -760,6 +761,9 @@ func paginatedGet(ctx context.Context, c interface {
 					}
 					allItems = append(allItems, nested...)
 					itemCount = len(nested)
+					if paginationType == "offset" && itemCount > 0 {
+						observedOffsetPageSize = itemCount
+					}
 				}
 
 				// Check for next cursor
@@ -798,6 +802,15 @@ func paginatedGet(ctx context.Context, c interface {
 								nextPageSize := pageSize
 								if nextPageSize <= 0 && paginationType == "offset" {
 									nextPageSize = itemCount
+									if nextPageSize <= 0 {
+										nextPageSize = observedOffsetPageSize
+									}
+									if nextPageSize <= 0 {
+										// A server can truthfully report more data after an
+										// empty page. Advance by one so --all does not stall
+										// forever when no page size has been observed yet.
+										nextPageSize = 1
+									}
 								}
 								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, nextPageSize); ok {
 									if page >= paginatedGetMaxPages {

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -671,6 +671,8 @@ func paginatedGet(ctx context.Context, c interface {
 	pageSize := 0
 	if paginationType == "offset" || paginationType == "page" {
 		pageSize = defaultPageSize
+		// A zero page size means the server controls the page size. Do not
+		// invent a limit or treat a short observed page as terminal.
 		hasPositiveLimit := false
 		if limitParam != "" {
 			if limit, err := strconv.Atoi(clean[limitParam]); err == nil && limit > 0 {
@@ -678,10 +680,7 @@ func paginatedGet(ctx context.Context, c interface {
 				hasPositiveLimit = true
 			}
 		}
-		if pageSize <= 0 {
-			pageSize = 100
-		}
-		if limitParam != "" && !hasPositiveLimit {
+		if limitParam != "" && !hasPositiveLimit && pageSize > 0 {
 			clean[limitParam] = strconv.Itoa(pageSize)
 		}
 	}
@@ -789,7 +788,11 @@ func paginatedGet(ctx context.Context, c interface {
 						var more bool
 						if json.Unmarshal(moreRaw, &more) == nil {
 							if more {
-								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, pageSize); ok {
+								nextPageSize := pageSize
+								if nextPageSize <= 0 && paginationType == "offset" {
+									nextPageSize = itemCount
+								}
+								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, nextPageSize); ok {
 									if page >= paginatedGetMaxPages {
 										emitPaginatedGetMaxPagesWarning(ctx)
 										break
@@ -935,8 +938,11 @@ func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationT
 	if (paginationType != "offset" && paginationType != "page") || itemCount == 0 {
 		return "", false
 	}
-	if pageSize <= 0 || itemCount < pageSize {
+	if pageSize > 0 && itemCount < pageSize {
 		return "", false
+	}
+	if pageSize <= 0 && paginationType == "offset" {
+		pageSize = itemCount
 	}
 	return nextClientSidePaginationCursor(params, cursorParam, paginationType, pageSize)
 }

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -695,6 +695,7 @@ func paginatedGet(ctx context.Context, c interface {
 		seenCursorTokens[sentCursor] = struct{}{}
 	}
 	foundCursorField := false
+	observedOffsetPageSize := 0
 	page := 0
 	for {
 		page++
@@ -753,6 +754,9 @@ func paginatedGet(ctx context.Context, c interface {
 					}
 					allItems = append(allItems, nested...)
 					itemCount = len(nested)
+					if paginationType == "offset" && itemCount > 0 {
+						observedOffsetPageSize = itemCount
+					}
 				}
 
 				// Check for next cursor
@@ -791,6 +795,15 @@ func paginatedGet(ctx context.Context, c interface {
 								nextPageSize := pageSize
 								if nextPageSize <= 0 && paginationType == "offset" {
 									nextPageSize = itemCount
+									if nextPageSize <= 0 {
+										nextPageSize = observedOffsetPageSize
+									}
+									if nextPageSize <= 0 {
+										// A server can truthfully report more data after an
+										// empty page. Advance by one so --all does not stall
+										// forever when no page size has been observed yet.
+										nextPageSize = 1
+									}
 								}
 								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, nextPageSize); ok {
 									if page >= paginatedGetMaxPages {

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -695,7 +695,6 @@ func paginatedGet(ctx context.Context, c interface {
 		seenCursorTokens[sentCursor] = struct{}{}
 	}
 	foundCursorField := false
-	observedOffsetPageSize := 0
 	page := 0
 	for {
 		page++
@@ -754,9 +753,6 @@ func paginatedGet(ctx context.Context, c interface {
 					}
 					allItems = append(allItems, nested...)
 					itemCount = len(nested)
-					if paginationType == "offset" && itemCount > 0 {
-						observedOffsetPageSize = itemCount
-					}
 				}
 
 				// Check for next cursor
@@ -795,9 +791,6 @@ func paginatedGet(ctx context.Context, c interface {
 								nextPageSize := pageSize
 								if nextPageSize <= 0 && paginationType == "offset" {
 									nextPageSize = itemCount
-									if nextPageSize <= 0 {
-										nextPageSize = observedOffsetPageSize
-									}
 									if nextPageSize <= 0 {
 										// A server can truthfully report more data after an
 										// empty page. Advance by one so --all does not stall

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -779,7 +779,6 @@ func paginatedGet(ctx context.Context, c interface {
 		seenCursorTokens[sentCursor] = struct{}{}
 	}
 	foundCursorField := false
-	observedOffsetPageSize := 0
 	page := 0
 	for {
 		page++
@@ -838,9 +837,6 @@ func paginatedGet(ctx context.Context, c interface {
 					}
 					allItems = append(allItems, nested...)
 					itemCount = len(nested)
-					if paginationType == "offset" && itemCount > 0 {
-						observedOffsetPageSize = itemCount
-					}
 				}
 
 				// Check for next cursor
@@ -879,9 +875,6 @@ func paginatedGet(ctx context.Context, c interface {
 								nextPageSize := pageSize
 								if nextPageSize <= 0 && paginationType == "offset" {
 									nextPageSize = itemCount
-									if nextPageSize <= 0 {
-										nextPageSize = observedOffsetPageSize
-									}
 									if nextPageSize <= 0 {
 										// A server can truthfully report more data after an
 										// empty page. Advance by one so --all does not stall

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -755,6 +755,8 @@ func paginatedGet(ctx context.Context, c interface {
 	pageSize := 0
 	if paginationType == "offset" || paginationType == "page" {
 		pageSize = defaultPageSize
+		// A zero page size means the server controls the page size. Do not
+		// invent a limit or treat a short observed page as terminal.
 		hasPositiveLimit := false
 		if limitParam != "" {
 			if limit, err := strconv.Atoi(clean[limitParam]); err == nil && limit > 0 {
@@ -762,10 +764,7 @@ func paginatedGet(ctx context.Context, c interface {
 				hasPositiveLimit = true
 			}
 		}
-		if pageSize <= 0 {
-			pageSize = 100
-		}
-		if limitParam != "" && !hasPositiveLimit {
+		if limitParam != "" && !hasPositiveLimit && pageSize > 0 {
 			clean[limitParam] = strconv.Itoa(pageSize)
 		}
 	}
@@ -873,7 +872,11 @@ func paginatedGet(ctx context.Context, c interface {
 						var more bool
 						if json.Unmarshal(moreRaw, &more) == nil {
 							if more {
-								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, pageSize); ok {
+								nextPageSize := pageSize
+								if nextPageSize <= 0 && paginationType == "offset" {
+									nextPageSize = itemCount
+								}
+								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, nextPageSize); ok {
 									if page >= paginatedGetMaxPages {
 										emitPaginatedGetMaxPagesWarning(ctx)
 										break
@@ -1019,8 +1022,11 @@ func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationT
 	if (paginationType != "offset" && paginationType != "page") || itemCount == 0 {
 		return "", false
 	}
-	if pageSize <= 0 || itemCount < pageSize {
+	if pageSize > 0 && itemCount < pageSize {
 		return "", false
+	}
+	if pageSize <= 0 && paginationType == "offset" {
+		pageSize = itemCount
 	}
 	return nextClientSidePaginationCursor(params, cursorParam, paginationType, pageSize)
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -779,6 +779,7 @@ func paginatedGet(ctx context.Context, c interface {
 		seenCursorTokens[sentCursor] = struct{}{}
 	}
 	foundCursorField := false
+	observedOffsetPageSize := 0
 	page := 0
 	for {
 		page++
@@ -837,6 +838,9 @@ func paginatedGet(ctx context.Context, c interface {
 					}
 					allItems = append(allItems, nested...)
 					itemCount = len(nested)
+					if paginationType == "offset" && itemCount > 0 {
+						observedOffsetPageSize = itemCount
+					}
 				}
 
 				// Check for next cursor
@@ -875,6 +879,15 @@ func paginatedGet(ctx context.Context, c interface {
 								nextPageSize := pageSize
 								if nextPageSize <= 0 && paginationType == "offset" {
 									nextPageSize = itemCount
+									if nextPageSize <= 0 {
+										nextPageSize = observedOffsetPageSize
+									}
+									if nextPageSize <= 0 {
+										// A server can truthfully report more data after an
+										// empty page. Advance by one so --all does not stall
+										// forever when no page size has been observed yet.
+										nextPageSize = 1
+									}
 								}
 								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, nextPageSize); ok {
 									if page >= paginatedGetMaxPages {

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
@@ -745,6 +745,8 @@ func paginatedGet(ctx context.Context, c interface {
 	pageSize := 0
 	if paginationType == "offset" || paginationType == "page" {
 		pageSize = defaultPageSize
+		// A zero page size means the server controls the page size. Do not
+		// invent a limit or treat a short observed page as terminal.
 		hasPositiveLimit := false
 		if limitParam != "" {
 			if limit, err := strconv.Atoi(clean[limitParam]); err == nil && limit > 0 {
@@ -752,10 +754,7 @@ func paginatedGet(ctx context.Context, c interface {
 				hasPositiveLimit = true
 			}
 		}
-		if pageSize <= 0 {
-			pageSize = 100
-		}
-		if limitParam != "" && !hasPositiveLimit {
+		if limitParam != "" && !hasPositiveLimit && pageSize > 0 {
 			clean[limitParam] = strconv.Itoa(pageSize)
 		}
 	}
@@ -863,7 +862,11 @@ func paginatedGet(ctx context.Context, c interface {
 						var more bool
 						if json.Unmarshal(moreRaw, &more) == nil {
 							if more {
-								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, pageSize); ok {
+								nextPageSize := pageSize
+								if nextPageSize <= 0 && paginationType == "offset" {
+									nextPageSize = itemCount
+								}
+								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, nextPageSize); ok {
 									if page >= paginatedGetMaxPages {
 										emitPaginatedGetMaxPagesWarning(ctx)
 										break
@@ -1009,8 +1012,11 @@ func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationT
 	if (paginationType != "offset" && paginationType != "page") || itemCount == 0 {
 		return "", false
 	}
-	if pageSize <= 0 || itemCount < pageSize {
+	if pageSize > 0 && itemCount < pageSize {
 		return "", false
+	}
+	if pageSize <= 0 && paginationType == "offset" {
+		pageSize = itemCount
 	}
 	return nextClientSidePaginationCursor(params, cursorParam, paginationType, pageSize)
 }

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
@@ -769,6 +769,7 @@ func paginatedGet(ctx context.Context, c interface {
 		seenCursorTokens[sentCursor] = struct{}{}
 	}
 	foundCursorField := false
+	observedOffsetPageSize := 0
 	page := 0
 	for {
 		page++
@@ -827,6 +828,9 @@ func paginatedGet(ctx context.Context, c interface {
 					}
 					allItems = append(allItems, nested...)
 					itemCount = len(nested)
+					if paginationType == "offset" && itemCount > 0 {
+						observedOffsetPageSize = itemCount
+					}
 				}
 
 				// Check for next cursor
@@ -865,6 +869,15 @@ func paginatedGet(ctx context.Context, c interface {
 								nextPageSize := pageSize
 								if nextPageSize <= 0 && paginationType == "offset" {
 									nextPageSize = itemCount
+									if nextPageSize <= 0 {
+										nextPageSize = observedOffsetPageSize
+									}
+									if nextPageSize <= 0 {
+										// A server can truthfully report more data after an
+										// empty page. Advance by one so --all does not stall
+										// forever when no page size has been observed yet.
+										nextPageSize = 1
+									}
 								}
 								if next, ok := nextClientSidePaginationCursor(clean, cursorParam, paginationType, nextPageSize); ok {
 									if page >= paginatedGetMaxPages {

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
@@ -769,7 +769,6 @@ func paginatedGet(ctx context.Context, c interface {
 		seenCursorTokens[sentCursor] = struct{}{}
 	}
 	foundCursorField := false
-	observedOffsetPageSize := 0
 	page := 0
 	for {
 		page++
@@ -828,9 +827,6 @@ func paginatedGet(ctx context.Context, c interface {
 					}
 					allItems = append(allItems, nested...)
 					itemCount = len(nested)
-					if paginationType == "offset" && itemCount > 0 {
-						observedOffsetPageSize = itemCount
-					}
 				}
 
 				// Check for next cursor
@@ -869,9 +865,6 @@ func paginatedGet(ctx context.Context, c interface {
 								nextPageSize := pageSize
 								if nextPageSize <= 0 && paginationType == "offset" {
 									nextPageSize = itemCount
-									if nextPageSize <= 0 {
-										nextPageSize = observedOffsetPageSize
-									}
 									if nextPageSize <= 0 {
 										// A server can truthfully report more data after an
 										// empty page. Advance by one so --all does not stall

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_list.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_list.go
@@ -26,7 +26,7 @@ func newItemsListCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			c = c.WithTier("free")
-			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "auto", "items", path, map[string]string{}, nil, flagAll, "cursor", "cursor", "limit", 100, "", "", "", cmd.ErrOrStderr())
+			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "auto", "items", path, map[string]string{}, nil, flagAll, "cursor", "cursor", "limit", 0, "", "", "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}


### PR DESCRIPTION
## Summary

- infer nested integer `pagination.next` paths so cursor-based `--all` requests follow the server continuation token
- remove the fabricated page-size fallback and use observed item counts for unknown-size page and offset pagination
- keep explicit `has_more` envelopes advancing unknown-size offsets, and update generated regressions and golden fixtures

## Validation

- `go test ./internal/openapi -count=1`
- focused pagination regressions in `internal/generator` and `internal/openapi`
- `go test ./... -run '^$' -count=1 -parallel=1 -p=1`
- `scripts/golden.sh verify` passed all 32 cases
- `scripts/verify-generator-output.sh` passed all 10 cases
- the full `internal/generator` test run was attempted with serialized execution but timed out in local generated-suite execution; focused tests and generated-output compilation pass

Closes #4004
Closes #3989
