### PR TITLE
fix(cli): emit valid Windows SQLite file URIs

### DIFF
--- a/internal/generator/templates/platform_conformance_test.go.tmpl
+++ b/internal/generator/templates/platform_conformance_test.go.tmpl
@@ -73,6 +73,47 @@ func setPlatformRoots(t *testing.T) string {
 	return root
 }
 
+func TestReadOnlySQLiteDSNUsesLocalFileURI(t *testing.T) {
+	for _, test := range []struct {
+		path string
+		want string
+	}{
+		{path: "C:/Users/example/data.db", want: "file:///C:/Users/example/data.db?mode=ro"},
+		{path: "data.db", want: "file:data.db?mode=ro"},
+		{path: "//server/share/data.db", want: "file:////server/share/data.db?mode=ro"},
+	} {
+		if got := readOnlySQLiteDSN(test.path); got != test.want {
+			t.Fatalf("SQLite DSN for %q = %q, want %q", test.path, got, test.want)
+		}
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE dsn_fixture (value TEXT NOT NULL); INSERT INTO dsn_fixture VALUES ('readable')`); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	readOnly, err := sql.Open("sqlite", readOnlySQLiteDSN(dbPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer readOnly.Close()
+	var value string
+	if err := readOnly.QueryRow("SELECT value FROM dsn_fixture").Scan(&value); err != nil {
+		t.Fatalf("read-only SQLite query failed: %v", err)
+	}
+	if value != "readable" {
+		t.Fatalf("read-only SQLite value = %q, want %q", value, "readable")
+	}
+}
+
 func validSyntheticProfile(name string) *Profile {
 	return &Profile{
 		SchemaVersion: 1,

--- a/internal/generator/templates/platform_migration.go.tmpl
+++ b/internal/generator/templates/platform_migration.go.tmpl
@@ -247,7 +247,7 @@ func readOnlySQLiteDSN(path string) string {
 	if strings.HasPrefix(slashed, "/") {
 		uri.Path = slashed
 	} else {
-		uri.Opaque = slashed
+		uri.Path = slashed
 	}
 	return uri.String()
 }

--- a/internal/generator/templates/platform_migration.go.tmpl
+++ b/internal/generator/templates/platform_migration.go.tmpl
@@ -247,7 +247,7 @@ func readOnlySQLiteDSN(path string) string {
 	if strings.HasPrefix(slashed, "/") {
 		uri.Path = slashed
 	} else {
-		uri.Path = slashed
+		uri.Opaque = url.PathEscape(slashed)
 	}
 	return uri.String()
 }

--- a/internal/generator/templates/platform_migration.go.tmpl
+++ b/internal/generator/templates/platform_migration.go.tmpl
@@ -239,5 +239,15 @@ func BackupLegacyArtifacts(state *LegacyMigrationState) error {
 }
 
 func readOnlySQLiteDSN(path string) string {
-	return (&url.URL{Scheme: "file", Path: filepath.ToSlash(path), RawQuery: "mode=ro"}).String()
+	slashed := filepath.ToSlash(path)
+	if len(slashed) >= 3 && slashed[1] == ':' && slashed[2] == '/' {
+		slashed = "/" + slashed
+	}
+	uri := &url.URL{Scheme: "file", RawQuery: "mode=ro"}
+	if strings.HasPrefix(slashed, "/") {
+		uri.Path = slashed
+	} else {
+		uri.Opaque = slashed
+	}
+	return uri.String()
 }


### PR DESCRIPTION
## Summary

Windows-generated CLIs now open legacy SQLite databases with a valid local file URI. Drive-letter paths use the empty-authority `file:///C:/...` form, while relative and UNC paths keep their intended URI shapes. Generated coverage checks all path classes and performs a real row read to exercise SQLite's lazy query failure behavior.

Closes #3986

## Scope

Primary area: generator platform migration templates.

Why this belongs in this repo: the malformed DSN is emitted by the Printing Press and affects every generated CLI that adopts a legacy SQLite database on Windows.

## Risk

The change only affects generated platform migration database opens. Existing POSIX behavior and UNC URI handling remain covered. It does not change the MCP surface, authentication, publish flow, or verifier behavior.

## Output Contract

Generated-output evidence covers the Windows drive-letter, relative, and UNC URI variants, plus a compiled generated CLI that creates a SQLite row and reads it through the read-only DSN. `scripts/golden.sh verify` also passed all 32 existing cases.

## Verification

- `go test ./internal/generator -run '^TestGeneratedPlatformRuntimeContract$' -count=1`
- `go test ./...`
- `scripts/golden.sh verify` (32 cases)
- `scripts/verify-generator-output.sh` (10 generated CLI cases)
- `golangci-lint run ./...` reports one unrelated pre-existing `modernize` warning in `internal/googlediscovery/parser.go`; no changed file is implicated
