### PR TITLE
fix(cli): redact live dogfood auth samples

### DIFF
--- a/internal/artifacts/secrets.go
+++ b/internal/artifacts/secrets.go
@@ -80,7 +80,9 @@ const (
 func RedactLiveOutputSecrets(data []byte, authEnvValue string) []byte {
 	out := append([]byte(nil), data...)
 	if len(authEnvValue) >= 16 {
-		out = bytes.ReplaceAll(out, []byte(authEnvValue), []byte(LiveOutputAuthEnvRedacted))
+		authValue := []byte(authEnvValue)
+		out = bytes.ReplaceAll(out, authValue, []byte(LiveOutputAuthEnvRedacted))
+		out = redactPartialLiveOutputAuth(out, authValue)
 	}
 	for _, pattern := range vendorPrefixSecretPatterns {
 		out = pattern.pattern.ReplaceAllFunc(out, func(match []byte) []byte {
@@ -92,6 +94,29 @@ func RedactLiveOutputSecrets(data []byte, authEnvValue string) []byte {
 		})
 	}
 	return out
+}
+
+func redactPartialLiveOutputAuth(data, authValue []byte) []byte {
+	prefixLength := min(len(authValue), 16)
+	prefix := authValue[:prefixLength]
+	for start := bytes.Index(data, prefix); start >= 0; {
+		tail := data[start:]
+		if len(tail) < len(authValue) && bytes.HasPrefix(authValue, tail) {
+			redacted := make([]byte, 0, start+len(LiveOutputAuthEnvRedacted))
+			redacted = append(redacted, data[:start]...)
+			return append(redacted, LiveOutputAuthEnvRedacted...)
+		}
+		next := start + 1
+		if next >= len(data) {
+			break
+		}
+		relative := bytes.Index(data[next:], prefix)
+		if relative < 0 {
+			break
+		}
+		start = next + relative
+	}
+	return data
 }
 
 type VendorPrefixSecretFinding struct {

--- a/internal/artifacts/secrets.go
+++ b/internal/artifacts/secrets.go
@@ -70,6 +70,30 @@ func RedactArchivedSpecSecrets(data []byte) []byte {
 	return out
 }
 
+const (
+	LiveOutputAuthEnvRedacted   = "<REDACTED:auth-env>"
+	LiveOutputVendorKeyRedacted = "<REDACTED:vendor-api-key>"
+)
+
+// Keep live samples aligned with publish scanning so credential-shaped output
+// cannot enter reports or proofs while known placeholders remain intact.
+func RedactLiveOutputSecrets(data []byte, authEnvValue string) []byte {
+	out := append([]byte(nil), data...)
+	if len(authEnvValue) >= 16 {
+		out = bytes.ReplaceAll(out, []byte(authEnvValue), []byte(LiveOutputAuthEnvRedacted))
+	}
+	for _, pattern := range vendorPrefixSecretPatterns {
+		out = pattern.pattern.ReplaceAllFunc(out, func(match []byte) []byte {
+			candidate := string(match)
+			if pattern.accept != nil && !pattern.accept(candidate) {
+				return match
+			}
+			return []byte(LiveOutputVendorKeyRedacted)
+		})
+	}
+	return out
+}
+
 type VendorPrefixSecretFinding struct {
 	Path        string
 	Line        int

--- a/internal/artifacts/secrets_test.go
+++ b/internal/artifacts/secrets_test.go
@@ -78,6 +78,15 @@ func TestRedactLiveOutputSecretsPreservesShortValuesAndPlaceholders(t *testing.T
 	require.Equal(t, "mode=test placeholder="+placeholder+" real="+LiveOutputVendorKeyRedacted, string(got))
 }
 
+func TestRedactLiveOutputSecretsRedactsPartialAuthAtCaptureBoundary(t *testing.T) {
+	authSecret := "auth-secret-" + strings.Repeat("x", 5000)
+	input := []byte("prefix " + authSecret[:len(authSecret)-100])
+
+	got := RedactLiveOutputSecrets(input, authSecret)
+
+	require.Equal(t, "prefix "+LiveOutputAuthEnvRedacted, string(got))
+}
+
 func TestFindVendorPrefixSecretsReportsFileAndLine(t *testing.T) {
 	root := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(root, ".manuscripts", "run-1", "research"), 0o755))

--- a/internal/artifacts/secrets_test.go
+++ b/internal/artifacts/secrets_test.go
@@ -49,6 +49,35 @@ func TestRedactArchivedSpecSecretsKeepsPlaceholders(t *testing.T) {
 	require.Equal(t, string(input), got)
 }
 
+func TestRedactLiveOutputSecretsRedactsConfiguredAndVendorCredentials(t *testing.T) {
+	authSecret := "auth-secret-value-1234567890"
+	vendorSecret := "sk_live_" + strings.Repeat("a", 20)
+	input := []byte("auth=" + authSecret + " vendor=" + vendorSecret)
+
+	got := string(RedactLiveOutputSecrets(input, authSecret))
+
+	require.NotContains(t, got, authSecret)
+	require.NotContains(t, got, vendorSecret)
+	require.Contains(t, got, LiveOutputAuthEnvRedacted)
+	require.Contains(t, got, LiveOutputVendorKeyRedacted)
+}
+
+func TestRedactLiveOutputSecretsLeavesUnmatchedOutputUnchanged(t *testing.T) {
+	input := []byte("request failed with status 503")
+
+	require.Equal(t, input, RedactLiveOutputSecrets(input, "auth-secret-value-1234567890"))
+}
+
+func TestRedactLiveOutputSecretsPreservesShortValuesAndPlaceholders(t *testing.T) {
+	placeholder := "AKIAIOSFODNN7EXAMPLE"
+	awsSecret := testSecret("AKIA", "1234567890ABCDEF")
+	input := []byte("mode=test placeholder=" + placeholder + " real=" + awsSecret)
+
+	got := RedactLiveOutputSecrets(input, "test")
+
+	require.Equal(t, "mode=test placeholder="+placeholder+" real="+LiveOutputVendorKeyRedacted, string(got))
+}
+
 func TestFindVendorPrefixSecretsReportsFileAndLine(t *testing.T) {
 	root := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(root, ".manuscripts", "run-1", "research"), 0o755))

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -16,6 +16,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/artifacts"
 	openapiparser "github.com/mvanhorn/cli-printing-press/v4/internal/openapi"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/piiplaceholders"
 	apispec "github.com/mvanhorn/cli-printing-press/v4/internal/spec"
@@ -216,6 +217,7 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 	ctx := resolveCtx{
 		binaryPath:       binaryPath,
 		cliDir:           opts.CLIDir,
+		authEnvValue:     os.Getenv(opts.AuthEnv),
 		siblings:         buildSiblingMap(commands),
 		cache:            newCompanionCache(),
 		timeout:          timeout,
@@ -625,6 +627,7 @@ type companionCache struct {
 type resolveCtx struct {
 	binaryPath       string
 	cliDir           string
+	authEnvValue     string
 	siblings         map[string][]liveDogfoodCommand
 	cache            *companionCache
 	timeout          time.Duration
@@ -1476,7 +1479,7 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 
 	helpArgs := append(append([]string{}, command.Path...), "--help")
 	helpRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, helpArgs, ctx.timeout)
-	helpResult := liveDogfoodResult(commandName, LiveDogfoodTestHelp, helpArgs, helpRun)
+	helpResult := liveDogfoodResult(commandName, LiveDogfoodTestHelp, helpArgs, helpRun, ctx.authEnvValue)
 	helpPassed := helpRun.exitCode == 0
 	help := helpRun.stdout + helpRun.stderr
 	if helpPassed && extractExamplesSection(help) == "" {
@@ -1598,7 +1601,7 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 			len(extractPositionalPlaceholders(liveDogfoodUsageSuffix(command.Help))), liveDogfoodFlagValueNames(command.Help), liveDogfoodFlagNames(command.Help))
 
 		happyRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, runArgs, ctx.timeout)
-		happyResult := liveDogfoodResult(commandName, LiveDogfoodTestHappy, runArgs, happyRun)
+		happyResult := liveDogfoodResult(commandName, LiveDogfoodTestHappy, runArgs, happyRun, ctx.authEnvValue)
 		happyResult.FixtureSource = fixtureSource
 		if successCodes[happyRun.exitCode] {
 			happyResult.Status = LiveDogfoodStatusPass
@@ -1636,7 +1639,7 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 			}
 			jsonArgs = appendJSONArg(jsonArgs)
 			jsonRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, jsonArgs, ctx.timeout)
-			jsonResult := liveDogfoodResult(commandName, LiveDogfoodTestJSON, jsonArgs, jsonRun)
+			jsonResult := liveDogfoodResult(commandName, LiveDogfoodTestJSON, jsonArgs, jsonRun, ctx.authEnvValue)
 			jsonResult.FixtureSource = fixtureSource
 			if jsonRun.exitCode == 0 {
 				if !liveDogfoodJSONValid(jsonRun) {
@@ -1707,7 +1710,7 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 			}
 
 			errorRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, errorArgs, ctx.timeout)
-			errorResult := liveDogfoodResult(commandName, LiveDogfoodTestError, errorArgs, errorRun)
+			errorResult := liveDogfoodResult(commandName, LiveDogfoodTestError, errorArgs, errorRun, ctx.authEnvValue)
 
 			if isSearch {
 				// Real-world feed/content APIs return recent items as a fallback
@@ -1899,14 +1902,14 @@ func liveDogfoodJSONValid(run liveDogfoodRun) bool {
 	return validLiveDogfoodJSONOutput(run.stdout)
 }
 
-func liveDogfoodResult(command string, kind LiveDogfoodTestKind, args []string, run liveDogfoodRun) LiveDogfoodTestResult {
+func liveDogfoodResult(command string, kind LiveDogfoodTestKind, args []string, run liveDogfoodRun, authEnvValue string) LiveDogfoodTestResult {
 	result := LiveDogfoodTestResult{
 		Command:      command,
 		Kind:         kind,
 		Args:         append([]string{}, args...),
 		Status:       LiveDogfoodStatusFail,
 		ExitCode:     run.exitCode,
-		OutputSample: sampleOutputParts(run.stdout, run.stderr),
+		OutputSample: sampleLiveDogfoodOutput(authEnvValue, run.stdout, run.stderr),
 	}
 	if run.exitCode != 0 {
 		result.Reason = fmt.Sprintf("exit %d", run.exitCode)
@@ -1915,6 +1918,40 @@ func liveDogfoodResult(command string, kind LiveDogfoodTestKind, args []string, 
 		result.Reason = run.err.Error()
 	}
 	return result
+}
+
+func sampleLiveDogfoodOutput(authEnvValue string, parts ...string) string {
+	combined := boundedLiveDogfoodOutput(parts...)
+	redacted := artifacts.RedactLiveOutputSecrets([]byte(combined), authEnvValue)
+	if bytes.Equal(redacted, []byte(combined)) {
+		return sampleOutputParts(parts...)
+	}
+	redactedParts := make([]string, len(parts))
+	for i, part := range parts {
+		redactedParts[i] = string(artifacts.RedactLiveOutputSecrets([]byte(part), authEnvValue))
+	}
+	if bytes.Equal(redacted, []byte(boundedLiveDogfoodOutput(redactedParts...))) {
+		return sampleOutputParts(redactedParts...)
+	}
+	return sampleOutput(string(redacted))
+}
+
+func boundedLiveDogfoodOutput(parts ...string) string {
+	remaining := outputSampleMaxBytes + sampleRedactionLookaheadBytes
+	var combined strings.Builder
+	combined.Grow(remaining)
+	for _, part := range parts {
+		if remaining == 0 {
+			break
+		}
+		if len(part) > remaining {
+			combined.WriteString(truncateUTF8(part, remaining))
+			break
+		}
+		combined.WriteString(part)
+		remaining -= len(part)
+	}
+	return combined.String()
 }
 
 func failedLiveDogfoodResult(command string, kind LiveDogfoodTestKind, args []string, reason string) LiveDogfoodTestResult {

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/artifacts"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/generator"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
@@ -1635,12 +1636,80 @@ func TestLiveDogfoodResultRedactsOutputSamplePII(t *testing.T) {
 		exitCode: 0,
 	}
 
-	result := liveDogfoodResult("widgets list", LiveDogfoodTestHappy, []string{"widgets", "list"}, run)
+	result := liveDogfoodResult("widgets list", LiveDogfoodTestHappy, []string{"widgets", "list"}, run, "")
 
 	require.NotContains(t, result.OutputSample, "Jane Doe")
 	require.NotContains(t, result.OutputSample, "jane@example.com")
 	require.Contains(t, result.OutputSample, `"name":"<redacted>"`)
 	require.Contains(t, result.OutputSample, `"email":"<redacted>"`)
+}
+
+func TestLiveDogfoodResultRedactsAuthEnvAndVendorSecretsAcrossOutputParts(t *testing.T) {
+	authSecret := "auth-secret-value-1234567890"
+	vendorSecret := "sk_live_" + strings.Repeat("a", 20)
+	run := liveDogfoodRun{
+		stdout:   "request failed with key " + authSecret[:len(authSecret)/2],
+		stderr:   authSecret[len(authSecret)/2:] + " and vendor token " + vendorSecret,
+		exitCode: 1,
+	}
+
+	result := liveDogfoodResult("widgets list", LiveDogfoodTestHappy, []string{"widgets", "list"}, run, authSecret)
+
+	require.NotContains(t, result.OutputSample, authSecret)
+	require.NotContains(t, result.OutputSample, vendorSecret)
+	require.Contains(t, result.OutputSample, artifacts.LiveOutputAuthEnvRedacted)
+	require.Contains(t, result.OutputSample, artifacts.LiveOutputVendorKeyRedacted)
+}
+
+func TestLiveDogfoodResultKeepsPIIRedactionWithAuthRedaction(t *testing.T) {
+	authSecret := "auth-secret-value-1234567890"
+	run := liveDogfoodRun{
+		stdout:   `{"name":"Jane Doe","auth":"` + authSecret[:len(authSecret)/2],
+		stderr:   authSecret[len(authSecret)/2:] + `"}`,
+		exitCode: 0,
+	}
+
+	result := liveDogfoodResult("widgets list", LiveDogfoodTestHappy, []string{"widgets", "list"}, run, authSecret)
+
+	require.NotContains(t, result.OutputSample, "Jane Doe")
+	require.Contains(t, result.OutputSample, `"name":"<redacted>"`)
+	require.Contains(t, result.OutputSample, artifacts.LiveOutputAuthEnvRedacted)
+}
+
+func TestLiveDogfoodResultLeavesOutputWithoutSecretsUnchanged(t *testing.T) {
+	run := liveDogfoodRun{stdout: "request failed", stderr: " with status 503", exitCode: 1}
+
+	result := liveDogfoodResult("widgets list", LiveDogfoodTestHappy, []string{"widgets", "list"}, run, "")
+
+	require.Equal(t, sampleOutputParts(run.stdout, run.stderr), result.OutputSample)
+}
+
+func TestRunLiveDogfoodRedactsAuthEnvOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	secret := "auth-secret-value-1234567890"
+	t.Setenv("PP_TEST_AUTH_SECRET", secret)
+	dir, binaryName := writeLiveDogfoodFixture(t, true)
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "quick",
+		Timeout:    2 * time.Second,
+		AuthEnv:    "PP_TEST_AUTH_SECRET",
+	})
+	require.NoError(t, err)
+
+	happy := findResultByCommandKind(report, "widgets list", LiveDogfoodTestHappy)
+	require.NotNil(t, happy)
+	require.NotContains(t, happy.OutputSample, secret)
+	require.Contains(t, happy.OutputSample, artifacts.LiveOutputAuthEnvRedacted)
+
+	jsonResult := findResultByCommandKind(report, "widgets list", LiveDogfoodTestJSON)
+	require.NotNil(t, jsonResult)
+	require.NotContains(t, jsonResult.OutputSample, secret)
+	require.Contains(t, jsonResult.OutputSample, artifacts.LiveOutputAuthEnvRedacted)
 }
 
 func TestRunLiveDogfoodErrorPathAcceptsExpectedNonZeroExit(t *testing.T) {
@@ -4242,6 +4311,9 @@ HELP
 fi
 
 if [ "$1" = "widgets" ] && [ "$2" = "list" ]; then
+  if [ -n "${PP_TEST_AUTH_SECRET:-}" ]; then
+    printf 'auth=%s\n' "$PP_TEST_AUTH_SECRET" >&2
+  fi
   if [ "${3:-}" = "--json" ]; then
     echo '{"results":[{"id":"123"}]}'
     exit 0


### PR DESCRIPTION
## Intent

Live dogfood JSON reports could persist the resolved `--auth-env` value and vendor-shaped credentials in `output_sample`, which publish copies into public proof artifacts.

Issue: Closes #4041

## Approach

Redact the resolved auth value and recognized vendor credential patterns before live output is sampled. Preserve the existing scanner placeholder rules, avoid replacing short values, and remove partial auth prefixes at the bounded capture boundary. Reports without matching secrets continue through the existing PII and byte-preserving sample path.

## Scope

Primary area: scorer and live dogfood report serialization

Why this belongs in this repo: This is a shared Printing Press pipeline behavior that affects every generated CLI's publish-visible live dogfood artifacts.

## Risk

The change affects only persisted `OutputSample` fields. Runtime command output and verdict classification are unchanged. Auth and vendor redaction runs before report persistence, with focused coverage for stdout/stderr splits, PII interaction, placeholders, short values, and capture-boundary partials.

## Output Contract

Live report and proof samples now replace matching auth values with `<REDACTED:auth-env>` and known vendor credentials with `<REDACTED:vendor-api-key>`. Unmatched output keeps the existing sample format and PII handling.

## Verification

- `go test ./internal/artifacts ./internal/pipeline -count=1`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./internal/artifacts ./internal/pipeline`
- `go test ./...` was also run. The orchestrator verify environment has unrelated failures in BLE probe expectations and generated learn/store/client fixtures; the changed artifacts and pipeline packages pass.
