### PR TITLE
fix(cli): preserve compact and select projection payloads

### DIFF
--- a/internal/generator/generated_examples.go
+++ b/internal/generator/generated_examples.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
@@ -110,6 +111,42 @@ func generatedExampleFields(typeDef spec.TypeDef) string {
 		}
 	}
 	return strings.Join(fields, ",")
+}
+
+// compactFieldNames returns the wire fields declared by a response item type.
+// The generated compact projection uses these as a floor beneath its
+// data-driven frequency heuristic so sparse documented fields remain visible.
+func compactFieldNames(typeName string, types map[string]spec.TypeDef) []string {
+	typeDef, ok := typeDefByName(types, strings.TrimSpace(typeName))
+	if !ok {
+		return nil
+	}
+	fields := make([]string, 0, len(typeDef.Fields))
+	seen := make(map[string]struct{}, len(typeDef.Fields))
+	for _, field := range typeDef.Fields {
+		name := strings.TrimSpace(field.Name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		fields = append(fields, name)
+	}
+	return fields
+}
+
+func compactFieldMapLiteral(typeName string, types map[string]spec.TypeDef) string {
+	fields := compactFieldNames(typeName, types)
+	if len(fields) == 0 {
+		return "nil"
+	}
+	quoted := make([]string, len(fields))
+	for i, field := range fields {
+		quoted[i] = strconv.Quote(field) + ": true"
+	}
+	return "map[string]bool{" + strings.Join(quoted, ", ") + "}"
 }
 
 func safeGeneratedExampleField(name string) bool {

--- a/internal/generator/generated_examples.go
+++ b/internal/generator/generated_examples.go
@@ -113,9 +113,6 @@ func generatedExampleFields(typeDef spec.TypeDef) string {
 	return strings.Join(fields, ",")
 }
 
-// compactFieldNames returns the wire fields declared by a response item type.
-// The generated compact projection uses these as a floor beneath its
-// data-driven frequency heuristic so sparse documented fields remain visible.
 func compactFieldNames(typeName string, types map[string]spec.TypeDef) []string {
 	typeDef, ok := typeDefByName(types, strings.TrimSpace(typeName))
 	if !ok {

--- a/internal/generator/generated_examples_test.go
+++ b/internal/generator/generated_examples_test.go
@@ -85,6 +85,23 @@ func TestSelectExampleRejectsUnsafeFieldNames(t *testing.T) {
 	assert.Empty(t, selectExample(apiSpec, syncable))
 }
 
+func TestCompactFieldMapLiteralUsesDocumentedWireFields(t *testing.T) {
+	t.Parallel()
+
+	types := map[string]spec.TypeDef{
+		"Event": {Fields: []spec.TypeField{
+			{Name: "id"},
+			{Name: "odds"},
+			{Name: "odds"},
+			{Name: "event_name"},
+			{Name: ""},
+		}},
+	}
+
+	assert.Equal(t, `map[string]bool{"id": true, "odds": true, "event_name": true}`, compactFieldMapLiteral("Event", types))
+	assert.Equal(t, "nil", compactFieldMapLiteral("Missing", types))
+}
+
 func TestGeneratedExamplesUseAPIModelAcrossDocsAndSyncHelp(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -368,6 +368,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"graphqlFieldSelection": func(typeName string, types map[string]spec.TypeDef) []string {
 			return graphqlFieldSelection(typeName, types)
 		},
+		"compactFieldMapLiteral":    compactFieldMapLiteral,
 		"isGraphQL":                 isGraphQLSpec,
 		"localReadIsList":           localReadIsList,
 		"localReadSupported":        localReadSupported,

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -7398,7 +7398,7 @@ func TestGeneratedOutput_MutatingCommandsHaveEnvelope(t *testing.T) {
 
 	// --select and --compact are applied to inner data before wrapping in envelope
 	assert.Contains(t, content, "filtered := data")
-	assert.Contains(t, content, "compactFields(filtered)")
+	assert.Contains(t, content, "compactFields(filtered,")
 	assert.Contains(t, content, "filterFields(filtered, flags.selectFields)")
 	assert.Contains(t, content, `json.Unmarshal(filtered, &parsed)`)
 

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -7,6 +7,7 @@
 {{- $hasJSONBody := and (or .Endpoint.Body .Endpoint.BodyJSONFallback) (not $isMultipart) (not $isForm)}}
 {{- $supportsAllPagination := and (ne .Endpoint.Pagination nil) (ne .Endpoint.Pagination.Type "id_walk") (eq .Endpoint.Method "GET") .IsReadOnly}}
 {{- $dataSourceStrategy := dataSourceStrategy .Resource .Endpoint}}
+{{- $documentedFields := compactFieldMapLiteral .Endpoint.Response.Item .Types}}
 
 package cli
 
@@ -816,7 +817,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if and .IsReadOnly (not .HasStore)}}
 			if isDryRunResponse(c.IsDryRun(), data) {
 				if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
-					return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "dry-run"})
+					return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "dry-run"}, {{$documentedFields}})
 				}
 				return nil
 			}
@@ -841,7 +842,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				if flags.csv {
 					data = append(append(json.RawMessage{'['}, data...), ']')
 				}
-				return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
+				return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"}, {{$documentedFields}})
 			}
 			_, err = cmd.OutOrStdout().Write([]byte(textEnvelope.Body))
 			return err
@@ -1045,7 +1046,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, {{$documentedFields}})
 				}
 				if len(filtered) > 0 {
 					var parsed any
@@ -1105,7 +1106,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, {{$documentedFields}})
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -1152,7 +1153,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, {{$documentedFields}})
 {{- end}}
 {{- end}}
 		},

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -12,6 +12,7 @@
 {{- $canWriteBack := and .HasStore $isWriteVerb (not .IsReadOnly) (not .Endpoint.UsesBinaryResponse) (not .Endpoint.UsesTextResponse)}}
 {{- $supportsAllPagination := and (ne .Endpoint.Pagination nil) (ne .Endpoint.Pagination.Type "id_walk") (eq $method "GET") .IsReadOnly}}
 {{- $dataSourceStrategy := dataSourceStrategy .Resource .Endpoint}}
+{{- $documentedFields := compactFieldMapLiteral .Endpoint.Response.Item .Types}}
 
 package cli
 
@@ -429,7 +430,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- if and .IsReadOnly (not .HasStore)}}
 			if isDryRunResponse(c.IsDryRun(), data) {
 				if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
-					return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "dry-run"})
+					return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "dry-run"}, {{$documentedFields}})
 				}
 				return nil
 			}
@@ -465,7 +466,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				if flags.csv {
 					data = append(append(json.RawMessage{'['}, data...), ']')
 				}
-				return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
+				return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"}, {{$documentedFields}})
 			}
 			_, err = cmd.OutOrStdout().Write([]byte(textEnvelope.Body))
 			return err
@@ -488,7 +489,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				if flags.csv {
 					data = append(append(json.RawMessage{'['}, data...), ']')
 				}
-				return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
+				return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"}, {{$documentedFields}})
 			}
 			_, err = cmd.OutOrStdout().Write(data)
 			return err
@@ -566,7 +567,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, {{$documentedFields}})
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -595,7 +596,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, {{$documentedFields}})
 {{- end}}
 		},
 	}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1891,6 +1891,9 @@ func extractPaginatedItemsMatchingPath(obj map[string]json.RawMessage, requestPa
 var envelopeMetadataArrayKeys = map[string]bool{
 	"errors": true, "Errors": true,
 	"warnings": true, "Warnings": true,
+	// fetch_failures is emitted by fan-out scaffolding. It is bookkeeping,
+	// not a competing domain payload array during compact projection.
+	"fetch_failures": true, "FetchFailures": true,
 }
 
 // envelopeMetadataKeys lists pagination and collection-envelope metadata
@@ -2579,7 +2582,7 @@ func isDryRunResponseForClient(c any, data json.RawMessage) bool {
 	return ok && isDryRunResponse(dryRunClient.IsDryRun(), data)
 }
 
-func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any) error {
+func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any, documentedFields ...map[string]bool) error {
 	if err := validatePlatformAnalytics(flags); err != nil {
 		return err
 	}
@@ -2591,7 +2594,7 @@ func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlag
 	if flags.selectFields != "" {
 		data = filterFields(data, flags.selectFields)
 	} else if flags.compact {
-		data = compactFields(data)
+		data = compactFields(data, documentedFields...)
 	}
 	if flags.agent && flags.asJSON && !flags.csv && !flags.plain && !flags.quiet {
 		wrapped, err := wrapAgentOutput(data, agentMeta)
@@ -2679,17 +2682,17 @@ var compactVerboseObjectFields = map[string]bool{
 // compactFields keeps only the most important fields for agent consumption.
 // For arrays: allowlist of high-gravity fields (no descriptions).
 // For single objects: blocklist that strips known-verbose fields (descriptions, comments, etc.).
-func compactFields(data json.RawMessage) json.RawMessage {
+func compactFields(data json.RawMessage, documentedFields ...map[string]bool) json.RawMessage {
 	// Try array first
 	var items []map[string]any
 	if err := json.Unmarshal(data, &items); err == nil {
-		return compactListFields(items)
+		return compactListFields(items, documentedFields...)
 	}
 
 	// Single object — use blocklist
 	var obj map[string]any
 	if err := json.Unmarshal(data, &obj); err == nil {
-		return compactObjectFields(obj)
+		return compactObjectFields(obj, documentedFields...)
 	}
 
 	return data
@@ -2714,7 +2717,7 @@ func compactFields(data json.RawMessage) json.RawMessage {
 // When an item still carries none of the keep keys, the original is
 // preserved so `--agent` does not silently emit {} for shapes whose key
 // names are entirely off-canonical.
-func compactListFields(items []map[string]any) json.RawMessage {
+func compactListFields(items []map[string]any, documentedFields ...map[string]bool) json.RawMessage {
 	keepFields := map[string]bool{
 		// Identity
 		"id": true, "name": true, "title": true, "identifier": true,
@@ -2736,6 +2739,11 @@ func compactListFields(items []map[string]any) json.RawMessage {
 		"date": true,
 		// Versioning
 		"version": true,
+	}
+	for _, fields := range documentedFields {
+		for field := range fields {
+			keepFields[field] = true
+		}
 	}
 	if len(items) > 0 {
 		keyCounts := map[string]int{}
@@ -2798,8 +2806,8 @@ func isCompactScalar(v any) bool {
 // "markdown" — those fields are payload on `get` commands and stripping them
 // under `--agent`/`--compact` is a silent loss; agents who want to omit them
 // can pass `--select` to specify only the fields they need.
-func compactObjectFields(obj map[string]any) json.RawMessage {
-	if compacted, ok := compactListEnvelopeObjectAtDepth(obj, 0); ok {
+func compactObjectFields(obj map[string]any, documentedFields ...map[string]bool) json.RawMessage {
+	if compacted, ok := compactListEnvelopeObjectAtDepth(obj, 0, documentedFields...); ok {
 		result, _ := json.Marshal(compacted)
 		return result
 	}
@@ -2813,25 +2821,34 @@ func compactObjectFields(obj map[string]any) json.RawMessage {
 	return result
 }
 
-func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int) (map[string]any, bool) {
+func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int, documentedFields ...map[string]bool) (map[string]any, bool) {
 	out := map[string]any{}
 	foundArray := false
+	payloadArrays := map[string]bool{}
 	for k, v := range obj {
-		if envelopeDepth == 0 && compactVerboseObjectFields[k] {
+		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
+			continue
+		}
+		if _, ok := compactObjectArrayValue(v, documentedFields...); ok {
+			payloadArrays[k] = true
+		}
+	}
+	for k, v := range obj {
+		if envelopeDepth == 0 && compactVerboseObjectFields[k] && (!payloadArrays[k] || len(payloadArrays) > 1) {
 			continue
 		}
 		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
 			out[k] = v
 			continue
 		}
-		if compacted, ok := compactObjectArrayValue(v); ok {
+		if compacted, ok := compactObjectArrayValue(v, documentedFields...); ok {
 			foundArray = true
 			out[k] = compacted
 			continue
 		}
 		if nested, ok := v.(map[string]any); ok {
 			if envelopeDepth < maxListEnvelopeDepth {
-				if compacted, ok := compactListEnvelopeObjectAtDepth(nested, envelopeDepth+1); ok {
+				if compacted, ok := compactListEnvelopeObjectAtDepth(nested, envelopeDepth+1, documentedFields...); ok {
 					foundArray = true
 					out[k] = compacted
 					continue
@@ -2846,7 +2863,7 @@ func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int) (ma
 	return out, true
 }
 
-func compactObjectArrayValue(v any) (any, bool) {
+func compactObjectArrayValue(v any, documentedFields ...map[string]bool) (any, bool) {
 	rawItems, ok := v.([]any)
 	if !ok || len(rawItems) == 0 {
 		return nil, false
@@ -2859,7 +2876,7 @@ func compactObjectArrayValue(v any) (any, bool) {
 		}
 		items = append(items, item)
 	}
-	compactedRaw := compactListFields(items)
+	compactedRaw := compactListFields(items, documentedFields...)
 	var compacted any
 	if err := json.Unmarshal(compactedRaw, &compacted); err != nil {
 		return nil, false

--- a/internal/generator/wrapped_projection_test.go
+++ b/internal/generator/wrapped_projection_test.go
@@ -192,6 +192,87 @@ func TestCompactFieldsProjectsHALEmbeddedArrays(t *testing.T) {
 	}
 }
 
+func TestCompactFieldsPreservesDocumentedSparseFields(t *testing.T) {
+	input := json.RawMessage(`+"`"+`[
+		{"id":"row-1","name":"One","odds":1.5,"ranking":7,"lean":"up","segment":"rare","undocumented":"drop"},
+		{"id":"row-2","name":"Two"},
+		{"id":"row-3","name":"Three"},
+		{"id":"row-4","name":"Four"},
+		{"id":"row-5","name":"Five"},
+		{"id":"row-6","name":"Six"},
+		{"id":"row-7","name":"Seven"},
+		{"id":"row-8","name":"Eight"},
+		{"id":"row-9","name":"Nine"},
+		{"id":"row-10","name":"Ten"}
+	]`+"`"+`)
+
+	got := compactFields(input, map[string]bool{
+		"odds": true, "ranking": true, "lean": true, "segment": true,
+	})
+	var rows []map[string]any
+	if err := json.Unmarshal(got, &rows); err != nil {
+		t.Fatalf("compactFields returned invalid JSON: %v\n%s", err, got)
+	}
+	first := rows[0]
+	for _, key := range []string{"odds", "ranking", "lean", "segment"} {
+		if _, ok := first[key]; !ok {
+			t.Fatalf("documented sparse field %q was dropped: %#v", key, first)
+		}
+	}
+	if _, ok := first["undocumented"]; ok {
+		t.Fatalf("undocumented sparse field survived compact projection: %#v", first)
+	}
+}
+
+func TestCompactFieldsPreservesSoleVerbosePayloadArray(t *testing.T) {
+	input := json.RawMessage(`+"`"+`{
+		"id": "issue-1",
+		"title": "Bug",
+		"description": "verbose metadata",
+		"comments": [{"id":"comment-1","body":"comment payload"}]
+	}`+"`"+`)
+
+	got := decodeObject(t, compactFields(input))
+	if _, ok := got["comments"].([]any); !ok {
+		t.Fatalf("sole payload comments array was stripped: %#v", got)
+	}
+	if _, ok := got["description"]; ok {
+		t.Fatalf("scalar description should remain blocklisted: %#v", got)
+	}
+}
+
+func TestCompactFieldsStripsVerboseArrayWhenPayloadCompetes(t *testing.T) {
+	input := json.RawMessage(`+"`"+`{
+		"id": "issue-1",
+		"body": "primary payload",
+		"comments": [{"id":"comment-1","body":"comment payload"}],
+		"tags": [{"id":"tag-1","label":"bug"}]
+	}`+"`"+`)
+
+	got := decodeObject(t, compactFields(input))
+	if _, ok := got["comments"]; ok {
+		t.Fatalf("verbose competing comments array survived: %#v", got)
+	}
+	if _, ok := got["tags"].([]any); !ok {
+		t.Fatalf("domain payload tags array was stripped: %#v", got)
+	}
+}
+
+func TestCompactFieldsPreservesFetchFailuresAlongsidePayload(t *testing.T) {
+	input := json.RawMessage(`+"`"+`{
+		"results": [{"id":"evt-1","name":"Launch","description":"verbose"}],
+		"fetch_failures": [{"resource":"venues","error":"timeout"}]
+	}`+"`"+`)
+
+	got := decodeObject(t, compactFields(input))
+	if _, ok := got["results"].([]any); !ok {
+		t.Fatalf("results payload was stripped: %#v", got)
+	}
+	if _, ok := got["fetch_failures"].([]any); !ok {
+		t.Fatalf("fetch_failures sidecar was stripped: %#v", got)
+	}
+}
+
 func TestCompactFieldsKeepsObjectBlocklistForDetailObjectsWithArrays(t *testing.T) {
 	input := json.RawMessage(`+"`"+`{
 		"id": "issue-1",
@@ -200,7 +281,8 @@ func TestCompactFieldsKeepsObjectBlocklistForDetailObjectsWithArrays(t *testing.
 		"body": "primary payload",
 		"comments": [
 			{"id":"comment-1","body":"verbose comment"}
-		]
+		],
+		"tags": [{"id":"tag-1","label":"bug"}]
 	}`+"`"+`)
 
 	got := decodeObject(t, compactFields(input))
@@ -214,6 +296,9 @@ func TestCompactFieldsKeepsObjectBlocklistForDetailObjectsWithArrays(t *testing.
 		if _, ok := got[key]; ok {
 			t.Fatalf("detail object kept object-path blocklisted %s field: %#v", key, got)
 		}
+	}
+	if _, ok := got["tags"].([]any); !ok {
+		t.Fatalf("detail object lost competing payload tags: %#v", got)
 	}
 }
 
@@ -265,5 +350,5 @@ func TestSelectFieldsProjectsHALEmbeddedArrays(t *testing.T) {
 `), 0o644))
 
 	requireGeneratedCompiles(t, outputDir)
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestCompactFieldsProjects|TestCompactFieldsKeeps|TestSelectFieldsProjects", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestCompactFieldsProjects|TestCompactFieldsPreserves|TestCompactFieldsStrips|TestCompactFieldsKeeps|TestSelectFieldsProjects", "-count=1")
 }

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
@@ -71,7 +71,7 @@ func newCustomersGetCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, map[string]bool{"email": true, "id": true, "subscriptions": true})
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -100,7 +100,7 @@ func newCustomersGetCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, map[string]bool{"email": true, "id": true, "subscriptions": true})
 		},
 	}
 

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -1277,6 +1277,9 @@ func extractPaginatedItemsMatchingPath(obj map[string]json.RawMessage, requestPa
 var envelopeMetadataArrayKeys = map[string]bool{
 	"errors": true, "Errors": true,
 	"warnings": true, "Warnings": true,
+	// fetch_failures is emitted by fan-out scaffolding. It is bookkeeping,
+	// not a competing domain payload array during compact projection.
+	"fetch_failures": true, "FetchFailures": true,
 }
 
 // envelopeMetadataKeys lists pagination and collection-envelope metadata
@@ -1962,7 +1965,7 @@ func isDryRunResponseForClient(c any, data json.RawMessage) bool {
 	return ok && isDryRunResponse(dryRunClient.IsDryRun(), data)
 }
 
-func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any) error {
+func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any, documentedFields ...map[string]bool) error {
 	if err := validatePlatformAnalytics(flags); err != nil {
 		return err
 	}
@@ -1974,7 +1977,7 @@ func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlag
 	if flags.selectFields != "" {
 		data = filterFields(data, flags.selectFields)
 	} else if flags.compact {
-		data = compactFields(data)
+		data = compactFields(data, documentedFields...)
 	}
 	if flags.agent && flags.asJSON && !flags.csv && !flags.plain && !flags.quiet {
 		wrapped, err := wrapAgentOutput(data, agentMeta)
@@ -2032,17 +2035,17 @@ var compactVerboseObjectFields = map[string]bool{
 // compactFields keeps only the most important fields for agent consumption.
 // For arrays: allowlist of high-gravity fields (no descriptions).
 // For single objects: blocklist that strips known-verbose fields (descriptions, comments, etc.).
-func compactFields(data json.RawMessage) json.RawMessage {
+func compactFields(data json.RawMessage, documentedFields ...map[string]bool) json.RawMessage {
 	// Try array first
 	var items []map[string]any
 	if err := json.Unmarshal(data, &items); err == nil {
-		return compactListFields(items)
+		return compactListFields(items, documentedFields...)
 	}
 
 	// Single object — use blocklist
 	var obj map[string]any
 	if err := json.Unmarshal(data, &obj); err == nil {
-		return compactObjectFields(obj)
+		return compactObjectFields(obj, documentedFields...)
 	}
 
 	return data
@@ -2067,7 +2070,7 @@ func compactFields(data json.RawMessage) json.RawMessage {
 // When an item still carries none of the keep keys, the original is
 // preserved so `--agent` does not silently emit {} for shapes whose key
 // names are entirely off-canonical.
-func compactListFields(items []map[string]any) json.RawMessage {
+func compactListFields(items []map[string]any, documentedFields ...map[string]bool) json.RawMessage {
 	keepFields := map[string]bool{
 		// Identity
 		"id": true, "name": true, "title": true, "identifier": true,
@@ -2089,6 +2092,11 @@ func compactListFields(items []map[string]any) json.RawMessage {
 		"date": true,
 		// Versioning
 		"version": true,
+	}
+	for _, fields := range documentedFields {
+		for field := range fields {
+			keepFields[field] = true
+		}
 	}
 	if len(items) > 0 {
 		keyCounts := map[string]int{}
@@ -2151,8 +2159,8 @@ func isCompactScalar(v any) bool {
 // "markdown" — those fields are payload on `get` commands and stripping them
 // under `--agent`/`--compact` is a silent loss; agents who want to omit them
 // can pass `--select` to specify only the fields they need.
-func compactObjectFields(obj map[string]any) json.RawMessage {
-	if compacted, ok := compactListEnvelopeObjectAtDepth(obj, 0); ok {
+func compactObjectFields(obj map[string]any, documentedFields ...map[string]bool) json.RawMessage {
+	if compacted, ok := compactListEnvelopeObjectAtDepth(obj, 0, documentedFields...); ok {
 		result, _ := json.Marshal(compacted)
 		return result
 	}
@@ -2166,25 +2174,34 @@ func compactObjectFields(obj map[string]any) json.RawMessage {
 	return result
 }
 
-func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int) (map[string]any, bool) {
+func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int, documentedFields ...map[string]bool) (map[string]any, bool) {
 	out := map[string]any{}
 	foundArray := false
+	payloadArrays := map[string]bool{}
 	for k, v := range obj {
-		if envelopeDepth == 0 && compactVerboseObjectFields[k] {
+		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
+			continue
+		}
+		if _, ok := compactObjectArrayValue(v, documentedFields...); ok {
+			payloadArrays[k] = true
+		}
+	}
+	for k, v := range obj {
+		if envelopeDepth == 0 && compactVerboseObjectFields[k] && (!payloadArrays[k] || len(payloadArrays) > 1) {
 			continue
 		}
 		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
 			out[k] = v
 			continue
 		}
-		if compacted, ok := compactObjectArrayValue(v); ok {
+		if compacted, ok := compactObjectArrayValue(v, documentedFields...); ok {
 			foundArray = true
 			out[k] = compacted
 			continue
 		}
 		if nested, ok := v.(map[string]any); ok {
 			if envelopeDepth < maxListEnvelopeDepth {
-				if compacted, ok := compactListEnvelopeObjectAtDepth(nested, envelopeDepth+1); ok {
+				if compacted, ok := compactListEnvelopeObjectAtDepth(nested, envelopeDepth+1, documentedFields...); ok {
 					foundArray = true
 					out[k] = compacted
 					continue
@@ -2199,7 +2216,7 @@ func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int) (ma
 	return out, true
 }
 
-func compactObjectArrayValue(v any) (any, bool) {
+func compactObjectArrayValue(v any, documentedFields ...map[string]bool) (any, bool) {
 	rawItems, ok := v.([]any)
 	if !ok || len(rawItems) == 0 {
 		return nil, false
@@ -2212,7 +2229,7 @@ func compactObjectArrayValue(v any) (any, bool) {
 		}
 		items = append(items, item)
 	}
-	compactedRaw := compactListFields(items)
+	compactedRaw := compactListFields(items, documentedFields...)
 	var compacted any
 	if err := json.Unmarshal(compactedRaw, &compacted); err != nil {
 		return nil, false

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
@@ -71,7 +71,7 @@ func newPagesGetCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, map[string]bool{"children": true, "id": true, "title": true})
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -100,7 +100,7 @@ func newPagesGetCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, map[string]bool{"children": true, "id": true, "title": true})
 		},
 	}
 

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
@@ -71,7 +71,7 @@ func newPlaylistsGetCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, map[string]bool{"id": true, "name": true, "tracks": true})
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -100,7 +100,7 @@ func newPlaylistsGetCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, map[string]bool{"id": true, "name": true, "tracks": true})
 		},
 	}
 

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_health.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_health.go
@@ -55,7 +55,7 @@ func newHealthPromotedCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, nil)
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -83,7 +83,7 @@ func newHealthPromotedCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, nil)
 		},
 	}
 

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_items.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_items.go
@@ -63,7 +63,7 @@ func newItemsPromotedCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, nil)
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -91,7 +91,7 @@ func newItemsPromotedCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, nil)
 		},
 	}
 

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_create.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_create.go
@@ -147,7 +147,7 @@ func newQuotesCreateCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, nil)
 				}
 				if len(filtered) > 0 {
 					var parsed any

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_delete.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_delete.go
@@ -144,7 +144,7 @@ func newQuotesDeleteCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, nil)
 				}
 				if len(filtered) > 0 {
 					var parsed any

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_get.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_get.go
@@ -69,7 +69,7 @@ func newQuotesGetCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, nil)
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -98,7 +98,7 @@ func newQuotesGetCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, nil)
 		},
 	}
 

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_list.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_list.go
@@ -50,7 +50,7 @@ func newQuotesListCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, map[string]bool{"id": true})
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -79,7 +79,7 @@ func newQuotesListCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, map[string]bool{"id": true})
 		},
 	}
 

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update-status.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update-status.go
@@ -166,7 +166,7 @@ func newQuotesUpdateStatusCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, nil)
 				}
 				if len(filtered) > 0 {
 					var parsed any

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update.go
@@ -166,7 +166,7 @@ func newQuotesUpdateCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, nil)
 				}
 				if len(filtered) > 0 {
 					var parsed any

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -1270,6 +1270,9 @@ func extractPaginatedItemsMatchingPath(obj map[string]json.RawMessage, requestPa
 var envelopeMetadataArrayKeys = map[string]bool{
 	"errors": true, "Errors": true,
 	"warnings": true, "Warnings": true,
+	// fetch_failures is emitted by fan-out scaffolding. It is bookkeeping,
+	// not a competing domain payload array during compact projection.
+	"fetch_failures": true, "FetchFailures": true,
 }
 
 // envelopeMetadataKeys lists pagination and collection-envelope metadata
@@ -1828,7 +1831,7 @@ func isDryRunResponseForClient(c any, data json.RawMessage) bool {
 	return ok && isDryRunResponse(dryRunClient.IsDryRun(), data)
 }
 
-func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any) error {
+func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any, documentedFields ...map[string]bool) error {
 	if err := validatePlatformAnalytics(flags); err != nil {
 		return err
 	}
@@ -1840,7 +1843,7 @@ func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlag
 	if flags.selectFields != "" {
 		data = filterFields(data, flags.selectFields)
 	} else if flags.compact {
-		data = compactFields(data)
+		data = compactFields(data, documentedFields...)
 	}
 	if flags.agent && flags.asJSON && !flags.csv && !flags.plain && !flags.quiet {
 		wrapped, err := wrapAgentOutput(data, agentMeta)
@@ -1898,17 +1901,17 @@ var compactVerboseObjectFields = map[string]bool{
 // compactFields keeps only the most important fields for agent consumption.
 // For arrays: allowlist of high-gravity fields (no descriptions).
 // For single objects: blocklist that strips known-verbose fields (descriptions, comments, etc.).
-func compactFields(data json.RawMessage) json.RawMessage {
+func compactFields(data json.RawMessage, documentedFields ...map[string]bool) json.RawMessage {
 	// Try array first
 	var items []map[string]any
 	if err := json.Unmarshal(data, &items); err == nil {
-		return compactListFields(items)
+		return compactListFields(items, documentedFields...)
 	}
 
 	// Single object — use blocklist
 	var obj map[string]any
 	if err := json.Unmarshal(data, &obj); err == nil {
-		return compactObjectFields(obj)
+		return compactObjectFields(obj, documentedFields...)
 	}
 
 	return data
@@ -1933,7 +1936,7 @@ func compactFields(data json.RawMessage) json.RawMessage {
 // When an item still carries none of the keep keys, the original is
 // preserved so `--agent` does not silently emit {} for shapes whose key
 // names are entirely off-canonical.
-func compactListFields(items []map[string]any) json.RawMessage {
+func compactListFields(items []map[string]any, documentedFields ...map[string]bool) json.RawMessage {
 	keepFields := map[string]bool{
 		// Identity
 		"id": true, "name": true, "title": true, "identifier": true,
@@ -1955,6 +1958,11 @@ func compactListFields(items []map[string]any) json.RawMessage {
 		"date": true,
 		// Versioning
 		"version": true,
+	}
+	for _, fields := range documentedFields {
+		for field := range fields {
+			keepFields[field] = true
+		}
 	}
 	if len(items) > 0 {
 		keyCounts := map[string]int{}
@@ -2017,8 +2025,8 @@ func isCompactScalar(v any) bool {
 // "markdown" — those fields are payload on `get` commands and stripping them
 // under `--agent`/`--compact` is a silent loss; agents who want to omit them
 // can pass `--select` to specify only the fields they need.
-func compactObjectFields(obj map[string]any) json.RawMessage {
-	if compacted, ok := compactListEnvelopeObjectAtDepth(obj, 0); ok {
+func compactObjectFields(obj map[string]any, documentedFields ...map[string]bool) json.RawMessage {
+	if compacted, ok := compactListEnvelopeObjectAtDepth(obj, 0, documentedFields...); ok {
 		result, _ := json.Marshal(compacted)
 		return result
 	}
@@ -2032,25 +2040,34 @@ func compactObjectFields(obj map[string]any) json.RawMessage {
 	return result
 }
 
-func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int) (map[string]any, bool) {
+func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int, documentedFields ...map[string]bool) (map[string]any, bool) {
 	out := map[string]any{}
 	foundArray := false
+	payloadArrays := map[string]bool{}
 	for k, v := range obj {
-		if envelopeDepth == 0 && compactVerboseObjectFields[k] {
+		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
+			continue
+		}
+		if _, ok := compactObjectArrayValue(v, documentedFields...); ok {
+			payloadArrays[k] = true
+		}
+	}
+	for k, v := range obj {
+		if envelopeDepth == 0 && compactVerboseObjectFields[k] && (!payloadArrays[k] || len(payloadArrays) > 1) {
 			continue
 		}
 		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
 			out[k] = v
 			continue
 		}
-		if compacted, ok := compactObjectArrayValue(v); ok {
+		if compacted, ok := compactObjectArrayValue(v, documentedFields...); ok {
 			foundArray = true
 			out[k] = compacted
 			continue
 		}
 		if nested, ok := v.(map[string]any); ok {
 			if envelopeDepth < maxListEnvelopeDepth {
-				if compacted, ok := compactListEnvelopeObjectAtDepth(nested, envelopeDepth+1); ok {
+				if compacted, ok := compactListEnvelopeObjectAtDepth(nested, envelopeDepth+1, documentedFields...); ok {
 					foundArray = true
 					out[k] = compacted
 					continue
@@ -2065,7 +2082,7 @@ func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int) (ma
 	return out, true
 }
 
-func compactObjectArrayValue(v any) (any, bool) {
+func compactObjectArrayValue(v any, documentedFields ...map[string]bool) (any, bool) {
 	rawItems, ok := v.([]any)
 	if !ok || len(rawItems) == 0 {
 		return nil, false
@@ -2078,7 +2095,7 @@ func compactObjectArrayValue(v any) (any, bool) {
 		}
 		items = append(items, item)
 	}
-	compactedRaw := compactListFields(items)
+	compactedRaw := compactListFields(items, documentedFields...)
 	var compacted any
 	if err := json.Unmarshal(compactedRaw, &compacted); err != nil {
 		return nil, false

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -1359,6 +1359,9 @@ func extractPaginatedItemsMatchingPath(obj map[string]json.RawMessage, requestPa
 var envelopeMetadataArrayKeys = map[string]bool{
 	"errors": true, "Errors": true,
 	"warnings": true, "Warnings": true,
+	// fetch_failures is emitted by fan-out scaffolding. It is bookkeeping,
+	// not a competing domain payload array during compact projection.
+	"fetch_failures": true, "FetchFailures": true,
 }
 
 // envelopeMetadataKeys lists pagination and collection-envelope metadata
@@ -1917,7 +1920,7 @@ func isDryRunResponseForClient(c any, data json.RawMessage) bool {
 	return ok && isDryRunResponse(dryRunClient.IsDryRun(), data)
 }
 
-func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any) error {
+func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any, documentedFields ...map[string]bool) error {
 	if err := validatePlatformAnalytics(flags); err != nil {
 		return err
 	}
@@ -1929,7 +1932,7 @@ func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlag
 	if flags.selectFields != "" {
 		data = filterFields(data, flags.selectFields)
 	} else if flags.compact {
-		data = compactFields(data)
+		data = compactFields(data, documentedFields...)
 	}
 	if flags.agent && flags.asJSON && !flags.csv && !flags.plain && !flags.quiet {
 		wrapped, err := wrapAgentOutput(data, agentMeta)
@@ -1987,17 +1990,17 @@ var compactVerboseObjectFields = map[string]bool{
 // compactFields keeps only the most important fields for agent consumption.
 // For arrays: allowlist of high-gravity fields (no descriptions).
 // For single objects: blocklist that strips known-verbose fields (descriptions, comments, etc.).
-func compactFields(data json.RawMessage) json.RawMessage {
+func compactFields(data json.RawMessage, documentedFields ...map[string]bool) json.RawMessage {
 	// Try array first
 	var items []map[string]any
 	if err := json.Unmarshal(data, &items); err == nil {
-		return compactListFields(items)
+		return compactListFields(items, documentedFields...)
 	}
 
 	// Single object — use blocklist
 	var obj map[string]any
 	if err := json.Unmarshal(data, &obj); err == nil {
-		return compactObjectFields(obj)
+		return compactObjectFields(obj, documentedFields...)
 	}
 
 	return data
@@ -2022,7 +2025,7 @@ func compactFields(data json.RawMessage) json.RawMessage {
 // When an item still carries none of the keep keys, the original is
 // preserved so `--agent` does not silently emit {} for shapes whose key
 // names are entirely off-canonical.
-func compactListFields(items []map[string]any) json.RawMessage {
+func compactListFields(items []map[string]any, documentedFields ...map[string]bool) json.RawMessage {
 	keepFields := map[string]bool{
 		// Identity
 		"id": true, "name": true, "title": true, "identifier": true,
@@ -2044,6 +2047,11 @@ func compactListFields(items []map[string]any) json.RawMessage {
 		"date": true,
 		// Versioning
 		"version": true,
+	}
+	for _, fields := range documentedFields {
+		for field := range fields {
+			keepFields[field] = true
+		}
 	}
 	if len(items) > 0 {
 		keyCounts := map[string]int{}
@@ -2106,8 +2114,8 @@ func isCompactScalar(v any) bool {
 // "markdown" — those fields are payload on `get` commands and stripping them
 // under `--agent`/`--compact` is a silent loss; agents who want to omit them
 // can pass `--select` to specify only the fields they need.
-func compactObjectFields(obj map[string]any) json.RawMessage {
-	if compacted, ok := compactListEnvelopeObjectAtDepth(obj, 0); ok {
+func compactObjectFields(obj map[string]any, documentedFields ...map[string]bool) json.RawMessage {
+	if compacted, ok := compactListEnvelopeObjectAtDepth(obj, 0, documentedFields...); ok {
 		result, _ := json.Marshal(compacted)
 		return result
 	}
@@ -2121,25 +2129,34 @@ func compactObjectFields(obj map[string]any) json.RawMessage {
 	return result
 }
 
-func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int) (map[string]any, bool) {
+func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int, documentedFields ...map[string]bool) (map[string]any, bool) {
 	out := map[string]any{}
 	foundArray := false
+	payloadArrays := map[string]bool{}
 	for k, v := range obj {
-		if envelopeDepth == 0 && compactVerboseObjectFields[k] {
+		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
+			continue
+		}
+		if _, ok := compactObjectArrayValue(v, documentedFields...); ok {
+			payloadArrays[k] = true
+		}
+	}
+	for k, v := range obj {
+		if envelopeDepth == 0 && compactVerboseObjectFields[k] && (!payloadArrays[k] || len(payloadArrays) > 1) {
 			continue
 		}
 		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
 			out[k] = v
 			continue
 		}
-		if compacted, ok := compactObjectArrayValue(v); ok {
+		if compacted, ok := compactObjectArrayValue(v, documentedFields...); ok {
 			foundArray = true
 			out[k] = compacted
 			continue
 		}
 		if nested, ok := v.(map[string]any); ok {
 			if envelopeDepth < maxListEnvelopeDepth {
-				if compacted, ok := compactListEnvelopeObjectAtDepth(nested, envelopeDepth+1); ok {
+				if compacted, ok := compactListEnvelopeObjectAtDepth(nested, envelopeDepth+1, documentedFields...); ok {
 					foundArray = true
 					out[k] = compacted
 					continue
@@ -2154,7 +2171,7 @@ func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int) (ma
 	return out, true
 }
 
-func compactObjectArrayValue(v any) (any, bool) {
+func compactObjectArrayValue(v any, documentedFields ...map[string]bool) (any, bool) {
 	rawItems, ok := v.([]any)
 	if !ok || len(rawItems) == 0 {
 		return nil, false
@@ -2167,7 +2184,7 @@ func compactObjectArrayValue(v any) (any, bool) {
 		}
 		items = append(items, item)
 	}
-	compactedRaw := compactListFields(items)
+	compactedRaw := compactListFields(items, documentedFields...)
 	var compacted any
 	if err := json.Unmarshal(compactedRaw, &compacted); err != nil {
 		return nil, false

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
@@ -171,7 +171,7 @@ func newProjectsAvatarUploadProjectCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, nil)
 				}
 				if len(filtered) > 0 {
 					var parsed any

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
@@ -196,7 +196,7 @@ func newProjectsCreateCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, map[string]bool{"id": true, "name": true, "status": true, "visibility": true})
 				}
 				if len(filtered) > 0 {
 					var parsed any

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
@@ -78,7 +78,7 @@ func newProjectsListCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, map[string]bool{"id": true, "name": true, "status": true, "visibility": true})
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -107,7 +107,7 @@ func newProjectsListCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, map[string]bool{"id": true, "name": true, "status": true, "visibility": true})
 		},
 	}
 	cmd.Flags().StringVar(&flagXApiVersion, "x-api-version", "2026-04-01", "Required API version header.")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
@@ -98,7 +98,7 @@ func newProjectsTasksListProjectCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, map[string]bool{"due_at": true, "id": true, "priority": true, "project_id": true, "title": true})
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -127,7 +127,7 @@ func newProjectsTasksListProjectCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, map[string]bool{"due_at": true, "id": true, "priority": true, "project_id": true, "title": true})
 		},
 	}
 	cmd.Flags().StringVar(&flagXApiVersion, "x-api-version", "2026-04-01", "Required API version header.")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
@@ -195,7 +195,7 @@ func newProjectsTasksUpdateProjectCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, nil)
 				}
 				if len(filtered) > 0 {
 					var parsed any

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_public.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_public.go
@@ -55,7 +55,7 @@ func newPublicPromotedCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, nil)
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -83,7 +83,7 @@ func newPublicPromotedCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, nil)
 		},
 	}
 

--- a/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/promoted_things.go
+++ b/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/promoted_things.go
@@ -54,7 +54,7 @@ func newThingsPromotedCmd(flags *rootFlags) *cobra.Command {
 			}
 			if isDryRunResponse(c.IsDryRun(), data) {
 				if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
-					return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "dry-run"})
+					return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "dry-run"}, nil)
 				}
 				return nil
 			}
@@ -75,7 +75,7 @@ func newThingsPromotedCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, nil)
 		},
 	}
 

--- a/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/things_list.go
+++ b/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/things_list.go
@@ -51,7 +51,7 @@ func newThingsListCmd(flags *rootFlags) *cobra.Command {
 			}
 			if isDryRunResponse(c.IsDryRun(), data) {
 				if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
-					return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "dry-run"})
+					return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "dry-run"}, nil)
 				}
 				return nil
 			}
@@ -151,7 +151,7 @@ func newThingsListCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, nil)
 				}
 				if len(filtered) > 0 {
 					var parsed any

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
@@ -1349,6 +1349,9 @@ func extractPaginatedItemsMatchingPath(obj map[string]json.RawMessage, requestPa
 var envelopeMetadataArrayKeys = map[string]bool{
 	"errors": true, "Errors": true,
 	"warnings": true, "Warnings": true,
+	// fetch_failures is emitted by fan-out scaffolding. It is bookkeeping,
+	// not a competing domain payload array during compact projection.
+	"fetch_failures": true, "FetchFailures": true,
 }
 
 // envelopeMetadataKeys lists pagination and collection-envelope metadata
@@ -1907,7 +1910,7 @@ func isDryRunResponseForClient(c any, data json.RawMessage) bool {
 	return ok && isDryRunResponse(dryRunClient.IsDryRun(), data)
 }
 
-func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any) error {
+func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any, documentedFields ...map[string]bool) error {
 	if err := validatePlatformAnalytics(flags); err != nil {
 		return err
 	}
@@ -1919,7 +1922,7 @@ func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlag
 	if flags.selectFields != "" {
 		data = filterFields(data, flags.selectFields)
 	} else if flags.compact {
-		data = compactFields(data)
+		data = compactFields(data, documentedFields...)
 	}
 	if flags.agent && flags.asJSON && !flags.csv && !flags.plain && !flags.quiet {
 		wrapped, err := wrapAgentOutput(data, agentMeta)
@@ -1977,17 +1980,17 @@ var compactVerboseObjectFields = map[string]bool{
 // compactFields keeps only the most important fields for agent consumption.
 // For arrays: allowlist of high-gravity fields (no descriptions).
 // For single objects: blocklist that strips known-verbose fields (descriptions, comments, etc.).
-func compactFields(data json.RawMessage) json.RawMessage {
+func compactFields(data json.RawMessage, documentedFields ...map[string]bool) json.RawMessage {
 	// Try array first
 	var items []map[string]any
 	if err := json.Unmarshal(data, &items); err == nil {
-		return compactListFields(items)
+		return compactListFields(items, documentedFields...)
 	}
 
 	// Single object — use blocklist
 	var obj map[string]any
 	if err := json.Unmarshal(data, &obj); err == nil {
-		return compactObjectFields(obj)
+		return compactObjectFields(obj, documentedFields...)
 	}
 
 	return data
@@ -2012,7 +2015,7 @@ func compactFields(data json.RawMessage) json.RawMessage {
 // When an item still carries none of the keep keys, the original is
 // preserved so `--agent` does not silently emit {} for shapes whose key
 // names are entirely off-canonical.
-func compactListFields(items []map[string]any) json.RawMessage {
+func compactListFields(items []map[string]any, documentedFields ...map[string]bool) json.RawMessage {
 	keepFields := map[string]bool{
 		// Identity
 		"id": true, "name": true, "title": true, "identifier": true,
@@ -2034,6 +2037,11 @@ func compactListFields(items []map[string]any) json.RawMessage {
 		"date": true,
 		// Versioning
 		"version": true,
+	}
+	for _, fields := range documentedFields {
+		for field := range fields {
+			keepFields[field] = true
+		}
 	}
 	if len(items) > 0 {
 		keyCounts := map[string]int{}
@@ -2096,8 +2104,8 @@ func isCompactScalar(v any) bool {
 // "markdown" — those fields are payload on `get` commands and stripping them
 // under `--agent`/`--compact` is a silent loss; agents who want to omit them
 // can pass `--select` to specify only the fields they need.
-func compactObjectFields(obj map[string]any) json.RawMessage {
-	if compacted, ok := compactListEnvelopeObjectAtDepth(obj, 0); ok {
+func compactObjectFields(obj map[string]any, documentedFields ...map[string]bool) json.RawMessage {
+	if compacted, ok := compactListEnvelopeObjectAtDepth(obj, 0, documentedFields...); ok {
 		result, _ := json.Marshal(compacted)
 		return result
 	}
@@ -2111,25 +2119,34 @@ func compactObjectFields(obj map[string]any) json.RawMessage {
 	return result
 }
 
-func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int) (map[string]any, bool) {
+func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int, documentedFields ...map[string]bool) (map[string]any, bool) {
 	out := map[string]any{}
 	foundArray := false
+	payloadArrays := map[string]bool{}
 	for k, v := range obj {
-		if envelopeDepth == 0 && compactVerboseObjectFields[k] {
+		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
+			continue
+		}
+		if _, ok := compactObjectArrayValue(v, documentedFields...); ok {
+			payloadArrays[k] = true
+		}
+	}
+	for k, v := range obj {
+		if envelopeDepth == 0 && compactVerboseObjectFields[k] && (!payloadArrays[k] || len(payloadArrays) > 1) {
 			continue
 		}
 		if envelopeMetadataArrayKeys[k] || envelopeMetadataKeys[k] {
 			out[k] = v
 			continue
 		}
-		if compacted, ok := compactObjectArrayValue(v); ok {
+		if compacted, ok := compactObjectArrayValue(v, documentedFields...); ok {
 			foundArray = true
 			out[k] = compacted
 			continue
 		}
 		if nested, ok := v.(map[string]any); ok {
 			if envelopeDepth < maxListEnvelopeDepth {
-				if compacted, ok := compactListEnvelopeObjectAtDepth(nested, envelopeDepth+1); ok {
+				if compacted, ok := compactListEnvelopeObjectAtDepth(nested, envelopeDepth+1, documentedFields...); ok {
 					foundArray = true
 					out[k] = compacted
 					continue
@@ -2144,7 +2161,7 @@ func compactListEnvelopeObjectAtDepth(obj map[string]any, envelopeDepth int) (ma
 	return out, true
 }
 
-func compactObjectArrayValue(v any) (any, bool) {
+func compactObjectArrayValue(v any, documentedFields ...map[string]bool) (any, bool) {
 	rawItems, ok := v.([]any)
 	if !ok || len(rawItems) == 0 {
 		return nil, false
@@ -2157,7 +2174,7 @@ func compactObjectArrayValue(v any) (any, bool) {
 		}
 		items = append(items, item)
 	}
-	compactedRaw := compactListFields(items)
+	compactedRaw := compactListFields(items, documentedFields...)
 	var compacted any
 	if err := json.Unmarshal(compactedRaw, &compacted); err != nil {
 		return nil, false

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
@@ -177,7 +177,7 @@ func newStoresCreateCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, map[string]bool{"id": true, "name": true})
 				}
 				if len(filtered) > 0 {
 					var parsed any

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
@@ -101,7 +101,7 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, map[string]bool{"id": true, "name": true})
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -130,7 +130,7 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, map[string]bool{"id": true, "name": true})
 		},
 	}
 	cmd.Flags().StringVar(&flagS, "address", "", "Street address")

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_games.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_games.go
@@ -55,7 +55,7 @@ func newGamesPromotedCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, nil)
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -83,7 +83,7 @@ func newGamesPromotedCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, nil)
 		},
 	}
 

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_leagues.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_leagues.go
@@ -69,7 +69,7 @@ func newLeaguesPromotedCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, nil)
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -97,7 +97,7 @@ func newLeaguesPromotedCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, nil)
 		},
 	}
 

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_enterprise.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_enterprise.go
@@ -51,7 +51,7 @@ func newItemsEnterpriseCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, nil)
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -80,7 +80,7 @@ func newItemsEnterpriseCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, nil)
 		},
 	}
 

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_list.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_list.go
@@ -51,7 +51,7 @@ func newItemsListCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, nil)
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -80,7 +80,7 @@ func newItemsListCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, nil)
 		},
 	}
 	cmd.Flags().BoolVar(&flagAll, "all", false, "Fetch all pages")

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_premium.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_premium.go
@@ -51,7 +51,7 @@ func newItemsPremiumCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered)
+					filtered = compactFields(filtered, nil)
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -80,7 +80,7 @@ func newItemsPremiumCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, nil)
 		},
 	}
 


### PR DESCRIPTION
## Summary

Compact and select output now preserve documented sparse response fields and raw HAL `_embedded` collections. Compact mode also keeps a response's only payload array, while still removing verbose sidecars when another payload competes and preserving `fetch_failures` bookkeeping.

## Approach

The generator passes response-item wire fields into every endpoint and promoted-command projection path. The emitted compact helper uses those fields as a floor under its frequency heuristic, identifies payload arrays before applying verbose-field rules, and treats `fetch_failures` as envelope metadata.

## Scope

Primary area: generator templates and generated projection helpers.

This belongs in the Printing Press because the behavior is emitted into every printed CLI, including raw-HAL passthrough commands.

## Risk

The change affects generated JSON projection only. Explicit `--select` remains higher priority than `--compact`; non-JSON output paths retain their existing behavior.

## Output Contract

Generated-output assertions cover emitted documented-field maps and projection call sites. A compiled generated CLI runtime matrix covers sparse rows, wrapped arrays, sole and competing payload arrays, `fetch_failures`, and HAL `_embedded` output. Golden and generator-output verification also pass.

## Verification

- `go test ./...`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- Focused generated runtime and generator tests

Closes #4125
Closes #4043
Closes #4096
