### PR TITLE
fix(cli): honor generated sync pagination contracts

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -4094,17 +4094,18 @@ type criticalResourceEntry struct {
 }
 
 type paginationDefaultEntry struct {
-	Key         string
-	Name        string
-	CursorParam string
-	CursorType  string
-	LimitParam  string
-	Limit       int
+	Key            string
+	Name           string
+	CursorParam    string
+	CursorType     string
+	NextCursorPath string
+	LimitParam     string
+	Limit          int
 }
 
 func paginationDefaultEntries(syncable []profiler.SyncableResource, dependent []profiler.DependentResource) []paginationDefaultEntry {
 	defaults := map[string]paginationDefaultEntry{}
-	add := func(key, name, cursorParam, cursorType, limitParam string, limit int, supportsPagination bool) {
+	add := func(key, name, cursorParam, cursorType, nextCursorPath, limitParam string, limit int, supportsPagination bool) {
 		if !supportsPagination || key == "" || name == "" {
 			return
 		}
@@ -4112,19 +4113,20 @@ func paginationDefaultEntries(syncable []profiler.SyncableResource, dependent []
 			return
 		}
 		defaults[key] = paginationDefaultEntry{
-			Key:         key,
-			Name:        name,
-			CursorParam: cursorParam,
-			CursorType:  cursorType,
-			LimitParam:  limitParam,
-			Limit:       limit,
+			Key:            key,
+			Name:           name,
+			CursorParam:    cursorParam,
+			CursorType:     cursorType,
+			NextCursorPath: nextCursorPath,
+			LimitParam:     limitParam,
+			Limit:          limit,
 		}
 	}
 	for _, resource := range syncable {
-		add(resource.Name, resource.Name, resource.PaginationCursorParam, resource.PaginationCursorType, resource.PaginationLimitParam, resource.PaginationPageSize, resource.SupportsPagination)
+		add(resource.Name, resource.Name, resource.PaginationCursorParam, resource.PaginationCursorType, resource.PaginationNextCursorPath, resource.PaginationLimitParam, resource.PaginationPageSize, resource.SupportsPagination)
 	}
 	for _, resource := range dependent {
-		add(resource.ParentResource+"/"+resource.Name, resource.Name, resource.PaginationCursorParam, resource.PaginationCursorType, resource.PaginationLimitParam, resource.PaginationPageSize, resource.SupportsPagination)
+		add(resource.ParentResource+"/"+resource.Name, resource.Name, resource.PaginationCursorParam, resource.PaginationCursorType, resource.PaginationNextCursorPath, resource.PaginationLimitParam, resource.PaginationPageSize, resource.SupportsPagination)
 	}
 
 	keys := make([]string, 0, len(defaults))

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -15146,15 +15146,15 @@ func TestGeneratedSyncUsesPerResourcePaginationDefaults(t *testing.T) {
 	assert.Contains(t, syncContent, `pageSize := determinePaginationDefaults(resource)`)
 	assert.Contains(t, syncContent, `func determinePaginationDefaults(resource string) paginationDefaults`)
 	assert.Contains(t, syncContent, `case "assets":`)
-	assert.Contains(t, syncContent, `cursorParam: "skip"`)
-	assert.Contains(t, syncContent, `cursorType:  "offset"`)
-	assert.Contains(t, syncContent, `limitParam:  "limit"`)
-	assert.Contains(t, syncContent, `limit:       50`)
+	assert.Contains(t, syncContent, `cursorParam:    "skip"`)
+	assert.Contains(t, syncContent, `cursorType:     "offset"`)
+	assert.Contains(t, syncContent, `limitParam:     "limit"`)
+	assert.Contains(t, syncContent, `limit:          50`)
 	assert.Contains(t, syncContent, `case "photos":`)
-	assert.Contains(t, syncContent, `cursorParam: "page"`)
-	assert.Contains(t, syncContent, `cursorType:  "page"`)
-	assert.Contains(t, syncContent, `limitParam:  "per_page"`)
-	assert.Contains(t, syncContent, `limit:       25`)
+	assert.Contains(t, syncContent, `cursorParam:    "page"`)
+	assert.Contains(t, syncContent, `cursorType:     "page"`)
+	assert.Contains(t, syncContent, `limitParam:     "per_page"`)
+	assert.Contains(t, syncContent, `limit:          25`)
 
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "build", "./internal/cli")
@@ -15163,21 +15163,23 @@ func TestGeneratedSyncUsesPerResourcePaginationDefaults(t *testing.T) {
 func TestPaginationDefaultEntriesDistinguishDependentContext(t *testing.T) {
 	entries := paginationDefaultEntries(
 		[]profiler.SyncableResource{{
-			Name:                  "tasks",
-			SupportsPagination:    true,
-			PaginationCursorParam: "after",
-			PaginationCursorType:  "cursor",
-			PaginationLimitParam:  "limit",
-			PaginationPageSize:    100,
+			Name:                     "tasks",
+			SupportsPagination:       true,
+			PaginationCursorParam:    "after",
+			PaginationCursorType:     "cursor",
+			PaginationNextCursorPath: "meta.next",
+			PaginationLimitParam:     "limit",
+			PaginationPageSize:       100,
 		}},
 		[]profiler.DependentResource{{
-			Name:                  "tasks",
-			ParentResource:        "projects",
-			SupportsPagination:    true,
-			PaginationCursorParam: "offset",
-			PaginationCursorType:  "offset",
-			PaginationLimitParam:  "per_page",
-			PaginationPageSize:    25,
+			Name:                     "tasks",
+			ParentResource:           "projects",
+			SupportsPagination:       true,
+			PaginationCursorParam:    "offset",
+			PaginationCursorType:     "offset",
+			PaginationNextCursorPath: "paging.next",
+			PaginationLimitParam:     "per_page",
+			PaginationPageSize:       25,
 		}},
 	)
 
@@ -15189,7 +15191,9 @@ func TestPaginationDefaultEntriesDistinguishDependentContext(t *testing.T) {
 	require.Contains(t, byKey, "tasks")
 	require.Contains(t, byKey, "projects/tasks")
 	assert.Equal(t, "after", byKey["tasks"].CursorParam)
+	assert.Equal(t, "meta.next", byKey["tasks"].NextCursorPath)
 	assert.Equal(t, "offset", byKey["projects/tasks"].CursorParam)
+	assert.Equal(t, "paging.next", byKey["projects/tasks"].NextCursorPath)
 	assert.Equal(t, "per_page", byKey["projects/tasks"].LimitParam)
 	assert.Equal(t, 25, byKey["projects/tasks"].Limit)
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -5117,11 +5117,11 @@ func TestSyncPageIntPaginationAdvancesAfterFullPage(t *testing.T) {
 				"sync.go must not synthesize page+1 when the envelope explicitly parsed has_more")
 			assert.Contains(t, src, `strconv.Itoa(currentPage + 1)`,
 				"page-int fallback must increment the integer cursor")
-			assert.Contains(t, src, `cursorType:  "page"`,
+			assert.Contains(t, src, `cursorType:     "page"`,
 				"determinePaginationDefaults must emit cursorType \"page\" when the profile selects it")
 			// CursorParam still carries the original-case param name so
 			// the HTTP request key matches the spec.
-			assert.Contains(t, src, `cursorParam: "`+tc.paramName+`"`,
+			assert.Contains(t, src, `cursorParam:    "`+tc.paramName+`"`,
 				"determinePaginationDefaults must preserve the original-case page-int param name")
 		})
 	}
@@ -14465,7 +14465,7 @@ func TestGeneratedSyncAdvancesOffsetWhenHasMoreWithoutCursor(t *testing.T) {
 		"sync loops must not require an API-returned next cursor for offset pagination")
 	assert.Contains(t, syncContent, `if !hasMore || shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit) {`,
 		"sync loops must break only on real done signals before handling cursor advancement")
-	assert.Contains(t, syncContent, `if pageSize.cursorType == "offset" {`,
+	assert.Contains(t, syncContent, `if pageSize.cursorParam != "" && pageSize.cursorType == "offset" {`,
 		"offset pagination must advance the cursor client-side when has_more is true")
 	assert.Contains(t, syncContent, `nextCursor = strconv.Itoa(currentOffset + pageSize.limit)`,
 		"offset pagination must compute the next offset from the current cursor and limit")
@@ -14516,7 +14516,16 @@ func TestGeneratedSyncAdvancesOffsetAfterFullPageWithoutHasMore(t *testing.T) {
 			ItemsKey:        "items",
 		},
 		SyncableResources: []profiler.SyncableResource{
-			{Name: "records", Path: "/records", Method: "GET", SupportsPagination: true},
+			{
+				Name:                  "records",
+				Path:                  "/records",
+				Method:                "GET",
+				SupportsPagination:    true,
+				PaginationCursorParam: "offset",
+				PaginationCursorType:  "offset",
+				PaginationLimitParam:  "limit",
+				PaginationPageSize:    2,
+			},
 		},
 	}
 	require.NoError(t, gen.Generate())
@@ -20577,7 +20586,7 @@ components:
 	assert.Contains(t, paginationSwitch[1], `case "usercollection-daily-sleep":`)
 	assert.NotContains(t, paginationSwitch[1], `case "usercollection-personal-info":`,
 		"single-object resources without cursor params must not be marked paginated")
-	assert.Contains(t, src, `cursorParam: "next_token"`,
+	assert.Contains(t, src, `cursorParam:    "next_token"`,
 		"the generated sync layer must derive the API cursor param instead of hardcoding after")
 
 	sinceFormatTest := `package cli

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -214,6 +214,19 @@ func TestGeneratedSyncShortPageTerminationRespectsPaginationType(t *testing.T) {
 				},
 			},
 		},
+		"uncursored": {
+			Description: "Manage uncursored pages",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/uncursored",
+					Description: "List uncursored pages",
+					Params:      []spec.Param{{Name: "limit", Type: "integer", Default: 1}},
+					Pagination:  &spec.Pagination{Type: "page", LimitParam: "limit"},
+					Response:    spec.ResponseDef{Type: "array", Item: "Uncursored"},
+				},
+			},
+		},
 	}
 
 	outputDir := filepath.Join(t.TempDir(), "sync-short-page-pp-cli")
@@ -439,6 +452,24 @@ func TestSyncResourceDoesNotAdvancePastNullItems(t *testing.T) {
 		t.Fatalf("saved cursor = %%q, want empty", cursor)
 	}
 }
+
+func TestSyncResourceDoesNotLoopWithoutCursorParam(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %%v", err)
+	}
+	defer db.Close()
+	client := &shortPageSyncClient{responses: []json.RawMessage{
+		json.RawMessage("{\"items\":[{\"id\":\"one\"}],\"has_more\":true}"),
+	}}
+	result := syncResource(context.Background(), client, db, "uncursored", "", true, 0, false, false, &syncUserParams{}, io.Discard)
+	if result.Err != nil || result.Warn != nil {
+		t.Fatalf("sync result error=%%v warning=%%v", result.Err, result.Warn)
+	}
+	if len(client.params) != 1 {
+		t.Fatalf("sync calls = %%d, want 1 when no cursor parameter is declared", len(client.params))
+	}
+}
 `, modulePath+"/internal/store")
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "sync_short_page_test.go"), []byte(behaviorTest), 0o644))
 	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "TestShortPageEndsPagination|TestCursorPageHasContinuation|TestExtractItemsByKnownKeys|TestSyncResource")
@@ -476,7 +507,7 @@ func TestGeneratedSyncNormalizesPagePaginationProfile(t *testing.T) {
 			outputDir := filepath.Join(t.TempDir(), "page-profile-pp-cli")
 			require.NoError(t, New(apiSpec, outputDir).Generate())
 			syncSrc := readGeneratedCLIFileContaining(t, outputDir, "func determinePaginationDefaults")
-			require.Contains(t, syncSrc, fmt.Sprintf(`cursorType:  %q`, tc.want), "generated sync must use the normalized pagination strategy")
+			require.Contains(t, syncSrc, fmt.Sprintf(`cursorType:     %q`, tc.want), "generated sync must use the normalized pagination strategy")
 			requireGeneratedCompiles(t, outputDir)
 		})
 	}

--- a/internal/generator/pagination_contract_test.go
+++ b/internal/generator/pagination_contract_test.go
@@ -1,0 +1,221 @@
+package generator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedSyncUsesDeclaredCursorPathAndNumericCursor(t *testing.T) {
+	apiSpec := minimalSpec("pagination-contract")
+	apiSpec.Resources = map[string]spec.Resource{
+		"items": {
+			Description: "Items",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/items",
+					Description: "List items",
+					Params: []spec.Param{
+						{Name: "limit", Type: "integer"},
+						{Name: "cursorId", Type: "string"},
+					},
+					Pagination: &spec.Pagination{
+						Type:           "cursor",
+						CursorParam:    "cursorId",
+						LimitParam:     "limit",
+						NextCursorPath: "pagination.continuation_marker",
+					},
+					Response: spec.ResponseDef{Type: "array", Item: "Item"},
+				},
+			},
+		},
+		"archives": {
+			Description: "Archives",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/archives",
+					Description: "List archives",
+					Params:      []spec.Param{{Name: "limit", Type: "integer"}},
+					Pagination:  &spec.Pagination{Type: "cursor", LimitParam: "limit"},
+					Response:    spec.ResponseDef{Type: "array", Item: "Archive"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	syncContent := string(syncGo)
+	assert.Contains(t, syncContent, `cursorParam:    "cursorId"`)
+	assert.Contains(t, syncContent, `nextCursorPath: "pagination.continuation_marker"`)
+	assert.Contains(t, syncContent, `case "archives":`)
+	assert.NotContains(t, syncContent, `cursorParam: "after"`, "a resource without a declared cursor must not fall back to after")
+
+	goMod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
+	require.NoError(t, err)
+	modulePath := strings.TrimPrefix(strings.SplitN(string(goMod), "\n", 2)[0], "module ")
+	behaviorTest := fmt.Sprintf(`package cli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"testing"
+
+	%q
+)
+
+func TestDeclaredPaginationCursorPath(t *testing.T) {
+	items, cursor, hasMore := extractPageItemsWithPagination(
+		json.RawMessage(`+"`"+`{"items":[{"id":"one"}],"pagination":{"continuation_marker":12345}}`+"`"+`),
+		"cursorId", "pagination.continuation_marker",
+	)
+	if len(items) != 1 || cursor != "12345" || !hasMore {
+		t.Fatalf("items=%%d cursor=%%q hasMore=%%v, want 1/12345/true", len(items), cursor, hasMore)
+	}
+}
+
+type paginationSyncClient struct {
+	responses []json.RawMessage
+	params    []map[string]string
+}
+
+func (c *paginationSyncClient) Get(_ context.Context, _ string, params map[string]string) (json.RawMessage, error) {
+	copied := make(map[string]string, len(params))
+	for key, value := range params {
+		copied[key] = value
+	}
+	c.params = append(c.params, copied)
+	response := c.responses[0]
+	c.responses = c.responses[1:]
+	return response, nil
+}
+
+func (c *paginationSyncClient) RateLimit() float64 { return 0 }
+
+func TestSyncUsesDeclaredNumericCursor(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %%v", err)
+	}
+	defer db.Close()
+	client := &paginationSyncClient{responses: []json.RawMessage{
+		json.RawMessage("{\"items\":[{\"id\":\"one\"}],\"pagination\":{\"continuation_marker\":12345}}"),
+		json.RawMessage("{\"items\":[{\"id\":\"two\"}],\"pagination\":{\"continuation_marker\":null}}"),
+	}}
+	result := syncResource(context.Background(), client, db, "items", "", true, 0, false, false, &syncUserParams{}, io.Discard)
+	if result.Err != nil || result.Warn != nil {
+		t.Fatalf("sync result error=%%v warning=%%v", result.Err, result.Warn)
+	}
+	if len(client.params) != 2 || client.params[1]["cursorId"] != "12345" {
+		t.Fatalf("sync params = %%#v, want a second request with cursorId=12345", client.params)
+	}
+}
+
+func TestUndeclaredPaginationCursorDoesNotUseFallback(t *testing.T) {
+	defaults := determinePaginationDefaults("archives")
+	if defaults.cursorParam != "" {
+		t.Fatalf("cursorParam=%%q, want empty", defaults.cursorParam)
+	}
+	_, cursor, hasMore := extractPageItemsWithPagination(
+		json.RawMessage(`+"`"+`{"items":[{"id":"one"}],"pagination":{"next":"page-2"}}`+"`"+`),
+		defaults.cursorParam, defaults.nextCursorPath,
+	)
+	if cursor != "" || hasMore {
+		t.Fatalf("cursor=%%q hasMore=%%v, want empty/false", cursor, hasMore)
+	}
+}
+`, modulePath+"/internal/store")
+	testPath := filepath.Join(outputDir, "internal", "cli", "pagination_contract_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(behaviorTest), 0o644))
+	runGoCommandRequired(t, outputDir, "mod", "tidy")
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "Test(DeclaredPaginationCursorPath|SyncUsesDeclaredNumericCursor|UndeclaredPaginationCursorDoesNotUseFallback)", "-count=1")
+}
+
+func TestGeneratedPostListDoesNotAdvertiseUnwiredAllFlag(t *testing.T) {
+	apiSpec := minimalSpec("post-pagination-contract")
+	apiSpec.Resources = map[string]spec.Resource{
+		"posts": {
+			Description: "Posts",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "POST",
+					Path:        "/posts/list",
+					Description: "List posts",
+					Params: []spec.Param{
+						{Name: "limit", Type: "integer"},
+						{Name: "cursor", Type: "string"},
+					},
+					Pagination: &spec.Pagination{Type: "cursor", CursorParam: "cursor", LimitParam: "limit"},
+					Response:   spec.ResponseDef{Type: "array", Item: "Post"},
+				},
+				"get": {
+					Method:   "GET",
+					Path:     "/posts/{id}",
+					Response: spec.ResponseDef{Type: "object", Item: "Post"},
+				},
+			},
+		},
+		"lookup": {
+			Description: "Lookup",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "POST",
+					Path:        "/lookup",
+					Description: "Lookup records",
+					Params:      []spec.Param{{Name: "limit", Type: "integer"}, {Name: "cursor", Type: "string"}},
+					Pagination:  &spec.Pagination{Type: "cursor", CursorParam: "cursor", LimitParam: "limit"},
+					Response:    spec.ResponseDef{Type: "array", Item: "Lookup"},
+				},
+			},
+		},
+		"things": {
+			Description: "Things",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/things",
+					Description: "List things",
+					Params:      []spec.Param{{Name: "limit", Type: "integer"}, {Name: "cursor", Type: "string"}},
+					Pagination:  &spec.Pagination{Type: "cursor", CursorParam: "cursor", LimitParam: "limit"},
+					Response:    spec.ResponseDef{Type: "array", Item: "Thing"},
+				},
+				"get": {
+					Method:   "GET",
+					Path:     "/things/{id}",
+					Response: spec.ResponseDef{Type: "object", Item: "Thing"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	postEndpoint := readGeneratedFile(t, outputDir, "internal", "cli", "posts_list.go")
+	postPromoted := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_lookup.go")
+	getEndpoint := readGeneratedFile(t, outputDir, "internal", "cli", "things_list.go")
+	assert.NotContains(t, postEndpoint, `"all"`)
+	assert.NotContains(t, postEndpoint, "flagAll")
+	assert.NotContains(t, postPromoted, `"all"`)
+	assert.NotContains(t, postPromoted, "flagAll")
+	assert.Contains(t, getEndpoint, `flagAll`)
+
+	runGoCommandRequired(t, outputDir, "mod", "tidy")
+	runGoCommandRequired(t, outputDir, "build", "./internal/cli")
+}

--- a/internal/generator/query_endpoint_sync_test.go
+++ b/internal/generator/query_endpoint_sync_test.go
@@ -58,7 +58,7 @@ func TestGeneratedQueryEndpointSyncEmitsConstructs(t *testing.T) {
 	// not added to the global extractor list used by ordinary resources.
 	assert.Contains(t, syncContent, `var dataEnvelopeKeys = []string{"data", "Data", "result", "Result"}`)
 	assert.Contains(t, syncContent, `return []string{"QueryResponse"}`)
-	assert.Contains(t, syncContent, `extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)`)
+	assert.Contains(t, syncContent, `extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(resource, path)...)`)
 
 	requireGeneratedCompiles(t, outputDir)
 }

--- a/internal/generator/read_search_extraction_test.go
+++ b/internal/generator/read_search_extraction_test.go
@@ -92,7 +92,7 @@ func TestGeneratedSyncExtractionHonorsResponsePath(t *testing.T) {
 
 	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
 	require.Contains(t, syncSrc, `responsePathForResource(resource, path)`)
-	require.Contains(t, syncSrc, `extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)`)
+	require.Contains(t, syncSrc, `extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(resource, path)...)`)
 
 	testPath := filepath.Join(outputDir, "internal", "cli", "sync_response_path_test.go")
 	require.NoError(t, os.WriteFile(testPath, []byte(`package cli

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -5,7 +5,7 @@
 {{- $isForm := endpointUsesForm .Endpoint}}
 {{- $isRaw := endpointUsesRawRequest .Endpoint}}
 {{- $hasJSONBody := and (or .Endpoint.Body .Endpoint.BodyJSONFallback) (not $isMultipart) (not $isForm)}}
-{{- $supportsAllPagination := and (ne .Endpoint.Pagination nil) (ne .Endpoint.Pagination.Type "id_walk") (or (not (eq .Endpoint.Method "GET")) .IsReadOnly)}}
+{{- $supportsAllPagination := and (ne .Endpoint.Pagination nil) (ne .Endpoint.Pagination.Type "id_walk") (eq .Endpoint.Method "GET") .IsReadOnly}}
 {{- $dataSourceStrategy := dataSourceStrategy .Resource .Endpoint}}
 
 package cli

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -10,7 +10,7 @@
 {{- $isReadVerb := or (eq $method "GET") (eq $method "HEAD") (eq $method "OPTIONS")}}
 {{- $isWriteVerb := or (eq $method "POST") (eq $method "PUT") (eq $method "PATCH")}}
 {{- $canWriteBack := and .HasStore $isWriteVerb (not .IsReadOnly) (not .Endpoint.UsesBinaryResponse) (not .Endpoint.UsesTextResponse)}}
-{{- $supportsAllPagination := and (ne .Endpoint.Pagination nil) (ne .Endpoint.Pagination.Type "id_walk") (or (not (eq $method "GET")) .IsReadOnly)}}
+{{- $supportsAllPagination := and (ne .Endpoint.Pagination nil) (ne .Endpoint.Pagination.Type "id_walk") (eq $method "GET") .IsReadOnly}}
 {{- $dataSourceStrategy := dataSourceStrategy .Resource .Endpoint}}
 
 package cli

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -750,7 +750,9 @@ func syncResource(ctx context.Context, c interface {
 {{- end}}
 		params[pageSize.limitParam] = strconv.Itoa(pageSize.limit)
 		if cursor != "" {
-			params[pageSize.cursorParam] = cursor
+			if pageSize.cursorParam != "" {
+				params[pageSize.cursorParam] = cursor
+			}
 		}
 	}
 
@@ -856,7 +858,7 @@ func syncResource(ctx context.Context, c interface {
 {{ end}}
 	// Try to extract items from the response.
 	// Strategy: try array first, then common wrapper keys.
-	items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
+	items, nextCursor, hasMore := extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(resource, path)...)
 	if sortEffective && maxPages > 0 {
 		for _, item := range items {
 			itemTimestamp, ok := restSyncTimestamp(item, sortField)
@@ -881,7 +883,8 @@ func syncResource(ctx context.Context, c interface {
 	// 1 even though more pages exist (the original symptom in #1296).
 	// Guard on cursorType, not cursorParam name, so all canonical
 	// spellings (page / page_number / pageNumber / page[number]) work.
-	if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+	// A declared strategy without a request parameter cannot advance safely.
+	if pageSize.cursorParam != "" && pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 		currentPage, _ := strconv.Atoi(cursor)
 		if currentPage < 1 {
 			currentPage = 1
@@ -889,7 +892,7 @@ func syncResource(ctx context.Context, c interface {
 		nextCursor = strconv.Itoa(currentPage + 1)
 		hasMore = true
 	}
-	if pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+	if pageSize.cursorParam != "" && pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 		currentOffset, _ := strconv.Atoi(cursor)
 		nextCursor = strconv.Itoa(currentOffset + pageSize.limit)
 		hasMore = true
@@ -1094,7 +1097,7 @@ func syncResource(ctx context.Context, c interface {
 				capExitCursor = nextCursor
 			}
 			if truncatedByCap && capExitCursor == "" {
-				if pageSize.cursorType == "offset" {
+				if pageSize.cursorParam != "" && pageSize.cursorType == "offset" {
 					currentOffset, _ := strconv.Atoi(cursor)
 					capExitCursor = strconv.Itoa(currentOffset + pageSize.limit)
 				} else {
@@ -1203,7 +1206,7 @@ func syncResource(ctx context.Context, c interface {
 			}
 {{- end}}
 		if nextCursor == "" {
-			if pageSize.cursorType == "offset" {
+			if pageSize.cursorParam != "" && pageSize.cursorType == "offset" {
 				// Cursor-based APIs return the next cursor in the envelope.
 				// Offset-based APIs carry their pagination position client-side.
 				currentOffset, _ := strconv.Atoi(cursor)
@@ -1327,10 +1330,11 @@ func syncResource(ctx context.Context, c interface {
 
 // paginationDefaults holds the resolved pagination parameter names and page size.
 type paginationDefaults struct {
-	cursorParam string
-	cursorType  string // paginator class: "", "cursor", "page_token", "offset", "page"
-	limitParam  string
-	limit       int
+	cursorParam    string
+	cursorType     string // paginator class: "", "cursor", "page_token", "offset", "page"
+	nextCursorPath string
+	limitParam     string
+	limit          int
 }
 
 func shortPageEndsPagination(cursorType string, fetched, limit int) bool {
@@ -1348,18 +1352,20 @@ func determinePaginationDefaults(resource string) paginationDefaults {
 {{- range .PaginationDefaultResources}}
 	case "{{.Key}}":
 		return paginationDefaults{
-			cursorParam: "{{if .CursorParam}}{{.CursorParam}}{{else}}{{$.Pagination.CursorParam}}{{end}}",
-			cursorType:  "{{if .CursorType}}{{.CursorType}}{{else}}{{$.Pagination.CursorType}}{{end}}",
-			limitParam:  "{{if .LimitParam}}{{.LimitParam}}{{else}}{{$.Pagination.PageSizeParam}}{{end}}",
+			cursorParam: "{{.CursorParam}}",
+			cursorType:  "{{.CursorType}}",
+			nextCursorPath: "{{.NextCursorPath}}",
+			limitParam:  "{{.LimitParam}}",
 			limit:       {{if .Limit}}{{.Limit}}{{else}}{{if $.Pagination.DefaultPageSize}}{{$.Pagination.DefaultPageSize}}{{else}}100{{end}}{{end}},
 		}
 {{- end}}
 	}
 	return paginationDefaults{
-		cursorParam: "{{if .Pagination.CursorParam}}{{.Pagination.CursorParam}}{{else}}after{{end}}",
-		cursorType:  "{{.Pagination.CursorType}}",
-		limitParam:  "{{if .Pagination.PageSizeParam}}{{.Pagination.PageSizeParam}}{{else}}limit{{end}}",
-		limit:       {{if .Pagination.DefaultPageSize}}{{.Pagination.DefaultPageSize}}{{else}}100{{end}},
+		cursorParam:    "{{.Pagination.CursorParam}}",
+		cursorType:     "{{.Pagination.CursorType}}",
+		nextCursorPath: "",
+		limitParam:     "{{if .Pagination.PageSizeParam}}{{.Pagination.PageSizeParam}}{{else}}limit{{end}}",
+		limit:          {{if .Pagination.DefaultPageSize}}{{.Pagination.DefaultPageSize}}{{else}}100{{end}},
 	}
 }
 
@@ -1747,6 +1753,10 @@ func determineDateRangeParam() string {
 // 3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
 // It also extracts the next cursor from common response fields.
 func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ...string) ([]json.RawMessage, string, bool) {
+	return extractPageItemsWithPagination(data, cursorParam, "", responsePaths...)
+}
+
+func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCursorPath string, responsePaths ...string) ([]json.RawMessage, string, bool) {
 	// Strategy 1: direct array
 	var items []json.RawMessage
 	if err := json.Unmarshal(data, &items); err == nil {
@@ -1767,9 +1777,9 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 		if items, ok := extractJSONItemsArray(pathData); ok {
 			nextCursor, hasMore := "", false
 			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
-				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam)
+				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
 			}
-			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 			if nextCursor == "" {
 				nextCursor = outerCursor
 			}
@@ -1779,8 +1789,8 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 		var inner map[string]json.RawMessage
 		if json.Unmarshal(pathData, &inner) == nil {
 			if items, ok := extractItemsFromEnvelope(inner); ok {
-				nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam)
-				outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam, nextCursorPath)
+				outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 				if nextCursor == "" {
 					nextCursor = outerCursor
 				}
@@ -1791,7 +1801,7 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 	}
 
 	if items, ok := extractItemsByKnownKeys(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 		return items, nextCursor, hasMore
 	}
 
@@ -1805,8 +1815,8 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 			continue
 		}
 		if items, ok := extractItemsFromEnvelope(inner); ok {
-			nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam)
-			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam, nextCursorPath)
+			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 			if nextCursor == "" {
 				nextCursor = outerCursor
 			}
@@ -1819,14 +1829,14 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 		var embedded map[string]json.RawMessage
 		if json.Unmarshal(raw, &embedded) == nil {
 			if items, ok := extractItemsFromEnvelope(embedded); ok {
-				nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 				return items, nextCursor, hasMore
 			}
 		}
 	}
 
 	if items, ok := extractSingleObjectArraySibling(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 		return items, nextCursor, hasMore
 	}
 
@@ -2200,15 +2210,29 @@ func isJSONResponse(data json.RawMessage) bool {
 }
 
 // extractPaginationFromEnvelope extracts cursor and has_more from a response envelope.
-func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorParam string) (string, bool) {
+func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorParam, nextCursorPath string) (string, bool) {
+	if strings.TrimSpace(cursorParam) == "" {
+		return "", false
+	}
 	var hasMore bool
 
-	nextCursor := nextCursorFromLinks(envelope, cursorParam)
+	nextCursor := ""
+	if nextCursorPath != "" {
+		if raw, ok := rawAtPath(envelope, nextCursorPath); ok {
+			nextCursor = cursorValue(raw)
+			if isFollowableNextURL(nextCursor) {
+				nextCursor = cursorFromNextURL(nextCursor, cursorParam)
+			}
+		}
+	}
+	if nextCursor == "" {
+		nextCursor = nextCursorFromLinks(envelope, cursorParam)
+	}
 
 	// Try common cursor field names
 	cursorKeys := []string{
 		"next_cursor", "nextCursor", "next_token", "nextToken", "cursor",
-		"next_page_token", "nextPageToken", "page_token", "after", "end_cursor", "endCursor",
+		"next_page_token", "nextPageToken", "page_token", "after", "end_cursor", "endCursor", "next",
 	}
 	if nextCursor == "" {
 		nextCursor = findCursorInMap(envelope, cursorKeys)
@@ -2421,7 +2445,7 @@ func cursorFromNextURL(nextURL string, cursorParam string) string {
 	return ""
 }
 
-// findCursorInMap returns the first non-empty string-typed value in m
+// findCursorInMap returns the first non-empty scalar value in m
 // whose key matches one of cursorKeys. Used by extractPaginationFromEnvelope
 // to scan both the top-level envelope and well-known wrapper objects with
 // the same name-match rules — extracted so the two scans can't drift.
@@ -2431,10 +2455,27 @@ func findCursorInMap(m map[string]json.RawMessage, cursorKeys []string) string {
 		if !ok {
 			continue
 		}
-		var s string
-		if err := json.Unmarshal(raw, &s); err == nil && s != "" {
-			return s
+		if key == "next" {
+			var value string
+			if json.Unmarshal(raw, &value) == nil && isFollowableNextURL(value) {
+				continue
+			}
 		}
+		if value := cursorValue(raw); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func cursorValue(raw json.RawMessage) string {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var number json.Number
+	if err := json.Unmarshal(raw, &number); err == nil {
+		return number.String()
 	}
 	return ""
 }
@@ -3203,7 +3244,9 @@ func syncOneParent(
 {{- end}}
 			params[pageSize.limitParam] = strconv.Itoa(pageSize.limit)
 			if cursor != "" {
-				params[pageSize.cursorParam] = cursor
+				if pageSize.cursorParam != "" {
+					params[pageSize.cursorParam] = cursor
+				}
 			}
 		}
 		if depSinceTS != "" {
@@ -3284,12 +3327,13 @@ func syncOneParent(
 		}
 
 {{ end}}
-		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(dep.Name, path)...)
+		items, nextCursor, hasMore := extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(dep.Name, path)...)
 
 		// Page-int paginator fallback: mirrors syncResource so dependent
 		// resources on integer ?page=N APIs also advance past page 1.
-		// Guard on cursorType to cover every canonical spelling.
-		if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+		// Guard on cursorType to cover every canonical spelling. A declared
+		// strategy without a request parameter cannot advance safely.
+		if pageSize.cursorParam != "" && pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentPage, _ := strconv.Atoi(cursor)
 			if currentPage < 1 {
 				currentPage = 1
@@ -3297,7 +3341,7 @@ func syncOneParent(
 			nextCursor = strconv.Itoa(currentPage + 1)
 			hasMore = true
 		}
-		if pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+		if pageSize.cursorParam != "" && pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentOffset, _ := strconv.Atoi(cursor)
 			nextCursor = strconv.Itoa(currentOffset + pageSize.limit)
 			hasMore = true
@@ -3434,7 +3478,7 @@ func syncOneParent(
 			break
 		}
 		if nextCursor == "" {
-			if pageSize.cursorType == "offset" {
+			if pageSize.cursorParam != "" && pageSize.cursorType == "offset" {
 				// Cursor-based APIs return the next cursor in the envelope.
 				// Offset-based APIs carry their pagination position client-side.
 				currentOffset, _ := strconv.Atoi(cursor)

--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -654,26 +654,26 @@ func runDataPipelineTest(binary, cliDir, mode string, envFn func() []string, exp
 
 	// Test sync (if it exists)
 	var syncErrors []error
-	syncErr := runCLI(binary, []string{"sync", "--db", dbPath, "--resources", "repos", "--full"}, env, 30*time.Second)
+	syncErr := runCLI(binary, boundedSyncProbeArgs(mode, []string{"sync", "--db", dbPath, "--resources", "repos", "--full"}), env, 30*time.Second)
 	if syncErr != nil {
 		syncErrors = append(syncErrors, syncErr)
-		syncErr = runCLI(binary, []string{"sync", "--db", dbPath, "--full"}, env, 30*time.Second)
+		syncErr = runCLI(binary, boundedSyncProbeArgs(mode, []string{"sync", "--db", dbPath, "--full"}), env, 30*time.Second)
 	}
 	if syncErr != nil {
 		syncErrors = append(syncErrors, syncErr)
 		// Sync might not accept --resources or --full; keep --db when
 		// possible so downstream sql probes read the same temporary store.
-		syncErr = runCLI(binary, []string{"sync", "--db", dbPath}, env, 30*time.Second)
+		syncErr = runCLI(binary, boundedSyncProbeArgs(mode, []string{"sync", "--db", dbPath}), env, 30*time.Second)
 	}
 	if syncErr != nil {
 		syncErrors = append(syncErrors, syncErr)
 		// Sync might not accept --db either; try the bare command before
 		// deciding the pipeline crashed.
-		syncErr = runCLI(binary, []string{"sync", "--full"}, env, 30*time.Second)
+		syncErr = runCLI(binary, boundedSyncProbeArgs(mode, []string{"sync", "--full"}), env, 30*time.Second)
 	}
 	if syncErr != nil {
 		syncErrors = append(syncErrors, syncErr)
-		syncErr = runCLI(binary, []string{"sync"}, env, 30*time.Second)
+		syncErr = runCLI(binary, boundedSyncProbeArgs(mode, []string{"sync"}), env, 30*time.Second)
 	}
 	if syncErr != nil {
 		syncErrors = append(syncErrors, syncErr)
@@ -749,6 +749,14 @@ func runDataPipelineTest(binary, cliDir, mode string, envFn func() []string, exp
 		return false, fmt.Sprintf("FAIL: %s has 0 rows after sync, expected at least %d (%s mode)", zeroDataTable, expectedRows, mode)
 	}
 	return false, fmt.Sprintf("FAIL: %d domain tables created but 0 rows after sync (%s mode)", len(tables), mode)
+}
+
+func boundedSyncProbeArgs(mode string, args []string) []string {
+	if mode != "live" {
+		return args
+	}
+	bounded := append([]string(nil), args...)
+	return append(bounded, "--max-pages", "1")
 }
 
 func allSyncAttemptsWereUnknownCommand(errs []error) bool {

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -332,6 +332,15 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 	})
 }
 
+func TestRunDataPipelineTestBoundsLiveSync(t *testing.T) {
+	binary := buildLiveBoundedSyncProbeBinary(t)
+
+	pass, detail := runDataPipelineTest(binary, "", "live", os.Environ, 1)
+
+	assert.True(t, pass)
+	assert.Contains(t, detail, "items has 1 rows")
+}
+
 func TestUnknownSyncFlagIgnoresEmptyFlagName(t *testing.T) {
 	flag, ok := unknownSyncFlag(errors.New("unknown flag: "))
 
@@ -863,6 +872,86 @@ func dbArg(args []string) string {
 `, rowCount))
 	binaryPath := filepath.Join(dir, "test-cli")
 	buildCmd := exec.Command("go", "build", "-o", binaryPath, mainFile)
+	out, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, "building test binary: %s", string(out))
+	return binaryPath
+}
+
+func buildLiveBoundedSyncProbeBinary(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	mainFile := filepath.Join(dir, "main.go")
+	writeTestFile(t, mainFile, `package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	args := os.Args[1:]
+	if len(args) == 0 {
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "sync":
+		if !hasFlagValue(args[1:], "--max-pages", "1") {
+			fmt.Fprintln(os.Stderr, "live sync probe requires --max-pages 1")
+			os.Exit(1)
+		}
+		dbPath := dbArg(args[1:])
+		if dbPath == "" {
+			os.Exit(1)
+		}
+		if err := os.WriteFile(dbPath+".marker", []byte(dbPath), 0o644); err != nil {
+			os.Exit(1)
+		}
+		return
+	case "sql":
+		dbPath := dbArg(args[1:])
+		if dbPath == "" {
+			os.Exit(1)
+		}
+		usedDB, err := os.ReadFile(dbPath + ".marker")
+		if err != nil || string(usedDB) != dbPath {
+			os.Exit(1)
+		}
+		query := args[len(args)-1]
+		if strings.Contains(query, "sqlite_master") {
+			fmt.Println("items")
+			return
+		}
+		if strings.Contains(query, "count(*)") {
+			fmt.Println(1)
+			return
+		}
+	}
+	os.Exit(1)
+}
+
+func hasFlagValue(args []string, flag, want string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == want {
+			return true
+		}
+	}
+	return false
+}
+
+func dbArg(args []string) string {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--db" {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+`)
+	binaryPath := filepath.Join(dir, "test-cli")
+	buildCmd := exec.Command("go", "build", "-o", "./test-cli", mainFile)
+	buildCmd.Dir = dir
 	out, err := buildCmd.CombinedOutput()
 	require.NoError(t, err, "building test binary: %s", string(out))
 	return binaryPath

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -138,10 +138,11 @@ type SyncableResource struct {
 	SupportsPagination bool
 	// Pagination* fields preserve the chosen list endpoint's concrete paging
 	// contract so generated sync does not reuse a different resource's default.
-	PaginationCursorParam string
-	PaginationCursorType  string
-	PaginationLimitParam  string
-	PaginationPageSize    int
+	PaginationCursorParam    string
+	PaginationCursorType     string
+	PaginationNextCursorPath string
+	PaginationLimitParam     string
+	PaginationPageSize       int
 	// PaginationSort* describe an explicit ascending last-modified ordering
 	// that is safe to send alongside an incremental temporal filter.
 	PaginationSortParam string
@@ -243,10 +244,11 @@ type DependentResource struct {
 	// that do not declare page-size pagination.
 	SupportsPagination bool
 	// Pagination* mirrors SyncableResource for child sync paths.
-	PaginationCursorParam string
-	PaginationCursorType  string
-	PaginationLimitParam  string
-	PaginationPageSize    int
+	PaginationCursorParam    string
+	PaginationCursorType     string
+	PaginationNextCursorPath string
+	PaginationLimitParam     string
+	PaginationPageSize       int
 
 	// UsesHTMLResponse and HTMLExtract mirror SyncableResource for child sync
 	// paths.
@@ -1754,31 +1756,32 @@ func dependentResourceFromEntry(entry parameterizedEntry, knownParents map[strin
 	keyField := parentIDFieldForDependent(ctx.parentResource, syncable)
 
 	return DependentResource{
-		Name:                  ctx.name,
-		ParentResource:        ctx.parentResource,
-		ParentIDParam:         dependentParentIDParam(entry.meta.Path, ctx.parentPathSegment, ctx.firstParam),
-		Path:                  entry.meta.Path,
-		Method:                entry.meta.Method,
-		Tier:                  entry.meta.Tier,
-		PathParams:            dependentPathParams(entry.meta.Path, ctx.parentPathSegment, ctx.firstParam, keyField),
-		parentPath:            dependentParentPath(entry.meta.Path, ctx.parentPathSegment),
-		IDField:               entry.meta.IDField,
-		Critical:              entry.meta.Critical,
-		SinceParam:            entry.meta.SinceParam,
-		SinceParamFormat:      entry.meta.SinceParamFormat,
-		SupportsPagination:    entry.meta.SupportsPagination,
-		PaginationCursorParam: entry.meta.PaginationCursorParam,
-		PaginationCursorType:  entry.meta.PaginationCursorType,
-		PaginationLimitParam:  entry.meta.PaginationLimitParam,
-		PaginationPageSize:    entry.meta.PaginationPageSize,
-		UsesHTMLResponse:      entry.meta.UsesHTMLResponse,
-		HTMLExtract:           entry.meta.HTMLExtract,
-		BodyFields:            entry.meta.BodyFields,
-		IDWalkFilterParam:     entry.meta.IDWalkFilterParam,
-		IDWalkLimitParam:      entry.meta.IDWalkLimitParam,
-		IDWalkPageSize:        entry.meta.IDWalkPageSize,
-		FieldSelector:         entry.meta.FieldSelector,
-		Discriminator:         entry.meta.Discriminator,
+		Name:                     ctx.name,
+		ParentResource:           ctx.parentResource,
+		ParentIDParam:            dependentParentIDParam(entry.meta.Path, ctx.parentPathSegment, ctx.firstParam),
+		Path:                     entry.meta.Path,
+		Method:                   entry.meta.Method,
+		Tier:                     entry.meta.Tier,
+		PathParams:               dependentPathParams(entry.meta.Path, ctx.parentPathSegment, ctx.firstParam, keyField),
+		parentPath:               dependentParentPath(entry.meta.Path, ctx.parentPathSegment),
+		IDField:                  entry.meta.IDField,
+		Critical:                 entry.meta.Critical,
+		SinceParam:               entry.meta.SinceParam,
+		SinceParamFormat:         entry.meta.SinceParamFormat,
+		SupportsPagination:       entry.meta.SupportsPagination,
+		PaginationCursorParam:    entry.meta.PaginationCursorParam,
+		PaginationCursorType:     entry.meta.PaginationCursorType,
+		PaginationNextCursorPath: entry.meta.PaginationNextCursorPath,
+		PaginationLimitParam:     entry.meta.PaginationLimitParam,
+		PaginationPageSize:       entry.meta.PaginationPageSize,
+		UsesHTMLResponse:         entry.meta.UsesHTMLResponse,
+		HTMLExtract:              entry.meta.HTMLExtract,
+		BodyFields:               entry.meta.BodyFields,
+		IDWalkFilterParam:        entry.meta.IDWalkFilterParam,
+		IDWalkLimitParam:         entry.meta.IDWalkLimitParam,
+		IDWalkPageSize:           entry.meta.IDWalkPageSize,
+		FieldSelector:            entry.meta.FieldSelector,
+		Discriminator:            entry.meta.Discriminator,
 	}, true
 }
 
@@ -1989,32 +1992,33 @@ func applySpecWalkers(s *spec.APISpec, deps []DependentResource, syncable map[st
 			}
 			meta := metaFromEndpoint(s, resourceName, r, e, types, resourceNameIndex)
 			deps = append(deps, DependentResource{
-				Name:                  spec.ToSnakeCase(resourceName),
-				ParentResource:        parent,
-				ParentIDParam:         keyParam,
-				Path:                  e.Path,
-				parentPathLock:        true,
-				Method:                meta.Method,
-				Tier:                  meta.Tier,
-				PathParams:            dependentPathParams(e.Path, parent, keyParam, keyField),
-				IDField:               meta.IDField,
-				Critical:              meta.Critical,
-				SinceParam:            meta.SinceParam,
-				SinceParamFormat:      meta.SinceParamFormat,
-				SupportsPagination:    meta.SupportsPagination,
-				PaginationCursorParam: meta.PaginationCursorParam,
-				PaginationCursorType:  meta.PaginationCursorType,
-				PaginationLimitParam:  meta.PaginationLimitParam,
-				PaginationPageSize:    meta.PaginationPageSize,
-				UsesHTMLResponse:      meta.UsesHTMLResponse,
-				HTMLExtract:           meta.HTMLExtract,
-				BodyFields:            meta.BodyFields,
-				IDWalkFilterParam:     meta.IDWalkFilterParam,
-				IDWalkLimitParam:      meta.IDWalkLimitParam,
-				IDWalkPageSize:        meta.IDWalkPageSize,
-				FieldSelector:         meta.FieldSelector,
-				Discriminator:         meta.Discriminator,
-				KeyField:              keyField,
+				Name:                     spec.ToSnakeCase(resourceName),
+				ParentResource:           parent,
+				ParentIDParam:            keyParam,
+				Path:                     e.Path,
+				parentPathLock:           true,
+				Method:                   meta.Method,
+				Tier:                     meta.Tier,
+				PathParams:               dependentPathParams(e.Path, parent, keyParam, keyField),
+				IDField:                  meta.IDField,
+				Critical:                 meta.Critical,
+				SinceParam:               meta.SinceParam,
+				SinceParamFormat:         meta.SinceParamFormat,
+				SupportsPagination:       meta.SupportsPagination,
+				PaginationCursorParam:    meta.PaginationCursorParam,
+				PaginationCursorType:     meta.PaginationCursorType,
+				PaginationNextCursorPath: meta.PaginationNextCursorPath,
+				PaginationLimitParam:     meta.PaginationLimitParam,
+				PaginationPageSize:       meta.PaginationPageSize,
+				UsesHTMLResponse:         meta.UsesHTMLResponse,
+				HTMLExtract:              meta.HTMLExtract,
+				BodyFields:               meta.BodyFields,
+				IDWalkFilterParam:        meta.IDWalkFilterParam,
+				IDWalkLimitParam:         meta.IDWalkLimitParam,
+				IDWalkPageSize:           meta.IDWalkPageSize,
+				FieldSelector:            meta.FieldSelector,
+				Discriminator:            meta.Discriminator,
+				KeyField:                 keyField,
 			})
 			byPath[lookupKey] = len(deps) - 1
 		}
@@ -2301,36 +2305,37 @@ func resolveParentResourceName(walkParent, paramName string, knownParents map[st
 // is still selecting between candidates (e.g., flat vs. paginated). It is
 // converted into a SyncableResource at the end of Profile().
 type syncableMeta struct {
-	Path                  string
-	Method                string
-	Tier                  string
-	SkipDefaultSync       bool
-	IDField               string
-	Critical              bool
-	SinceParam            string
-	SinceParamFormat      string
-	SupportsPagination    bool
-	PaginationCursorParam string
-	PaginationCursorType  string
-	PaginationLimitParam  string
-	PaginationPageSize    int
-	PaginationSortParam   string
-	PaginationSortValue   string
-	PaginationSortField   string
-	UsesHTMLResponse      bool
-	HTMLExtract           *spec.HTMLExtract
-	BodyFields            []SyncBodyField
-	IDWalkFilterParam     string
-	IDWalkLimitParam      string
-	IDWalkPageSize        int
-	FieldSelector         FieldSelector
-	Discriminator         DiscriminatorDispatch
-	ResponseItem          string
-	QueryEntity           string
-	TenantScopeColumn     string
-	HydratePath           string
-	HydrateIDParam        string
-	MembershipField       string
+	Path                     string
+	Method                   string
+	Tier                     string
+	SkipDefaultSync          bool
+	IDField                  string
+	Critical                 bool
+	SinceParam               string
+	SinceParamFormat         string
+	SupportsPagination       bool
+	PaginationCursorParam    string
+	PaginationCursorType     string
+	PaginationNextCursorPath string
+	PaginationLimitParam     string
+	PaginationPageSize       int
+	PaginationSortParam      string
+	PaginationSortValue      string
+	PaginationSortField      string
+	UsesHTMLResponse         bool
+	HTMLExtract              *spec.HTMLExtract
+	BodyFields               []SyncBodyField
+	IDWalkFilterParam        string
+	IDWalkLimitParam         string
+	IDWalkPageSize           int
+	FieldSelector            FieldSelector
+	Discriminator            DiscriminatorDispatch
+	ResponseItem             string
+	QueryEntity              string
+	TenantScopeColumn        string
+	HydratePath              string
+	HydrateIDParam           string
+	MembershipField          string
 }
 
 type syncableCandidate struct {
@@ -2357,38 +2362,43 @@ func metaFromEndpoint(s *spec.APISpec, resourceName string, resource spec.Resour
 	paginationCursorParam, paginationCursorType, paginationLimitParam, paginationPageSize := syncPaginationDefaultsFromEndpoint(e)
 	paginationSortParam, paginationSortValue := detectEndpointSyncSort(e)
 	paginationSortField := temporalSortField(paginationSortValue)
+	nextCursorPath := ""
+	if e.Pagination != nil {
+		nextCursorPath = strings.TrimSpace(e.Pagination.NextCursorPath)
+	}
 	hydratePath, hydrateIDParam := scalarIDHydrationTarget(s, resourceName, e, types)
 	return syncableMeta{
-		Path:                  e.Path,
-		Method:                strings.ToUpper(e.Method),
-		Tier:                  s.EffectiveTier(resource, e),
-		SkipDefaultSync:       isAuthTaggedEndpoint(e) || hasTypedResponseWithoutRuntimeID(resourceName, e, types),
-		IDField:               e.IDField,
-		Critical:              e.Critical,
-		SinceParam:            sinceParam,
-		SinceParamFormat:      sinceParamFormat,
-		SupportsPagination:    endpointSupportsPagination(e),
-		PaginationCursorParam: paginationCursorParam,
-		PaginationCursorType:  paginationCursorType,
-		PaginationLimitParam:  paginationLimitParam,
-		PaginationPageSize:    paginationPageSize,
-		PaginationSortParam:   paginationSortParam,
-		PaginationSortValue:   paginationSortValue,
-		PaginationSortField:   paginationSortField,
-		UsesHTMLResponse:      e.UsesHTMLResponse(),
-		HTMLExtract:           e.HTMLExtract,
-		BodyFields:            syncBodyFieldsFromEndpoint(e),
-		IDWalkFilterParam:     idWalkFilterParam,
-		IDWalkLimitParam:      idWalkLimitParam,
-		IDWalkPageSize:        idWalkPageSize,
-		FieldSelector:         detectEndpointFieldSelector(e),
-		Discriminator:         discriminatorDispatchForEndpoint(e, types, resourceNameIndex),
-		ResponseItem:          e.Response.Item,
-		QueryEntity:           queryEntityForEndpoint(s, e),
-		TenantScopeColumn:     e.TenantScopeColumn,
-		HydratePath:           hydratePath,
-		HydrateIDParam:        hydrateIDParam,
-		MembershipField:       e.MembershipField,
+		Path:                     e.Path,
+		Method:                   strings.ToUpper(e.Method),
+		Tier:                     s.EffectiveTier(resource, e),
+		SkipDefaultSync:          isAuthTaggedEndpoint(e) || hasTypedResponseWithoutRuntimeID(resourceName, e, types),
+		IDField:                  e.IDField,
+		Critical:                 e.Critical,
+		SinceParam:               sinceParam,
+		SinceParamFormat:         sinceParamFormat,
+		SupportsPagination:       endpointSupportsPagination(e),
+		PaginationCursorParam:    paginationCursorParam,
+		PaginationCursorType:     paginationCursorType,
+		PaginationNextCursorPath: nextCursorPath,
+		PaginationLimitParam:     paginationLimitParam,
+		PaginationPageSize:       paginationPageSize,
+		PaginationSortParam:      paginationSortParam,
+		PaginationSortValue:      paginationSortValue,
+		PaginationSortField:      paginationSortField,
+		UsesHTMLResponse:         e.UsesHTMLResponse(),
+		HTMLExtract:              e.HTMLExtract,
+		BodyFields:               syncBodyFieldsFromEndpoint(e),
+		IDWalkFilterParam:        idWalkFilterParam,
+		IDWalkLimitParam:         idWalkLimitParam,
+		IDWalkPageSize:           idWalkPageSize,
+		FieldSelector:            detectEndpointFieldSelector(e),
+		Discriminator:            discriminatorDispatchForEndpoint(e, types, resourceNameIndex),
+		ResponseItem:             e.Response.Item,
+		QueryEntity:              queryEntityForEndpoint(s, e),
+		TenantScopeColumn:        e.TenantScopeColumn,
+		HydratePath:              hydratePath,
+		HydrateIDParam:           hydrateIDParam,
+		MembershipField:          e.MembershipField,
 	}
 }
 
@@ -3347,36 +3357,37 @@ func sortedSyncableResources(m map[string]syncableMeta) []SyncableResource {
 	for i, name := range names {
 		meta := m[name]
 		resources[i] = SyncableResource{
-			Name:                  name,
-			Path:                  meta.Path,
-			Method:                meta.Method,
-			Tier:                  meta.Tier,
-			SkipDefaultSync:       meta.SkipDefaultSync,
-			IDField:               meta.IDField,
-			Critical:              meta.Critical,
-			SinceParam:            meta.SinceParam,
-			SinceParamFormat:      meta.SinceParamFormat,
-			SupportsPagination:    meta.SupportsPagination,
-			PaginationCursorParam: meta.PaginationCursorParam,
-			PaginationCursorType:  meta.PaginationCursorType,
-			PaginationLimitParam:  meta.PaginationLimitParam,
-			PaginationPageSize:    meta.PaginationPageSize,
-			PaginationSortParam:   meta.PaginationSortParam,
-			PaginationSortValue:   meta.PaginationSortValue,
-			PaginationSortField:   meta.PaginationSortField,
-			UsesHTMLResponse:      meta.UsesHTMLResponse,
-			HTMLExtract:           meta.HTMLExtract,
-			BodyFields:            meta.BodyFields,
-			IDWalkFilterParam:     meta.IDWalkFilterParam,
-			IDWalkLimitParam:      meta.IDWalkLimitParam,
-			IDWalkPageSize:        meta.IDWalkPageSize,
-			FieldSelector:         meta.FieldSelector,
-			Discriminator:         meta.Discriminator,
-			QueryEntity:           meta.QueryEntity,
-			TenantScopeColumn:     meta.TenantScopeColumn,
-			HydratePath:           meta.HydratePath,
-			HydrateIDParam:        meta.HydrateIDParam,
-			MembershipField:       meta.MembershipField,
+			Name:                     name,
+			Path:                     meta.Path,
+			Method:                   meta.Method,
+			Tier:                     meta.Tier,
+			SkipDefaultSync:          meta.SkipDefaultSync,
+			IDField:                  meta.IDField,
+			Critical:                 meta.Critical,
+			SinceParam:               meta.SinceParam,
+			SinceParamFormat:         meta.SinceParamFormat,
+			SupportsPagination:       meta.SupportsPagination,
+			PaginationCursorParam:    meta.PaginationCursorParam,
+			PaginationCursorType:     meta.PaginationCursorType,
+			PaginationNextCursorPath: meta.PaginationNextCursorPath,
+			PaginationLimitParam:     meta.PaginationLimitParam,
+			PaginationPageSize:       meta.PaginationPageSize,
+			PaginationSortParam:      meta.PaginationSortParam,
+			PaginationSortValue:      meta.PaginationSortValue,
+			PaginationSortField:      meta.PaginationSortField,
+			UsesHTMLResponse:         meta.UsesHTMLResponse,
+			HTMLExtract:              meta.HTMLExtract,
+			BodyFields:               meta.BodyFields,
+			IDWalkFilterParam:        meta.IDWalkFilterParam,
+			IDWalkLimitParam:         meta.IDWalkLimitParam,
+			IDWalkPageSize:           meta.IDWalkPageSize,
+			FieldSelector:            meta.FieldSelector,
+			Discriminator:            meta.Discriminator,
+			QueryEntity:              meta.QueryEntity,
+			TenantScopeColumn:        meta.TenantScopeColumn,
+			HydratePath:              meta.HydratePath,
+			HydrateIDParam:           meta.HydrateIDParam,
+			MembershipField:          meta.MembershipField,
 		}
 	}
 	return resources

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -553,7 +553,9 @@ func syncResource(ctx context.Context, c interface {
 		if resourceSupportsPagination(resource) {
 			params[pageSize.limitParam] = strconv.Itoa(pageSize.limit)
 			if cursor != "" {
-				params[pageSize.cursorParam] = cursor
+				if pageSize.cursorParam != "" {
+					params[pageSize.cursorParam] = cursor
+				}
 			}
 		}
 
@@ -599,7 +601,7 @@ func syncResource(ctx context.Context, c interface {
 
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
-		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
+		items, nextCursor, hasMore := extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(resource, path)...)
 		if sortEffective && maxPages > 0 {
 			for _, item := range items {
 				itemTimestamp, ok := restSyncTimestamp(item, sortField)
@@ -624,7 +626,8 @@ func syncResource(ctx context.Context, c interface {
 		// 1 even though more pages exist (the original symptom in #1296).
 		// Guard on cursorType, not cursorParam name, so all canonical
 		// spellings (page / page_number / pageNumber / page[number]) work.
-		if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+		// A declared strategy without a request parameter cannot advance safely.
+		if pageSize.cursorParam != "" && pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentPage, _ := strconv.Atoi(cursor)
 			if currentPage < 1 {
 				currentPage = 1
@@ -632,7 +635,7 @@ func syncResource(ctx context.Context, c interface {
 			nextCursor = strconv.Itoa(currentPage + 1)
 			hasMore = true
 		}
-		if pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+		if pageSize.cursorParam != "" && pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentOffset, _ := strconv.Atoi(cursor)
 			nextCursor = strconv.Itoa(currentOffset + pageSize.limit)
 			hasMore = true
@@ -782,7 +785,7 @@ func syncResource(ctx context.Context, c interface {
 				capExitCursor = nextCursor
 			}
 			if truncatedByCap && capExitCursor == "" {
-				if pageSize.cursorType == "offset" {
+				if pageSize.cursorParam != "" && pageSize.cursorType == "offset" {
 					currentOffset, _ := strconv.Atoi(cursor)
 					capExitCursor = strconv.Itoa(currentOffset + pageSize.limit)
 				} else {
@@ -849,7 +852,7 @@ func syncResource(ctx context.Context, c interface {
 			break
 		}
 		if nextCursor == "" {
-			if pageSize.cursorType == "offset" {
+			if pageSize.cursorParam != "" && pageSize.cursorType == "offset" {
 				// Cursor-based APIs return the next cursor in the envelope.
 				// Offset-based APIs carry their pagination position client-side.
 				currentOffset, _ := strconv.Atoi(cursor)
@@ -973,10 +976,11 @@ func syncResource(ctx context.Context, c interface {
 
 // paginationDefaults holds the resolved pagination parameter names and page size.
 type paginationDefaults struct {
-	cursorParam string
-	cursorType  string // paginator class: "", "cursor", "page_token", "offset", "page"
-	limitParam  string
-	limit       int
+	cursorParam    string
+	cursorType     string // paginator class: "", "cursor", "page_token", "offset", "page"
+	nextCursorPath string
+	limitParam     string
+	limit          int
 }
 
 func shortPageEndsPagination(cursorType string, fetched, limit int) bool {
@@ -993,24 +997,27 @@ func determinePaginationDefaults(resource string) paginationDefaults {
 	switch resource {
 	case "projects":
 		return paginationDefaults{
-			cursorParam: "cursor",
-			cursorType:  "cursor",
-			limitParam:  "limit",
-			limit:       25,
+			cursorParam:    "cursor",
+			cursorType:     "cursor",
+			nextCursorPath: "",
+			limitParam:     "limit",
+			limit:          25,
 		}
 	case "projects/tasks":
 		return paginationDefaults{
-			cursorParam: "cursor",
-			cursorType:  "cursor",
-			limitParam:  "limit",
-			limit:       50,
+			cursorParam:    "cursor",
+			cursorType:     "cursor",
+			nextCursorPath: "",
+			limitParam:     "limit",
+			limit:          50,
 		}
 	}
 	return paginationDefaults{
-		cursorParam: "cursor",
-		cursorType:  "cursor",
-		limitParam:  "limit",
-		limit:       100,
+		cursorParam:    "cursor",
+		cursorType:     "cursor",
+		nextCursorPath: "",
+		limitParam:     "limit",
+		limit:          100,
 	}
 }
 
@@ -1091,6 +1098,10 @@ func formatSyncSinceValue(value string, paramFormat string) string {
 // 3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
 // It also extracts the next cursor from common response fields.
 func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ...string) ([]json.RawMessage, string, bool) {
+	return extractPageItemsWithPagination(data, cursorParam, "", responsePaths...)
+}
+
+func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCursorPath string, responsePaths ...string) ([]json.RawMessage, string, bool) {
 	// Strategy 1: direct array
 	var items []json.RawMessage
 	if err := json.Unmarshal(data, &items); err == nil {
@@ -1111,9 +1122,9 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 		if items, ok := extractJSONItemsArray(pathData); ok {
 			nextCursor, hasMore := "", false
 			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
-				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam)
+				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
 			}
-			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 			if nextCursor == "" {
 				nextCursor = outerCursor
 			}
@@ -1123,8 +1134,8 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 		var inner map[string]json.RawMessage
 		if json.Unmarshal(pathData, &inner) == nil {
 			if items, ok := extractItemsFromEnvelope(inner); ok {
-				nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam)
-				outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam, nextCursorPath)
+				outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 				if nextCursor == "" {
 					nextCursor = outerCursor
 				}
@@ -1135,7 +1146,7 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 	}
 
 	if items, ok := extractItemsByKnownKeys(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 		return items, nextCursor, hasMore
 	}
 
@@ -1149,8 +1160,8 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 			continue
 		}
 		if items, ok := extractItemsFromEnvelope(inner); ok {
-			nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam)
-			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam, nextCursorPath)
+			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 			if nextCursor == "" {
 				nextCursor = outerCursor
 			}
@@ -1163,14 +1174,14 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 		var embedded map[string]json.RawMessage
 		if json.Unmarshal(raw, &embedded) == nil {
 			if items, ok := extractItemsFromEnvelope(embedded); ok {
-				nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 				return items, nextCursor, hasMore
 			}
 		}
 	}
 
 	if items, ok := extractSingleObjectArraySibling(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 		return items, nextCursor, hasMore
 	}
 
@@ -1432,15 +1443,29 @@ func isJSONResponse(data json.RawMessage) bool {
 }
 
 // extractPaginationFromEnvelope extracts cursor and has_more from a response envelope.
-func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorParam string) (string, bool) {
+func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorParam, nextCursorPath string) (string, bool) {
+	if strings.TrimSpace(cursorParam) == "" {
+		return "", false
+	}
 	var hasMore bool
 
-	nextCursor := nextCursorFromLinks(envelope, cursorParam)
+	nextCursor := ""
+	if nextCursorPath != "" {
+		if raw, ok := rawAtPath(envelope, nextCursorPath); ok {
+			nextCursor = cursorValue(raw)
+			if isFollowableNextURL(nextCursor) {
+				nextCursor = cursorFromNextURL(nextCursor, cursorParam)
+			}
+		}
+	}
+	if nextCursor == "" {
+		nextCursor = nextCursorFromLinks(envelope, cursorParam)
+	}
 
 	// Try common cursor field names
 	cursorKeys := []string{
 		"next_cursor", "nextCursor", "next_token", "nextToken", "cursor",
-		"next_page_token", "nextPageToken", "page_token", "after", "end_cursor", "endCursor",
+		"next_page_token", "nextPageToken", "page_token", "after", "end_cursor", "endCursor", "next",
 	}
 	if nextCursor == "" {
 		nextCursor = findCursorInMap(envelope, cursorKeys)
@@ -1653,7 +1678,7 @@ func cursorFromNextURL(nextURL string, cursorParam string) string {
 	return ""
 }
 
-// findCursorInMap returns the first non-empty string-typed value in m
+// findCursorInMap returns the first non-empty scalar value in m
 // whose key matches one of cursorKeys. Used by extractPaginationFromEnvelope
 // to scan both the top-level envelope and well-known wrapper objects with
 // the same name-match rules — extracted so the two scans can't drift.
@@ -1663,10 +1688,27 @@ func findCursorInMap(m map[string]json.RawMessage, cursorKeys []string) string {
 		if !ok {
 			continue
 		}
-		var s string
-		if err := json.Unmarshal(raw, &s); err == nil && s != "" {
-			return s
+		if key == "next" {
+			var value string
+			if json.Unmarshal(raw, &value) == nil && isFollowableNextURL(value) {
+				continue
+			}
 		}
+		if value := cursorValue(raw); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func cursorValue(raw json.RawMessage) string {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var number json.Number
+	if err := json.Unmarshal(raw, &number); err == nil {
+		return number.String()
 	}
 	return ""
 }
@@ -2154,7 +2196,9 @@ func syncOneParent(
 		if resourceSupportsPagination(dep.Name) {
 			params[pageSize.limitParam] = strconv.Itoa(pageSize.limit)
 			if cursor != "" {
-				params[pageSize.cursorParam] = cursor
+				if pageSize.cursorParam != "" {
+					params[pageSize.cursorParam] = cursor
+				}
 			}
 		}
 		if depSinceTS != "" {
@@ -2201,12 +2245,13 @@ func syncOneParent(
 			return rep
 		}
 
-		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(dep.Name, path)...)
+		items, nextCursor, hasMore := extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(dep.Name, path)...)
 
 		// Page-int paginator fallback: mirrors syncResource so dependent
 		// resources on integer ?page=N APIs also advance past page 1.
-		// Guard on cursorType to cover every canonical spelling.
-		if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+		// Guard on cursorType to cover every canonical spelling. A declared
+		// strategy without a request parameter cannot advance safely.
+		if pageSize.cursorParam != "" && pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentPage, _ := strconv.Atoi(cursor)
 			if currentPage < 1 {
 				currentPage = 1
@@ -2214,7 +2259,7 @@ func syncOneParent(
 			nextCursor = strconv.Itoa(currentPage + 1)
 			hasMore = true
 		}
-		if pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+		if pageSize.cursorParam != "" && pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentOffset, _ := strconv.Atoi(cursor)
 			nextCursor = strconv.Itoa(currentOffset + pageSize.limit)
 			hasMore = true
@@ -2335,7 +2380,7 @@ func syncOneParent(
 			break
 		}
 		if nextCursor == "" {
-			if pageSize.cursorType == "offset" {
+			if pageSize.cursorParam != "" && pageSize.cursorType == "offset" {
 				// Cursor-based APIs return the next cursor in the envelope.
 				// Offset-based APIs carry their pagination position client-side.
 				currentOffset, _ := strconv.Atoi(cursor)

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -514,7 +514,9 @@ func syncResource(ctx context.Context, c interface {
 		if resourceSupportsPagination(resource) {
 			params[pageSize.limitParam] = strconv.Itoa(pageSize.limit)
 			if cursor != "" {
-				params[pageSize.cursorParam] = cursor
+				if pageSize.cursorParam != "" {
+					params[pageSize.cursorParam] = cursor
+				}
 			}
 		}
 
@@ -583,7 +585,7 @@ func syncResource(ctx context.Context, c interface {
 
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
-		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
+		items, nextCursor, hasMore := extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(resource, path)...)
 		if sortEffective && maxPages > 0 {
 			for _, item := range items {
 				itemTimestamp, ok := restSyncTimestamp(item, sortField)
@@ -608,7 +610,8 @@ func syncResource(ctx context.Context, c interface {
 		// 1 even though more pages exist (the original symptom in #1296).
 		// Guard on cursorType, not cursorParam name, so all canonical
 		// spellings (page / page_number / pageNumber / page[number]) work.
-		if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+		// A declared strategy without a request parameter cannot advance safely.
+		if pageSize.cursorParam != "" && pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentPage, _ := strconv.Atoi(cursor)
 			if currentPage < 1 {
 				currentPage = 1
@@ -616,7 +619,7 @@ func syncResource(ctx context.Context, c interface {
 			nextCursor = strconv.Itoa(currentPage + 1)
 			hasMore = true
 		}
-		if pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+		if pageSize.cursorParam != "" && pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentOffset, _ := strconv.Atoi(cursor)
 			nextCursor = strconv.Itoa(currentOffset + pageSize.limit)
 			hasMore = true
@@ -793,7 +796,7 @@ func syncResource(ctx context.Context, c interface {
 				capExitCursor = nextCursor
 			}
 			if truncatedByCap && capExitCursor == "" {
-				if pageSize.cursorType == "offset" {
+				if pageSize.cursorParam != "" && pageSize.cursorType == "offset" {
 					currentOffset, _ := strconv.Atoi(cursor)
 					capExitCursor = strconv.Itoa(currentOffset + pageSize.limit)
 				} else {
@@ -872,7 +875,7 @@ func syncResource(ctx context.Context, c interface {
 			break
 		}
 		if nextCursor == "" {
-			if pageSize.cursorType == "offset" {
+			if pageSize.cursorParam != "" && pageSize.cursorType == "offset" {
 				// Cursor-based APIs return the next cursor in the envelope.
 				// Offset-based APIs carry their pagination position client-side.
 				currentOffset, _ := strconv.Atoi(cursor)
@@ -996,10 +999,11 @@ func syncResource(ctx context.Context, c interface {
 
 // paginationDefaults holds the resolved pagination parameter names and page size.
 type paginationDefaults struct {
-	cursorParam string
-	cursorType  string // paginator class: "", "cursor", "page_token", "offset", "page"
-	limitParam  string
-	limit       int
+	cursorParam    string
+	cursorType     string // paginator class: "", "cursor", "page_token", "offset", "page"
+	nextCursorPath string
+	limitParam     string
+	limit          int
 }
 
 func shortPageEndsPagination(cursorType string, fetched, limit int) bool {
@@ -1016,10 +1020,11 @@ func determinePaginationDefaults(resource string) paginationDefaults {
 	switch resource {
 	}
 	return paginationDefaults{
-		cursorParam: "after",
-		cursorType:  "",
-		limitParam:  "limit",
-		limit:       100,
+		cursorParam:    "after",
+		cursorType:     "",
+		nextCursorPath: "",
+		limitParam:     "limit",
+		limit:          100,
 	}
 }
 
@@ -1096,6 +1101,10 @@ func formatSyncSinceValue(value string, paramFormat string) string {
 // 3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
 // It also extracts the next cursor from common response fields.
 func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ...string) ([]json.RawMessage, string, bool) {
+	return extractPageItemsWithPagination(data, cursorParam, "", responsePaths...)
+}
+
+func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCursorPath string, responsePaths ...string) ([]json.RawMessage, string, bool) {
 	// Strategy 1: direct array
 	var items []json.RawMessage
 	if err := json.Unmarshal(data, &items); err == nil {
@@ -1116,9 +1125,9 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 		if items, ok := extractJSONItemsArray(pathData); ok {
 			nextCursor, hasMore := "", false
 			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
-				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam)
+				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
 			}
-			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 			if nextCursor == "" {
 				nextCursor = outerCursor
 			}
@@ -1128,8 +1137,8 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 		var inner map[string]json.RawMessage
 		if json.Unmarshal(pathData, &inner) == nil {
 			if items, ok := extractItemsFromEnvelope(inner); ok {
-				nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam)
-				outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam, nextCursorPath)
+				outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 				if nextCursor == "" {
 					nextCursor = outerCursor
 				}
@@ -1140,7 +1149,7 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 	}
 
 	if items, ok := extractItemsByKnownKeys(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 		return items, nextCursor, hasMore
 	}
 
@@ -1154,8 +1163,8 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 			continue
 		}
 		if items, ok := extractItemsFromEnvelope(inner); ok {
-			nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam)
-			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam, nextCursorPath)
+			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 			if nextCursor == "" {
 				nextCursor = outerCursor
 			}
@@ -1168,14 +1177,14 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 		var embedded map[string]json.RawMessage
 		if json.Unmarshal(raw, &embedded) == nil {
 			if items, ok := extractItemsFromEnvelope(embedded); ok {
-				nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 				return items, nextCursor, hasMore
 			}
 		}
 	}
 
 	if items, ok := extractSingleObjectArraySibling(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 		return items, nextCursor, hasMore
 	}
 
@@ -1437,15 +1446,29 @@ func isJSONResponse(data json.RawMessage) bool {
 }
 
 // extractPaginationFromEnvelope extracts cursor and has_more from a response envelope.
-func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorParam string) (string, bool) {
+func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorParam, nextCursorPath string) (string, bool) {
+	if strings.TrimSpace(cursorParam) == "" {
+		return "", false
+	}
 	var hasMore bool
 
-	nextCursor := nextCursorFromLinks(envelope, cursorParam)
+	nextCursor := ""
+	if nextCursorPath != "" {
+		if raw, ok := rawAtPath(envelope, nextCursorPath); ok {
+			nextCursor = cursorValue(raw)
+			if isFollowableNextURL(nextCursor) {
+				nextCursor = cursorFromNextURL(nextCursor, cursorParam)
+			}
+		}
+	}
+	if nextCursor == "" {
+		nextCursor = nextCursorFromLinks(envelope, cursorParam)
+	}
 
 	// Try common cursor field names
 	cursorKeys := []string{
 		"next_cursor", "nextCursor", "next_token", "nextToken", "cursor",
-		"next_page_token", "nextPageToken", "page_token", "after", "end_cursor", "endCursor",
+		"next_page_token", "nextPageToken", "page_token", "after", "end_cursor", "endCursor", "next",
 	}
 	if nextCursor == "" {
 		nextCursor = findCursorInMap(envelope, cursorKeys)
@@ -1658,7 +1681,7 @@ func cursorFromNextURL(nextURL string, cursorParam string) string {
 	return ""
 }
 
-// findCursorInMap returns the first non-empty string-typed value in m
+// findCursorInMap returns the first non-empty scalar value in m
 // whose key matches one of cursorKeys. Used by extractPaginationFromEnvelope
 // to scan both the top-level envelope and well-known wrapper objects with
 // the same name-match rules — extracted so the two scans can't drift.
@@ -1668,10 +1691,27 @@ func findCursorInMap(m map[string]json.RawMessage, cursorKeys []string) string {
 		if !ok {
 			continue
 		}
-		var s string
-		if err := json.Unmarshal(raw, &s); err == nil && s != "" {
-			return s
+		if key == "next" {
+			var value string
+			if json.Unmarshal(raw, &value) == nil && isFollowableNextURL(value) {
+				continue
+			}
 		}
+		if value := cursorValue(raw); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func cursorValue(raw json.RawMessage) string {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var number json.Number
+	if err := json.Unmarshal(raw, &number); err == nil {
+		return number.String()
 	}
 	return ""
 }

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -553,7 +553,9 @@ func syncResource(ctx context.Context, c interface {
 		if resourceSupportsPagination(resource) {
 			params[pageSize.limitParam] = strconv.Itoa(pageSize.limit)
 			if cursor != "" {
-				params[pageSize.cursorParam] = cursor
+				if pageSize.cursorParam != "" {
+					params[pageSize.cursorParam] = cursor
+				}
 			}
 		}
 
@@ -599,7 +601,7 @@ func syncResource(ctx context.Context, c interface {
 
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
-		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
+		items, nextCursor, hasMore := extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(resource, path)...)
 		if sortEffective && maxPages > 0 {
 			for _, item := range items {
 				itemTimestamp, ok := restSyncTimestamp(item, sortField)
@@ -624,7 +626,8 @@ func syncResource(ctx context.Context, c interface {
 		// 1 even though more pages exist (the original symptom in #1296).
 		// Guard on cursorType, not cursorParam name, so all canonical
 		// spellings (page / page_number / pageNumber / page[number]) work.
-		if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+		// A declared strategy without a request parameter cannot advance safely.
+		if pageSize.cursorParam != "" && pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentPage, _ := strconv.Atoi(cursor)
 			if currentPage < 1 {
 				currentPage = 1
@@ -632,7 +635,7 @@ func syncResource(ctx context.Context, c interface {
 			nextCursor = strconv.Itoa(currentPage + 1)
 			hasMore = true
 		}
-		if pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+		if pageSize.cursorParam != "" && pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentOffset, _ := strconv.Atoi(cursor)
 			nextCursor = strconv.Itoa(currentOffset + pageSize.limit)
 			hasMore = true
@@ -782,7 +785,7 @@ func syncResource(ctx context.Context, c interface {
 				capExitCursor = nextCursor
 			}
 			if truncatedByCap && capExitCursor == "" {
-				if pageSize.cursorType == "offset" {
+				if pageSize.cursorParam != "" && pageSize.cursorType == "offset" {
 					currentOffset, _ := strconv.Atoi(cursor)
 					capExitCursor = strconv.Itoa(currentOffset + pageSize.limit)
 				} else {
@@ -849,7 +852,7 @@ func syncResource(ctx context.Context, c interface {
 			break
 		}
 		if nextCursor == "" {
-			if pageSize.cursorType == "offset" {
+			if pageSize.cursorParam != "" && pageSize.cursorType == "offset" {
 				// Cursor-based APIs return the next cursor in the envelope.
 				// Offset-based APIs carry their pagination position client-side.
 				currentOffset, _ := strconv.Atoi(cursor)
@@ -973,10 +976,11 @@ func syncResource(ctx context.Context, c interface {
 
 // paginationDefaults holds the resolved pagination parameter names and page size.
 type paginationDefaults struct {
-	cursorParam string
-	cursorType  string // paginator class: "", "cursor", "page_token", "offset", "page"
-	limitParam  string
-	limit       int
+	cursorParam    string
+	cursorType     string // paginator class: "", "cursor", "page_token", "offset", "page"
+	nextCursorPath string
+	limitParam     string
+	limit          int
 }
 
 func shortPageEndsPagination(cursorType string, fetched, limit int) bool {
@@ -993,10 +997,11 @@ func determinePaginationDefaults(resource string) paginationDefaults {
 	switch resource {
 	}
 	return paginationDefaults{
-		cursorParam: "after",
-		cursorType:  "",
-		limitParam:  "limit",
-		limit:       100,
+		cursorParam:    "after",
+		cursorType:     "",
+		nextCursorPath: "",
+		limitParam:     "limit",
+		limit:          100,
 	}
 }
 
@@ -1073,6 +1078,10 @@ func formatSyncSinceValue(value string, paramFormat string) string {
 // 3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
 // It also extracts the next cursor from common response fields.
 func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ...string) ([]json.RawMessage, string, bool) {
+	return extractPageItemsWithPagination(data, cursorParam, "", responsePaths...)
+}
+
+func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCursorPath string, responsePaths ...string) ([]json.RawMessage, string, bool) {
 	// Strategy 1: direct array
 	var items []json.RawMessage
 	if err := json.Unmarshal(data, &items); err == nil {
@@ -1093,9 +1102,9 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 		if items, ok := extractJSONItemsArray(pathData); ok {
 			nextCursor, hasMore := "", false
 			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
-				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam)
+				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
 			}
-			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 			if nextCursor == "" {
 				nextCursor = outerCursor
 			}
@@ -1105,8 +1114,8 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 		var inner map[string]json.RawMessage
 		if json.Unmarshal(pathData, &inner) == nil {
 			if items, ok := extractItemsFromEnvelope(inner); ok {
-				nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam)
-				outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam, nextCursorPath)
+				outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 				if nextCursor == "" {
 					nextCursor = outerCursor
 				}
@@ -1117,7 +1126,7 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 	}
 
 	if items, ok := extractItemsByKnownKeys(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 		return items, nextCursor, hasMore
 	}
 
@@ -1131,8 +1140,8 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 			continue
 		}
 		if items, ok := extractItemsFromEnvelope(inner); ok {
-			nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam)
-			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam, nextCursorPath)
+			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 			if nextCursor == "" {
 				nextCursor = outerCursor
 			}
@@ -1145,14 +1154,14 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 		var embedded map[string]json.RawMessage
 		if json.Unmarshal(raw, &embedded) == nil {
 			if items, ok := extractItemsFromEnvelope(embedded); ok {
-				nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 				return items, nextCursor, hasMore
 			}
 		}
 	}
 
 	if items, ok := extractSingleObjectArraySibling(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 		return items, nextCursor, hasMore
 	}
 
@@ -1414,15 +1423,29 @@ func isJSONResponse(data json.RawMessage) bool {
 }
 
 // extractPaginationFromEnvelope extracts cursor and has_more from a response envelope.
-func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorParam string) (string, bool) {
+func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorParam, nextCursorPath string) (string, bool) {
+	if strings.TrimSpace(cursorParam) == "" {
+		return "", false
+	}
 	var hasMore bool
 
-	nextCursor := nextCursorFromLinks(envelope, cursorParam)
+	nextCursor := ""
+	if nextCursorPath != "" {
+		if raw, ok := rawAtPath(envelope, nextCursorPath); ok {
+			nextCursor = cursorValue(raw)
+			if isFollowableNextURL(nextCursor) {
+				nextCursor = cursorFromNextURL(nextCursor, cursorParam)
+			}
+		}
+	}
+	if nextCursor == "" {
+		nextCursor = nextCursorFromLinks(envelope, cursorParam)
+	}
 
 	// Try common cursor field names
 	cursorKeys := []string{
 		"next_cursor", "nextCursor", "next_token", "nextToken", "cursor",
-		"next_page_token", "nextPageToken", "page_token", "after", "end_cursor", "endCursor",
+		"next_page_token", "nextPageToken", "page_token", "after", "end_cursor", "endCursor", "next",
 	}
 	if nextCursor == "" {
 		nextCursor = findCursorInMap(envelope, cursorKeys)
@@ -1635,7 +1658,7 @@ func cursorFromNextURL(nextURL string, cursorParam string) string {
 	return ""
 }
 
-// findCursorInMap returns the first non-empty string-typed value in m
+// findCursorInMap returns the first non-empty scalar value in m
 // whose key matches one of cursorKeys. Used by extractPaginationFromEnvelope
 // to scan both the top-level envelope and well-known wrapper objects with
 // the same name-match rules — extracted so the two scans can't drift.
@@ -1645,10 +1668,27 @@ func findCursorInMap(m map[string]json.RawMessage, cursorKeys []string) string {
 		if !ok {
 			continue
 		}
-		var s string
-		if err := json.Unmarshal(raw, &s); err == nil && s != "" {
-			return s
+		if key == "next" {
+			var value string
+			if json.Unmarshal(raw, &value) == nil && isFollowableNextURL(value) {
+				continue
+			}
 		}
+		if value := cursorValue(raw); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func cursorValue(raw json.RawMessage) string {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var number json.Number
+	if err := json.Unmarshal(raw, &number); err == nil {
+		return number.String()
 	}
 	return ""
 }
@@ -2125,7 +2165,9 @@ func syncOneParent(
 		if resourceSupportsPagination(dep.Name) {
 			params[pageSize.limitParam] = strconv.Itoa(pageSize.limit)
 			if cursor != "" {
-				params[pageSize.cursorParam] = cursor
+				if pageSize.cursorParam != "" {
+					params[pageSize.cursorParam] = cursor
+				}
 			}
 		}
 		if depSinceTS != "" {
@@ -2172,12 +2214,13 @@ func syncOneParent(
 			return rep
 		}
 
-		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(dep.Name, path)...)
+		items, nextCursor, hasMore := extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(dep.Name, path)...)
 
 		// Page-int paginator fallback: mirrors syncResource so dependent
 		// resources on integer ?page=N APIs also advance past page 1.
-		// Guard on cursorType to cover every canonical spelling.
-		if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+		// Guard on cursorType to cover every canonical spelling. A declared
+		// strategy without a request parameter cannot advance safely.
+		if pageSize.cursorParam != "" && pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentPage, _ := strconv.Atoi(cursor)
 			if currentPage < 1 {
 				currentPage = 1
@@ -2185,7 +2228,7 @@ func syncOneParent(
 			nextCursor = strconv.Itoa(currentPage + 1)
 			hasMore = true
 		}
-		if pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+		if pageSize.cursorParam != "" && pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentOffset, _ := strconv.Atoi(cursor)
 			nextCursor = strconv.Itoa(currentOffset + pageSize.limit)
 			hasMore = true
@@ -2306,7 +2349,7 @@ func syncOneParent(
 			break
 		}
 		if nextCursor == "" {
-			if pageSize.cursorType == "offset" {
+			if pageSize.cursorParam != "" && pageSize.cursorType == "offset" {
 				// Cursor-based APIs return the next cursor in the envelope.
 				// Offset-based APIs carry their pagination position client-side.
 				currentOffset, _ := strconv.Atoi(cursor)

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -514,7 +514,9 @@ func syncResource(ctx context.Context, c interface {
 		if resourceSupportsPagination(resource) {
 			params[pageSize.limitParam] = strconv.Itoa(pageSize.limit)
 			if cursor != "" {
-				params[pageSize.cursorParam] = cursor
+				if pageSize.cursorParam != "" {
+					params[pageSize.cursorParam] = cursor
+				}
 			}
 		}
 
@@ -560,7 +562,7 @@ func syncResource(ctx context.Context, c interface {
 
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
-		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
+		items, nextCursor, hasMore := extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(resource, path)...)
 		if sortEffective && maxPages > 0 {
 			for _, item := range items {
 				itemTimestamp, ok := restSyncTimestamp(item, sortField)
@@ -585,7 +587,8 @@ func syncResource(ctx context.Context, c interface {
 		// 1 even though more pages exist (the original symptom in #1296).
 		// Guard on cursorType, not cursorParam name, so all canonical
 		// spellings (page / page_number / pageNumber / page[number]) work.
-		if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+		// A declared strategy without a request parameter cannot advance safely.
+		if pageSize.cursorParam != "" && pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentPage, _ := strconv.Atoi(cursor)
 			if currentPage < 1 {
 				currentPage = 1
@@ -593,7 +596,7 @@ func syncResource(ctx context.Context, c interface {
 			nextCursor = strconv.Itoa(currentPage + 1)
 			hasMore = true
 		}
-		if pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+		if pageSize.cursorParam != "" && pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentOffset, _ := strconv.Atoi(cursor)
 			nextCursor = strconv.Itoa(currentOffset + pageSize.limit)
 			hasMore = true
@@ -743,7 +746,7 @@ func syncResource(ctx context.Context, c interface {
 				capExitCursor = nextCursor
 			}
 			if truncatedByCap && capExitCursor == "" {
-				if pageSize.cursorType == "offset" {
+				if pageSize.cursorParam != "" && pageSize.cursorType == "offset" {
 					currentOffset, _ := strconv.Atoi(cursor)
 					capExitCursor = strconv.Itoa(currentOffset + pageSize.limit)
 				} else {
@@ -810,7 +813,7 @@ func syncResource(ctx context.Context, c interface {
 			break
 		}
 		if nextCursor == "" {
-			if pageSize.cursorType == "offset" {
+			if pageSize.cursorParam != "" && pageSize.cursorType == "offset" {
 				// Cursor-based APIs return the next cursor in the envelope.
 				// Offset-based APIs carry their pagination position client-side.
 				currentOffset, _ := strconv.Atoi(cursor)
@@ -934,10 +937,11 @@ func syncResource(ctx context.Context, c interface {
 
 // paginationDefaults holds the resolved pagination parameter names and page size.
 type paginationDefaults struct {
-	cursorParam string
-	cursorType  string // paginator class: "", "cursor", "page_token", "offset", "page"
-	limitParam  string
-	limit       int
+	cursorParam    string
+	cursorType     string // paginator class: "", "cursor", "page_token", "offset", "page"
+	nextCursorPath string
+	limitParam     string
+	limit          int
 }
 
 func shortPageEndsPagination(cursorType string, fetched, limit int) bool {
@@ -954,17 +958,19 @@ func determinePaginationDefaults(resource string) paginationDefaults {
 	switch resource {
 	case "items":
 		return paginationDefaults{
-			cursorParam: "cursor",
-			cursorType:  "cursor",
-			limitParam:  "limit",
-			limit:       100,
+			cursorParam:    "cursor",
+			cursorType:     "cursor",
+			nextCursorPath: "",
+			limitParam:     "limit",
+			limit:          100,
 		}
 	}
 	return paginationDefaults{
-		cursorParam: "cursor",
-		cursorType:  "cursor",
-		limitParam:  "limit",
-		limit:       100,
+		cursorParam:    "cursor",
+		cursorType:     "cursor",
+		nextCursorPath: "",
+		limitParam:     "limit",
+		limit:          100,
 	}
 }
 
@@ -1043,6 +1049,10 @@ func formatSyncSinceValue(value string, paramFormat string) string {
 // 3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
 // It also extracts the next cursor from common response fields.
 func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ...string) ([]json.RawMessage, string, bool) {
+	return extractPageItemsWithPagination(data, cursorParam, "", responsePaths...)
+}
+
+func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCursorPath string, responsePaths ...string) ([]json.RawMessage, string, bool) {
 	// Strategy 1: direct array
 	var items []json.RawMessage
 	if err := json.Unmarshal(data, &items); err == nil {
@@ -1063,9 +1073,9 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 		if items, ok := extractJSONItemsArray(pathData); ok {
 			nextCursor, hasMore := "", false
 			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
-				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam)
+				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
 			}
-			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 			if nextCursor == "" {
 				nextCursor = outerCursor
 			}
@@ -1075,8 +1085,8 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 		var inner map[string]json.RawMessage
 		if json.Unmarshal(pathData, &inner) == nil {
 			if items, ok := extractItemsFromEnvelope(inner); ok {
-				nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam)
-				outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam, nextCursorPath)
+				outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 				if nextCursor == "" {
 					nextCursor = outerCursor
 				}
@@ -1087,7 +1097,7 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 	}
 
 	if items, ok := extractItemsByKnownKeys(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 		return items, nextCursor, hasMore
 	}
 
@@ -1101,8 +1111,8 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 			continue
 		}
 		if items, ok := extractItemsFromEnvelope(inner); ok {
-			nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam)
-			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam, nextCursorPath)
+			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 			if nextCursor == "" {
 				nextCursor = outerCursor
 			}
@@ -1115,14 +1125,14 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 		var embedded map[string]json.RawMessage
 		if json.Unmarshal(raw, &embedded) == nil {
 			if items, ok := extractItemsFromEnvelope(embedded); ok {
-				nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 				return items, nextCursor, hasMore
 			}
 		}
 	}
 
 	if items, ok := extractSingleObjectArraySibling(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 		return items, nextCursor, hasMore
 	}
 
@@ -1384,15 +1394,29 @@ func isJSONResponse(data json.RawMessage) bool {
 }
 
 // extractPaginationFromEnvelope extracts cursor and has_more from a response envelope.
-func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorParam string) (string, bool) {
+func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorParam, nextCursorPath string) (string, bool) {
+	if strings.TrimSpace(cursorParam) == "" {
+		return "", false
+	}
 	var hasMore bool
 
-	nextCursor := nextCursorFromLinks(envelope, cursorParam)
+	nextCursor := ""
+	if nextCursorPath != "" {
+		if raw, ok := rawAtPath(envelope, nextCursorPath); ok {
+			nextCursor = cursorValue(raw)
+			if isFollowableNextURL(nextCursor) {
+				nextCursor = cursorFromNextURL(nextCursor, cursorParam)
+			}
+		}
+	}
+	if nextCursor == "" {
+		nextCursor = nextCursorFromLinks(envelope, cursorParam)
+	}
 
 	// Try common cursor field names
 	cursorKeys := []string{
 		"next_cursor", "nextCursor", "next_token", "nextToken", "cursor",
-		"next_page_token", "nextPageToken", "page_token", "after", "end_cursor", "endCursor",
+		"next_page_token", "nextPageToken", "page_token", "after", "end_cursor", "endCursor", "next",
 	}
 	if nextCursor == "" {
 		nextCursor = findCursorInMap(envelope, cursorKeys)
@@ -1605,7 +1629,7 @@ func cursorFromNextURL(nextURL string, cursorParam string) string {
 	return ""
 }
 
-// findCursorInMap returns the first non-empty string-typed value in m
+// findCursorInMap returns the first non-empty scalar value in m
 // whose key matches one of cursorKeys. Used by extractPaginationFromEnvelope
 // to scan both the top-level envelope and well-known wrapper objects with
 // the same name-match rules — extracted so the two scans can't drift.
@@ -1615,10 +1639,27 @@ func findCursorInMap(m map[string]json.RawMessage, cursorKeys []string) string {
 		if !ok {
 			continue
 		}
-		var s string
-		if err := json.Unmarshal(raw, &s); err == nil && s != "" {
-			return s
+		if key == "next" {
+			var value string
+			if json.Unmarshal(raw, &value) == nil && isFollowableNextURL(value) {
+				continue
+			}
 		}
+		if value := cursorValue(raw); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func cursorValue(raw json.RawMessage) string {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var number json.Number
+	if err := json.Unmarshal(raw, &number); err == nil {
+		return number.String()
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary

Generated sync now uses each endpoint’s declared cursor parameter, cursor type, and next-cursor path, including numeric cursor values. List commands expose `--all` only where generated pagination can actually advance, so POST list endpoints no longer ship a hollow flag. Live verification bounds sync probes to one page per resource so large catalogs do not exceed the verifier budget.

## Validation

- Focused generator and pipeline pagination tests pass.
- `scripts/golden.sh verify` passes all 32 cases.
- `scripts/verify-generator-output.sh` passes all 10 cases.
- `go build -o ./cli-printing-press ./cmd/cli-printing-press` passes.
- Full `go test ./...` reaches unrelated failures under required `PRINTING_PRESS_VERIFY=1`: BLE availability expectation, generated self-learning/store/rate-limit tests, and live-dogfood help probes.
- `golangci-lint run ./...` reports one pre-existing `modernize` finding in another worktree’s `internal/googlediscovery/parser.go`.

Closes #4034
Closes #4035
Closes #4047