### PR TITLE
fix(cli): handle auth-none generation metadata

### DIFF
--- a/internal/generator/credential_codegen_roundtrip_test.go
+++ b/internal/generator/credential_codegen_roundtrip_test.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -125,21 +126,25 @@ func TestCredentialAliasFieldsRoundTripIndependently(t *testing.T) {
 func TestGeneratedNoAuthCredentialsTestsDoNotAssertAnAuthHeader(t *testing.T) {
 	t.Parallel()
 
-	apiSpec := minimalSpec("no-auth-credentials")
-	apiSpec.Auth = spec.AuthConfig{
-		Type:             "none",
-		AuthorizationURL: "https://auth.example.com/authorize",
+	for _, authType := range []string{"none", "   "} {
+		t.Run(fmt.Sprintf("auth type %q", authType), func(t *testing.T) {
+			apiSpec := minimalSpec("no-auth-credentials")
+			apiSpec.Auth = spec.AuthConfig{
+				Type:             authType,
+				AuthorizationURL: "https://auth.example.com/authorize",
+			}
+			outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+			require.NoError(t, New(apiSpec, outputDir).Generate())
+
+			credentialTests := readGeneratedFile(t, outputDir, "internal", "cliutil", "credentials_test.go")
+			require.NotContains(t, credentialTests, "want config-file value and not credentials-file value")
+			require.NotContains(t, credentialTests, "want legacy credential")
+			require.Contains(t, credentialTests, "assertConfigCredential(t, cfg, \"legacy-secret\")")
+
+			requireGeneratedCompiles(t, outputDir)
+			runGoCommandRequired(t, outputDir, "test", "./internal/cliutil")
+		})
 	}
-	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
-	require.NoError(t, New(apiSpec, outputDir).Generate())
-
-	credentialTests := readGeneratedFile(t, outputDir, "internal", "cliutil", "credentials_test.go")
-	require.NotContains(t, credentialTests, "want config-file value and not credentials-file value")
-	require.NotContains(t, credentialTests, "want legacy credential")
-	require.Contains(t, credentialTests, "assertConfigCredential(t, cfg, \"legacy-secret\")")
-
-	requireGeneratedCompiles(t, outputDir)
-	runGoCommandRequired(t, outputDir, "test", "./internal/cliutil")
 }
 
 func TestGeneratedSingleKeyCredentialsTestsAssertAnAuthHeader(t *testing.T) {

--- a/internal/generator/credential_codegen_roundtrip_test.go
+++ b/internal/generator/credential_codegen_roundtrip_test.go
@@ -126,7 +126,7 @@ func TestCredentialAliasFieldsRoundTripIndependently(t *testing.T) {
 func TestGeneratedNoAuthCredentialsTestsDoNotAssertAnAuthHeader(t *testing.T) {
 	t.Parallel()
 
-	for _, authType := range []string{"none", "   "} {
+	for _, authType := range []string{"none", "None", "   "} {
 		t.Run(fmt.Sprintf("auth type %q", authType), func(t *testing.T) {
 			apiSpec := minimalSpec("no-auth-credentials")
 			apiSpec.Auth = spec.AuthConfig{

--- a/internal/generator/credential_codegen_roundtrip_test.go
+++ b/internal/generator/credential_codegen_roundtrip_test.go
@@ -122,6 +122,47 @@ func TestCredentialAliasFieldsRoundTripIndependently(t *testing.T) {
 	}
 }
 
+func TestGeneratedNoAuthCredentialsTestsDoNotAssertAnAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("no-auth-credentials")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:             "none",
+		AuthorizationURL: "https://auth.example.com/authorize",
+	}
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	credentialTests := readGeneratedFile(t, outputDir, "internal", "cliutil", "credentials_test.go")
+	require.NotContains(t, credentialTests, "want config-file value and not credentials-file value")
+	require.NotContains(t, credentialTests, "want legacy credential")
+	require.Contains(t, credentialTests, "assertConfigCredential(t, cfg, \"legacy-secret\")")
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommandRequired(t, outputDir, "test", "./internal/cliutil")
+}
+
+func TestGeneratedSingleKeyCredentialsTestsAssertAnAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("single-key-credentials")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:    "api_key",
+		In:      "header",
+		Header:  "X-API-Key",
+		EnvVars: []string{"SINGLE_API_KEY"},
+	}
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	credentialTests := readGeneratedFile(t, outputDir, "internal", "cliutil", "credentials_test.go")
+	require.Contains(t, credentialTests, "cfg.AuthHeader()")
+	require.Contains(t, credentialTests, "want config-file value and not credentials-file value")
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommandRequired(t, outputDir, "test", "./internal/cliutil")
+}
+
 func TestGeneratedRequiredCredentialPairPassesCredentialTests(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -238,6 +238,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"title":                               cases.Title(language.English).String,
 		"lower":                               strings.ToLower,
 		"upper":                               strings.ToUpper,
+		"trimSpace":                           strings.TrimSpace,
 		"join":                                strings.Join,
 		"camel":                               toCamel,
 		"cmdIdent":                            commandIdent,

--- a/internal/generator/templates/cliutil_credentials_test.go.tmpl
+++ b/internal/generator/templates/cliutil_credentials_test.go.tmpl
@@ -3,7 +3,7 @@
 {{- $requiredCredentialVars := requiredRequestAuthEnvVars .Auth}}
 {{- $basicCredentialVars := basicAuthEnvVars .Auth}}
 {{- $hasMultiVariableBasicAuth := gt (len $basicCredentialVars) 1}}
-{{- $hasAuthHeader := and (ne (trimSpace .Auth.Type) "") (ne (trimSpace .Auth.Type) "none")}}
+{{- $hasAuthHeader := and (ne (trimSpace .Auth.Type) "") (ne (lower (trimSpace .Auth.Type)) "none")}}
 
 package cliutil_test
 

--- a/internal/generator/templates/cliutil_credentials_test.go.tmpl
+++ b/internal/generator/templates/cliutil_credentials_test.go.tmpl
@@ -3,12 +3,13 @@
 {{- $requiredCredentialVars := requiredRequestAuthEnvVars .Auth}}
 {{- $basicCredentialVars := basicAuthEnvVars .Auth}}
 {{- $hasMultiVariableBasicAuth := gt (len $basicCredentialVars) 1}}
+{{- $hasAuthHeader := and (ne .Auth.Type "") (ne .Auth.Type "none")}}
 
 package cliutil_test
 
 import (
 	"bytes"
-{{- if $hasMultiVariableBasicAuth}}
+{{- if and $hasAuthHeader $hasMultiVariableBasicAuth}}
 	"encoding/base64"
 {{- end}}
 {{- if ne .Config.Format "toml"}}
@@ -78,9 +79,9 @@ func TestConfigFileWinsWhenCredentialsFileAlsoHasSecrets(t *testing.T) {
 		t.Fatalf("Load() error = %v", err)
 	}
 	assertConfigCredential(t, cfg, "legacy-secret")
-{{- if $hasMultiVariableBasicAuth}}
+{{- if and $hasAuthHeader $hasMultiVariableBasicAuth}}
 	assertAuthHeaderCredential(t, cfg, "legacy-secret", "data-secret")
-{{- else}}
+{{- else if $hasAuthHeader}}
 	if got := cfg.AuthHeader(); !strings.Contains(got, "legacy-secret") || strings.Contains(got, "data-secret") {
 		t.Fatalf("AuthHeader() = %q, want config-file value and not credentials-file value", got)
 	}
@@ -315,9 +316,9 @@ func TestCorruptCredentialsDoesNotOverrideLegacyConfig(t *testing.T) {
 			t.Fatalf("Load() error = %v", err)
 		}
 		assertConfigCredential(t, cfg, "legacy-secret")
-{{- if $hasMultiVariableBasicAuth}}
+{{- if and $hasAuthHeader $hasMultiVariableBasicAuth}}
 		assertAuthHeaderCredential(t, cfg, "legacy-secret", "")
-{{- else}}
+{{- else if $hasAuthHeader}}
 		if got := cfg.AuthHeader(); !strings.Contains(got, "legacy-secret") {
 			t.Fatalf("AuthHeader() = %q, want legacy credential", got)
 		}
@@ -392,9 +393,9 @@ func TestEmptyCredentialsFileDoesNotClearLegacyConfig(t *testing.T) {
 		t.Fatalf("Load() error = %v", err)
 	}
 	assertConfigCredential(t, cfg, "legacy-secret")
-{{- if $hasMultiVariableBasicAuth}}
+{{- if and $hasAuthHeader $hasMultiVariableBasicAuth}}
 	assertAuthHeaderCredential(t, cfg, "legacy-secret", "")
-{{- else}}
+{{- else if $hasAuthHeader}}
 	if got := cfg.AuthHeader(); !strings.Contains(got, "legacy-secret") {
 		t.Fatalf("AuthHeader() = %q, want legacy credential", got)
 	}

--- a/internal/generator/templates/cliutil_credentials_test.go.tmpl
+++ b/internal/generator/templates/cliutil_credentials_test.go.tmpl
@@ -3,7 +3,7 @@
 {{- $requiredCredentialVars := requiredRequestAuthEnvVars .Auth}}
 {{- $basicCredentialVars := basicAuthEnvVars .Auth}}
 {{- $hasMultiVariableBasicAuth := gt (len $basicCredentialVars) 1}}
-{{- $hasAuthHeader := and (ne .Auth.Type "") (ne .Auth.Type "none")}}
+{{- $hasAuthHeader := and (ne (trimSpace .Auth.Type) "") (ne (trimSpace .Auth.Type) "none")}}
 
 package cliutil_test
 

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -931,8 +931,12 @@ func populateMCPMetadata(m *CLIManifest, parsed *spec.APISpec) {
 	m.MCPBinary = naming.MCP(mcpName)
 	m.MCPToolCount = total
 	m.MCPPublicToolCount = public
-	m.MCPReady = computeMCPReady(parsed.Auth.Type)
-	m.AuthType = parsed.Auth.Type
+	authType := parsed.Auth.Type
+	if strings.TrimSpace(authType) == "" {
+		authType = spec.TierAuthTypeNone
+	}
+	m.MCPReady = computeMCPReady(authType)
+	m.AuthType = authType
 	m.AuthPreference = strings.TrimSpace(parsed.Auth.Scheme)
 	envVarSpecs := manifestAuthEnvVarSpecs(parsed)
 	m.AuthEnvVars = manifestAuthEnvVarNames(parsed, envVarSpecs)

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -874,6 +874,38 @@ func TestWriteManifestForGenerateRecordsAuthPreference(t *testing.T) {
 	assert.Equal(t, "ApiKeyAuth", got.AuthPreference)
 }
 
+func TestWriteManifestForGenerateDefaultsMissingAuthTypeToNone(t *testing.T) {
+	for _, authType := range []string{"", "   "} {
+		t.Run(authType, func(t *testing.T) {
+			dir := t.TempDir()
+
+			err := WriteManifestForGenerate(GenerateManifestParams{
+				APIName:   "public-api",
+				OutputDir: dir,
+				Spec: &spec.APISpec{
+					Name: "public-api",
+					Auth: spec.AuthConfig{Type: authType},
+					Resources: map[string]spec.Resource{
+						"items": {Endpoints: map[string]spec.Endpoint{
+							"list": {Method: "GET", Path: "/items"},
+						}},
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+			require.NoError(t, err)
+			var raw map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(data, &raw))
+			assert.Equal(t, json.RawMessage(`"none"`), raw["auth_type"])
+
+			got := readPublishedManifest(t, dir)
+			assert.Equal(t, "none", got.AuthType)
+		})
+	}
+}
+
 func TestWriteManifestForGenerateClearsStaleAuthPreference(t *testing.T) {
 	dir := t.TempDir()
 	writeManifest(t, dir, CLIManifest{


### PR DESCRIPTION
## Summary

Fix auth-none generation at both affected surfaces:

- Generated credential tests no longer assert an AuthHeader for auth-none configurations, while keyed-auth credential assertions remain covered.
- Generated `.printing-press.json` manifests serialize a blank auth type as `"none"` for MCP registry validation.

## Validation

- Focused generated auth-none and keyed-auth credential tests
- Focused manifest metadata tests
- `scripts/golden.sh verify` (32 cases)
- `scripts/verify-generator-output.sh` (10 cases)
- `go test ./...` attempted; unrelated verify-mode BLE and generated learn/store/rate-limit integration failures remain
- `golangci-lint run ./...` reports an unrelated pre-existing `slicesbackward` modernization finding in `internal/googlediscovery/parser.go`

Closes #4071
Closes #4072
