### PR TITLE
fix(cli): speed up generated Windows shellout tests

### DIFF
--- a/internal/generator/cobratree_shellout_test.go
+++ b/internal/generator/cobratree_shellout_test.go
@@ -24,4 +24,5 @@ func TestGeneratedWindowsShelloutLargeOutputUsesPowerShell(t *testing.T) {
 	assert.NotContains(t, source, "for /L %%i in (1,1,70000)")
 
 	requireGeneratedCompiles(t, outputDir)
+	runGoCommandRequired(t, outputDir, "test", "./internal/mcp/cobratree", "-run", "^Test(ShellOutBoundsFinalError|RunCLICommandBoundsFailureOutput)$", "-count=1")
 }

--- a/internal/generator/cobratree_shellout_test.go
+++ b/internal/generator/cobratree_shellout_test.go
@@ -1,0 +1,27 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedWindowsShelloutLargeOutputUsesPowerShell(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("shellout-large-output")
+	outputDir := filepath.Join(t.TempDir(), "shellout-large-output-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	shelloutTest, err := os.ReadFile(filepath.Join(outputDir, "internal", "mcp", "cobratree", "shellout_test.go"))
+	require.NoError(t, err)
+	source := string(shelloutTest)
+	assert.Contains(t, source, `[Console]::Error.Write((New-Object string([char]0x78,70000)))`)
+	assert.Contains(t, source, `[Console]::Out.Write((New-Object string([char]0x78,70000)))`)
+	assert.NotContains(t, source, "for /L %%i in (1,1,70000)")
+
+	requireGeneratedCompiles(t, outputDir)
+}

--- a/internal/generator/templates/cobratree/shellout_test.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout_test.go.tmpl
@@ -751,9 +751,9 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		case "fail-stdout":
 			body = "@echo off\r\necho stdout failure\r\nexit /b 7\r\n"
 		case "fail-large-stderr":
-			body = "@echo off\r\nfor /L %%i in (1,1,70000) do <nul set /p =x 1>&2\r\nexit /b 7\r\n"
+			body = "@echo off\r\npowershell -NoProfile -Command \"[Console]::Error.Write((New-Object string([char]0x78,70000)))\"\r\nexit /b 7\r\n"
 		case "fail-large-stdout":
-			body = "@echo off\r\nfor /L %%i in (1,1,70000) do <nul set /p =x\r\nexit /b 7\r\n"
+			body = "@echo off\r\npowershell -NoProfile -Command \"[Console]::Out.Write((New-Object string([char]0x78,70000)))\"\r\nexit /b 7\r\n"
 		default:
 			t.Fatalf("unknown mode %q", mode)
 		}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
@@ -751,9 +751,9 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		case "fail-stdout":
 			body = "@echo off\r\necho stdout failure\r\nexit /b 7\r\n"
 		case "fail-large-stderr":
-			body = "@echo off\r\nfor /L %%i in (1,1,70000) do <nul set /p =x 1>&2\r\nexit /b 7\r\n"
+			body = "@echo off\r\npowershell -NoProfile -Command \"[Console]::Error.Write((New-Object string([char]0x78,70000)))\"\r\nexit /b 7\r\n"
 		case "fail-large-stdout":
-			body = "@echo off\r\nfor /L %%i in (1,1,70000) do <nul set /p =x\r\nexit /b 7\r\n"
+			body = "@echo off\r\npowershell -NoProfile -Command \"[Console]::Out.Write((New-Object string([char]0x78,70000)))\"\r\nexit /b 7\r\n"
 		default:
 			t.Fatalf("unknown mode %q", mode)
 		}


### PR DESCRIPTION
## Summary

Replace the generated Windows shellout test helper's 70,000-iteration `cmd.exe` loops with single-process PowerShell writes for stdout and stderr. This keeps the failure output contract while removing the per-iteration interpreter overhead that times out generated CLI tests on Windows.

Add generator-output coverage that rejects the old loop, checks both emitted stream commands, compiles the generated module, and runs the generated cobratree shellout regression tests. Update the representative golden artifact.

Closes #3987

## Validation

- `go test ./internal/generator -run '^TestGeneratedWindowsShelloutLargeOutputUsesPowerShell$' -count=1`
- `scripts/golden.sh verify` (32 cases)
- `scripts/verify-generator-output.sh` (10 cases)
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...` was run but remains red on unrelated verify-mode BLE, generated learn/store persistence, rate-limit, and generated-module tests.
- `golangci-lint run ./...` reports one pre-existing modernize finding in `internal/googlediscovery/parser.go`.
- Windows `cmd.exe` and PowerShell execution was not available on this macOS worker.
