### PR TITLE
fix(windows): generated CLIs could neither build nor test on Windows

### DIFF
--- a/internal/generator/creds_read_perms_test.go
+++ b/internal/generator/creds_read_perms_test.go
@@ -154,6 +154,9 @@ func TestGeneratedConfigPermissionTestsIgnoreSeededCredentialsStore(t *testing.T
 // shouldEmitAuth(): a spec with no auth persists no token, so shipping the
 // check would be dead weight. public-param-names declares auth.type: none.
 func TestGenerate_NoCredsPermsForNonAuthSpec(t *testing.T) {
+	if testing.Short() {
+		t.Skip("generated CLI compile tests run in the full generated-test CI lane")
+	}
 	t.Parallel()
 
 	apiSpec, err := spec.Parse(filepath.Join("..", "..", "testdata", "golden", "fixtures", "public-param-names.yaml"))
@@ -164,4 +167,18 @@ func TestGenerate_NoCredsPermsForNonAuthSpec(t *testing.T) {
 
 	_, err = os.Stat(filepath.Join(outputDir, "internal", "cliutil", "creds_perms_eval.go"))
 	require.True(t, os.IsNotExist(err), "creds_perms_eval.go must not be emitted for a non-auth spec")
+
+	winSrc := readGeneratedFile(t, outputDir, "internal", "platform", "perms_windows.go")
+	require.Contains(t, winSrc, "func verifyPrivatePerms")
+	require.NotContains(t, winSrc, "cliutil.VerifyCredsPerms",
+		"the no-auth Windows hook must not reference the auth-gated credentials helper")
+
+	cmd := exec.Command("go", "build", "-mod=mod", "./...")
+	cmd.Dir = outputDir
+	cacheDir, err := goBuildCacheDir(outputDir)
+	require.NoError(t, err)
+	cmd.Env = append(os.Environ(), "GOOS=windows", "GOCACHE="+cacheDir)
+	cmd.Env = append(cmd.Env, sandboxHomeEnv(t)...)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "generated no-auth CLI must build for Windows:\n%s", output)
 }

--- a/internal/generator/templates/platform_cli_test.go.tmpl
+++ b/internal/generator/templates/platform_cli_test.go.tmpl
@@ -864,13 +864,8 @@ func TestPlatformMigrationAdoptsOnlyVerifiedTenantDatabase(t *testing.T) {
 	if err != nil {
 		t.Fatalf("recoverable backup missing: err=%v", err)
 	}
-	// The 0600 assertion is POSIX-only. NTFS carries no mode bits, os.Chmod is a
-	// no-op there, and Go reports a writable file as 0666 — so asserting 0600 on
-	// Windows fails for a backup that was written correctly. This mirrors what the
-	// generated perms_windows.go already documents ("Windows mode bits do not model
-	// access control") and the runtime.GOOS guard used by the creds-perms tests.
-	// Existence and recoverability are asserted on every platform; only the mode
-	// check is skipped where the concept does not exist.
+	// NTFS does not expose POSIX mode bits, so assert the backup mode only where
+	// it is meaningful while retaining the cross-platform recoverability check.
 	if runtime.GOOS != "windows" && backupInfo.Mode().Perm() != 0o600 {
 		t.Fatalf("recoverable backup perm = %04o, want 0600", backupInfo.Mode().Perm())
 	}

--- a/internal/generator/templates/platform_cli_test.go.tmpl
+++ b/internal/generator/templates/platform_cli_test.go.tmpl
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -860,8 +861,18 @@ func TestPlatformMigrationAdoptsOnlyVerifiedTenantDatabase(t *testing.T) {
 	}
 	backupPath := legacyDB + ".printing-press-backup"
 	backupInfo, err := os.Stat(backupPath)
-	if err != nil || backupInfo.Mode().Perm() != 0o600 {
-		t.Fatalf("recoverable backup info=%v err=%v", backupInfo, err)
+	if err != nil {
+		t.Fatalf("recoverable backup missing: err=%v", err)
+	}
+	// The 0600 assertion is POSIX-only. NTFS carries no mode bits, os.Chmod is a
+	// no-op there, and Go reports a writable file as 0666 — so asserting 0600 on
+	// Windows fails for a backup that was written correctly. This mirrors what the
+	// generated perms_windows.go already documents ("Windows mode bits do not model
+	// access control") and the runtime.GOOS guard used by the creds-perms tests.
+	// Existence and recoverability are asserted on every platform; only the mode
+	// check is skipped where the concept does not exist.
+	if runtime.GOOS != "windows" && backupInfo.Mode().Perm() != 0o600 {
+		t.Fatalf("recoverable backup perm = %04o, want 0600", backupInfo.Mode().Perm())
 	}
 	repeatCleanup := RootCmd()
 	repeatCleanup.SetOut(&bytes.Buffer{})

--- a/internal/generator/templates/platform_perms_windows.go.tmpl
+++ b/internal/generator/templates/platform_perms_windows.go.tmpl
@@ -32,26 +32,12 @@ func verifyPrivatePerms(path string, _ os.FileInfo, label string) error {
 	return nil
 }
 {{else}}//
-// This spec declares no auth, so cliutil's credentials-permission evaluator
-// (VerifyCredsPerms / evalCredsSecurity) is deliberately NOT emitted — see
-// renderOptionalSupportFiles, which gates it on shouldEmitAuth(), and
-// TestGenerate_NoCredsPermsForNonAuthSpec, which pins that behaviour.
-//
-// The files this guards (client profile, cache fingerprint key) still exist in a
-// no-auth CLI, so the hook must still exist — but it cannot delegate to a helper
-// that was never generated. Delegating unconditionally is what produced
-// "undefined: cliutil.VerifyCredsPerms" on every no-auth Windows build.
-//
-// A no-auth CLI persists no secret, and the Windows check is advisory even when
-// present, so the honest no-auth behaviour is a documented no-op rather than a
-// duplicated SDDL evaluator in this package.
+// The remaining profile and cache metadata contain no credential material, and
+// Windows mode bits do not model access control, so this check is a no-op.
 package platform
 
 import "os"
 
-// verifyPrivatePerms is a no-op on Windows for a no-auth CLI. The artifacts it
-// guards hold no credential material, and NTFS carries no mode bits to check.
-// Signature matches perms_unix.go so platform code compiles unchanged.
 func verifyPrivatePerms(_ string, _ os.FileInfo, _ string) error {
 	return nil
 }

--- a/internal/generator/templates/platform_perms_windows.go.tmpl
+++ b/internal/generator/templates/platform_perms_windows.go.tmpl
@@ -5,9 +5,12 @@
 
 // Private-file permission checks (Windows).
 //
-// Windows mode bits do not model access control. Reuse cliutil's owner and DACL
-// check, but report it as advisory because generated writers do not establish
-// an explicit Windows DACL.
+// Windows mode bits do not model access control, so the POSIX 0600 check in
+// perms_unix.go has no meaning here.
+{{if ne .Auth.Type "none"}}//
+// Auth is configured, so cliutil carries the owner+DACL evaluator
+// (VerifyCredsPerms). Reuse it, but report the result as advisory because
+// generated writers do not establish an explicit Windows DACL.
 package platform
 
 import (
@@ -28,3 +31,28 @@ func verifyPrivatePerms(path string, _ os.FileInfo, label string) error {
 	}
 	return nil
 }
+{{else}}//
+// This spec declares no auth, so cliutil's credentials-permission evaluator
+// (VerifyCredsPerms / evalCredsSecurity) is deliberately NOT emitted — see
+// renderOptionalSupportFiles, which gates it on shouldEmitAuth(), and
+// TestGenerate_NoCredsPermsForNonAuthSpec, which pins that behaviour.
+//
+// The files this guards (client profile, cache fingerprint key) still exist in a
+// no-auth CLI, so the hook must still exist — but it cannot delegate to a helper
+// that was never generated. Delegating unconditionally is what produced
+// "undefined: cliutil.VerifyCredsPerms" on every no-auth Windows build.
+//
+// A no-auth CLI persists no secret, and the Windows check is advisory even when
+// present, so the honest no-auth behaviour is a documented no-op rather than a
+// duplicated SDDL evaluator in this package.
+package platform
+
+import "os"
+
+// verifyPrivatePerms is a no-op on Windows for a no-auth CLI. The artifacts it
+// guards hold no credential material, and NTFS carries no mode bits to check.
+// Signature matches perms_unix.go so platform code compiles unchanged.
+func verifyPrivatePerms(_ string, _ os.FileInfo, _ string) error {
+	return nil
+}
+{{end}}


### PR DESCRIPTION
Two independent Windows-only defects, both found while generating a real CLI for a **no-auth local API** (ComfyUI) on Windows with Go 1.26.5 and printing-press 4.30.2.

## 1. Build break for every no-auth spec

`internal/platform/perms_windows.go` is emitted **unconditionally** (the `singleFiles` map) and calls `cliutil.VerifyCredsPerms`. That helper lives in `cliutil/creds_perms_windows.go`, which `renderOptionalSupportFiles` emits **only under `shouldEmitAuth()`**.

So any spec with `auth.type: none` produced a module that does not compile:

```
internal\platform\perms_windows.go:24:20: undefined: cliutil.VerifyCredsPerms
```

**Why the fix is in the template, not the emission gate.** Two other approaches are wrong:

- *Emit the creds helpers unconditionally* — `TestGenerate_NoCredsPermsForNonAuthSpec` deliberately pins the auth-gating. (I tried this first; the test correctly caught it.)
- *Gate `platform/perms_*.go` on auth too* — `platform/profile.go` calls `verifyPrivatePerms` for the **client profile** and the **cache fingerprint key**, neither of which is auth-related, so the hook is genuinely needed in a no-auth CLI.

The Windows template now branches: delegate to `cliutil` when auth exists, and compile a documented no-op when it does not. A no-auth CLI persists no secret, and this check is *advisory* on Windows even when present — so a no-op is the honest behaviour rather than duplicating the SDDL evaluator into `platform`.

## 2. Test failure on Windows, regardless of auth

`TestPlatformMigrationAdoptsOnlyVerifiedTenantDatabase` asserted `backupInfo.Mode().Perm() == 0o600` on the recoverable backup. NTFS carries no POSIX mode bits, `os.Chmod` is a no-op there, and Go reports a writable file as `0666` — so the assertion fails for a backup that was written correctly.

The generated `perms_windows.go` documents this exact fact in its own header comment ("Windows mode bits do not model access control").

Existence and recoverability are still asserted on every platform; only the mode check is skipped on Windows, using the `runtime.GOOS` guard already established in `cliutil_credentials_perms_test.go.tmpl`.

## Verification

- `go test ./internal/generator/ -run 'CredsPerms|PlatformPerms'` — passes. Both the no-auth pin **and** the auth-case assertion (`winSrc` must contain `cliutil.VerifyCredsPerms`) still hold, because the conditional satisfies each in its own branch.
- A full `generate --spec <no-auth spec> --validate` now passes every gate: `go mod tidy`, `go test ./...`, `govulncheck`, `go vet`, `go build`, runnable binary, `--help`, `version`, `doctor`.
- The resulting CLI was then driven against a live server successfully.

Happy to split this into two PRs if you'd prefer them reviewed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)