### PR TITLE
fix(cli): scope browser credentials by host

### DIFF
--- a/internal/generator/auth_chrome_channel_test.go
+++ b/internal/generator/auth_chrome_channel_test.go
@@ -80,7 +80,7 @@ func TestCookieAuthRefreshResolvesChannel(t *testing.T) {
 
 	// The persisted field exists in config with an omitempty tag.
 	configGo := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
-	assert.Contains(t, configGo, "ChromeProfile string")
+	assert.Contains(t, configGo, "ChromeProfile")
 	assert.Contains(t, configGo, "chrome_profile,omitempty")
 
 	requireGeneratedCompiles(t, outputDir)

--- a/internal/generator/client_cookie_jar_seed_test.go
+++ b/internal/generator/client_cookie_jar_seed_test.go
@@ -110,6 +110,10 @@ func TestSeedCookieJarForDomainAttachesSubdomainCookies(t *testing.T) {
 	if cs := jar.Cookies(u); len(cs) != 1 || cs[0].Name != "session_id" || cs[0].Value != "abc" {
 		t.Fatalf("domain-scoped seed did not attach to API subdomain: %v", cs)
 	}
+	u, _ = url.Parse("https://api.other.example/items")
+	if cs := jar.Cookies(u); len(cs) != 0 {
+		t.Fatalf("domain-scoped seed leaked outside its binding: %v", cs)
+	}
 }
 
 func TestSeedCookieJarIgnoresBareToken(t *testing.T) {
@@ -203,13 +207,34 @@ func TestWriteCookieJarReplacesWWWShadow(t *testing.T) {
 		t.Fatalf("shadowing www cookie was not replaced: %#v", after)
 	}
 }
+
+func TestClearCookieJarRemovesPersistedCredentials(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := WriteCookieJarFromMap(".cookieseed.example", map[string]string{"session_id": "secret"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ClearCookieJar(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(cookieJarPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rows []persistedCookie
+	if err := json.Unmarshal(data, &rows); err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("ClearCookieJar left persisted credentials: %#v", rows)
+	}
+}
 `
 	require.NoError(t, os.WriteFile(
 		filepath.Join(outputDir, "internal", "client", "seed_runtime_test.go"),
 		[]byte(runtimeTest), 0o600))
 
 	runGoCommand(t, outputDir, "mod", "tidy")
-	runGoCommand(t, outputDir, "test", "./internal/client/", "-run", "TestSeedCookieJar|TestLooksLikeCookieJar")
+	runGoCommand(t, outputDir, "test", "./internal/client/", "-run", "TestSeedCookieJar|TestLooksLikeCookieJar|TestClearCookieJar")
 }
 
 // TestBearerAuthClientOmitsCookieJarSeed pins the negative: bearer/api_key auth

--- a/internal/generator/client_cookie_jar_seed_test.go
+++ b/internal/generator/client_cookie_jar_seed_test.go
@@ -31,6 +31,7 @@ func TestCookieAuthClientSeedsJar(t *testing.T) {
 
 	outputDir := filepath.Join(t.TempDir(), "cookieseed-pp-cli")
 	require.NoError(t, New(apiSpec, outputDir).Generate())
+	requireGeneratedCompiles(t, outputDir)
 
 	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
 	configSrc := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
@@ -39,7 +40,9 @@ func TestCookieAuthClientSeedsJar(t *testing.T) {
 	assert.Contains(t, clientSrc, "cookieJar := LoadCookieJar()",
 		"cookie-auth New() must build the persistent jar")
 	assert.Contains(t, clientSrc, "SeedCookieJar(cookieJar, cfg.BaseURL, cfg.CookieCredential())",
-		"cookie-auth New() must seed the jar from the stored cookie credential")
+		"cookie-auth New() must seed legacy credentials at the configured base URL")
+	assert.Contains(t, clientSrc, "SeedCookieJarForDomain(cookieJar, seedBaseURL, cfg.CookieCredential(), cfg.CredentialDomain)",
+		"cookie-auth New() must seed the jar from the stored cookie credential at its bound domain")
 	assert.Contains(t, clientSrc, "httpClient := newHTTPClient(timeout, cookieJar)",
 		"cookie-auth client must use the seeded jar, not a nil jar")
 	assert.NotContains(t, clientSrc, "newHTTPClient(timeout, nil)",
@@ -97,6 +100,15 @@ func TestSeedCookieJarAttachesStoredCookies(t *testing.T) {
 	}
 	if got["session_id"] != "abc" || got["csrf_token"] != "def" {
 		t.Fatalf("seeded jar did not attach stored cookies for the base URL: %v", got)
+	}
+}
+
+func TestSeedCookieJarForDomainAttachesSubdomainCookies(t *testing.T) {
+	jar, _ := cookiejar.New(nil)
+	SeedCookieJarForDomain(jar, "https://auth.example.com", "session_id=abc", ".auth.example.com")
+	u, _ := url.Parse("https://api.auth.example.com/items")
+	if cs := jar.Cookies(u); len(cs) != 1 || cs[0].Name != "session_id" || cs[0].Value != "abc" {
+		t.Fatalf("domain-scoped seed did not attach to API subdomain: %v", cs)
 	}
 }
 

--- a/internal/generator/client_credential_domain_test.go
+++ b/internal/generator/client_credential_domain_test.go
@@ -93,7 +93,9 @@ func TestGeneratedBrowserCredentialBindsToCapturedDomain(t *testing.T) {
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 	"time"
 
@@ -179,8 +181,61 @@ func TestCookieOverrideDoesNotInheritPersistedBrowserJar(t *testing.T) {
 		t.Fatal("environment override inherited a stale browser domain binding")
 	}
 }
+
+func TestCookieOverrideRotatesInMemoryWithoutPersisting(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := WriteCookieJarFromMap(".auth.example.com", map[string]string{"session_id": "browser"}); err != nil {
+		t.Fatal(err)
+	}
+	path := cookieJarPath()
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		want := "session_id=env"
+		if requests == 2 {
+			want = "session_id=rotated"
+		}
+		if got := r.Header.Get("Cookie"); got != want {
+			t.Errorf("request %d Cookie = %q, want %q", requests, got, want)
+		}
+		if requests == 1 {
+			http.SetCookie(w, &http.Cookie{Name: "session_id", Value: "rotated", Path: "/"})
+		}
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		BaseURL:          server.URL,
+		AccessToken:      "session_id=env",
+		AuthSource:       "env:CREDENTIALDOMAIN_SESSION",
+		CredentialSource: "env:CREDENTIALDOMAIN_SESSION",
+	}
+	client := New(cfg, time.Second, 0)
+	for i := 0; i < 2; i++ {
+		resp, err := client.HTTPClient.Get(server.URL + "/rotate")
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+	}
+	if requests != 2 {
+		t.Fatalf("server saw %d requests, want 2", requests)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("override response cookie changed persisted browser jar: before=%s after=%s", before, after)
+	}
+}
 `
 	runtimePath := filepath.Join(outputDir, "internal", "client", "credential_domain_runtime_test.go")
 	require.NoError(t, os.WriteFile(runtimePath, []byte(runtimeTest), 0o600))
-	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^TestCredentialAppliesToURL$", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^Test(CredentialAppliesToURL|CookieOverrideDoesNotInheritPersistedBrowserJar|CookieOverrideRotatesInMemoryWithoutPersisting)$", "-count=1")
 }

--- a/internal/generator/client_credential_domain_test.go
+++ b/internal/generator/client_credential_domain_test.go
@@ -1,0 +1,108 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedBrowserCredentialBindsToCapturedDomain(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("credentialdomain")
+	apiSpec.BaseURL = "https://api.credential-free.example"
+	apiSpec.Auth = spec.AuthConfig{
+		Type:         "composed",
+		Header:       "Authorization",
+		Format:       "Bearer {token}",
+		CookieDomain: ".auth.example.com",
+		Cookies:      []string{"session_id"},
+		EnvVars:      []string{"CREDENTIALDOMAIN_SESSION"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "credentialdomain-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	requireGeneratedCompiles(t, outputDir)
+
+	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
+	configSrc := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+	authSrc := readGeneratedFile(t, outputDir, "internal", "cli", "auth.go")
+	goMod := readGeneratedFile(t, outputDir, "go.mod")
+
+	assert.Contains(t, configSrc, "CredentialDomain",
+		"browser-session config must persist the captured credential domain")
+	assert.Contains(t, configSrc, `toml:"credential_domain,omitempty"`,
+		"browser-session config must serialize the captured credential domain")
+	assert.Contains(t, configSrc, "CredentialDomain: c.CredentialDomain",
+		"persisted config must carry the captured credential domain")
+	assert.Contains(t, authSrc, `cfg.CredentialDomain = ".auth.example.com"`,
+		"browser login and refresh must bind the stored credential to the capture domain")
+	assert.Contains(t, clientSrc, `seedBaseURL := "https://" + strings.TrimPrefix(cfg.CredentialDomain, ".")`,
+		"cookie seeding must use the captured domain instead of the merged BaseURL")
+	assert.Contains(t, clientSrc, "SeedCookieJarForDomain(cookieJar, seedBaseURL, cfg.CookieCredential(), cfg.CredentialDomain)",
+		"cookie seeding must preserve the captured domain across its subdomains")
+	assert.Contains(t, clientSrc, "credentialAllowed := c.credentialAppliesToURL(targetURL)",
+		"requests must check the captured credential domain before injection")
+	assert.Contains(t, clientSrc, "if authHeader != \"\" && credentialAllowed {",
+		"the primary auth header must be withheld from unrelated hosts")
+	assert.Contains(t, clientSrc, "req.URL.Host == via[0].URL.Host && c.credentialAppliesToURL(req.URL.String())",
+		"same-host redirect re-stamping must retain the credential-domain gate")
+	assert.Contains(t, clientSrc, "publicsuffix.EffectiveTLDPlusOne",
+		"credential matching must use registrable domains")
+	assert.Contains(t, goMod, "golang.org/x/net v0.55.0",
+		"browser-session clients must declare the publicsuffix dependency")
+
+	// The negative path must remain unchanged for ordinary token auth: it has
+	// no capture-time domain to bind and should not gain browser-only baggage.
+	bearer := minimalSpec("credentialdomain-bearer")
+	bearerDir := filepath.Join(t.TempDir(), "credentialdomain-bearer-pp-cli")
+	require.NoError(t, New(bearer, bearerDir).Generate())
+	bearerClient := readGeneratedFile(t, bearerDir, "internal", "client", "client.go")
+	bearerMod := readGeneratedFile(t, bearerDir, "go.mod")
+	assert.NotContains(t, bearerClient, "credentialAppliesToURL",
+		"ordinary token auth must not emit browser credential binding")
+	assert.NotContains(t, bearerMod, "golang.org/x/net v0.55.0",
+		"ordinary token auth must not gain the browser-only dependency")
+	assert.Equal(t, 1, strings.Count(authSrc, `cfg.CredentialDomain = ".auth.example.com"`),
+		"browser login should record the capture domain")
+
+	runtimeTest := `package client
+
+import (
+	"testing"
+
+	"credentialdomain-pp-cli/internal/config"
+)
+
+func TestCredentialAppliesToURL(t *testing.T) {
+	c := &Client{Config: &config.Config{CredentialDomain: ".auth.example.com"}}
+	for _, tc := range []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "captured host", url: "https://login.auth.example.com/session", want: true},
+		{name: "same registrable domain", url: "https://api.auth.example.com/items", want: true},
+		{name: "credential-free host", url: "https://api.credential-free.example/items", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := c.credentialAppliesToURL(tc.url); got != tc.want {
+				t.Fatalf("credentialAppliesToURL(%q) = %v, want %v", tc.url, got, tc.want)
+			}
+		})
+	}
+	t.Setenv("PRINTING_PRESS_VERIFY_LIVE_HTTP", "1")
+	if !c.credentialAppliesToURL("https://api.credential-free.example/items") {
+		t.Fatal("verify-live HTTP must preserve mock-host credential behavior")
+	}
+}
+`
+	runtimePath := filepath.Join(outputDir, "internal", "client", "credential_domain_runtime_test.go")
+	require.NoError(t, os.WriteFile(runtimePath, []byte(runtimeTest), 0o600))
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^TestCredentialAppliesToURL$", "-count=1")
+}

--- a/internal/generator/client_credential_domain_test.go
+++ b/internal/generator/client_credential_domain_test.go
@@ -23,6 +23,10 @@ func TestGeneratedBrowserCredentialBindsToCapturedDomain(t *testing.T) {
 		CookieDomain: ".auth.example.com",
 		Cookies:      []string{"session_id"},
 		EnvVars:      []string{"CREDENTIALDOMAIN_SESSION"},
+		AdditionalHeaders: []spec.AdditionalAuthHeader{
+			{Header: "X-Extra", In: "header", EnvVar: spec.AuthEnvVar{Name: "CREDENTIALDOMAIN_EXTRA"}},
+			{Header: "extra_query", In: "query", EnvVar: spec.AuthEnvVar{Name: "CREDENTIALDOMAIN_QUERY"}},
+		},
 	}
 
 	outputDir := filepath.Join(t.TempDir(), "credentialdomain-pp-cli")
@@ -31,6 +35,7 @@ func TestGeneratedBrowserCredentialBindsToCapturedDomain(t *testing.T) {
 
 	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
 	configSrc := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+	credentialsSrc := readGeneratedFile(t, outputDir, "internal", "cliutil", "credentials.go")
 	authSrc := readGeneratedFile(t, outputDir, "internal", "cli", "auth.go")
 	goMod := readGeneratedFile(t, outputDir, "go.mod")
 
@@ -40,6 +45,12 @@ func TestGeneratedBrowserCredentialBindsToCapturedDomain(t *testing.T) {
 		"browser-session config must serialize the captured credential domain")
 	assert.Contains(t, configSrc, "CredentialDomain: c.CredentialDomain",
 		"persisted config must carry the captured credential domain")
+	assert.Contains(t, configSrc, "CredentialDomain = \"\"",
+		"environment auth overrides must clear a stale browser binding")
+	assert.Contains(t, configSrc, "UsePersistedCookieJar",
+		"cookie clients must be able to suppress stale persisted browser cookies")
+	assert.Contains(t, credentialsSrc, "credential_domain",
+		"external credentials must carry the browser binding with the credential")
 	assert.Contains(t, authSrc, `cfg.CredentialDomain = ".auth.example.com"`,
 		"browser login and refresh must bind the stored credential to the capture domain")
 	assert.Contains(t, clientSrc, `seedBaseURL := "https://" + strings.TrimPrefix(cfg.CredentialDomain, ".")`,
@@ -63,9 +74,16 @@ func TestGeneratedBrowserCredentialBindsToCapturedDomain(t *testing.T) {
 	bearerDir := filepath.Join(t.TempDir(), "credentialdomain-bearer-pp-cli")
 	require.NoError(t, New(bearer, bearerDir).Generate())
 	bearerClient := readGeneratedFile(t, bearerDir, "internal", "client", "client.go")
+	bearerConfig := readGeneratedFile(t, bearerDir, "internal", "config", "config.go")
+	bearerAuth := readGeneratedFile(t, bearerDir, "internal", "cli", "auth.go")
 	bearerMod := readGeneratedFile(t, bearerDir, "go.mod")
+	requireGeneratedCompiles(t, bearerDir)
 	assert.NotContains(t, bearerClient, "credentialAppliesToURL",
 		"ordinary token auth must not emit browser credential binding")
+	assert.NotContains(t, bearerConfig, "CredentialDomain",
+		"ordinary token auth config must not emit browser credential binding")
+	assert.NotContains(t, bearerAuth, "CredentialDomain",
+		"ordinary token auth commands must not reference browser credential binding")
 	assert.NotContains(t, bearerMod, "golang.org/x/net v0.55.0",
 		"ordinary token auth must not gain the browser-only dependency")
 	assert.Equal(t, 1, strings.Count(authSrc, `cfg.CredentialDomain = ".auth.example.com"`),
@@ -74,7 +92,10 @@ func TestGeneratedBrowserCredentialBindsToCapturedDomain(t *testing.T) {
 	runtimeTest := `package client
 
 import (
+	"net/http"
+	"net/url"
 	"testing"
+	"time"
 
 	"credentialdomain-pp-cli/internal/config"
 )
@@ -96,9 +117,66 @@ func TestCredentialAppliesToURL(t *testing.T) {
 			}
 		})
 	}
+	t.Setenv("PRINTING_PRESS_VERIFY", "1")
 	t.Setenv("PRINTING_PRESS_VERIFY_LIVE_HTTP", "1")
-	if !c.credentialAppliesToURL("https://api.credential-free.example/items") {
-		t.Fatal("verify-live HTTP must preserve mock-host credential behavior")
+	if !c.credentialAppliesToURL("http://127.0.0.1:12345/items") {
+		t.Fatal("verified live HTTP must preserve mock-host credential behavior")
+	}
+	if c.credentialAppliesToURL("https://api.credential-free.example/items") {
+		t.Fatal("verify-live HTTP must not bypass matching for real targets")
+	}
+}
+
+func TestCredentialRedirectStripsCrossHostCredentials(t *testing.T) {
+	cfg := &config.Config{
+		BaseURL:          "https://api.auth.example.com",
+		AuthHeaderVal:    "Bearer primary",
+		AccessToken:      "session_id=browser",
+		CredentialDomain: ".auth.example.com",
+	}
+	c := New(cfg, time.Second, 0)
+	viaURL, _ := url.Parse("https://api.auth.example.com/start")
+	targetURL, _ := url.Parse("https://evil.example.net/done?extra_query=secret&keep=1")
+	via := &http.Request{URL: viaURL}
+	req := &http.Request{URL: targetURL, Header: http.Header{
+		"Authorization": {"Bearer primary"},
+		"X-Extra":       {"additional"},
+		"Cookie":        {"session_id=browser"},
+	}}
+	if err := c.HTTPClient.CheckRedirect(req, []*http.Request{via}); err != nil {
+		t.Fatalf("CheckRedirect returned error: %v", err)
+	}
+	for _, name := range []string{"Authorization", "X-Extra", "Cookie"} {
+		if got := req.Header.Get(name); got != "" {
+			t.Fatalf("cross-host redirect retained %s=%q", name, got)
+		}
+	}
+	if got := req.URL.Query().Get("extra_query"); got != "" {
+		t.Fatalf("cross-host redirect retained additional query credential %q", got)
+	}
+}
+
+func TestCookieOverrideDoesNotInheritPersistedBrowserJar(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := WriteCookieJarFromMap(".auth.example.com", map[string]string{"session_id": "browser"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{
+		BaseURL:          "https://api.auth.example.com",
+		AccessToken:      "session_id=env",
+		AuthSource:       "env:CREDENTIALDOMAIN_SESSION",
+		CredentialSource: "env:CREDENTIALDOMAIN_SESSION",
+		CredentialDomain: ".auth.example.com",
+	}
+	client := New(cfg, time.Second, 0)
+	target, _ := url.Parse("https://api.auth.example.com/items")
+	cookies := client.HTTPClient.Jar.Cookies(target)
+	if len(cookies) != 1 || cookies[0].Value != "env" {
+		t.Fatalf("env cookie override inherited a persisted browser jar: %v", cookies)
+	}
+	cfg.AuthSource = "env:CREDENTIALDOMAIN_SESSION"
+	if !client.credentialAppliesToURL("https://api.credential-free.example/items") {
+		t.Fatal("environment override inherited a stale browser domain binding")
 	}
 }
 `

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -11319,6 +11319,11 @@ func TestGeneratedHelpers_AuthWithKeyURL_Compiles(t *testing.T) {
 	gen := New(apiSpec, outputDir)
 	require.NoError(t, gen.Generate())
 
+	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
+	assert.Contains(t, clientSrc, "q := req.URL.Query()",
+		"query API-key auth must emit cross-host query cleanup")
+	assert.Contains(t, clientSrc, "req.URL.RawQuery = q.Encode()",
+		"query API-key auth must write the cleaned query back")
 	requireGeneratedCompiles(t, outputDir)
 }
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1405,6 +1405,7 @@ func TestGenerateComposedApiKeyPlusBearerEmitsAdditionalHeader(t *testing.T) {
 	mcpSrc := string(mcpBytes)
 	assert.Contains(t, mcpSrc, `"ST_APP_KEY"`,
 		"MCP context must expose sibling apiKey credentials to agents")
+	requireGeneratedCompiles(t, outputDir)
 }
 
 func TestGenerateComposedHeaderApiKeyDerivesMissingSiblingEnvVar(t *testing.T) {

--- a/internal/generator/redirect_auth_header_test.go
+++ b/internal/generator/redirect_auth_header_test.go
@@ -22,9 +22,9 @@ func TestClientCheckRedirectDeletesHeaderOnCrossHost(t *testing.T) {
 		client := generateClientSource(t, apiSpec)
 		closure := checkRedirectClosureBody(t, client)
 
+		require.Contains(t, closure, `if req.URL.Host != via[0].URL.Host {`)
 		require.Contains(t, closure, `if req.URL.Host == via[0].URL.Host {`)
 		require.Contains(t, closure, `req.Header.Set("X-Api-Key", h)`)
-		require.Contains(t, closure, `} else {`)
 		require.Contains(t, closure, `req.Header.Del("X-Api-Key")`)
 	})
 

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -391,6 +391,9 @@ profile by name when the installed backend supports it.`,
 {{- if .Auth.RequiresBrowserSession}}
 			cfg.ChromeProfile = loginProfileLocation
 {{- end}}
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+			cfg.CredentialDomain = "{{.Auth.CookieDomain}}"
+{{- end}}
 
 			if err := cfg.SaveTokens("", "", composed, "", time.Time{}); err != nil {
 				return configErr(fmt.Errorf("saving auth: %w", err))
@@ -415,6 +418,9 @@ profile by name when the installed backend supports it.`,
 			fmt.Fprintf(w, "Validating browser session...")
 			if err := validateAndWriteBrowserSessionProof(cmd.Context(), cfg, flags); err != nil {
 				_ = cfg.ClearTokens()
+{{- if .Auth.HasCookies}}
+				_ = client.ClearCookieJar()
+{{- end}}
 				_ = clearBrowserSessionProof(cfg)
 				fmt.Fprintf(w, " %s\n", red("failed"))
 				return authErr(fmt.Errorf("browser session validation failed: %w", err))
@@ -459,6 +465,9 @@ profile by name when the installed backend supports it.`,
 {{- if .Auth.RequiresBrowserSession}}
 			cfg.ChromeProfile = loginProfileLocation
 {{- end}}
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+			cfg.CredentialDomain = "{{.Auth.CookieDomain}}"
+{{- end}}
 
 			if err := cfg.SaveTokens("", "", cookies, "", time.Time{}); err != nil {
 				return configErr(fmt.Errorf("saving cookies: %w", err))
@@ -482,6 +491,9 @@ profile by name when the installed backend supports it.`,
 			fmt.Fprintf(w, "Validating browser session...")
 			if err := validateAndWriteBrowserSessionProof(cmd.Context(), cfg, flags); err != nil {
 				_ = cfg.ClearTokens()
+{{- if .Auth.HasCookies}}
+				_ = client.ClearCookieJar()
+{{- end}}
 				_ = clearBrowserSessionProof(cfg)
 				fmt.Fprintf(w, " %s\n", red("failed"))
 				return authErr(fmt.Errorf("browser session validation failed: %w", err))
@@ -593,6 +605,9 @@ when the CDP path is not available (other machine, headless server, etc.).`,
 				return configErr(err)
 			}
 			cfg.AuthHeaderVal = ""
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+			cfg.CredentialDomain = ""
+{{- end}}
 			if err := cfg.SaveTokens("", "", token, "", time.Time{}); err != nil {
 				return configErr(fmt.Errorf("saving token: %w", err))
 			}
@@ -1020,6 +1035,7 @@ func refreshStoredBrowserCookies(cfg *config.Config, w io.Writer) error {
 	for _, name := range requiredCookies {
 		composed = strings.ReplaceAll(composed, "{"+name+"}", cookieMap[name])
 	}
+	cfg.CredentialDomain = "{{.Auth.CookieDomain}}"
 	if err := cfg.SaveTokens("", "", composed, "", time.Time{}); err != nil {
 		return configErr(fmt.Errorf("saving auth: %w", err))
 	}
@@ -1055,6 +1071,7 @@ func refreshStoredBrowserCookies(cfg *config.Config, w io.Writer) error {
 	}
 	cookies = strings.Join(kept, "; ")
 {{- end}}
+	cfg.CredentialDomain = "{{.Auth.CookieDomain}}"
 	if err := cfg.SaveTokens("", "", cookies, "", time.Time{}); err != nil {
 		return configErr(fmt.Errorf("saving cookies: %w", err))
 	}
@@ -1394,6 +1411,9 @@ func newAuthSetTokenCmd(flags *rootFlags) *cobra.Command {
 			// 401 on the next API call, same as the rest of the browser-auth
 			// flow. Matches ClearTokens / SaveBearerToken's zero-on-write
 			// invariant in config.go.tmpl.
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+			cfg.CredentialDomain = ""
+{{- end}}
 			if err := cfg.SaveTokens("", "", token, "", time.Time{}); err != nil {
 				return configErr(fmt.Errorf("saving token: %w", err))
 			}
@@ -1444,6 +1464,11 @@ func newAuthLogoutCmd(flags *rootFlags) *cobra.Command {
 			if err := cfg.ClearTokens(); err != nil {
 				return configErr(fmt.Errorf("clearing tokens: %w", err))
 			}
+{{- if .Auth.HasCookies}}
+			if err := client.ClearCookieJar(); err != nil {
+				return configErr(fmt.Errorf("clearing cookie jar: %w", err))
+			}
+{{- end}}
 {{- if .Auth.RequiresBrowserSession}}
 			if err := clearBrowserSessionProof(cfg); err != nil {
 				return configErr(fmt.Errorf("clearing browser-session proof: %w", err))

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -711,7 +711,6 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 {{- end}}
 {{- end}}
 			req.URL.RawQuery = q.Encode()
-		}
 {{- end}}
 		}
 {{- end}}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -618,11 +618,14 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 {{- if .Auth.HasCookies}}
 	cookieJar := LoadCookieJar()
 {{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+	if cfg != nil && !cfg.UsePersistedCookieJar() {
+		cookieJar = NewCookieJar()
+	}
 	// Seed the jar from a session captured via the env var or stored in
 	// credentials but not yet in cookies.json, so the credential rides every
 	// request and net/http absorbs Set-Cookie rotation across the session.
 	if cfg != nil {
-		if cfg.CredentialDomain != "" {
+		if cfg.CredentialDomain != "" && cfg.UsePersistedCookieJar() {
 			seedBaseURL := "https://" + strings.TrimPrefix(cfg.CredentialDomain, ".")
 			SeedCookieJarForDomain(cookieJar, seedBaseURL, cfg.CookieCredential(), cfg.CredentialDomain)
 		} else {
@@ -677,6 +680,41 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			// "Moved Permanently" body back to the caller.
 			return errors.New("stopped after 10 redirects")
 		}
+{{- if and (ne .Auth.Type "none") (ne .Auth.Type "")}}
+		// Never carry credential material across a host-changing redirect.
+		// Go strips Authorization and Cookie in common cases, but custom
+		// headers and URL query values need explicit removal here.
+		if req.URL.Host != via[0].URL.Host {
+			req.Header.Del("{{authParameterName .Auth}}")
+{{- if eq .Auth.Type "session_handshake"}}
+			req.Header.Del("{{.Auth.TokenParamName}}")
+{{- end}}
+{{- if or (eq .Auth.In "cookie") (eq .Auth.Type "cookie")}}
+			req.Header.Del("Cookie")
+{{- end}}
+{{- range .Auth.AdditionalHeaders}}
+{{- if eq .In "header"}}
+			req.Header.Del("{{.Header}}")
+{{- end}}
+{{- end}}
+{{- if or (eq .Auth.In "query") (eq .Auth.TokenParamIn "query")}}
+			q := req.URL.Query()
+{{- if eq .Auth.In "query"}}
+			q.Del("{{authParameterName .Auth}}")
+{{- end}}
+{{- if and (eq .Auth.Type "session_handshake") (eq .Auth.TokenParamIn "query")}}
+			q.Del("{{.Auth.TokenParamName}}")
+{{- end}}
+{{- range .Auth.AdditionalHeaders}}
+{{- if eq .In "query"}}
+			q.Del("{{.Header}}")
+{{- end}}
+{{- end}}
+			req.URL.RawQuery = q.Encode()
+		}
+{{- end}}
+		}
+{{- end}}
 {{- if .HasTierRouting}}
 		// Tier routing picks header vs query at request time on a WithTier copy,
 		// while this redirect callback is installed once on the shared
@@ -708,8 +746,8 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 		}
 {{- end}}
 {{- else if and .Auth .Auth.In (eq .Auth.In "query")}}
-		// Auth lives on URL query; Go preserves the query on relative
-		// redirects, so nothing to re-derive.
+		// Query credentials are removed above on cross-host hops and remain
+		// unchanged on same-host redirects.
 {{- else if and .Auth .Auth.In (eq .Auth.In "cookie") (not (isBrowserCookieAuth .Auth))}}
 		// The auth cookie set on the initial request is carried verbatim by Go
 		// on same-host redirects, so re-adding it here would double the Cookie
@@ -732,11 +770,6 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 		// cookie carriage on 3xx hops natively. Setting the Cookie header
 		// manually here would double the jar's cookies on the redirected
 		// request.
-{{- if and .Auth.Header (ne .Auth.Header "Cookie")}}
-		if req.URL.Host != via[0].URL.Host {
-			req.Header.Del("{{.Auth.Header}}")
-		}
-{{- end}}
 {{- else}}
 		// Same-host gate mirrors Go's shouldCopyHeaderOnRedirect: a
 		// cross-domain 3xx (open redirect or partner handoff) must not
@@ -746,22 +779,6 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			if h, err := c.authHeader(req.Context()); err == nil && h != "" {
 				req.Header.Set("{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}", h)
 			}
-		} else {
-			// Cross-host hop: Go strips standard auth headers (Authorization,
-			// Cookie) but not custom ones, so a custom API-key header would be
-			// forwarded verbatim to the redirect target. Delete it explicitly.
-			req.Header.Del("{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}")
-{{- if eq .Auth.Type "composed"}}
-{{- range .Auth.AdditionalHeaders}}
-{{- if eq .In "header"}}
-			req.Header.Del("{{.Header}}")
-{{- else if eq .In "query"}}
-			q := req.URL.Query()
-			q.Del("{{.Header}}")
-			req.URL.RawQuery = q.Encode()
-{{- end}}
-{{- end}}
-{{- end}}
 		}
 {{- end}}
 		return nil
@@ -2960,7 +2977,10 @@ func isAbsoluteURL(path string) bool {
 // registrable domain. An empty binding preserves legacy credentials and
 // explicit verify-live HTTP uses mock hosts that cannot match the real site.
 func (c *Client) credentialAppliesToURL(rawURL string) bool {
-	if c == nil || c.Config == nil || strings.TrimSpace(c.Config.CredentialDomain) == "" || cliutil.IsVerifyLiveHTTPEnv() {
+	if c == nil || c.Config == nil || !c.Config.UsePersistedCookieJar() || strings.TrimSpace(c.Config.CredentialDomain) == "" {
+		return true
+	}
+	if cliutil.IsVerifyEnv() && cliutil.IsVerifyLiveHTTPEnv() && isVerifyMockURL(rawURL) {
 		return true
 	}
 	target, err := url.Parse(rawURL)
@@ -2975,6 +2995,19 @@ func (c *Client) credentialAppliesToURL(rawURL string) bool {
 	targetRegistered, targetErr := publicsuffix.EffectiveTLDPlusOne(targetHost)
 	boundRegistered, boundErr := publicsuffix.EffectiveTLDPlusOne(boundHost)
 	return targetErr == nil && boundErr == nil && targetRegistered == boundRegistered
+}
+
+func isVerifyMockURL(rawURL string) bool {
+	target, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(target.Hostname())
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 {{end -}}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -34,6 +34,9 @@ import (
 {{- if eq .Auth.Subtype "google_service_account"}}
 	"golang.org/x/oauth2/google"
 {{- end}}
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+	"golang.org/x/net/publicsuffix"
+{{- end}}
 {{- if .UsesBrowserHTTPTransport}}
 	enetxhttp "github.com/enetx/http"
 	"github.com/enetx/surf"
@@ -619,7 +622,12 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	// credentials but not yet in cookies.json, so the credential rides every
 	// request and net/http absorbs Set-Cookie rotation across the session.
 	if cfg != nil {
-		SeedCookieJar(cookieJar, cfg.BaseURL, cfg.CookieCredential())
+		if cfg.CredentialDomain != "" {
+			seedBaseURL := "https://" + strings.TrimPrefix(cfg.CredentialDomain, ".")
+			SeedCookieJarForDomain(cookieJar, seedBaseURL, cfg.CookieCredential(), cfg.CredentialDomain)
+		} else {
+			SeedCookieJar(cookieJar, cfg.BaseURL, cfg.CookieCredential())
+		}
 	}
 {{- end}}
 	httpClient := newHTTPClient(timeout, cookieJar{{if .UsesBrowserHTTPTransport}}, cfg.SkipTLSVerify{{end}})
@@ -724,12 +732,17 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 		// cookie carriage on 3xx hops natively. Setting the Cookie header
 		// manually here would double the jar's cookies on the redirected
 		// request.
+{{- if and .Auth.Header (ne .Auth.Header "Cookie")}}
+		if req.URL.Host != via[0].URL.Host {
+			req.Header.Del("{{.Auth.Header}}")
+		}
+{{- end}}
 {{- else}}
 		// Same-host gate mirrors Go's shouldCopyHeaderOnRedirect: a
 		// cross-domain 3xx (open redirect or partner handoff) must not
 		// receive the auth credential, even though we are inside
 		// CheckRedirect where Go's automatic stripping has already run.
-		if req.URL.Host == via[0].URL.Host {
+		if req.URL.Host == via[0].URL.Host{{- if eq .Auth.Type "composed"}} && c.credentialAppliesToURL(req.URL.String()){{- end}} {
 			if h, err := c.authHeader(req.Context()); err == nil && h != "" {
 				req.Header.Set("{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}", h)
 			}
@@ -738,6 +751,17 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			// Cookie) but not custom ones, so a custom API-key header would be
 			// forwarded verbatim to the redirect target. Delete it explicitly.
 			req.Header.Del("{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}")
+{{- if eq .Auth.Type "composed"}}
+{{- range .Auth.AdditionalHeaders}}
+{{- if eq .In "header"}}
+			req.Header.Del("{{.Header}}")
+{{- else if eq .In "query"}}
+			q := req.URL.Query()
+			q.Del("{{.Header}}")
+			req.URL.RawQuery = q.Encode()
+{{- end}}
+{{- end}}
+{{- end}}
 		}
 {{- end}}
 		return nil
@@ -1774,6 +1798,12 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	if err != nil {
 		return nil, 0, err
 	}
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+	credentialAllowed := c.credentialAppliesToURL(targetURL)
+	if !credentialAllowed {
+		authHeader = ""
+	}
+{{- end}}
 {{- if eq .Auth.Type "session_handshake"}}
 	// For session-handshake auth, authHeader() only returns the cached token
 	// (or empty). On the live path, ensure a fresh token if none is cached.
@@ -1893,7 +1923,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		}
 {{- end}}
 
-		if authHeader != "" {
+		if authHeader != ""{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}} && credentialAllowed{{- end}} {
 {{- if .HasTierRouting}}
 			if authInfo.In == "query" {
 				q := req.URL.Query()
@@ -1943,7 +1973,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		// Composed-scheme per-call credentials carried by sibling apiKey schemes.
 		// Sent independently of authHeader: the API requires both the primary
 		// auth credential and each sibling credential on every request.
-		if c.Config != nil {
+		if {{if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}credentialAllowed && {{end}}c.Config != nil {
 {{- range .Auth.AdditionalHeaders}}
 			if v := c.Config.{{resolveEnvVarField .EnvVar.Name}}; v != "" {
 				if authHeaderLooksLikePlaceholderCredential(v) {
@@ -2922,6 +2952,29 @@ func (c *Client) refreshAccessToken(ctx context.Context) error {
 // path; the relative-path concat with c.BaseURL must be skipped for those calls.
 func isAbsoluteURL(path string) bool {
 	return strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "http://")
+}
+
+{{end -}}
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+// credentialAppliesToURL keeps a browser-captured credential on its own
+// registrable domain. An empty binding preserves legacy credentials and
+// explicit verify-live HTTP uses mock hosts that cannot match the real site.
+func (c *Client) credentialAppliesToURL(rawURL string) bool {
+	if c == nil || c.Config == nil || strings.TrimSpace(c.Config.CredentialDomain) == "" || cliutil.IsVerifyLiveHTTPEnv() {
+		return true
+	}
+	target, err := url.Parse(rawURL)
+	if err != nil || target.Hostname() == "" {
+		return false
+	}
+	targetHost := strings.ToLower(strings.TrimSuffix(target.Hostname(), "."))
+	boundHost := strings.ToLower(strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(c.Config.CredentialDomain), "."), "."))
+	if targetHost == boundHost || strings.HasSuffix(targetHost, "."+boundHost) {
+		return true
+	}
+	targetRegistered, targetErr := publicsuffix.EffectiveTLDPlusOne(targetHost)
+	boundRegistered, boundErr := publicsuffix.EffectiveTLDPlusOne(boundHost)
+	return targetErr == nil && boundErr == nil && targetRegistered == boundRegistered
 }
 
 {{end -}}

--- a/internal/generator/templates/cliutil_credentials.go.tmpl
+++ b/internal/generator/templates/cliutil_credentials.go.tmpl
@@ -33,6 +33,9 @@ type Credentials struct {
 {{- end}}
 	ClientID     string `toml:"client_id"`
 	ClientSecret string `toml:"client_secret"`
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+	CredentialDomain string `toml:"credential_domain,omitempty"`
+{{- end}}
 {{- range .CredentialFields}}
 	{{.GoField}} string `toml:"{{.Tag}}"`
 {{- end}}

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -251,6 +251,9 @@ func Load(configPath string) (*Config, error) {
 {{- if $.HasAuthCommand}}
 		cfg.CredentialSource = "env:{{.Name}}"
 {{- end}}
+{{- if or (eq $.Auth.Type "cookie") (eq $.Auth.Type "composed")}}
+		cfg.CredentialDomain = ""
+{{- end}}
 	}
 {{- end}}
 {{- else if .Auth.EnvVars}}
@@ -262,6 +265,9 @@ func Load(configPath string) (*Config, error) {
 		cfg.AuthSource = "env:{{.}}"
 {{- if $.HasAuthCommand}}
 		cfg.CredentialSource = "env:{{.}}"
+{{- end}}
+{{- if or (eq $.Auth.Type "cookie") (eq $.Auth.Type "composed")}}
+		cfg.CredentialDomain = ""
 {{- end}}
 	}
 {{- end}}
@@ -912,6 +918,24 @@ func (c *Config) CookieCredential() string {
 }
 {{- end}}
 
+{{- if or (eq .Auth.Type "composed") (eq .Auth.Type "cookie")}}
+// UsePersistedCookieJar keeps disk cookies only when the active credential is
+// config-backed or carries its own browser binding. Environment and external
+// store overrides without a binding must not inherit a stale browser session.
+func (c *Config) UsePersistedCookieJar() bool {
+	if c == nil {
+		return true
+	}
+	if strings.HasPrefix(c.AuthSource, "env:") {
+		return false
+	}
+	if c.CredentialSource == "credentials file" || c.CredentialSource == "agentcookie" {
+		return strings.TrimSpace(c.CredentialDomain) != ""
+	}
+	return true
+}
+{{- end}}
+
 // Raw browser-session values count as credentials even when no header
 // representation exists; hand-coded flows may also preserve a working header.
 func (c *Config) CredentialConfigured() bool {
@@ -1159,6 +1183,9 @@ func (c *Config) credentials() *cliutil.Credentials {
 {{- end}}
 		ClientID:     c.ClientID,
 		ClientSecret: c.ClientSecret,
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+		CredentialDomain: c.CredentialDomain,
+{{- end}}
 {{- range .CredentialFields}}
 		{{.GoField}}: c.{{.GoField}},
 {{- end}}
@@ -1192,6 +1219,13 @@ func (c *Config) applyCredentials(creds *cliutil.Credentials) {
 	if c.ClientSecret == "" {
 		c.ClientSecret = creds.ClientSecret
 	}
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+	// An external credential owns its browser binding. An empty binding clears
+	// stale config-file state instead of allowing an unrelated token to inherit it.
+	if creds.AuthHeaderVal != "" || creds.AccessToken != "" {
+		c.CredentialDomain = creds.CredentialDomain
+	}
+{{- end}}
 {{- range .CredentialFields}}
 	if c.{{.GoField}} == "" {
 		c.{{.GoField}} = creds.{{.GoField}}

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -90,6 +90,13 @@ type Config struct {
 	GoogleImpersonate string   `{{configTag .Config.Format}}:"google_impersonate,omitempty"`
 	GoogleScopes     []string `{{configTag .Config.Format}}:"google_scopes,omitempty"`
 {{- end}}
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+	// CredentialDomain binds browser-captured credentials to the registrable
+	// domain they came from. It is intentionally per-CLI config state rather
+	// than shared credential-store state because one credential file can serve
+	// unrelated printed CLIs.
+	CredentialDomain string `{{configTag .Config.Format}}:"credential_domain,omitempty"`
+{{- end}}
 {{- end}}
 	Path           string `{{configTag .Config.Format}}:"-"`
 	envOverrides   map[string]bool `{{configTag .Config.Format}}:"-"`
@@ -1126,6 +1133,9 @@ func (c *Config) clearCredentialFields() {
 	c.TokenExpiry = time.Time{}
 	c.ClientID = ""
 	c.ClientSecret = ""
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+	c.CredentialDomain = ""
+{{- end}}
 {{- if eq .Auth.Subtype "google_service_account"}}
 	c.GoogleImpersonate = ""
 	c.GoogleScopes = nil
@@ -1371,6 +1381,9 @@ func (c *Config) ClearTokens() error {
 	c.TokenExpiry = time.Time{}
 	c.ClientID = ""
 	c.ClientSecret = ""
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+	c.CredentialDomain = ""
+{{- end}}
 {{- if eq .Auth.Subtype "google_service_account"}}
 	c.GoogleImpersonate = ""
 	c.GoogleScopes = nil
@@ -1654,6 +1667,9 @@ type persistedConfig struct {
 {{- if .Auth.RequiresBrowserSession}}
 	ChromeProfile string `{{configTag .Config.Format}}:"chrome_profile,omitempty"`
 {{- end}}
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+	CredentialDomain string `{{configTag .Config.Format}}:"credential_domain,omitempty"`
+{{- end}}
 {{- if .HasRequiredRoles}}
 	AuthRole string `{{configTag .Config.Format}}:"auth_role,omitempty"`
 {{- end}}
@@ -1687,6 +1703,9 @@ func (c *Config) persisted() persistedConfig {
 		Headers: c.Headers,
 {{- if .Auth.RequiresBrowserSession}}
 		ChromeProfile: c.ChromeProfile,
+{{- end}}
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+		CredentialDomain: c.CredentialDomain,
 {{- end}}
 {{- if .HasRequiredRoles}}
 		AuthRole: c.AuthRole,

--- a/internal/generator/templates/cookiejar.go.tmpl
+++ b/internal/generator/templates/cookiejar.go.tmpl
@@ -45,11 +45,13 @@ func LoadCookieJar() http.CookieJar {
 	return jar
 }
 
-// NewCookieJar returns an empty persistent wrapper without loading cookies
-// from disk. Config.Load uses it when an env or external-store override has
-// replaced a browser session, so an old browser jar cannot ride along.
+// NewCookieJar returns an empty in-memory jar without loading or persisting
+// cookies. Config.Load uses it when an env or external-store override has
+// replaced a browser session, so an old browser jar cannot ride along or be
+// contaminated by response cookies.
 func NewCookieJar() http.CookieJar {
-	return newCookieJar()
+	jar, _ := cookiejar.New(nil)
+	return jar
 }
 
 func newCookieJar() *cookieJar {

--- a/internal/generator/templates/cookiejar.go.tmpl
+++ b/internal/generator/templates/cookiejar.go.tmpl
@@ -55,6 +55,17 @@ func cookieJarPath() string {
 	return filepath.Join(dir, "cookies.json")
 }
 
+// ClearCookieJar removes the persisted session cookies for this printed CLI.
+// Logout must clear both config credentials and the jar because net/http can
+// otherwise continue sending a valid cookie after the config is cleared.
+func ClearCookieJar() error {
+	path := cookieJarPath()
+	if path == "" {
+		return nil
+	}
+	return mergeAndWriteCookieRows(path, nil)
+}
+
 // looksLikeCookieJar reports whether s is a cookie-jar string ("name=value;
 // name=value") rather than a bare token. The session env var and the browser
 // AccessToken both store the full Cookie header, so the seed is gated on a real
@@ -126,6 +137,17 @@ func parseCookieJar(s string) []*http.Cookie {
 // A no-op when the credential is empty, is not a cookie-jar string, or baseURL
 // does not parse.
 func SeedCookieJar(jar http.CookieJar, baseURL, cookieStr string) {
+	seedCookieJar(jar, baseURL, cookieStr, "")
+}
+
+// SeedCookieJarForDomain seeds a captured cookie session for the captured
+// domain and its subdomains, while still requiring callers to choose the
+// capture root explicitly.
+func SeedCookieJarForDomain(jar http.CookieJar, baseURL, cookieStr, domain string) {
+	seedCookieJar(jar, baseURL, cookieStr, strings.TrimPrefix(strings.TrimSpace(domain), "."))
+}
+
+func seedCookieJar(jar http.CookieJar, baseURL, cookieStr, cookieDomain string) {
 	if jar == nil || !looksLikeCookieJar(cookieStr) {
 		return
 	}
@@ -136,6 +158,11 @@ func SeedCookieJar(jar http.CookieJar, baseURL, cookieStr string) {
 	cookies := parseCookieJar(cookieStr)
 	if len(cookies) == 0 {
 		return
+	}
+	if cookieDomain != "" {
+		for _, cookie := range cookies {
+			cookie.Domain = cookieDomain
+		}
 	}
 	// Seed the in-memory jar only — never persist. The wrapper's SetCookies
 	// writes through to cookies.json (persistLocked -> mergeAndWriteCookieRows),

--- a/internal/generator/templates/cookiejar.go.tmpl
+++ b/internal/generator/templates/cookiejar.go.tmpl
@@ -40,11 +40,22 @@ type persistedCookie struct {
 // LoadCookieJar returns a persistent cookie jar pre-populated from the canonical
 // cookie file on disk. Falls back to an empty in-memory jar when no file exists.
 func LoadCookieJar() http.CookieJar {
-	inner, _ := cookiejar.New(nil)
-	path := cookieJarPath()
-	jar := &cookieJar{inner: inner, path: path}
+	jar := newCookieJar()
 	jar.loadFromDisk()
 	return jar
+}
+
+// NewCookieJar returns an empty persistent wrapper without loading cookies
+// from disk. Config.Load uses it when an env or external-store override has
+// replaced a browser session, so an old browser jar cannot ride along.
+func NewCookieJar() http.CookieJar {
+	return newCookieJar()
+}
+
+func newCookieJar() *cookieJar {
+	inner, _ := cookiejar.New(nil)
+	path := cookieJarPath()
+	return &cookieJar{inner: inner, path: path}
 }
 
 func cookieJarPath() string {
@@ -63,7 +74,14 @@ func ClearCookieJar() error {
 	if path == "" {
 		return nil
 	}
-	return mergeAndWriteCookieRows(path, nil)
+	data, err := json.Marshal([]persistedCookie{})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
 }
 
 // looksLikeCookieJar reports whether s is a cookie-jar string ("name=value;

--- a/internal/generator/templates/go.mod.tmpl
+++ b/internal/generator/templates/go.mod.tmpl
@@ -21,7 +21,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/pelletier/go-toml/v2 v2.2.4
-{{- if .HasHTMLExtraction}}
+{{- if or .HasHTMLExtraction (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
 	golang.org/x/net v0.55.0
 {{- end}}
 )

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/pelletier/go-toml/v2 v2.2.4
+	golang.org/x/net v0.55.0
 )
 require modernc.org/sqlite v1.37.0
 require github.com/mark3labs/mcp-go v0.57.0

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
@@ -267,6 +267,7 @@ profile by name when the installed backend supports it.`,
 			if err != nil {
 				return configErr(err)
 			}
+			cfg.CredentialDomain = ".cookie-auth.example"
 
 			if err := cfg.SaveTokens("", "", cookies, "", time.Time{}); err != nil {
 				return configErr(fmt.Errorf("saving cookies: %w", err))
@@ -392,6 +393,7 @@ func newAuthSetTokenCmd(flags *rootFlags) *cobra.Command {
 			// 401 on the next API call, same as the rest of the browser-auth
 			// flow. Matches ClearTokens / SaveBearerToken's zero-on-write
 			// invariant in config.go.tmpl.
+			cfg.CredentialDomain = ""
 			if err := cfg.SaveTokens("", "", token, "", time.Time{}); err != nil {
 				return configErr(fmt.Errorf("saving token: %w", err))
 			}
@@ -440,6 +442,9 @@ func newAuthLogoutCmd(flags *rootFlags) *cobra.Command {
 
 			if err := cfg.ClearTokens(); err != nil {
 				return configErr(fmt.Errorf("clearing tokens: %w", err))
+			}
+			if err := client.ClearCookieJar(); err != nil {
+				return configErr(fmt.Errorf("clearing cookie jar: %w", err))
 			}
 			if os.Getenv("COOKIE_AUTH_SESSION") != "" {
 				fmt.Fprintf(cmd.OutOrStdout(), "Config cleared. Note: %s env var is still set.\n", "COOKIE_AUTH_SESSION")

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"golang.org/x/net/publicsuffix"
 	"golden-api-cookie-auth-pp-cli/internal/cliutil"
 	"golden-api-cookie-auth-pp-cli/internal/config"
 	"golden-api-cookie-auth-pp-cli/internal/platform"
@@ -251,7 +252,12 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	// credentials but not yet in cookies.json, so the credential rides every
 	// request and net/http absorbs Set-Cookie rotation across the session.
 	if cfg != nil {
-		SeedCookieJar(cookieJar, cfg.BaseURL, cfg.CookieCredential())
+		if cfg.CredentialDomain != "" {
+			seedBaseURL := "https://" + strings.TrimPrefix(cfg.CredentialDomain, ".")
+			SeedCookieJarForDomain(cookieJar, seedBaseURL, cfg.CookieCredential(), cfg.CredentialDomain)
+		} else {
+			SeedCookieJar(cookieJar, cfg.BaseURL, cfg.CookieCredential())
+		}
 	}
 	httpClient := newHTTPClient(timeout, cookieJar)
 	c := &Client{
@@ -871,6 +877,10 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	if err != nil {
 		return nil, 0, err
 	}
+	credentialAllowed := c.credentialAppliesToURL(targetURL)
+	if !credentialAllowed {
+		authHeader = ""
+	}
 
 	// Build the request for dry-run display or actual execution
 	if c.DryRun {
@@ -929,7 +939,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			req.URL.RawQuery = q.Encode()
 		}
 
-		if authHeader != "" {
+		if authHeader != "" && credentialAllowed {
 			// Cookie-auth: the cookie jar is the sole source of outbound
 			// cookies. New() loads it from cookies.json and seeds it from
 			// the env-var / credentials session via SeedCookieJar, so every
@@ -1246,6 +1256,27 @@ func authPlaceholderCredentialErrorWithSetup(cfg *config.Config, setup string) e
 		location = cfg.Path
 	}
 	return fmt.Errorf("%w configured in %s; set a real token with: %s", ErrPlaceholderCredential, location, setup)
+}
+
+// credentialAppliesToURL keeps a browser-captured credential on its own
+// registrable domain. An empty binding preserves legacy credentials and
+// explicit verify-live HTTP uses mock hosts that cannot match the real site.
+func (c *Client) credentialAppliesToURL(rawURL string) bool {
+	if c == nil || c.Config == nil || strings.TrimSpace(c.Config.CredentialDomain) == "" || cliutil.IsVerifyLiveHTTPEnv() {
+		return true
+	}
+	target, err := url.Parse(rawURL)
+	if err != nil || target.Hostname() == "" {
+		return false
+	}
+	targetHost := strings.ToLower(strings.TrimSuffix(target.Hostname(), "."))
+	boundHost := strings.ToLower(strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(c.Config.CredentialDomain), "."), "."))
+	if targetHost == boundHost || strings.HasSuffix(targetHost, "."+boundHost) {
+		return true
+	}
+	targetRegistered, targetErr := publicsuffix.EffectiveTLDPlusOne(targetHost)
+	boundRegistered, boundErr := publicsuffix.EffectiveTLDPlusOne(boundHost)
+	return targetErr == nil && boundErr == nil && targetRegistered == boundRegistered
 }
 
 // binaryResponseEnvelope wraps a non-textual success body so it survives the

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -248,11 +248,14 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 		cacheDir = filepath.Join(dir, "http")
 	}
 	cookieJar := LoadCookieJar()
+	if cfg != nil && !cfg.UsePersistedCookieJar() {
+		cookieJar = NewCookieJar()
+	}
 	// Seed the jar from a session captured via the env var or stored in
 	// credentials but not yet in cookies.json, so the credential rides every
 	// request and net/http absorbs Set-Cookie rotation across the session.
 	if cfg != nil {
-		if cfg.CredentialDomain != "" {
+		if cfg.CredentialDomain != "" && cfg.UsePersistedCookieJar() {
 			seedBaseURL := "https://" + strings.TrimPrefix(cfg.CredentialDomain, ".")
 			SeedCookieJarForDomain(cookieJar, seedBaseURL, cfg.CookieCredential(), cfg.CredentialDomain)
 		} else {
@@ -282,6 +285,13 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			// would then classify as a successful response and hand the HTML
 			// "Moved Permanently" body back to the caller.
 			return errors.New("stopped after 10 redirects")
+		}
+		// Never carry credential material across a host-changing redirect.
+		// Go strips Authorization and Cookie in common cases, but custom
+		// headers and URL query values need explicit removal here.
+		if req.URL.Host != via[0].URL.Host {
+			req.Header.Del("Cookie")
+			req.Header.Del("Cookie")
 		}
 		// Cookie-auth redirects: Go's http.Client + http.CookieJar handle
 		// cookie carriage on 3xx hops natively. Setting the Cookie header
@@ -1262,7 +1272,10 @@ func authPlaceholderCredentialErrorWithSetup(cfg *config.Config, setup string) e
 // registrable domain. An empty binding preserves legacy credentials and
 // explicit verify-live HTTP uses mock hosts that cannot match the real site.
 func (c *Client) credentialAppliesToURL(rawURL string) bool {
-	if c == nil || c.Config == nil || strings.TrimSpace(c.Config.CredentialDomain) == "" || cliutil.IsVerifyLiveHTTPEnv() {
+	if c == nil || c.Config == nil || !c.Config.UsePersistedCookieJar() || strings.TrimSpace(c.Config.CredentialDomain) == "" {
+		return true
+	}
+	if cliutil.IsVerifyEnv() && cliutil.IsVerifyLiveHTTPEnv() && isVerifyMockURL(rawURL) {
 		return true
 	}
 	target, err := url.Parse(rawURL)
@@ -1277,6 +1290,19 @@ func (c *Client) credentialAppliesToURL(rawURL string) bool {
 	targetRegistered, targetErr := publicsuffix.EffectiveTLDPlusOne(targetHost)
 	boundRegistered, boundErr := publicsuffix.EffectiveTLDPlusOne(boundHost)
 	return targetErr == nil && boundErr == nil && targetRegistered == boundRegistered
+}
+
+func isVerifyMockURL(rawURL string) bool {
+	target, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(target.Hostname())
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // binaryResponseEnvelope wraps a non-textual success body so it survives the

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/cookiejar.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/cookiejar.go
@@ -45,11 +45,13 @@ func LoadCookieJar() http.CookieJar {
 	return jar
 }
 
-// NewCookieJar returns an empty persistent wrapper without loading cookies
-// from disk. Config.Load uses it when an env or external-store override has
-// replaced a browser session, so an old browser jar cannot ride along.
+// NewCookieJar returns an empty in-memory jar without loading or persisting
+// cookies. Config.Load uses it when an env or external-store override has
+// replaced a browser session, so an old browser jar cannot ride along or be
+// contaminated by response cookies.
 func NewCookieJar() http.CookieJar {
-	return newCookieJar()
+	jar, _ := cookiejar.New(nil)
+	return jar
 }
 
 func newCookieJar() *cookieJar {

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/cookiejar.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/cookiejar.go
@@ -55,6 +55,17 @@ func cookieJarPath() string {
 	return filepath.Join(dir, "cookies.json")
 }
 
+// ClearCookieJar removes the persisted session cookies for this printed CLI.
+// Logout must clear both config credentials and the jar because net/http can
+// otherwise continue sending a valid cookie after the config is cleared.
+func ClearCookieJar() error {
+	path := cookieJarPath()
+	if path == "" {
+		return nil
+	}
+	return mergeAndWriteCookieRows(path, nil)
+}
+
 // looksLikeCookieJar reports whether s is a cookie-jar string ("name=value;
 // name=value") rather than a bare token. The session env var and the browser
 // AccessToken both store the full Cookie header, so the seed is gated on a real
@@ -126,6 +137,17 @@ func parseCookieJar(s string) []*http.Cookie {
 // A no-op when the credential is empty, is not a cookie-jar string, or baseURL
 // does not parse.
 func SeedCookieJar(jar http.CookieJar, baseURL, cookieStr string) {
+	seedCookieJar(jar, baseURL, cookieStr, "")
+}
+
+// SeedCookieJarForDomain seeds a captured cookie session for the captured
+// domain and its subdomains, while still requiring callers to choose the
+// capture root explicitly.
+func SeedCookieJarForDomain(jar http.CookieJar, baseURL, cookieStr, domain string) {
+	seedCookieJar(jar, baseURL, cookieStr, strings.TrimPrefix(strings.TrimSpace(domain), "."))
+}
+
+func seedCookieJar(jar http.CookieJar, baseURL, cookieStr, cookieDomain string) {
 	if jar == nil || !looksLikeCookieJar(cookieStr) {
 		return
 	}
@@ -136,6 +158,11 @@ func SeedCookieJar(jar http.CookieJar, baseURL, cookieStr string) {
 	cookies := parseCookieJar(cookieStr)
 	if len(cookies) == 0 {
 		return
+	}
+	if cookieDomain != "" {
+		for _, cookie := range cookies {
+			cookie.Domain = cookieDomain
+		}
 	}
 	// Seed the in-memory jar only — never persist. The wrapper's SetCookies
 	// writes through to cookies.json (persistLocked -> mergeAndWriteCookieRows),

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/cookiejar.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/cookiejar.go
@@ -40,11 +40,22 @@ type persistedCookie struct {
 // LoadCookieJar returns a persistent cookie jar pre-populated from the canonical
 // cookie file on disk. Falls back to an empty in-memory jar when no file exists.
 func LoadCookieJar() http.CookieJar {
-	inner, _ := cookiejar.New(nil)
-	path := cookieJarPath()
-	jar := &cookieJar{inner: inner, path: path}
+	jar := newCookieJar()
 	jar.loadFromDisk()
 	return jar
+}
+
+// NewCookieJar returns an empty persistent wrapper without loading cookies
+// from disk. Config.Load uses it when an env or external-store override has
+// replaced a browser session, so an old browser jar cannot ride along.
+func NewCookieJar() http.CookieJar {
+	return newCookieJar()
+}
+
+func newCookieJar() *cookieJar {
+	inner, _ := cookiejar.New(nil)
+	path := cookieJarPath()
+	return &cookieJar{inner: inner, path: path}
 }
 
 func cookieJarPath() string {
@@ -63,7 +74,14 @@ func ClearCookieJar() error {
 	if path == "" {
 		return nil
 	}
-	return mergeAndWriteCookieRows(path, nil)
+	data, err := json.Marshal([]persistedCookie{})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
 }
 
 // looksLikeCookieJar reports whether s is a cookie-jar string ("name=value;

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -270,6 +270,12 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			// "Moved Permanently" body back to the caller.
 			return errors.New("stopped after 10 redirects")
 		}
+		// Never carry credential material across a host-changing redirect.
+		// Go strips Authorization and Cookie in common cases, but custom
+		// headers and URL query values need explicit removal here.
+		if req.URL.Host != via[0].URL.Host {
+			req.Header.Del("Authorization")
+		}
 		// Same-host gate mirrors Go's shouldCopyHeaderOnRedirect: a
 		// cross-domain 3xx (open redirect or partner handoff) must not
 		// receive the auth credential, even though we are inside
@@ -278,11 +284,6 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			if h, err := c.authHeader(req.Context()); err == nil && h != "" {
 				req.Header.Set("Authorization", h)
 			}
-		} else {
-			// Cross-host hop: Go strips standard auth headers (Authorization,
-			// Cookie) but not custom ones, so a custom API-key header would be
-			// forwarded verbatim to the redirect target. Delete it explicitly.
-			req.Header.Del("Authorization")
 		}
 		return nil
 	}

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -275,6 +275,12 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			// "Moved Permanently" body back to the caller.
 			return errors.New("stopped after 10 redirects")
 		}
+		// Never carry credential material across a host-changing redirect.
+		// Go strips Authorization and Cookie in common cases, but custom
+		// headers and URL query values need explicit removal here.
+		if req.URL.Host != via[0].URL.Host {
+			req.Header.Del("Authorization")
+		}
 		// Same-host gate mirrors Go's shouldCopyHeaderOnRedirect: a
 		// cross-domain 3xx (open redirect or partner handoff) must not
 		// receive the auth credential, even though we are inside
@@ -283,11 +289,6 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			if h, err := c.authHeader(req.Context()); err == nil && h != "" {
 				req.Header.Set("Authorization", h)
 			}
-		} else {
-			// Cross-host hop: Go strips standard auth headers (Authorization,
-			// Cookie) but not custom ones, so a custom API-key header would be
-			// forwarded verbatim to the redirect target. Delete it explicitly.
-			req.Header.Del("Authorization")
 		}
 		return nil
 	}

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -270,6 +270,12 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			// "Moved Permanently" body back to the caller.
 			return errors.New("stopped after 10 redirects")
 		}
+		// Never carry credential material across a host-changing redirect.
+		// Go strips Authorization and Cookie in common cases, but custom
+		// headers and URL query values need explicit removal here.
+		if req.URL.Host != via[0].URL.Host {
+			req.Header.Del("Authorization")
+		}
 		// Same-host gate mirrors Go's shouldCopyHeaderOnRedirect: a
 		// cross-domain 3xx (open redirect or partner handoff) must not
 		// receive the auth credential, even though we are inside
@@ -278,11 +284,6 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			if h, err := c.authHeader(req.Context()); err == nil && h != "" {
 				req.Header.Set("Authorization", h)
 			}
-		} else {
-			// Cross-host hop: Go strips standard auth headers (Authorization,
-			// Cookie) but not custom ones, so a custom API-key header would be
-			// forwarded verbatim to the redirect target. Delete it explicitly.
-			req.Header.Del("Authorization")
 		}
 		return nil
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -271,6 +271,12 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			// "Moved Permanently" body back to the caller.
 			return errors.New("stopped after 10 redirects")
 		}
+		// Never carry credential material across a host-changing redirect.
+		// Go strips Authorization and Cookie in common cases, but custom
+		// headers and URL query values need explicit removal here.
+		if req.URL.Host != via[0].URL.Host {
+			req.Header.Del("X-API-Key")
+		}
 		// Same-host gate mirrors Go's shouldCopyHeaderOnRedirect: a
 		// cross-domain 3xx (open redirect or partner handoff) must not
 		// receive the auth credential, even though we are inside
@@ -279,11 +285,6 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			if h, err := c.authHeader(req.Context()); err == nil && h != "" {
 				req.Header.Set("X-API-Key", h)
 			}
-		} else {
-			// Cross-host hop: Go strips standard auth headers (Authorization,
-			// Cookie) but not custom ones, so a custom API-key header would be
-			// forwarded verbatim to the redirect target. Delete it explicitly.
-			req.Header.Del("X-API-Key")
 		}
 		return nil
 	}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -374,6 +374,12 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			// "Moved Permanently" body back to the caller.
 			return errors.New("stopped after 10 redirects")
 		}
+		// Never carry credential material across a host-changing redirect.
+		// Go strips Authorization and Cookie in common cases, but custom
+		// headers and URL query values need explicit removal here.
+		if req.URL.Host != via[0].URL.Host {
+			req.Header.Del("Authorization")
+		}
 		// Tier routing picks header vs query at request time on a WithTier copy,
 		// while this redirect callback is installed once on the shared
 		// http.Client. On cross-host redirects, delete every tier auth header


### PR DESCRIPTION
## Summary

Browser-captured cookie and composed credentials now stay bound to the domain policy from which they were captured. Requests and seeded cookies are withheld from unrelated hosts, including redirect targets, while environment and external-store overrides cannot inherit stale browser bindings.

## Approach

- Persist the captured credential domain with the generated config and external credential record.
- Scope primary, additional-header, query, and cookie credentials during request construction and redirects.
- Keep verify-live behavior limited to verified loopback mock targets, and clear cookie jars on logout or failed browser validation.

Fixes #4099.

## Verification

- `go fmt ./...`
- `PRINTING_PRESS_VERIFY= PRINTING_PRESS_VERIFY_LIVE_HTTP= go test ./...`
- `scripts/golden.sh verify` (32 cases)
- `scripts/verify-generator-output.sh` (10 generated modules compiled)
- Focused generated runtime tests for domain matching, sibling cookie seeding, redirects, override isolation, logout clearing, and verify-live safety.
- `golangci-lint run ./...` reached one unrelated pre-existing `modernize` finding in `internal/googlediscovery/parser.go`.
