### PR TITLE
fix(cli): preserve zero-valued integer query params

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -268,6 +268,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"zeroValForBodyParam":                 zeroValForBodyParam,
 		"paramIsHeader":                       paramIsHeader,
 		"paramPresenceExpr":                   paramPresenceExpr,
+		"readParamPresenceExpr":               readParamPresenceExpr,
 		"endpointHasHeaderParams":             endpointHasHeaderParams,
 		"positionalArgs":                      positionalArgs,
 		"configTag":                           configTag,
@@ -7343,7 +7344,17 @@ func paramIsHeader(p spec.Param) bool {
 }
 
 func paramPresenceExpr(p spec.Param) string {
+	if primitiveKind(p.Type) == "int" && (p.Required || paramHasDefault(p)) {
+		return "true"
+	}
 	return fmt.Sprintf("(%s || flag%s != %s)", flagChangedExpr(p), toCamel(paramIdent(p)), zeroValForParamRequired(p.Name, p.Type, p.Required, paramHasDefault(p)))
+}
+
+func readParamPresenceExpr(p spec.Param) string {
+	if primitiveKind(p.Type) == "int" && (p.Required || paramHasDefault(p)) {
+		return "true"
+	}
+	return fmt.Sprintf("flag%s != %s", toCamel(paramIdent(p)), zeroValForParamRequired(p.Name, p.Type, p.Required, paramHasDefault(p)))
 }
 
 func endpointHasHeaderParams(endpoint spec.Endpoint) bool {

--- a/internal/generator/mutating_query_params_test.go
+++ b/internal/generator/mutating_query_params_test.go
@@ -1,6 +1,9 @@
 package generator
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -205,6 +208,83 @@ func TestEndpointMCPPreservesHeaderAndEmptyValues(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "mcp", "empty_wire_runtime_test.go"), []byte(mcpRuntimeTest), 0o644))
 	runGoCommand(t, outputDir, "test", "./internal/mcp", "-run", "TestEndpointMCPPreservesHeaderAndEmptyValues", "-count=1")
 	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestGeneratedGetEmitsRequiredAndDefaultedZeroQueryParams(t *testing.T) {
+	requests := make(chan url.Values, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	apiSpec := minimalSpec("zero-query")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.BaseURL = server.URL
+	apiSpec.Resources = map[string]spec.Resource{
+		"items": {
+			Description: "Manage items",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/items",
+					Description: "List items",
+					Params: []spec.Param{
+						{Name: "requiredOffset", In: "query", Type: "int", Required: true},
+						{Name: "defaultOffset", In: "query", Type: "int", Default: 0},
+						{Name: "optionalOffset", In: "query", Type: "int"},
+					},
+				},
+				"get": {
+					Method:      "GET",
+					Path:        "/items/{id}",
+					Description: "Get an item",
+					Params:      []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true, PathParam: true}},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	listSrc := readGeneratedFile(t, outputDir, "internal", "cli", "items_list.go")
+	assert.Contains(t, listSrc, `if true {`, "required and explicitly defaulted params must be emitted even when their value is zero")
+	assert.Contains(t, listSrc, `if flagOptionalOffset != 0 {`, "optional params without defaults must retain zero-value omission")
+
+	binaryPath := filepath.Join(outputDir, "zero-query-pp-cli")
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/zero-query-pp-cli")
+	t.Setenv("ZERO_QUERY_BASE_URL", server.URL)
+	runGeneratedBinary(t, binaryPath, "items", "list", "--required-offset", "0", "--json")
+
+	got := <-requests
+	assert.Equal(t, []string{"0"}, got["requiredOffset"])
+	assert.Equal(t, []string{"0"}, got["defaultOffset"])
+	assert.NotContains(t, got, "optionalOffset")
+
+	promotedSpec := minimalSpec("zero-promoted")
+	promotedSpec.Auth = spec.AuthConfig{Type: "none"}
+	promotedSpec.Resources = map[string]spec.Resource{
+		"items": {
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method: "GET",
+					Path:   "/items",
+					Params: []spec.Param{
+						{Name: "requiredOffset", In: "query", Type: "int", Required: true},
+						{Name: "defaultOffset", In: "query", Type: "int", Default: 0},
+						{Name: "optionalOffset", In: "query", Type: "int"},
+					},
+				},
+			},
+		},
+	}
+	promotedDir := filepath.Join(t.TempDir(), naming.CLI(promotedSpec.Name))
+	require.NoError(t, New(promotedSpec, promotedDir).Generate())
+	promotedSrc := readPromotedCommandFile(t, promotedDir)
+	assert.Contains(t, promotedSrc, `if true {`)
+	assert.Contains(t, promotedSrc, `if flagOptionalOffset != 0 {`)
+	requireGeneratedCompiles(t, promotedDir)
 }
 
 func TestGenerateMutatingEndpointPassesQueryParams(t *testing.T) {

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -247,7 +247,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			htmlRequestParams["{{.Name}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .)) (not (isDeepObjectQueryParam .))}}
-			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
+			if {{readParamPresenceExpr .}} {
 				htmlRequestParams["{{.Name}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
@@ -416,7 +416,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .)) (not (isDeepObjectQueryParam .))}}
-				if {{if or (eq $.Endpoint.Method "GET") (eq $.Endpoint.Method "HEAD")}}flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}}{{else}}{{paramPresenceExpr .}}{{end}} {
+				if {{if or (eq $.Endpoint.Method "GET") (eq $.Endpoint.Method "HEAD")}}{{readParamPresenceExpr .}}{{else}}{{paramPresenceExpr .}}{{end}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -209,7 +209,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			htmlRequestParams["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .)) (not (isDeepObjectQueryParam .))}}
-				if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
+				if {{readParamPresenceExpr .}} {
 					htmlRequestParams["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 				}
 {{- end}}
@@ -279,7 +279,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam) (not (paramIsHeader .)) (not (isArrayQueryParam .)) (not (isDeepObjectQueryParam .))}}
-			if {{if $isReadVerb}}flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}}{{else}}{{paramPresenceExpr .}}{{end}} {
+			if {{if $isReadVerb}}{{readParamPresenceExpr .}}{{else}}{{paramPresenceExpr .}}{{end}} {
 				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}


### PR DESCRIPTION
## Summary

- Preserve zero-valued integer query parameters when the spec marks them required or gives them an explicit default, including `default: 0`.
- Keep omitting optional integer parameters with no declared default when their value is zero.
- Apply the corrected presence checks to endpoint and promoted command templates for read and mutation paths.

## Validation

- `go test ./...`
- `scripts/golden.sh verify` (32 cases)
- `scripts/verify-generator-output.sh` (10 cases)

Closes #3948
