### PR TITLE
fix(cli): preserve multi-spec merge integrity

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1562,6 +1562,274 @@ func TestMergeSpecsDeduplicatesTrailingSlashEndpointResourceCollision(t *testing
 	assert.Equal(t, "/v1beta/accounts", merged.Resources["accounts"].Endpoints["list"].Path)
 }
 
+func TestMergeSpecsPreservesPrimaryAuthModelWhileFillingMissingOAuthMetadata(t *testing.T) {
+	t.Parallel()
+
+	primary := &spec.APISpec{
+		Name:    "curated",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:   "bearer_token",
+			Header: "Authorization",
+			Format: "Bearer {token}",
+			EnvVars: []string{
+				"CURATED_TOKEN",
+			},
+			EnvVarSpecs: []spec.AuthEnvVar{
+				{Name: "CURATED_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+			},
+		},
+		Resources: map[string]spec.Resource{
+			"items": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/items"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	secondary := &spec.APISpec{
+		Name:    "vendor",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:             "bearer_token",
+			Header:           "Authorization",
+			Format:           "Bearer {access_token}",
+			AuthorizationURL: "https://accounts.example.com/authorize",
+			TokenURL:         "https://accounts.example.com/token",
+			EnvVars:          []string{"VENDOR_ACCESS_TOKEN"},
+			EnvVarSpecs: []spec.AuthEnvVar{
+				{Name: "VENDOR_ACCESS_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+			},
+		},
+		Resources: map[string]spec.Resource{
+			"vendor": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/vendor"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{primary, secondary}, "combo")
+
+	assert.Equal(t, "bearer_token", merged.Auth.Type)
+	assert.Equal(t, "Authorization", merged.Auth.Header)
+	assert.Equal(t, "Bearer {token}", merged.Auth.Format)
+	assert.Equal(t, []string{"CURATED_TOKEN"}, merged.Auth.EnvVars)
+	assert.Equal(t, []string{"CURATED_TOKEN"}, authEnvVarNames(merged.Auth.EnvVarSpecs))
+	assert.Equal(t, "https://accounts.example.com/authorize", merged.Auth.AuthorizationURL)
+	assert.Equal(t, "https://accounts.example.com/token", merged.Auth.TokenURL)
+}
+
+func TestMergeSpecsDoesNotCopyOAuthMetadataAcrossAuthModels(t *testing.T) {
+	t.Parallel()
+
+	primary := &spec.APISpec{
+		Name:    "keyed",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:   "api_key",
+			Header: "X-API-Key",
+			In:     "header",
+			EnvVarSpecs: []spec.AuthEnvVar{
+				{Name: "API_KEY", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+			},
+		},
+		Resources: map[string]spec.Resource{
+			"items": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/items"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	secondary := &spec.APISpec{
+		Name:    "oauth",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:             "bearer_token",
+			Header:           "Authorization",
+			AuthorizationURL: "https://accounts.example.com/authorize",
+			TokenURL:         "https://accounts.example.com/token",
+		},
+		Resources: map[string]spec.Resource{
+			"oauth": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/oauth"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{primary, secondary}, "combo")
+
+	assert.Equal(t, "api_key", merged.Auth.Type)
+	assert.Empty(t, merged.Auth.AuthorizationURL)
+	assert.Empty(t, merged.Auth.TokenURL)
+	assert.Equal(t, []string{"API_KEY"}, authEnvVarNames(merged.Auth.EnvVarSpecs))
+}
+
+func TestMergeSpecsPreservesRequiredHeadersAndLearnFromLaterSpecs(t *testing.T) {
+	t.Parallel()
+
+	primary := &spec.APISpec{
+		Name:            "primary",
+		Version:         "0.1.0",
+		BaseURL:         "https://api.example.com",
+		RequiredHeaders: []spec.RequiredHeader{{Name: "X-Primary", Value: "one"}},
+		Learn: spec.LearnConfig{
+			TickerPatterns: []string{"PRIMARY-[0-9]+"},
+		},
+		Resources: map[string]spec.Resource{
+			"primary": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/primary"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	secondary := &spec.APISpec{
+		Name:            "secondary",
+		Version:         "0.1.0",
+		BaseURL:         "https://api.example.com",
+		RequiredHeaders: []spec.RequiredHeader{{Name: "X-Secondary", Value: "two"}},
+		Learn: spec.LearnConfig{
+			Enabled:        true,
+			TickerPatterns: []string{"SECONDARY-[0-9]+", "PRIMARY-[0-9]+"},
+			Stopwords:      []string{"the"},
+			Synonyms:       map[string]string{"yesterday": "prior day"},
+			EntityLookupSeeds: map[string][]spec.LookupSeed{
+				"team": {{Canonical: "Acme", Aliases: []string{"acme corp"}}},
+			},
+		},
+		Resources: map[string]spec.Resource{
+			"secondary": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/secondary"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{primary, secondary}, "combo")
+
+	assert.Equal(t, []spec.RequiredHeader{
+		{Name: "X-Primary", Value: "one"},
+		{Name: "X-Secondary", Value: "two"},
+	}, merged.RequiredHeaders)
+	assert.Equal(t, spec.LearnConfig{
+		Enabled:        true,
+		TickerPatterns: []string{"PRIMARY-[0-9]+", "SECONDARY-[0-9]+"},
+		Stopwords:      []string{"the"},
+		Synonyms:       map[string]string{"yesterday": "prior day"},
+		EntityLookupSeeds: map[string][]spec.LookupSeed{
+			"team": {{Canonical: "Acme", Aliases: []string{"acme corp"}}},
+		},
+	}, merged.Learn)
+}
+
+func TestMergeSpecsDeduplicatesAcrossResourceNamesButKeepsDistinctEndpoints(t *testing.T) {
+	t.Parallel()
+
+	primary := &spec.APISpec{
+		Name:    "curated",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"messages": {Endpoints: map[string]spec.Endpoint{
+				"create": {Method: "POST", Path: "/messages", Params: []spec.Param{{Name: "channel", In: "query", Type: "string", Required: true}}},
+			}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	secondary := &spec.APISpec{
+		Name:    "vendor",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"chat": {Endpoints: map[string]spec.Endpoint{
+				"post_message": {Method: "POST", Path: "/messages", Params: []spec.Param{{Name: "channel", In: "query", Type: "string", Required: true}}},
+				"history":      {Method: "GET", Path: "/messages/history"},
+			}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{primary, secondary}, "combo")
+
+	require.Contains(t, merged.Resources, "chat")
+	assert.NotContains(t, merged.Resources["chat"].Endpoints, "post_message")
+	assert.Contains(t, merged.Resources["chat"].Endpoints, "history")
+}
+
+func TestMergeSpecsRewritesMCPIntentWhenDuplicateResourceIsDropped(t *testing.T) {
+	t.Parallel()
+
+	primary := &spec.APISpec{
+		Name:    "curated",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"messages": {Endpoints: map[string]spec.Endpoint{
+				"create": {Method: "POST", Path: "/messages"},
+			}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	secondary := &spec.APISpec{
+		Name:    "vendor",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"chat": {Endpoints: map[string]spec.Endpoint{
+				"post_message": {Method: "POST", Path: "/messages"},
+			}},
+		},
+		Types: map[string]spec.TypeDef{},
+		MCP: spec.MCPConfig{
+			Intents: []spec.Intent{{
+				Name:        "send_message",
+				Description: "Send a message",
+				Steps:       []spec.IntentStep{{Endpoint: "chat.post_message"}},
+			}},
+		},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{primary, secondary}, "combo")
+
+	assert.NotContains(t, merged.Resources, "chat")
+	require.Len(t, merged.MCP.Intents, 1)
+	require.Len(t, merged.MCP.Intents[0].Steps, 1)
+	assert.Equal(t, "messages.create", merged.MCP.Intents[0].Steps[0].Endpoint)
+	assert.NoError(t, merged.Validate())
+}
+
+func TestMergeSpecsKeepsSameRouteWhenParameterShapesDiffer(t *testing.T) {
+	t.Parallel()
+
+	specA := &spec.APISpec{
+		Name:    "a",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"items": {Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/items", Params: []spec.Param{{Name: "limit", In: "query", Type: "integer"}}},
+			}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	specB := &spec.APISpec{
+		Name:    "b",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"items": {Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/items", Params: []spec.Param{{Name: "cursor", In: "query", Type: "string"}}},
+			}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{specA, specB}, "combo")
+
+	assert.Contains(t, merged.Resources, "items")
+	assert.Contains(t, merged.Resources, "b-items")
+}
+
+func authEnvVarNames(envVars []spec.AuthEnvVar) []string {
+	names := make([]string, 0, len(envVars))
+	for _, envVar := range envVars {
+		names = append(names, envVar.Name)
+	}
+	return names
+}
+
 func TestMergeSpecsNamePrefixOptInKeepsNamespacedResourceForm(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1994,6 +1994,49 @@ func TestMergeSpecsRewritesLaterDuplicateToRenamedCanonicalResource(t *testing.T
 	assert.NoError(t, merged.Validate())
 }
 
+func TestMergeSpecsRewritesSiblingDuplicateToRenamedCanonicalResource(t *testing.T) {
+	t.Parallel()
+
+	primary := &spec.APISpec{
+		Name:    "primary",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"chat": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/chat"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	secondary := &spec.APISpec{
+		Name:    "vendor",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"chat": {Endpoints: map[string]spec.Endpoint{
+				"first":  {Method: "GET", Path: "/chat/history"},
+				"second": {Method: "GET", Path: "/chat/history"},
+			}},
+		},
+		Types: map[string]spec.TypeDef{},
+		MCP: spec.MCPConfig{
+			Intents: []spec.Intent{{
+				Name:        "read_history",
+				Description: "Read history",
+				Steps:       []spec.IntentStep{{Endpoint: "chat.second"}},
+			}},
+		},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{primary, secondary}, "combo")
+
+	require.Contains(t, merged.Resources, "vendor-chat")
+	assert.Contains(t, merged.Resources["vendor-chat"].Endpoints, "first")
+	assert.NotContains(t, merged.Resources["vendor-chat"].Endpoints, "second")
+	require.Len(t, merged.MCP.Intents, 1)
+	require.Len(t, merged.MCP.Intents[0].Steps, 1)
+	assert.Equal(t, "vendor-chat.first", merged.MCP.Intents[0].Steps[0].Endpoint)
+	assert.NoError(t, merged.Validate())
+}
+
 func TestMergeSpecsKeepsSameRouteWhenParameterShapesDiffer(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1703,6 +1703,46 @@ func TestMergeSpecsRejectsConflictingOAuthAuthoritiesAndGrants(t *testing.T) {
 	assert.Equal(t, spec.OAuth2GrantAuthorizationCode, merged.Auth.OAuth2Grant)
 }
 
+func TestMergeSpecsRejectsConflictingBearerOAuthGrants(t *testing.T) {
+	t.Parallel()
+
+	primary := &spec.APISpec{
+		Name:    "primary",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:             "bearer_token",
+			Header:           "Authorization",
+			AuthorizationURL: "https://idp-primary.example.com/authorize",
+		},
+		Resources: map[string]spec.Resource{
+			"items": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/items"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	secondary := &spec.APISpec{
+		Name:    "secondary",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:             "bearer_token",
+			Header:           "Authorization",
+			AuthorizationURL: "https://idp-secondary.example.com/authorize",
+			TokenURL:         "https://idp-secondary.example.com/token",
+			OAuth2Grant:      spec.OAuth2GrantClientCredentials,
+		},
+		Resources: map[string]spec.Resource{
+			"other": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/other"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{primary, secondary}, "combo")
+
+	assert.Equal(t, "https://idp-primary.example.com/authorize", merged.Auth.AuthorizationURL)
+	assert.Empty(t, merged.Auth.TokenURL)
+}
+
 func TestMergeSpecsPreservesRequiredHeadersAndLearnFromLaterSpecs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1661,6 +1661,48 @@ func TestMergeSpecsDoesNotCopyOAuthMetadataAcrossAuthModels(t *testing.T) {
 	assert.Equal(t, []string{"API_KEY"}, authEnvVarNames(merged.Auth.EnvVarSpecs))
 }
 
+func TestMergeSpecsRejectsConflictingOAuthAuthoritiesAndGrants(t *testing.T) {
+	t.Parallel()
+
+	primary := &spec.APISpec{
+		Name:    "primary",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:             "oauth2",
+			Header:           "Authorization",
+			AuthorizationURL: "https://idp-primary.example.com/authorize",
+			OAuth2Grant:      spec.OAuth2GrantAuthorizationCode,
+		},
+		Resources: map[string]spec.Resource{
+			"items": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/items"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	secondary := &spec.APISpec{
+		Name:    "secondary",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:             "oauth2",
+			Header:           "Authorization",
+			AuthorizationURL: "https://idp-secondary.example.com/authorize",
+			TokenURL:         "https://idp-secondary.example.com/token",
+			OAuth2Grant:      spec.OAuth2GrantClientCredentials,
+		},
+		Resources: map[string]spec.Resource{
+			"other": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/other"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{primary, secondary}, "combo")
+
+	assert.Equal(t, "https://idp-primary.example.com/authorize", merged.Auth.AuthorizationURL)
+	assert.Empty(t, merged.Auth.TokenURL)
+	assert.Equal(t, spec.OAuth2GrantAuthorizationCode, merged.Auth.OAuth2Grant)
+}
+
 func TestMergeSpecsPreservesRequiredHeadersAndLearnFromLaterSpecs(t *testing.T) {
 	t.Parallel()
 
@@ -1712,6 +1754,77 @@ func TestMergeSpecsPreservesRequiredHeadersAndLearnFromLaterSpecs(t *testing.T) 
 			"team": {{Canonical: "Acme", Aliases: []string{"acme corp"}}},
 		},
 	}, merged.Learn)
+}
+
+func TestMergeSpecsScopesConflictingRequiredHeadersToTheirSourceEndpoints(t *testing.T) {
+	t.Parallel()
+
+	primary := &spec.APISpec{
+		Name:            "primary",
+		Version:         "0.1.0",
+		BaseURL:         "https://api.example.com",
+		RequiredHeaders: []spec.RequiredHeader{{Name: "X-API-Version", Value: "v1"}},
+		Resources: map[string]spec.Resource{
+			"items": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/items"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	secondary := &spec.APISpec{
+		Name:            "secondary",
+		Version:         "0.1.0",
+		BaseURL:         "https://api.example.com",
+		RequiredHeaders: []spec.RequiredHeader{{Name: "x-api-version", Value: "v2"}},
+		Resources: map[string]spec.Resource{
+			"other": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/other"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{primary, secondary}, "combo")
+
+	assert.Equal(t, []spec.RequiredHeader{{Name: "X-API-Version", Value: "v1"}}, merged.RequiredHeaders)
+	assert.Equal(t, []spec.RequiredHeader{{Name: "x-api-version", Value: "v2"}}, merged.Resources["other"].Endpoints["list"].HeaderOverrides)
+}
+
+func TestMergeSpecsDeduplicatesSiblingEndpointsAsTheyAreIndexed(t *testing.T) {
+	t.Parallel()
+
+	primary := &spec.APISpec{
+		Name:    "primary",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"items": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/items"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	secondary := &spec.APISpec{
+		Name:    "secondary",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"chat": {Endpoints: map[string]spec.Endpoint{
+				"first":  {Method: "GET", Path: "/chat"},
+				"second": {Method: "GET", Path: "/chat"},
+			}},
+		},
+		Types: map[string]spec.TypeDef{},
+		MCP: spec.MCPConfig{
+			Intents: []spec.Intent{{
+				Name:  "read_chat",
+				Steps: []spec.IntentStep{{Endpoint: "chat.second"}},
+			}},
+		},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{primary, secondary}, "combo")
+
+	require.Contains(t, merged.Resources, "chat")
+	assert.Contains(t, merged.Resources["chat"].Endpoints, "first")
+	assert.NotContains(t, merged.Resources["chat"].Endpoints, "second")
+	require.Len(t, merged.MCP.Intents, 1)
+	require.Len(t, merged.MCP.Intents[0].Steps, 1)
+	assert.Equal(t, "chat.first", merged.MCP.Intents[0].Steps[0].Endpoint)
 }
 
 func TestMergeSpecsDeduplicatesAcrossResourceNamesButKeepsDistinctEndpoints(t *testing.T) {

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1943,6 +1943,57 @@ func TestMergeSpecsRewritesMCPIntentWhenDuplicateResourceIsDropped(t *testing.T)
 	assert.NoError(t, merged.Validate())
 }
 
+func TestMergeSpecsRewritesLaterDuplicateToRenamedCanonicalResource(t *testing.T) {
+	t.Parallel()
+
+	primary := &spec.APISpec{
+		Name:    "primary",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"chat": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/chat"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	secondary := &spec.APISpec{
+		Name:    "vendor",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"chat": {Endpoints: map[string]spec.Endpoint{
+				"list":    {Method: "GET", Path: "/chat"},
+				"history": {Method: "GET", Path: "/chat/history"},
+			}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	later := &spec.APISpec{
+		Name:    "later",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"other": {Endpoints: map[string]spec.Endpoint{"history": {Method: "GET", Path: "/chat/history"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+		MCP: spec.MCPConfig{
+			Intents: []spec.Intent{{
+				Name:        "read_history",
+				Description: "Read history",
+				Steps:       []spec.IntentStep{{Endpoint: "other.history"}},
+			}},
+		},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{primary, secondary, later}, "combo")
+
+	require.Contains(t, merged.Resources, "vendor-chat")
+	assert.Contains(t, merged.Resources["vendor-chat"].Endpoints, "history")
+	require.Len(t, merged.MCP.Intents, 1)
+	require.Len(t, merged.MCP.Intents[0].Steps, 1)
+	assert.Equal(t, "vendor-chat.history", merged.MCP.Intents[0].Steps[0].Endpoint)
+	assert.NoError(t, merged.Validate())
+}
+
 func TestMergeSpecsKeepsSameRouteWhenParameterShapesDiffer(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1348,6 +1348,7 @@ func mergeSpecsWithOptions(specs []*spec.APISpec, name string, opts mergeSpecOpt
 			resource = rewriteDefaultResourceDescription(resource, resourceName, key)
 			if key != resourceName {
 				resourceRenames[resourceName] = key
+				rekeyResourceEndpointReferences(seenEndpointRefs, resource, resourceName, key)
 			}
 			merged.Resources[key] = resource
 			acceptedResourceKeys = append(acceptedResourceKeys, key)
@@ -1947,6 +1948,46 @@ func addResourceEndpointReferences(references map[string]string, resource spec.R
 			sub.BaseURL = resource.BaseURL
 		}
 		addResourceEndpointReferences(references, sub, resourceRef+"."+name)
+	}
+}
+
+func rekeyResourceEndpointReferences(references map[string]string, resource spec.Resource, oldRef, newRef string) {
+	if oldRef == newRef {
+		return
+	}
+	rekeyResourceEndpointReferencesWithBase(references, resource, oldRef, newRef, "")
+}
+
+func rekeyResourceEndpointReferencesWithBase(references map[string]string, resource spec.Resource, oldRef, newRef, inheritedBaseURL string) {
+	baseURL := resource.BaseURL
+	if baseURL == "" {
+		baseURL = inheritedBaseURL
+	}
+	signatureResource := resource
+	signatureResource.BaseURL = baseURL
+
+	endpointNames := make([]string, 0, len(resource.Endpoints))
+	for name := range resource.Endpoints {
+		endpointNames = append(endpointNames, name)
+	}
+	sort.Strings(endpointNames)
+	for _, name := range endpointNames {
+		endpoint := resource.Endpoints[name]
+		signature := endpointSignature(signatureResource, endpoint)
+		oldEndpointRef := oldRef + "." + name
+		if references[signature] == oldEndpointRef {
+			references[signature] = newRef + "." + name
+		}
+	}
+
+	subResourceNames := make([]string, 0, len(resource.SubResources))
+	for name := range resource.SubResources {
+		subResourceNames = append(subResourceNames, name)
+	}
+	sort.Strings(subResourceNames)
+	for _, name := range subResourceNames {
+		sub := resource.SubResources[name]
+		rekeyResourceEndpointReferencesWithBase(references, sub, oldRef+"."+name, newRef+"."+name, baseURL)
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1485,8 +1485,10 @@ func compatibleMultiSpecAuthModels(base, incoming spec.AuthConfig) bool {
 		!compatibleMultiSpecAuthField(base.RefreshTokenMechanism, incoming.RefreshTokenMechanism) {
 		return false
 	}
-	if baseType == "oauth2" && base.EffectiveOAuth2Grant() != incoming.EffectiveOAuth2Grant() {
-		return false
+	if baseType == "oauth2" || strings.TrimSpace(base.OAuth2Grant) != "" || strings.TrimSpace(incoming.OAuth2Grant) != "" {
+		if base.EffectiveOAuth2Grant() != incoming.EffectiveOAuth2Grant() {
+			return false
+		}
 	}
 	return true
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1271,12 +1271,14 @@ func mergeSpecsWithOptions(specs []*spec.APISpec, name string, opts mergeSpecOpt
 	sharedPathPrefix := sharedMultiSpecEndpointPathPrefix(specs)
 
 	merged := &spec.APISpec{
-		Name:        name,
-		Description: "Combined CLI for multiple API services",
-		Version:     specs[0].Version,
-		BaseURL:     mergedBaseURL,
-		BasePath:    specs[0].BasePath,
-		Auth:        mergeMultiSpecAuth(specs),
+		Name:            name,
+		Description:     "Combined CLI for multiple API services",
+		Version:         specs[0].Version,
+		BaseURL:         mergedBaseURL,
+		BasePath:        specs[0].BasePath,
+		Auth:            mergeMultiSpecAuth(specs),
+		RequiredHeaders: mergeMultiSpecRequiredHeaders(specs),
+		Learn:           mergeMultiSpecLearn(specs),
 		Config: spec.ConfigSpec{
 			Format: "toml",
 			Path:   fmt.Sprintf("~/.config/%s-pp-cli/config.toml", name),
@@ -1285,6 +1287,8 @@ func mergeSpecsWithOptions(specs []*spec.APISpec, name string, opts mergeSpecOpt
 		Types:     map[string]spec.TypeDef{},
 	}
 
+	seenEndpointSignatures := map[string]struct{}{}
+	seenEndpointRefs := map[string]string{}
 	for i, s := range specs {
 		if merged.SpecSource == "" || merged.SpecSource == "official" {
 			switch s.SpecSource {
@@ -1304,6 +1308,8 @@ func mergeSpecsWithOptions(specs []*spec.APISpec, name string, opts mergeSpecOpt
 
 		prefix := perSpecPathPrefix[i]
 		resourceRenames := map[string]string{}
+		duplicateEndpointRefs := map[string]string{}
+		acceptedResourceKeys := make([]string, 0, len(s.Resources))
 		for resourceName, resource := range s.Resources {
 			if prefix != "" {
 				// Same-host/different-path specs are normalized by folding each
@@ -1313,6 +1319,13 @@ func mergeSpecsWithOptions(specs []*spec.APISpec, name string, opts mergeSpecOpt
 				resource = prefixResourceEndpointPaths(resource, prefix, s.BaseURL)
 			} else {
 				resource = resourceWithMergedSpecBaseURL(resource, s.BaseURL, merged.BaseURL)
+			}
+			if !opts.NamePrefix && i > 0 {
+				var keep bool
+				resource, keep = filterDuplicateResourceEndpoints(resource, resourceName, seenEndpointRefs, duplicateEndpointRefs)
+				if !keep {
+					continue
+				}
 			}
 			key := multiSpecResourceName(s, resourceName, sharedPathPrefix)
 			if opts.NamePrefix {
@@ -1330,6 +1343,14 @@ func mergeSpecsWithOptions(specs []*spec.APISpec, name string, opts mergeSpecOpt
 				resourceRenames[resourceName] = key
 			}
 			merged.Resources[key] = resource
+			acceptedResourceKeys = append(acceptedResourceKeys, key)
+		}
+		if !opts.NamePrefix {
+			for _, key := range acceptedResourceKeys {
+				resource := merged.Resources[key]
+				addResourceEndpointSignatures(seenEndpointSignatures, resource)
+				addResourceEndpointReferences(seenEndpointRefs, resource, key)
+			}
 		}
 
 		for typeName, typeDef := range s.Types {
@@ -1341,7 +1362,7 @@ func mergeSpecsWithOptions(specs []*spec.APISpec, name string, opts mergeSpecOpt
 		}
 
 		if mcpConfigured(s.MCP) && !mcpConfigured(merged.MCP) {
-			merged.MCP = rewriteMCPIntentEndpointRefs(s.MCP, resourceRenames)
+			merged.MCP = rewriteMCPIntentEndpointRefs(s.MCP, resourceRenames, duplicateEndpointRefs)
 		}
 	}
 
@@ -1376,11 +1397,18 @@ func mergeMultiSpecAuth(specs []*spec.APISpec) spec.AuthConfig {
 
 	auth := specs[0].Auth
 	authSpecIndex := 0
-	if auth.AuthorizationURL == "" {
+	if !authConfigHasModel(auth) {
 		for i, s := range specs[1:] {
 			if s.Auth.AuthorizationURL != "" {
 				auth = s.Auth
 				authSpecIndex = i + 1
+				break
+			}
+		}
+	} else {
+		for _, s := range specs[1:] {
+			if s.Auth.AuthorizationURL != "" && compatibleMultiSpecAuthModels(auth, s.Auth) {
+				fillMissingAuthFields(&auth, s.Auth)
 				break
 			}
 		}
@@ -1412,6 +1440,170 @@ func mergeMultiSpecAuth(specs []*spec.APISpec) spec.AuthConfig {
 	auth.Scopes = sortedScopes(scopeSet)
 	auth.AdditionalHeaders = headers
 	return auth
+}
+
+func authConfigHasModel(auth spec.AuthConfig) bool {
+	typeName := strings.TrimSpace(auth.Type)
+	if typeName != "" && !strings.EqualFold(typeName, "none") {
+		return true
+	}
+	return strings.TrimSpace(auth.Header) != "" ||
+		strings.TrimSpace(auth.Format) != "" ||
+		len(auth.EnvVars) > 0 ||
+		len(auth.EnvVarSpecs) > 0 ||
+		auth.HasCookies() ||
+		len(auth.AdditionalHeaders) > 0 ||
+		strings.TrimSpace(auth.AuthorizationURL) != ""
+}
+
+func compatibleMultiSpecAuthModels(base, incoming spec.AuthConfig) bool {
+	baseType := strings.ToLower(strings.TrimSpace(base.Type))
+	incomingType := strings.ToLower(strings.TrimSpace(incoming.Type))
+	if baseType == "" || incomingType == "" ||
+		baseType == spec.TierAuthTypeNone || incomingType == spec.TierAuthTypeNone ||
+		baseType != incomingType {
+		return false
+	}
+	if base.Header != "" && incoming.Header != "" && !strings.EqualFold(base.Header, incoming.Header) {
+		return false
+	}
+	if base.In != "" && incoming.In != "" && !strings.EqualFold(base.In, incoming.In) {
+		return false
+	}
+	return true
+}
+
+func fillMissingAuthFields(dst *spec.AuthConfig, src spec.AuthConfig) {
+	if dst == nil {
+		return
+	}
+	if dst.Subtype == "" {
+		dst.Subtype = src.Subtype
+	}
+	if dst.Header == "" {
+		dst.Header = src.Header
+	}
+	if dst.Prefix == "" {
+		dst.Prefix = src.Prefix
+	}
+	if dst.Format == "" {
+		dst.Format = src.Format
+	}
+	if dst.In == "" {
+		dst.In = src.In
+	}
+	if dst.Scheme == "" {
+		dst.Scheme = src.Scheme
+	}
+	if dst.AuthorizationURL == "" {
+		dst.AuthorizationURL = src.AuthorizationURL
+	}
+	if dst.DeviceAuthorizationURL == "" {
+		dst.DeviceAuthorizationURL = src.DeviceAuthorizationURL
+	}
+	if dst.TokenURL == "" {
+		dst.TokenURL = src.TokenURL
+	}
+	if dst.DefaultClientID == "" {
+		dst.DefaultClientID = src.DefaultClientID
+	}
+	if strings.EqualFold(dst.Type, "oauth2") {
+		if dst.OAuth2Grant == "" {
+			dst.OAuth2Grant = src.OAuth2Grant
+		}
+		if dst.RefreshTokenMechanism == "" {
+			dst.RefreshTokenMechanism = src.RefreshTokenMechanism
+		}
+	}
+}
+
+func mergeMultiSpecRequiredHeaders(specs []*spec.APISpec) []spec.RequiredHeader {
+	var merged []spec.RequiredHeader
+	seen := map[string]struct{}{}
+	for _, s := range specs {
+		for _, header := range s.RequiredHeaders {
+			key := strings.ToLower(strings.TrimSpace(header.Name))
+			if key != "" {
+				// Required headers are global on the merged client, so the first
+				// value wins when specs declare the same name differently.
+				if _, exists := seen[key]; exists {
+					continue
+				}
+				seen[key] = struct{}{}
+			}
+			merged = append(merged, header)
+		}
+	}
+	return merged
+}
+
+func mergeMultiSpecLearn(specs []*spec.APISpec) spec.LearnConfig {
+	var merged spec.LearnConfig
+	controlConfigured := false
+	for _, s := range specs {
+		learn := s.Learn
+		if !learnConfigConfigured(learn) {
+			continue
+		}
+		if !controlConfigured && (learn.Enabled || learn.Disabled || learn.EnabledSet) {
+			merged.Enabled = learn.Enabled
+			merged.Disabled = learn.Disabled
+			merged.EnabledSet = learn.EnabledSet
+			controlConfigured = true
+		}
+		merged.TickerPatterns = appendUniqueStrings(merged.TickerPatterns, learn.TickerPatterns)
+		merged.Stopwords = appendUniqueStrings(merged.Stopwords, learn.Stopwords)
+		if merged.Synonyms == nil && len(learn.Synonyms) > 0 {
+			merged.Synonyms = map[string]string{}
+		}
+		for key, value := range learn.Synonyms {
+			if _, exists := merged.Synonyms[key]; !exists {
+				merged.Synonyms[key] = value
+			}
+		}
+		if merged.EntityLookupSeeds == nil && len(learn.EntityLookupSeeds) > 0 {
+			merged.EntityLookupSeeds = map[string][]spec.LookupSeed{}
+		}
+		for kind, seeds := range learn.EntityLookupSeeds {
+			for _, seed := range seeds {
+				merged.EntityLookupSeeds[kind] = appendUniqueLookupSeed(merged.EntityLookupSeeds[kind], seed)
+			}
+		}
+	}
+	return merged
+}
+
+func learnConfigConfigured(learn spec.LearnConfig) bool {
+	return learn.Enabled || learn.Disabled || learn.EnabledSet ||
+		len(learn.TickerPatterns) > 0 || len(learn.Stopwords) > 0 ||
+		len(learn.Synonyms) > 0 || len(learn.EntityLookupSeeds) > 0
+}
+
+func appendUniqueStrings(dst, src []string) []string {
+	seen := make(map[string]struct{}, len(dst)+len(src))
+	for _, value := range dst {
+		seen[value] = struct{}{}
+	}
+	for _, value := range src {
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		dst = append(dst, value)
+	}
+	return dst
+}
+
+func appendUniqueLookupSeed(dst []spec.LookupSeed, seed spec.LookupSeed) []spec.LookupSeed {
+	for i := range dst {
+		if dst[i].Canonical != seed.Canonical {
+			continue
+		}
+		dst[i].Aliases = appendUniqueStrings(dst[i].Aliases, seed.Aliases)
+		return dst
+	}
+	seed.Aliases = appendUniqueStrings(nil, seed.Aliases)
+	return append(dst, seed)
 }
 
 func seedAuthHeaderDedupe(seenHeaders, seenEnvVars map[string]struct{}, auth spec.AuthConfig, headers []spec.AdditionalAuthHeader) {
@@ -1571,8 +1763,8 @@ func normalizeAuthURL(raw string) string {
 	return parsed.String()
 }
 
-func rewriteMCPIntentEndpointRefs(mcp spec.MCPConfig, resourceRenames map[string]string) spec.MCPConfig {
-	if len(resourceRenames) == 0 || len(mcp.Intents) == 0 {
+func rewriteMCPIntentEndpointRefs(mcp spec.MCPConfig, resourceRenames, duplicateEndpointRefs map[string]string) spec.MCPConfig {
+	if len(resourceRenames) == 0 && len(duplicateEndpointRefs) == 0 || len(mcp.Intents) == 0 {
 		return mcp
 	}
 	mcp.Intents = append([]spec.Intent(nil), mcp.Intents...)
@@ -1583,7 +1775,13 @@ func rewriteMCPIntentEndpointRefs(mcp spec.MCPConfig, resourceRenames map[string
 		}
 		intent.Steps = append([]spec.IntentStep(nil), intent.Steps...)
 		for stepIndex := range intent.Steps {
-			intent.Steps[stepIndex].Endpoint = rewriteEndpointResourceRef(intent.Steps[stepIndex].Endpoint, resourceRenames)
+			endpoint := intent.Steps[stepIndex].Endpoint
+			if canonical, ok := duplicateEndpointRefs[endpoint]; ok {
+				endpoint = canonical
+			} else {
+				endpoint = rewriteEndpointResourceRef(endpoint, resourceRenames)
+			}
+			intent.Steps[stepIndex].Endpoint = endpoint
 		}
 		mcp.Intents[intentIndex] = intent
 	}
@@ -1633,6 +1831,136 @@ func addResourceEndpointSignatures(signatures map[string]struct{}, resource spec
 	}
 }
 
+func addResourceEndpointReferences(references map[string]string, resource spec.Resource, resourceRef string) {
+	for name, endpoint := range resource.Endpoints {
+		signature := endpointSignature(resource, endpoint)
+		if _, exists := references[signature]; !exists {
+			references[signature] = resourceRef + "." + name
+		}
+	}
+	for name, sub := range resource.SubResources {
+		if sub.BaseURL == "" {
+			sub.BaseURL = resource.BaseURL
+		}
+		addResourceEndpointReferences(references, sub, resourceRef+"."+name)
+	}
+}
+
+func filterDuplicateResourceEndpoints(resource spec.Resource, resourceName string, seen map[string]string, duplicateRefs map[string]string) (spec.Resource, bool) {
+	return filterDuplicateResourceEndpointsWithBase(resource, resourceName, "", seen, duplicateRefs)
+}
+
+func filterDuplicateResourceEndpointsWithBase(resource spec.Resource, refPrefix, inheritedBaseURL string, seen map[string]string, duplicateRefs map[string]string) (spec.Resource, bool) {
+	originalHasEndpointOrOperation := resourceHasEndpointOrOperation(resource)
+	baseURL := resource.BaseURL
+	if baseURL == "" {
+		baseURL = inheritedBaseURL
+	}
+	signatureResource := resource
+	signatureResource.BaseURL = baseURL
+
+	filteredEndpoints := make(map[string]spec.Endpoint, len(resource.Endpoints))
+	for name, endpoint := range resource.Endpoints {
+		if canonical, exists := seen[endpointSignature(signatureResource, endpoint)]; exists {
+			duplicateRefs[refPrefix+"."+name] = canonical
+			continue
+		}
+		filteredEndpoints[name] = endpoint
+	}
+	if len(resource.Endpoints) > 0 {
+		resource.Endpoints = filteredEndpoints
+	}
+
+	filteredSubResources := make(map[string]spec.Resource, len(resource.SubResources))
+	for name, subResource := range resource.SubResources {
+		filtered, keep := filterDuplicateResourceEndpointsWithBase(subResource, refPrefix+"."+name, baseURL, seen, duplicateRefs)
+		if keep {
+			filteredSubResources[name] = filtered
+		}
+	}
+	if len(resource.SubResources) > 0 {
+		resource.SubResources = filteredSubResources
+	}
+
+	if !originalHasEndpointOrOperation || resourceHasEndpointOrOperation(resource) {
+		return resource, true
+	}
+	return resource, false
+}
+
+func resourceHasEndpointOrOperation(resource spec.Resource) bool {
+	if len(resource.Endpoints) > 0 || len(resource.Operations) > 0 {
+		return true
+	}
+	for _, subResource := range resource.SubResources {
+		if resourceHasEndpointOrOperation(subResource) {
+			return true
+		}
+	}
+	return false
+}
+
+type endpointParameterSignature struct {
+	Name                 string   `json:"name,omitempty"`
+	In                   string   `json:"in,omitempty"`
+	FlagName             string   `json:"flag_name,omitempty"`
+	URLName              string   `json:"url_name,omitempty"`
+	BodyName             string   `json:"body_name,omitempty"`
+	Type                 string   `json:"type,omitempty"`
+	Required             bool     `json:"required,omitempty"`
+	Positional           bool     `json:"positional,omitempty"`
+	PathParam            bool     `json:"path_param,omitempty"`
+	GlobalScope          bool     `json:"global_scope,omitempty"`
+	Default              any      `json:"default,omitempty"`
+	Enum                 []string `json:"enum,omitempty"`
+	Format               string   `json:"format,omitempty"`
+	QueryStyle           string   `json:"query_style,omitempty"`
+	QueryExplode         *bool    `json:"query_explode,omitempty"`
+	ItemType             string   `json:"item_type,omitempty"`
+	FieldSelectorDefault string   `json:"field_selector_default,omitempty"`
+	Fields               []endpointParameterSignature
+}
+
+func endpointParameterShape(param spec.Param) endpointParameterSignature {
+	fields := make([]endpointParameterSignature, 0, len(param.Fields))
+	for _, field := range param.Fields {
+		fields = append(fields, endpointParameterShape(field))
+	}
+	return endpointParameterSignature{
+		Name:                 param.Name,
+		In:                   param.In,
+		FlagName:             param.FlagName,
+		URLName:              param.URLName,
+		BodyName:             param.BodyName,
+		Type:                 param.Type,
+		Required:             param.Required,
+		Positional:           param.Positional,
+		PathParam:            param.PathParam,
+		GlobalScope:          param.GlobalScope,
+		Default:              param.Default,
+		Enum:                 param.Enum,
+		Format:               param.Format,
+		QueryStyle:           param.QueryStyle,
+		QueryExplode:         param.QueryExplode,
+		ItemType:             param.ItemType,
+		FieldSelectorDefault: param.FieldSelectorDefault,
+		Fields:               fields,
+	}
+}
+
+func endpointParameterSignatures(params []spec.Param) []string {
+	shapes := make([]string, 0, len(params))
+	for _, param := range params {
+		encoded, err := json.Marshal(endpointParameterShape(param))
+		if err != nil {
+			encoded = []byte(fmt.Sprintf("%#v", endpointParameterShape(param)))
+		}
+		shapes = append(shapes, string(encoded))
+	}
+	sort.Strings(shapes)
+	return shapes
+}
+
 func endpointSignature(resource spec.Resource, endpoint spec.Endpoint) string {
 	baseURL := strings.TrimRight(strings.TrimSpace(endpoint.BaseURL), "/")
 	if baseURL == "" {
@@ -1640,7 +1968,54 @@ func endpointSignature(resource spec.Resource, endpoint spec.Endpoint) string {
 	}
 	method := strings.ToUpper(strings.TrimSpace(endpoint.Method))
 	path := strings.TrimRight(strings.TrimSpace(endpoint.Path), "/")
-	return method + " " + baseURL + " " + path
+	shape := struct {
+		Mutation           bool                  `json:"mutation,omitempty"`
+		RequestContentType string                `json:"request_content_type,omitempty"`
+		BodyJSONFallback   bool                  `json:"body_json_fallback,omitempty"`
+		BodyRequired       bool                  `json:"body_required,omitempty"`
+		BodyIsArray        bool                  `json:"body_is_array,omitempty"`
+		Response           spec.ResponseDef      `json:"response"`
+		ResponseFormat     string                `json:"response_format,omitempty"`
+		ResponsePath       string                `json:"response_path,omitempty"`
+		DataSourceStrategy string                `json:"data_source_strategy,omitempty"`
+		Pagination         *spec.Pagination      `json:"pagination,omitempty"`
+		HeaderOverrides    []spec.RequiredHeader `json:"header_overrides,omitempty"`
+		NoAuth             bool                  `json:"no_auth,omitempty"`
+		ObservedAuth       []string              `json:"observed_auth,omitempty"`
+		Tier               string                `json:"tier,omitempty"`
+		RequiresRole       string                `json:"requires_role,omitempty"`
+		Critical           bool                  `json:"critical,omitempty"`
+		Syncable           bool                  `json:"syncable,omitempty"`
+		Walker             *spec.WalkerConfig    `json:"walker,omitempty"`
+		Params             []string              `json:"params,omitempty"`
+		Body               []string              `json:"body,omitempty"`
+	}{
+		Mutation:           endpoint.Mutation,
+		RequestContentType: endpoint.RequestContentType,
+		BodyJSONFallback:   endpoint.BodyJSONFallback,
+		BodyRequired:       endpoint.BodyRequired,
+		BodyIsArray:        endpoint.BodyIsArray,
+		Response:           endpoint.Response,
+		ResponseFormat:     endpoint.ResponseFormat,
+		ResponsePath:       endpoint.ResponsePath,
+		DataSourceStrategy: endpoint.DataSourceStrategy,
+		Pagination:         endpoint.Pagination,
+		HeaderOverrides:    endpoint.HeaderOverrides,
+		NoAuth:             endpoint.NoAuth,
+		ObservedAuth:       endpoint.ObservedAuth,
+		Tier:               endpoint.Tier,
+		RequiresRole:       endpoint.RequiresRole,
+		Critical:           endpoint.Critical,
+		Syncable:           endpoint.Syncable,
+		Walker:             endpoint.Walker,
+		Params:             endpointParameterSignatures(endpoint.Params),
+		Body:               endpointParameterSignatures(endpoint.Body),
+	}
+	encoded, err := json.Marshal(shape)
+	if err != nil {
+		encoded = []byte(fmt.Sprintf("%#v", shape))
+	}
+	return method + " " + baseURL + " " + path + " " + string(encoded)
 }
 
 func multiSpecResourceName(s *spec.APISpec, resourceName string, sharedPathPrefix []string) string {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1348,7 +1348,12 @@ func mergeSpecsWithOptions(specs []*spec.APISpec, name string, opts mergeSpecOpt
 			resource = rewriteDefaultResourceDescription(resource, resourceName, key)
 			if key != resourceName {
 				resourceRenames[resourceName] = key
-				rekeyResourceEndpointReferences(seenEndpointRefs, resource, resourceName, key)
+				endpointRefRenames := rekeyResourceEndpointReferences(seenEndpointRefs, resource, resourceName, key)
+				for duplicateRef, canonicalRef := range duplicateEndpointRefs {
+					if renamed, ok := endpointRefRenames[canonicalRef]; ok {
+						duplicateEndpointRefs[duplicateRef] = renamed
+					}
+				}
 			}
 			merged.Resources[key] = resource
 			acceptedResourceKeys = append(acceptedResourceKeys, key)
@@ -1951,14 +1956,16 @@ func addResourceEndpointReferences(references map[string]string, resource spec.R
 	}
 }
 
-func rekeyResourceEndpointReferences(references map[string]string, resource spec.Resource, oldRef, newRef string) {
+func rekeyResourceEndpointReferences(references map[string]string, resource spec.Resource, oldRef, newRef string) map[string]string {
 	if oldRef == newRef {
-		return
+		return nil
 	}
-	rekeyResourceEndpointReferencesWithBase(references, resource, oldRef, newRef, "")
+	renamed := make(map[string]string)
+	rekeyResourceEndpointReferencesWithBase(references, resource, oldRef, newRef, "", renamed)
+	return renamed
 }
 
-func rekeyResourceEndpointReferencesWithBase(references map[string]string, resource spec.Resource, oldRef, newRef, inheritedBaseURL string) {
+func rekeyResourceEndpointReferencesWithBase(references map[string]string, resource spec.Resource, oldRef, newRef, inheritedBaseURL string, renamed map[string]string) {
 	baseURL := resource.BaseURL
 	if baseURL == "" {
 		baseURL = inheritedBaseURL
@@ -1976,7 +1983,9 @@ func rekeyResourceEndpointReferencesWithBase(references map[string]string, resou
 		signature := endpointSignature(signatureResource, endpoint)
 		oldEndpointRef := oldRef + "." + name
 		if references[signature] == oldEndpointRef {
-			references[signature] = newRef + "." + name
+			newEndpointRef := newRef + "." + name
+			references[signature] = newEndpointRef
+			renamed[oldEndpointRef] = newEndpointRef
 		}
 	}
 
@@ -1987,7 +1996,7 @@ func rekeyResourceEndpointReferencesWithBase(references map[string]string, resou
 	sort.Strings(subResourceNames)
 	for _, name := range subResourceNames {
 		sub := resource.SubResources[name]
-		rekeyResourceEndpointReferencesWithBase(references, sub, oldRef+"."+name, newRef+"."+name, baseURL)
+		rekeyResourceEndpointReferencesWithBase(references, sub, oldRef+"."+name, newRef+"."+name, baseURL, renamed)
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1287,7 +1287,6 @@ func mergeSpecsWithOptions(specs []*spec.APISpec, name string, opts mergeSpecOpt
 		Types:     map[string]spec.TypeDef{},
 	}
 
-	seenEndpointSignatures := map[string]struct{}{}
 	seenEndpointRefs := map[string]string{}
 	for i, s := range specs {
 		if merged.SpecSource == "" || merged.SpecSource == "official" {
@@ -1309,8 +1308,15 @@ func mergeSpecsWithOptions(specs []*spec.APISpec, name string, opts mergeSpecOpt
 		prefix := perSpecPathPrefix[i]
 		resourceRenames := map[string]string{}
 		duplicateEndpointRefs := map[string]string{}
+		conflictingRequiredHeaders := conflictingMultiSpecRequiredHeaderOverrides(merged.RequiredHeaders, s.RequiredHeaders)
 		acceptedResourceKeys := make([]string, 0, len(s.Resources))
-		for resourceName, resource := range s.Resources {
+		resourceNames := make([]string, 0, len(s.Resources))
+		for resourceName := range s.Resources {
+			resourceNames = append(resourceNames, resourceName)
+		}
+		sort.Strings(resourceNames)
+		for _, resourceName := range resourceNames {
+			resource := s.Resources[resourceName]
 			if prefix != "" {
 				// Same-host/different-path specs are normalized by folding each
 				// spec's path prefix into endpoint paths. Do not also preserve
@@ -1320,6 +1326,7 @@ func mergeSpecsWithOptions(specs []*spec.APISpec, name string, opts mergeSpecOpt
 			} else {
 				resource = resourceWithMergedSpecBaseURL(resource, s.BaseURL, merged.BaseURL)
 			}
+			resource = applyRequiredHeaderOverrides(resource, conflictingRequiredHeaders)
 			if !opts.NamePrefix && i > 0 {
 				var keep bool
 				resource, keep = filterDuplicateResourceEndpoints(resource, resourceName, seenEndpointRefs, duplicateEndpointRefs)
@@ -1348,7 +1355,6 @@ func mergeSpecsWithOptions(specs []*spec.APISpec, name string, opts mergeSpecOpt
 		if !opts.NamePrefix {
 			for _, key := range acceptedResourceKeys {
 				resource := merged.Resources[key]
-				addResourceEndpointSignatures(seenEndpointSignatures, resource)
 				addResourceEndpointReferences(seenEndpointRefs, resource, key)
 			}
 		}
@@ -1470,7 +1476,31 @@ func compatibleMultiSpecAuthModels(base, incoming spec.AuthConfig) bool {
 	if base.In != "" && incoming.In != "" && !strings.EqualFold(base.In, incoming.In) {
 		return false
 	}
+	if !compatibleMultiSpecAuthField(base.Subtype, incoming.Subtype) ||
+		!compatibleMultiSpecAuthField(base.Scheme, incoming.Scheme) ||
+		!compatibleMultiSpecAuthURL(base.AuthorizationURL, incoming.AuthorizationURL) ||
+		!compatibleMultiSpecAuthURL(base.DeviceAuthorizationURL, incoming.DeviceAuthorizationURL) ||
+		!compatibleMultiSpecAuthURL(base.TokenURL, incoming.TokenURL) ||
+		!compatibleMultiSpecAuthField(base.DefaultClientID, incoming.DefaultClientID) ||
+		!compatibleMultiSpecAuthField(base.RefreshTokenMechanism, incoming.RefreshTokenMechanism) {
+		return false
+	}
+	if baseType == "oauth2" && base.EffectiveOAuth2Grant() != incoming.EffectiveOAuth2Grant() {
+		return false
+	}
 	return true
+}
+
+func compatibleMultiSpecAuthField(base, incoming string) bool {
+	base = strings.TrimSpace(base)
+	incoming = strings.TrimSpace(incoming)
+	return base == "" || incoming == "" || base == incoming
+}
+
+func compatibleMultiSpecAuthURL(base, incoming string) bool {
+	base = normalizeAuthURL(base)
+	incoming = normalizeAuthURL(incoming)
+	return base == "" || incoming == "" || base == incoming
 }
 
 func fillMissingAuthFields(dst *spec.AuthConfig, src spec.AuthConfig) {
@@ -1535,6 +1565,66 @@ func mergeMultiSpecRequiredHeaders(specs []*spec.APISpec) []spec.RequiredHeader 
 		}
 	}
 	return merged
+}
+
+func conflictingMultiSpecRequiredHeaderOverrides(existing, incoming []spec.RequiredHeader) map[string]string {
+	existingByName := make(map[string]string, len(existing))
+	for _, header := range existing {
+		name := strings.ToLower(strings.TrimSpace(header.Name))
+		if name != "" {
+			existingByName[name] = header.Value
+		}
+	}
+
+	overrides := make(map[string]string)
+	for _, header := range incoming {
+		name := strings.ToLower(strings.TrimSpace(header.Name))
+		if name == "" {
+			continue
+		}
+		if value, exists := existingByName[name]; exists && value != header.Value {
+			overrides[header.Name] = header.Value
+		}
+	}
+	return overrides
+}
+
+func applyRequiredHeaderOverrides(resource spec.Resource, overrides map[string]string) spec.Resource {
+	if len(overrides) == 0 {
+		return resource
+	}
+
+	headerNames := make([]string, 0, len(overrides))
+	for name := range overrides {
+		headerNames = append(headerNames, name)
+	}
+	sort.Strings(headerNames)
+
+	for name, endpoint := range resource.Endpoints {
+		for _, headerName := range headerNames {
+			if hasHeaderOverride(endpoint.HeaderOverrides, headerName) {
+				continue
+			}
+			endpoint.HeaderOverrides = append(endpoint.HeaderOverrides, spec.RequiredHeader{
+				Name:  headerName,
+				Value: overrides[headerName],
+			})
+		}
+		resource.Endpoints[name] = endpoint
+	}
+	for name, subResource := range resource.SubResources {
+		resource.SubResources[name] = applyRequiredHeaderOverrides(subResource, overrides)
+	}
+	return resource
+}
+
+func hasHeaderOverride(overrides []spec.RequiredHeader, name string) bool {
+	for _, override := range overrides {
+		if strings.EqualFold(strings.TrimSpace(override.Name), strings.TrimSpace(name)) {
+			return true
+		}
+	}
+	return false
 }
 
 func mergeMultiSpecLearn(specs []*spec.APISpec) spec.LearnConfig {
@@ -1832,13 +1922,25 @@ func addResourceEndpointSignatures(signatures map[string]struct{}, resource spec
 }
 
 func addResourceEndpointReferences(references map[string]string, resource spec.Resource, resourceRef string) {
-	for name, endpoint := range resource.Endpoints {
+	endpointNames := make([]string, 0, len(resource.Endpoints))
+	for name := range resource.Endpoints {
+		endpointNames = append(endpointNames, name)
+	}
+	sort.Strings(endpointNames)
+	for _, name := range endpointNames {
+		endpoint := resource.Endpoints[name]
 		signature := endpointSignature(resource, endpoint)
 		if _, exists := references[signature]; !exists {
 			references[signature] = resourceRef + "." + name
 		}
 	}
-	for name, sub := range resource.SubResources {
+	subResourceNames := make([]string, 0, len(resource.SubResources))
+	for name := range resource.SubResources {
+		subResourceNames = append(subResourceNames, name)
+	}
+	sort.Strings(subResourceNames)
+	for _, name := range subResourceNames {
+		sub := resource.SubResources[name]
 		if sub.BaseURL == "" {
 			sub.BaseURL = resource.BaseURL
 		}
@@ -1860,19 +1962,33 @@ func filterDuplicateResourceEndpointsWithBase(resource spec.Resource, refPrefix,
 	signatureResource.BaseURL = baseURL
 
 	filteredEndpoints := make(map[string]spec.Endpoint, len(resource.Endpoints))
-	for name, endpoint := range resource.Endpoints {
-		if canonical, exists := seen[endpointSignature(signatureResource, endpoint)]; exists {
+	endpointNames := make([]string, 0, len(resource.Endpoints))
+	for name := range resource.Endpoints {
+		endpointNames = append(endpointNames, name)
+	}
+	sort.Strings(endpointNames)
+	for _, name := range endpointNames {
+		endpoint := resource.Endpoints[name]
+		signature := endpointSignature(signatureResource, endpoint)
+		if canonical, exists := seen[signature]; exists {
 			duplicateRefs[refPrefix+"."+name] = canonical
 			continue
 		}
 		filteredEndpoints[name] = endpoint
+		seen[signature] = refPrefix + "." + name
 	}
 	if len(resource.Endpoints) > 0 {
 		resource.Endpoints = filteredEndpoints
 	}
 
 	filteredSubResources := make(map[string]spec.Resource, len(resource.SubResources))
-	for name, subResource := range resource.SubResources {
+	subResourceNames := make([]string, 0, len(resource.SubResources))
+	for name := range resource.SubResources {
+		subResourceNames = append(subResourceNames, name)
+	}
+	sort.Strings(subResourceNames)
+	for _, name := range subResourceNames {
+		subResource := resource.SubResources[name]
 		filtered, keep := filterDuplicateResourceEndpointsWithBase(subResource, refPrefix+"."+name, baseURL, seen, duplicateRefs)
 		if keep {
 			filteredSubResources[name] = filtered


### PR DESCRIPTION
## Summary

Multi-spec generation now retains the primary auth model and credential configuration while filling compatible missing OAuth metadata. It also preserves required headers and learn configuration, and removes duplicate request endpoints across resource names without changing explicit `--name-prefix` behavior. MCP intents that refer to a removed duplicate endpoint are redirected to the retained endpoint.

## Validation

- `go test ./internal/cli -run 'Test(MergeSpecs|GenerateMultiSpec)' -count=1`
- `scripts/golden.sh verify` (32 cases)
- `gofmt` and `git diff --check`
- `golangci-lint run ./...` (only a pre-existing warning in `internal/googlediscovery/parser.go:455`)
- `go test ./...` reached a green `internal/cli` package result; unrelated verify-mode and generated-fixture failures remain outside this change.

Closes #3953
Closes #3954
Closes #3743
