### PR TITLE
fix(cli): repair generated which scoring

### DIFF
--- a/internal/generator/templates/which.go.tmpl
+++ b/internal/generator/templates/which.go.tmpl
@@ -47,9 +47,9 @@ type whichMatch struct {
 //
 //	+3  exact token match on the command's leaf or full path
 //	+2  substring match on the command (any part)
-//	+2  substring match on the description
-//	+2  per-token match on the description
-//	+1  group tag contains the query as a word
+//	+2  substring match on description or why_it_matters
+//	+1  per-token match on description or why_it_matters (capped at 3)
+//	+1  group tag contains the query as a whole token
 //
 // Ties break on declaration order in the index. An empty query returns
 // every entry at score 0 in declaration order - this is the "list all"
@@ -110,7 +110,9 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 	// ties on the group token alone and index order decides the answer.
 	cmdTokens := whichSubTokens(cmd)
 	desc := strings.ToLower(e.Description)
-	descTokens := strings.Fields(desc)
+	descTokens := whichSubTokens(desc)
+	why := strings.ToLower(e.WhyItMatters)
+	whyTokens := whichSubTokens(why)
 	group := strings.ToLower(e.Group)
 
 	// Exact token match on the command path (any token).
@@ -126,34 +128,38 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 	if strings.Contains(cmd, query) {
 		score += 2
 	}
-	// Substring match on the description.
-	if strings.Contains(desc, query) {
+	// Description and rationale are correlated prose fields. Share the existing
+	// per-token cap so repeating the same query in both fields cannot outweigh
+	// an exact command match. A rationale-only match needs two tokens or an
+	// exact multi-token phrase to avoid promoting incidental prose words.
+	descPhrase := strings.Contains(desc, query)
+	descCredit := whichFieldCredit(qTokens, descTokens)
+	whyCredit := whichFieldCredit(qTokens, whyTokens)
+	whyPhrase := len(qTokens) > 1 && strings.Contains(why, query)
+	if score == 0 && whyCredit < 2 && !whyPhrase {
+		whyCredit = 0
+	}
+	if descPhrase || whyPhrase {
 		score += 2
 	}
-	// Per-token description match, CAPPED: natural-language requests often say
-	// "top coins by market cap" and the endpoint doc uses the same words - but
-	// uncapped description credit lets long token-soup descriptions outrank the
-	// precise command path, so the credit saturates at 3.
-	descCredit := 0
-	for _, qt := range qTokens {
-		for _, dt := range descTokens {
-			if whichTokenMatch(qt, dt) {
-				descCredit++
-				break
-			}
-		}
-		if descCredit == 3 {
-			break
-		}
+	if whyCredit > descCredit {
+		score += whyCredit
+	} else {
+		score += descCredit
 	}
-	score += descCredit
-	// Group tag match.
-	if group != "" {
-		for _, qt := range qTokens {
-			if strings.Contains(group, qt) {
+	// Group tag match requires a whole token, not an arbitrary substring.
+	groupTokens := whichSubTokens(group)
+	groupMatched := false
+	for _, qt := range qTokens {
+		for _, gt := range groupTokens {
+			if whichTokenMatch(qt, gt) {
 				score += 1
+				groupMatched = true
 				break
 			}
+		}
+		if groupMatched {
+			break
 		}
 	}
 	// Possessive aliasing: "my/mine/me/current" in a request is API-speak for
@@ -220,6 +226,22 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 		score -= unmatched
 	}
 	return score
+}
+
+func whichFieldCredit(qTokens, fieldTokens []string) int {
+	credit := 0
+	for _, qt := range qTokens {
+		for _, ft := range fieldTokens {
+			if whichTokenMatch(qt, ft) {
+				credit++
+				break
+			}
+		}
+		if credit == 3 {
+			break
+		}
+	}
+	return credit
 }
 
 func whichTokenMatch(a, b string) bool {

--- a/internal/generator/templates/which.go.tmpl
+++ b/internal/generator/templates/which.go.tmpl
@@ -230,9 +230,15 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 
 func whichFieldCredit(qTokens, fieldTokens []string) int {
 	credit := 0
+	matched := make(map[string]struct{})
 	for _, qt := range qTokens {
 		for _, ft := range fieldTokens {
 			if whichTokenMatch(qt, ft) {
+				key := whichTokenKey(ft)
+				if _, ok := matched[key]; ok {
+					break
+				}
+				matched[key] = struct{}{}
 				credit++
 				break
 			}
@@ -242,6 +248,14 @@ func whichFieldCredit(qTokens, fieldTokens []string) int {
 		}
 	}
 	return credit
+}
+
+func whichTokenKey(token string) string {
+	token = strings.Trim(strings.ToLower(token), ".,:;!?()[]{}\"'")
+	if alias := whichTokenAliases[token]; alias != "" {
+		return alias
+	}
+	return whichSingular(token)
 }
 
 func whichTokenMatch(a, b string) bool {

--- a/internal/generator/templates/which_test.go.tmpl
+++ b/internal/generator/templates/which_test.go.tmpl
@@ -41,6 +41,83 @@ func TestRankWhich_DescriptionMatch(t *testing.T) {
 	}
 }
 
+func TestRankWhich_WhyItMattersMatch(t *testing.T) {
+	index := []whichEntry{
+		{
+			Command:      "students at-risk",
+			Description:  "List students",
+			WhyItMatters: "Use this for early-alert outreach; answer who is falling behind right now",
+		},
+		{
+			Command:     "students summary",
+			Description: "Summarize student status",
+		},
+	}
+	got := rankWhich(index, "who is falling behind", 1)
+	if len(got) != 1 || got[0].Entry.Command != "students at-risk" || got[0].Score <= 0 {
+		t.Fatalf("expected the why-it-matters entry as the top match, got %+v", got)
+	}
+}
+
+func TestRankWhich_GroupMatchRequiresWholeToken(t *testing.T) {
+	index := []whichEntry{
+		{
+			Command:     "risk",
+			Description: "Student risk",
+			Group:       "Local snapshots that compound",
+		},
+	}
+	got := rankWhich(index, "at", 1)
+	if len(got) != 0 {
+		t.Fatalf("substring-only group match should be discarded, got %+v", got)
+	}
+}
+
+func TestRankWhich_GroupCreditIsCapped(t *testing.T) {
+	index := []whichEntry{
+		{Command: "local", Group: "Local state"},
+	}
+	got := rankWhich(index, "local state", 1)
+	if len(got) != 1 || got[0].Score != 4 {
+		t.Fatalf("group match should add one point per entry, got %+v", got)
+	}
+}
+
+func TestRankWhich_DescriptionSubTokens(t *testing.T) {
+	index := []whichEntry{
+		{Command: "show", Description: "Grade-distribution"},
+	}
+	got := rankWhich(index, "distribution", 1)
+	if len(got) != 1 || got[0].Score != 3 {
+		t.Fatalf("hyphenated description token should receive substring and token credit, got %+v", got)
+	}
+}
+
+func TestRankWhich_ProseCreditDoesNotDoubleCount(t *testing.T) {
+	index := []whichEntry{
+		{Command: "grades distribution", Description: "Grade breakdown"},
+		{
+			Command:      "class overview",
+			Description:  "Summarize grade distribution report",
+			WhyItMatters: "Read the grade distribution report by class",
+		},
+	}
+	got := rankWhich(index, "grade distribution report", 1)
+	if len(got) != 1 || got[0].Entry.Command != "grades distribution" {
+		t.Fatalf("exact command match should outrank repeated prose, got %+v", got)
+	}
+}
+
+func TestRankWhich_IncidentalWhyItMattersTokenDoesNotAdmitEntry(t *testing.T) {
+	index := []whichEntry{
+		{Command: "risk", WhyItMatters: "Use this to help agents answer questions"},
+	}
+	got := rankWhich(index, "agents", 1)
+	if len(got) != 0 {
+		t.Fatalf("incidental rationale token should not create confidence, got %+v", got)
+	}
+}
+
 // Happy path: a multi-word query resolves to the best single match by
 // summing per-token scores.
 func TestRankWhich_MultiTokenQuery(t *testing.T) {

--- a/internal/generator/templates/which_test.go.tmpl
+++ b/internal/generator/templates/which_test.go.tmpl
@@ -118,6 +118,18 @@ func TestRankWhich_IncidentalWhyItMattersTokenDoesNotAdmitEntry(t *testing.T) {
 	}
 }
 
+func TestRankWhich_WhyItMattersCreditDeduplicatesEquivalentTokens(t *testing.T) {
+	index := []whichEntry{
+		{Command: "risk", WhyItMatters: "Use this to coordinate repositories"},
+	}
+	for _, query := range []string{"repositories repositories", "repo repositories"} {
+		got := rankWhich(index, query, 1)
+		if len(got) != 0 {
+			t.Fatalf("duplicate rationale concepts should not create confidence for %q, got %+v", query, got)
+		}
+	}
+}
+
 // Happy path: a multi-word query resolves to the best single match by
 // summing per-token scores.
 func TestRankWhich_MultiTokenQuery(t *testing.T) {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
@@ -43,9 +43,9 @@ type whichMatch struct {
 //
 //	+3  exact token match on the command's leaf or full path
 //	+2  substring match on the command (any part)
-//	+2  substring match on the description
-//	+2  per-token match on the description
-//	+1  group tag contains the query as a word
+//	+2  substring match on description or why_it_matters
+//	+1  per-token match on description or why_it_matters (capped at 3)
+//	+1  group tag contains the query as a whole token
 //
 // Ties break on declaration order in the index. An empty query returns
 // every entry at score 0 in declaration order - this is the "list all"
@@ -106,7 +106,9 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 	// ties on the group token alone and index order decides the answer.
 	cmdTokens := whichSubTokens(cmd)
 	desc := strings.ToLower(e.Description)
-	descTokens := strings.Fields(desc)
+	descTokens := whichSubTokens(desc)
+	why := strings.ToLower(e.WhyItMatters)
+	whyTokens := whichSubTokens(why)
 	group := strings.ToLower(e.Group)
 
 	// Exact token match on the command path (any token).
@@ -122,34 +124,38 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 	if strings.Contains(cmd, query) {
 		score += 2
 	}
-	// Substring match on the description.
-	if strings.Contains(desc, query) {
+	// Description and rationale are correlated prose fields. Share the existing
+	// per-token cap so repeating the same query in both fields cannot outweigh
+	// an exact command match. A rationale-only match needs two tokens or an
+	// exact multi-token phrase to avoid promoting incidental prose words.
+	descPhrase := strings.Contains(desc, query)
+	descCredit := whichFieldCredit(qTokens, descTokens)
+	whyCredit := whichFieldCredit(qTokens, whyTokens)
+	whyPhrase := len(qTokens) > 1 && strings.Contains(why, query)
+	if score == 0 && whyCredit < 2 && !whyPhrase {
+		whyCredit = 0
+	}
+	if descPhrase || whyPhrase {
 		score += 2
 	}
-	// Per-token description match, CAPPED: natural-language requests often say
-	// "top coins by market cap" and the endpoint doc uses the same words - but
-	// uncapped description credit lets long token-soup descriptions outrank the
-	// precise command path, so the credit saturates at 3.
-	descCredit := 0
-	for _, qt := range qTokens {
-		for _, dt := range descTokens {
-			if whichTokenMatch(qt, dt) {
-				descCredit++
-				break
-			}
-		}
-		if descCredit == 3 {
-			break
-		}
+	if whyCredit > descCredit {
+		score += whyCredit
+	} else {
+		score += descCredit
 	}
-	score += descCredit
-	// Group tag match.
-	if group != "" {
-		for _, qt := range qTokens {
-			if strings.Contains(group, qt) {
+	// Group tag match requires a whole token, not an arbitrary substring.
+	groupTokens := whichSubTokens(group)
+	groupMatched := false
+	for _, qt := range qTokens {
+		for _, gt := range groupTokens {
+			if whichTokenMatch(qt, gt) {
 				score += 1
+				groupMatched = true
 				break
 			}
+		}
+		if groupMatched {
+			break
 		}
 	}
 	// Possessive aliasing: "my/mine/me/current" in a request is API-speak for
@@ -216,6 +222,22 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 		score -= unmatched
 	}
 	return score
+}
+
+func whichFieldCredit(qTokens, fieldTokens []string) int {
+	credit := 0
+	for _, qt := range qTokens {
+		for _, ft := range fieldTokens {
+			if whichTokenMatch(qt, ft) {
+				credit++
+				break
+			}
+		}
+		if credit == 3 {
+			break
+		}
+	}
+	return credit
 }
 
 func whichTokenMatch(a, b string) bool {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
@@ -226,9 +226,15 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 
 func whichFieldCredit(qTokens, fieldTokens []string) int {
 	credit := 0
+	matched := make(map[string]struct{})
 	for _, qt := range qTokens {
 		for _, ft := range fieldTokens {
 			if whichTokenMatch(qt, ft) {
+				key := whichTokenKey(ft)
+				if _, ok := matched[key]; ok {
+					break
+				}
+				matched[key] = struct{}{}
 				credit++
 				break
 			}
@@ -238,6 +244,14 @@ func whichFieldCredit(qTokens, fieldTokens []string) int {
 		}
 	}
 	return credit
+}
+
+func whichTokenKey(token string) string {
+	token = strings.Trim(strings.ToLower(token), ".,:;!?()[]{}\"'")
+	if alias := whichTokenAliases[token]; alias != "" {
+		return alias
+	}
+	return whichSingular(token)
 }
 
 func whichTokenMatch(a, b string) bool {


### PR DESCRIPTION
## Intent

`which` now returns useful matches for rationale queries and hyphenated descriptions. Group matching no longer accepts substring-only hits or awards duplicate group credit.

Issue: Closes #4016

## Approach

The generated ranker tokenizes descriptions and group text with the same sub-tokenizer used for commands. It scores rationale text through a shared prose budget and requires whole-token group matches. Generated regressions cover rationale matches, group boundaries and capping, hyphenated descriptions, duplicate prose, incidental rationale words, and existing command-name behavior.

## Scope

Primary area: Generator and generated `which` scoring

Why this belongs in this repo: This changes the Printing Press template and its representative generated golden output, so future printed CLIs inherit the corrected scoring contract.

## Risk

Ranking changes are limited to the affected description, rationale, and group fields. Command-name matching remains covered by the existing generated tests.

## Output Contract

The representative generated CLI golden is updated. Generated output compiles across 10 generator cases, and the focused generated ranking tests pass.

## Verification

- `go fmt ./...`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify` (32 cases)
- Focused generated test: `go test ./internal/cli -run '^(TestRankWhich_|TestWhichTokenMatch_)' -count=1`
- `go test ./...` reaches unrelated worker-environment failures in verify-mode BLE messaging and generated learn/store state tests.

Closes #4016
