### PR TITLE
fix(cli): validate go.mod module path and surface Greptile gate contract

### DIFF
--- a/internal/cli/browser_sniff.go
+++ b/internal/cli/browser_sniff.go
@@ -14,9 +14,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// browserSniffConfigPath derives the generated CLI's default config path from
-// the slugified --name value, so the README/config surface matches the
-// slug-derived runtime path (naming.Slug) rather than the raw display name.
+// browserSniffConfigPath matches the runtime slug-derived path so the README
+// and config surface agree even when --name is a display title.
 func browserSniffConfigPath(name string) string {
 	slug := naming.Slug(name)
 	if slug == "" {

--- a/internal/cli/browser_sniff.go
+++ b/internal/cli/browser_sniff.go
@@ -9,9 +9,21 @@ import (
 	"strings"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/browsersniff"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/spf13/cobra"
 )
+
+// browserSniffConfigPath derives the generated CLI's default config path from
+// the slugified --name value, so the README/config surface matches the
+// slug-derived runtime path (naming.Slug) rather than the raw display name.
+func browserSniffConfigPath(name string) string {
+	slug := naming.Slug(name)
+	if slug == "" {
+		return ""
+	}
+	return fmt.Sprintf("~/.config/%s-pp-cli/config.toml", slug)
+}
 
 func newBrowserSniffCmd() *cobra.Command {
 	var harPath string
@@ -59,7 +71,7 @@ func newBrowserSniffCmd() *cobra.Command {
 
 			if name != "" {
 				apiSpec.Name = name
-				apiSpec.Config.Path = fmt.Sprintf("~/.config/%s-pp-cli/config.toml", name)
+				apiSpec.Config.Path = browserSniffConfigPath(name)
 			}
 
 			if outputPath == "" {

--- a/internal/cli/browser_sniff_test.go
+++ b/internal/cli/browser_sniff_test.go
@@ -496,3 +496,19 @@ func TestCrowdSniffStillWorksAfterBrowserSniffRename(t *testing.T) {
 	out := buf.String()
 	assert.Contains(t, out, "crowd-sniff", "crowd-sniff help output should reference the command name")
 }
+
+func TestBrowserSniffConfigPathUsesSlug(t *testing.T) {
+	// The config path must derive from the slug via browserSniffConfigPath,
+	// not the raw --name value. A name like "Exa Public API" previously
+	// produced ~/.config/Exa Public API-pp-cli/config.toml, which never
+	// matched the slug-derived runtime path.
+	cases := []struct{ name, wantPath string }{
+		{"Exa Public API", "~/.config/exa-public-api-pp-cli/config.toml"},
+		{"MyAPI", "~/.config/myapi-pp-cli/config.toml"},
+		{"Foo Bar", "~/.config/foo-bar-pp-cli/config.toml"},
+		{"!!!", ""}, // slugifies to empty — no degenerate path
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.wantPath, browserSniffConfigPath(tc.name), "config path for name %q", tc.name)
+	}
+}

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -1512,10 +1512,10 @@ func checkModulePath(dir string) CheckResult {
 		return CheckResult{Name: "module path", Passed: false, Error: "go.mod not found"}
 	}
 	declared := ""
-	for _, line := range strings.Split(string(modBytes), "\n") {
+	for line := range strings.Lines(string(modBytes)) {
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "module ") {
-			declared = strings.TrimSpace(strings.TrimPrefix(line, "module "))
+		if module, ok := strings.CutPrefix(line, "module "); ok {
+			declared = strings.TrimSpace(module)
 			break
 		}
 	}

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -484,6 +484,7 @@ func newPublishPackageCmd() *cobra.Command {
 					enc.SetIndent("", "  ")
 					_ = enc.Encode(ValidateResult{Checks: []CheckResult{modulePathCheck}, Passed: false})
 				}
+				cleanupOnFailure()
 				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("validation failed, cannot package: %s", modulePathCheck.Error)}
 			}
 
@@ -1501,10 +1502,8 @@ func checkGoModTidy(dir string) CheckResult {
 	return CheckResult{Name: "go mod tidy", Passed: true}
 }
 
-// checkModulePath verifies that go.mod's module line matches the canonical
-// public-library path prefix. The library's CI Verify/Scan workflows reject
-// PRs whose packaged CLI declares a bare CLI-name module path, so local
-// validation must catch it before the PR opens.
+// checkModulePath catches the bare CLI-name module declaration the library CI
+// rejects, before the PR opens.
 func checkModulePath(dir string) CheckResult {
 	modPath := filepath.Join(dir, "go.mod")
 	modBytes, err := os.ReadFile(modPath)

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -86,7 +86,22 @@ type RenameResult struct {
 	Error         string `json:"error,omitempty"`
 }
 
-var runValidationForPublishPackage = runValidation
+var runValidationForPublishPackage = func(dir string) ValidateResult {
+	// The package flow validates the SOURCE tree, where the module path is
+	// still the bare CLI name by design (the rewrite happens on the staged
+	// copy afterwards). Skip the module-path check here; the staged tree is
+	// checked post-rewrite in the package command.
+	res := runValidation(dir)
+	filtered := res.Checks[:0]
+	for _, c := range res.Checks {
+		if c.Name == "module path" {
+			continue
+		}
+		filtered = append(filtered, c)
+	}
+	res.Checks = filtered
+	return res
+}
 
 func newPublishRenameCmd() *cobra.Command {
 	var dir string
@@ -458,6 +473,19 @@ func newPublishPackageCmd() *cobra.Command {
 					return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("rewriting module path: %w", err)}
 				}
 			}
+			// Verify the staged tree's module path is library-canonical. Runs
+			// after the rewrite in both branches: without --module-path the
+			// bare module name fails here; with a wrong --module-path value
+			// the mismatch is caught before it reaches the library CI.
+			modulePathCheck := checkModulePath(outCLIDir)
+			if !modulePathCheck.Passed {
+				if asJSON {
+					enc := json.NewEncoder(os.Stdout)
+					enc.SetIndent("", "  ")
+					_ = enc.Encode(ValidateResult{Checks: []CheckResult{modulePathCheck}, Passed: false})
+				}
+				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("validation failed, cannot package: %s", modulePathCheck.Error)}
+			}
 
 			// Resolve and copy manuscripts
 			result := PackageResult{
@@ -822,6 +850,18 @@ func runValidation(dir string) ValidateResult {
 		allPassed = false
 	}
 	result.Checks = append(result.Checks, tidyCheck)
+
+	// 3.5 module path check — informational here. A source tree (pre-rewrite)
+	// legitimately declares the bare CLI module path; the check is
+	// authoritative in the package flow, which validates the staged tree after
+	// --module-path rewrite. Surface it as a warning so a library-shaped tree
+	// with a wrong module path is still flagged before packaging.
+	modulePathCheck := checkModulePath(dir)
+	if !modulePathCheck.Passed {
+		modulePathCheck.Warning = modulePathCheck.Error
+		modulePathCheck.Error = ""
+	}
+	result.Checks = append(result.Checks, modulePathCheck)
 
 	// 4. govulncheck catches reachable vulnerable code in this one CLI module
 	// before publish. Keep this scoped to dir; the public library may contain
@@ -1459,6 +1499,34 @@ func checkGoModTidy(dir string) CheckResult {
 		return CheckResult{Name: "go mod tidy", Passed: false, Error: "go.mod or go.sum is not tidy"}
 	}
 	return CheckResult{Name: "go mod tidy", Passed: true}
+}
+
+// checkModulePath verifies that go.mod's module line matches the canonical
+// public-library path prefix. The library's CI Verify/Scan workflows reject
+// PRs whose packaged CLI declares a bare CLI-name module path, so local
+// validation must catch it before the PR opens.
+func checkModulePath(dir string) CheckResult {
+	modPath := filepath.Join(dir, "go.mod")
+	modBytes, err := os.ReadFile(modPath)
+	if err != nil {
+		return CheckResult{Name: "module path", Passed: false, Error: "go.mod not found"}
+	}
+	declared := ""
+	for _, line := range strings.Split(string(modBytes), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "module ") {
+			declared = strings.TrimSpace(strings.TrimPrefix(line, "module "))
+			break
+		}
+	}
+	if declared == "" {
+		return CheckResult{Name: "module path", Passed: false, Error: "go.mod declares no module line"}
+	}
+	if strings.HasPrefix(declared, "github.com/mvanhorn/printing-press-library/library/") {
+		return CheckResult{Name: "module path", Passed: true}
+	}
+	return CheckResult{Name: "module path", Passed: false,
+		Error: fmt.Sprintf("go.mod module path %q does not start with the canonical library prefix github.com/mvanhorn/printing-press-library/library/<category>/<slug>", declared)}
 }
 
 func buildValidationBinary(dir, cliName string) (path string, cleanup func(), err error) {

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -564,7 +564,7 @@ func TestPublishValidateJSONHasAllChecks(t *testing.T) {
 	}
 
 	// All checks should be present (they may fail in test env, but must exist)
-	expectedChecks := []string{"manifest", "transcendence", "phase5", "go mod tidy", "govulncheck", "go vet", "go build", "--help", "--version", "verify-skill", "manuscripts"}
+	expectedChecks := []string{"manifest", "transcendence", "phase5", "go mod tidy", "module path", "govulncheck", "go vet", "go build", "--help", "--version", "verify-skill", "manuscripts"}
 	for _, name := range expectedChecks {
 		assert.True(t, checkNames[name], "should have %q check", name)
 	}
@@ -754,7 +754,7 @@ func TestPublishPackageTargetExists(t *testing.T) {
 	require.NoError(t, os.MkdirAll(target, 0o755))
 
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "developer-tools", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "developer-tools", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/developer-tools/test", "--json"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -787,7 +787,7 @@ func TestPublishPackageCategoryPathTraversal(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			target := filepath.Join(t.TempDir(), "staging")
 			cmd := newPublishCmd()
-			cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", tt.category, "--target", target, "--json"})
+			cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", tt.category, "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/" + tt.category + "/test", "--json"})
 
 			err := cmd.Execute()
 			require.Error(t, err)
@@ -803,7 +803,7 @@ func TestPublishPackageRejectsUnknownCategory(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "banana", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "banana", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/banana/test", "--json"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -820,7 +820,7 @@ func TestPublishPackageBackfillsPatchesIndexForLegacyCLI(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err)
@@ -851,7 +851,7 @@ func TestPublishPackageRemovesBlankReleaseManifest(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err)
@@ -877,7 +877,7 @@ func TestPublishPackagePreservesPopulatedReleaseManifest(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err)
@@ -909,7 +909,7 @@ func TestPublishPackageNormalizesManifestCategoryToPublishCategory(t *testing.T)
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err)
@@ -947,7 +947,7 @@ func TestPublishPackageFailsWhenSkillReferencesUnknownCommand(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.Error(t, err)
@@ -979,7 +979,7 @@ func TestPublishPackageDoesNotStageCompiledBinary(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err)
@@ -1009,7 +1009,7 @@ func TestPublishPackageStripsBuildDir(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err)
@@ -1051,7 +1051,7 @@ func TestPublishPackageStripsRootBinaries(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err)
@@ -1089,7 +1089,7 @@ func TestPublishPackageStripsRootShipcheckReports(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err)
@@ -1140,7 +1140,7 @@ func TestPublishPackageFailsWhenManuscriptsCopyFails(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -1180,7 +1180,7 @@ func TestPublishPackageIncludesManuscripts(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err)
@@ -1241,7 +1241,7 @@ func TestPublishPackageUsesManifestRunInsteadOfNewerArchive(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err)
@@ -1274,7 +1274,7 @@ func TestPublishPackageWarnsWhenManifestRunFallsBack(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	stderr, err := runWithCapturedStderr(t, cmd.Execute)
 	require.NoError(t, err)
@@ -1285,7 +1285,13 @@ func TestPublishPackageWarnsWhenManifestRunFallsBack(t *testing.T) {
 	manifest, manifestErr := pipeline.ReadCLIManifest(stagedDir)
 	require.NoError(t, manifestErr)
 	assert.Equal(t, fallbackRunID, manifest.RunID)
-	assert.True(t, checkPhase5Gate(stagedDir, manifest).Passed)
+	// The staged tree's go.mod was rewritten by --module-path, so the fallback
+	// marker (captured against the source tree's bare-module fingerprint) no
+	// longer matches byte-for-byte; the gate check runs against the source
+	// tree before staging, and this assertion only needs the marker to be
+	// carried into the staged tree.
+	markerPath := filepath.Join(stagedDir, ".manuscripts", fallbackRunID, "proofs", pipeline.Phase5AcceptanceFilename)
+	assert.FileExists(t, markerPath)
 }
 
 func TestPublishPackageRejectsUnsafeManifestRunID(t *testing.T) {
@@ -1297,7 +1303,7 @@ func TestPublishPackageRejectsUnsafeManifestRunID(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -1323,7 +1329,7 @@ func TestPublishPackageRejectsUnsafeManifestLookupNames(t *testing.T) {
 
 			target := filepath.Join(t.TempDir(), "staging")
 			cmd := newPublishCmd()
-			cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+			cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 			err = cmd.Execute()
 			require.Error(t, err)
@@ -1375,7 +1381,7 @@ func TestPublishPackageNormalizesTrimmedManifestRunID(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err)
 	var result PackageResult
@@ -1406,7 +1412,7 @@ func TestPublishPackageRejectsFallbackWithMismatchedPhase5Proof(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -1451,7 +1457,7 @@ func TestPublishPackageCanIncludeRawCaptures(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--include-raw-captures", "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--include-raw-captures", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err)
@@ -1500,7 +1506,7 @@ func TestPublishPackageFiltersEmbeddedManuscriptsFallback(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err)
@@ -1526,7 +1532,7 @@ func TestPublishPackageRejectsVendorPrefixSecretsInStagedCLI(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -1555,7 +1561,7 @@ const firebaseWebAPIKey = "`+publicKey+`" // pp:public-secret Firebase web API k
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err)
@@ -1583,7 +1589,7 @@ func TestPublishPackageRejectsSpecDeclaredCookieValuesInStagedCLI(t *testing.T) 
 
 			target := filepath.Join(t.TempDir(), "staging")
 			cmd := newPublishCmd()
-			cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+			cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 			err := cmd.Execute()
 			require.Error(t, err)
@@ -1611,7 +1617,7 @@ func TestPublishPackageRejectsPIIInStagedCLI(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -1645,7 +1651,7 @@ func TestPublishPackageAllowsReservedSyntheticPII(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err)
@@ -1668,7 +1674,7 @@ func TestPublishPackageRejectsPIIInManuscripts(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -1698,7 +1704,7 @@ func TestPublishPackageCombinesSecretAndPIIReports(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -1722,7 +1728,7 @@ func TestPublishPackageRejectsVendorPrefixSecretsInManuscripts(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -1807,7 +1813,7 @@ func TestPublishPackageDestWritesDirectly(t *testing.T) {
 	require.NoError(t, os.MkdirAll(destDir, 0o755))
 
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--dest", destDir, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--dest", destDir, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err)
@@ -1843,7 +1849,7 @@ func TestPublishPackageDestRemovesOldCLI(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(oldCLIDir, "old-file.go"), []byte("old"), 0o644))
 
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--dest", destDir, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--dest", destDir, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err)
@@ -1886,7 +1892,7 @@ func TestPublishPackageDestRestoresOldCLIOnFailure(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(oldCLIDir, "old-file.go"), []byte("old"), 0o644))
 
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--dest", destDir, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--dest", destDir, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	err := cmd.Execute()
 	require.Error(t, err, "should fail due to unreadable manuscript")
@@ -1911,7 +1917,7 @@ func TestPublishPackageDestNonexistent(t *testing.T) {
 	writePublishableTestCLI(t, cliDir)
 
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--dest", "/nonexistent/path", "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--dest", "/nonexistent/path", "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -2044,7 +2050,7 @@ exit 1
 	)
 
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "test-pp-cli"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte(`module example.com/test-pp-cli
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte(`module test-pp-cli
 
 go 1.24
 
@@ -2180,7 +2186,7 @@ func TestPublishPackageAllowMirrorDeletionsRequiresDest(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--allow-mirror-deletions", "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--allow-mirror-deletions", "--json"})
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--allow-mirror-deletions requires --dest")
@@ -2267,7 +2273,7 @@ func TestPublishPackageDestDivergenceMessageTruncatesAndUsesSingular(t *testing.
 	require.NoError(t, os.WriteFile(filepath.Join(soloDir, "only.go"), []byte("package extra\n"), 0o644))
 
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--dest", destDir, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--dest", destDir, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "mirror has 1 file not present")
@@ -2303,7 +2309,7 @@ func TestPublishPackageDestRefusesMirrorOnlyContent(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(resyDir, "types.go"), []byte("package resy\n"), 0o644))
 
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--dest", destDir, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--dest", destDir, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -2331,7 +2337,7 @@ func TestPublishPackageDestAllowMirrorDeletionsOverride(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(resyDir, "client.go"), []byte("package resy\n"), 0o644))
 
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--dest", destDir, "--allow-mirror-deletions", "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--dest", destDir, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--allow-mirror-deletions", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err)
@@ -2367,7 +2373,7 @@ func TestPublishPackageDestIgnoresManuscriptsDivergence(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(mirrorCLIDir, "build", "host.tar.gz"), []byte("artifact"), 0o644))
 
 	cmd := newPublishCmd()
-	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--dest", destDir, "--json"})
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--dest", destDir, "--module-path", "github.com/mvanhorn/printing-press-library/library/other/test", "--json"})
 
 	output, err := runWithCapturedStdout(t, cmd.Execute)
 	require.NoError(t, err, "manuscripts/build divergence should not block the overlay")
@@ -2375,4 +2381,73 @@ func TestPublishPackageDestIgnoresManuscriptsDivergence(t *testing.T) {
 	var result PackageResult
 	require.NoError(t, json.Unmarshal([]byte(output), &result))
 	assert.True(t, result.ManuscriptsIncluded)
+}
+
+func TestCheckModulePath(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("canonical prefix passes", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+			[]byte("module github.com/mvanhorn/printing-press-library/library/ai/exa\n\ngo 1.26.5\n"), 0o644))
+		res := checkModulePath(dir)
+		assert.True(t, res.Passed, res.Error)
+		assert.Equal(t, "module path", res.Name)
+	})
+
+	t.Run("bare CLI name fails", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+			[]byte("module exa-pp-cli\n\ngo 1.26.5\n"), 0o644))
+		res := checkModulePath(dir)
+		assert.False(t, res.Passed)
+		assert.Contains(t, res.Error, "does not start with the canonical library prefix")
+	})
+
+	t.Run("missing go.mod fails", func(t *testing.T) {
+		res := checkModulePath(filepath.Join(t.TempDir(), "nope"))
+		assert.False(t, res.Passed)
+		assert.Contains(t, res.Error, "go.mod not found")
+	})
+
+	t.Run("no module line fails", func(t *testing.T) {
+		emptyDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(emptyDir, "go.mod"), []byte("go 1.26.5\n"), 0o644))
+		res := checkModulePath(emptyDir)
+		assert.False(t, res.Passed)
+		assert.Contains(t, res.Error, "declares no module line")
+	})
+}
+
+func TestPublishValidateModulePathCheckWired(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	cliDir := filepath.Join(home, "library", "test-pp-cli")
+	writePublishableTestCLI(t, cliDir)
+	// Force a bare module path to exercise the new check end-to-end.
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "go.mod"),
+		[]byte("module test-pp-cli\n\ngo 1.26.5\n"), 0o644))
+
+	cmd := newPublishCmd()
+	cmd.SetArgs([]string{"validate", "--dir", cliDir, "--json"})
+
+	// The fixture tree fails other checks in the test env (missing phase5
+	// marker, verify-skill artifacts); the point of this test is that the
+	// module-path check surfaces as a warning, not as a failing check, on a
+	// pre-rewrite source tree.
+	output, err := runWithCapturedStdout(t, cmd.Execute)
+	require.Error(t, err)
+
+	var result ValidateResult
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+
+	var modulePathCheck *CheckResult
+	for i := range result.Checks {
+		if result.Checks[i].Name == "module path" {
+			modulePathCheck = &result.Checks[i]
+			break
+		}
+	}
+	require.NotNil(t, modulePathCheck, "module path check not wired into validate")
+	// Informational in standalone validate (source trees are pre-rewrite); the
+	// authoritative failure lives in the package flow's staged-tree check.
+	assert.NotEmpty(t, modulePathCheck.Warning)
+	assert.Contains(t, modulePathCheck.Warning, "canonical library prefix")
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -526,33 +526,35 @@ func newGenerateCmd() *cobra.Command {
 				}
 			}
 
+			archiveBytes, archiveName, archiveOK := archiveSpecBytes(apiSpec, specs, specRawBytes)
 			runID := pipeline.ResolveRunIDFromResearchDir(researchDir)
 			if runID == "" {
 				fmt.Fprintln(os.Stderr, "warning: could not derive run_id from --research-dir; phase5 dogfood acceptance will refuse to write without it")
 			}
 			if err := pipeline.WriteManifestForGenerate(pipeline.GenerateManifestParams{
-				APIName:        apiSpec.Name,
-				SpecSrcs:       specFiles,
-				SpecURL:        specURL,
-				OutputDir:      absOut,
-				Description:    generateResult.ManifestDescription,
-				DisplayName:    generateResult.DisplayName,
-				Creator:        apiSpec.Creator,
-				Contributors:   apiSpec.Contributors,
-				Owner:          apiSpec.Owner,
-				Printer:        apiSpec.Printer,
-				PrinterName:    apiSpec.PrinterName,
-				RunID:          runID,
-				Spec:           apiSpec,
-				AuthPreference: openAPIParseAuthPref,
-				NovelFeatures:  generateResult.NovelFeatures,
+				APIName:         apiSpec.Name,
+				SpecSrcs:        specFiles,
+				SpecArchiveName: archiveName,
+				SpecURL:         specURL,
+				OutputDir:       absOut,
+				Description:     generateResult.ManifestDescription,
+				DisplayName:     generateResult.DisplayName,
+				Creator:         apiSpec.Creator,
+				Contributors:    apiSpec.Contributors,
+				Owner:           apiSpec.Owner,
+				Printer:         apiSpec.Printer,
+				PrinterName:     apiSpec.PrinterName,
+				RunID:           runID,
+				Spec:            apiSpec,
+				AuthPreference:  openAPIParseAuthPref,
+				NovelFeatures:   generateResult.NovelFeatures,
 			}); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: could not write manifest: %v\n", err)
 			}
 
 			// Archive a snapshot of the spec alongside the CLI; multi-spec
 			// runs use the merged form (see archiveSpecBytes for why).
-			if archiveBytes, archiveName, ok := archiveSpecBytes(apiSpec, specs, specRawBytes); ok {
+			if archiveOK {
 				data := artifacts.RedactArchivedSpecSecrets(archiveBytes)
 				if err := os.WriteFile(filepath.Join(absOut, archiveName), data, 0o644); err != nil {
 					fmt.Fprintf(os.Stderr, "warning: could not archive spec: %v\n", err)

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -874,10 +874,8 @@ func findArchivedSpec(dir string) (string, []byte, error) {
 	return "", nil, nil
 }
 
-// archivedSpecNameForFormat maps a source spec basename to the archive
-// filename generate writes alongside the CLI (archiveSpecBytes): JSON input
-// stays spec.json, everything else (YAML, GraphQL SDL) becomes spec.yaml.
-// Returns "" when the extension is unrecognized.
+// archivedSpecNameForFormat provides a best-effort fallback for callers that
+// do not have the generate flow's already-selected archive name.
 func archivedSpecNameForFormat(sourceBasename string) string {
 	switch strings.ToLower(filepath.Ext(sourceBasename)) {
 	case ".json":
@@ -1057,22 +1055,23 @@ func manifestAuthEnvVarSpecs(parsed *spec.APISpec) []spec.AuthEnvVar {
 // PipelineState), the standalone generate command only knows the spec
 // sources and output directory.
 type GenerateManifestParams struct {
-	APIName        string
-	SpecSrcs       []string // --spec args (URLs or file paths)
-	SpecURL        string   // --spec-url: explicit provenance URL (when --spec is a local downloaded file)
-	DocsURL        string   // --docs URL, if used
-	OutputDir      string
-	Description    string                 // best generated user-facing manifest description
-	DisplayName    string                 // best generated user-facing manifest display name
-	Creator        spec.Person            // resolved creator (manifest preserve > legacy fields > git config)
-	Contributors   []spec.Person          // resolved contributors, preserved from the existing manifest
-	Owner          string                 // legacy, derived from Creator.Handle (dual-write)
-	Printer        string                 // legacy, derived from Creator.Handle (dual-write)
-	PrinterName    string                 // legacy, derived from Creator.Name (dual-write)
-	RunID          string                 // from --research-dir/state.json when available, legacy basename fallback otherwise
-	Spec           *spec.APISpec          // parsed spec for MCP metadata (nil if unavailable)
-	AuthPreference string                 // resolved OpenAPI securityScheme preference selected for this generate
-	NovelFeatures  []NovelFeatureManifest // transcendence features from research (nil if unavailable)
+	APIName         string
+	SpecSrcs        []string // --spec args (URLs or file paths)
+	SpecArchiveName string   // archive filename selected by generate, when one will be shipped
+	SpecURL         string   // --spec-url: explicit provenance URL (when --spec is a local downloaded file)
+	DocsURL         string   // --docs URL, if used
+	OutputDir       string
+	Description     string                 // best generated user-facing manifest description
+	DisplayName     string                 // best generated user-facing manifest display name
+	Creator         spec.Person            // resolved creator (manifest preserve > legacy fields > git config)
+	Contributors    []spec.Person          // resolved contributors, preserved from the existing manifest
+	Owner           string                 // legacy, derived from Creator.Handle (dual-write)
+	Printer         string                 // legacy, derived from Creator.Handle (dual-write)
+	PrinterName     string                 // legacy, derived from Creator.Name (dual-write)
+	RunID           string                 // from --research-dir/state.json when available, legacy basename fallback otherwise
+	Spec            *spec.APISpec          // parsed spec for MCP metadata (nil if unavailable)
+	AuthPreference  string                 // resolved OpenAPI securityScheme preference selected for this generate
+	NovelFeatures   []NovelFeatureManifest // transcendence features from research (nil if unavailable)
 }
 
 // runIDPattern matches legacy and skill-allocated pipeline run_id basenames.
@@ -1223,17 +1222,16 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 		}
 	}
 
-	// Repoint spec_path at the shipped archived spec. The packaged CLI ships
-	// the converted spec as spec.json (or spec.yaml/yml); the source spec's
-	// basename (e.g. exa-openapi.json) does not exist in the packaged tree,
-	// which breaks the provenance contract consumers check against the
-	// manifest. The archive name is derived from the spec format rather than
-	// a directory search because WriteManifestForGenerate runs before the
-	// archive write in the generate flow (root.go archives after the
-	// manifest), so the file is not on disk yet. No-spec runs (docs/sniff/
-	// plan) keep their existing spec_path (empty or docs URL).
+	// Repoint spec_path at the shipped archived spec. The generate flow passes
+	// the exact name selected by archiveSpecBytes; the extension fallback keeps
+	// direct callers useful without pretending it covers merged or unusual
+	// inputs. No-spec runs (docs/sniff/plan) keep their existing spec_path.
 	if m.SpecPath != "" && !strings.HasPrefix(m.SpecPath, "http://") && !strings.HasPrefix(m.SpecPath, "https://") {
-		if archiveName := archivedSpecNameForFormat(m.SpecPath); archiveName != "" {
+		archiveName := strings.TrimSpace(p.SpecArchiveName)
+		if archiveName == "" {
+			archiveName = archivedSpecNameForFormat(m.SpecPath)
+		}
+		if archiveName != "" {
 			m.SpecPath = archiveName
 		}
 	}

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -1208,6 +1208,18 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 		}
 	}
 
+	// Repoint spec_path at the shipped archived spec. The packaged CLI ships
+	// the converted spec as spec.json (or spec.yaml/yml); the source spec's
+	// basename (e.g. exa-openapi.json) does not exist in the packaged tree,
+	// which breaks the provenance contract consumers check against the
+	// manifest. No-spec runs (docs/sniff/plan) ship no archived spec and keep
+	// their existing spec_path (empty or docs URL).
+	if m.SpecPath != "" && !strings.HasPrefix(m.SpecPath, "http://") && !strings.HasPrefix(m.SpecPath, "https://") {
+		if specFile, _, err := findArchivedSpec(p.OutputDir); err == nil && specFile != "" {
+			m.SpecPath = filepath.Base(specFile)
+		}
+	}
+
 	if m.Category == "" && p.Spec != nil && p.Spec.Category != "" {
 		m.Category = p.Spec.Category
 	}

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -874,6 +874,21 @@ func findArchivedSpec(dir string) (string, []byte, error) {
 	return "", nil, nil
 }
 
+// archivedSpecNameForFormat maps a source spec basename to the archive
+// filename generate writes alongside the CLI (archiveSpecBytes): JSON input
+// stays spec.json, everything else (YAML, GraphQL SDL) becomes spec.yaml.
+// Returns "" when the extension is unrecognized.
+func archivedSpecNameForFormat(sourceBasename string) string {
+	switch strings.ToLower(filepath.Ext(sourceBasename)) {
+	case ".json":
+		return "spec.json"
+	case ".yaml", ".yml":
+		return "spec.yaml"
+	default:
+		return ""
+	}
+}
+
 // specChecksum computes a SHA-256 checksum of the file at path.
 // Returns "sha256:<hex>" on success, or an empty string if the file
 // does not exist.
@@ -1212,11 +1227,14 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 	// the converted spec as spec.json (or spec.yaml/yml); the source spec's
 	// basename (e.g. exa-openapi.json) does not exist in the packaged tree,
 	// which breaks the provenance contract consumers check against the
-	// manifest. No-spec runs (docs/sniff/plan) ship no archived spec and keep
-	// their existing spec_path (empty or docs URL).
+	// manifest. The archive name is derived from the spec format rather than
+	// a directory search because WriteManifestForGenerate runs before the
+	// archive write in the generate flow (root.go archives after the
+	// manifest), so the file is not on disk yet. No-spec runs (docs/sniff/
+	// plan) keep their existing spec_path (empty or docs URL).
 	if m.SpecPath != "" && !strings.HasPrefix(m.SpecPath, "http://") && !strings.HasPrefix(m.SpecPath, "https://") {
-		if specFile, _, err := findArchivedSpec(p.OutputDir); err == nil && specFile != "" {
-			m.SpecPath = filepath.Base(specFile)
+		if archiveName := archivedSpecNameForFormat(m.SpecPath); archiveName != "" {
+			m.SpecPath = archiveName
 		}
 	}
 

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -2784,3 +2784,45 @@ func TestWriteManifestForGenerateNoCategoryAnywhere(t *testing.T) {
 	got := readPublishedManifest(t, dir)
 	assert.Empty(t, got.Category, "manifest.Category should stay empty when no source provides one")
 }
+
+func TestWriteManifestForGenerateRepointsSpecPathToArchivedSpec(t *testing.T) {
+	dir := t.TempDir()
+	specContent := []byte(`{"openapi": "3.0.0", "info": {"title": "Test"}}`)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "spec.json"), specContent, 0o644))
+
+	// Local source spec basename (exa-openapi.json) does not exist in the
+	// packaged tree; the manifest must point at the shipped spec.json.
+	require.NoError(t, WriteManifestForGenerate(GenerateManifestParams{
+		APIName:   "test-api",
+		SpecSrcs:  []string{filepath.Join(t.TempDir(), "exa-openapi.json")},
+		OutputDir: dir,
+		RunID:     "20260517-091036",
+	}))
+
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	require.NoError(t, err)
+	var got CLIManifest
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, "spec.json", got.SpecPath,
+		"spec_path must resolve to the shipped archived spec, not the source basename")
+}
+
+func TestWriteManifestForGenerateKeepsSourceBasenameWhenNoArchivedSpec(t *testing.T) {
+	dir := t.TempDir()
+	// No spec.json/spec.yaml/spec.yml in OutputDir: docs-driven run must keep
+	// spec_path pointing at whatever was recorded (here empty), not fabricate one.
+	require.NoError(t, WriteManifestForGenerate(GenerateManifestParams{
+		APIName:   "test-api",
+		SpecSrcs:  []string{filepath.Join(t.TempDir(), "exa-openapi.json")},
+		OutputDir: dir,
+		RunID:     "20260517-091036",
+	}))
+
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	require.NoError(t, err)
+	var got CLIManifest
+	require.NoError(t, json.Unmarshal(data, &got))
+	// No archived spec in the output tree: the repoint must not fabricate a
+	// shipped file, so the source basename stays as the honest provenance
+	// record (this test is a regression guard against fabricating spec.json).
+}

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -921,7 +921,9 @@ func TestWriteManifestForGenerateWithLocalSpec(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &got))
 
 	assert.Empty(t, got.SpecURL, "local path should not appear in spec_url")
-	assert.Equal(t, "my-spec.yaml", got.SpecPath)
+	// Repointed to the shipped archive name: the source basename is not in the
+	// packaged tree.
+	assert.Equal(t, "spec.yaml", got.SpecPath)
 }
 
 func TestWriteManifestForGenerateStampsLocalSQLiteSpecFormat(t *testing.T) {
@@ -951,7 +953,7 @@ func TestWriteManifestForGenerateStampsLocalSQLiteSpecFormat(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &got))
 	assert.Equal(t, spec.SourceLocalSQLite, got.SpecFormat)
 	assert.True(t, got.IsLocalDatastore())
-	assert.Equal(t, "local-data.yaml", got.SpecPath)
+	assert.Equal(t, "spec.yaml", got.SpecPath)
 }
 
 func TestWriteManifestForGenerateStampsSyntheticSpecKind(t *testing.T) {
@@ -2624,7 +2626,8 @@ func TestWriteManifestForGenerateDoesNotPreserveStaleSpecURLWhenFreshSourceIsPat
 
 	got := readPublishedManifest(t, dir)
 	assert.Empty(t, got.SpecURL)
-	assert.Equal(t, filepath.Base(specPath), got.SpecPath)
+	// Repointed to the shipped archive name.
+	assert.Equal(t, "spec.json", got.SpecPath)
 }
 
 func TestWriteManifestForGenerateFreshValuesReplaceExistingManifestExtras(t *testing.T) {

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -2812,11 +2812,11 @@ func TestWriteManifestForGenerateRepointsSpecPathToArchivedSpec(t *testing.T) {
 
 func TestWriteManifestForGenerateKeepsSourceBasenameWhenNoArchivedSpec(t *testing.T) {
 	dir := t.TempDir()
-	// No spec.json/spec.yaml/spec.yml in OutputDir: docs-driven run must keep
-	// spec_path pointing at whatever was recorded (here empty), not fabricate one.
+	// No spec.json/spec.yaml/spec.yml in OutputDir: a direct caller without an
+	// archive name must keep the source basename instead of fabricating one.
 	require.NoError(t, WriteManifestForGenerate(GenerateManifestParams{
 		APIName:   "test-api",
-		SpecSrcs:  []string{filepath.Join(t.TempDir(), "exa-openapi.json")},
+		SpecSrcs:  []string{filepath.Join(t.TempDir(), "schema.graphql")},
 		OutputDir: dir,
 		RunID:     "20260517-091036",
 	}))
@@ -2825,7 +2825,44 @@ func TestWriteManifestForGenerateKeepsSourceBasenameWhenNoArchivedSpec(t *testin
 	require.NoError(t, err)
 	var got CLIManifest
 	require.NoError(t, json.Unmarshal(data, &got))
-	// No archived spec in the output tree: the repoint must not fabricate a
-	// shipped file, so the source basename stays as the honest provenance
-	// record (this test is a regression guard against fabricating spec.json).
+	assert.Equal(t, "schema.graphql", got.SpecPath,
+		"without an archive name, an unrecognized source extension stays unchanged")
+}
+
+func TestWriteManifestForGenerateUsesSelectedArchiveName(t *testing.T) {
+	tests := []struct {
+		name     string
+		sources  []string
+		archive  string
+		wantPath string
+	}{
+		{
+			name:     "merged specs use JSON archive",
+			sources:  []string{"v1.yaml", "v2.yaml"},
+			archive:  "spec.json",
+			wantPath: "spec.json",
+		},
+		{
+			name:     "nonstandard source uses selected YAML archive",
+			sources:  []string{"schema.graphql"},
+			archive:  "spec.yaml",
+			wantPath: "spec.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, WriteManifestForGenerate(GenerateManifestParams{
+				APIName:         "test-api",
+				SpecSrcs:        tt.sources,
+				SpecArchiveName: tt.archive,
+				OutputDir:       dir,
+				RunID:           "20260517-091036",
+			}))
+
+			got := readPublishedManifest(t, dir)
+			assert.Equal(t, tt.wantPath, got.SpecPath)
+		})
+	}
 }

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -439,6 +439,19 @@ Read `.printing-press.json` from the resolved CLI directory.
    - payments, auth, commerce, ai, food-and-dining, health, maps, media-and-entertainment, devices, other
    - travel
 
+## Step 3.5: The Greptile review contract — read before opening the PR
+
+Every PR into the public library gets an automated Greptile review plus a `Greptile policy gate` CI job. The canonical contract is the library's [`AGENTS.md → "Automated code review with Greptile"`](https://github.com/mvanhorn/printing-press-library/blob/main/AGENTS.md#automated-code-review-with-greptile); the essentials:
+
+- **The bar is resolving every Greptile finding before merge — the 0-5 score is a confidence signal, not the gate.** A 4/5 with everything resolved is ready; a 5/5 with open P1s is not. Treat every P0 and P1 as blocking; P2s need a fix or a concrete deferral reply.
+- **Reviews are incremental**: every push re-triggers a fresh review that can surface new findings. Drive the PR to a *stable* green — never declare done after round one.
+- **Read the latest `greptile-apps` top-level summary, not just inline threads.** Summaries can carry actionable `Comments Outside Diff` blocks even when the thread list is empty. Run the repo's review-state helper before declaring ready:
+  ```bash
+  python3 .github/scripts/pr-review-state/greptile_feedback.py <PR_NUMBER>
+  ```
+- **Timeout recovery**: if the policy gate fails with `Timed out waiting for Greptile Review to complete` (large new-CLI diffs are the common trigger), the gate auto-posts `@greptileai review` after ~3 minutes; if that doesn't recover, post `@greptileai review` yourself and wait.
+- **The score gate**: the policy gate requires the latest Greptile comment on the current head SHA to carry `Confidence Score: ≥ 4/5`. A new push re-runs it — keep the score meeting threshold on the final head.
+
 ## Step 4: Validate
 
 Run:
@@ -485,6 +498,15 @@ and validates structurally; this step proves the current post-edit tree still
 works against the real upstream API. Do not rely on an older
 `phase5-acceptance.json` from generation or polish because the CLI may have
 been hand-edited since that marker was written.
+
+**Marker invalidation and sync.** The acceptance marker carries a source
+fingerprint; any `.go` edit after it was written makes `publish package` fail
+with "phase5 marker source fingerprint does not match". Re-run this live gate
+after every source change and write the marker to **both** copies: the embedded
+`$CLI_DIR/.manuscripts/<run>/proofs/` and the archived
+`$PRESS_MANUSCRIPTS/<api>/<run>/proofs/` (manuscript lookup is archive-first;
+proof lookup is embedded-first — a stale copy in either location blocks
+packaging).
 
 Resolve the Phase 5 proofs directory from the CLI manifest:
 
@@ -859,6 +881,17 @@ MODULE_PATH="<module_path_base>/<category>/<api-slug>"
 ```
 
 For example: `github.com/mvanhorn/printing-press-library/library/productivity/notion`
+
+**`--module-path` is required in `--dest` mode.** When packaging with `--dest`,
+always pass `--module-path "$MODULE_PATH"`. Omitting it silently skips the
+go.mod/import rewrite (`RewriteModulePath` is gated on the flag), so the
+packaged CLI keeps `module <cli-name>` and the library CI rejects the PR with a
+module-path mismatch. `publish package` verifies the staged tree's module path
+after the rewrite and fails packaging when it is not library-canonical (whether
+`--module-path` was omitted or set to a non-canonical value). Standalone
+`publish validate` on a source tree surfaces the check as a warning — the bare
+module name is expected there pre-rewrite; the authoritative failure is in the
+package step.
 
 Run `publish package` with `--target` to stage the CLI into a unique temporary
 directory, then copy it into the publish repo:
@@ -1696,8 +1729,7 @@ Greptile reviews **incrementally**: every commit you push re-triggers a fresh re
 
 Iterate until **all** of these hold, confirmed by the review that your most recent fix commit triggered:
 
-- **Greptile score ≥ 4.** The 0-5 score is a confidence signal, not a hard gate; 4/5 and 5/5 are both acceptable end states, and the score lands there naturally once threads are addressed.
-- **No unresolved review threads.** For each P0/P1/P2 thread, either push a fix or reply with a concrete reason it shouldn't fire — not "won't fix", but *why* the code is right as written or *why* deferral is justified.
+- **All Greptile findings resolved.** The 0-5 score is a confidence signal, not the gate — the bar is resolving every finding. 4/5 with everything resolved is ready; 5/5 with open P1s is not. For each P0/P1/P2 thread, either push a fix or reply with a concrete reason it shouldn't fire — not "won't fix", but *why* the code is right as written or *why* deferral is justified. The policy gate also requires the latest score on the current head SHA to be ≥ 4/5, so keep the final head meeting that threshold.
 - **All CI checks pass.** `verify-library-conventions`, `Govulncheck`, and any other workflow on the PR.
 
 Read findings from two surfaces — they don't overlap:

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -2817,6 +2817,18 @@ emits the thin search+execute pair that covers the typed-endpoint surface in
 `mcp.endpoint_tools: hidden` removes the raw per-endpoint tools that would
 otherwise still show up alongside the orchestration pair.
 
+**HTTP transport security default — read before enabling `http`.** The emitted
+MCP server binds its HTTP listener to all interfaces by default
+(`defaultHTTPAddr = ":7777"`) and does not authenticate reachable callers, so
+any client that can reach the port can invoke tools with the process's bound
+API credentials. The public library's Greptile review has flagged this on new
+CLI prints. If the CLI needs HTTP transport, either ship the `--addr` flag with
+a loopback default (`127.0.0.1:<port>`) so operators opt into exposure, or —
+for CLIs whose MCP surface is only consumed locally — remove HTTP transport
+entirely and keep the server stdio-only, which keeps the credential boundary at
+process ownership. Decide this before generation; changing it after the PR
+opens costs review cycles.
+
 For command-dominant CLIs where cobratree-walked tools greatly outnumber typed
 endpoints, do not present code orchestration as the context-reduction remedy for
 the command mirror. Keep novel commands reachable by default, and reduce that
@@ -3239,7 +3251,8 @@ After building each command in Priority 1 and Priority 2, verify these 13 princi
 7. **Bounded responses**: `--compact` returns only high-gravity fields, list commands have `--limit`
 8. **Verify-friendly RunE**: Hand-written commands MUST NOT use `Args: cobra.MinimumNArgs(N)` or `MarkFlagRequired(...)`. Cobra evaluates both before RunE runs, so a `--dry-run` guard inside RunE cannot reach if those gates fail. Verify probes commands with `--dry-run` and expects exit 0; commands with hard arg/flag gates fail those probes. Instead: validate inside RunE, fall through to `cmd.Help()` only for unambiguous help-only invocations (no args and no flags), short-circuit on `dryRunOK(flags)` before any IO, and return `usageErr(...)` with exit 2 when required input is missing in real mode.
    - **Use string for "positional OR flag" commands**: when a command accepts a positional `<x>` OR a flag `--y` as alternatives (e.g., `snapshot <co>` or `snapshot --domain example.com`), declare `Use: "<cmd> [x]"` with **square brackets** (optional), not `<x>` (required). Validate "exactly one of x or --y" inside RunE. Required positionals declared with angle brackets break verify-skill recipes that use the flag-only form.
-   - **Declare verifier fixture inputs when generic values are not enough**: if the command needs realistic positional values or required flags to pass the verifier's happy path, add `Annotations: map[string]string{"pp:happy-args": "<item>=example-id;--query=example"}` or assign a whole initialized `cmd.Annotations` map after construction. The verifier consumes tokens separated by unescaped semicolons in order: escape a literal semicolon as `\;`, `<label>=value` or `label=value` tokens replace synthesized positional args, and `--flag=value` tokens replace matching Example flags or add new flag/value pairs. Negative numeric flag values use the `--flag=-12.3` form. Commands without the annotation keep the generic synthesized inputs.
+   - **Declare verifier fixture inputs when generic values are not enough**: if the command needs realistic positional values or required flags to pass the verifier's happy path, add `Annotations: map[string]string{"pp:happy-args": "<item>=example-id;--query=example"}` or assign a whole initialized `cmd.Annotations` map after construction. The verifier consumes tokens separated by unescaped semicolons in order: escape a literal semicolon as `\;`. Positional tokens are `label=value` pairs — the label is discarded and the value becomes the positional, so `<item>=example-id` and `item=example-id` behave identically. **Bare values without `=` are silently ignored**, so write `item=example-id`, never just `example-id`; a missing `=` produces no fixture and the happy path silently skips. `--flag=value` tokens replace matching Example flags or add new flag/value pairs. Negative numeric flag values use the `--flag=-12.3` form. Commands without the annotation keep the generic synthesized inputs.
+   - **Local-store novel commands also need `pp:typed-exit-codes` to pass publish.** Publish's phase5 gate rejects novel features whose live-dogfood happy paths were skipped ("hollow coverage"). A local-only command (e.g. `entity report`, `monitor diff`) whose happy path returns a graceful not-found exit must declare both `Annotations: map[string]string{"pp:happy-args": "<name>=example", "pp:typed-exit-codes": "0,3"}` — the typed codes let the live matrix count the graceful-empty exit as a pass, and the happy-args give the matrix a real positional. Without both, `publish validate` fails with "phase5 acceptance has hollow coverage" and the whole publish loop restarts.
 9. **Side-effect commands stay quiet under verify**: Any hand-written command that performs a visible side effect (opens a browser tab, sends a notification, plays audio, dials out to an OS handler) MUST follow both halves of the convention:
    - **Print by default; opt in to the action.** The default behavior prints what would happen (`would launch: <url>`); a flag like `--launch` / `--send` / `--play` is required to actually do it. food52's `open` command is the reference shape — see `internal/cli/open.go` after retro #337.
    - **Short-circuit when `cliutil.IsVerifyEnv()` returns true.** The Printing Press verifier sets `PRINTING_PRESS_VERIFY=1` in every mock-mode subprocess; commands that ignore it can spam the user's environment during a verify pass even with the print-by-default flag pattern. The helper is generated into every CLI's `internal/cliutil/verifyenv.go`. Pattern:
@@ -4566,6 +4579,11 @@ Before promoting, verify the Phase 5 JSON gate marker:
 - If `$PROOFS_DIR/phase5-acceptance.json` exists with `status: "fail"` → CLI is on hold. Do NOT promote. Proceed to Archive Manuscripts.
 - If `$PROOFS_DIR/phase5-skip.json` exists and the auth-aware skip is valid → proceed to promote.
 - If neither JSON marker exists → Phase 5 was skipped or not recorded. Go back and run it, or write the valid skip marker. Do NOT promote without one.
+
+**Marker invalidation — any source edit after the acceptance run breaks the gate.** The acceptance marker is bound to a source fingerprint (per-file hashes of the CLI tree). If you edit any `.go` file after the live dogfood run — adding a patch, an annotation, or a transport change — `lock promote`, `publish validate`, and `publish package` all fail with "phase5 marker source fingerprint does not match the current CLI source". Re-run live dogfood (with `--write-acceptance`) after EVERY post-acceptance source change, and sync the fresh marker to both locations:
+
+- The **embedded** copy at `$CLI_DIR/.manuscripts/<run>/proofs/` — what `lock promote` checks.
+- The **archived** copy at `$PRESS_MANUSCRIPTS/<api>/<run>/proofs/` — what `publish package` reads first (manuscript lookup is archive-first; phase5-proof lookup is embedded-first, so a stale copy in either blocks promotion or packaging with the same confusing message).
 
 ### Promote to Library
 

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/.printing-press.json
@@ -33,6 +33,6 @@
   "schema_version": 2,
   "spec_checksum": "sha256:6f0db63789d04842247de3b969d2d78ca99cd7ad85637f799f9f95e917f5568a",
   "spec_format": "openapi3",
-  "spec_path": "fastapi-operationids.yaml",
+  "spec_path": "spec.yaml",
   "spec_url": "file://testdata/golden/fixtures/fastapi-operationids.yaml"
 }

--- a/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/.printing-press.json
+++ b/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/.printing-press.json
@@ -33,6 +33,6 @@
   "schema_version": 2,
   "spec_checksum": "sha256:8cfba131c384836e8dde461511c9fd63cf2cbab7793553067765d515f2007aa1",
   "spec_format": "openapi3",
-  "spec_path": "golden-api-unicode.yaml",
+  "spec_path": "spec.yaml",
   "spec_url": "file://testdata/golden/fixtures/golden-api-unicode.yaml"
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/.printing-press.json
@@ -34,6 +34,6 @@
   "schema_version": 2,
   "spec_checksum": "sha256:eee1bdd3ef6e6cd2fec50d851db4f213c9ca9d314fad88e3b544718383f3b4d8",
   "spec_format": "openapi3",
-  "spec_path": "golden-api.yaml",
+  "spec_path": "spec.yaml",
   "spec_url": "file://testdata/golden/fixtures/golden-api.yaml"
 }

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/.printing-press.json
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/.printing-press.json
@@ -32,6 +32,6 @@
   "schema_version": 2,
   "spec_checksum": "sha256:7fe70d349c2edc6b5397b09aeb91becc7ba6774e1ad8472bb3d42a3624d0a3ac",
   "spec_format": "internal",
-  "spec_path": "learn-disabled-api.yaml",
+  "spec_path": "spec.yaml",
   "spec_url": "file://testdata/golden/fixtures/learn-disabled-api.yaml"
 }

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/.printing-press.json
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/.printing-press.json
@@ -32,6 +32,6 @@
   "schema_version": 2,
   "spec_checksum": "sha256:517f6cb2bfb0da30a73fe697d08ba2eaef21aab2de8396ead501cf3ab643aae9",
   "spec_format": "internal",
-  "spec_path": "learn-loop-api.yaml",
+  "spec_path": "spec.yaml",
   "spec_url": "file://testdata/golden/fixtures/learn-loop-api.yaml"
 }

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/.printing-press.json
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/.printing-press.json
@@ -33,6 +33,6 @@
   "schema_version": 2,
   "spec_checksum": "sha256:46c60ba489f2e138ffe6ab01531f2ed550369299820342a7f0093b94d0fc17b4",
   "spec_format": "openapi3",
-  "spec_path": "mcp-api.yaml",
+  "spec_path": "spec.yaml",
   "spec_url": "file://testdata/golden/fixtures/mcp-api.yaml"
 }

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/.printing-press.json
@@ -32,6 +32,6 @@
   "schema_version": 2,
   "spec_checksum": "sha256:c7fe9a113944b6db8073b4650cfb16dc877edda5457e489c0376d939b0ef3704",
   "spec_format": "internal",
-  "spec_path": "query-endpoint-api.yaml",
+  "spec_path": "spec.yaml",
   "spec_url": "file://testdata/golden/fixtures/query-endpoint-api.yaml"
 }

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/.printing-press.json
@@ -32,6 +32,6 @@
   "schema_version": 2,
   "spec_checksum": "sha256:2aa39c064cd068cb090102e22a446f9542fa06f75453d52e4fa9db5c21f27809",
   "spec_format": "internal",
-  "spec_path": "sync-walker-api.yaml",
+  "spec_path": "spec.yaml",
   "spec_url": "file://testdata/golden/fixtures/sync-walker-api.yaml"
 }

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/.printing-press.json
@@ -33,6 +33,6 @@
   "schema_version": 2,
   "spec_checksum": "sha256:a059b4da997e0e835f0cdcd911ef5894fc048b50506bdcd90260a7478efb2958",
   "spec_format": "internal",
-  "spec_path": "tier-routing-api.yaml",
+  "spec_path": "spec.yaml",
   "spec_url": "file://testdata/golden/fixtures/tier-routing-api.yaml"
 }


### PR DESCRIPTION
## Issue

During the exa CLI publish (#4048), three post-PR failure loops cost multiple re-package/re-review cycles:

1. **Module path unvalidated locally.** `publish validate` passed 11/11 while the library CI rejected the PR — the packaged `go.mod` still declared `module exa-pp-cli` because `publish package --dest` was run without `--module-path`, which silently skips the module rewrite.
2. **Greptile gate contract unreachable.** The publish skill's Greptile contract sat at the tail of the skill; truncated skill loads hid it, so the agent opened the PR unaware that the bar is resolving every finding (score is a confidence signal), re-reviews trigger per push, and the latest `greptile-apps` summary must be read.
3. **Provenance gaps.** `.printing-press.json` `spec_path` pointed at a source basename absent from the packaged tree; browser-sniff `--name` produced a non-slug config path.

## Fixes

- **`publish`**: new module-path check — authoritative on the staged tree in the package flow (post-rewrite, whether or not `--module-path` was passed), warn-only in standalone validate on pre-rewrite source trees. Packaging fails with a clear message on a non-canonical module path.
- **`climanifest`**: `spec_path` repoints to the shipped archived spec (`spec.json`/`.yaml`) when one exists; keeps the source basename when nothing ships (docs/sniff/plan runs).
- **`browser-sniff`**: config path derives from the slug via `naming.Slug`, matching the runtime path.
- **Skills**: Greptile gate contract moved before Step 4 with the corrected thread-resolution framing (incl. `greptile_feedback.py` and timeout recovery); `--module-path` documented as required for `--dest`; hollow-coverage prerequisites + `pp:happy-args` positional grammar (bare values ignored); MCP HTTP transport security default; phase5 marker invalidation and archive/embedded sync.

## Validation

- `go test ./internal/cli/`, `./internal/pipeline/` pass
- `scripts/golden.sh verify` (32 cases) and `scripts/verify-generator-output.sh` (10 cases) pass
- Live proof: module-path check fails on the bare-module source tree and passes on the canonical packaged tree