### PR TITLE
fix(skills): harden retro artifact upload gates

### DIFF
--- a/skills/printing-press-retro/SKILL.md
+++ b/skills/printing-press-retro/SKILL.md
@@ -867,6 +867,11 @@ If the user picks "Save locally only," skip Steps 3 and 4 — the retro is alrea
 saved to manuscript proofs and `/tmp/printing-press/retro/`. Clean up the staging
 folder, then jump to Step 6.
 
+If the user picks **Submit**, set `SUBMISSION_CONFIRMED=true` immediately before
+running Step 3. Leave it unset or set it to `false` for the other choices; the
+artifact-packaging reference refuses public uploads unless this explicit consent
+marker and the successful scrub marker are both present.
+
 If the user wants to override a dedup decision before submitting (e.g.,
 "file new for WU-2 instead of commenting"), accept the override: clear
 `WU_DEDUP[i]` for that WU and proceed.

--- a/skills/printing-press-retro/references/artifact-packaging.md
+++ b/skills/printing-press-retro/references/artifact-packaging.md
@@ -64,6 +64,25 @@ the staging copies. The scrub file expects `$STAGING_MANUSCRIPTS` and
 If the post-scrub verification reports unresolved secrets, **do not proceed with upload**.
 Save the zips locally and tell the user to review manually.
 
+Initialize the upload gate before running the scrub, so skipped or failed
+verification cannot accidentally enable a public upload:
+
+```bash
+SCRUB_VERIFIED=false
+```
+
+After applying all scrub layers, run the post-scrub verification block from
+`references/secret-scrubbing.md`. Record success only when that block completes
+with no unresolved findings (`FINAL_CHECK=false`):
+
+```bash
+if [ "${FINAL_CHECK:-true}" = false ]; then
+  SCRUB_VERIFIED=true
+else
+  echo "Upload blocked: post-scrub verification found unresolved findings or did not run."
+fi
+```
+
 ## Step 4: Zip artifacts
 
 ```bash
@@ -90,38 +109,53 @@ CLI_SOURCE_URL=""
 RETRO_DOC_URL=""
 UPLOAD_FAILED=false
 
+if [ "${SUBMISSION_CONFIRMED:-false}" != "true" ] || [ "${SCRUB_VERIFIED:-false}" != "true" ]; then
+  echo "REFUSING upload: explicit submission consent and successful secret-scrub verification are both required."
+  UPLOAD_FAILED=true
+else
+
+catbox_upload() {
+  # $1 = path to file. Prints the URL on success, returns non-zero on failure.
+  local response
+  response=$(curl -sf -F "reqtype=fileupload" -F "fileToUpload=@$1" https://catbox.moe/user/api.php 2>/dev/null) || return 1
+  if printf '%s' "$response" | grep -Eq '^https://files\.catbox\.moe/[A-Za-z0-9._-]+$'; then
+    printf '%s' "$response"
+  else
+    return 1
+  fi
+}
+
 # Upload retro document (raw .md — viewable directly in browser)
-RESPONSE=$(curl -s -F "reqtype=fileupload" -F "fileToUpload=@$RETRO_PROOF_PATH" https://catbox.moe/user/api.php 2>/dev/null)
-if echo "$RESPONSE" | grep -q "^https://"; then
-  RETRO_DOC_URL="$RESPONSE"
+if RETRO_DOC_URL=$(catbox_upload "$RETRO_PROOF_PATH"); then
   echo "Retro document uploaded: $RETRO_DOC_URL"
 else
-  echo "WARNING: Failed to upload retro document to catbox.moe. Response: $RESPONSE"
+  echo "WARNING: Failed to upload retro document to catbox.moe."
+  RETRO_DOC_URL=""
   UPLOAD_FAILED=true
 fi
 
 # Upload manuscripts zip
-RESPONSE=$(curl -s -F "reqtype=fileupload" -F "fileToUpload=@$MANUSCRIPTS_ZIP" https://catbox.moe/user/api.php 2>/dev/null)
-if echo "$RESPONSE" | grep -q "^https://"; then
-  MANUSCRIPTS_URL="$RESPONSE"
+if MANUSCRIPTS_URL=$(catbox_upload "$MANUSCRIPTS_ZIP"); then
   echo "Manuscripts uploaded: $MANUSCRIPTS_URL"
 else
-  echo "WARNING: Failed to upload manuscripts to catbox.moe. Response: $RESPONSE"
+  echo "WARNING: Failed to upload manuscripts to catbox.moe."
+  MANUSCRIPTS_URL=""
   UPLOAD_FAILED=true
 fi
 
 # Upload CLI source (only if it was packaged)
 if [ -n "$CLI_SOURCE_ZIP" ] && [ -f "$CLI_SOURCE_ZIP" ]; then
-  RESPONSE=$(curl -s -F "reqtype=fileupload" -F "fileToUpload=@$CLI_SOURCE_ZIP" https://catbox.moe/user/api.php 2>/dev/null)
-  if echo "$RESPONSE" | grep -q "^https://"; then
-    CLI_SOURCE_URL="$RESPONSE"
+  if CLI_SOURCE_URL=$(catbox_upload "$CLI_SOURCE_ZIP"); then
     echo "CLI source uploaded: $CLI_SOURCE_URL"
   else
-    echo "WARNING: Failed to upload CLI source to catbox.moe. Response: $RESPONSE"
+    echo "WARNING: Failed to upload CLI source to catbox.moe."
+    CLI_SOURCE_URL=""
     UPLOAD_FAILED=true
   fi
 else
   echo "No CLI source to upload (manuscripts-only mode)."
+fi
+
 fi
 ```
 
@@ -172,6 +206,8 @@ eventually. Do not let cleanup failure block the rest of the workflow.
 | `$RETRO_DOC_URL` | catbox URL for retro .md file (viewable in browser), or empty if upload failed |
 | `$MANUSCRIPTS_URL` | catbox URL for manuscripts zip, or empty if upload failed |
 | `$CLI_SOURCE_URL` | catbox URL for CLI source zip, or empty if upload failed |
+| `$SUBMISSION_CONFIRMED` | `true` only after the user selected Submit in Phase 6 Step 2; uploads are refused otherwise |
+| `$SCRUB_VERIFIED` | `true` only when Step 3's post-scrub verification completed with no unresolved findings; uploads are refused otherwise |
 | `$UPLOAD_FAILED` | `true` if any upload failed, `false` otherwise |
 | `$MANUSCRIPTS_ZIP` | Local path to manuscripts zip (in staging, deleted after cleanup) |
 | `$CLI_SOURCE_ZIP` | Local path to CLI source zip (in staging, deleted after cleanup) |

--- a/skills/printing-press-retro/references/secret-scrubbing.md
+++ b/skills/printing-press-retro/references/secret-scrubbing.md
@@ -397,7 +397,10 @@ After all layers complete, do a final scan for obvious leaks:
 
 ```bash
 FINAL_CHECK=false
-CRED_REGEX='(sk_live_|sk_test_|ghp_|gho_|Bearer [A-Za-z0-9]{20})'
+# CRED_REGEX must mirror the vendor-prefix patterns in Layer 0 and Layer 2
+# above; update both together so the verification step does not silently stop
+# checking a credential shape the scrub loop still redacts.
+CRED_REGEX='(sk_live_[A-Za-z0-9]{20,}|sk_test_[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{36,}|gho_[A-Za-z0-9]{36,}|ghs_[A-Za-z0-9]{36,}|xoxb-[A-Za-z0-9-]{20,}|xoxp-[A-Za-z0-9-]{20,}|\bAKIA[0-9A-Z]{16}\b|sk-or-v1-[A-Za-z0-9_-]{24,}|sk-ant-api03-[A-Za-z0-9_-]{40,}|\blin_api_[A-Za-z0-9_-]{32,}|\b[a-f0-9]{32}-us[0-9]{1,2}\b|\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{5,}|Bearer [A-Za-z0-9._~+/=-]{20,})'
 # PII_REGEX must mirror the shapes in PII_PATTERNS above; update both together
 # (e.g. when adding Partita IVA with an allowlist) so the verification step
 # does not silently stop checking a shape the scrub loop still redacts.

--- a/skills/printing-press-retro/references/secret-scrubbing.md
+++ b/skills/printing-press-retro/references/secret-scrubbing.md
@@ -399,22 +399,48 @@ After all layers complete, do a final scan for obvious leaks:
 FINAL_CHECK=false
 # CRED_REGEX must mirror the vendor-prefix patterns in Layer 0 and Layer 2
 # above; update both together so the verification step does not silently stop
-# checking a credential shape the scrub loop still redacts.
-CRED_REGEX='(sk_live_[A-Za-z0-9]{20,}|sk_test_[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{36,}|gho_[A-Za-z0-9]{36,}|ghs_[A-Za-z0-9]{36,}|xoxb-[A-Za-z0-9-]{20,}|xoxp-[A-Za-z0-9-]{20,}|\bAKIA[0-9A-Z]{16}\b|sk-or-v1-[A-Za-z0-9_-]{24,}|sk-ant-api03-[A-Za-z0-9_-]{40,}|\blin_api_[A-Za-z0-9_-]{32,}|\b[a-f0-9]{32}-us[0-9]{1,2}\b|\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{5,}|Bearer [A-Za-z0-9._~+/=-]{20,})'
+# checking a credential shape the scrub loop still redacts. The JWT shape
+# intentionally matches Layer 2's two-segment form; that also catches the
+# first two segments of a conventional three-segment JWT.
+CRED_REGEX='(sk_live_[A-Za-z0-9]{20,}|sk_test_[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{36,}|gho_[A-Za-z0-9]{36,}|ghs_[A-Za-z0-9]{36,}|xoxb-[A-Za-z0-9-]{20,}|xoxp-[A-Za-z0-9-]{20,}|\bAKIA[0-9A-Z]{16}\b|sk-or-v1-[A-Za-z0-9_-]{24,}|sk-ant-api03-[A-Za-z0-9_-]{40,}|\blin_api_[A-Za-z0-9_-]{32,}|\b[a-f0-9]{32}-us[0-9]{1,2}\b|\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|Bearer [A-Za-z0-9._~+/=-]{20,})'
 # PII_REGEX must mirror the shapes in PII_PATTERNS above; update both together
 # (e.g. when adding Partita IVA with an allowlist) so the verification step
 # does not silently stop checking a shape the scrub loop still redacts.
 PII_REGEX='(\b[A-Z]{6}[0-9]{2}[A-Z][0-9]{2}[A-Z][0-9]{3}[A-Z]\b|\b(AD|AT|BE|BG|CH|CY|CZ|DE|DK|EE|ES|FI|FR|GB|GI|GR|HR|HU|IE|IS|IT|LI|LT|LU|LV|MC|MT|NL|NO|PL|PT|RO|SE|SI|SK|SM|VA)[0-9]{2}[A-Z0-9]{11,30}\b|\b[0-9]{3}-[0-9]{2}-[0-9]{4}\b)'
+SCAN_FAILED=false
 for dir in "$STAGING_MANUSCRIPTS" "$STAGING_CLI_SOURCE"; do
   [ -d "$dir" ] || continue
-  CRED_MATCHES=$(grep -rEi "$CRED_REGEX" "$dir" 2>/dev/null | grep -v 'REDACTED' | head -5)
-  PII_MATCHES=$(grep -rEi "$PII_REGEX" "$dir" 2>/dev/null | grep -v 'REDACTED' | head -5)
+  if CRED_RAW=$(grep -rEi "$CRED_REGEX" "$dir" 2>/dev/null); then
+    :
+  else
+    CRED_STATUS=$?
+    if [ "$CRED_STATUS" -gt 1 ]; then
+      echo "WARNING: Credential scan could not read all files under $dir."
+      SCAN_FAILED=true
+    fi
+  fi
+  if PII_RAW=$(grep -rEi "$PII_REGEX" "$dir" 2>/dev/null); then
+    :
+  else
+    PII_STATUS=$?
+    if [ "$PII_STATUS" -gt 1 ]; then
+      echo "WARNING: PII scan could not read all files under $dir."
+      SCAN_FAILED=true
+    fi
+  fi
+  CRED_MATCHES=$(printf '%s\n' "$CRED_RAW" | grep -v 'REDACTED' | head -5)
+  PII_MATCHES=$(printf '%s\n' "$PII_RAW" | grep -v 'REDACTED' | head -5)
   if [ -n "$CRED_MATCHES" ] || [ -n "$PII_MATCHES" ]; then
     [ -n "$CRED_MATCHES" ] && echo "$CRED_MATCHES"
     [ -n "$PII_MATCHES" ] && echo "$PII_MATCHES"
     FINAL_CHECK=true
   fi
 done
+if [ "$SCAN_FAILED" = true ]; then
+  FINAL_CHECK=true
+  echo "WARNING: One or more post-scrub scans did not complete successfully."
+  echo "Artifacts will NOT be uploaded until the scan errors are resolved."
+fi
 if [ "$FINAL_CHECK" = true ]; then
   echo "WARNING: Potential secrets or PII still found after scrubbing. Review the matches above."
   echo "Artifacts will NOT be uploaded until this is resolved."


### PR DESCRIPTION
## Intent

The retro skill now fails closed before publishing artifacts to public anonymous storage. It requires both a successful post-scrub verification and an explicit user choice to submit. The owning issue is [#4078](https://github.com/mvanhorn/cli-printing-press/issues/4078).

Original contributor credit: @GvAiSuperAdmin (Octopuss), whose contributor PR [#3705](https://github.com/mvanhorn/cli-printing-press/pull/3705) identified the Socket audit scope. This maintainer-owned replacement preserves that intent and supersedes #3705.

## Approach

- Keep scrub verification false until the documented `FINAL_CHECK=false` result is available.
- Set `SUBMISSION_CONFIRMED=true` only after the Phase 6 user prompt returns Submit.
- Require both markers before any Catbox request, while preserving local failure handling.
- Use `curl -sf` and accept only the exact Catbox URL shape.

## Scope

Primary area: `skills/printing-press-retro` artifact packaging and Phase 6 upload instructions.

Why this belongs in this repo: this is reusable Printing Press skill behavior that governs public artifact handling for future retros; it is not a printed-CLI-specific repair.

## Risk

If either marker is absent or false, the upload step now skips public requests and routes to the existing local-save failure path. No generated CLI, MCP surface, auth flow, release behavior, or API contract changes.

## Output Contract

N/A — no generator output, manifest, command output, MCP schema, scorecard output, or pipeline artifact changed.

## Verification

- `bash -n` checks passed for the new scrub and upload blocks.
- Mocked upload checks passed for valid Catbox responses, malformed-response rejection, and the fail-closed consent gate.
- `bash .github/scripts/validate-skill-docs.sh` passed.
- `go vet ./...` passed.
- `go build -o ./cli-printing-press ./cmd/cli-printing-press` passed.
- `scripts/golden.sh verify` passed all 32 cases.
- `go test ./...` ran to completion; existing generator HTML extraction and pagination tests fail with `invalid character 'w' looking for beginning of value`, unrelated to this skill-only diff. The affected tests were rerun and reproduced the same failure.
- `golangci-lint run ./...` reports the unchanged `internal/googlediscovery/parser.go:455` `slicesbackward` finding.
- Generator-output compile checks are N/A because no generator or template source changed.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change
