### PR TITLE
fix(cli): bump mark3labs/mcp-go template pin to v0.57.0

### DIFF
--- a/internal/generator/device.go
+++ b/internal/generator/device.go
@@ -342,7 +342,7 @@ go {{goDirectiveVersion}}
 toolchain {{goToolchainVersion}}
 
 require (
-	github.com/mark3labs/mcp-go v0.47.0
+	github.com/mark3labs/mcp-go v0.57.0
 	github.com/spf13/cobra v1.9.1
 	tinygo.org/x/bluetooth v0.15.0
 )

--- a/internal/generator/templates/go.mod.tmpl
+++ b/internal/generator/templates/go.mod.tmpl
@@ -31,7 +31,7 @@ require modernc.org/sqlite v1.37.0
 {{- end}}
 
 {{- if .VisionSet.MCP}}
-require github.com/mark3labs/mcp-go v0.47.0
+require github.com/mark3labs/mcp-go v0.57.0
 {{- end}}
 
 {{- if .HasAuthCommand}}

--- a/internal/pipeline/mcpsync/sync.go
+++ b/internal/pipeline/mcpsync/sync.go
@@ -874,7 +874,7 @@ const mcpGoModulePath = "github.com/mark3labs/mcp-go"
 // the cobratree-era templates compile against. Pinned to whatever the
 // generator's go.mod template currently emits — bump both together.
 // TestMinMCPGoVersionMatchesGoModTemplate keeps them in lockstep.
-const minMCPGoVersionForCobratree = "v0.47.0"
+const minMCPGoVersionForCobratree = "v0.57.0"
 
 // ensureMCPGoMinVersion bumps the mark3labs/mcp-go require directive
 // in go.mod to minMCPGoVersionForCobratree when the existing pin is

--- a/internal/pipeline/mcpsync/sync_test.go
+++ b/internal/pipeline/mcpsync/sync_test.go
@@ -723,7 +723,7 @@ require github.com/mark3labs/mcp-go v0.26.0
 
 	updated, err := os.ReadFile(filepath.Join(cliDir, "go.mod"))
 	require.NoError(t, err)
-	assert.Contains(t, string(updated), "github.com/mark3labs/mcp-go v0.47.0")
+	assert.Contains(t, string(updated), "github.com/mark3labs/mcp-go v0.57.0")
 	assert.NotContains(t, string(updated), "github.com/mark3labs/mcp-go v0.26.0")
 	// Surrounding directives must be preserved.
 	assert.Contains(t, string(updated), "module example.com/foo")
@@ -735,7 +735,7 @@ require github.com/mark3labs/mcp-go v0.26.0
 // already-current CLIs.
 func TestEnsureMCPGoMinVersionNoOpAtOrAboveFloor(t *testing.T) {
 	t.Parallel()
-	for _, version := range []string{"v0.47.0", "v0.48.0", "v1.0.0"} {
+	for _, version := range []string{"v0.57.0", "v0.58.0", "v1.0.0"} {
 		t.Run(version, func(t *testing.T) {
 			t.Parallel()
 			cliDir := t.TempDir()
@@ -795,7 +795,7 @@ replace github.com/mark3labs/mcp-go => github.com/myfork/mcp-go v0.30.0
 
 	updated, err := os.ReadFile(filepath.Join(cliDir, "go.mod"))
 	require.NoError(t, err)
-	assert.Contains(t, string(updated), "github.com/mark3labs/mcp-go v0.47.0",
+	assert.Contains(t, string(updated), "github.com/mark3labs/mcp-go v0.57.0",
 		"require entry must be bumped to the floor")
 	assert.Contains(t, string(updated), "github.com/myfork/mcp-go v0.30.0",
 		"replace directive's target must be untouched")

--- a/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/go.mod
+++ b/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 toolchain go1.26.5
 
 require (
-	github.com/mark3labs/mcp-go v0.47.0
+	github.com/mark3labs/mcp-go v0.57.0
 	github.com/spf13/cobra v1.9.1
 	tinygo.org/x/bluetooth v0.15.0
 )

--- a/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/go.mod
+++ b/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 toolchain go1.26.5
 
 require (
-	github.com/mark3labs/mcp-go v0.47.0
+	github.com/mark3labs/mcp-go v0.57.0
 	github.com/spf13/cobra v1.9.1
 	tinygo.org/x/bluetooth v0.15.0
 )

--- a/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/go.mod
+++ b/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 toolchain go1.26.5
 
 require (
-	github.com/mark3labs/mcp-go v0.47.0
+	github.com/mark3labs/mcp-go v0.57.0
 	github.com/spf13/cobra v1.9.1
 	tinygo.org/x/bluetooth v0.15.0
 )

--- a/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/go.mod
+++ b/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 toolchain go1.26.5
 
 require (
-	github.com/mark3labs/mcp-go v0.47.0
+	github.com/mark3labs/mcp-go v0.57.0
 	github.com/spf13/cobra v1.9.1
 	tinygo.org/x/bluetooth v0.15.0
 )

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4
 )
 require modernc.org/sqlite v1.37.0
-require github.com/mark3labs/mcp-go v0.47.0
+require github.com/mark3labs/mcp-go v0.57.0
 
 // x/sys is a DIRECT dependency for token-bearing bundles: the read-time
 // credentials-perms guard's Windows surface (internal/cliutil/creds_perms_windows.go)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/go.mod
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4
 )
 require modernc.org/sqlite v1.37.0
-require github.com/mark3labs/mcp-go v0.47.0
+require github.com/mark3labs/mcp-go v0.57.0
 
 // x/sys is a DIRECT dependency for token-bearing bundles: the read-time
 // credentials-perms guard's Windows surface (internal/cliutil/creds_perms_windows.go)


### PR DESCRIPTION
Bumps the mark3labs/mcp-go pin in the generator templates from v0.47.0 to v0.57.0 - the go.mod template, the device-CLI template, and the mcpsync floor move together (the lockstep test enforces it), so `sync` will also lift older printed CLIs to the new pin.

Main motivation: generated `--transport http` binds localhost, and v0.56.0 added default Host-header protection against DNS rebinding there (mark3labs/mcp-go#921; opt-out exists for reverse-proxy setups). v0.57.0 is current and folds in the later fixes.

Verified: full suite green including the golden prints. The goldens aren't a compilable module, so I also compiled a small probe against v0.57.0 referencing every mcp-go symbol the templates emit (NewTool, the annotation options, GetArguments, NewMCPServer, WithToolCapabilities, ServeStdio, NewStreamableHTTPServer, ToolHandlerFunc, TextContent) - no API breaks on the template surface between 0.47 and 0.57.

Interim hardening only - The fuller direction is the go-sdk migration proposed in #4051.