### PR TITLE
fix(cli): route generated error output and preserve no-op semantics

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -8238,11 +8238,8 @@ func TestClassifyAPIError409RequiresIdempotent(t *testing.T) {
 	stdout, stderr, err := captureStdoutStderr(t, func() error {
 		return classifyAPIError(os.Stdout, errors.New("HTTP 409: conflict"), &rootFlags{idempotent: true, asJSON: true})
 	})
-	if err == nil {
-		t.Fatal("idempotent 409 must remain a non-nil error")
-	}
-	if ExitCode(err) != 5 {
-		t.Fatalf("idempotent 409 should retain API exit code, got %d", ExitCode(err))
+	if err != nil {
+		t.Fatalf("idempotent 409 should remain a successful no-op: %v", err)
 	}
 	if stderr != "" {
 		t.Fatalf("json noop should not write stderr, got %q", stderr)
@@ -8253,8 +8250,8 @@ func TestClassifyAPIError409RequiresIdempotent(t *testing.T) {
 func TestClassifyAPIErrorUsesProvidedWriter(t *testing.T) {
 	var out bytes.Buffer
 	err := classifyAPIError(&out, errors.New("HTTP 409: conflict"), &rootFlags{idempotent: true, asJSON: true})
-	if err == nil {
-		t.Fatal("idempotent 409 must remain a non-nil error")
+	if err != nil {
+		t.Fatalf("idempotent 409 should remain a successful no-op: %v", err)
 	}
 	requireNoopJSON(t, out.String(), "already_exists")
 
@@ -8270,6 +8267,18 @@ func TestClassifyAPIErrorUsesProvidedWriter(t *testing.T) {
 	if envelope["code"] != float64(5) {
 		t.Fatalf("error envelope code = %v, want 5", envelope["code"])
 	}
+}
+
+func TestWriteNoopReturnsTypedError(t *testing.T) {
+	var out bytes.Buffer
+	err := writeNoop(&out, &rootFlags{asJSON: true}, "already_exists", "already exists (no-op)")
+	if err == nil {
+		t.Fatal("writeNoop must return a non-nil typed error")
+	}
+	if ExitCode(err) != 5 {
+		t.Fatalf("writeNoop exit code = %d, want 5", ExitCode(err))
+	}
+	requireNoopJSON(t, out.String(), "already_exists")
 }
 
 func TestClassifyAPIErrorOnlyDoesNotWrite(t *testing.T) {
@@ -8334,11 +8343,8 @@ func TestClassifyDeleteError404RequiresIgnoreMissing(t *testing.T) {
 	stdout, stderr, err := captureStdoutStderr(t, func() error {
 		return classifyDeleteError(os.Stdout, errors.New("HTTP 404: not found"), &rootFlags{ignoreMissing: true, asJSON: true})
 	})
-	if err == nil {
-		t.Fatal("ignore-missing 404 must remain a non-nil error")
-	}
-	if ExitCode(err) != 5 {
-		t.Fatalf("ignore-missing 404 should retain API exit code, got %d", ExitCode(err))
+	if err != nil {
+		t.Fatalf("ignore-missing 404 should remain a successful no-op: %v", err)
 	}
 	if stderr != "" {
 		t.Fatalf("json noop should not write stderr, got %q", stderr)

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -8281,6 +8281,22 @@ func TestWriteNoopReturnsTypedError(t *testing.T) {
 	requireNoopJSON(t, out.String(), "already_exists")
 }
 
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("output writer failed")
+}
+
+func TestClassifyAPIErrorPropagatesNoopWriteError(t *testing.T) {
+	err := classifyAPIError(failingWriter{}, errors.New("HTTP 409: conflict"), &rootFlags{idempotent: true, asJSON: true})
+	if err == nil {
+		t.Fatal("failed noop output must return a non-nil error")
+	}
+	if ExitCode(err) != 5 {
+		t.Fatalf("failed noop output exit code = %d, want 5", ExitCode(err))
+	}
+}
+
 func TestClassifyAPIErrorOnlyDoesNotWrite(t *testing.T) {
 	stdout, stderr, err := captureStdoutStderr(t, func() error {
 		return classifyAPIErrorOnly(errors.New("HTTP 409: conflict"))

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -8370,7 +8370,8 @@ func TestClassifyDeleteError404RequiresIgnoreMissing(t *testing.T) {
 `
 	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
 
-	runGoCommandRequired(t, outputDir, "test", "-run", "TestClassify", "./internal/cli")
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommandRequired(t, outputDir, "test", "-run", "Test(Classify|WriteNoop)", "./internal/cli")
 }
 
 func TestGeneratedExport_ValidatesResourceArgument(t *testing.T) {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -8177,6 +8177,7 @@ func TestGeneratedHelpers_IdempotentNoopsRequireOptIn(t *testing.T) {
 	inlineTest := `package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
@@ -8226,7 +8227,7 @@ func requireNoopJSON(t *testing.T, body, reason string) {
 }
 
 func TestClassifyAPIError409RequiresIdempotent(t *testing.T) {
-	err := classifyAPIError(errors.New("HTTP 409: conflict"), &rootFlags{})
+	err := classifyAPIError(os.Stdout, errors.New("HTTP 409: conflict"), &rootFlags{})
 	if err == nil {
 		t.Fatal("409 without --idempotent must be an error")
 	}
@@ -8235,15 +8236,55 @@ func TestClassifyAPIError409RequiresIdempotent(t *testing.T) {
 	}
 
 	stdout, stderr, err := captureStdoutStderr(t, func() error {
-		return classifyAPIError(errors.New("HTTP 409: conflict"), &rootFlags{idempotent: true, asJSON: true})
+		return classifyAPIError(os.Stdout, errors.New("HTTP 409: conflict"), &rootFlags{idempotent: true, asJSON: true})
 	})
-	if err != nil {
-		t.Fatalf("idempotent 409 returned error: %v", err)
+	if err == nil {
+		t.Fatal("idempotent 409 must remain a non-nil error")
+	}
+	if ExitCode(err) != 5 {
+		t.Fatalf("idempotent 409 should retain API exit code, got %d", ExitCode(err))
 	}
 	if stderr != "" {
 		t.Fatalf("json noop should not write stderr, got %q", stderr)
 	}
 	requireNoopJSON(t, stdout, "already_exists")
+}
+
+func TestClassifyAPIErrorUsesProvidedWriter(t *testing.T) {
+	var out bytes.Buffer
+	err := classifyAPIError(&out, errors.New("HTTP 409: conflict"), &rootFlags{idempotent: true, asJSON: true})
+	if err == nil {
+		t.Fatal("idempotent 409 must remain a non-nil error")
+	}
+	requireNoopJSON(t, out.String(), "already_exists")
+
+	out.Reset()
+	err = classifyAPIError(&out, errors.New("HTTP 500: server error"), &rootFlags{asJSON: true})
+	if err == nil {
+		t.Fatal("HTTP 500 must remain a non-nil error")
+	}
+	var envelope map[string]any
+	if decodeErr := json.Unmarshal(out.Bytes(), &envelope); decodeErr != nil {
+		t.Fatalf("error envelope must be JSON: %v; body=%q", decodeErr, out.String())
+	}
+	if envelope["code"] != float64(5) {
+		t.Fatalf("error envelope code = %v, want 5", envelope["code"])
+	}
+}
+
+func TestClassifyAPIErrorOnlyDoesNotWrite(t *testing.T) {
+	stdout, stderr, err := captureStdoutStderr(t, func() error {
+		return classifyAPIErrorOnly(errors.New("HTTP 409: conflict"))
+	})
+	if err == nil {
+		t.Fatal("classify-only helper must return a non-nil error")
+	}
+	if ExitCode(err) != 5 {
+		t.Fatalf("classify-only HTTP error should use API exit code, got %d", ExitCode(err))
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("classify-only helper wrote output: stdout=%q stderr=%q", stdout, stderr)
+	}
 }
 
 func TestClassifyAPIErrorPreservesTypedCLIError(t *testing.T) {
@@ -8262,7 +8303,7 @@ func TestClassifyAPIErrorPreservesTypedCLIError(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			stdout, stderr, classified := captureStdoutStderr(t, func() error {
-				return classifyAPIError(tc.err, tc.flags)
+				return classifyAPIError(os.Stdout, tc.err, tc.flags)
 			})
 
 			if classified != tc.err {
@@ -8282,7 +8323,7 @@ func TestClassifyAPIErrorPreservesTypedCLIError(t *testing.T) {
 }
 
 func TestClassifyDeleteError404RequiresIgnoreMissing(t *testing.T) {
-	err := classifyDeleteError(errors.New("HTTP 404: not found"), &rootFlags{})
+	err := classifyDeleteError(os.Stdout, errors.New("HTTP 404: not found"), &rootFlags{})
 	if err == nil {
 		t.Fatal("404 delete without --ignore-missing must be an error")
 	}
@@ -8291,10 +8332,13 @@ func TestClassifyDeleteError404RequiresIgnoreMissing(t *testing.T) {
 	}
 
 	stdout, stderr, err := captureStdoutStderr(t, func() error {
-		return classifyDeleteError(errors.New("HTTP 404: not found"), &rootFlags{ignoreMissing: true, asJSON: true})
+		return classifyDeleteError(os.Stdout, errors.New("HTTP 404: not found"), &rootFlags{ignoreMissing: true, asJSON: true})
 	})
-	if err != nil {
-		t.Fatalf("ignore-missing 404 returned error: %v", err)
+	if err == nil {
+		t.Fatal("ignore-missing 404 must remain a non-nil error")
+	}
+	if ExitCode(err) != 5 {
+		t.Fatalf("ignore-missing 404 should retain API exit code, got %d", ExitCode(err))
 	}
 	if stderr != "" {
 		t.Fatalf("json noop should not write stderr, got %q", stderr)
@@ -8304,7 +8348,7 @@ func TestClassifyDeleteError404RequiresIgnoreMissing(t *testing.T) {
 `
 	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
 
-	runGoCommandRequired(t, outputDir, "test", "./internal/cli")
+	runGoCommandRequired(t, outputDir, "test", "-run", "TestClassify", "./internal/cli")
 }
 
 func TestGeneratedExport_ValidatesResourceArgument(t *testing.T) {

--- a/internal/generator/placeholder_auth_test.go
+++ b/internal/generator/placeholder_auth_test.go
@@ -170,6 +170,7 @@ func TestRealTokensReachTransport(t *testing.T) {
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -177,7 +178,7 @@ import (
 )
 
 func TestPlaceholderAuthErrorClassifiesAsExitCode4(t *testing.T) {
-	err := classifyAPIError(fmt.Errorf("%w configured in /tmp/config.toml; set a real token with: export PLACEHOLDER_AUTH_TOKEN=<your-token> or placeholder-auth-pp-cli auth set-token <token>", client.ErrPlaceholderCredential), &rootFlags{})
+	err := classifyAPIError(os.Stdout, fmt.Errorf("%w configured in /tmp/config.toml; set a real token with: export PLACEHOLDER_AUTH_TOKEN=<your-token> or placeholder-auth-pp-cli auth set-token <token>", client.ErrPlaceholderCredential), &rootFlags{})
 	if ExitCode(err) != 4 {
 		t.Fatalf("placeholder auth error exit code = %d, want 4", ExitCode(err))
 	}
@@ -195,7 +196,7 @@ func TestPlaceholderAuthErrorClassifiesAsExitCode4(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(syncSrc), "var firstPlaceholderErr error")
 	require.Contains(t, string(syncSrc), "errors.Is(res.Err, client.ErrPlaceholderCredential)")
-	require.Contains(t, string(syncSrc), "return classifyAPIError(firstPlaceholderErr, flags)")
+	require.Contains(t, string(syncSrc), "return classifyAPIError(cmd.OutOrStdout(), firstPlaceholderErr, flags)")
 
 	runGoCommand(t, outputDir, "test", "./internal/client", "./internal/cli", "-run", "TestPlaceholder", "-count=1")
 }

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -807,11 +807,11 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- if eq .Endpoint.Method "DELETE"}}
 			if err != nil {
-				return classifyDeleteError(err, flags)
+				return classifyDeleteError(cmd.OutOrStdout(), err, flags)
 			}
 {{- else}}
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 {{- if and .IsReadOnly (not .HasStore)}}
 			if isDryRunResponse(c.IsDryRun(), data) {

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -424,7 +424,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- end}}
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 {{- if and .IsReadOnly (not .HasStore)}}
 			if isDryRunResponse(c.IsDryRun(), data) {

--- a/internal/generator/templates/export.go.tmpl
+++ b/internal/generator/templates/export.go.tmpl
@@ -118,7 +118,7 @@ large datasets as it has no memory pressure.`,
 				}
 				data, err := c.Get(cmd.Context(), path, params)
 				if err != nil {
-					return classifyAPIError(err, flags)
+					return classifyAPIError(cmd.OutOrStdout(), err, flags)
 				}
 				if singleItem {
 					count = 1

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -233,7 +233,7 @@ Exit codes & warnings:
 			if errCount > 0 {
 {{- if and .Auth.Type (ne .Auth.Type "none")}}
 				if firstPlaceholderErr != nil {
-					return classifyAPIError(firstPlaceholderErr, flags)
+					return classifyAPIError(cmd.OutOrStdout(), firstPlaceholderErr, flags)
 				}
 {{- end}}
 				return fmt.Errorf("%d resource(s) failed to sync", errCount)

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1169,7 +1169,9 @@ func classifyAPIError(w io.Writer, err error, flags *rootFlags) error {
 	if strings.Contains(msg, "HTTP 409") {
 {{- if .HasCreateCommands}}
 		if flags != nil && flags.idempotent {
-			return writeNoop(w, flags, "already_exists", "already exists (no-op)")
+			// Generated endpoint commands preserve their established successful no-op contract.
+			_ = writeNoop(w, flags, "already_exists", "already exists (no-op)")
+			return nil
 		}
 {{- end}}
 	}
@@ -1183,7 +1185,9 @@ func classifyAPIError(w io.Writer, err error, flags *rootFlags) error {
 func classifyDeleteError(w io.Writer, err error, flags *rootFlags) error {
 	msg := err.Error()
 	if strings.Contains(msg, "HTTP 404") && flags != nil && flags.ignoreMissing {
-		return writeNoop(w, flags, "already_deleted", "already deleted (no-op)")
+		// Generated endpoint commands preserve their established successful no-op contract.
+		_ = writeNoop(w, flags, "already_deleted", "already deleted (no-op)")
+		return nil
 	}
 	return classifyAPIError(w, err, flags)
 }

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1008,26 +1008,31 @@ type noopResult struct {
 	Reason string `json:"reason"`
 }
 
-func writeNoop(flags *rootFlags, reason, prose string) error {
+func writeNoop(w io.Writer, flags *rootFlags, reason, prose string) error {
 	if flags != nil && flags.asJSON {
-		return json.NewEncoder(os.Stdout).Encode(noopResult{Status: "noop", Reason: reason})
+		_ = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
+		return apiErr(errors.New(prose))
 	}
 	fmt.Fprintln(os.Stderr, prose)
-	return nil
+	return apiErr(errors.New(prose))
 }
 
-func writeAPIErrorEnvelope(flags *rootFlags, err error, code int) {
+func writeAPIErrorEnvelope(w io.Writer, flags *rootFlags, err error, code int) {
 	if flags == nil || !flags.asJSON {
 		return
 	}
-	_ = json.NewEncoder(os.Stdout).Encode(map[string]any{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"error": err.Error(),
 		"code":  code,
 	})
 }
 
-// classifyAPIError maps API errors to structured exit codes with actionable hints.
-func classifyAPIError(err error, flags *rootFlags) error {
+// classifyAPIErrorOnly maps API errors to structured exit codes without writing.
+// Hand-written commands should use this helper when they own output sequencing.
+func classifyAPIErrorOnly(err error) error {
+	if err == nil {
+		return nil
+	}
 	var typed *cliError
 	if errors.As(err, &typed) {
 		return err
@@ -1036,14 +1041,7 @@ func classifyAPIError(err error, flags *rootFlags) error {
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "HTTP 409"):
-{{- if .HasCreateCommands}}
-		if flags != nil && flags.idempotent {
-			return writeNoop(flags, "already_exists", "already exists (no-op)")
-		}
-{{- end}}
-		classified := apiErr(err)
-		writeAPIErrorEnvelope(flags, classified, ExitCode(classified))
-		return classified
+		return apiErr(err)
 {{- if and .Auth.Type (ne .Auth.Type "none")}}
 	case errors.Is(err, client.ErrPlaceholderCredential):
 		return authErr(err)
@@ -1158,14 +1156,36 @@ func classifyAPIError(err error, flags *rootFlags) error {
 	}
 }
 
+// classifyAPIError maps API errors to structured exit codes with actionable hints.
+func classifyAPIError(w io.Writer, err error, flags *rootFlags) error {
+	if err == nil {
+		return nil
+	}
+	var typed *cliError
+	if errors.As(err, &typed) {
+		return err
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "HTTP 409") {
+{{- if .HasCreateCommands}}
+		if flags != nil && flags.idempotent {
+			return writeNoop(w, flags, "already_exists", "already exists (no-op)")
+		}
+{{- end}}
+	}
+	classified := classifyAPIErrorOnly(err)
+	writeAPIErrorEnvelope(w, flags, classified, ExitCode(classified))
+	return classified
+}
+
 {{- if .HasDelete}}
 // classifyDeleteError maps DELETE errors and supports explicit idempotent no-op handling.
-func classifyDeleteError(err error, flags *rootFlags) error {
+func classifyDeleteError(w io.Writer, err error, flags *rootFlags) error {
 	msg := err.Error()
 	if strings.Contains(msg, "HTTP 404") && flags != nil && flags.ignoreMissing {
-		return writeNoop(flags, "already_deleted", "already deleted (no-op)")
+		return writeNoop(w, flags, "already_deleted", "already deleted (no-op)")
 	}
-	return classifyAPIError(err, flags)
+	return classifyAPIError(w, err, flags)
 }
 {{- end}}
 

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1008,13 +1008,34 @@ type noopResult struct {
 	Reason string `json:"reason"`
 }
 
+type noopWriteError struct {
+	prose string
+	cause error
+}
+
+func (e *noopWriteError) Error() string {
+	if e.cause == nil {
+		return e.prose
+	}
+	return fmt.Sprintf("%s: %v", e.prose, e.cause)
+}
+
+func (e *noopWriteError) Unwrap() error { return e.cause }
+
 func writeNoop(w io.Writer, flags *rootFlags, reason, prose string) error {
+	result := &noopWriteError{prose: prose}
 	if flags != nil && flags.asJSON {
-		_ = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
-		return apiErr(errors.New(prose))
+		result.cause = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
+		return apiErr(result)
 	}
 	fmt.Fprintln(os.Stderr, prose)
-	return apiErr(errors.New(prose))
+	return apiErr(result)
+}
+
+func successfulNoop(err error) bool {
+	var typed *cliError
+	var result *noopWriteError
+	return errors.As(err, &typed) && errors.As(typed.err, &result) && result.cause == nil
 }
 
 func writeAPIErrorEnvelope(w io.Writer, flags *rootFlags, err error, code int) {
@@ -1170,8 +1191,11 @@ func classifyAPIError(w io.Writer, err error, flags *rootFlags) error {
 {{- if .HasCreateCommands}}
 		if flags != nil && flags.idempotent {
 			// Generated endpoint commands preserve their established successful no-op contract.
-			_ = writeNoop(w, flags, "already_exists", "already exists (no-op)")
-			return nil
+			noopErr := writeNoop(w, flags, "already_exists", "already exists (no-op)")
+			if successfulNoop(noopErr) {
+				return nil
+			}
+			return noopErr
 		}
 {{- end}}
 	}
@@ -1186,8 +1210,11 @@ func classifyDeleteError(w io.Writer, err error, flags *rootFlags) error {
 	msg := err.Error()
 	if strings.Contains(msg, "HTTP 404") && flags != nil && flags.ignoreMissing {
 		// Generated endpoint commands preserve their established successful no-op contract.
-		_ = writeNoop(w, flags, "already_deleted", "already deleted (no-op)")
-		return nil
+		noopErr := writeNoop(w, flags, "already_deleted", "already deleted (no-op)")
+		if successfulNoop(noopErr) {
+			return nil
+		}
+		return noopErr
 	}
 	return classifyAPIError(w, err, flags)
 }

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1028,7 +1028,7 @@ func writeNoop(w io.Writer, flags *rootFlags, reason, prose string) error {
 		result.cause = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
 		return apiErr(result)
 	}
-	fmt.Fprintln(os.Stderr, prose)
+	_, result.cause = fmt.Fprintln(w, prose)
 	return apiErr(result)
 }
 

--- a/internal/generator/templates/import.go.tmpl
+++ b/internal/generator/templates/import.go.tmpl
@@ -86,7 +86,7 @@ but do not stop the import.`,
 				if err != nil {
 					failed++
 					if status == 401 || status == 403 {
-						terminalErr = classifyAPIError(err, flags)
+						terminalErr = classifyAPIError(cmd.OutOrStdout(), err, flags)
 						continue
 					}
 					fmt.Fprintf(os.Stderr, "warning: failed to import record: %v\n", err)

--- a/internal/generator/templates/search.go.tmpl
+++ b/internal/generator/templates/search.go.tmpl
@@ -169,7 +169,7 @@ Run sync first to populate the local search index.`,
 				}
 				// Check if it's a network error for auto-mode fallback
 				if flags.dataSource == "live" || !isNetworkError(getErr) {
-					return classifyAPIError(getErr, flags)
+					return classifyAPIError(cmd.OutOrStdout(), getErr, flags)
 				}
 				// auto mode + network error: fall through to local FTS
 				fmt.Fprintf(cmd.ErrOrStderr(), "API unreachable, falling back to local search.\n")

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -526,7 +526,7 @@ Resource scoping:
 			// without reading the CHANGELOG.
 {{- if and .Auth.Type (ne .Auth.Type "none")}}
 			if firstPlaceholderErr != nil {
-				return classifyAPIError(firstPlaceholderErr, flags)
+				return classifyAPIError(cmd.OutOrStdout(), firstPlaceholderErr, flags)
 			}
 {{- end}}
 			if strict && errCount > 0 {

--- a/internal/generator/templates/tail.go.tmpl
+++ b/internal/generator/templates/tail.go.tmpl
@@ -100,7 +100,7 @@ native streaming instead of polling.`,
 			// Initial fetch
 			if err := fetchAndEmit(cmd.Context(), c, path, readConfig, enc); err != nil {
 				if !follow {
-					return classifyAPIError(err, flags)
+					return classifyAPIError(cmd.OutOrStdout(), err, flags)
 				}
 				fmt.Fprintf(os.Stderr, "warning: initial fetch failed: %v\n", err)
 			}

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
@@ -48,7 +48,7 @@ func newCustomersGetCmd(flags *rootFlags) *cobra.Command {
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "customers", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			outputData := data
 			// Print provenance to stderr for human-facing output only.

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -511,13 +511,34 @@ type noopResult struct {
 	Reason string `json:"reason"`
 }
 
+type noopWriteError struct {
+	prose string
+	cause error
+}
+
+func (e *noopWriteError) Error() string {
+	if e.cause == nil {
+		return e.prose
+	}
+	return fmt.Sprintf("%s: %v", e.prose, e.cause)
+}
+
+func (e *noopWriteError) Unwrap() error { return e.cause }
+
 func writeNoop(w io.Writer, flags *rootFlags, reason, prose string) error {
+	result := &noopWriteError{prose: prose}
 	if flags != nil && flags.asJSON {
-		_ = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
-		return apiErr(errors.New(prose))
+		result.cause = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
+		return apiErr(result)
 	}
 	fmt.Fprintln(os.Stderr, prose)
-	return apiErr(errors.New(prose))
+	return apiErr(result)
+}
+
+func successfulNoop(err error) bool {
+	var typed *cliError
+	var result *noopWriteError
+	return errors.As(err, &typed) && errors.As(typed.err, &result) && result.cause == nil
 }
 
 func writeAPIErrorEnvelope(w io.Writer, flags *rootFlags, err error, code int) {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -531,7 +531,7 @@ func writeNoop(w io.Writer, flags *rootFlags, reason, prose string) error {
 		result.cause = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
 		return apiErr(result)
 	}
-	fmt.Fprintln(os.Stderr, prose)
+	_, result.cause = fmt.Fprintln(w, prose)
 	return apiErr(result)
 }
 

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -511,26 +511,31 @@ type noopResult struct {
 	Reason string `json:"reason"`
 }
 
-func writeNoop(flags *rootFlags, reason, prose string) error {
+func writeNoop(w io.Writer, flags *rootFlags, reason, prose string) error {
 	if flags != nil && flags.asJSON {
-		return json.NewEncoder(os.Stdout).Encode(noopResult{Status: "noop", Reason: reason})
+		_ = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
+		return apiErr(errors.New(prose))
 	}
 	fmt.Fprintln(os.Stderr, prose)
-	return nil
+	return apiErr(errors.New(prose))
 }
 
-func writeAPIErrorEnvelope(flags *rootFlags, err error, code int) {
+func writeAPIErrorEnvelope(w io.Writer, flags *rootFlags, err error, code int) {
 	if flags == nil || !flags.asJSON {
 		return
 	}
-	_ = json.NewEncoder(os.Stdout).Encode(map[string]any{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"error": err.Error(),
 		"code":  code,
 	})
 }
 
-// classifyAPIError maps API errors to structured exit codes with actionable hints.
-func classifyAPIError(err error, flags *rootFlags) error {
+// classifyAPIErrorOnly maps API errors to structured exit codes without writing.
+// Hand-written commands should use this helper when they own output sequencing.
+func classifyAPIErrorOnly(err error) error {
+	if err == nil {
+		return nil
+	}
 	var typed *cliError
 	if errors.As(err, &typed) {
 		return err
@@ -539,9 +544,7 @@ func classifyAPIError(err error, flags *rootFlags) error {
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "HTTP 409"):
-		classified := apiErr(err)
-		writeAPIErrorEnvelope(flags, classified, ExitCode(classified))
-		return classified
+		return apiErr(err)
 	case errors.Is(err, client.ErrPlaceholderCredential):
 		return authErr(err)
 	case strings.Contains(msg, "HTTP 400") && cliutil.LooksLikeAuthError(msg):
@@ -565,6 +568,23 @@ func classifyAPIError(err error, flags *rootFlags) error {
 	default:
 		return apiErr(err)
 	}
+}
+
+// classifyAPIError maps API errors to structured exit codes with actionable hints.
+func classifyAPIError(w io.Writer, err error, flags *rootFlags) error {
+	if err == nil {
+		return nil
+	}
+	var typed *cliError
+	if errors.As(err, &typed) {
+		return err
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "HTTP 409") {
+	}
+	classified := classifyAPIErrorOnly(err)
+	writeAPIErrorEnvelope(w, flags, classified, ExitCode(classified))
+	return classified
 }
 
 func truncate(s string, max int) string {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
@@ -48,7 +48,7 @@ func newPagesGetCmd(flags *rootFlags) *cobra.Command {
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "pages", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			outputData := data
 			// Print provenance to stderr for human-facing output only.

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
@@ -48,7 +48,7 @@ func newPlaylistsGetCmd(flags *rootFlags) *cobra.Command {
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "playlists", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			outputData := data
 			// Print provenance to stderr for human-facing output only.

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_health.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_health.go
@@ -29,7 +29,7 @@ func newHealthPromotedCmd(flags *rootFlags) *cobra.Command {
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "health", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			outputData := data
 			// Print provenance to stderr for human-facing output only.

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_items.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_items.go
@@ -36,7 +36,7 @@ func newItemsPromotedCmd(flags *rootFlags) *cobra.Command {
 			data, _, err := c.PostQueryWithParams(cmd.Context(), path, params, body)
 
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			prov := attachFreshness(DataProvenance{Source: "live"}, flags)
 			outputData := data

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_create.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_create.go
@@ -46,7 +46,7 @@ func newQuotesCreateCmd(flags *rootFlags) *cobra.Command {
 			}
 			data, statusCode, err := c.PostWithParams(cmd.Context(), path, params, body)
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			// Inspect the mutate response body for a partial-failure-shaped
 			// field (e.g. Google Ads `partialFailureError`). Several Google

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_delete.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_delete.go
@@ -46,7 +46,7 @@ func newQuotesDeleteCmd(flags *rootFlags) *cobra.Command {
 			params := map[string]string{}
 			data, statusCode, err := c.DeleteWithParams(cmd.Context(), path, params)
 			if err != nil {
-				return classifyDeleteError(err, flags)
+				return classifyDeleteError(cmd.OutOrStdout(), err, flags)
 			}
 			// Inspect the mutate response body for a partial-failure-shaped
 			// field (e.g. Google Ads `partialFailureError`). Several Google

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_get.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_get.go
@@ -46,7 +46,7 @@ func newQuotesGetCmd(flags *rootFlags) *cobra.Command {
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "quotes", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			outputData := data
 			// Print provenance to stderr for human-facing output only.

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_list.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_list.go
@@ -27,7 +27,7 @@ func newQuotesListCmd(flags *rootFlags) *cobra.Command {
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "quotes", true, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			outputData := data
 			// Print provenance to stderr for human-facing output only.

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update-status.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update-status.go
@@ -65,7 +65,7 @@ func newQuotesUpdateStatusCmd(flags *rootFlags) *cobra.Command {
 			}
 			data, statusCode, err := c.PostWithParams(cmd.Context(), path, params, body)
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			// Inspect the mutate response body for a partial-failure-shaped
 			// field (e.g. Google Ads `partialFailureError`). Several Google

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update.go
@@ -65,7 +65,7 @@ func newQuotesUpdateCmd(flags *rootFlags) *cobra.Command {
 			}
 			data, statusCode, err := c.PatchWithParams(cmd.Context(), path, params, body)
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			// Inspect the mutate response body for a partial-failure-shaped
 			// field (e.g. Google Ads `partialFailureError`). Several Google

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -530,7 +530,7 @@ func writeNoop(w io.Writer, flags *rootFlags, reason, prose string) error {
 		result.cause = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
 		return apiErr(result)
 	}
-	fmt.Fprintln(os.Stderr, prose)
+	_, result.cause = fmt.Fprintln(w, prose)
 	return apiErr(result)
 }
 

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -510,13 +510,34 @@ type noopResult struct {
 	Reason string `json:"reason"`
 }
 
+type noopWriteError struct {
+	prose string
+	cause error
+}
+
+func (e *noopWriteError) Error() string {
+	if e.cause == nil {
+		return e.prose
+	}
+	return fmt.Sprintf("%s: %v", e.prose, e.cause)
+}
+
+func (e *noopWriteError) Unwrap() error { return e.cause }
+
 func writeNoop(w io.Writer, flags *rootFlags, reason, prose string) error {
+	result := &noopWriteError{prose: prose}
 	if flags != nil && flags.asJSON {
-		_ = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
-		return apiErr(errors.New(prose))
+		result.cause = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
+		return apiErr(result)
 	}
 	fmt.Fprintln(os.Stderr, prose)
-	return apiErr(errors.New(prose))
+	return apiErr(result)
+}
+
+func successfulNoop(err error) bool {
+	var typed *cliError
+	var result *noopWriteError
+	return errors.As(err, &typed) && errors.As(typed.err, &result) && result.cause == nil
 }
 
 func writeAPIErrorEnvelope(w io.Writer, flags *rootFlags, err error, code int) {

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -510,26 +510,31 @@ type noopResult struct {
 	Reason string `json:"reason"`
 }
 
-func writeNoop(flags *rootFlags, reason, prose string) error {
+func writeNoop(w io.Writer, flags *rootFlags, reason, prose string) error {
 	if flags != nil && flags.asJSON {
-		return json.NewEncoder(os.Stdout).Encode(noopResult{Status: "noop", Reason: reason})
+		_ = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
+		return apiErr(errors.New(prose))
 	}
 	fmt.Fprintln(os.Stderr, prose)
-	return nil
+	return apiErr(errors.New(prose))
 }
 
-func writeAPIErrorEnvelope(flags *rootFlags, err error, code int) {
+func writeAPIErrorEnvelope(w io.Writer, flags *rootFlags, err error, code int) {
 	if flags == nil || !flags.asJSON {
 		return
 	}
-	_ = json.NewEncoder(os.Stdout).Encode(map[string]any{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"error": err.Error(),
 		"code":  code,
 	})
 }
 
-// classifyAPIError maps API errors to structured exit codes with actionable hints.
-func classifyAPIError(err error, flags *rootFlags) error {
+// classifyAPIErrorOnly maps API errors to structured exit codes without writing.
+// Hand-written commands should use this helper when they own output sequencing.
+func classifyAPIErrorOnly(err error) error {
+	if err == nil {
+		return nil
+	}
 	var typed *cliError
 	if errors.As(err, &typed) {
 		return err
@@ -538,9 +543,7 @@ func classifyAPIError(err error, flags *rootFlags) error {
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "HTTP 409"):
-		classified := apiErr(err)
-		writeAPIErrorEnvelope(flags, classified, ExitCode(classified))
-		return classified
+		return apiErr(err)
 	case errors.Is(err, client.ErrPlaceholderCredential):
 		return authErr(err)
 	case strings.Contains(msg, "HTTP 400") && cliutil.LooksLikeAuthError(msg):
@@ -564,6 +567,23 @@ func classifyAPIError(err error, flags *rootFlags) error {
 	default:
 		return apiErr(err)
 	}
+}
+
+// classifyAPIError maps API errors to structured exit codes with actionable hints.
+func classifyAPIError(w io.Writer, err error, flags *rootFlags) error {
+	if err == nil {
+		return nil
+	}
+	var typed *cliError
+	if errors.As(err, &typed) {
+		return err
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "HTTP 409") {
+	}
+	classified := classifyAPIErrorOnly(err)
+	writeAPIErrorEnvelope(w, flags, classified, ExitCode(classified))
+	return classified
 }
 
 func truncate(s string, max int) string {

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 86
+    "total": 87
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 87
+    "total": 88
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -605,7 +605,7 @@ func writeNoop(w io.Writer, flags *rootFlags, reason, prose string) error {
 		result.cause = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
 		return apiErr(result)
 	}
-	fmt.Fprintln(os.Stderr, prose)
+	_, result.cause = fmt.Fprintln(w, prose)
 	return apiErr(result)
 }
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -656,7 +656,9 @@ func classifyAPIError(w io.Writer, err error, flags *rootFlags) error {
 	msg := err.Error()
 	if strings.Contains(msg, "HTTP 409") {
 		if flags != nil && flags.idempotent {
-			return writeNoop(w, flags, "already_exists", "already exists (no-op)")
+			// Generated endpoint commands preserve their established successful no-op contract.
+			_ = writeNoop(w, flags, "already_exists", "already exists (no-op)")
+			return nil
 		}
 	}
 	classified := classifyAPIErrorOnly(err)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -585,13 +585,34 @@ type noopResult struct {
 	Reason string `json:"reason"`
 }
 
+type noopWriteError struct {
+	prose string
+	cause error
+}
+
+func (e *noopWriteError) Error() string {
+	if e.cause == nil {
+		return e.prose
+	}
+	return fmt.Sprintf("%s: %v", e.prose, e.cause)
+}
+
+func (e *noopWriteError) Unwrap() error { return e.cause }
+
 func writeNoop(w io.Writer, flags *rootFlags, reason, prose string) error {
+	result := &noopWriteError{prose: prose}
 	if flags != nil && flags.asJSON {
-		_ = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
-		return apiErr(errors.New(prose))
+		result.cause = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
+		return apiErr(result)
 	}
 	fmt.Fprintln(os.Stderr, prose)
-	return apiErr(errors.New(prose))
+	return apiErr(result)
+}
+
+func successfulNoop(err error) bool {
+	var typed *cliError
+	var result *noopWriteError
+	return errors.As(err, &typed) && errors.As(typed.err, &result) && result.cause == nil
 }
 
 func writeAPIErrorEnvelope(w io.Writer, flags *rootFlags, err error, code int) {
@@ -657,8 +678,11 @@ func classifyAPIError(w io.Writer, err error, flags *rootFlags) error {
 	if strings.Contains(msg, "HTTP 409") {
 		if flags != nil && flags.idempotent {
 			// Generated endpoint commands preserve their established successful no-op contract.
-			_ = writeNoop(w, flags, "already_exists", "already exists (no-op)")
-			return nil
+			noopErr := writeNoop(w, flags, "already_exists", "already exists (no-op)")
+			if successfulNoop(noopErr) {
+				return nil
+			}
+			return noopErr
 		}
 	}
 	classified := classifyAPIErrorOnly(err)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -585,26 +585,31 @@ type noopResult struct {
 	Reason string `json:"reason"`
 }
 
-func writeNoop(flags *rootFlags, reason, prose string) error {
+func writeNoop(w io.Writer, flags *rootFlags, reason, prose string) error {
 	if flags != nil && flags.asJSON {
-		return json.NewEncoder(os.Stdout).Encode(noopResult{Status: "noop", Reason: reason})
+		_ = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
+		return apiErr(errors.New(prose))
 	}
 	fmt.Fprintln(os.Stderr, prose)
-	return nil
+	return apiErr(errors.New(prose))
 }
 
-func writeAPIErrorEnvelope(flags *rootFlags, err error, code int) {
+func writeAPIErrorEnvelope(w io.Writer, flags *rootFlags, err error, code int) {
 	if flags == nil || !flags.asJSON {
 		return
 	}
-	_ = json.NewEncoder(os.Stdout).Encode(map[string]any{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"error": err.Error(),
 		"code":  code,
 	})
 }
 
-// classifyAPIError maps API errors to structured exit codes with actionable hints.
-func classifyAPIError(err error, flags *rootFlags) error {
+// classifyAPIErrorOnly maps API errors to structured exit codes without writing.
+// Hand-written commands should use this helper when they own output sequencing.
+func classifyAPIErrorOnly(err error) error {
+	if err == nil {
+		return nil
+	}
 	var typed *cliError
 	if errors.As(err, &typed) {
 		return err
@@ -613,12 +618,7 @@ func classifyAPIError(err error, flags *rootFlags) error {
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "HTTP 409"):
-		if flags != nil && flags.idempotent {
-			return writeNoop(flags, "already_exists", "already exists (no-op)")
-		}
-		classified := apiErr(err)
-		writeAPIErrorEnvelope(flags, classified, ExitCode(classified))
-		return classified
+		return apiErr(err)
 	case errors.Is(err, client.ErrPlaceholderCredential):
 		return authErr(err)
 	case strings.Contains(msg, "HTTP 400") && cliutil.LooksLikeAuthError(msg):
@@ -642,6 +642,26 @@ func classifyAPIError(err error, flags *rootFlags) error {
 	default:
 		return apiErr(err)
 	}
+}
+
+// classifyAPIError maps API errors to structured exit codes with actionable hints.
+func classifyAPIError(w io.Writer, err error, flags *rootFlags) error {
+	if err == nil {
+		return nil
+	}
+	var typed *cliError
+	if errors.As(err, &typed) {
+		return err
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "HTTP 409") {
+		if flags != nil && flags.idempotent {
+			return writeNoop(w, flags, "already_exists", "already exists (no-op)")
+		}
+	}
+	classified := classifyAPIErrorOnly(err)
+	writeAPIErrorEnvelope(w, flags, classified, ExitCode(classified))
+	return classified
 }
 
 func truncate(s string, max int) string {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/import.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/import.go
@@ -86,7 +86,7 @@ but do not stop the import.`,
 				if err != nil {
 					failed++
 					if status == 401 || status == 403 {
-						terminalErr = classifyAPIError(err, flags)
+						terminalErr = classifyAPIError(cmd.OutOrStdout(), err, flags)
 						continue
 					}
 					fmt.Fprintf(os.Stderr, "warning: failed to import record: %v\n", err)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
@@ -70,7 +70,7 @@ func newProjectsAvatarUploadProjectCmd(flags *rootFlags) *cobra.Command {
 
 			data, statusCode, err := c.PutMultipartWithParamsAndHeaders(cmd.Context(), path, params, fields, fileFields, headerOverrides)
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			// Inspect the mutate response body for a partial-failure-shaped
 			// field (e.g. Google Ads `partialFailureError`). Several Google

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
@@ -95,7 +95,7 @@ func newProjectsCreateCmd(flags *rootFlags) *cobra.Command {
 			}
 			data, statusCode, err := c.PostWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			// Inspect the mutate response body for a partial-failure-shaped
 			// field (e.g. Google Ads `partialFailureError`). Several Google

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
@@ -55,7 +55,7 @@ func newProjectsListCmd(flags *rootFlags) *cobra.Command {
 				"cursor": formatCLIParamValue(flagCursor),
 			}, headerOverrides, flagAll, "cursor", "cursor", "limit", 25, "", "", "", cmd.ErrOrStderr())
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			outputData := collectionItemsForOutput(data, path)
 			// Print provenance to stderr for human-facing output only.

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
@@ -75,7 +75,7 @@ func newProjectsTasksListProjectCmd(flags *rootFlags) *cobra.Command {
 				"cursor":   formatCLIParamValue(flagCursor),
 			}, headerOverrides, flagAll, "cursor", "cursor", "limit", 50, "", "", "", cmd.ErrOrStderr())
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			outputData := collectionItemsForOutput(data, path)
 			// Print provenance to stderr for human-facing output only.

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
@@ -94,7 +94,7 @@ func newProjectsTasksUpdateProjectCmd(flags *rootFlags) *cobra.Command {
 			}
 			data, statusCode, err := c.PatchWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			// Inspect the mutate response body for a partial-failure-shaped
 			// field (e.g. Google Ads `partialFailureError`). Several Google

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_public.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_public.go
@@ -29,7 +29,7 @@ func newPublicPromotedCmd(flags *rootFlags) *cobra.Command {
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "public", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			outputData := data
 			// Print provenance to stderr for human-facing output only.

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
@@ -62,7 +62,7 @@ func newReportsExportReportYearCmd(flags *rootFlags) *cobra.Command {
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "live", "export", false, path, params, headerOverrides, "", cmd.ErrOrStderr())
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			_ = json.Valid
 			_ = os.Stderr

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -367,7 +367,7 @@ Resource scoping:
 			// CI scripts that depend on $? != 0 can discover the contract change
 			// without reading the CHANGELOG.
 			if firstPlaceholderErr != nil {
-				return classifyAPIError(firstPlaceholderErr, flags)
+				return classifyAPIError(cmd.OutOrStdout(), firstPlaceholderErr, flags)
 			}
 			if strict && errCount > 0 {
 				return errors.New(describeFailedResources(errCount, failedResources))

--- a/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/promoted_things.go
+++ b/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/promoted_things.go
@@ -50,7 +50,7 @@ func newThingsPromotedCmd(flags *rootFlags) *cobra.Command {
 			data, _, err := c.PostQueryWithParams(cmd.Context(), path, params, body)
 
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			if isDryRunResponse(c.IsDryRun(), data) {
 				if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {

--- a/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/things_list.go
+++ b/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/things_list.go
@@ -47,7 +47,7 @@ func newThingsListCmd(flags *rootFlags) *cobra.Command {
 			}
 			data, statusCode, err := c.PostQueryWithParams(cmd.Context(), path, params, body)
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			if isDryRunResponse(c.IsDryRun(), data) {
 				if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
@@ -591,26 +591,31 @@ type noopResult struct {
 	Reason string `json:"reason"`
 }
 
-func writeNoop(flags *rootFlags, reason, prose string) error {
+func writeNoop(w io.Writer, flags *rootFlags, reason, prose string) error {
 	if flags != nil && flags.asJSON {
-		return json.NewEncoder(os.Stdout).Encode(noopResult{Status: "noop", Reason: reason})
+		_ = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
+		return apiErr(errors.New(prose))
 	}
 	fmt.Fprintln(os.Stderr, prose)
-	return nil
+	return apiErr(errors.New(prose))
 }
 
-func writeAPIErrorEnvelope(flags *rootFlags, err error, code int) {
+func writeAPIErrorEnvelope(w io.Writer, flags *rootFlags, err error, code int) {
 	if flags == nil || !flags.asJSON {
 		return
 	}
-	_ = json.NewEncoder(os.Stdout).Encode(map[string]any{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"error": err.Error(),
 		"code":  code,
 	})
 }
 
-// classifyAPIError maps API errors to structured exit codes with actionable hints.
-func classifyAPIError(err error, flags *rootFlags) error {
+// classifyAPIErrorOnly maps API errors to structured exit codes without writing.
+// Hand-written commands should use this helper when they own output sequencing.
+func classifyAPIErrorOnly(err error) error {
+	if err == nil {
+		return nil
+	}
 	var typed *cliError
 	if errors.As(err, &typed) {
 		return err
@@ -619,12 +624,7 @@ func classifyAPIError(err error, flags *rootFlags) error {
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "HTTP 409"):
-		if flags != nil && flags.idempotent {
-			return writeNoop(flags, "already_exists", "already exists (no-op)")
-		}
-		classified := apiErr(err)
-		writeAPIErrorEnvelope(flags, classified, ExitCode(classified))
-		return classified
+		return apiErr(err)
 	case strings.Contains(msg, "HTTP 401"):
 		return authErr(fmt.Errorf("%w\nhint: check your API credentials."+
 			"\n      Run 'public-param-golden-pp-cli doctor' to check auth status.", err))
@@ -638,6 +638,26 @@ func classifyAPIError(err error, flags *rootFlags) error {
 	default:
 		return apiErr(err)
 	}
+}
+
+// classifyAPIError maps API errors to structured exit codes with actionable hints.
+func classifyAPIError(w io.Writer, err error, flags *rootFlags) error {
+	if err == nil {
+		return nil
+	}
+	var typed *cliError
+	if errors.As(err, &typed) {
+		return err
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "HTTP 409") {
+		if flags != nil && flags.idempotent {
+			return writeNoop(w, flags, "already_exists", "already exists (no-op)")
+		}
+	}
+	classified := classifyAPIErrorOnly(err)
+	writeAPIErrorEnvelope(w, flags, classified, ExitCode(classified))
+	return classified
 }
 
 func truncate(s string, max int) string {

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
@@ -611,7 +611,7 @@ func writeNoop(w io.Writer, flags *rootFlags, reason, prose string) error {
 		result.cause = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
 		return apiErr(result)
 	}
-	fmt.Fprintln(os.Stderr, prose)
+	_, result.cause = fmt.Fprintln(w, prose)
 	return apiErr(result)
 }
 

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
@@ -591,13 +591,34 @@ type noopResult struct {
 	Reason string `json:"reason"`
 }
 
+type noopWriteError struct {
+	prose string
+	cause error
+}
+
+func (e *noopWriteError) Error() string {
+	if e.cause == nil {
+		return e.prose
+	}
+	return fmt.Sprintf("%s: %v", e.prose, e.cause)
+}
+
+func (e *noopWriteError) Unwrap() error { return e.cause }
+
 func writeNoop(w io.Writer, flags *rootFlags, reason, prose string) error {
+	result := &noopWriteError{prose: prose}
 	if flags != nil && flags.asJSON {
-		_ = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
-		return apiErr(errors.New(prose))
+		result.cause = json.NewEncoder(w).Encode(noopResult{Status: "noop", Reason: reason})
+		return apiErr(result)
 	}
 	fmt.Fprintln(os.Stderr, prose)
-	return apiErr(errors.New(prose))
+	return apiErr(result)
+}
+
+func successfulNoop(err error) bool {
+	var typed *cliError
+	var result *noopWriteError
+	return errors.As(err, &typed) && errors.As(typed.err, &result) && result.cause == nil
 }
 
 func writeAPIErrorEnvelope(w io.Writer, flags *rootFlags, err error, code int) {
@@ -653,8 +674,11 @@ func classifyAPIError(w io.Writer, err error, flags *rootFlags) error {
 	if strings.Contains(msg, "HTTP 409") {
 		if flags != nil && flags.idempotent {
 			// Generated endpoint commands preserve their established successful no-op contract.
-			_ = writeNoop(w, flags, "already_exists", "already exists (no-op)")
-			return nil
+			noopErr := writeNoop(w, flags, "already_exists", "already exists (no-op)")
+			if successfulNoop(noopErr) {
+				return nil
+			}
+			return noopErr
 		}
 	}
 	classified := classifyAPIErrorOnly(err)

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
@@ -652,7 +652,9 @@ func classifyAPIError(w io.Writer, err error, flags *rootFlags) error {
 	msg := err.Error()
 	if strings.Contains(msg, "HTTP 409") {
 		if flags != nil && flags.idempotent {
-			return writeNoop(w, flags, "already_exists", "already exists (no-op)")
+			// Generated endpoint commands preserve their established successful no-op contract.
+			_ = writeNoop(w, flags, "already_exists", "already exists (no-op)")
+			return nil
 		}
 	}
 	classified := classifyAPIErrorOnly(err)

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
@@ -76,7 +76,7 @@ func newStoresCreateCmd(flags *rootFlags) *cobra.Command {
 			}
 			data, statusCode, err := c.PostWithParams(cmd.Context(), path, params, body)
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			// Inspect the mutate response body for a partial-failure-shaped
 			// field (e.g. Google Ads `partialFailureError`). Several Google

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
@@ -78,7 +78,7 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 			}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "stores", true, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			outputData := data
 			// Print provenance to stderr for human-facing output only.

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -328,7 +328,7 @@ Resource scoping:
 			// CI scripts that depend on $? != 0 can discover the contract change
 			// without reading the CHANGELOG.
 			if firstPlaceholderErr != nil {
-				return classifyAPIError(firstPlaceholderErr, flags)
+				return classifyAPIError(cmd.OutOrStdout(), firstPlaceholderErr, flags)
 			}
 			if strict && errCount > 0 {
 				return errors.New(describeFailedResources(errCount, failedResources))

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_games.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_games.go
@@ -29,7 +29,7 @@ func newGamesPromotedCmd(flags *rootFlags) *cobra.Command {
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "games", true, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			outputData := data
 			// Print provenance to stderr for human-facing output only.

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_leagues.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_leagues.go
@@ -43,7 +43,7 @@ func newLeaguesPromotedCmd(flags *rootFlags) *cobra.Command {
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "live", "leagues", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			outputData := data
 			// Print provenance to stderr for human-facing output only.

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -367,7 +367,7 @@ Resource scoping:
 			// CI scripts that depend on $? != 0 can discover the contract change
 			// without reading the CHANGELOG.
 			if firstPlaceholderErr != nil {
-				return classifyAPIError(firstPlaceholderErr, flags)
+				return classifyAPIError(cmd.OutOrStdout(), firstPlaceholderErr, flags)
 			}
 			if strict && errCount > 0 {
 				return errors.New(describeFailedResources(errCount, failedResources))

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_enterprise.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_enterprise.go
@@ -28,7 +28,7 @@ func newItemsEnterpriseCmd(flags *rootFlags) *cobra.Command {
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "items", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			outputData := data
 			// Print provenance to stderr for human-facing output only.

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_list.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_list.go
@@ -28,7 +28,7 @@ func newItemsListCmd(flags *rootFlags) *cobra.Command {
 			c = c.WithTier("free")
 			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "auto", "items", path, map[string]string{}, nil, flagAll, "cursor", "cursor", "limit", 0, "", "", "", cmd.ErrOrStderr())
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			outputData := collectionItemsForOutput(data, path)
 			// Print provenance to stderr for human-facing output only.

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_premium.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_premium.go
@@ -28,7 +28,7 @@ func newItemsPremiumCmd(flags *rootFlags) *cobra.Command {
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "items", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
-				return classifyAPIError(err, flags)
+				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}
 			outputData := data
 			// Print provenance to stderr for human-facing output only.

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -328,7 +328,7 @@ Resource scoping:
 			// CI scripts that depend on $? != 0 can discover the contract change
 			// without reading the CHANGELOG.
 			if firstPlaceholderErr != nil {
-				return classifyAPIError(firstPlaceholderErr, flags)
+				return classifyAPIError(cmd.OutOrStdout(), firstPlaceholderErr, flags)
 			}
 			if strict && errCount > 0 {
 				return errors.New(describeFailedResources(errCount, failedResources))


### PR DESCRIPTION
## Intent

Fix issue #3974 so shared generated error classification respects each command's configured output writer and gives hand-written commands a silent classification path.

Closes #3974

## Approach

The generated helpers now route no-op and API error envelopes through the supplied writer. `classifyAPIErrorOnly` maps non-nil API errors without emitting output, while generated endpoint no-ops preserve their existing successful behavior and propagate writer failures instead of reporting false success.

## Scope

Primary area: generator templates and generated-output regression coverage.

Why this belongs in this repo: the defect is emitted by the shared Printing Press helpers and affects every printed CLI using the classifier.

## Risk

The change affects generated error output and no-op handling. Existing endpoint exit semantics are preserved; golden fixtures and compiled generated cases cover the affected variants.

## Output Contract

Generated JSON error and no-op envelopes now use the command writer, including redirected or captured output. The classify-only helper emits no output and returns typed errors for non-nil inputs.

## Verification

- [x] `go test ./internal/generator -run 'TestGeneratedHelpers_(ConditionalClassifyDeleteError|IdempotentNoopsRequireOptIn)$|TestGeneratedClientRejectsPlaceholderConfigTokenBeforeRequest$' -count=1`
- [x] `scripts/golden.sh verify` passed for 32 cases
- [x] `scripts/verify-generator-output.sh` passed for 10 compiled generated cases
- [x] Added coverage for configured writers, classify-only silence, successful no-ops, and failed no-op writers
