### PR TITLE
fix(cli): accept object release ledger changes

### DIFF
--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -866,14 +866,21 @@ func TestPublishPackagePreservesPopulatedReleaseManifest(t *testing.T) {
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
 	stubPublishPackageValidation(t)
-	require.NoError(t, os.WriteFile(filepath.Join(cliDir, pipeline.CLIReleaseManifestFilename), []byte(`{
+	releaseLedger := []byte(`{
   "schema_version": 1,
   "slug": "test",
   "cli_name": "test-pp-cli",
   "version": "2026.6.2",
   "released_at": "2026-06-02T00:00:00Z",
-  "source_commit": "abc123"
-}`+"\n"), 0o644))
+  "source_commit": "abc123",
+  "changes": [{
+    "title": "feat(test): preserve release history",
+    "pr": 1372,
+    "url": "https://github.com/mvanhorn/printing-press-library/pull/1372",
+    "commit": "14a3685ce9929e28fe44aabd980d8bda8f53088b"
+  }]
+}` + "\n")
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, pipeline.CLIReleaseManifestFilename), releaseLedger, 0o644))
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
@@ -886,7 +893,7 @@ func TestPublishPackagePreservesPopulatedReleaseManifest(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(output), &result))
 	got, err := os.ReadFile(filepath.Join(result.StagedDir, pipeline.CLIReleaseManifestFilename))
 	require.NoError(t, err)
-	assert.Contains(t, string(got), `"version": "2026.6.2"`)
+	assert.Equal(t, releaseLedger, got)
 }
 
 func TestPublishPackageNormalizesManifestCategoryToPublishCategory(t *testing.T) {

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -202,15 +202,15 @@ type ReviewedSecretSuppression struct {
 // release-ledger workflow. Version fields are intentionally blank at print
 // time: the library owns final release accounting to avoid PR-time conflicts.
 type CLIReleaseManifest struct {
-	SchemaVersion        int      `json:"schema_version"`
-	Slug                 string   `json:"slug"`
-	CLIName              string   `json:"cli_name,omitempty"`
-	Version              string   `json:"version"`
-	ReleasedAt           string   `json:"released_at"`
-	SourceCommit         string   `json:"source_commit"`
-	PrintingPressVersion string   `json:"printing_press_version,omitempty"`
-	RunID                string   `json:"run_id,omitempty"`
-	Changes              []string `json:"changes,omitempty"`
+	SchemaVersion        int             `json:"schema_version"`
+	Slug                 string          `json:"slug"`
+	CLIName              string          `json:"cli_name,omitempty"`
+	Version              string          `json:"version"`
+	ReleasedAt           string          `json:"released_at"`
+	SourceCommit         string          `json:"source_commit"`
+	PrintingPressVersion string          `json:"printing_press_version,omitempty"`
+	RunID                string          `json:"run_id,omitempty"`
+	Changes              json.RawMessage `json:"changes,omitempty"`
 }
 
 // IsLocalDatastore reports whether the manifest describes a local-datastore


### PR DESCRIPTION
## Summary

`publish package` now accepts the populated release ledgers written by `printing-press-library`, including ledgers whose `changes` entries are objects. Updating an already-published CLI no longer stops with a JSON unmarshal error, and the staged ledger remains byte-for-byte unchanged.

Closes #4039

## Approach

The release-ledger reader keeps the `changes` value as raw JSON because packaging only inspects the release metadata fields needed to identify a blank ledger. This accepts both the older string form and the current object form without rewriting the ledger.

## Scope

Primary area: publish-package release-ledger parsing.

Why this belongs in this repo: this is shared Printing Press packaging behavior that affects every published CLI update.

## Risk

Low. Blank and absent ledgers retain their existing behavior. Populated ledgers continue to be copied unchanged after parsing.

## Output Contract

No generated CLI output changes. The publish package regression test covers the current stamped ledger shape and byte-for-byte staging preservation.

## Verification

- `go test ./internal/cli ./internal/pipeline` passed.
- `go build -o ./cli-printing-press ./cmd/cli-printing-press` passed.
- `go test ./...` reached unrelated generated-CLI and BLE probe failures under the mandated `PRINTING_PRESS_VERIFY=1` environment; affected packages passed.
- `golangci-lint run ./...` reported one unrelated existing `modernize` finding in `internal/googlediscovery/parser.go:455`.
- Local Greptile review completed with no review comments.
