### PR TITLE
fix(cli): derive generated examples from API models

### DIFF
--- a/internal/generator/first_command_example.go
+++ b/internal/generator/first_command_example.go
@@ -9,6 +9,49 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 )
 
+type commandExampleCandidate struct {
+	resourceName string
+	resource     spec.Resource
+	endpointName string
+	endpoint     spec.Endpoint
+}
+
+func firstCommandExampleCandidate(resources map[string]spec.Resource) (commandExampleCandidate, bool) {
+	var empty commandExampleCandidate
+	var resNames []string
+	for name := range resources {
+		resNames = append(resNames, name)
+	}
+	sort.Strings(resNames)
+	preferredVerbs := []string{"list", "get", "search", "query"}
+
+	for _, rName := range resNames {
+		r := resources[rName]
+		for _, verb := range preferredVerbs {
+			if ep, ok := r.Endpoints[verb]; ok && endpointIsReadCommand(ep, verb) {
+				return commandExampleCandidate{resourceName: rName, resource: r, endpointName: verb, endpoint: ep}, true
+			}
+		}
+	}
+	for _, rName := range resNames {
+		r := resources[rName]
+		for _, eName := range sortedEndpointNames(r.Endpoints) {
+			if ep := r.Endpoints[eName]; endpointIsReadCommand(ep, eName) {
+				return commandExampleCandidate{resourceName: rName, resource: r, endpointName: eName, endpoint: ep}, true
+			}
+		}
+	}
+	for _, rName := range resNames {
+		r := resources[rName]
+		eNames := sortedEndpointNames(r.Endpoints)
+		if len(eNames) > 0 {
+			eName := eNames[0]
+			return commandExampleCandidate{resourceName: rName, resource: r, endpointName: eName, endpoint: r.Endpoints[eName]}, true
+		}
+	}
+	return empty, false
+}
+
 // firstCommandExample returns a runnable "resource [endpoint] <pos1> <pos2>..."
 // invocation for docs that need a concrete example. Required public flags are
 // included so generated docs do not advertise commands that fail immediately.
@@ -31,51 +74,23 @@ import (
 // the mock-value catch-all. This keeps SKILL examples honest enough that
 // verify-skill exits 0 on first generation.
 func firstCommandExample(resources map[string]spec.Resource) string {
-	var resNames []string
-	for name := range resources {
-		resNames = append(resNames, name)
+	candidate, ok := firstCommandExampleCandidate(resources)
+	if !ok {
+		return ""
 	}
-	sort.Strings(resNames)
-	preferredVerbs := []string{"list", "get", "search", "query"}
-
-	pathFor := func(rName string, r spec.Resource, eName string, ep spec.Endpoint) string {
+	pathFor := func(rName string, r spec.Resource, ep spec.Endpoint) string {
 		// Kebab the resource segment to match the actual cobra command name
 		// (mirrors toKebab(resourceName) in buildPromotedCommands). PascalCase
 		// or snake_case spec keys would otherwise advertise an unrunnable path.
 		parts := []string{toKebab(rName)}
 		if !isPromotableSingleEndpoint(rName, r) {
-			parts = append(parts, toKebab(eName))
+			parts = append(parts, toKebab(candidate.endpointName))
 		}
 		parts = append(parts, readmeExampleArgs(ep)...)
 		return strings.Join(parts, " ")
 	}
 
-	for _, rName := range resNames {
-		r := resources[rName]
-		for _, verb := range preferredVerbs {
-			if ep, ok := r.Endpoints[verb]; ok && endpointIsReadCommand(ep, verb) {
-				return pathFor(rName, r, verb, ep)
-			}
-		}
-	}
-	for _, rName := range resNames {
-		r := resources[rName]
-		for _, eName := range sortedEndpointNames(r.Endpoints) {
-			if ep := r.Endpoints[eName]; endpointIsReadCommand(ep, eName) {
-				return pathFor(rName, r, eName, ep)
-			}
-		}
-	}
-	// Preserve examples for mutation-only specs; callers use empty to mean that
-	// the spec has no endpoints.
-	for _, rName := range resNames {
-		r := resources[rName]
-		eNames := sortedEndpointNames(r.Endpoints)
-		if len(eNames) > 0 {
-			return pathFor(rName, r, eNames[0], r.Endpoints[eNames[0]])
-		}
-	}
-	return ""
+	return pathFor(candidate.resourceName, candidate.resource, candidate.endpoint)
 }
 func commandExampleArgs(ep spec.Endpoint) string {
 	return strings.Join(commandExampleArgParts(ep), " ")

--- a/internal/generator/generated_examples.go
+++ b/internal/generator/generated_examples.go
@@ -120,7 +120,7 @@ func safeGeneratedExampleField(name string) bool {
 		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
 			continue
 		}
-		if strings.ContainsRune("_.-", r) {
+		if strings.ContainsRune("_-", r) {
 			continue
 		}
 		return false

--- a/internal/generator/generated_examples.go
+++ b/internal/generator/generated_examples.go
@@ -73,23 +73,59 @@ func selectExample(apiSpec *spec.APISpec, syncable []profiler.SyncableResource) 
 		if !ok {
 			continue
 		}
+		return generatedExampleFields(typeDef)
+	}
+	return ""
+}
 
-		fields := make([]string, 0, generatedExampleFieldLimit)
-		for _, field := range typeDef.Fields {
-			name := strings.TrimSpace(field.Name)
-			if name == "" || strings.ContainsAny(name, ",\r\n") {
-				continue
-			}
-			fields = append(fields, name)
-			if len(fields) == generatedExampleFieldLimit {
-				return strings.Join(fields, ",")
-			}
+func selectExampleForCommand(apiSpec *spec.APISpec) string {
+	if apiSpec == nil {
+		return ""
+	}
+	candidate, ok := firstCommandExampleCandidate(apiSpec.Resources)
+	if !ok {
+		return ""
+	}
+	item := strings.TrimSpace(candidate.endpoint.Response.Item)
+	if item == "" {
+		return ""
+	}
+	typeDef, ok := typeDefByName(apiSpec.Types, item)
+	if !ok {
+		return ""
+	}
+	return generatedExampleFields(typeDef)
+}
+
+func generatedExampleFields(typeDef spec.TypeDef) string {
+	fields := make([]string, 0, generatedExampleFieldLimit)
+	for _, field := range typeDef.Fields {
+		name := strings.TrimSpace(field.Name)
+		if !safeGeneratedExampleField(name) {
+			continue
 		}
-		if len(fields) > 0 {
+		fields = append(fields, name)
+		if len(fields) == generatedExampleFieldLimit {
 			return strings.Join(fields, ",")
 		}
 	}
-	return ""
+	return strings.Join(fields, ",")
+}
+
+func safeGeneratedExampleField(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			continue
+		}
+		if strings.ContainsRune("_.-", r) {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func endpointForSyncableResource(resources map[string]spec.Resource, syncable profiler.SyncableResource) (spec.Endpoint, bool) {

--- a/internal/generator/generated_examples.go
+++ b/internal/generator/generated_examples.go
@@ -1,0 +1,168 @@
+package generator
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+)
+
+const generatedExampleFieldLimit = 3
+
+// syncResourcesExample returns a small, deterministic selection of resources
+// from the profile so generated sync examples remain valid for each API.
+func syncResourcesExample(syncable []profiler.SyncableResource, dependent []profiler.DependentResource) string {
+	resources := append([]profiler.SyncableResource(nil), syncable...)
+	sort.Slice(resources, func(i, j int) bool { return resources[i].Name < resources[j].Name })
+
+	parents := make(map[string]bool, len(dependent))
+	for _, resource := range dependent {
+		if name := strings.TrimSpace(resource.ParentResource); name != "" {
+			parents[name] = true
+		}
+	}
+
+	selected := make([]string, 0, 2)
+	seen := make(map[string]bool, 2)
+	appendResource := func(resource profiler.SyncableResource) {
+		name := strings.TrimSpace(resource.Name)
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		selected = append(selected, name)
+	}
+
+	for _, resource := range resources {
+		if parents[resource.Name] {
+			appendResource(resource)
+			break
+		}
+	}
+	for _, resource := range resources {
+		if len(selected) >= 2 {
+			break
+		}
+		appendResource(resource)
+	}
+
+	return strings.Join(selected, ",")
+}
+
+// selectExample returns the first few fields from the first syncable resource
+// whose response model is known. It intentionally returns empty when the API
+// model cannot support a trustworthy field selection example.
+func selectExample(apiSpec *spec.APISpec, syncable []profiler.SyncableResource) string {
+	if apiSpec == nil {
+		return ""
+	}
+
+	resources := append([]profiler.SyncableResource(nil), syncable...)
+	sort.Slice(resources, func(i, j int) bool { return resources[i].Name < resources[j].Name })
+	for _, resource := range resources {
+		endpoint, ok := endpointForSyncableResource(apiSpec.Resources, resource)
+		if !ok {
+			continue
+		}
+		item := strings.TrimSpace(endpoint.Response.Item)
+		if item == "" {
+			continue
+		}
+		typeDef, ok := typeDefByName(apiSpec.Types, item)
+		if !ok {
+			continue
+		}
+
+		fields := make([]string, 0, generatedExampleFieldLimit)
+		for _, field := range typeDef.Fields {
+			name := strings.TrimSpace(field.Name)
+			if name == "" || strings.ContainsAny(name, ",\r\n") {
+				continue
+			}
+			fields = append(fields, name)
+			if len(fields) == generatedExampleFieldLimit {
+				return strings.Join(fields, ",")
+			}
+		}
+		if len(fields) > 0 {
+			return strings.Join(fields, ",")
+		}
+	}
+	return ""
+}
+
+func endpointForSyncableResource(resources map[string]spec.Resource, syncable profiler.SyncableResource) (spec.Endpoint, bool) {
+	type endpointCandidate struct {
+		resourceName string
+		endpoint     spec.Endpoint
+	}
+
+	var candidates []endpointCandidate
+	var walk func(map[string]spec.Resource)
+	walk = func(current map[string]spec.Resource) {
+		resourceNames := make([]string, 0, len(current))
+		for name := range current {
+			resourceNames = append(resourceNames, name)
+		}
+		sort.Strings(resourceNames)
+		for _, resourceName := range resourceNames {
+			resource := current[resourceName]
+			endpointNames := make([]string, 0, len(resource.Endpoints))
+			for name := range resource.Endpoints {
+				endpointNames = append(endpointNames, name)
+			}
+			sort.Strings(endpointNames)
+			for _, endpointName := range endpointNames {
+				candidates = append(candidates, endpointCandidate{
+					resourceName: resourceName,
+					endpoint:     resource.Endpoints[endpointName],
+				})
+			}
+			walk(resource.SubResources)
+		}
+	}
+	walk(resources)
+
+	resourceName := strings.TrimSpace(syncable.Name)
+	path := strings.TrimSpace(syncable.Path)
+	method := strings.ToUpper(strings.TrimSpace(syncable.Method))
+	for _, candidate := range candidates {
+		if candidate.resourceName == resourceName && endpointMatches(candidate.endpoint, path, method) {
+			return candidate.endpoint, true
+		}
+	}
+	for _, candidate := range candidates {
+		if endpointMatches(candidate.endpoint, path, method) {
+			return candidate.endpoint, true
+		}
+	}
+	for _, candidate := range candidates {
+		if candidate.resourceName == resourceName {
+			return candidate.endpoint, true
+		}
+	}
+	return spec.Endpoint{}, false
+}
+
+func endpointMatches(endpoint spec.Endpoint, path, method string) bool {
+	if path != "" && strings.TrimSpace(endpoint.Path) != path {
+		return false
+	}
+	if method != "" && strings.ToUpper(strings.TrimSpace(endpoint.Method)) != method {
+		return false
+	}
+	return true
+}
+
+func typeDefByName(types map[string]spec.TypeDef, name string) (spec.TypeDef, bool) {
+	if typeDef, ok := types[name]; ok {
+		return typeDef, true
+	}
+	for typeName, typeDef := range types {
+		if strings.EqualFold(typeName, name) {
+			return typeDef, true
+		}
+	}
+	return spec.TypeDef{}, false
+}

--- a/internal/generator/generated_examples_test.go
+++ b/internal/generator/generated_examples_test.go
@@ -77,7 +77,7 @@ func TestSelectExampleRejectsUnsafeFieldNames(t *testing.T) {
 			}},
 		},
 		Types: map[string]spec.TypeDef{
-			"Item": {Fields: []spec.TypeField{{Name: `bad"field`}}},
+			"Item": {Fields: []spec.TypeField{{Name: "meta.id"}}},
 		},
 	}
 

--- a/internal/generator/generated_examples_test.go
+++ b/internal/generator/generated_examples_test.go
@@ -1,0 +1,163 @@
+package generator
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/graphql"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncResourcesExamplePrefersParentWithDependent(t *testing.T) {
+	t.Parallel()
+
+	syncable := []profiler.SyncableResource{
+		{Name: "accounts"},
+		{Name: "projects"},
+		{Name: "users"},
+	}
+	dependent := []profiler.DependentResource{{Name: "project_items", ParentResource: "projects"}}
+
+	assert.Equal(t, "projects,accounts", syncResourcesExample(syncable, dependent))
+}
+
+func TestSelectExampleUsesFirstSyncableResponseFields(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Resources: map[string]spec.Resource{
+			"initiatives": {Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:   "GET",
+					Path:     "/initiatives",
+					Response: spec.ResponseDef{Type: "array", Item: "Initiative"},
+				},
+			}},
+		},
+		Types: map[string]spec.TypeDef{
+			"Initiative": {Fields: []spec.TypeField{
+				{Name: "idIniziativa"},
+				{Name: "titoloIniziativa"},
+				{Name: "stato"},
+				{Name: "dataFine"},
+			}},
+		},
+	}
+
+	syncable := []profiler.SyncableResource{{Name: "initiatives", Path: "/initiatives", Method: "GET"}}
+	assert.Equal(t, "idIniziativa,titoloIniziativa,stato", selectExample(apiSpec, syncable))
+}
+
+func TestSelectExampleOmitsWhenResponseFieldsAreUnknown(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Resources: map[string]spec.Resource{
+			"items": {Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/items", Response: spec.ResponseDef{Type: "array"}},
+			}},
+		},
+	}
+
+	syncable := []profiler.SyncableResource{{Name: "items", Path: "/items", Method: "GET"}}
+	assert.Empty(t, selectExample(apiSpec, syncable))
+}
+
+func TestGeneratedExamplesUseAPIModelAcrossDocsAndSyncHelp(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := modelExamplesSpec("model-examples")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, MCP: true}
+	require.NoError(t, gen.Generate())
+
+	readme := readGeneratedFile(t, outputDir, "README.md")
+	skill := readGeneratedFile(t, outputDir, "SKILL.md")
+	root := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	sync := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	wantResources := syncResourcesExample(gen.profile.SyncableResources, gen.profile.DependentSyncResources)
+
+	for _, content := range []string{readme, skill} {
+		assert.Contains(t, content, "--select invoice_id,title,state")
+		assert.NotContains(t, content, "--select id,name,status")
+	}
+	assert.Contains(t, root, "--select invoice_id,title,state")
+	assert.NotContains(t, root, "--select id,name,status")
+	assert.Contains(t, sync, "--resources "+wantResources)
+	assert.NotContains(t, sync, "--resources channels,messages")
+}
+
+func TestGeneratedGraphQLSyncExampleUsesAPIModel(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := graphql.ParseSDL(filepath.Join("..", "..", "testdata", "graphql", "test.graphql"))
+	require.NoError(t, err)
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, MCP: true}
+	require.NoError(t, gen.Generate())
+	sync := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	want := syncResourcesExample(gen.profile.SyncableResources, gen.profile.DependentSyncResources)
+	require.NotEmpty(t, want, "GraphQL fixture should expose at least one sync resource")
+	assert.Contains(t, sync, "--resources "+want)
+	assert.NotContains(t, sync, "--resources channels,messages")
+}
+
+func TestGeneratedDocsOmitUnverifiableSelectExample(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := modelExamplesSpec("unknown-select-example")
+	for name, resource := range apiSpec.Resources {
+		for endpointName, endpoint := range resource.Endpoints {
+			endpoint.Response.Item = ""
+			resource.Endpoints[endpointName] = endpoint
+		}
+		apiSpec.Resources[name] = resource
+	}
+	apiSpec.Types = nil
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, MCP: true}
+	require.NoError(t, gen.Generate())
+
+	readme := readGeneratedFile(t, outputDir, "README.md")
+	skill := readGeneratedFile(t, outputDir, "SKILL.md")
+	root := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	assert.Contains(t, readme, "--select <field>[,<field>...]")
+	assert.NotContains(t, skill, "--select id,name,status")
+	assert.NotContains(t, skill, " --select ")
+	assert.NotContains(t, root, "--select id,name,status")
+}
+
+func modelExamplesSpec(name string) *spec.APISpec {
+	return &spec.APISpec{
+		Name:    name,
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:    "api_key",
+			Header:  "Authorization",
+			Format:  "Bearer {token}",
+			EnvVars: []string{"MODEL_EXAMPLES_TOKEN"},
+		},
+		Config: spec.ConfigSpec{Format: "toml", Path: "~/.config/" + name + "-pp-cli/config.toml"},
+		Resources: map[string]spec.Resource{
+			"invoices": {Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/invoices", Response: spec.ResponseDef{Type: "array", Item: "Invoice"}, IDField: "invoice_id"},
+			}},
+			"zcustomers": {Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/customers", Response: spec.ResponseDef{Type: "array", Item: "Customer"}, IDField: "customer_id"},
+			}},
+		},
+		Types: map[string]spec.TypeDef{
+			"Invoice":  {Fields: []spec.TypeField{{Name: "invoice_id"}, {Name: "title"}, {Name: "state"}}},
+			"Customer": {Fields: []spec.TypeField{{Name: "customer_id"}, {Name: "display_name"}}},
+		},
+	}
+}

--- a/internal/generator/generated_examples_test.go
+++ b/internal/generator/generated_examples_test.go
@@ -67,6 +67,24 @@ func TestSelectExampleOmitsWhenResponseFieldsAreUnknown(t *testing.T) {
 	assert.Empty(t, selectExample(apiSpec, syncable))
 }
 
+func TestSelectExampleRejectsUnsafeFieldNames(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Resources: map[string]spec.Resource{
+			"items": {Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/items", Response: spec.ResponseDef{Type: "array", Item: "Item"}},
+			}},
+		},
+		Types: map[string]spec.TypeDef{
+			"Item": {Fields: []spec.TypeField{{Name: `bad"field`}}},
+		},
+	}
+
+	syncable := []profiler.SyncableResource{{Name: "items", Path: "/items", Method: "GET"}}
+	assert.Empty(t, selectExample(apiSpec, syncable))
+}
+
 func TestGeneratedExamplesUseAPIModelAcrossDocsAndSyncHelp(t *testing.T) {
 	t.Parallel()
 
@@ -88,7 +106,8 @@ func TestGeneratedExamplesUseAPIModelAcrossDocsAndSyncHelp(t *testing.T) {
 	}
 	assert.Contains(t, root, "--select invoice_id,title,state")
 	assert.NotContains(t, root, "--select id,name,status")
-	assert.Contains(t, sync, "--resources "+wantResources)
+	assert.Equal(t, "invoices,zcustomers", wantResources)
+	assert.Contains(t, sync, "--resources invoices,zcustomers")
 	assert.NotContains(t, sync, "--resources channels,messages")
 }
 
@@ -112,14 +131,9 @@ func TestGeneratedDocsOmitUnverifiableSelectExample(t *testing.T) {
 	t.Parallel()
 
 	apiSpec := modelExamplesSpec("unknown-select-example")
-	for name, resource := range apiSpec.Resources {
-		for endpointName, endpoint := range resource.Endpoints {
-			endpoint.Response.Item = ""
-			resource.Endpoints[endpointName] = endpoint
-		}
-		apiSpec.Resources[name] = resource
-	}
-	apiSpec.Types = nil
+	apiSpec.Resources["aempty"] = spec.Resource{Endpoints: map[string]spec.Endpoint{
+		"list": {Method: "GET", Path: "/aempty", Response: spec.ResponseDef{Type: "array"}, IDField: "aempty_id"},
+	}}
 
 	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
 	gen := New(apiSpec, outputDir)
@@ -129,6 +143,7 @@ func TestGeneratedDocsOmitUnverifiableSelectExample(t *testing.T) {
 	readme := readGeneratedFile(t, outputDir, "README.md")
 	skill := readGeneratedFile(t, outputDir, "SKILL.md")
 	root := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	assert.Empty(t, selectExampleForCommand(apiSpec))
 	assert.Contains(t, readme, "--select <field>[,<field>...]")
 	assert.NotContains(t, skill, "--select id,name,status")
 	assert.NotContains(t, skill, " --select ")

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1135,7 +1135,7 @@ func (g *Generator) readmeData() *readmeTemplateData {
 		HasAuth:               hasAuth(g.Spec.Auth),
 		HasAuthCommand:        g.shouldEmitAuth(),
 		HasAutoRefresh:        g.hasAutoRefresh(),
-		SelectExample:         selectExample(g.Spec, syncable),
+		SelectExample:         selectExampleForCommand(g.Spec),
 		SyncResourcesExample:  syncResourcesExample(syncable, dependent),
 		FreshnessCommands:     g.freshnessCommandPaths(),
 		TrafficAnalysis:       g.trafficAnalysisData(),
@@ -5235,7 +5235,7 @@ func (g *Generator) renderRootProjectFiles(promotedCommands []PromotedCommand, p
 		HasDelete:             helperFlags.HasDelete,
 		HasMutationEndpoints:  helperFlags.HasMutationEndpoints,
 		HasAutoRefresh:        g.hasAutoRefresh(),
-		SelectExample:         selectExample(g.Spec, g.profile.SyncableResources),
+		SelectExample:         selectExampleForCommand(g.Spec),
 		HasWorkflow:           g.hasWorkflowSurface(),
 		CompactDescription:    g.compactDescription(),
 	}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1057,10 +1057,12 @@ type readmeTemplateData struct {
 	// command emission. Distinct from HasAuth: an empty auth type still emits
 	// the auth surface, and docs must follow the emitted surface, not the
 	// spec's declared type.
-	HasAuthCommand    bool
-	HasAutoRefresh    bool
-	FreshnessCommands []string
-	TrafficAnalysis   *trafficAnalysisTemplateData
+	HasAuthCommand       bool
+	HasAutoRefresh       bool
+	SelectExample        string
+	SyncResourcesExample string
+	FreshnessCommands    []string
+	TrafficAnalysis      *trafficAnalysisTemplateData
 	// PromotedResourceNames maps a resource name to true when the generator
 	// collapsed that single-endpoint resource into a leaf command. Templates
 	// (notably skill.md.tmpl's Command Reference) use this to emit `<cli>
@@ -1109,6 +1111,12 @@ func (g *Generator) readmeData() *readmeTemplateData {
 			g.Spec.WebsiteURL = u.Scheme + "://" + u.Host
 		}
 	}
+	var syncable []profiler.SyncableResource
+	var dependent []profiler.DependentResource
+	if g.profile != nil {
+		syncable = g.profile.SyncableResources
+		dependent = g.profile.DependentSyncResources
+	}
 	return &readmeTemplateData{
 		APISpec:               g.Spec,
 		Sources:               g.Sources,
@@ -1127,6 +1135,8 @@ func (g *Generator) readmeData() *readmeTemplateData {
 		HasAuth:               hasAuth(g.Spec.Auth),
 		HasAuthCommand:        g.shouldEmitAuth(),
 		HasAutoRefresh:        g.hasAutoRefresh(),
+		SelectExample:         selectExample(g.Spec, syncable),
+		SyncResourcesExample:  syncResourcesExample(syncable, dependent),
 		FreshnessCommands:     g.freshnessCommandPaths(),
 		TrafficAnalysis:       g.trafficAnalysisData(),
 		PromotedResourceNames: g.PromotedResourceNames,
@@ -4059,6 +4069,7 @@ type visionRenderData struct {
 	HasSync                      bool
 	SyncableResources            []profiler.SyncableResource
 	DependentSyncResources       []profiler.DependentResource
+	SyncResourcesExample         string
 	TenantScopedParents          []profiler.TenantScopedParent
 	MembershipScopedParents      []profiler.MembershipScopedParent
 	PaginationSupportedResources []string
@@ -4453,6 +4464,7 @@ func (g *Generator) visionRenderData(schema []TableDef) visionRenderData {
 		HasSync:                      g.hasGeneratedSyncImplementation(),
 		SyncableResources:            g.profile.SyncableResources,
 		DependentSyncResources:       g.profile.DependentSyncResources,
+		SyncResourcesExample:         syncResourcesExample(g.profile.SyncableResources, g.profile.DependentSyncResources),
 		TenantScopedParents:          g.profile.TenantScopedParents(),
 		MembershipScopedParents:      g.profile.MembershipScopedParents(),
 		PaginationSupportedResources: paginationSupportedResources(g.profile.SyncableResources, g.profile.DependentSyncResources),
@@ -5201,6 +5213,7 @@ func (g *Generator) renderRootProjectFiles(promotedCommands []PromotedCommand, p
 		HasDelete             bool
 		HasMutationEndpoints  bool
 		HasAutoRefresh        bool
+		SelectExample         string
 		HasWorkflow           bool
 		CompactDescription    string
 	}{
@@ -5222,6 +5235,7 @@ func (g *Generator) renderRootProjectFiles(promotedCommands []PromotedCommand, p
 		HasDelete:             helperFlags.HasDelete,
 		HasMutationEndpoints:  helperFlags.HasMutationEndpoints,
 		HasAutoRefresh:        g.hasAutoRefresh(),
+		SelectExample:         selectExample(g.Spec, g.profile.SyncableResources),
 		HasWorkflow:           g.hasWorkflowSurface(),
 		CompactDescription:    g.compactDescription(),
 	}

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -62,8 +62,10 @@ Exit codes & warnings:
 		Example: `  # Sync all resources
   {{.Name}}-pp-cli sync
 
+{{- if .SyncResourcesExample}}
   # Sync specific resources only
-  {{.Name}}-pp-cli sync --resources channels,messages
+  {{.Name}}-pp-cli sync --resources {{.SyncResourcesExample}}
+{{- end}}
 
   # Full resync (ignore previous checkpoint)
   {{.Name}}-pp-cli sync --full

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -519,8 +519,13 @@ The local store's schema version stamp is one-way: once this version of `{{$.Nam
 # JSON for scripting and agents
 {{.Name}}-pp-cli {{$example}} --json
 
+{{- if .SelectExample}}
 # Filter to specific fields
-{{.Name}}-pp-cli {{$example}} --json --select id,name,status
+{{.Name}}-pp-cli {{$example}} --json --select {{.SelectExample}}
+{{- else}}
+# Filter to specific fields by name
+{{.Name}}-pp-cli {{$example}} --json --select <field>[,<field>...]
+{{- end}}
 
 # Dry run — show the request without sending
 {{.Name}}-pp-cli {{$example}} --dry-run
@@ -533,7 +538,7 @@ The local store's schema version stamp is one-way: once this version of `{{$.Nam
 Every command supports these output flags:
 
 - `--json` — structured output for scripting and agents
-- `--select id,name,status` — filter to specific fields
+- `--select <field>[,<field>...]` — filter to specific fields
 - `--dry-run` — preview the request without sending
 - `--agent` — JSON + compact + non-interactive in one flag
 {{- end}}
@@ -544,7 +549,7 @@ This CLI is designed for AI agent consumption:
 
 - **Non-interactive** - never prompts, every input is a flag
 - **Pipeable** - `--json` output to stdout, errors to stderr
-- **Filterable** - `--select id,name` returns only fields you need
+- **Filterable** - `--select <field>[,<field>...]` returns only fields you need
 - **Previewable** - `--dry-run` shows the request without sending
 {{- if .HasWriteCommands}}
 {{- if or .HasCreateCommands .HasDelete}}

--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -365,7 +365,7 @@ Run '{{.Name}}-pp-cli doctor' to verify auth and connectivity.{{backtick}},
 {{- if .HasDelete}}
 	rootCmd.PersistentFlags().BoolVar(&flags.ignoreMissing, "ignore-missing", false, "Treat missing delete targets as a successful no-op")
 {{- end}}
-	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output (e.g. --select id,name,status)")
+	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output{{if .SelectExample}} (e.g. --select {{.SelectExample}}){{end}}")
 	rootCmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Skip confirmation prompts (for agents and scripts)")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colored output")
 	rootCmd.PersistentFlags().BoolVar(&humanFriendly, "human-friendly", false, "Enable colored output and rich formatting")

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -316,7 +316,7 @@ Add `--agent` to any command. Expands to: `--json --compact --no-input --no-colo
   ```bash
   {{- $agentExample := firstCommandExample .Resources}}
   {{- if $agentExample}}
-  {{.Name}}-pp-cli {{$agentExample}} --agent --select id,name,status
+  {{.Name}}-pp-cli {{$agentExample}} --agent{{if .SelectExample}} --select {{.SelectExample}}{{end}}
   {{- else}}
   {{.Name}}-pp-cli --help
   {{- end}}

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -158,8 +158,10 @@ Resource scoping:
 		Example: `  # Sync all resources
   {{.Name}}-pp-cli sync
 
+{{- if .SyncResourcesExample}}
   # Sync specific resources only
-  {{.Name}}-pp-cli sync --resources channels,messages
+  {{.Name}}-pp-cli sync --resources {{.SyncResourcesExample}}
+{{- end}}
 
   # Full resync (ignore previous checkpoint)
   {{.Name}}-pp-cli sync --full

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/root.go
@@ -241,7 +241,7 @@ Run 'fastapi-operationids-golden-pp-cli doctor' to verify auth and connectivity.
 	rootCmd.PersistentFlags().BoolVar(&flags.noInput, "no-input", false, "Disable all interactive prompts (for CI/agents)")
 	rootCmd.PersistentFlags().BoolVar(&flags.idempotent, "idempotent", false, "Treat already-existing create results as a successful no-op")
 	rootCmd.PersistentFlags().BoolVar(&flags.ignoreMissing, "ignore-missing", false, "Treat missing delete targets as a successful no-op")
-	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output (e.g. --select id)")
+	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output")
 	rootCmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Skip confirmation prompts (for agents and scripts)")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colored output")
 	rootCmd.PersistentFlags().BoolVar(&humanFriendly, "human-friendly", false, "Enable colored output and rich formatting")

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/root.go
@@ -241,7 +241,7 @@ Run 'fastapi-operationids-golden-pp-cli doctor' to verify auth and connectivity.
 	rootCmd.PersistentFlags().BoolVar(&flags.noInput, "no-input", false, "Disable all interactive prompts (for CI/agents)")
 	rootCmd.PersistentFlags().BoolVar(&flags.idempotent, "idempotent", false, "Treat already-existing create results as a successful no-op")
 	rootCmd.PersistentFlags().BoolVar(&flags.ignoreMissing, "ignore-missing", false, "Treat missing delete targets as a successful no-op")
-	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output (e.g. --select id,name,status)")
+	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output (e.g. --select id)")
 	rootCmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Skip confirmation prompts (for agents and scripts)")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colored output")
 	rootCmd.PersistentFlags().BoolVar(&humanFriendly, "human-friendly", false, "Enable colored output and rich formatting")

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/README.md
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/README.md
@@ -235,9 +235,8 @@ printing-press-oauth2-pp-cli items
 
 # JSON for scripting and agents
 printing-press-oauth2-pp-cli items --json
-
 # Filter to specific fields
-printing-press-oauth2-pp-cli items --json --select id,name,status
+printing-press-oauth2-pp-cli items --json --select id,name
 
 # Dry run — show the request without sending
 printing-press-oauth2-pp-cli items --dry-run
@@ -252,7 +251,7 @@ This CLI is designed for AI agent consumption:
 
 - **Non-interactive** - never prompts, every input is a flag
 - **Pipeable** - `--json` output to stdout, errors to stderr
-- **Filterable** - `--select id,name` returns only fields you need
+- **Filterable** - `--select <field>[,<field>...]` returns only fields you need
 - **Previewable** - `--dry-run` shows the request without sending
 - **Read-only by default** - this CLI does not create, update, delete, publish, send, or mutate remote resources
 - **Offline-friendly** - sync/search commands can use the local SQLite store when available

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/SKILL.md
@@ -73,7 +73,7 @@ Add `--agent` to any command. Expands to: `--json --compact --no-input --no-colo
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
 
   ```bash
-  printing-press-oauth2-pp-cli items --agent --select id,name,status
+  printing-press-oauth2-pp-cli items --agent --select id,name
   ```
 - **Previewable** — `--dry-run` shows the request without sending
 - **Offline-friendly** — sync/search commands can use the local SQLite store when available

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/README.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/README.md
@@ -227,9 +227,8 @@ printing-press-rich-pp-cli items
 
 # JSON for scripting and agents
 printing-press-rich-pp-cli items --json
-
 # Filter to specific fields
-printing-press-rich-pp-cli items --json --select id,name,status
+printing-press-rich-pp-cli items --json --select id,name
 
 # Dry run — show the request without sending
 printing-press-rich-pp-cli items --dry-run
@@ -244,7 +243,7 @@ This CLI is designed for AI agent consumption:
 
 - **Non-interactive** - never prompts, every input is a flag
 - **Pipeable** - `--json` output to stdout, errors to stderr
-- **Filterable** - `--select id,name` returns only fields you need
+- **Filterable** - `--select <field>[,<field>...]` returns only fields you need
 - **Previewable** - `--dry-run` shows the request without sending
 - **Read-only by default** - this CLI does not create, update, delete, publish, send, or mutate remote resources
 - **Offline-friendly** - sync/search commands can use the local SQLite store when available

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/SKILL.md
@@ -71,7 +71,7 @@ Add `--agent` to any command. Expands to: `--json --compact --no-input --no-colo
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
 
   ```bash
-  printing-press-rich-pp-cli items --agent --select id,name,status
+  printing-press-rich-pp-cli items --agent --select id,name
   ```
 - **Previewable** — `--dry-run` shows the request without sending
 - **Offline-friendly** — sync/search commands can use the local SQLite store when available

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
@@ -246,9 +246,8 @@ printing-press-golden-pp-cli currencies --x-api-version example-value
 
 # JSON for scripting and agents
 printing-press-golden-pp-cli currencies --x-api-version example-value --json
-
 # Filter to specific fields
-printing-press-golden-pp-cli currencies --x-api-version example-value --json --select id,name,status
+printing-press-golden-pp-cli currencies --x-api-version example-value --json --select code,decimals,symbol
 
 # Dry run — show the request without sending
 printing-press-golden-pp-cli currencies --x-api-version example-value --dry-run
@@ -263,7 +262,7 @@ This CLI is designed for AI agent consumption:
 
 - **Non-interactive** - never prompts, every input is a flag
 - **Pipeable** - `--json` output to stdout, errors to stderr
-- **Filterable** - `--select id,name` returns only fields you need
+- **Filterable** - `--select <field>[,<field>...]` returns only fields you need
 - **Previewable** - `--dry-run` shows the request without sending
 - **Explicit retries** - add `--idempotent` to create retries when a no-op success is acceptable
 - **Confirmable** - `--yes` for explicit confirmation of destructive actions

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
@@ -97,7 +97,7 @@ Add `--agent` to any command. Expands to: `--json --compact --no-input --no-colo
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
 
   ```bash
-  printing-press-golden-pp-cli currencies --x-api-version example-value --agent --select id,name,status
+  printing-press-golden-pp-cli currencies --x-api-version example-value --agent --select code,decimals,symbol
   ```
 - **Previewable** — `--dry-run` shows the request without sending
 - **Offline-friendly** — sync/search commands can use the local SQLite store when available

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
@@ -268,7 +268,7 @@ Run 'printing-press-golden-pp-cli doctor' to verify auth and connectivity.`,
 	rootCmd.PersistentFlags().StringVar(&flags.auditDir, "audit-dir", "", "Aggregate the receipt and index under this audit directory")
 	rootCmd.PersistentFlags().BoolVar(&flags.noInput, "no-input", false, "Disable all interactive prompts (for CI/agents)")
 	rootCmd.PersistentFlags().BoolVar(&flags.idempotent, "idempotent", false, "Treat already-existing create results as a successful no-op")
-	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output (e.g. --select id,name,status)")
+	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output (e.g. --select code,decimals,symbol)")
 	rootCmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Skip confirmation prompts (for agents and scripts)")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colored output")
 	rootCmd.PersistentFlags().BoolVar(&humanFriendly, "human-friendly", false, "Enable colored output and rich formatting")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -96,9 +96,8 @@ Resource scoping:
   from a prior sync.`,
 		Example: `  # Sync all resources
   printing-press-golden-pp-cli sync
-
   # Sync specific resources only
-  printing-press-golden-pp-cli sync --resources channels,messages
+  printing-press-golden-pp-cli sync --resources projects,currencies
 
   # Full resync (ignore previous checkpoint)
   printing-press-golden-pp-cli sync --full

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/README.md
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/README.md
@@ -222,9 +222,8 @@ learn-disabled-example-pp-cli games
 
 # JSON for scripting and agents
 learn-disabled-example-pp-cli games --json
-
-# Filter to specific fields
-learn-disabled-example-pp-cli games --json --select id,name,status
+# Filter to specific fields by name
+learn-disabled-example-pp-cli games --json --select <field>[,<field>...]
 
 # Dry run — show the request without sending
 learn-disabled-example-pp-cli games --dry-run
@@ -239,7 +238,7 @@ This CLI is designed for AI agent consumption:
 
 - **Non-interactive** - never prompts, every input is a flag
 - **Pipeable** - `--json` output to stdout, errors to stderr
-- **Filterable** - `--select id,name` returns only fields you need
+- **Filterable** - `--select <field>[,<field>...]` returns only fields you need
 - **Previewable** - `--dry-run` shows the request without sending
 - **Read-only by default** - this CLI does not create, update, delete, publish, send, or mutate remote resources
 - **Offline-friendly** - sync/search commands can use the local SQLite store when available

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/SKILL.md
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/SKILL.md
@@ -80,7 +80,7 @@ Add `--agent` to any command. Expands to: `--json --compact --no-input --no-colo
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
 
   ```bash
-  learn-disabled-example-pp-cli games --agent --select id,name,status
+  learn-disabled-example-pp-cli games --agent
   ```
 - **Previewable** — `--dry-run` shows the request without sending
 - **Offline-friendly** — sync/search commands can use the local SQLite store when available

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/cli/root.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/cli/root.go
@@ -242,7 +242,7 @@ Run 'learn-disabled-example-pp-cli doctor' to verify auth and connectivity.`,
 	rootCmd.PersistentFlags().StringVar(&flags.receiptFile, "receipt-file", "", "Override the run receipt destination")
 	rootCmd.PersistentFlags().StringVar(&flags.auditDir, "audit-dir", "", "Aggregate the receipt and index under this audit directory")
 	rootCmd.PersistentFlags().BoolVar(&flags.noInput, "no-input", false, "Disable all interactive prompts (for CI/agents)")
-	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output (e.g. --select id,name,status)")
+	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output")
 	rootCmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Skip confirmation prompts (for agents and scripts)")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colored output")
 	rootCmd.PersistentFlags().BoolVar(&humanFriendly, "human-friendly", false, "Enable colored output and rich formatting")

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/README.md
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/README.md
@@ -248,9 +248,8 @@ learn-loop-example-pp-cli games
 
 # JSON for scripting and agents
 learn-loop-example-pp-cli games --json
-
-# Filter to specific fields
-learn-loop-example-pp-cli games --json --select id,name,status
+# Filter to specific fields by name
+learn-loop-example-pp-cli games --json --select <field>[,<field>...]
 
 # Dry run — show the request without sending
 learn-loop-example-pp-cli games --dry-run
@@ -265,7 +264,7 @@ This CLI is designed for AI agent consumption:
 
 - **Non-interactive** - never prompts, every input is a flag
 - **Pipeable** - `--json` output to stdout, errors to stderr
-- **Filterable** - `--select id,name` returns only fields you need
+- **Filterable** - `--select <field>[,<field>...]` returns only fields you need
 - **Previewable** - `--dry-run` shows the request without sending
 - **Read-only by default** - this CLI does not create, update, delete, publish, send, or mutate remote resources
 - **Offline-friendly** - sync/search commands can use the local SQLite store when available

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/SKILL.md
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/SKILL.md
@@ -87,7 +87,7 @@ Add `--agent` to any command. Expands to: `--json --compact --no-input --no-colo
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
 
   ```bash
-  learn-loop-example-pp-cli games --agent --select id,name,status
+  learn-loop-example-pp-cli games --agent
   ```
 - **Previewable** — `--dry-run` shows the request without sending
 - **Offline-friendly** — sync/search commands can use the local SQLite store when available

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/root.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/root.go
@@ -261,7 +261,7 @@ Run 'learn-loop-example-pp-cli doctor' to verify auth and connectivity.`,
 	rootCmd.PersistentFlags().StringVar(&flags.receiptFile, "receipt-file", "", "Override the run receipt destination")
 	rootCmd.PersistentFlags().StringVar(&flags.auditDir, "audit-dir", "", "Aggregate the receipt and index under this audit directory")
 	rootCmd.PersistentFlags().BoolVar(&flags.noInput, "no-input", false, "Disable all interactive prompts (for CI/agents)")
-	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output (e.g. --select id,name,status)")
+	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output")
 	rootCmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Skip confirmation prompts (for agents and scripts)")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colored output")
 	rootCmd.PersistentFlags().BoolVar(&humanFriendly, "human-friendly", false, "Enable colored output and rich formatting")

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/README.md
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/README.md
@@ -214,9 +214,8 @@ public-param-golden-pp-cli stores find --address example-value --city example-va
 
 # JSON for scripting and agents
 public-param-golden-pp-cli stores find --address example-value --city example-value --location-id 550e8400-e29b-41d4-a716-446655440000 --json
-
 # Filter to specific fields
-public-param-golden-pp-cli stores find --address example-value --city example-value --location-id 550e8400-e29b-41d4-a716-446655440000 --json --select id,name,status
+public-param-golden-pp-cli stores find --address example-value --city example-value --location-id 550e8400-e29b-41d4-a716-446655440000 --json --select id,name
 
 # Dry run — show the request without sending
 public-param-golden-pp-cli stores find --address example-value --city example-value --location-id 550e8400-e29b-41d4-a716-446655440000 --dry-run
@@ -231,7 +230,7 @@ This CLI is designed for AI agent consumption:
 
 - **Non-interactive** - never prompts, every input is a flag
 - **Pipeable** - `--json` output to stdout, errors to stderr
-- **Filterable** - `--select id,name` returns only fields you need
+- **Filterable** - `--select <field>[,<field>...]` returns only fields you need
 - **Previewable** - `--dry-run` shows the request without sending
 - **Explicit retries** - add `--idempotent` to create retries when a no-op success is acceptable
 - **Confirmable** - `--yes` for explicit confirmation of destructive actions

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/SKILL.md
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/SKILL.md
@@ -63,7 +63,7 @@ Add `--agent` to any command. Expands to: `--json --compact --no-input --no-colo
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
 
   ```bash
-  public-param-golden-pp-cli stores find --address example-value --city example-value --location-id 550e8400-e29b-41d4-a716-446655440000 --agent --select id,name,status
+  public-param-golden-pp-cli stores find --address example-value --city example-value --location-id 550e8400-e29b-41d4-a716-446655440000 --agent --select id,name
   ```
 - **Previewable** — `--dry-run` shows the request without sending
 - **Offline-friendly** — sync/search commands can use the local SQLite store when available

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -94,9 +94,8 @@ Resource scoping:
   from a prior sync.`,
 		Example: `  # Sync all resources
   query-endpoint-golden-pp-cli sync
-
   # Sync specific resources only
-  query-endpoint-golden-pp-cli sync --resources channels,messages
+  query-endpoint-golden-pp-cli sync --resources gadgets,widgets
 
   # Full resync (ignore previous checkpoint)
   query-endpoint-golden-pp-cli sync --full

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -96,9 +96,8 @@ Resource scoping:
   from a prior sync.`,
 		Example: `  # Sync all resources
   sync-walker-golden-pp-cli sync
-
   # Sync specific resources only
-  sync-walker-golden-pp-cli sync --resources channels,messages
+  sync-walker-golden-pp-cli sync --resources games
 
   # Full resync (ignore previous checkpoint)
   sync-walker-golden-pp-cli sync --full

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -94,9 +94,8 @@ Resource scoping:
   from a prior sync.`,
 		Example: `  # Sync all resources
   tier-routing-golden-pp-cli sync
-
   # Sync specific resources only
-  tier-routing-golden-pp-cli sync --resources channels,messages
+  tier-routing-golden-pp-cli sync --resources items
 
   # Full resync (ignore previous checkpoint)
   tier-routing-golden-pp-cli sync --full


### PR DESCRIPTION
## Summary

The generator now derives `sync --resources` and `--select` examples from the current API model instead of emitting fixed values that are often invalid. The generated root help, README, and SKILL use the same command and response-field selection logic, with a generic fallback when no safe concrete example can be derived.

## Implementation

- Derive sync resource examples from the profile's actual syncable and dependent resources.
- Derive selector examples from the response item model for the selected command.
- Share first-command selection between generated help and documentation so examples stay aligned.
- Omit unverifiable selector values rather than emitting unsafe or guessed field names.
- Add REST and GraphQL generation fixtures covering concrete examples, fallback behavior, and help/documentation parity.

## Verification

- Focused `internal/generator` tests for resource derivation, field derivation, REST and GraphQL output, fallback behavior, and parity.
- `scripts/golden.sh verify` passed all 32 cases.
- `scripts/verify-generator-output.sh` passed all 10 cases.
- `go fmt ./...` passed.
- `golangci-lint run ./internal/generator` passed.
- `go build -o ./cli-printing-press ./cmd/cli-printing-press` passed.
- `git diff --check` passed.

A full `go test ./...` run was attempted. It remains blocked by unrelated verify-mode BLE expectations and environment-sensitive generated learning/store tests; the affected generator tests and generated-output compilation checks pass.

Closes #4052
Closes #3971
