### PR TITLE
fix(cli): harden generated SQLite concurrency

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -4311,17 +4311,55 @@ func TestGenerateStoreDSNOrdersBusyTimeoutBeforeJournalMode(t *testing.T) {
 	// the read-write DSN, so a file-wide strings.Index for it always hits
 	// the read-only DSN first and the ordering check passes regardless of
 	// the read-write DSN's internal order. Scope the busy_timeout search to
-	// the read-write DSN by starting at its "?_pragma=" query prefix — the
-	// read-only DSN begins with "?mode=ro&_pragma=", so "?_pragma=" uniquely
-	// marks the read-write query string.
+	// the read-write DSN by starting at its "?_txlock=immediate" query prefix —
+	// the read-only DSN begins with "?mode=ro", so this uniquely marks the
+	// read-write query string.
 	idxJournal := strings.Index(codeOnly, "_pragma=journal_mode(WAL)")
 	require.GreaterOrEqual(t, idxJournal, 0, "read-write DSN must set journal_mode(WAL)")
-	dsnStart := strings.LastIndex(codeOnly[:idxJournal], "?_pragma=")
+	dsnStart := strings.LastIndex(codeOnly[:idxJournal], "?_txlock=immediate")
 	require.GreaterOrEqual(t, dsnStart, 0,
-		"read-write DSN must list busy_timeout(5000) before journal_mode(WAL): no ?_pragma= query prefix precedes journal_mode(WAL) (see #2926)")
+		"read-write DSN must list busy_timeout(5000) before journal_mode(WAL): no ?_txlock=immediate query prefix precedes journal_mode(WAL) (see #2926)")
 	idxBusy := strings.Index(codeOnly[dsnStart:idxJournal], "_pragma=busy_timeout(5000)")
 	require.GreaterOrEqual(t, idxBusy, 0,
 		"read-write DSN must list busy_timeout(5000) before journal_mode(WAL) so the WAL conversion runs with the busy handler active (see #2926)")
+}
+
+// TestGenerateStoreDSNUsesImmediateTransactionsAndProfileJournalMode pins
+// the two profile shapes that share the generated store. Cache-enabled
+// profiles write local state during reads and must avoid WAL sidecars; the
+// default store profile retains WAL for concurrent analytical reads.
+func TestGenerateStoreDSNUsesImmediateTransactionsAndProfileJournalMode(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		cache       bool
+		journalMode string
+		otherMode   string
+	}{
+		{name: "default WAL", journalMode: "WAL", otherMode: "TRUNCATE"},
+		{name: "cache rollback journal", cache: true, journalMode: "TRUNCATE", otherMode: "WAL"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			apiSpec := minimalSpec("dsn-concurrency-" + strings.ToLower(strings.ReplaceAll(tc.name, " ", "-")))
+			apiSpec.Cache.Enabled = tc.cache
+			outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+			gen := New(apiSpec, outputDir)
+			gen.VisionSet = VisionTemplateSet{Store: true, MCP: true}
+			require.NoError(t, gen.Generate())
+
+			storeSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+			require.NoError(t, err)
+			codeOnly := stripGoComments(string(storeSrc))
+
+			assert.Contains(t, codeOnly, "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode("+tc.journalMode+")",
+				"read-write DSN must acquire immediate transactions and select the profile journal mode")
+			assert.NotContains(t, codeOnly, "_pragma=journal_mode("+tc.otherMode+")&_pragma=synchronous",
+				"read-write DSN must not emit the other profile journal mode")
+			requireGeneratedCompiles(t, outputDir)
+			runGoCommandRequired(t, outputDir, "test", "./internal/store", "-run", "^Test(OpenHardensSQLiteFilePermissions|HardenSQLiteFilesSkipsSymlinkSidecars|OpenAppliesPragmas)$", "-count=1")
+		})
+	}
 }
 
 // Callers gating on existence rely on errors.Is(err, sql.ErrNoRows); the

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -4324,10 +4324,10 @@ func TestGenerateStoreDSNOrdersBusyTimeoutBeforeJournalMode(t *testing.T) {
 		"read-write DSN must list busy_timeout(5000) before journal_mode(WAL) so the WAL conversion runs with the busy handler active (see #2926)")
 }
 
-// TestGenerateStoreDSNUsesImmediateTransactionsAndProfileJournalMode pins
-// the two profile shapes that share the generated store. Cache-enabled
-// profiles write local state during reads and must avoid WAL sidecars; the
-// default store profile retains WAL for concurrent analytical reads.
+// Verify that generated stores choose the journal and transaction settings
+// required by each profile. Cache-enabled profiles write local state during
+// reads and must avoid WAL sidecars; the default profile retains WAL for
+// concurrent analytical reads.
 func TestGenerateStoreDSNUsesImmediateTransactionsAndProfileJournalMode(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/learnings.go.tmpl
+++ b/internal/generator/templates/learnings.go.tmpl
@@ -320,8 +320,8 @@ func (s *Store) UpsertLearning(ctx context.Context, in UpsertLearningInput) (int
 		return 0, false, fmt.Errorf("upsert learning: query normalized to empty string")
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	now := time.Now().UTC()
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -519,8 +519,8 @@ func (s *Store) ForgetLearnings(ctx context.Context, f ForgetLearningsFilter) (i
 		return 0, fmt.Errorf("forget learnings: query normalized to empty string")
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	clauses := []string{"query_pattern = ?"}
 	args := []any{pattern}

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -178,12 +178,11 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	return s, nil
 }
 
-// rejectNewerSchemaBeforeJournalMode uses a lightweight read-only connection so an
-// old binary can reject a future schema before the read-write DSN attempts
-// journal-mode conversion. The conversion may wait behind a peer writer, but a
-// committed PRAGMA user_version remains readable while that writer is active.
-// Other probe errors are left to the normal open/migration path, which returns
-// the more precise corruption, permission, or lock error.
+// A newer schema must be rejected before a read-write connection can attempt
+// journal-mode conversion. This lightweight read-only probe can read a
+// committed PRAGMA user_version while a peer writer is active; other probe
+// errors remain with the normal open/migration path, which returns the more
+// precise corruption, permission, or lock error.
 func rejectNewerSchemaBeforeJournalMode(ctx context.Context, dbPath string) error {
 	info, err := os.Stat(dbPath)
 	if os.IsNotExist(err) || (err == nil && info.Size() == 0) {
@@ -232,6 +231,20 @@ func hardenSQLiteFiles(dbPath string) {
 		}
 		_ = file.Close()
 	}
+}
+
+// lockForWrite and unlockAfterWrite keep SQLite sidecars private across the
+// lifetime of every serialized writer. TRUNCATE journaling reuses its journal
+// file and can restore its mode when a later transaction starts, after the
+// one-time OpenWithContext hardening has already run.
+func (s *Store) lockForWrite() {
+	s.writeMu.Lock()
+	hardenSQLiteFiles(s.path)
+}
+
+func (s *Store) unlockAfterWrite() {
+	hardenSQLiteFiles(s.path)
+	s.writeMu.Unlock()
 }
 
 func ensureSQLiteDriverInitialized(ctx context.Context, dsn string) error {
@@ -1038,8 +1051,8 @@ func (s *Store) upsertGenericResourceTx(tx *sql.Tx, resourceType, id string, dat
 }
 
 func (s *Store) Upsert(resourceType, id string, data json.RawMessage) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
@@ -1474,8 +1487,8 @@ func (s *Store) Upsert{{pascal .Name}}(data json.RawMessage) error {
 	}
 	storageID := resourceStorageID("{{.Resource}}", id, obj)
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
@@ -1791,8 +1804,8 @@ func deriveScopeColumns(obj map[string]any) {
 {{- if emitsDomainTable .}}{{$hasDomainTable = true}}{{end}}
 {{- end}}
 func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, int, error) {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
 		return 0, 0, fmt.Errorf("starting batch transaction: %w", err)
@@ -1966,8 +1979,8 @@ func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
 // watermark represented by at. Callers use this when the watermark belongs to
 // the data just fetched rather than to the instant the checkpoint is written.
 func (s *Store) SaveSyncStateAt(resourceType, cursor string, count int, at time.Time) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	_, err := s.db.Exec(
 		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
 		 VALUES (?, ?, ?, ?)
@@ -1982,8 +1995,8 @@ func (s *Store) SaveSyncStateAt(resourceType, cursor string, count int, at time.
 // incremental watermark. A new row gets a parseable zero timestamp so
 // GetSyncState can scan it into time.Time without a NULL conversion error.
 func (s *Store) SaveSyncProgress(resourceType, cursor string, count int) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	_, err := s.db.Exec(
 		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
 		 VALUES (?, ?, ?, ?)
@@ -1998,8 +2011,8 @@ func (s *Store) SaveSyncProgress(resourceType, cursor string, count int) error {
 
 func (s *Store) UpsertStreamFrame(data json.RawMessage) error {
 	id := streamObjectID(data, "event_id", "channel_id", "call_id", "id")
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	_, err := s.db.Exec(
 		`INSERT INTO {{safeNameSuffix (snake .Name) "_stream_frames"}} (id, data, received_at)
 		 VALUES (?, ?, CURRENT_TIMESTAMP)
@@ -2014,8 +2027,8 @@ func (s *Store) UpsertStreamMetadata(primaryKey, status string, data json.RawMes
 		primaryKey = "id"
 	}
 	id := streamObjectID(data, primaryKey, "id", "event_id", "channel_id", "call_id")
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	_, err := s.db.Exec(
 		`INSERT INTO {{safeNameSuffix (snake .Name) "_stream_metadata"}} (status, metadata_id, data, refreshed_at)
 		 VALUES (?, ?, ?, CURRENT_TIMESTAMP)
@@ -2026,8 +2039,8 @@ func (s *Store) UpsertStreamMetadata(primaryKey, status string, data json.RawMes
 }
 
 func (s *Store) RecordRebaseEvent(eventType, reason, detail string) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	_, err := s.db.Exec(
 		`INSERT INTO {{safeNameSuffix (snake .Name) "_rebase_log"}} (event_type, reason, detail, created_at)
 		 VALUES (?, ?, ?, CURRENT_TIMESTAMP)`,
@@ -2067,8 +2080,8 @@ func (s *Store) GetSyncState(resourceType string) (cursor string, lastSynced tim
 
 // SaveSyncCursor stores the pagination cursor for a resource type.
 func (s *Store) SaveSyncCursor(resourceType, cursor string) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	now := time.Now().UTC().Format(time.RFC3339)
 	_, err := s.db.Exec(
 		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
@@ -2347,8 +2360,8 @@ func (s *Store) GetLastSyncedAt(resourceType string) string {
 
 // ClearSyncCursors resets all sync state for a full resync.
 func (s *Store) ClearSyncCursors() error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	_, err := s.db.Exec("DELETE FROM sync_state")
 	return err
 }
@@ -2443,8 +2456,8 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	if genericScopeJSONPath == "" || scopeValue == "" {
 		return 0, fmt.Errorf("reconcile %s: empty partition scope", resourceType)
 	}
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	tx, err := s.db.Begin()
 	if err != nil {

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -140,6 +140,9 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 		return nil, fmt.Errorf("creating db directory: %w", err)
 	}
 	hardenSQLiteFiles(dbPath)
+	{{- if .Cache.Enabled}}
+	ensureSQLiteJournalPrivate(dbPath)
+	{{- end}}
 	defer hardenSQLiteFiles(dbPath)
 	if err := rejectNewerSchemaBeforeJournalMode(ctx, dbPath); err != nil {
 		return nil, err
@@ -233,12 +236,30 @@ func hardenSQLiteFiles(dbPath string) {
 	}
 }
 
+// ensureSQLiteJournalPrivate creates the cache-profile rollback journal before
+// SQLite starts a write transaction, so its mode is private for the whole
+// transaction rather than only after the journal has been created.
+func ensureSQLiteJournalPrivate(dbPath string) {
+	journalPath := dbPath + "-journal"
+	file, err := os.OpenFile(journalPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err == nil {
+		_ = file.Close()
+		return
+	}
+	if os.IsExist(err) {
+		hardenSQLiteFiles(dbPath)
+	}
+}
+
 // lockForWrite and unlockAfterWrite keep SQLite sidecars private across the
 // lifetime of every serialized writer. TRUNCATE journaling reuses its journal
 // file and can restore its mode when a later transaction starts, after the
 // one-time OpenWithContext hardening has already run.
 func (s *Store) lockForWrite() {
 	s.writeMu.Lock()
+	{{- if .Cache.Enabled}}
+	ensureSQLiteJournalPrivate(s.path)
+	{{- end}}
 	hardenSQLiteFiles(s.path)
 }
 

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -141,20 +141,21 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	}
 	hardenSQLiteFiles(dbPath)
 	defer hardenSQLiteFiles(dbPath)
-	if err := rejectNewerSchemaBeforeWAL(ctx, dbPath); err != nil {
+	if err := rejectNewerSchemaBeforeJournalMode(ctx, dbPath); err != nil {
 		return nil, err
 	}
 
-	// Pragma order is load-bearing: busy_timeout must engage BEFORE
-	// journal_mode(WAL) so the delete→WAL conversion (an exclusive
-	// operation on a fresh DB) runs with a busy handler active. With the
-	// timeout listed after the conversion, concurrent first-run opens
-	// race the WAL switch and fail SQLITE_BUSY instead of waiting. This
-	// mirrors the OpenReadOnly DSN and works alongside the retryOnBusy
-	// wrapper around Conn() acquisition below; both layers are needed
-	// because modernc.org/sqlite's connect-time conversion is not fully
-	// covered by the statement-level busy handler alone.
-	dsn := dbPath + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
+	// Pragma order is load-bearing: busy_timeout must engage BEFORE the
+	// journal-mode conversion so concurrent first-run opens wait instead of
+	// racing the exclusive conversion. Cache-enabled profiles write local
+	// state during reads, so they use a rollback journal and avoid WAL sidecar
+	// teardown races between short-lived processes. Other store profiles keep
+	// WAL for concurrent analytical reads.
+	{{- if .Cache.Enabled}}
+	dsn := dbPath + "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(TRUNCATE)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
+	{{- else}}
+	dsn := dbPath + "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
+	{{- end}}
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}
@@ -164,9 +165,8 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 		return nil, fmt.Errorf("opening database: %w", err)
 	}
 
-	// WAL mode + 2 connections allows one read cursor open while a second
-	// query executes (e.g., analytics commands calling helpers during row
-	// iteration). Writes are still serialized by SQLite's WAL lock.
+	// Two connections allow one read cursor to remain open while a second query
+	// executes (e.g., analytics commands calling helpers during row iteration).
 	db.SetMaxOpenConns(2)
 
 	s := &Store{db: db, path: dbPath}
@@ -178,13 +178,13 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	return s, nil
 }
 
-// rejectNewerSchemaBeforeWAL uses a lightweight read-only connection so an
+// rejectNewerSchemaBeforeJournalMode uses a lightweight read-only connection so an
 // old binary can reject a future schema before the read-write DSN attempts
-// journal_mode(WAL). The WAL conversion may wait behind a peer writer, but a
+// journal-mode conversion. The conversion may wait behind a peer writer, but a
 // committed PRAGMA user_version remains readable while that writer is active.
 // Other probe errors are left to the normal open/migration path, which returns
 // the more precise corruption, permission, or lock error.
-func rejectNewerSchemaBeforeWAL(ctx context.Context, dbPath string) error {
+func rejectNewerSchemaBeforeJournalMode(ctx context.Context, dbPath string) error {
 	info, err := os.Stat(dbPath)
 	if os.IsNotExist(err) || (err == nil && info.Size() == 0) {
 		return nil
@@ -215,7 +215,7 @@ func rejectNewerSchemaBeforeWAL(ctx context.Context, dbPath string) error {
 // hardenSQLiteFiles is best-effort so stores on filesystems without Unix modes
 // remain usable. The deferred call catches files the SQLite driver creates.
 func hardenSQLiteFiles(dbPath string) {
-	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+	for _, path := range []string{dbPath, dbPath + "-journal", dbPath + "-wal", dbPath + "-shm"} {
 		info, err := os.Lstat(path)
 		if err != nil || !info.Mode().IsRegular() {
 			continue
@@ -249,7 +249,7 @@ func ensureSQLiteDriverInitialized(ctx context.Context, dsn string) error {
 	defer db.Close()
 
 	// Acquiring the first physical connection runs the DSN _pragma directives,
-	// including the journal_mode(WAL) conversion for a read-write DSN. On a
+	// including the journal-mode conversion for a read-write DSN. On a
 	// fresh DB opened concurrently — e.g. the scorecard live-check probing
 	// sampled commands in parallel — that conversion can return SQLITE_BUSY
 	// before the DSN's busy_timeout engages, so retry the acquisition against a

--- a/internal/generator/templates/store_candidates.go.tmpl
+++ b/internal/generator/templates/store_candidates.go.tmpl
@@ -112,8 +112,8 @@ func (s *Store) DeriveCandidate(class, payload, signature, queryFamily, commandP
 		return CandidateRow{}, false, fmt.Errorf("derive candidate: derivation signature is required")
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	now := time.Now().UTC().Format(candidateTimeFormat)
 	res, err := s.db.Exec(`INSERT INTO learn_candidates
@@ -219,8 +219,8 @@ func (s *Store) ListCandidates(f ListCandidatesFilter) ([]CandidateRow, error) {
 // machinery) and happens before this state change so a failed
 // materialization leaves the candidate open and retryable.
 func (s *Store) ConfirmCandidate(id int64) (CandidateRow, error) {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -240,8 +240,8 @@ func (s *Store) ConfirmCandidate(id int64) (CandidateRow, error) {
 }
 
 func (s *Store) ConfirmCandidateWithPlaybook(id int64, in UpsertPlaybookInput) (CandidateRow, int64, bool, error) {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -273,8 +273,8 @@ func (s *Store) ConfirmCandidateWithPlaybook(id int64, in UpsertPlaybookInput) (
 }
 
 func (s *Store) ConfirmCandidateWithPlaybookNote(id int64, family, marker string) (CandidateRow, int64, bool, error) {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -351,8 +351,8 @@ func markCandidateConfirmedTx(tx *sql.Tx, row CandidateRow, now time.Time) (Cand
 // candidate created the row rather than updating pre-existing guidance.
 // A confirmed flag_alias returns ErrConfirmedFlagAliasReject.
 func (s *Store) RejectCandidate(id int64) (CandidateRow, error) {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -402,8 +402,8 @@ func (s *Store) ExpireCandidates(ttl time.Duration) (int64, error) {
 		ttl = DefaultCandidateTTL
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	now := time.Now().UTC()
 	cutoff := now.Add(-ttl).Format(candidateTimeFormat)
@@ -425,8 +425,8 @@ func (s *Store) ExpireCandidates(ttl time.Duration) (int64, error) {
 // which re-allows derivation of those signatures. Open rows are never
 // purged. Returns how many rows were deleted.
 func (s *Store) PurgeCandidates(includeTombstones bool) (int64, error) {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	statuses := `(?, ?)`
 	args := []any{CandidateStatusExpired, CandidateStatusConfirmed}

--- a/internal/generator/templates/store_events.go.tmpl
+++ b/internal/generator/templates/store_events.go.tmpl
@@ -137,8 +137,8 @@ func (s *Store) InsertLearnEvent(event, familyHash string, matchedRowID int64, e
 		match = 1
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	_, err := s.db.Exec(`INSERT INTO learn_events
 		(ts, event, query_family_hash, matched_row_id, entity_match, surface)
@@ -164,8 +164,8 @@ func (s *Store) PruneLearnEvents(maxRows int, maxAge time.Duration) (int64, erro
 		maxAge = DefaultLearnEventMaxAge
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	var pruned int64
 	cutoff := time.Now().UTC().Add(-maxAge).Format(learnEventTimeFormat)
@@ -200,8 +200,8 @@ func (s *Store) DeleteLearnEventsByFamilyHash(hash string) (int64, error) {
 		return 0, nil
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	res, err := s.db.Exec(`DELETE FROM learn_events WHERE query_family_hash = ?`, hash)
 	if err != nil {

--- a/internal/generator/templates/store_playbooks.go.tmpl
+++ b/internal/generator/templates/store_playbooks.go.tmpl
@@ -60,8 +60,8 @@ func (s *Store) UpsertPlaybook(in UpsertPlaybookInput) (int64, bool, error) {
 		source = LearningSourceTaught
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	now := time.Now().UTC()
 	tx, err := s.db.Begin()
@@ -161,8 +161,8 @@ func (s *Store) AppendPlaybookNotes(family, marker string) (int64, bool, error) 
 		return 0, false, fmt.Errorf("append playbook notes: marker is required")
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	now := time.Now().UTC()
 	tx, err := s.db.Begin()

--- a/internal/generator/templates/store_schema_version_test.go.tmpl
+++ b/internal/generator/templates/store_schema_version_test.go.tmpl
@@ -54,6 +54,11 @@ func TestOpenHardensSQLiteFilePermissions(t *testing.T) {
 			{{- if not .Cache.Enabled}}
 			assertPrivateMode(t, dbPath+"-wal", 0o600)
 			assertPrivateMode(t, dbPath+"-shm", 0o600)
+			{{- else}}
+			if err := s.Upsert("permission-test", "id", []byte(`{"id":"id"}`)); err != nil {
+				t.Fatalf("write after open: %v", err)
+			}
+			assertPrivateMode(t, dbPath+"-journal", 0o600)
 			{{- end}}
 		})
 	}

--- a/internal/generator/templates/store_schema_version_test.go.tmpl
+++ b/internal/generator/templates/store_schema_version_test.go.tmpl
@@ -51,8 +51,10 @@ func TestOpenHardensSQLiteFilePermissions(t *testing.T) {
 
 			assertPrivateMode(t, filepath.Dir(dbPath), tc.wantDirMode)
 			assertPrivateMode(t, dbPath, 0o600)
+			{{- if not .Cache.Enabled}}
 			assertPrivateMode(t, dbPath+"-wal", 0o600)
 			assertPrivateMode(t, dbPath+"-shm", 0o600)
+			{{- end}}
 		})
 	}
 }
@@ -78,8 +80,12 @@ func TestOpenWithRelativePathDoesNotChmodWorkingDirectory(t *testing.T) {
 
 	assertPrivateMode(t, ".", wantDirMode)
 	assertPrivateMode(t, "data.db", 0o600)
+	{{- if .Cache.Enabled}}
+	assertPrivateMode(t, "data.db-journal", 0o600)
+	{{- else}}
 	assertPrivateMode(t, "data.db-wal", 0o600)
 	assertPrivateMode(t, "data.db-shm", 0o600)
+	{{- end}}
 }
 
 func TestHardenSQLiteFilesSkipsSymlinkSidecars(t *testing.T) {
@@ -96,10 +102,15 @@ func TestHardenSQLiteFilesSkipsSymlinkSidecars(t *testing.T) {
 	if err := os.Symlink(targetPath, dbPath+"-wal"); err != nil {
 		t.Fatalf("create WAL symlink: %v", err)
 	}
+	journalPath := dbPath + "-journal"
+	if err := os.WriteFile(journalPath, nil, 0o644); err != nil {
+		t.Fatalf("create journal sidecar: %v", err)
+	}
 
 	hardenSQLiteFiles(dbPath)
 
 	assertPrivateMode(t, targetPath, 0o644)
+	assertPrivateMode(t, journalPath, 0o600)
 }
 
 func assertPrivateMode(t *testing.T, path string, want os.FileMode) {
@@ -135,11 +146,10 @@ func TestSchemaVersion_StampedOnFreshDB(t *testing.T) {
 }
 
 // TestOpenAppliesPragmas pins the connection-string contract: the store
-// must open in WAL journal mode with a non-zero busy_timeout so a read
-// concurrent with a write waits on the lock instead of failing immediately
-// with SQLITE_BUSY. It fails the instant the DSN regresses to the mattn-
-// style _journal_mode=WAL form, which modernc.org/sqlite silently drops —
-// see the OpenReadOnly comment for the driver-syntax detail.
+// must use the profile-selected journal mode with a non-zero busy_timeout so
+// concurrent opens wait on the lock instead of failing immediately with
+// SQLITE_BUSY. It fails the instant the DSN regresses to the mattn-style
+// pragma form, which modernc.org/sqlite silently drops.
 func TestOpenAppliesPragmas(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "data.db")
 	s, err := Open(dbPath)
@@ -148,19 +158,30 @@ func TestOpenAppliesPragmas(t *testing.T) {
 	}
 	defer s.Close()
 
+	{{- if .Cache.Enabled}}
+	requirePragma(t, s.DB(), "journal_mode", "truncate")
+	{{- else}}
 	requirePragma(t, s.DB(), "journal_mode", "wal")
+	{{- end}}
 	requirePragma(t, s.DB(), "busy_timeout", "5000")
 
-	// The read-only handle (MCP sql/search, analytics) must see the same WAL
-	// file mode and carry the busy_timeout so it waits on a concurrent writer
-	// rather than erroring.
+	// The read-only handle (MCP sql/search, analytics) must retain its
+	// profile-compatible journal mode and carry the busy_timeout so it waits
+	// on a concurrent writer rather than erroring.
 	ro, err := OpenReadOnly(dbPath)
 	if err != nil {
 		t.Fatalf("open read-only: %v", err)
 	}
 	defer ro.Close()
 
+	{{- if .Cache.Enabled}}
+	// TRUNCATE is a per-connection setting. A read-only handle that does not
+	// set journal_mode reports SQLite's default delete mode, which is safe
+	// because the handle never creates a journal.
+	requirePragma(t, ro.DB(), "journal_mode", "delete")
+	{{- else}}
 	requirePragma(t, ro.DB(), "journal_mode", "wal")
+	{{- end}}
 	requirePragma(t, ro.DB(), "busy_timeout", "5000")
 }
 

--- a/internal/generator/templates/store_schema_version_test.go.tmpl
+++ b/internal/generator/templates/store_schema_version_test.go.tmpl
@@ -51,15 +51,25 @@ func TestOpenHardensSQLiteFilePermissions(t *testing.T) {
 
 			assertPrivateMode(t, filepath.Dir(dbPath), tc.wantDirMode)
 			assertPrivateMode(t, dbPath, 0o600)
-			{{- if not .Cache.Enabled}}
-			assertPrivateMode(t, dbPath+"-wal", 0o600)
-			assertPrivateMode(t, dbPath+"-shm", 0o600)
-			{{- else}}
-			if err := s.Upsert("permission-test", "id", []byte(`{"id":"id"}`)); err != nil {
-				t.Fatalf("write after open: %v", err)
-			}
-			assertPrivateMode(t, dbPath+"-journal", 0o600)
-			{{- end}}
+		{{- if not .Cache.Enabled}}
+		assertPrivateMode(t, dbPath+"-wal", 0o600)
+		assertPrivateMode(t, dbPath+"-shm", 0o600)
+		{{- else}}
+		s.lockForWrite()
+		defer s.unlockAfterWrite()
+		tx, err := s.db.Begin()
+		if err != nil {
+			t.Fatalf("begin write transaction: %v", err)
+		}
+		if _, err := tx.Exec(`INSERT INTO resources (id, resource_type, data) VALUES (?, ?, ?)`, "id", "permission-test", `{"id":"id"}`); err != nil {
+			_ = tx.Rollback()
+			t.Fatalf("write in transaction: %v", err)
+		}
+		assertPrivateMode(t, dbPath+"-journal", 0o600)
+		if err := tx.Rollback(); err != nil {
+			t.Fatalf("rollback write transaction: %v", err)
+		}
+		{{- end}}
 		})
 	}
 }

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -224,6 +224,21 @@ func hardenSQLiteFiles(dbPath string) {
 	}
 }
 
+// ensureSQLiteJournalPrivate creates the cache-profile rollback journal before
+// SQLite starts a write transaction, so its mode is private for the whole
+// transaction rather than only after the journal has been created.
+func ensureSQLiteJournalPrivate(dbPath string) {
+	journalPath := dbPath + "-journal"
+	file, err := os.OpenFile(journalPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err == nil {
+		_ = file.Close()
+		return
+	}
+	if os.IsExist(err) {
+		hardenSQLiteFiles(dbPath)
+	}
+}
+
 // lockForWrite and unlockAfterWrite keep SQLite sidecars private across the
 // lifetime of every serialized writer. TRUNCATE journaling reuses its journal
 // file and can restore its mode when a later transaction starts, after the

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -136,20 +136,17 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	}
 	hardenSQLiteFiles(dbPath)
 	defer hardenSQLiteFiles(dbPath)
-	if err := rejectNewerSchemaBeforeWAL(ctx, dbPath); err != nil {
+	if err := rejectNewerSchemaBeforeJournalMode(ctx, dbPath); err != nil {
 		return nil, err
 	}
 
-	// Pragma order is load-bearing: busy_timeout must engage BEFORE
-	// journal_mode(WAL) so the delete→WAL conversion (an exclusive
-	// operation on a fresh DB) runs with a busy handler active. With the
-	// timeout listed after the conversion, concurrent first-run opens
-	// race the WAL switch and fail SQLITE_BUSY instead of waiting. This
-	// mirrors the OpenReadOnly DSN and works alongside the retryOnBusy
-	// wrapper around Conn() acquisition below; both layers are needed
-	// because modernc.org/sqlite's connect-time conversion is not fully
-	// covered by the statement-level busy handler alone.
-	dsn := dbPath + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
+	// Pragma order is load-bearing: busy_timeout must engage BEFORE the
+	// journal-mode conversion so concurrent first-run opens wait instead of
+	// racing the exclusive conversion. Cache-enabled profiles write local
+	// state during reads, so they use a rollback journal and avoid WAL sidecar
+	// teardown races between short-lived processes. Other store profiles keep
+	// WAL for concurrent analytical reads.
+	dsn := dbPath + "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}
@@ -159,9 +156,8 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 		return nil, fmt.Errorf("opening database: %w", err)
 	}
 
-	// WAL mode + 2 connections allows one read cursor open while a second
-	// query executes (e.g., analytics commands calling helpers during row
-	// iteration). Writes are still serialized by SQLite's WAL lock.
+	// Two connections allow one read cursor to remain open while a second query
+	// executes (e.g., analytics commands calling helpers during row iteration).
 	db.SetMaxOpenConns(2)
 
 	s := &Store{db: db, path: dbPath}
@@ -173,13 +169,13 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	return s, nil
 }
 
-// rejectNewerSchemaBeforeWAL uses a lightweight read-only connection so an
+// rejectNewerSchemaBeforeJournalMode uses a lightweight read-only connection so an
 // old binary can reject a future schema before the read-write DSN attempts
-// journal_mode(WAL). The WAL conversion may wait behind a peer writer, but a
+// journal-mode conversion. The conversion may wait behind a peer writer, but a
 // committed PRAGMA user_version remains readable while that writer is active.
 // Other probe errors are left to the normal open/migration path, which returns
 // the more precise corruption, permission, or lock error.
-func rejectNewerSchemaBeforeWAL(ctx context.Context, dbPath string) error {
+func rejectNewerSchemaBeforeJournalMode(ctx context.Context, dbPath string) error {
 	info, err := os.Stat(dbPath)
 	if os.IsNotExist(err) || (err == nil && info.Size() == 0) {
 		return nil
@@ -210,7 +206,7 @@ func rejectNewerSchemaBeforeWAL(ctx context.Context, dbPath string) error {
 // hardenSQLiteFiles is best-effort so stores on filesystems without Unix modes
 // remain usable. The deferred call catches files the SQLite driver creates.
 func hardenSQLiteFiles(dbPath string) {
-	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+	for _, path := range []string{dbPath, dbPath + "-journal", dbPath + "-wal", dbPath + "-shm"} {
 		info, err := os.Lstat(path)
 		if err != nil || !info.Mode().IsRegular() {
 			continue
@@ -244,7 +240,7 @@ func ensureSQLiteDriverInitialized(ctx context.Context, dsn string) error {
 	defer db.Close()
 
 	// Acquiring the first physical connection runs the DSN _pragma directives,
-	// including the journal_mode(WAL) conversion for a read-write DSN. On a
+	// including the journal-mode conversion for a read-write DSN. On a
 	// fresh DB opened concurrently — e.g. the scorecard live-check probing
 	// sampled commands in parallel — that conversion can return SQLITE_BUSY
 	// before the DSN's busy_timeout engages, so retry the acquisition against a

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -169,12 +169,11 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	return s, nil
 }
 
-// rejectNewerSchemaBeforeJournalMode uses a lightweight read-only connection so an
-// old binary can reject a future schema before the read-write DSN attempts
-// journal-mode conversion. The conversion may wait behind a peer writer, but a
-// committed PRAGMA user_version remains readable while that writer is active.
-// Other probe errors are left to the normal open/migration path, which returns
-// the more precise corruption, permission, or lock error.
+// A newer schema must be rejected before a read-write connection can attempt
+// journal-mode conversion. This lightweight read-only probe can read a
+// committed PRAGMA user_version while a peer writer is active; other probe
+// errors remain with the normal open/migration path, which returns the more
+// precise corruption, permission, or lock error.
 func rejectNewerSchemaBeforeJournalMode(ctx context.Context, dbPath string) error {
 	info, err := os.Stat(dbPath)
 	if os.IsNotExist(err) || (err == nil && info.Size() == 0) {
@@ -223,6 +222,20 @@ func hardenSQLiteFiles(dbPath string) {
 		}
 		_ = file.Close()
 	}
+}
+
+// lockForWrite and unlockAfterWrite keep SQLite sidecars private across the
+// lifetime of every serialized writer. TRUNCATE journaling reuses its journal
+// file and can restore its mode when a later transaction starts, after the
+// one-time OpenWithContext hardening has already run.
+func (s *Store) lockForWrite() {
+	s.writeMu.Lock()
+	hardenSQLiteFiles(s.path)
+}
+
+func (s *Store) unlockAfterWrite() {
+	hardenSQLiteFiles(s.path)
+	s.writeMu.Unlock()
 }
 
 func ensureSQLiteDriverInitialized(ctx context.Context, dsn string) error {
@@ -800,8 +813,8 @@ func (s *Store) upsertGenericResourceTx(tx *sql.Tx, resourceType, id string, dat
 }
 
 func (s *Store) Upsert(resourceType, id string, data json.RawMessage) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
@@ -1411,8 +1424,8 @@ func deriveScopeColumns(obj map[string]any) {
 // downstream typed table is misconfigured. Failures are surfaced via a
 // trailing stderr warning rather than aborting the batch.
 func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, int, error) {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
 		return 0, 0, fmt.Errorf("starting batch transaction: %w", err)
@@ -1506,8 +1519,8 @@ func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
 // watermark represented by at. Callers use this when the watermark belongs to
 // the data just fetched rather than to the instant the checkpoint is written.
 func (s *Store) SaveSyncStateAt(resourceType, cursor string, count int, at time.Time) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	_, err := s.db.Exec(
 		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
 		 VALUES (?, ?, ?, ?)
@@ -1522,8 +1535,8 @@ func (s *Store) SaveSyncStateAt(resourceType, cursor string, count int, at time.
 // incremental watermark. A new row gets a parseable zero timestamp so
 // GetSyncState can scan it into time.Time without a NULL conversion error.
 func (s *Store) SaveSyncProgress(resourceType, cursor string, count int) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	_, err := s.db.Exec(
 		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
 		 VALUES (?, ?, ?, ?)
@@ -1547,8 +1560,8 @@ func (s *Store) GetSyncState(resourceType string) (cursor string, lastSynced tim
 
 // SaveSyncCursor stores the pagination cursor for a resource type.
 func (s *Store) SaveSyncCursor(resourceType, cursor string) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	now := time.Now().UTC().Format(time.RFC3339)
 	_, err := s.db.Exec(
 		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
@@ -1827,8 +1840,8 @@ func (s *Store) GetLastSyncedAt(resourceType string) string {
 
 // ClearSyncCursors resets all sync state for a full resync.
 func (s *Store) ClearSyncCursors() error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	_, err := s.db.Exec("DELETE FROM sync_state")
 	return err
 }
@@ -1923,8 +1936,8 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	if genericScopeJSONPath == "" || scopeValue == "" {
 		return 0, fmt.Errorf("reconcile %s: empty partition scope", resourceType)
 	}
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	tx, err := s.db.Begin()
 	if err != nil {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/candidates.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/candidates.go
@@ -112,8 +112,8 @@ func (s *Store) DeriveCandidate(class, payload, signature, queryFamily, commandP
 		return CandidateRow{}, false, fmt.Errorf("derive candidate: derivation signature is required")
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	now := time.Now().UTC().Format(candidateTimeFormat)
 	res, err := s.db.Exec(`INSERT INTO learn_candidates
@@ -219,8 +219,8 @@ func (s *Store) ListCandidates(f ListCandidatesFilter) ([]CandidateRow, error) {
 // machinery) and happens before this state change so a failed
 // materialization leaves the candidate open and retryable.
 func (s *Store) ConfirmCandidate(id int64) (CandidateRow, error) {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -240,8 +240,8 @@ func (s *Store) ConfirmCandidate(id int64) (CandidateRow, error) {
 }
 
 func (s *Store) ConfirmCandidateWithPlaybook(id int64, in UpsertPlaybookInput) (CandidateRow, int64, bool, error) {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -273,8 +273,8 @@ func (s *Store) ConfirmCandidateWithPlaybook(id int64, in UpsertPlaybookInput) (
 }
 
 func (s *Store) ConfirmCandidateWithPlaybookNote(id int64, family, marker string) (CandidateRow, int64, bool, error) {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -351,8 +351,8 @@ func markCandidateConfirmedTx(tx *sql.Tx, row CandidateRow, now time.Time) (Cand
 // candidate created the row rather than updating pre-existing guidance.
 // A confirmed flag_alias returns ErrConfirmedFlagAliasReject.
 func (s *Store) RejectCandidate(id int64) (CandidateRow, error) {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -402,8 +402,8 @@ func (s *Store) ExpireCandidates(ttl time.Duration) (int64, error) {
 		ttl = DefaultCandidateTTL
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	now := time.Now().UTC()
 	cutoff := now.Add(-ttl).Format(candidateTimeFormat)
@@ -425,8 +425,8 @@ func (s *Store) ExpireCandidates(ttl time.Duration) (int64, error) {
 // which re-allows derivation of those signatures. Open rows are never
 // purged. Returns how many rows were deleted.
 func (s *Store) PurgeCandidates(includeTombstones bool) (int64, error) {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	statuses := `(?, ?)`
 	args := []any{CandidateStatusExpired, CandidateStatusConfirmed}

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/events.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/events.go
@@ -137,8 +137,8 @@ func (s *Store) InsertLearnEvent(event, familyHash string, matchedRowID int64, e
 		match = 1
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	_, err := s.db.Exec(`INSERT INTO learn_events
 		(ts, event, query_family_hash, matched_row_id, entity_match, surface)
@@ -164,8 +164,8 @@ func (s *Store) PruneLearnEvents(maxRows int, maxAge time.Duration) (int64, erro
 		maxAge = DefaultLearnEventMaxAge
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	var pruned int64
 	cutoff := time.Now().UTC().Add(-maxAge).Format(learnEventTimeFormat)
@@ -200,8 +200,8 @@ func (s *Store) DeleteLearnEventsByFamilyHash(hash string) (int64, error) {
 		return 0, nil
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	res, err := s.db.Exec(`DELETE FROM learn_events WHERE query_family_hash = ?`, hash)
 	if err != nil {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/learnings.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/learnings.go
@@ -320,8 +320,8 @@ func (s *Store) UpsertLearning(ctx context.Context, in UpsertLearningInput) (int
 		return 0, false, fmt.Errorf("upsert learning: query normalized to empty string")
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	now := time.Now().UTC()
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -519,8 +519,8 @@ func (s *Store) ForgetLearnings(ctx context.Context, f ForgetLearningsFilter) (i
 		return 0, fmt.Errorf("forget learnings: query normalized to empty string")
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	clauses := []string{"query_pattern = ?"}
 	args := []any{pattern}

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -140,20 +140,17 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	}
 	hardenSQLiteFiles(dbPath)
 	defer hardenSQLiteFiles(dbPath)
-	if err := rejectNewerSchemaBeforeWAL(ctx, dbPath); err != nil {
+	if err := rejectNewerSchemaBeforeJournalMode(ctx, dbPath); err != nil {
 		return nil, err
 	}
 
-	// Pragma order is load-bearing: busy_timeout must engage BEFORE
-	// journal_mode(WAL) so the delete→WAL conversion (an exclusive
-	// operation on a fresh DB) runs with a busy handler active. With the
-	// timeout listed after the conversion, concurrent first-run opens
-	// race the WAL switch and fail SQLITE_BUSY instead of waiting. This
-	// mirrors the OpenReadOnly DSN and works alongside the retryOnBusy
-	// wrapper around Conn() acquisition below; both layers are needed
-	// because modernc.org/sqlite's connect-time conversion is not fully
-	// covered by the statement-level busy handler alone.
-	dsn := dbPath + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
+	// Pragma order is load-bearing: busy_timeout must engage BEFORE the
+	// journal-mode conversion so concurrent first-run opens wait instead of
+	// racing the exclusive conversion. Cache-enabled profiles write local
+	// state during reads, so they use a rollback journal and avoid WAL sidecar
+	// teardown races between short-lived processes. Other store profiles keep
+	// WAL for concurrent analytical reads.
+	dsn := dbPath + "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}
@@ -163,9 +160,8 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 		return nil, fmt.Errorf("opening database: %w", err)
 	}
 
-	// WAL mode + 2 connections allows one read cursor open while a second
-	// query executes (e.g., analytics commands calling helpers during row
-	// iteration). Writes are still serialized by SQLite's WAL lock.
+	// Two connections allow one read cursor to remain open while a second query
+	// executes (e.g., analytics commands calling helpers during row iteration).
 	db.SetMaxOpenConns(2)
 
 	s := &Store{db: db, path: dbPath}
@@ -177,13 +173,13 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	return s, nil
 }
 
-// rejectNewerSchemaBeforeWAL uses a lightweight read-only connection so an
+// rejectNewerSchemaBeforeJournalMode uses a lightweight read-only connection so an
 // old binary can reject a future schema before the read-write DSN attempts
-// journal_mode(WAL). The WAL conversion may wait behind a peer writer, but a
+// journal-mode conversion. The conversion may wait behind a peer writer, but a
 // committed PRAGMA user_version remains readable while that writer is active.
 // Other probe errors are left to the normal open/migration path, which returns
 // the more precise corruption, permission, or lock error.
-func rejectNewerSchemaBeforeWAL(ctx context.Context, dbPath string) error {
+func rejectNewerSchemaBeforeJournalMode(ctx context.Context, dbPath string) error {
 	info, err := os.Stat(dbPath)
 	if os.IsNotExist(err) || (err == nil && info.Size() == 0) {
 		return nil
@@ -214,7 +210,7 @@ func rejectNewerSchemaBeforeWAL(ctx context.Context, dbPath string) error {
 // hardenSQLiteFiles is best-effort so stores on filesystems without Unix modes
 // remain usable. The deferred call catches files the SQLite driver creates.
 func hardenSQLiteFiles(dbPath string) {
-	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+	for _, path := range []string{dbPath, dbPath + "-journal", dbPath + "-wal", dbPath + "-shm"} {
 		info, err := os.Lstat(path)
 		if err != nil || !info.Mode().IsRegular() {
 			continue
@@ -248,7 +244,7 @@ func ensureSQLiteDriverInitialized(ctx context.Context, dsn string) error {
 	defer db.Close()
 
 	// Acquiring the first physical connection runs the DSN _pragma directives,
-	// including the journal_mode(WAL) conversion for a read-write DSN. On a
+	// including the journal-mode conversion for a read-write DSN. On a
 	// fresh DB opened concurrently — e.g. the scorecard live-check probing
 	// sampled commands in parallel — that conversion can return SQLITE_BUSY
 	// before the DSN's busy_timeout engages, so retry the acquisition against a

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -173,12 +173,11 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	return s, nil
 }
 
-// rejectNewerSchemaBeforeJournalMode uses a lightweight read-only connection so an
-// old binary can reject a future schema before the read-write DSN attempts
-// journal-mode conversion. The conversion may wait behind a peer writer, but a
-// committed PRAGMA user_version remains readable while that writer is active.
-// Other probe errors are left to the normal open/migration path, which returns
-// the more precise corruption, permission, or lock error.
+// A newer schema must be rejected before a read-write connection can attempt
+// journal-mode conversion. This lightweight read-only probe can read a
+// committed PRAGMA user_version while a peer writer is active; other probe
+// errors remain with the normal open/migration path, which returns the more
+// precise corruption, permission, or lock error.
 func rejectNewerSchemaBeforeJournalMode(ctx context.Context, dbPath string) error {
 	info, err := os.Stat(dbPath)
 	if os.IsNotExist(err) || (err == nil && info.Size() == 0) {
@@ -227,6 +226,20 @@ func hardenSQLiteFiles(dbPath string) {
 		}
 		_ = file.Close()
 	}
+}
+
+// lockForWrite and unlockAfterWrite keep SQLite sidecars private across the
+// lifetime of every serialized writer. TRUNCATE journaling reuses its journal
+// file and can restore its mode when a later transaction starts, after the
+// one-time OpenWithContext hardening has already run.
+func (s *Store) lockForWrite() {
+	s.writeMu.Lock()
+	hardenSQLiteFiles(s.path)
+}
+
+func (s *Store) unlockAfterWrite() {
+	hardenSQLiteFiles(s.path)
+	s.writeMu.Unlock()
 }
 
 func ensureSQLiteDriverInitialized(ctx context.Context, dsn string) error {
@@ -962,8 +975,8 @@ func (s *Store) upsertGenericResourceTx(tx *sql.Tx, resourceType, id string, dat
 }
 
 func (s *Store) Upsert(resourceType, id string, data json.RawMessage) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
@@ -1329,8 +1342,8 @@ func (s *Store) UpsertLeagues(data json.RawMessage) error {
 	}
 	storageID := resourceStorageID("leagues", id, obj)
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
@@ -1631,8 +1644,8 @@ func deriveScopeColumns(obj map[string]any) {
 // downstream typed table is misconfigured. Failures are surfaced via a
 // trailing stderr warning rather than aborting the batch.
 func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, int, error) {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
 		return 0, 0, fmt.Errorf("starting batch transaction: %w", err)
@@ -1761,8 +1774,8 @@ func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
 // watermark represented by at. Callers use this when the watermark belongs to
 // the data just fetched rather than to the instant the checkpoint is written.
 func (s *Store) SaveSyncStateAt(resourceType, cursor string, count int, at time.Time) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	_, err := s.db.Exec(
 		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
 		 VALUES (?, ?, ?, ?)
@@ -1777,8 +1790,8 @@ func (s *Store) SaveSyncStateAt(resourceType, cursor string, count int, at time.
 // incremental watermark. A new row gets a parseable zero timestamp so
 // GetSyncState can scan it into time.Time without a NULL conversion error.
 func (s *Store) SaveSyncProgress(resourceType, cursor string, count int) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	_, err := s.db.Exec(
 		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
 		 VALUES (?, ?, ?, ?)
@@ -1802,8 +1815,8 @@ func (s *Store) GetSyncState(resourceType string) (cursor string, lastSynced tim
 
 // SaveSyncCursor stores the pagination cursor for a resource type.
 func (s *Store) SaveSyncCursor(resourceType, cursor string) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	now := time.Now().UTC().Format(time.RFC3339)
 	_, err := s.db.Exec(
 		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
@@ -2082,8 +2095,8 @@ func (s *Store) GetLastSyncedAt(resourceType string) string {
 
 // ClearSyncCursors resets all sync state for a full resync.
 func (s *Store) ClearSyncCursors() error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	_, err := s.db.Exec("DELETE FROM sync_state")
 	return err
 }
@@ -2178,8 +2191,8 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	if genericScopeJSONPath == "" || scopeValue == "" {
 		return 0, fmt.Errorf("reconcile %s: empty partition scope", resourceType)
 	}
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	tx, err := s.db.Begin()
 	if err != nil {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -228,6 +228,21 @@ func hardenSQLiteFiles(dbPath string) {
 	}
 }
 
+// ensureSQLiteJournalPrivate creates the cache-profile rollback journal before
+// SQLite starts a write transaction, so its mode is private for the whole
+// transaction rather than only after the journal has been created.
+func ensureSQLiteJournalPrivate(dbPath string) {
+	journalPath := dbPath + "-journal"
+	file, err := os.OpenFile(journalPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err == nil {
+		_ = file.Close()
+		return
+	}
+	if os.IsExist(err) {
+		hardenSQLiteFiles(dbPath)
+	}
+}
+
 // lockForWrite and unlockAfterWrite keep SQLite sidecars private across the
 // lifetime of every serialized writer. TRUNCATE journaling reuses its journal
 // file and can restore its mode when a later transaction starts, after the

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -173,12 +173,11 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	return s, nil
 }
 
-// rejectNewerSchemaBeforeJournalMode uses a lightweight read-only connection so an
-// old binary can reject a future schema before the read-write DSN attempts
-// journal-mode conversion. The conversion may wait behind a peer writer, but a
-// committed PRAGMA user_version remains readable while that writer is active.
-// Other probe errors are left to the normal open/migration path, which returns
-// the more precise corruption, permission, or lock error.
+// A newer schema must be rejected before a read-write connection can attempt
+// journal-mode conversion. This lightweight read-only probe can read a
+// committed PRAGMA user_version while a peer writer is active; other probe
+// errors remain with the normal open/migration path, which returns the more
+// precise corruption, permission, or lock error.
 func rejectNewerSchemaBeforeJournalMode(ctx context.Context, dbPath string) error {
 	info, err := os.Stat(dbPath)
 	if os.IsNotExist(err) || (err == nil && info.Size() == 0) {
@@ -227,6 +226,20 @@ func hardenSQLiteFiles(dbPath string) {
 		}
 		_ = file.Close()
 	}
+}
+
+// lockForWrite and unlockAfterWrite keep SQLite sidecars private across the
+// lifetime of every serialized writer. TRUNCATE journaling reuses its journal
+// file and can restore its mode when a later transaction starts, after the
+// one-time OpenWithContext hardening has already run.
+func (s *Store) lockForWrite() {
+	s.writeMu.Lock()
+	hardenSQLiteFiles(s.path)
+}
+
+func (s *Store) unlockAfterWrite() {
+	hardenSQLiteFiles(s.path)
+	s.writeMu.Unlock()
 }
 
 func ensureSQLiteDriverInitialized(ctx context.Context, dsn string) error {
@@ -968,8 +981,8 @@ func (s *Store) upsertGenericResourceTx(tx *sql.Tx, resourceType, id string, dat
 }
 
 func (s *Store) Upsert(resourceType, id string, data json.RawMessage) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
@@ -1335,8 +1348,8 @@ func (s *Store) UpsertGadgets(data json.RawMessage) error {
 	}
 	storageID := resourceStorageID("gadgets", id, obj)
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
@@ -1387,8 +1400,8 @@ func (s *Store) UpsertWidgets(data json.RawMessage) error {
 	}
 	storageID := resourceStorageID("widgets", id, obj)
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
@@ -1681,8 +1694,8 @@ func deriveScopeColumns(obj map[string]any) {
 // downstream typed table is misconfigured. Failures are surfaced via a
 // trailing stderr warning rather than aborting the batch.
 func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, int, error) {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
 		return 0, 0, fmt.Errorf("starting batch transaction: %w", err)
@@ -1813,8 +1826,8 @@ func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
 // watermark represented by at. Callers use this when the watermark belongs to
 // the data just fetched rather than to the instant the checkpoint is written.
 func (s *Store) SaveSyncStateAt(resourceType, cursor string, count int, at time.Time) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	_, err := s.db.Exec(
 		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
 		 VALUES (?, ?, ?, ?)
@@ -1829,8 +1842,8 @@ func (s *Store) SaveSyncStateAt(resourceType, cursor string, count int, at time.
 // incremental watermark. A new row gets a parseable zero timestamp so
 // GetSyncState can scan it into time.Time without a NULL conversion error.
 func (s *Store) SaveSyncProgress(resourceType, cursor string, count int) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	_, err := s.db.Exec(
 		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
 		 VALUES (?, ?, ?, ?)
@@ -1854,8 +1867,8 @@ func (s *Store) GetSyncState(resourceType string) (cursor string, lastSynced tim
 
 // SaveSyncCursor stores the pagination cursor for a resource type.
 func (s *Store) SaveSyncCursor(resourceType, cursor string) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	now := time.Now().UTC().Format(time.RFC3339)
 	_, err := s.db.Exec(
 		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
@@ -2134,8 +2147,8 @@ func (s *Store) GetLastSyncedAt(resourceType string) string {
 
 // ClearSyncCursors resets all sync state for a full resync.
 func (s *Store) ClearSyncCursors() error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	_, err := s.db.Exec("DELETE FROM sync_state")
 	return err
 }
@@ -2230,8 +2243,8 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	if genericScopeJSONPath == "" || scopeValue == "" {
 		return 0, fmt.Errorf("reconcile %s: empty partition scope", resourceType)
 	}
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	tx, err := s.db.Begin()
 	if err != nil {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -140,20 +140,17 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	}
 	hardenSQLiteFiles(dbPath)
 	defer hardenSQLiteFiles(dbPath)
-	if err := rejectNewerSchemaBeforeWAL(ctx, dbPath); err != nil {
+	if err := rejectNewerSchemaBeforeJournalMode(ctx, dbPath); err != nil {
 		return nil, err
 	}
 
-	// Pragma order is load-bearing: busy_timeout must engage BEFORE
-	// journal_mode(WAL) so the delete→WAL conversion (an exclusive
-	// operation on a fresh DB) runs with a busy handler active. With the
-	// timeout listed after the conversion, concurrent first-run opens
-	// race the WAL switch and fail SQLITE_BUSY instead of waiting. This
-	// mirrors the OpenReadOnly DSN and works alongside the retryOnBusy
-	// wrapper around Conn() acquisition below; both layers are needed
-	// because modernc.org/sqlite's connect-time conversion is not fully
-	// covered by the statement-level busy handler alone.
-	dsn := dbPath + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
+	// Pragma order is load-bearing: busy_timeout must engage BEFORE the
+	// journal-mode conversion so concurrent first-run opens wait instead of
+	// racing the exclusive conversion. Cache-enabled profiles write local
+	// state during reads, so they use a rollback journal and avoid WAL sidecar
+	// teardown races between short-lived processes. Other store profiles keep
+	// WAL for concurrent analytical reads.
+	dsn := dbPath + "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}
@@ -163,9 +160,8 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 		return nil, fmt.Errorf("opening database: %w", err)
 	}
 
-	// WAL mode + 2 connections allows one read cursor open while a second
-	// query executes (e.g., analytics commands calling helpers during row
-	// iteration). Writes are still serialized by SQLite's WAL lock.
+	// Two connections allow one read cursor to remain open while a second query
+	// executes (e.g., analytics commands calling helpers during row iteration).
 	db.SetMaxOpenConns(2)
 
 	s := &Store{db: db, path: dbPath}
@@ -177,13 +173,13 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	return s, nil
 }
 
-// rejectNewerSchemaBeforeWAL uses a lightweight read-only connection so an
+// rejectNewerSchemaBeforeJournalMode uses a lightweight read-only connection so an
 // old binary can reject a future schema before the read-write DSN attempts
-// journal_mode(WAL). The WAL conversion may wait behind a peer writer, but a
+// journal-mode conversion. The conversion may wait behind a peer writer, but a
 // committed PRAGMA user_version remains readable while that writer is active.
 // Other probe errors are left to the normal open/migration path, which returns
 // the more precise corruption, permission, or lock error.
-func rejectNewerSchemaBeforeWAL(ctx context.Context, dbPath string) error {
+func rejectNewerSchemaBeforeJournalMode(ctx context.Context, dbPath string) error {
 	info, err := os.Stat(dbPath)
 	if os.IsNotExist(err) || (err == nil && info.Size() == 0) {
 		return nil
@@ -214,7 +210,7 @@ func rejectNewerSchemaBeforeWAL(ctx context.Context, dbPath string) error {
 // hardenSQLiteFiles is best-effort so stores on filesystems without Unix modes
 // remain usable. The deferred call catches files the SQLite driver creates.
 func hardenSQLiteFiles(dbPath string) {
-	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+	for _, path := range []string{dbPath, dbPath + "-journal", dbPath + "-wal", dbPath + "-shm"} {
 		info, err := os.Lstat(path)
 		if err != nil || !info.Mode().IsRegular() {
 			continue
@@ -248,7 +244,7 @@ func ensureSQLiteDriverInitialized(ctx context.Context, dsn string) error {
 	defer db.Close()
 
 	// Acquiring the first physical connection runs the DSN _pragma directives,
-	// including the journal_mode(WAL) conversion for a read-write DSN. On a
+	// including the journal-mode conversion for a read-write DSN. On a
 	// fresh DB opened concurrently — e.g. the scorecard live-check probing
 	// sampled commands in parallel — that conversion can return SQLITE_BUSY
 	// before the DSN's busy_timeout engages, so retry the acquisition against a

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -228,6 +228,21 @@ func hardenSQLiteFiles(dbPath string) {
 	}
 }
 
+// ensureSQLiteJournalPrivate creates the cache-profile rollback journal before
+// SQLite starts a write transaction, so its mode is private for the whole
+// transaction rather than only after the journal has been created.
+func ensureSQLiteJournalPrivate(dbPath string) {
+	journalPath := dbPath + "-journal"
+	file, err := os.OpenFile(journalPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err == nil {
+		_ = file.Close()
+		return
+	}
+	if os.IsExist(err) {
+		hardenSQLiteFiles(dbPath)
+	}
+}
+
 // lockForWrite and unlockAfterWrite keep SQLite sidecars private across the
 // lifetime of every serialized writer. TRUNCATE journaling reuses its journal
 // file and can restore its mode when a later transaction starts, after the

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -140,20 +140,17 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	}
 	hardenSQLiteFiles(dbPath)
 	defer hardenSQLiteFiles(dbPath)
-	if err := rejectNewerSchemaBeforeWAL(ctx, dbPath); err != nil {
+	if err := rejectNewerSchemaBeforeJournalMode(ctx, dbPath); err != nil {
 		return nil, err
 	}
 
-	// Pragma order is load-bearing: busy_timeout must engage BEFORE
-	// journal_mode(WAL) so the delete→WAL conversion (an exclusive
-	// operation on a fresh DB) runs with a busy handler active. With the
-	// timeout listed after the conversion, concurrent first-run opens
-	// race the WAL switch and fail SQLITE_BUSY instead of waiting. This
-	// mirrors the OpenReadOnly DSN and works alongside the retryOnBusy
-	// wrapper around Conn() acquisition below; both layers are needed
-	// because modernc.org/sqlite's connect-time conversion is not fully
-	// covered by the statement-level busy handler alone.
-	dsn := dbPath + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
+	// Pragma order is load-bearing: busy_timeout must engage BEFORE the
+	// journal-mode conversion so concurrent first-run opens wait instead of
+	// racing the exclusive conversion. Cache-enabled profiles write local
+	// state during reads, so they use a rollback journal and avoid WAL sidecar
+	// teardown races between short-lived processes. Other store profiles keep
+	// WAL for concurrent analytical reads.
+	dsn := dbPath + "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}
@@ -163,9 +160,8 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 		return nil, fmt.Errorf("opening database: %w", err)
 	}
 
-	// WAL mode + 2 connections allows one read cursor open while a second
-	// query executes (e.g., analytics commands calling helpers during row
-	// iteration). Writes are still serialized by SQLite's WAL lock.
+	// Two connections allow one read cursor to remain open while a second query
+	// executes (e.g., analytics commands calling helpers during row iteration).
 	db.SetMaxOpenConns(2)
 
 	s := &Store{db: db, path: dbPath}
@@ -177,13 +173,13 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	return s, nil
 }
 
-// rejectNewerSchemaBeforeWAL uses a lightweight read-only connection so an
+// rejectNewerSchemaBeforeJournalMode uses a lightweight read-only connection so an
 // old binary can reject a future schema before the read-write DSN attempts
-// journal_mode(WAL). The WAL conversion may wait behind a peer writer, but a
+// journal-mode conversion. The conversion may wait behind a peer writer, but a
 // committed PRAGMA user_version remains readable while that writer is active.
 // Other probe errors are left to the normal open/migration path, which returns
 // the more precise corruption, permission, or lock error.
-func rejectNewerSchemaBeforeWAL(ctx context.Context, dbPath string) error {
+func rejectNewerSchemaBeforeJournalMode(ctx context.Context, dbPath string) error {
 	info, err := os.Stat(dbPath)
 	if os.IsNotExist(err) || (err == nil && info.Size() == 0) {
 		return nil
@@ -214,7 +210,7 @@ func rejectNewerSchemaBeforeWAL(ctx context.Context, dbPath string) error {
 // hardenSQLiteFiles is best-effort so stores on filesystems without Unix modes
 // remain usable. The deferred call catches files the SQLite driver creates.
 func hardenSQLiteFiles(dbPath string) {
-	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+	for _, path := range []string{dbPath, dbPath + "-journal", dbPath + "-wal", dbPath + "-shm"} {
 		info, err := os.Lstat(path)
 		if err != nil || !info.Mode().IsRegular() {
 			continue
@@ -248,7 +244,7 @@ func ensureSQLiteDriverInitialized(ctx context.Context, dsn string) error {
 	defer db.Close()
 
 	// Acquiring the first physical connection runs the DSN _pragma directives,
-	// including the journal_mode(WAL) conversion for a read-write DSN. On a
+	// including the journal-mode conversion for a read-write DSN. On a
 	// fresh DB opened concurrently — e.g. the scorecard live-check probing
 	// sampled commands in parallel — that conversion can return SQLITE_BUSY
 	// before the DSN's busy_timeout engages, so retry the acquisition against a

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -173,12 +173,11 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	return s, nil
 }
 
-// rejectNewerSchemaBeforeJournalMode uses a lightweight read-only connection so an
-// old binary can reject a future schema before the read-write DSN attempts
-// journal-mode conversion. The conversion may wait behind a peer writer, but a
-// committed PRAGMA user_version remains readable while that writer is active.
-// Other probe errors are left to the normal open/migration path, which returns
-// the more precise corruption, permission, or lock error.
+// A newer schema must be rejected before a read-write connection can attempt
+// journal-mode conversion. This lightweight read-only probe can read a
+// committed PRAGMA user_version while a peer writer is active; other probe
+// errors remain with the normal open/migration path, which returns the more
+// precise corruption, permission, or lock error.
 func rejectNewerSchemaBeforeJournalMode(ctx context.Context, dbPath string) error {
 	info, err := os.Stat(dbPath)
 	if os.IsNotExist(err) || (err == nil && info.Size() == 0) {
@@ -227,6 +226,20 @@ func hardenSQLiteFiles(dbPath string) {
 		}
 		_ = file.Close()
 	}
+}
+
+// lockForWrite and unlockAfterWrite keep SQLite sidecars private across the
+// lifetime of every serialized writer. TRUNCATE journaling reuses its journal
+// file and can restore its mode when a later transaction starts, after the
+// one-time OpenWithContext hardening has already run.
+func (s *Store) lockForWrite() {
+	s.writeMu.Lock()
+	hardenSQLiteFiles(s.path)
+}
+
+func (s *Store) unlockAfterWrite() {
+	hardenSQLiteFiles(s.path)
+	s.writeMu.Unlock()
 }
 
 func ensureSQLiteDriverInitialized(ctx context.Context, dsn string) error {
@@ -962,8 +975,8 @@ func (s *Store) upsertGenericResourceTx(tx *sql.Tx, resourceType, id string, dat
 }
 
 func (s *Store) Upsert(resourceType, id string, data json.RawMessage) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
@@ -1329,8 +1342,8 @@ func (s *Store) UpsertLeagues(data json.RawMessage) error {
 	}
 	storageID := resourceStorageID("leagues", id, obj)
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
@@ -1631,8 +1644,8 @@ func deriveScopeColumns(obj map[string]any) {
 // downstream typed table is misconfigured. Failures are surfaced via a
 // trailing stderr warning rather than aborting the batch.
 func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, int, error) {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
 		return 0, 0, fmt.Errorf("starting batch transaction: %w", err)
@@ -1761,8 +1774,8 @@ func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
 // watermark represented by at. Callers use this when the watermark belongs to
 // the data just fetched rather than to the instant the checkpoint is written.
 func (s *Store) SaveSyncStateAt(resourceType, cursor string, count int, at time.Time) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	_, err := s.db.Exec(
 		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
 		 VALUES (?, ?, ?, ?)
@@ -1777,8 +1790,8 @@ func (s *Store) SaveSyncStateAt(resourceType, cursor string, count int, at time.
 // incremental watermark. A new row gets a parseable zero timestamp so
 // GetSyncState can scan it into time.Time without a NULL conversion error.
 func (s *Store) SaveSyncProgress(resourceType, cursor string, count int) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	_, err := s.db.Exec(
 		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
 		 VALUES (?, ?, ?, ?)
@@ -1802,8 +1815,8 @@ func (s *Store) GetSyncState(resourceType string) (cursor string, lastSynced tim
 
 // SaveSyncCursor stores the pagination cursor for a resource type.
 func (s *Store) SaveSyncCursor(resourceType, cursor string) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	now := time.Now().UTC().Format(time.RFC3339)
 	_, err := s.db.Exec(
 		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
@@ -2082,8 +2095,8 @@ func (s *Store) GetLastSyncedAt(resourceType string) string {
 
 // ClearSyncCursors resets all sync state for a full resync.
 func (s *Store) ClearSyncCursors() error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 	_, err := s.db.Exec("DELETE FROM sync_state")
 	return err
 }
@@ -2178,8 +2191,8 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	if genericScopeJSONPath == "" || scopeValue == "" {
 		return 0, fmt.Errorf("reconcile %s: empty partition scope", resourceType)
 	}
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.lockForWrite()
+	defer s.unlockAfterWrite()
 
 	tx, err := s.db.Begin()
 	if err != nil {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -228,6 +228,21 @@ func hardenSQLiteFiles(dbPath string) {
 	}
 }
 
+// ensureSQLiteJournalPrivate creates the cache-profile rollback journal before
+// SQLite starts a write transaction, so its mode is private for the whole
+// transaction rather than only after the journal has been created.
+func ensureSQLiteJournalPrivate(dbPath string) {
+	journalPath := dbPath + "-journal"
+	file, err := os.OpenFile(journalPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err == nil {
+		_ = file.Close()
+		return
+	}
+	if os.IsExist(err) {
+		hardenSQLiteFiles(dbPath)
+	}
+}
+
 // lockForWrite and unlockAfterWrite keep SQLite sidecars private across the
 // lifetime of every serialized writer. TRUNCATE journaling reuses its journal
 // file and can restore its mode when a later transaction starts, after the


### PR DESCRIPTION
## Intent

Concurrent short-lived commands sharing a generated SQLite store could SIGBUS or report false malformed-database errors. This fixes read-write transaction acquisition and journal selection in generated CLIs.

Closes #4128

## Approach

Read-write DSNs use `_txlock=immediate`. Cache-enabled profiles use TRUNCATE rollback journaling to avoid WAL sidecar teardown races. Other profiles retain WAL for analytical readers. Sidecar permission hardening now covers `-journal`, `-wal`, and `-shm`. Read-only DSNs remain unchanged.

## Scope

Primary area: generated SQLite store setup and emitted store tests.

Why this belongs in this repo: the issue affects every future printed CLI that uses the generated store, so the source-of-truth fix belongs in the Printing Press generator.

## Risk

Cache-enabled profiles trade WAL reader concurrency for rollback-journal behavior. Default WAL and read-only DSN contracts remain covered by profile-specific generated tests and golden output.

## Output Contract

The generator emits profile-specific read-write DSNs and sidecar permission checks. Coverage includes emitted-code assertions, compiled generated modules, both cache variants, 32 golden cases, and 10 generated-output cases.

## Verification

- `go test ./internal/generator -run 'TestGenerateStore(DSNOrdersBusyTimeoutBeforeJournalMode|DSNUsesImmediateTransactionsAndProfileJournalMode|MigrateUsesBeginImmediate)' -count=1`
- `scripts/golden.sh verify` passed all 32 cases
- `scripts/verify-generator-output.sh` passed all 10 cases
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./internal/generator`
- Full repository and generator-package suites were attempted, but the existing generated no-auth learn/store failures and concurrent batch workload prevented a clean broad-suite result.
