### PR TITLE
fix(cli): harden generated credential writes

### DIFF
--- a/internal/generator/creds_read_perms_test.go
+++ b/internal/generator/creds_read_perms_test.go
@@ -65,9 +65,20 @@ func TestGenerate_EmitsCredsPermsForTokenSpec(t *testing.T) {
 	// in-package (not cliutil.VerifyCredsPerms).
 	credsSrc := readGeneratedFile(t, outputDir, "internal", "cliutil", "credentials.go")
 	require.Contains(t, credsSrc, "VerifyCredsPerms(", "LoadCredentials must guard the credentials-file read with the perms check")
+	require.Contains(t, credsSrc, "type CredentialsPermissionError", "credential saves must report a landed file that fails the permission guard")
+	require.Contains(t, credsSrc, "filepath.EvalSymlinks(path)", "credential saves must verify the file that was actually published")
+	require.Contains(t, credsSrc, "VerifyCredsPerms(real)", "credential saves must verify permissions after publication")
 
 	_, err = os.Stat(filepath.Join(outputDir, "internal", "cliutil", "credentials_perms_test.go"))
 	require.NoError(t, err, "cliutil credentials read-time perms behavioral test must be emitted")
+
+	rootSrc := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	require.Contains(t, rootSrc, "writeCredentialSaveErrorEnvelope", "JSON auth failures must report post-save credential permission refusals")
+	require.Contains(t, rootSrc, "envelopeWriter := io.Writer(os.Stdout)", "credential permission failures must use the normal JSON output stream")
+	require.Contains(t, rootSrc, `"permissions_verified": false`, "JSON auth failures must flag the unsafe landed file")
+	pathsSrc := readGeneratedFile(t, outputDir, "internal", "cliutil", "paths.go")
+	require.Contains(t, pathsSrc, "renamePrivateFileWithRetryFunc", "private-file publication must expose a testable bounded retry path")
+	requireGeneratedCompiles(t, outputDir)
 
 	// A5: creds_perms_windows.go imports golang.org/x/sys/windows, which makes
 	// golang.org/x/sys a DIRECT dependency of a token-bearing bundle. The

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1084,6 +1084,7 @@ type generatorTemplateData struct {
 type rootTestTemplateData struct {
 	*spec.APISpec
 	ExpectedCommandPaths []string
+	HasAuthCommand       bool
 }
 
 type trafficAnalysisTemplateData struct {
@@ -2559,6 +2560,7 @@ func (g *Generator) renderSingleFiles() error {
 			data = &rootTestTemplateData{
 				APISpec:              g.Spec,
 				ExpectedCommandPaths: expectedCommandPaths(buildCommandSurface(g.Spec, g.PromotedCommands)),
+				HasAuthCommand:       g.shouldEmitAuth(),
 			}
 		case "doctor.go.tmpl":
 			data = &doctorTemplateData{

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1894,6 +1894,7 @@ func TestGenerateOAuth2DeviceCodeAuth(t *testing.T) {
 	assert.Contains(t, authGo, `fmt.Fprintln(w, "  deviceauth-pp-cli auth poll")`, "headless login resumes without exposing the raw device_code")
 	assert.NotContains(t, authGo, `auth poll --device-code`, "raw device_code must not be printed into shell commands")
 	assert.Contains(t, authGo, `cfg.AuthHeaderVal = ""`, "OAuth token saves must clear stale manual auth headers")
+	assert.Contains(t, authGo, `w = cmd.ErrOrStderr()`, "machine-mode device login progress must not corrupt the JSON failure envelope")
 	assert.Contains(t, authGo, `deviceAuthorizationURL := cfg.DeviceAuthorizationURL`, "login honors device endpoint overrides")
 	assert.Contains(t, authGo, `"https://login.example.com/device"`, "login falls back to the configured device endpoint")
 	assert.Contains(t, authGo, `"public-client-id"`, "login uses the spec default client id")

--- a/internal/generator/templates/auth_device_code.go.tmpl
+++ b/internal/generator/templates/auth_device_code.go.tmpl
@@ -138,6 +138,9 @@ for CLIs and agents: no localhost callback server and no client secret.
 			}
 
 			w := cmd.OutOrStdout()
+			if flags.asJSON {
+				w = cmd.ErrOrStderr()
+			}
 			if device.Message != "" {
 				fmt.Fprintln(w, device.Message)
 			} else {

--- a/internal/generator/templates/cliutil_credentials.go.tmpl
+++ b/internal/generator/templates/cliutil_credentials.go.tmpl
@@ -38,6 +38,19 @@ type Credentials struct {
 {{- end}}
 }
 
+// CredentialsPermissionError means the credentials bytes were published but
+// the landed file failed the platform-specific private-file guard.
+type CredentialsPermissionError struct {
+	Path string
+	Err  error
+}
+
+func (e *CredentialsPermissionError) Error() string {
+	return fmt.Sprintf("credentials file saved but permissions are unsafe for %s: %v", e.Path, e.Err)
+}
+
+func (e *CredentialsPermissionError) Unwrap() error { return e.Err }
+
 func credentialsFileFrom(creds *Credentials) map[string]interface{} {
 	values := map[string]interface{}{}
 	if creds == nil {
@@ -216,7 +229,17 @@ func SaveCredentials(creds *Credentials) error {
 	if err != nil {
 		return fmt.Errorf("marshaling credentials: %w", err)
 	}
-	return AtomicWritePrivateFile(path, data, 0o600, 0o700)
+	if err := AtomicWritePrivateFile(path, data, 0o600, 0o700); err != nil {
+		return err
+	}
+	real, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return &CredentialsPermissionError{Path: path, Err: fmt.Errorf("resolving saved file: %w", err)}
+	}
+	if err := VerifyCredsPerms(real); err != nil {
+		return &CredentialsPermissionError{Path: path, Err: err}
+	}
+	return nil
 }
 
 func RemoveCredentials() error {

--- a/internal/generator/templates/cliutil_credentials_perms_test.go.tmpl
+++ b/internal/generator/templates/cliutil_credentials_perms_test.go.tmpl
@@ -14,9 +14,12 @@
 package cliutil
 
 import (
+	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"{{modulePath}}/internal/cliutil/testenv"
@@ -114,5 +117,42 @@ func TestLoadCredentials_RefusesOverPermissiveFileOnRead(t *testing.T) {
 	}
 	if creds != nil {
 		t.Errorf("over-permissive credentials file must surface no credential, got %+v", creds)
+	}
+}
+
+// TestSaveCredentialsVerifiesWrittenFile exercises the NTFS case where a
+// credentials file inherits a broad ACE even though the writer requested 0600.
+func TestSaveCredentialsVerifiesWrittenFile(t *testing.T) {
+	isolateCredsHome(t)
+	dataDir, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir() error = %v", err)
+	}
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		t.Fatalf("mkdir data dir: %v", err)
+	}
+	if runtime.GOOS == "windows" {
+		if err := runCredsPermsCmd(t, "icacls", dataDir, "/grant", "*S-1-5-32-545:(OI)(CI)(R)"); err != nil {
+			t.Skipf("icacls inherited grant failed; skipping environment-sensitive test: %v", err)
+		}
+		err = SaveCredentials(&Credentials{AccessToken: credsSampleReadPermsToken})
+		var permissionErr *CredentialsPermissionError
+		if err == nil || !strings.Contains(err.Error(), "permissions") || !errors.As(err, &permissionErr) {
+			t.Fatalf("SaveCredentials() error = %v, want post-save permission refusal", err)
+		}
+		if permissionErr.Path != filepath.Join(dataDir, credentialsFileName) {
+			t.Fatalf("permission error path = %q, want %q", permissionErr.Path, filepath.Join(dataDir, credentialsFileName))
+		}
+		data, readErr := os.ReadFile(permissionErr.Path)
+		if readErr != nil {
+			t.Fatalf("read saved credentials after permission refusal: %v", readErr)
+		}
+		if !strings.Contains(string(data), credsSampleReadPermsToken) {
+			t.Fatalf("saved credentials do not contain test token: %q", data)
+		}
+		return
+	}
+	if err := SaveCredentials(&Credentials{AccessToken: credsSampleReadPermsToken}); err != nil {
+		t.Fatalf("SaveCredentials() on a normal POSIX file error = %v", err)
 	}
 }

--- a/internal/generator/templates/cliutil_paths.go.tmpl
+++ b/internal/generator/templates/cliutil_paths.go.tmpl
@@ -6,10 +6,14 @@ package cliutil
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
+	"syscall"
+	"time"
 )
 
 const appName = "{{.Name}}-pp-cli"
@@ -146,11 +150,46 @@ func AtomicWritePrivateFile(path string, data []byte, fileMode, dirMode os.FileM
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("closing temporary private file: %w", err)
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
+	if err := renamePrivateFileWithRetry(tmpPath, path); err != nil {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("publishing private file: %w", err)
 	}
 	return nil
+}
+
+const privateFileRenameAttempts = 12
+
+func renamePrivateFileWithRetry(tmpPath, path string) error {
+	return renamePrivateFileWithRetryFunc(os.Rename, tmpPath, path)
+}
+
+func renamePrivateFileWithRetryFunc(rename func(string, string) error, tmpPath, path string) error {
+	delay := 2 * time.Millisecond
+	var err error
+	for attempt := 0; attempt < privateFileRenameAttempts; attempt++ {
+		if err = rename(tmpPath, path); err == nil {
+			return nil
+		}
+		if !privateFileRenameRetryable(err) {
+			return err
+		}
+		if attempt+1 < privateFileRenameAttempts {
+			time.Sleep(delay)
+			if delay < 64*time.Millisecond {
+				delay *= 2
+			}
+		}
+	}
+	return err
+}
+
+// Windows MoveFileEx reports a destination held open by another writer as
+// ERROR_SHARING_VIOLATION (32), which is distinct from fs.ErrPermission.
+const windowsSharingViolation = syscall.Errno(32)
+
+func privateFileRenameRetryable(err error) bool {
+	return runtime.GOOS == "windows" &&
+		(errors.Is(err, fs.ErrPermission) || errors.Is(err, windowsSharingViolation))
 }
 
 func KindDir(kind PathKind) (string, error) {

--- a/internal/generator/templates/cliutil_paths_test.go.tmpl
+++ b/internal/generator/templates/cliutil_paths_test.go.tmpl
@@ -6,9 +6,12 @@ package cliutil
 import (
 	"bytes"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 
 	"{{modulePath}}/internal/cliutil/testenv"
@@ -43,6 +46,44 @@ func TestKindDirDefaultsMatchLegacyLayout(t *testing.T) {
 		}
 		if got != tt.want {
 			t.Fatalf("KindDir(%s) = %q, want %q", kindName(tt.kind), got, tt.want)
+		}
+	}
+}
+
+func TestRenamePrivateFileWithRetryRetriesWindowsPermissionFailures(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only retry behavior")
+	}
+
+	dir := t.TempDir()
+	tmpPath := filepath.Join(dir, "temporary")
+	path := filepath.Join(dir, "published")
+	if err := os.WriteFile(tmpPath, []byte("credential"), 0o600); err != nil {
+		t.Fatalf("write temporary file: %v", err)
+	}
+	for _, failure := range []error{fs.ErrPermission, syscall.Errno(32)} {
+		attempts := 0
+		err := renamePrivateFileWithRetryFunc(func(source, target string) error {
+			attempts++
+			if attempts == 1 {
+				return failure
+			}
+			return os.Rename(source, target)
+		}, tmpPath, path)
+		if err != nil {
+			t.Fatalf("renamePrivateFileWithRetryFunc(%v) error = %v", failure, err)
+		}
+		if attempts != 2 {
+			t.Fatalf("rename attempts for %v = %d, want 2", failure, attempts)
+		}
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("published file missing after retry for %v: %v", failure, err)
+		}
+		if err := os.Remove(path); err != nil {
+			t.Fatalf("remove published test file: %v", err)
+		}
+		if err := os.WriteFile(tmpPath, []byte("credential"), 0o600); err != nil {
+			t.Fatalf("rewrite temporary file: %v", err)
 		}
 	}
 }

--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -5,6 +5,9 @@ package cli
 
 import (
 	"bytes"
+	{{- if .HasAuthCommand}}
+	"encoding/json"
+	{{- end}}
 	"errors"
 	"fmt"
 	"io"
@@ -155,6 +158,18 @@ func Execute() (retErr error) {
 	if errors.Is(err, pflag.ErrHelp) {
 		return nil
 	}
+	{{- if .HasAuthCommand}}
+	envelopeWriter := io.Writer(os.Stdout)
+	if flags.deliverBuf != nil {
+		envelopeWriter = io.MultiWriter(os.Stdout, flags.deliverBuf)
+	}
+	envelopeWritten := writeCredentialSaveErrorEnvelope(envelopeWriter, &flags, err)
+	if envelopeWritten && flags.deliverBuf != nil {
+		if derr := Deliver(flags.deliverSink, flags.deliverBuf.Bytes(), flags.compact); derr != nil {
+			fmt.Fprintf(os.Stderr, "warning: deliver to %s:%s failed: %v\n", flags.deliverSink.Scheme, flags.deliverSink.Target, derr)
+		}
+	}
+	{{- end}}
 	if err != nil && strings.Contains(err.Error(), "unknown flag") {
 		msg := err.Error()
 		// Extract the flag name from the error message (e.g., "unknown flag: --foob")
@@ -200,6 +215,26 @@ func Execute() (retErr error) {
 	}
 	return err
 }
+
+{{ if .HasAuthCommand }}
+func writeCredentialSaveErrorEnvelope(w io.Writer, flags *rootFlags, err error) bool {
+	if flags == nil || !flags.asJSON || err == nil {
+		return false
+	}
+	var permissionErr *cliutil.CredentialsPermissionError
+	if !errors.As(err, &permissionErr) {
+		return false
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"saved":                 true,
+		"credentials_path":     permissionErr.Path,
+		"permissions_verified": false,
+		"error":                permissionErr.Error(),
+		"code":                 ExitCode(err),
+	})
+	return true
+}
+{{ end }}
 
 // isCobraUsageError reports whether err matches one of Cobra/pflag's
 // pre-RunE usage-error shapes. Detection is by message prefix to match

--- a/internal/generator/templates/root_test.go.tmpl
+++ b/internal/generator/templates/root_test.go.tmpl
@@ -4,12 +4,18 @@
 package cli
 
 import (
+	{{ if .HasAuthCommand }}
+	"bytes"
+	{{ end }}
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
+	{{ if .HasAuthCommand }}
+	"{{modulePath}}/internal/cliutil"
+	{{ end }}
 	"github.com/spf13/cobra"
 )
 
@@ -77,6 +83,33 @@ func TestNoDuplicateCommandNames(t *testing.T) {
 		t.Fatalf("generated Cobra tree contains duplicate sibling command names: %s", strings.Join(duplicates, ", "))
 	}
 }
+
+{{- if .HasAuthCommand}}
+func TestWriteCredentialSaveErrorEnvelope(t *testing.T) {
+	var out bytes.Buffer
+	cause := &cliutil.CredentialsPermissionError{
+		Path: "/tmp/credentials.toml",
+		Err:  errors.New("unsafe permissions"),
+	}
+	if !writeCredentialSaveErrorEnvelope(&out, &rootFlags{asJSON: true}, fmt.Errorf("saving token: %w", cause)) {
+		t.Fatal("permission failure envelope was not written")
+	}
+
+	var payload struct {
+		Saved              bool   `json:"saved"`
+		CredentialsPath    string `json:"credentials_path"`
+		PermissionsVerified bool  `json:"permissions_verified"`
+		Error              string `json:"error"`
+		Code               int    `json:"code"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("permission failure envelope must be valid JSON: %v\n%s", err, out.String())
+	}
+	if !payload.Saved || payload.CredentialsPath != cause.Path || payload.PermissionsVerified || payload.Error == "" || payload.Code == 0 {
+		t.Fatalf("permission failure envelope = %+v, want saved path, unsafe permissions, error, and non-zero code", payload)
+	}
+}
+{{- end}}
 
 // TestIsCobraUsageError covers the six pre-RunE error shapes Cobra and
 // pflag can produce before any user RunE runs. Each must be detected so

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/cli/auth.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/cli/auth.go
@@ -112,6 +112,9 @@ for CLIs and agents: no localhost callback server and no client secret.
 			}
 
 			w := cmd.OutOrStdout()
+			if flags.asJSON {
+				w = cmd.ErrOrStderr()
+			}
 			if device.Message != "" {
 				fmt.Fprintln(w, device.Message)
 			} else {

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/root_test.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/root_test.go
@@ -4,11 +4,15 @@
 package cli
 
 import (
+	"bytes"
+
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"testing"
+
+	"printing-press-rich-pp-cli/internal/cliutil"
 
 	"github.com/spf13/cobra"
 )
@@ -73,6 +77,30 @@ func TestNoDuplicateCommandNames(t *testing.T) {
 	}
 	if len(duplicates) > 0 {
 		t.Fatalf("generated Cobra tree contains duplicate sibling command names: %s", strings.Join(duplicates, ", "))
+	}
+}
+func TestWriteCredentialSaveErrorEnvelope(t *testing.T) {
+	var out bytes.Buffer
+	cause := &cliutil.CredentialsPermissionError{
+		Path: "/tmp/credentials.toml",
+		Err:  errors.New("unsafe permissions"),
+	}
+	if !writeCredentialSaveErrorEnvelope(&out, &rootFlags{asJSON: true}, fmt.Errorf("saving token: %w", cause)) {
+		t.Fatal("permission failure envelope was not written")
+	}
+
+	var payload struct {
+		Saved               bool   `json:"saved"`
+		CredentialsPath     string `json:"credentials_path"`
+		PermissionsVerified bool   `json:"permissions_verified"`
+		Error               string `json:"error"`
+		Code                int    `json:"code"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("permission failure envelope must be valid JSON: %v\n%s", err, out.String())
+	}
+	if !payload.Saved || payload.CredentialsPath != cause.Path || payload.PermissionsVerified || payload.Error == "" || payload.Code == 0 {
+		t.Fatalf("permission failure envelope = %+v, want saved path, unsafe permissions, error, and non-zero code", payload)
 	}
 }
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -128,6 +129,16 @@ func Execute() (retErr error) {
 	if errors.Is(err, pflag.ErrHelp) {
 		return nil
 	}
+	envelopeWriter := io.Writer(os.Stdout)
+	if flags.deliverBuf != nil {
+		envelopeWriter = io.MultiWriter(os.Stdout, flags.deliverBuf)
+	}
+	envelopeWritten := writeCredentialSaveErrorEnvelope(envelopeWriter, &flags, err)
+	if envelopeWritten && flags.deliverBuf != nil {
+		if derr := Deliver(flags.deliverSink, flags.deliverBuf.Bytes(), flags.compact); derr != nil {
+			fmt.Fprintf(os.Stderr, "warning: deliver to %s:%s failed: %v\n", flags.deliverSink.Scheme, flags.deliverSink.Target, derr)
+		}
+	}
 	if err != nil && strings.Contains(err.Error(), "unknown flag") {
 		msg := err.Error()
 		// Extract the flag name from the error message (e.g., "unknown flag: --foob")
@@ -168,6 +179,24 @@ func Execute() (retErr error) {
 		return usageErr(err)
 	}
 	return err
+}
+
+func writeCredentialSaveErrorEnvelope(w io.Writer, flags *rootFlags, err error) bool {
+	if flags == nil || !flags.asJSON || err == nil {
+		return false
+	}
+	var permissionErr *cliutil.CredentialsPermissionError
+	if !errors.As(err, &permissionErr) {
+		return false
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"saved":                true,
+		"credentials_path":     permissionErr.Path,
+		"permissions_verified": false,
+		"error":                permissionErr.Error(),
+		"code":                 ExitCode(err),
+	})
+	return true
 }
 
 // isCobraUsageError reports whether err matches one of Cobra/pflag's

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root_test.go
@@ -4,11 +4,15 @@
 package cli
 
 import (
+	"bytes"
+
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"testing"
+
+	"printing-press-golden-pp-cli/internal/cliutil"
 
 	"github.com/spf13/cobra"
 )
@@ -88,6 +92,30 @@ func TestNoDuplicateCommandNames(t *testing.T) {
 	}
 	if len(duplicates) > 0 {
 		t.Fatalf("generated Cobra tree contains duplicate sibling command names: %s", strings.Join(duplicates, ", "))
+	}
+}
+func TestWriteCredentialSaveErrorEnvelope(t *testing.T) {
+	var out bytes.Buffer
+	cause := &cliutil.CredentialsPermissionError{
+		Path: "/tmp/credentials.toml",
+		Err:  errors.New("unsafe permissions"),
+	}
+	if !writeCredentialSaveErrorEnvelope(&out, &rootFlags{asJSON: true}, fmt.Errorf("saving token: %w", cause)) {
+		t.Fatal("permission failure envelope was not written")
+	}
+
+	var payload struct {
+		Saved               bool   `json:"saved"`
+		CredentialsPath     string `json:"credentials_path"`
+		PermissionsVerified bool   `json:"permissions_verified"`
+		Error               string `json:"error"`
+		Code                int    `json:"code"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("permission failure envelope must be valid JSON: %v\n%s", err, out.String())
+	}
+	if !payload.Saved || payload.CredentialsPath != cause.Path || payload.PermissionsVerified || payload.Error == "" || payload.Code == 0 {
+		t.Fatalf("permission failure envelope = %+v, want saved path, unsafe permissions, error, and non-zero code", payload)
 	}
 }
 

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/cli/root.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/cli/root.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -110,6 +111,16 @@ func Execute() (retErr error) {
 	if errors.Is(err, pflag.ErrHelp) {
 		return nil
 	}
+	envelopeWriter := io.Writer(os.Stdout)
+	if flags.deliverBuf != nil {
+		envelopeWriter = io.MultiWriter(os.Stdout, flags.deliverBuf)
+	}
+	envelopeWritten := writeCredentialSaveErrorEnvelope(envelopeWriter, &flags, err)
+	if envelopeWritten && flags.deliverBuf != nil {
+		if derr := Deliver(flags.deliverSink, flags.deliverBuf.Bytes(), flags.compact); derr != nil {
+			fmt.Fprintf(os.Stderr, "warning: deliver to %s:%s failed: %v\n", flags.deliverSink.Scheme, flags.deliverSink.Target, derr)
+		}
+	}
 	if err != nil && strings.Contains(err.Error(), "unknown flag") {
 		msg := err.Error()
 		// Extract the flag name from the error message (e.g., "unknown flag: --foob")
@@ -143,6 +154,24 @@ func Execute() (retErr error) {
 		return usageErr(err)
 	}
 	return err
+}
+
+func writeCredentialSaveErrorEnvelope(w io.Writer, flags *rootFlags, err error) bool {
+	if flags == nil || !flags.asJSON || err == nil {
+		return false
+	}
+	var permissionErr *cliutil.CredentialsPermissionError
+	if !errors.As(err, &permissionErr) {
+		return false
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"saved":                true,
+		"credentials_path":     permissionErr.Path,
+		"permissions_verified": false,
+		"error":                permissionErr.Error(),
+		"code":                 ExitCode(err),
+	})
+	return true
 }
 
 // isCobraUsageError reports whether err matches one of Cobra/pflag's

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/root.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/root.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -122,6 +123,16 @@ func Execute() (retErr error) {
 	if errors.Is(err, pflag.ErrHelp) {
 		return nil
 	}
+	envelopeWriter := io.Writer(os.Stdout)
+	if flags.deliverBuf != nil {
+		envelopeWriter = io.MultiWriter(os.Stdout, flags.deliverBuf)
+	}
+	envelopeWritten := writeCredentialSaveErrorEnvelope(envelopeWriter, &flags, err)
+	if envelopeWritten && flags.deliverBuf != nil {
+		if derr := Deliver(flags.deliverSink, flags.deliverBuf.Bytes(), flags.compact); derr != nil {
+			fmt.Fprintf(os.Stderr, "warning: deliver to %s:%s failed: %v\n", flags.deliverSink.Scheme, flags.deliverSink.Target, derr)
+		}
+	}
 	if err != nil && strings.Contains(err.Error(), "unknown flag") {
 		msg := err.Error()
 		// Extract the flag name from the error message (e.g., "unknown flag: --foob")
@@ -162,6 +173,24 @@ func Execute() (retErr error) {
 		return usageErr(err)
 	}
 	return err
+}
+
+func writeCredentialSaveErrorEnvelope(w io.Writer, flags *rootFlags, err error) bool {
+	if flags == nil || !flags.asJSON || err == nil {
+		return false
+	}
+	var permissionErr *cliutil.CredentialsPermissionError
+	if !errors.As(err, &permissionErr) {
+		return false
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"saved":                true,
+		"credentials_path":     permissionErr.Path,
+		"permissions_verified": false,
+		"error":                permissionErr.Error(),
+		"code":                 ExitCode(err),
+	})
+	return true
 }
 
 // isCobraUsageError reports whether err matches one of Cobra/pflag's


### PR DESCRIPTION
## Intent

Generated auth saves could fail in two consecutive parts of one credential write. On Windows, a concurrent reader could make the final rename fail even though the contention was transient. On NTFS, the file could be saved with an inherited broad ACE even though the writer requested `0600`, and the CLI did not verify the file it had just published.

Closes #4001
Closes #3969

## Approach

The generated credential writer now retries bounded Windows rename contention, including sharing violations, and verifies the canonical file after publication. Unsafe landed files return a typed error that reports the saved path and produces a JSON result with `saved: true` and `permissions_verified: false`. External credential-store saves remain unchanged. Device-login progress is sent to stderr in JSON mode so it cannot corrupt the failure envelope.

## Scope

Primary area: generator-owned credential persistence, auth output, and generated regression coverage.

Why this belongs in this repo: the behavior is emitted by the Printing Press and must be corrected for future printed CLIs.

## Risk

The change affects generated auth saves, Windows file publication, and JSON error output. The permission guard reports unsafe files after their bytes are published; it does not add a new temporary-file DACL mutation path.

## Output Contract

Generated auth permission failures preserve the saved path and return structured JSON with `saved`, `credentials_path`, `permissions_verified`, `error`, and `code` fields. Golden fixtures, emitted-code assertions, and compiled generated CLI cases cover auth and non-auth variants.

## Verification

- [x] Generator/template output verified with `scripts/golden.sh verify` for 32 cases
- [x] Generated output compiled with `scripts/verify-generator-output.sh` for 10 cases
- [x] Focused generator tests passed for credential permissions, credential round trips, required credential pairs, and OAuth2 device-code auth
- [x] Decoy HOME, USERPROFILE, and XDG profile proof passed with generated Stytch CLI tests, vulnerability scan, vet, build, and byte-identical profile snapshots
- [x] `go build -o ./cli-printing-press ./cmd/cli-printing-press` and `git diff --check` passed
- [ ] Full local test and lint runs: HTML extraction cases encountered shared developer-store schema-version contamination, and lint reported an unrelated existing `internal/googlediscovery/parser.go:455` modernization finding outside this diff; the affected cases pass with isolated HOME/XDG
