### PR TITLE
fix(cli): wire stdin fixtures through verification

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -49,6 +49,7 @@ in the same change as any new `Extensions["x-*"]` lookup in that file.
 | `x-live-dogfood-requires-tier` | path item or operation | `Endpoint.LiveDogfoodRequiresTier` | No |
 | `x-requires-role` | operation | `Endpoint.RequiresRole` | No |
 | `x-happy-args` | operation | `Endpoint.HappyArgs` | No |
+| `x-happy-stdin` | operation | `Endpoint.HappyStdin` | No |
 | `x-pp-example` | operation | `Endpoint.Example` (verbatim Cobra example override) | No |
 | `x-pp-resource` | operation | resource name override | No |
 | `x-pp-pagination` | operation | `Endpoint.Pagination` | No |
@@ -1714,6 +1715,33 @@ paths:
     get:
       operationId: listReferents
       x-happy-args: "--song-id=378195"
+      responses:
+        "200": {description: ok}
+```
+
+### `x-happy-stdin`
+
+Declares a JSON request-body fixture for a live-dogfood command that reads its
+input from stdin. The generator emits the fixture as the `pp:happy-stdin`
+annotation, and the matrix pipes it to both the happy-path and JSON-fidelity
+probes.
+
+Parsed field: `Endpoint.HappyStdin`
+
+Rules:
+- Optional.
+- Must be on an operation, not the root, `info`, or path item.
+- Must be a string containing valid JSON.
+- Commands that require stdin but do not declare this fixture are skipped with
+  reason `no-stdin-fixture`; the runner never synthesizes a request body.
+
+Example:
+
+```yaml
+paths:
+  /widgets/inspect:
+    post:
+      x-happy-stdin: '{"name":"synthetic"}'
       responses:
         "200": {description: ok}
 ```

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -7931,6 +7931,7 @@ func TestEndpointFixturesEmittedFromSpec(t *testing.T) {
 					Params:                  []spec.Param{{Name: "q", Type: "string", Required: true}},
 					Example:                 "  endpoint-fixtures-pp-cli lookup --q example-page",
 					HappyArgs:               "--q=example-page",
+					HappyStdin:              `{"query":"synthetic"}`,
 					LiveDogfoodRequiresTier: "enterprise",
 				},
 			},
@@ -7966,6 +7967,8 @@ func TestEndpointFixturesEmittedFromSpec(t *testing.T) {
 		"promoted command must prefer the spec-declared Cobra example")
 	assert.Contains(t, promoted, `"pp:happy-args": "--q=example-page"`,
 		"promoted command must carry spec-declared happy-path fixtures for live dogfood")
+	assert.Contains(t, promoted, `"pp:happy-stdin": "{\"query\":\"synthetic\"}"`,
+		"promoted command must carry spec-declared stdin fixtures for live dogfood")
 	assert.Contains(t, promoted, `"pp:requires-tier": "enterprise"`,
 		"promoted command must carry spec-declared live dogfood tier requirements")
 

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -79,7 +79,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 		// TODO: replace placeholder example values before relying on this for live dogfood.
 {{- end}}
 		Example: {{printf "%q" $example}},
-		Annotations: map[string]string{ {{- if not .APISpec.IsLocalSQLiteSource}}"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, {{end}}"pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if endpointSkipsErrorPathProbe .Endpoint}}, "pp:no-error-path-probe": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}},
+		Annotations: map[string]string{ {{- if not .APISpec.IsLocalSQLiteSource}}"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, {{end}}"pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if endpointSkipsErrorPathProbe .Endpoint}}, "pp:no-error-path-probe": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.HappyStdin}}, "pp:happy-stdin": {{printf "%q" .Endpoint.HappyStdin}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 {{- if endpointHasRequiredInput .Endpoint}}
 			// Bare invocation of a command with required input prints help

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -66,7 +66,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 		// TODO: replace placeholder example values before relying on this for live dogfood.
 {{- end}}
 		Example: {{printf "%q" $example}},
-		Annotations: map[string]string{ {{- if not .APISpec.IsLocalSQLiteSource}}"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, {{end}}"pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if endpointSkipsErrorPathProbe .Endpoint}}, "pp:no-error-path-probe": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}},
+		Annotations: map[string]string{ {{- if not .APISpec.IsLocalSQLiteSource}}"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, {{end}}"pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if endpointSkipsErrorPathProbe .Endpoint}}, "pp:no-error-path-probe": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.HappyStdin}}, "pp:happy-stdin": {{printf "%q" .Endpoint.HappyStdin}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 {{- if endpointHasRequiredInput .Endpoint}}
 			// Bare invocation of a command with a required flag/body prints help

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -74,6 +74,7 @@ const (
 	extensionPPPagination          = "x-pp-pagination"
 	extensionSyncWalker            = "x-pp-sync-walker"
 	extensionHappyArgs             = "x-happy-args"
+	extensionHappyStdin            = "x-happy-stdin"
 	extensionPPExample             = "x-pp-example"
 	extensionLiveDogfoodTier       = "x-live-dogfood-requires-tier"
 	extensionDispatchParam         = "x-pp-dispatch-param"
@@ -3648,6 +3649,7 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) error {
 				endpoint.DataSourceStrategy = pathDataSourceStrategy
 			}
 			endpoint.HappyArgs = readHappyArgsExtension(op.Extensions, fmt.Sprintf("%s %q", strings.ToUpper(method), path))
+			endpoint.HappyStdin = readHappyStdinExtension(op.Extensions, fmt.Sprintf("%s %q", strings.ToUpper(method), path))
 			if ex := readExampleExtension(op.Extensions, fmt.Sprintf("%s %q", strings.ToUpper(method), path)); ex != "" {
 				endpoint.Example = ex
 			}
@@ -5909,6 +5911,27 @@ func readHappyArgsExtension(extensions map[string]any, context string) string {
 		return ""
 	}
 	return strings.TrimSpace(value)
+}
+
+func readHappyStdinExtension(extensions map[string]any, context string) string {
+	if extensions == nil {
+		return ""
+	}
+	raw, ok := extensions[extensionHappyStdin]
+	if !ok || raw == nil {
+		return ""
+	}
+	value, ok := raw.(string)
+	if !ok {
+		warnf("%s: %s must be a string, got %T; ignoring", context, extensionHappyStdin, raw)
+		return ""
+	}
+	value = strings.TrimSpace(value)
+	if value == "" || !json.Valid([]byte(value)) {
+		warnf("%s: %s must contain valid JSON; ignoring", context, extensionHappyStdin)
+		return ""
+	}
+	return value
 }
 
 // readExampleExtension reads an operation-level x-pp-example string and returns

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -8131,6 +8131,52 @@ paths:
 	require.Empty(t, songs.HappyArgs)
 }
 
+func TestParseHappyStdinExtension(t *testing.T) {
+	t.Parallel()
+
+	specYAML := []byte(`
+openapi: 3.0.0
+info:
+  title: stdin fixtures
+  version: "1"
+paths:
+  /items:
+    post:
+      x-happy-stdin: '{"name":"synthetic"}'
+      responses:
+        "200":
+          description: ok
+`)
+
+	parsed, err := ParseWithOptions(specYAML, ParseOptions{Path: "stdin-fixture.yaml"})
+	require.NoError(t, err)
+	endpoint := parsed.Resources["items"].Endpoints["create"]
+	require.NotNil(t, endpoint)
+	assert.Equal(t, `{"name":"synthetic"}`, endpoint.HappyStdin)
+}
+
+func TestParseHappyStdinExtensionRejectsInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	specYAML := []byte(`
+openapi: 3.0.0
+info:
+  title: stdin fixtures
+  version: "1"
+paths:
+  /items:
+    post:
+      x-happy-stdin: not-json
+      responses:
+        "200":
+          description: ok
+`)
+
+	parsed, err := ParseWithOptions(specYAML, ParseOptions{Path: "stdin-fixture.yaml"})
+	require.NoError(t, err)
+	assert.Empty(t, parsed.Resources["items"].Endpoints["create"].HappyStdin)
+}
+
 func TestParseExampleExtension(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -1561,7 +1561,7 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 	}
 	happyArgs, ok, parsedHappyArgs := liveDogfoodHappyArgsParsed(command)
 	if stdinFixture != "" {
-		happyArgs = append(append([]string{}, command.Path...), "--stdin")
+		happyArgs = liveDogfoodAppendStdinArg(happyArgs)
 		ok = true
 	}
 	if !ok {
@@ -1796,11 +1796,12 @@ func commandSupportsSearch(help string) bool {
 	return slices.Contains(extractPositionalPlaceholders(liveDogfoodUsageSuffix(help)), "query")
 }
 
-// liveDogfoodCommandStdinOnly identifies generated body commands that have no
-// runnable input other than --stdin. These commands must either declare a
-// pp:happy-stdin fixture or be reported as an honest matrix skip.
+// liveDogfoodCommandStdinOnly reports body commands with no command-local
+// request input besides --stdin. Inherited global flags are runner controls,
+// not request inputs, so they do not prevent the honest no-fixture skip.
 func liveDogfoodCommandStdinOnly(command liveDogfoodCommand) bool {
-	if !slices.Contains(extractFlagNames(extractFlagsSection(command.Help)), "stdin") ||
+	flags := extractCommandFlagsSection(command.Help)
+	if !slices.Contains(extractFlagNames(flags), "stdin") ||
 		liveDogfoodCommandTakesArg(command.Help) {
 		return false
 	}
@@ -1808,12 +1809,39 @@ func liveDogfoodCommandStdinOnly(command liveDogfoodCommand) bool {
 		"all": true, "content-type": true, "dry-run": true, "file": true,
 		"json": true, "stdin": true,
 	}
-	for _, name := range extractFlagNames(extractFlagsSection(command.Help)) {
+	for _, name := range extractFlagNames(flags) {
 		if !allowed[name] {
 			return false
 		}
 	}
 	return true
+}
+
+// extractCommandFlagsSection returns only the command-local Cobra "Flags:"
+// block. "Global Flags:" contains process controls such as --config and
+// --timeout, which are not request inputs for stdin-only classification.
+func extractCommandFlagsSection(help string) string {
+	lines := strings.Split(help, "\n")
+	var out []string
+	inFlags := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "Flags:" {
+			inFlags = true
+			continue
+		}
+		if trimmed == "Global Flags:" {
+			inFlags = false
+			continue
+		}
+		if inFlags {
+			if trimmed == "" {
+				break
+			}
+			out = append(out, line)
+		}
+	}
+	return strings.Join(out, "\n")
 }
 
 // extractFlagsSection returns the body of a Cobra `--help` "Flags:" or
@@ -2292,6 +2320,15 @@ func fileExistsRelativeTo(p, cliDir string) bool {
 func liveDogfoodHappyArgs(command liveDogfoodCommand) ([]string, bool) {
 	args, ok, _ := liveDogfoodHappyArgsParsed(command)
 	return args, ok
+}
+
+func liveDogfoodAppendStdinArg(args []string) []string {
+	if slices.ContainsFunc(args, func(arg string) bool {
+		return arg == "--stdin" || strings.HasPrefix(arg, "--stdin=")
+	}) {
+		return args
+	}
+	return append(append([]string{}, args...), "--stdin")
 }
 
 func liveDogfoodHappyArgsParsed(command liveDogfoodCommand) ([]string, bool, happyArgs) {

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -72,6 +72,7 @@ const reasonFeatureAbsentFixture = "blocked-fixture: feature absent for runner c
 const reasonNoErrorPathProbeAnnotation = "no-error-path-probe annotation"
 const reasonInteractiveCommand = "interactive command requires human input"
 const reasonUnsynthesizableBody = "unsynthesizable-body"
+const reasonNoStdinFixture = "no-stdin-fixture"
 
 // dogfoodEnvVar is the env signal every live-dogfood subprocess
 // inherits. Generated commands with a long-running happy path detect
@@ -1426,7 +1427,7 @@ func normalizeLiveDogfoodPath(path string) string {
 }
 
 func liveDogfoodUnsynthesizableBodyFixtureSkip(command liveDogfoodCommand, fixtures []liveDogfoodBodyFixture) string {
-	if strings.TrimSpace(command.Annotations[happyArgsAnnotation]) == "" {
+	if strings.TrimSpace(command.Annotations[happyArgsAnnotation]) == "" && strings.TrimSpace(command.Annotations[happyStdinAnnotation]) == "" {
 		endpointName := strings.TrimSpace(command.Annotations[endpointAnnotation])
 		if endpointName == "" {
 			return ""
@@ -1537,7 +1538,32 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 	}
 
 	bodyFixtureSkip := liveDogfoodUnsynthesizableBodyFixtureSkip(command, ctx.bodyFixtures)
+	stdinFixture := strings.TrimSpace(command.Annotations[happyStdinAnnotation])
+	stdinOnly := liveDogfoodCommandStdinOnly(command)
+	if stdinOnly && stdinFixture == "" {
+		results = append(results,
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, reasonNoStdinFixture),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, reasonNoStdinFixture),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestError, reasonNoStdinFixture),
+		)
+		return results
+	}
+	var stdinPayload []byte
+	if stdinFixture != "" {
+		stdinPayload = []byte(stdinFixture)
+		if !json.Valid(stdinPayload) {
+			results = append(results,
+				failedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, nil, "invalid pp:happy-stdin fixture"),
+				failedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, nil, "invalid pp:happy-stdin fixture"),
+			)
+			return results
+		}
+	}
 	happyArgs, ok, parsedHappyArgs := liveDogfoodHappyArgsParsed(command)
+	if stdinFixture != "" {
+		happyArgs = append(append([]string{}, command.Path...), "--stdin")
+		ok = true
+	}
 	if !ok {
 		if bodyFixtureSkip != "" {
 			results = append(results,
@@ -1600,7 +1626,7 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 		runArgs = protectLiveDogfoodNegativeNumericPositionals(runArgs, command.Path,
 			len(extractPositionalPlaceholders(liveDogfoodUsageSuffix(command.Help))), liveDogfoodFlagValueNames(command.Help), liveDogfoodFlagNames(command.Help))
 
-		happyRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, runArgs, ctx.timeout)
+		happyRun := runLiveDogfoodProcessWithStdin(ctx.binaryPath, ctx.cliDir, runArgs, ctx.timeout, stdinPayload)
 		happyResult := liveDogfoodResult(commandName, LiveDogfoodTestHappy, runArgs, happyRun, ctx.authEnvValue)
 		happyResult.FixtureSource = fixtureSource
 		if successCodes[happyRun.exitCode] {
@@ -1638,7 +1664,7 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 				jsonArgs = removeNonJSONOutputModes(jsonArgs)
 			}
 			jsonArgs = appendJSONArg(jsonArgs)
-			jsonRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, jsonArgs, ctx.timeout)
+			jsonRun := runLiveDogfoodProcessWithStdin(ctx.binaryPath, ctx.cliDir, jsonArgs, ctx.timeout, stdinPayload)
 			jsonResult := liveDogfoodResult(commandName, LiveDogfoodTestJSON, jsonArgs, jsonRun, ctx.authEnvValue)
 			jsonResult.FixtureSource = fixtureSource
 			if jsonRun.exitCode == 0 {
@@ -1770,6 +1796,26 @@ func commandSupportsSearch(help string) bool {
 	return slices.Contains(extractPositionalPlaceholders(liveDogfoodUsageSuffix(help)), "query")
 }
 
+// liveDogfoodCommandStdinOnly identifies generated body commands that have no
+// runnable input other than --stdin. These commands must either declare a
+// pp:happy-stdin fixture or be reported as an honest matrix skip.
+func liveDogfoodCommandStdinOnly(command liveDogfoodCommand) bool {
+	if !slices.Contains(extractFlagNames(extractFlagsSection(command.Help)), "stdin") ||
+		liveDogfoodCommandTakesArg(command.Help) {
+		return false
+	}
+	allowed := map[string]bool{
+		"all": true, "content-type": true, "dry-run": true, "file": true,
+		"json": true, "stdin": true,
+	}
+	for _, name := range extractFlagNames(extractFlagsSection(command.Help)) {
+		if !allowed[name] {
+			return false
+		}
+	}
+	return true
+}
+
 // extractFlagsSection returns the body of a Cobra `--help` "Flags:" or
 // "Global Flags:" block — everything from the section header through the
 // next blank line. Used to scope flag-name extraction so cross-reference
@@ -1796,8 +1842,12 @@ func extractFlagsSection(help string) string {
 }
 
 func runLiveDogfoodProcess(binaryPath, cliDir string, args []string, timeout time.Duration) liveDogfoodRun {
+	return runLiveDogfoodProcessWithStdin(binaryPath, cliDir, args, timeout, nil)
+}
+
+func runLiveDogfoodProcessWithStdin(binaryPath, cliDir string, args []string, timeout time.Duration, stdin []byte) liveDogfoodRun {
 	deadline := time.Now().Add(timeout)
-	run := runLiveDogfoodProcessOnce(binaryPath, cliDir, args, timeout)
+	run := runLiveDogfoodProcessOnceWithStdin(binaryPath, cliDir, args, timeout, stdin)
 	if !liveDogfoodRetryableAuth401(run) || time.Until(deadline) <= liveDogfoodAuthRetryDelay {
 		return run
 	}
@@ -1806,10 +1856,10 @@ func runLiveDogfoodProcess(binaryPath, cliDir string, args []string, timeout tim
 	if remaining <= 0 {
 		return run
 	}
-	return runLiveDogfoodProcessOnce(binaryPath, cliDir, args, remaining)
+	return runLiveDogfoodProcessOnceWithStdin(binaryPath, cliDir, args, remaining, stdin)
 }
 
-func runLiveDogfoodProcessOnce(binaryPath, cliDir string, args []string, timeout time.Duration) liveDogfoodRun {
+func runLiveDogfoodProcessOnceWithStdin(binaryPath, cliDir string, args []string, timeout time.Duration, stdin []byte) liveDogfoodRun {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -1839,6 +1889,9 @@ func runLiveDogfoodProcessOnce(binaryPath, cliDir string, args []string, timeout
 		cmd.Stdout = stdoutCap
 	}
 	cmd.Stderr = stderrCap
+	if stdin != nil {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
 
 	err := cmd.Run()
 	rawJSONValid := false

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -271,6 +271,56 @@ func TestRunLiveDogfoodRunsBodyFixtureWhenHappyArgsProvided(t *testing.T) {
 	}
 }
 
+func TestRunLiveDogfoodRunsHappyStdinFixture(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir, binaryName := writeLiveDogfoodStdinFixture(t, `{"name":"synthetic"}`)
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "PASS", report.Verdict, report.Tests)
+
+	happy := findResultByCommandKind(report, "widgets inspect", LiveDogfoodTestHappy)
+	require.NotNil(t, happy)
+	assert.Equal(t, LiveDogfoodStatusPass, happy.Status, happy.Reason)
+	assert.Equal(t, []string{"widgets", "inspect", "--stdin"}, happy.Args)
+
+	jsonResult := findResultByCommandKind(report, "widgets inspect", LiveDogfoodTestJSON)
+	require.NotNil(t, jsonResult)
+	assert.Equal(t, LiveDogfoodStatusPass, jsonResult.Status, jsonResult.Reason)
+	assert.Equal(t, []string{"widgets", "inspect", "--stdin", "--json"}, jsonResult.Args)
+}
+
+func TestRunLiveDogfoodSkipsUnannotatedStdinOnlyCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir, binaryName := writeLiveDogfoodStdinFixture(t, "")
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "PASS", report.Verdict, report.Tests)
+
+	for _, kind := range []LiveDogfoodTestKind{LiveDogfoodTestHappy, LiveDogfoodTestJSON} {
+		result := findResultByCommandKind(report, "widgets inspect", kind)
+		require.NotNil(t, result)
+		assert.Equal(t, LiveDogfoodStatusSkip, result.Status)
+		assert.Equal(t, reasonNoStdinFixture, result.Reason)
+		assert.Empty(t, result.Args)
+	}
+}
+
 func TestRunLiveDogfoodWritesAcceptanceMarkerOnPass(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")
@@ -4694,6 +4744,66 @@ echo "unexpected args: $*" >&2
 exit 99
 `, annotation)
 	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755))
+	return dir, binaryName
+}
+
+func writeLiveDogfoodStdinFixture(t *testing.T, happyStdin string) (dir string, binaryName string) {
+	t.Helper()
+
+	dir = t.TempDir()
+	binaryName = "fixture-pp-cli"
+	writeTestManifestForLiveDogfood(t, dir)
+	annotation := ""
+	if happyStdin != "" {
+		annotation = fmt.Sprintf(`,"pp:happy-stdin":%q`, happyStdin)
+	}
+	script := fmt.Sprintf(`#!/bin/sh
+set -u
+
+if [ "${1:-}" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"widgets","subcommands":[
+      {"name":"inspect","annotations":{"pp:endpoint":"widgets.inspect","pp:method":"POST","pp:path":"/widgets/inspect"%s}}
+    ]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "${1:-}" = "widgets" ] && [ "${2:-}" = "inspect" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Inspect widgets.
+
+Usage:
+  fixture-pp-cli widgets inspect [flags]
+
+Examples:
+  fixture-pp-cli widgets inspect --stdin
+
+Flags:
+      --json    Output JSON
+      --stdin   Read request body from stdin
+HELP
+  exit 0
+fi
+
+if [ "${1:-}" = "widgets" ] && [ "${2:-}" = "inspect" ]; then
+  input=$(cat)
+  if [ "$input" != '{"name":"synthetic"}' ]; then
+    echo "unexpected stdin: $input" >&2
+    exit 99
+  fi
+  echo '{"ok":true}'
+  exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`, annotation)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, binaryName), []byte(script), 0o755))
 	return dir, binaryName
 }
 

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -321,6 +321,50 @@ func TestRunLiveDogfoodSkipsUnannotatedStdinOnlyCommand(t *testing.T) {
 	}
 }
 
+func TestLiveDogfoodStdinOnlyIgnoresGlobalFlags(t *testing.T) {
+	command := liveDogfoodCommand{Help: `
+Usage:
+  fixture-pp-cli widgets inspect [flags]
+
+Flags:
+      --json    Output JSON
+      --stdin   Read request body from stdin
+
+Global Flags:
+      --config   Config path
+      --timeout  Request timeout
+      --compact  Compact output
+`}
+
+	assert.True(t, liveDogfoodCommandStdinOnly(command))
+}
+
+func TestLiveDogfoodStdinFixturePreservesHappyArgs(t *testing.T) {
+	command := liveDogfoodCommand{
+		Path: []string{"widgets", "inspect"},
+		Help: `
+Usage:
+  fixture-pp-cli widgets inspect [flags]
+
+Examples:
+  fixture-pp-cli widgets inspect --name=synthetic
+
+Flags:
+      --name    Widget name
+      --stdin   Read request body from stdin
+`,
+		Annotations: map[string]string{
+			happyStdinAnnotation: `{"body":"synthetic"}`,
+		},
+	}
+
+	happyArgs, ok, _ := liveDogfoodHappyArgsParsed(command)
+	require.True(t, ok)
+	happyArgs = liveDogfoodAppendStdinArg(happyArgs)
+
+	assert.Equal(t, []string{"widgets", "inspect", "--name=synthetic", "--stdin"}, happyArgs)
+}
+
 func TestRunLiveDogfoodWritesAcceptanceMarkerOnPass(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")

--- a/internal/pipeline/runtime_annotations.go
+++ b/internal/pipeline/runtime_annotations.go
@@ -41,7 +41,7 @@ func sourceCommandAnnotations(dir string) map[string]map[string]string {
 	out := map[string]map[string]string{}
 	for _, path := range files {
 		data, err := os.ReadFile(path)
-		if err != nil || (!bytes.Contains(data, []byte(typedExitCodesAnnotation)) && !bytes.Contains(data, []byte(happyArgsAnnotation))) {
+		if err != nil || (!bytes.Contains(data, []byte(typedExitCodesAnnotation)) && !bytes.Contains(data, []byte(happyArgsAnnotation)) && !bytes.Contains(data, []byte(happyStdinAnnotation))) {
 			continue
 		}
 		file, err := parser.ParseFile(fset, path, data, parser.SkipObjectResolution)

--- a/internal/pipeline/runtime_commands.go
+++ b/internal/pipeline/runtime_commands.go
@@ -115,7 +115,10 @@ type discoveredCommand struct {
 	Annotations map[string]string
 }
 
-const happyArgsAnnotation = "pp:happy-args"
+const (
+	happyArgsAnnotation  = "pp:happy-args"
+	happyStdinAnnotation = "pp:happy-stdin"
+)
 
 type happyArgs struct {
 	positionals []string

--- a/internal/pipeline/workflow_manifest.go
+++ b/internal/pipeline/workflow_manifest.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,6 +28,7 @@ type WorkflowStep struct {
 	Command      string            `yaml:"command" json:"command"`
 	Args         map[string]string `yaml:"args,omitempty" json:"args,omitempty"`
 	ArgsStdin    bool              `yaml:"args_stdin,omitempty" json:"args_stdin,omitempty"`
+	StdinJSON    map[string]any    `yaml:"stdin_json,omitempty" json:"stdin_json,omitempty"`
 	Extract      map[string]string `yaml:"extract,omitempty" json:"extract,omitempty"`
 	Mode         StepMode          `yaml:"mode" json:"mode"`
 	ExpectFields []string          `yaml:"expect_fields,omitempty" json:"expect_fields,omitempty"`
@@ -101,7 +103,9 @@ func LoadWorkflowManifest(dir string) (*WorkflowManifest, error) {
 	}
 
 	var manifest WorkflowManifest
-	if err := yaml.Unmarshal(data, &manifest); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&manifest); err != nil {
 		return nil, fmt.Errorf("parsing workflow manifest: %w", err)
 	}
 

--- a/internal/pipeline/workflow_manifest_test.go
+++ b/internal/pipeline/workflow_manifest_test.go
@@ -34,6 +34,9 @@ const testManifestYAML = `workflows:
         mode: local
       - command: "orders price_order"
         args_stdin: true
+        stdin_json:
+          input:
+            ref: "thing:synthetic"
         mode: mock
         expect_fields:
           - "Order.Amounts.Customer"
@@ -87,6 +90,9 @@ func TestLoadWorkflowManifest_Valid(t *testing.T) {
 	assert.Equal(t, "orders price_order", s4.Command)
 	assert.Equal(t, StepModeMock, s4.Mode)
 	assert.True(t, s4.ArgsStdin)
+	assert.Equal(t, map[string]any{
+		"input": map[string]any{"ref": "thing:synthetic"},
+	}, s4.StdinJSON)
 	assert.Equal(t, []string{"Order.Amounts.Customer", "Order.Products"}, s4.ExpectFields)
 }
 
@@ -106,6 +112,23 @@ func TestLoadWorkflowManifest_InvalidYAML(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, m)
 	assert.Contains(t, err.Error(), "parsing workflow manifest")
+}
+
+func TestLoadWorkflowManifest_RejectsUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "workflow_verify.yaml"), `workflows:
+  - name: test
+    steps:
+      - command: inspect
+        mode: local
+        stdin_json: {input: ok}
+        unsupported: true
+`)
+
+	m, err := LoadWorkflowManifest(dir)
+	assert.Error(t, err)
+	assert.Nil(t, m)
+	assert.Contains(t, err.Error(), "unsupported")
 }
 
 func TestPrimaryWorkflow(t *testing.T) {

--- a/internal/pipeline/workflow_verify.go
+++ b/internal/pipeline/workflow_verify.go
@@ -147,11 +147,24 @@ func executeStep(binary string, step WorkflowStep, cmdExpanded string, dir strin
 
 	var output string
 	var cmdErr error
+	var stdin []byte
+	if step.ArgsStdin {
+		var err error
+		stdin, err = json.Marshal(step.StdinJSON)
+		if err != nil {
+			sr.Status = StepStatusFailCLIBug
+			sr.Error = fmt.Sprintf("invalid stdin_json payload: %v", err)
+			return sr
+		}
+	}
 
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		cmd := exec.CommandContext(ctx, binary, args...)
 		cmd.Dir = dir
+		if stdin != nil {
+			cmd.Stdin = strings.NewReader(string(stdin))
+		}
 		applyDefaultSubprocessEnv(cmd)
 		// Strip verify-mode env from the subprocess so an inherited
 		// PRINTING_PRESS_VERIFY=1 cannot short-circuit the live workflow

--- a/internal/pipeline/workflow_verify.go
+++ b/internal/pipeline/workflow_verify.go
@@ -138,6 +138,9 @@ func executeStep(binary string, step WorkflowStep, cmdExpanded string, dir strin
 	}
 
 	args := strings.Fields(cmdExpanded)
+	if step.ArgsStdin && !workflowArgsContainFlag(args, "stdin") {
+		args = append(args, "--stdin")
+	}
 	args = append(args, "--json")
 
 	maxAttempts := 1
@@ -230,6 +233,16 @@ func executeStep(binary string, step WorkflowStep, cmdExpanded string, dir strin
 
 	sr.Status = StepStatusPass
 	return sr
+}
+
+func workflowArgsContainFlag(args []string, name string) bool {
+	prefix := "--" + name
+	for _, arg := range args {
+		if arg == prefix || strings.HasPrefix(arg, prefix+"=") {
+			return true
+		}
+	}
+	return false
 }
 
 // classifyError determines the step status from a command failure.

--- a/internal/pipeline/workflow_verify.go
+++ b/internal/pipeline/workflow_verify.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -138,7 +139,7 @@ func executeStep(binary string, step WorkflowStep, cmdExpanded string, dir strin
 	}
 
 	args := strings.Fields(cmdExpanded)
-	if step.ArgsStdin && !workflowArgsContainFlag(args, "stdin") {
+	if step.ArgsStdin && !workflowArgsEnableFlag(args, "stdin") {
 		args = append(args, "--stdin")
 	}
 	args = append(args, "--json")
@@ -235,11 +236,18 @@ func executeStep(binary string, step WorkflowStep, cmdExpanded string, dir strin
 	return sr
 }
 
-func workflowArgsContainFlag(args []string, name string) bool {
+func workflowArgsEnableFlag(args []string, name string) bool {
 	prefix := "--" + name
 	for _, arg := range args {
-		if arg == prefix || strings.HasPrefix(arg, prefix+"=") {
+		if arg == prefix {
 			return true
+		}
+		value, ok := strings.CutPrefix(arg, prefix+"=")
+		if ok {
+			enabled, err := strconv.ParseBool(value)
+			if err == nil && enabled {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/pipeline/workflow_verify_test.go
+++ b/internal/pipeline/workflow_verify_test.go
@@ -4,11 +4,37 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestExecuteStepWiresStdinJSON(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir := t.TempDir()
+	binary := filepath.Join(dir, "stdin-cli")
+	writeTestFile(t, binary, `#!/bin/sh
+set -eu
+[ "$1" = "inspect" ]
+cat
+`)
+	require.NoError(t, os.Chmod(binary, 0o755))
+
+	result := executeStep(binary, WorkflowStep{
+		Command:   "inspect",
+		ArgsStdin: true,
+		StdinJSON: map[string]any{"input": map[string]any{"ref": "thing:synthetic"}},
+		Mode:      StepModeLocal,
+	}, "inspect", dir)
+
+	assert.Equal(t, StepStatusPass, result.Status, result.Error)
+	assert.JSONEq(t, `{"input":{"ref":"thing:synthetic"}}`, result.Output)
+}
 
 func TestRunWorkflowVerification_NoManifest(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/pipeline/workflow_verify_test.go
+++ b/internal/pipeline/workflow_verify_test.go
@@ -21,6 +21,7 @@ func TestExecuteStepWiresStdinJSON(t *testing.T) {
 	writeTestFile(t, binary, `#!/bin/sh
 set -eu
 [ "$1" = "inspect" ]
+[ "$2" = "--stdin" ]
 cat
 `)
 	require.NoError(t, os.Chmod(binary, 0o755))
@@ -34,6 +35,12 @@ cat
 
 	assert.Equal(t, StepStatusPass, result.Status, result.Error)
 	assert.JSONEq(t, `{"input":{"ref":"thing:synthetic"}}`, result.Output)
+}
+
+func TestWorkflowArgsContainFlag(t *testing.T) {
+	assert.True(t, workflowArgsContainFlag([]string{"inspect", "--stdin"}, "stdin"))
+	assert.True(t, workflowArgsContainFlag([]string{"inspect", "--stdin=true"}, "stdin"))
+	assert.False(t, workflowArgsContainFlag([]string{"inspect", "--json"}, "stdin"))
 }
 
 func TestRunWorkflowVerification_NoManifest(t *testing.T) {

--- a/internal/pipeline/workflow_verify_test.go
+++ b/internal/pipeline/workflow_verify_test.go
@@ -37,10 +37,11 @@ cat
 	assert.JSONEq(t, `{"input":{"ref":"thing:synthetic"}}`, result.Output)
 }
 
-func TestWorkflowArgsContainFlag(t *testing.T) {
-	assert.True(t, workflowArgsContainFlag([]string{"inspect", "--stdin"}, "stdin"))
-	assert.True(t, workflowArgsContainFlag([]string{"inspect", "--stdin=true"}, "stdin"))
-	assert.False(t, workflowArgsContainFlag([]string{"inspect", "--json"}, "stdin"))
+func TestWorkflowArgsEnableFlag(t *testing.T) {
+	assert.True(t, workflowArgsEnableFlag([]string{"inspect", "--stdin"}, "stdin"))
+	assert.True(t, workflowArgsEnableFlag([]string{"inspect", "--stdin=true"}, "stdin"))
+	assert.False(t, workflowArgsEnableFlag([]string{"inspect", "--stdin=false"}, "stdin"))
+	assert.False(t, workflowArgsEnableFlag([]string{"inspect", "--json"}, "stdin"))
 }
 
 func TestRunWorkflowVerification_NoManifest(t *testing.T) {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -2311,6 +2311,10 @@ type Endpoint struct {
 	// conditional input contract. The runtime consumes it from the generated
 	// Cobra annotation `pp:happy-args`.
 	HappyArgs string `yaml:"happy_args,omitempty" json:"happy_args,omitempty"`
+	// HappyStdin declares a JSON request-body fixture for live dogfood probes
+	// of commands whose input is read from stdin. The generator emits it as
+	// the `pp:happy-stdin` Cobra annotation.
+	HappyStdin string `yaml:"happy_stdin,omitempty" json:"happy_stdin,omitempty"`
 	// LiveDogfoodRequiresTier declares the runner credential tier required
 	// before live dogfood should probe this endpoint. It is dogfood-only and
 	// does not select an upstream auth route; the runtime consumes it from the

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -239,6 +239,7 @@ resources:
         path: /geography/counties
         example: "fixture-api-pp-cli geography counties --zip 60614"
         happy_args: "--zip=60614"
+        happy_stdin: '{"query":"synthetic"}'
         live_dogfood_requires_tier: enterprise
         params:
           - name: zip
@@ -255,6 +256,7 @@ resources:
 	counties := s.Resources["geography"].Endpoints["counties"]
 	assert.Equal(t, "fixture-api-pp-cli geography counties --zip 60614", counties.Example)
 	assert.Equal(t, "--zip=60614", counties.HappyArgs)
+	assert.Equal(t, `{"query":"synthetic"}`, counties.HappyStdin)
 	assert.Equal(t, "enterprise", counties.LiveDogfoodRequiresTier)
 
 	states := s.Resources["geography"].Endpoints["states"]


### PR DESCRIPTION
## Intent

Live dogfood could not execute request-body commands whose only input was stdin, and workflow verification discarded declared stdin payloads. This PR makes JSON stdin fixtures executable, reports unannotated stdin-only commands with `no-stdin-fixture`, wires workflow `stdin_json` into subprocesses, and rejects unknown manifest fields.

Issue: #4132, #3983

## Approach

Add the operation-level `x-happy-stdin` fixture contract and emit it as `pp:happy-stdin` in generated commands. The live matrix pipes declared JSON to happy-path and JSON probes, while unannotated stdin-only commands receive an explicit skip instead of a synthesized body. Workflow manifests now decode `stdin_json` strictly and pass its JSON bytes to every retry attempt.

## Scope

Primary area: Printing Press generator/spec metadata and internal pipeline verification runners.

Why this belongs in this repo: both failures are systemic verification behavior in the Printing Press, not fixes for one printed CLI.

## Risk

The change affects generated command annotations, live dogfood subprocess input, workflow manifest compatibility, and verifier verdicts. Invalid stdin fixtures fail clearly; missing fixtures skip honestly. Existing non-stdin command paths keep the prior subprocess behavior.

## Output Contract

Generated commands may now contain `pp:happy-stdin`. Workflow manifests may now contain `stdin_json`, and unknown manifest fields fail parsing. The new contracts are covered by emitted-code assertions, parser tests, workflow tests, and golden verification.

## Verification

- `go test ./internal/pipeline -run 'TestRunLiveDogfoodRunsHappyStdinFixture|TestRunLiveDogfoodSkipsUnannotatedStdinOnlyCommand|TestExecuteStepWiresStdinJSON|TestLoadWorkflowManifest_RejectsUnknownFields|TestLoadWorkflowManifest_Valid' -count=1`
- Focused OpenAPI, spec, and generator tests
- `scripts/golden.sh verify` (32 cases)
- `scripts/verify-generator-output.sh`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...` reports one unrelated pre-existing `slicesbackward` warning in `internal/googlediscovery/parser.go`

Closes #4132
Closes #3983
