### PR TITLE
fix(cli): register novel framework commands and manifest entries

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3233,6 +3233,9 @@ func (g *Generator) activeFrameworkCobraUseNames() map[string]struct{} {
 	if g.VisionSet.Sync {
 		names["sync"] = struct{}{}
 	}
+	if g.Spec.Streaming.Enabled() {
+		names["live"] = struct{}{}
+	}
 	if g.VisionSet.Tail {
 		names["tail"] = struct{}{}
 	}
@@ -5209,48 +5212,50 @@ func (g *Generator) renderRootProjectFiles(promotedCommands []PromotedCommand, p
 
 	rootData := struct {
 		*spec.APISpec
-		VisionSet             VisionTemplateSet
-		VisionCmdNames        map[string]bool
-		WorkflowConstructors  []string
-		InsightConstructors   []string
-		NovelCommandStubs     []novelFeatureCommandRender
-		PromotedCommands      []PromotedCommand
-		PromotedResourceNames map[string]bool
-		Narrative             *ReadmeNarrative
-		TopNovelFeatures      []NovelFeature
-		NovelOverflowCount    int
-		HasAsyncJobs          bool
-		AsyncJobCount         int
-		HasAuthCommand        bool
-		HasCreateCommands     bool
-		HasDelete             bool
-		HasMutationEndpoints  bool
-		HasAutoRefresh        bool
-		SelectExample         string
-		HasWorkflow           bool
-		CompactDescription    string
+		VisionSet              VisionTemplateSet
+		VisionCmdNames         map[string]bool
+		WorkflowConstructors   []string
+		InsightConstructors    []string
+		NovelCommandStubs      []novelFeatureCommandRender
+		NovelFrameworkChildren map[string][]novelFeatureChildRender
+		PromotedCommands       []PromotedCommand
+		PromotedResourceNames  map[string]bool
+		Narrative              *ReadmeNarrative
+		TopNovelFeatures       []NovelFeature
+		NovelOverflowCount     int
+		HasAsyncJobs           bool
+		AsyncJobCount          int
+		HasAuthCommand         bool
+		HasCreateCommands      bool
+		HasDelete              bool
+		HasMutationEndpoints   bool
+		HasAutoRefresh         bool
+		SelectExample          string
+		HasWorkflow            bool
+		CompactDescription     string
 	}{
-		APISpec:               g.Spec,
-		VisionSet:             g.dataSurfaceVisionSet(),
-		VisionCmdNames:        g.VisionSet.CmdNames(),
-		WorkflowConstructors:  renderedWorkflowConstructors,
-		InsightConstructors:   renderedInsightConstructors,
-		NovelCommandStubs:     novelCommandStubs,
-		PromotedCommands:      promotedCommands,
-		PromotedResourceNames: promotedResourceNames,
-		Narrative:             g.Narrative,
-		TopNovelFeatures:      shownNovel,
-		NovelOverflowCount:    overflow,
-		HasAsyncJobs:          len(g.AsyncJobs) > 0,
-		AsyncJobCount:         len(g.AsyncJobs),
-		HasAuthCommand:        hasAuthCommand,
-		HasCreateCommands:     hasCreateCommands(g.Spec.Resources),
-		HasDelete:             helperFlags.HasDelete,
-		HasMutationEndpoints:  helperFlags.HasMutationEndpoints,
-		HasAutoRefresh:        g.hasAutoRefresh(),
-		SelectExample:         selectExampleForCommand(g.Spec),
-		HasWorkflow:           g.hasWorkflowSurface(),
-		CompactDescription:    g.compactDescription(),
+		APISpec:                g.Spec,
+		VisionSet:              g.dataSurfaceVisionSet(),
+		VisionCmdNames:         g.VisionSet.CmdNames(),
+		WorkflowConstructors:   renderedWorkflowConstructors,
+		InsightConstructors:    renderedInsightConstructors,
+		NovelCommandStubs:      novelCommandStubs,
+		NovelFrameworkChildren: g.novelFeatureFrameworkChildren(),
+		PromotedCommands:       promotedCommands,
+		PromotedResourceNames:  promotedResourceNames,
+		Narrative:              g.Narrative,
+		TopNovelFeatures:       shownNovel,
+		NovelOverflowCount:     overflow,
+		HasAsyncJobs:           len(g.AsyncJobs) > 0,
+		AsyncJobCount:          len(g.AsyncJobs),
+		HasAuthCommand:         hasAuthCommand,
+		HasCreateCommands:      hasCreateCommands(g.Spec.Resources),
+		HasDelete:              helperFlags.HasDelete,
+		HasMutationEndpoints:   helperFlags.HasMutationEndpoints,
+		HasAutoRefresh:         g.hasAutoRefresh(),
+		SelectExample:          selectExampleForCommand(g.Spec),
+		HasWorkflow:            g.hasWorkflowSurface(),
+		CompactDescription:     g.compactDescription(),
 	}
 	if err := g.renderTemplate("root.go.tmpl", filepath.Join("internal", "cli", "root.go"), rootData); err != nil {
 		return fmt.Errorf("rendering root: %w", err)

--- a/internal/generator/novel_feature_stubs.go
+++ b/internal/generator/novel_feature_stubs.go
@@ -134,6 +134,21 @@ func (g *Generator) novelFeatureChildrenByParent() map[string][]novelFeatureChil
 	return out
 }
 
+func (g *Generator) novelFeatureFrameworkChildren() map[string][]novelFeatureChildRender {
+	all := g.novelFeatureChildrenByParent()
+	active := g.activeFrameworkCobraUseNames()
+	out := map[string][]novelFeatureChildRender{}
+	for parent, children := range all {
+		if strings.ContainsAny(parent, " \t") {
+			continue
+		}
+		if _, ok := active[parent]; ok {
+			out[parent] = children
+		}
+	}
+	return out
+}
+
 func (g *Generator) renderNovelFeatureNode(node *novelFeatureStubNode, generatedPaths map[string]struct{}) (*novelFeatureCommandRender, error) {
 	var renderedChildren []novelFeatureChildRender
 	for _, child := range sortedNovelChildren(node) {

--- a/internal/generator/novel_feature_stubs_test.go
+++ b/internal/generator/novel_feature_stubs_test.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -110,10 +111,91 @@ func TestNovelFeatureStubsResolveAtRuntime(t *testing.T) {
 		}
 	}
 }
+
 `)
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "novel_stub_runtime_test.go"), []byte(runtimeTest.String()), 0o644))
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "test", "./internal/cli")
+}
+
+func TestGeneratorRegistersNovelFeatureUnderFrameworkParent(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("framework-novel")
+	apiSpec.Streaming = spec.StreamingConfig{
+		Transport: spec.StreamingTransportWebSocket,
+		URL:       "wss://api.example.com/v1/ws",
+		Framing:   spec.StreamingFramingNDJSON,
+	}
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	gen.NovelFeatures = []NovelFeature{{
+		Name:        "Verify sync",
+		Command:     "sync verify",
+		Description: "Verify synchronized data.",
+		Example:     "framework-novel-pp-cli sync verify",
+	}, {
+		Name:        "Verify live stream",
+		Command:     "live verify",
+		Description: "Verify the live stream.",
+		Example:     "framework-novel-pp-cli live verify",
+	}, {
+		Name:        "Explain help",
+		Command:     "help explain",
+		Description: "Explain help topics.",
+		Example:     "framework-novel-pp-cli help explain",
+	}, {
+		Name:        "Check completion",
+		Command:     "completion check",
+		Description: "Check completion setup.",
+		Example:     "framework-novel-pp-cli completion check",
+	}}
+	require.NoError(t, gen.Generate())
+
+	root := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	assert.Contains(t, root, `rootCmd.Find(strings.Fields("sync"))`)
+	assert.Contains(t, root, "addNovelCommandIfAbsent(parent, newNovelSyncVerifyCmd(flags))")
+	assert.Contains(t, root, "addNovelCommandIfAbsent(parent, newNovelLiveVerifyCmd(flags))")
+
+	// Exercise the generated Cobra tree so this regression catches a missing
+	// framework-parent AddCommand rather than only checking template text.
+	testPath := filepath.Join(outputDir, "internal", "cli", "framework_novel_wiring_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import "testing"
+
+func TestNovelFrameworkParentReachable(t *testing.T) {
+	for _, path := range [][]string{
+		{"sync", "verify"},
+		{"live", "verify"},
+		{"help", "explain"},
+		{"completion", "check"},
+	} {
+		command, _, err := RootCmd().Find(path)
+		if err != nil {
+			t.Fatalf("Find(%v) error = %v", path, err)
+		}
+		if command == nil || command.Name() != path[len(path)-1] {
+			t.Fatalf("Find(%v) = %#v", path, command)
+		}
+	}
+}
+`), 0o644))
+
+	cmd := exec.Command("go", "test", "-mod=mod", "./internal/cli", "-run", "TestNovelFrameworkParentReachable", "-count=1")
+	cmd.Dir = outputDir
+	cmd.Env = os.Environ()
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	plainDir := filepath.Join(t.TempDir(), naming.CLI("framework-plain"))
+	plainSpec := minimalSpec("framework-plain")
+	plainGen := New(plainSpec, plainDir)
+	plainGen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, plainGen.Generate())
+	plainRoot := readGeneratedFile(t, plainDir, "internal", "cli", "root.go")
+	assert.NotContains(t, plainRoot, `rootCmd.Find(strings.Fields(`)
 }
 
 func TestGeneratorMarksAllGETNovelFeatureStubsReadOnly(t *testing.T) {

--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -615,6 +615,20 @@ Run '{{.Name}}-pp-cli doctor' to verify auth and connectivity.{{backtick}},
 	for _, hook := range novelCommandHooks {
 		hook(rootCmd, flags)
 	}
+{{- if .NovelFrameworkChildren}}
+	// Cobra creates its default help and completion parents lazily during
+	// Execute. Initialize them here too so novel features can attach to the
+	// same framework command tree when RootCmd is inspected directly.
+	rootCmd.InitDefaultHelpCmd()
+	rootCmd.InitDefaultCompletionCmd()
+{{- range $parent, $children := .NovelFrameworkChildren}}
+	if parent, _, err := rootCmd.Find(strings.Fields({{printf "%q" $parent}})); err == nil {
+{{- range $children}}
+		addNovelCommandIfAbsent(parent, newNovel{{.Ident}}Cmd(flags))
+{{- end}}
+	}
+{{- end}}
+{{- end}}
 {{- range .NovelCommandStubs}}
 	addNovelCommandIfAbsent(rootCmd, newNovel{{.Ident}}Cmd(flags))
 {{- end}}

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -1337,9 +1337,26 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 	if err := writeCLIManifestForGenerate(p.OutputDir, m, existingRaw, clearFields); err != nil {
 		return err
 	}
+	toolsManifestPath := filepath.Join(p.OutputDir, ToolsManifestFilename)
+	if _, err := os.Stat(toolsManifestPath); os.IsNotExist(err) {
+		if p.Spec == nil {
+			// Direct low-level callers may only be writing provenance; the
+			// generate command normally creates this file before this step.
+			return writeGenerateManifestArtifacts(p, m)
+		}
+		if err := WriteToolsManifestWithDescription(p.OutputDir, p.Spec, m.Description); err != nil {
+			return fmt.Errorf("writing tools manifest: %w", err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("checking tools manifest: %w", err)
+	}
 	if err := syncToolsManifestNovelFeatures(p.OutputDir, m.NovelFeatures); err != nil {
 		return fmt.Errorf("syncing novel features to tools manifest: %w", err)
 	}
+	return writeGenerateManifestArtifacts(p, m)
+}
+
+func writeGenerateManifestArtifacts(p GenerateManifestParams, m CLIManifest) error {
 	// Emit the customizations directory alongside .printing-press.json. The
 	// library's Verify CI requires every fresh-print publish to ship a patches
 	// index; preserve-on-regen keeps agent-applied patch entries from being

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -1337,6 +1337,9 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 	if err := writeCLIManifestForGenerate(p.OutputDir, m, existingRaw, clearFields); err != nil {
 		return err
 	}
+	if err := syncToolsManifestNovelFeatures(p.OutputDir, m.NovelFeatures); err != nil {
+		return fmt.Errorf("syncing novel features to tools manifest: %w", err)
+	}
 	// Emit the customizations directory alongside .printing-press.json. The
 	// library's Verify CI requires every fresh-print publish to ship a patches
 	// index; preserve-on-regen keeps agent-applied patch entries from being

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -412,7 +412,7 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 		return err
 	}
 	if err := syncToolsManifestNovelFeatures(dir, m.NovelFeatures); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: could not sync tools manifest novel features: %v\n", err)
+		return fmt.Errorf("syncing novel features to tools manifest: %w", err)
 	}
 	return nil
 }

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -408,7 +408,13 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 	if m.SpecPath != "" && m.SpecURL == "" {
 		clearFields["spec_url"] = struct{}{}
 	}
-	return writeCLIManifestPreservingRawFields(dir, m, existingRaw, clearFields)
+	if err := writeCLIManifestPreservingRawFields(dir, m, existingRaw, clearFields); err != nil {
+		return err
+	}
+	if err := syncToolsManifestNovelFeatures(dir, m.NovelFeatures); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not sync tools manifest novel features: %v\n", err)
+	}
+	return nil
 }
 
 func archivedSpecDescription(data []byte) string {

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -204,6 +204,7 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 		RunID:                state.RunID,
 	}
 	var existingDescription string
+	toolsManifestExpected := false
 
 	// Carry forward metadata from the generated manifest when publish-time
 	// parsing is unavailable or lossy for the original spec format. NovelFeatures
@@ -330,6 +331,7 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 		// (auth-doctor, mcp-audit). Non-blocking: log warning on error
 		// but don't fail the publish.
 		if parsed != nil {
+			toolsManifestExpected = true
 			if tmErr := WriteToolsManifestWithDescription(dir, parsed, m.Description); tmErr != nil {
 				fmt.Fprintf(os.Stderr, "warning: could not write tools manifest: %v\n", tmErr)
 			}
@@ -412,6 +414,9 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 		return err
 	}
 	if err := syncToolsManifestNovelFeatures(dir, m.NovelFeatures); err != nil {
+		if os.IsNotExist(err) && !toolsManifestExpected {
+			return nil
+		}
 		return fmt.Errorf("syncing novel features to tools manifest: %w", err)
 	}
 	return nil

--- a/internal/pipeline/publish_test.go
+++ b/internal/pipeline/publish_test.go
@@ -376,6 +376,37 @@ func TestWriteCLIManifestForPublish_NovelFeaturesFromSkillFlowResearch(t *testin
 	assert.Equal(t, "today", m.NovelFeatures[1].Command)
 }
 
+func TestWriteCLIManifestForPublishSynchronizesToolsManifestNovelFeatures(t *testing.T) {
+	_, state := publishManifestEnvSetup(t, "20260427-tools-manifest")
+	require.NoError(t, os.WriteFile(filepath.Join(state.WorkingDir, "spec.yaml"), []byte(`
+name: test-api
+description: Test API
+version: "1.0"
+base_url: https://api.example.com
+auth:
+  type: none
+resources: {}
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(state.WorkingDir, ToolsManifestFilename), []byte(`{
+  "api_name": "test-api",
+  "tools": [],
+  "novel_features": [{"name": "Stale", "command": "stale"}]
+}`), 0o644))
+
+	built := []NovelFeature{{Name: "Fresh", Command: "fresh", Description: "Verified feature."}}
+	writeResearchAt(t, RunRoot(state.RunID), &ResearchResult{
+		APIName:            "test-api",
+		NovelFeaturesBuilt: &built,
+	})
+
+	require.NoError(t, writeCLIManifestForPublish(state, state.WorkingDir))
+
+	cliManifest := readPublishedManifest(t, state.WorkingDir)
+	toolsManifest, err := ReadToolsManifest(state.WorkingDir)
+	require.NoError(t, err)
+	assert.Equal(t, cliManifest.NovelFeatures, toolsManifest.NovelFeatures)
+}
+
 func TestWriteCLIManifestForPublishPreservesGeneratedDescription(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("PRINTING_PRESS_HOME", tmp)

--- a/internal/pipeline/toolsmanifest.go
+++ b/internal/pipeline/toolsmanifest.go
@@ -26,16 +26,17 @@ const ToolsManifestFilename = "tools-manifest.json"
 // ToolsManifest describes every MCP tool for an API, along with API-level
 // metadata, in a form the diagnostic commands can read directly.
 type ToolsManifest struct {
-	APIName         string           `json:"api_name"`
-	BaseURL         string           `json:"base_url"`
-	Description     string           `json:"description"`
-	MCPReady        string           `json:"mcp_ready"`
-	HTTPTransport   string           `json:"http_transport,omitempty"`
-	MCP             *ManifestMCP     `json:"mcp,omitempty"`
-	Auth            ManifestAuth     `json:"auth"`
-	TierRouting     *ManifestTiers   `json:"tier_routing,omitempty"`
-	RequiredHeaders []ManifestHeader `json:"required_headers"`
-	Tools           []ManifestTool   `json:"tools"`
+	APIName         string                 `json:"api_name"`
+	BaseURL         string                 `json:"base_url"`
+	Description     string                 `json:"description"`
+	MCPReady        string                 `json:"mcp_ready"`
+	HTTPTransport   string                 `json:"http_transport,omitempty"`
+	MCP             *ManifestMCP           `json:"mcp,omitempty"`
+	Auth            ManifestAuth           `json:"auth"`
+	TierRouting     *ManifestTiers         `json:"tier_routing,omitempty"`
+	RequiredHeaders []ManifestHeader       `json:"required_headers"`
+	Tools           []ManifestTool         `json:"tools"`
+	NovelFeatures   []NovelFeatureManifest `json:"novel_features,omitempty"`
 }
 
 // ManifestMCP persists the endpoint visibility fields needed by manifest
@@ -200,6 +201,11 @@ func WriteToolsManifestWithDescription(dir string, parsed *spec.APISpec, manifes
 		RequiredHeaders: make([]ManifestHeader, 0, len(parsed.RequiredHeaders)),
 		Tools:           make([]ManifestTool, 0),
 	}
+	if novelFeatures, err := novelFeaturesForToolsManifest(dir); err != nil {
+		return err
+	} else {
+		manifest.NovelFeatures = novelFeatures
+	}
 	if parsed.MCP.EndpointTools != "" || parsed.MCP.Orchestration != "" {
 		manifest.MCP = &ManifestMCP{
 			EndpointTools: parsed.MCP.EndpointTools,
@@ -240,6 +246,37 @@ func WriteToolsManifestWithDescription(dir string, parsed *spec.APISpec, manifes
 	}
 	data = append(data, '\n')
 
+	if err := os.WriteFile(filepath.Join(dir, ToolsManifestFilename), data, 0o644); err != nil {
+		return fmt.Errorf("writing tools manifest: %w", err)
+	}
+	return nil
+}
+
+func novelFeaturesForToolsManifest(dir string) ([]NovelFeatureManifest, error) {
+	cliManifest, err := ReadCLIManifest(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading %s for tools manifest: %w", CLIManifestFilename, err)
+	}
+	return append([]NovelFeatureManifest(nil), cliManifest.NovelFeatures...), nil
+}
+
+func syncToolsManifestNovelFeatures(dir string, features []NovelFeatureManifest) error {
+	manifest, err := ReadToolsManifest(dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	manifest.NovelFeatures = append([]NovelFeatureManifest(nil), features...)
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling tools manifest: %w", err)
+	}
+	data = append(data, '\n')
 	if err := os.WriteFile(filepath.Join(dir, ToolsManifestFilename), data, 0o644); err != nil {
 		return fmt.Errorf("writing tools manifest: %w", err)
 	}

--- a/internal/pipeline/toolsmanifest.go
+++ b/internal/pipeline/toolsmanifest.go
@@ -265,9 +265,6 @@ func novelFeaturesForToolsManifest(dir string) ([]NovelFeatureManifest, error) {
 
 func syncToolsManifestNovelFeatures(dir string, features []NovelFeatureManifest) error {
 	manifest, err := ReadToolsManifest(dir)
-	if os.IsNotExist(err) {
-		return nil
-	}
 	if err != nil {
 		return err
 	}

--- a/internal/pipeline/toolsmanifest_test.go
+++ b/internal/pipeline/toolsmanifest_test.go
@@ -127,6 +127,70 @@ func TestWriteToolsManifest_MultipleResources(t *testing.T) {
 	assert.Equal(t, "/store/inventory", got.Tools[3].Path)
 }
 
+func TestWriteToolsManifestIncludesNovelFeaturesFromCLIManifest(t *testing.T) {
+	dir := t.TempDir()
+	features := []NovelFeatureManifest{{
+		Name:        "Verify sync",
+		Command:     "sync verify",
+		Description: "Verify synchronized data.",
+	}}
+	require.NoError(t, WriteCLIManifest(dir, CLIManifest{NovelFeatures: features}))
+	parsed := &spec.APISpec{
+		Name:    "novel-manifest",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+	}
+
+	require.NoError(t, WriteToolsManifest(dir, parsed))
+	got, err := ReadToolsManifest(dir)
+	require.NoError(t, err)
+	assert.Equal(t, features, got.NovelFeatures)
+}
+
+func TestWriteToolsManifestOmitsNovelFeaturesWithoutCLIManifest(t *testing.T) {
+	dir := t.TempDir()
+	parsed := &spec.APISpec{
+		Name:    "plain-manifest",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+	}
+
+	require.NoError(t, WriteToolsManifest(dir, parsed))
+	got, err := ReadToolsManifest(dir)
+	require.NoError(t, err)
+	assert.Empty(t, got.NovelFeatures)
+
+	raw, err := os.ReadFile(filepath.Join(dir, ToolsManifestFilename))
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), `"novel_features"`)
+}
+
+func TestWriteManifestForGenerateSynchronizesNovelFeaturesToToolsManifest(t *testing.T) {
+	dir := t.TempDir()
+	parsed := &spec.APISpec{
+		Name:    "generate-novel-manifest",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+	}
+	require.NoError(t, WriteToolsManifest(dir, parsed))
+	features := []NovelFeatureManifest{{
+		Name:        "Verify sync",
+		Command:     "sync verify",
+		Description: "Verify synchronized data.",
+	}}
+
+	require.NoError(t, WriteManifestForGenerate(GenerateManifestParams{
+		APIName:       parsed.Name,
+		OutputDir:     dir,
+		Spec:          parsed,
+		NovelFeatures: features,
+	}))
+
+	got, err := ReadToolsManifest(dir)
+	require.NoError(t, err)
+	assert.Equal(t, features, got.NovelFeatures)
+}
+
 func TestWriteToolsManifest_OpenAPIDanglingOperationSecurityUsesRootAPIKey(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/toolsmanifest_test.go
+++ b/internal/pipeline/toolsmanifest_test.go
@@ -191,6 +191,12 @@ func TestWriteManifestForGenerateSynchronizesNovelFeaturesToToolsManifest(t *tes
 	assert.Equal(t, features, got.NovelFeatures)
 }
 
+func TestSyncToolsManifestNovelFeaturesRequiresManifest(t *testing.T) {
+	err := syncToolsManifestNovelFeatures(t.TempDir(), nil)
+	require.Error(t, err)
+	assert.True(t, os.IsNotExist(err))
+}
+
 func TestWriteToolsManifest_OpenAPIDanglingOperationSecurityUsesRootAPIKey(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Intent

Novel features under framework-owned Cobra parents now remain reachable, and the same feature records appear in both `.printing-press.json` and `tools-manifest.json` after generation and publish hydration.

## Approach

The generator attaches novel children to active framework parents after preserved hooks, including conditionally emitted streaming `live` and Cobra's lazy `help` and `completion` parents. Manifest generation reads the CLI manifest and both generate and publish flows reconcile the tools manifest after the final feature list is known.

## Scope

Primary area: generator command-tree wiring and pipeline manifest assembly.

This belongs in the Printing Press because the behavior is emitted and assembled by the generator and pipeline for every printed CLI.

## Risk

The change affects generated root command registration and the agent-facing tools manifest. Existing hook precedence and no-novel output remain unchanged.

## Verification

- Focused generator and pipeline tests pass, including generated runtime reachability for `sync`, `live`, `help`, and `completion`.
- `scripts/golden.sh verify` passes all 32 cases.
- `scripts/verify-generator-output.sh` passes all 10 cases.
- `go test ./...` was attempted; unrelated generated learn/store/client fixture state tests still fail in the existing full-suite environment.
- Local Greptile review completed with no actionable findings.

Closes #4131
Closes #3849

Not included: #3854 was already fixed on `main` and closed as a duplicate of #3722.
