### PR TITLE
fix(cli): preserve mcp-sync intent parity and reject version skew

### DIFF
--- a/internal/cli/mcp_sync.go
+++ b/internal/cli/mcp_sync.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline/mcpsync"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -30,6 +31,9 @@ a usable brand name.`,
 				return &ExitError{Code: ExitInputError, Err: fmt.Errorf("resolving cli dir: %w", err)}
 			}
 			if err := ensureNotOlderThanCLIManifest(cliDir, "mcp-sync"); err != nil {
+				return &ExitError{Code: ExitInputError, Err: err}
+			}
+			if err := ensureMCPVersionCompatibleWithCLIManifest(cliDir, version.Get()); err != nil {
 				return &ExitError{Code: ExitInputError, Err: err}
 			}
 			result, err := mcpsync.Sync(cliDir, mcpsync.Options{Force: force})

--- a/internal/cli/version_skew.go
+++ b/internal/cli/version_skew.go
@@ -15,6 +15,29 @@ func ensureNotOlderThanCLIManifest(cliDir, commandName string) error {
 	return ensureVersionNotOlderThanCLIManifest(cliDir, commandName, version.Get())
 }
 
+func ensureMCPVersionCompatibleWithCLIManifest(cliDir, currentVersion string) error {
+	manifest, err := pipeline.ReadCLIManifest(cliDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("reading %s: %w", pipeline.CLIManifestFilename, err)
+	}
+	required := strings.TrimSpace(manifest.PrintingPressVersion)
+	if required == "" {
+		return nil
+	}
+	current := normalizeSemver(currentVersion)
+	required = normalizeSemver(required)
+	if !semver.IsValid(current) || !semver.IsValid(required) {
+		return fmt.Errorf("cannot compare cli-printing-press version %q with %s printing_press_version %q", currentVersion, pipeline.CLIManifestFilename, manifest.PrintingPressVersion)
+	}
+	if semver.MajorMinor(current) != semver.MajorMinor(required) {
+		return fmt.Errorf("mcp-sync refused: cli-printing-press %s does not match the target CLI's generating minor version %s; reprint required before regenerating the MCP surface", strings.TrimPrefix(current, "v"), strings.TrimPrefix(semver.MajorMinor(required), "v"))
+	}
+	return nil
+}
+
 func ensureVersionNotOlderThanCLIManifest(cliDir, commandName, currentVersion string) error {
 	manifest, err := pipeline.ReadCLIManifest(cliDir)
 	if err != nil {

--- a/internal/cli/version_skew_test.go
+++ b/internal/cli/version_skew_test.go
@@ -77,6 +77,69 @@ func TestEnsureVersionNotOlderThanCLIManifestSkipsMissingOrLegacyManifest(t *tes
 	require.NoError(t, ensureVersionNotOlderThanCLIManifest(dir, "mcp-sync", "4.22.1"))
 }
 
+func TestEnsureMCPVersionCompatibleWithCLIManifest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		current    string
+		generated  string
+		wantErr    bool
+		wantErrSub string
+	}{
+		{name: "same version runs", current: "4.30.2", generated: "4.30.2"},
+		{name: "same minor patch drift runs", current: "4.30.3", generated: "4.30.2"},
+		{
+			name:       "newer minor refuses",
+			current:    "4.31.0",
+			generated:  "4.30.2",
+			wantErr:    true,
+			wantErrSub: "mcp-sync refused: cli-printing-press 4.31.0 does not match the target CLI's generating minor version 4.30; reprint required",
+		},
+		{
+			name:       "older minor refuses",
+			current:    "4.29.9",
+			generated:  "4.30.2",
+			wantErr:    true,
+			wantErrSub: "mcp-sync refused: cli-printing-press 4.29.9 does not match the target CLI's generating minor version 4.30; reprint required",
+		},
+		{
+			name:       "invalid version refuses",
+			current:    "not-a-version",
+			generated:  "4.30.2",
+			wantErr:    true,
+			wantErrSub: "cannot compare cli-printing-press version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			writeManifestVersion(t, dir, tt.generated)
+
+			err := ensureMCPVersionCompatibleWithCLIManifest(dir, tt.current)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrSub)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestEnsureMCPVersionCompatibleWithCLIManifestSkipsMissingOrLegacyManifest(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ensureMCPVersionCompatibleWithCLIManifest(t.TempDir(), "4.31.0"))
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, pipeline.CLIManifestFilename), []byte(`{"schema_version":1}`), 0o644))
+	require.NoError(t, ensureMCPVersionCompatibleWithCLIManifest(dir, "4.31.0"))
+}
+
 func TestRegenMergeCommandRefusesStaleBinaryBeforeClassify(t *testing.T) {
 	t.Parallel()
 
@@ -110,4 +173,21 @@ func TestMCPSyncCommandRefusesStaleBinaryBeforeSync(t *testing.T) {
 	require.True(t, errors.As(err, &exitErr))
 	assert.Equal(t, ExitInputError, exitErr.Code)
 	assert.Contains(t, err.Error(), "mcp-sync refused")
+}
+
+func TestMCPSyncCommandRefusesDifferentMinorVersionBeforeSync(t *testing.T) {
+	t.Parallel()
+
+	cliDir := t.TempDir()
+	writeManifestVersion(t, cliDir, "4.29.0")
+
+	cmd := newMCPSyncCmd()
+	cmd.SetArgs([]string{cliDir})
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	var exitErr *ExitError
+	require.True(t, errors.As(err, &exitErr))
+	assert.Equal(t, ExitInputError, exitErr.Code)
+	assert.Contains(t, err.Error(), "reprint required")
 }

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -138,11 +138,13 @@ type Generator struct {
 	DiscoveryPages     []string         // Pages visited during browser-sniff discovery
 	NovelFeatures      []NovelFeature   // Transcendence features for README/SKILL
 	Narrative          *ReadmeNarrative // LLM-authored prose for README/SKILL; optional
-	// PreserveMCPIntentRegistration keeps RegisterTools wired to an existing
-	// generated intents.go when a partial regeneration lacks the narrative
-	// source that originally lifted recipe intents.
+	// Partial regeneration must retain generated intent wiring because the
+	// narrative source used to lift recipe intents is no longer available.
 	PreserveMCPIntentRegistration bool
-	AsyncJobs                     map[string]AsyncJobInfo // Detected async-job endpoints, keyed by "<resource>/<endpoint>"
+	// PreserveMCPIntentFile keeps a legacy combined intents.go untouched when
+	// no explicit intents need regeneration.
+	PreserveMCPIntentFile bool
+	AsyncJobs             map[string]AsyncJobInfo // Detected async-job endpoints, keyed by "<resource>/<endpoint>"
 
 	// ModulePath overrides the Go module import path emitted by templates that
 	// reference internal packages (`{{modulePath}}/internal/client`, etc.).
@@ -4993,28 +4995,32 @@ func (g *Generator) renderMCPToolFiles(schema []TableDef) error {
 		recipeIntents := buildRecipeIntents(g.Spec.Name, g.Narrative, reservedIntentNames)
 		mcpData := struct {
 			*spec.APISpec
-			SyncableResources []profiler.SyncableResource
-			SearchableFields  map[string][]string
-			Tables            []TableDef
-			VisionSet         VisionTemplateSet
-			MCPTotalCount     int
-			MCPPublicCount    int
-			NovelFeatures     []NovelFeature
-			DomainContext     DomainContext
-			RecipeIntents     []RecipeIntent
-			HasMCPIntents     bool
+			SyncableResources             []profiler.SyncableResource
+			SearchableFields              map[string][]string
+			Tables                        []TableDef
+			VisionSet                     VisionTemplateSet
+			MCPTotalCount                 int
+			MCPPublicCount                int
+			NovelFeatures                 []NovelFeature
+			DomainContext                 DomainContext
+			RecipeIntents                 []RecipeIntent
+			HasMCPIntents                 bool
+			PreserveMCPIntentRegistration bool
+			PreserveMCPIntentFile         bool
 		}{
-			APISpec:           g.Spec,
-			SyncableResources: g.profile.SyncableResources,
-			SearchableFields:  g.profile.SearchableFields,
-			Tables:            schema,
-			VisionSet:         g.dataSurfaceVisionSet(),
-			MCPTotalCount:     mcpTotal,
-			MCPPublicCount:    mcpPublic,
-			NovelFeatures:     g.NovelFeatures,
-			DomainContext:     domainCtx,
-			RecipeIntents:     recipeIntents,
-			HasMCPIntents:     len(g.Spec.MCP.Intents) > 0 || len(recipeIntents) > 0 || g.PreserveMCPIntentRegistration,
+			APISpec:                       g.Spec,
+			SyncableResources:             g.profile.SyncableResources,
+			SearchableFields:              g.profile.SearchableFields,
+			Tables:                        schema,
+			VisionSet:                     g.dataSurfaceVisionSet(),
+			MCPTotalCount:                 mcpTotal,
+			MCPPublicCount:                mcpPublic,
+			NovelFeatures:                 g.NovelFeatures,
+			DomainContext:                 domainCtx,
+			RecipeIntents:                 recipeIntents,
+			HasMCPIntents:                 len(g.Spec.MCP.Intents) > 0 || len(recipeIntents) > 0 || g.PreserveMCPIntentRegistration,
+			PreserveMCPIntentRegistration: g.PreserveMCPIntentRegistration,
+			PreserveMCPIntentFile:         g.PreserveMCPIntentFile,
 		}
 		if err := g.renderTemplate("mcp_platform_gate.go.tmpl", filepath.Join("internal", "mcp", "platform_gate.go"), mcpData); err != nil {
 			return fmt.Errorf("rendering MCP tenant gate: %w", err)
@@ -5030,7 +5036,7 @@ func (g *Generator) renderMCPToolFiles(schema []TableDef) error {
 				return fmt.Errorf("rendering MCP tools tests: %w", err)
 			}
 		}
-		if (len(g.Spec.MCP.Intents) > 0 || len(recipeIntents) > 0) && !g.PreserveMCPIntentRegistration {
+		if mcpData.HasMCPIntents && !g.PreserveMCPIntentFile {
 			if err := g.renderTemplate("mcp_intents.go.tmpl", filepath.Join("internal", "mcp", "intents.go"), mcpData); err != nil {
 				return fmt.Errorf("rendering MCP intents: %w", err)
 			}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -134,11 +134,15 @@ type Generator struct {
 	visionCommandNames map[string]string
 	FixtureSet         *browsersniff.FixtureSet
 	TrafficAnalysis    *browsersniff.TrafficAnalysis
-	Sources            []ReadmeSource          // Ecosystem tools to credit in README
-	DiscoveryPages     []string                // Pages visited during browser-sniff discovery
-	NovelFeatures      []NovelFeature          // Transcendence features for README/SKILL
-	Narrative          *ReadmeNarrative        // LLM-authored prose for README/SKILL; optional
-	AsyncJobs          map[string]AsyncJobInfo // Detected async-job endpoints, keyed by "<resource>/<endpoint>"
+	Sources            []ReadmeSource   // Ecosystem tools to credit in README
+	DiscoveryPages     []string         // Pages visited during browser-sniff discovery
+	NovelFeatures      []NovelFeature   // Transcendence features for README/SKILL
+	Narrative          *ReadmeNarrative // LLM-authored prose for README/SKILL; optional
+	// PreserveMCPIntentRegistration keeps RegisterTools wired to an existing
+	// generated intents.go when a partial regeneration lacks the narrative
+	// source that originally lifted recipe intents.
+	PreserveMCPIntentRegistration bool
+	AsyncJobs                     map[string]AsyncJobInfo // Detected async-job endpoints, keyed by "<resource>/<endpoint>"
 
 	// ModulePath overrides the Go module import path emitted by templates that
 	// reference internal packages (`{{modulePath}}/internal/client`, etc.).
@@ -5010,7 +5014,7 @@ func (g *Generator) renderMCPToolFiles(schema []TableDef) error {
 			NovelFeatures:     g.NovelFeatures,
 			DomainContext:     domainCtx,
 			RecipeIntents:     recipeIntents,
-			HasMCPIntents:     len(g.Spec.MCP.Intents) > 0 || len(recipeIntents) > 0,
+			HasMCPIntents:     len(g.Spec.MCP.Intents) > 0 || len(recipeIntents) > 0 || g.PreserveMCPIntentRegistration,
 		}
 		if err := g.renderTemplate("mcp_platform_gate.go.tmpl", filepath.Join("internal", "mcp", "platform_gate.go"), mcpData); err != nil {
 			return fmt.Errorf("rendering MCP tenant gate: %w", err)
@@ -5026,7 +5030,7 @@ func (g *Generator) renderMCPToolFiles(schema []TableDef) error {
 				return fmt.Errorf("rendering MCP tools tests: %w", err)
 			}
 		}
-		if mcpData.HasMCPIntents {
+		if (len(g.Spec.MCP.Intents) > 0 || len(recipeIntents) > 0) && !g.PreserveMCPIntentRegistration {
 			if err := g.renderTemplate("mcp_intents.go.tmpl", filepath.Join("internal", "mcp", "intents.go"), mcpData); err != nil {
 				return fmt.Errorf("rendering MCP intents: %w", err)
 			}

--- a/internal/generator/templates/mcp_intents.go.tmpl
+++ b/internal/generator/templates/mcp_intents.go.tmpl
@@ -16,16 +16,22 @@
 package mcp
 
 import (
+	{{- if or .MCP.Intents .RecipeIntents}}
 	"context"
+{{- end}}
 {{- if .MCP.Intents}}
 	"encoding/json"
 {{- end}}
+	{{- if or .MCP.Intents .RecipeIntents}}
 	"fmt"
 	"strings"
+{{- end}}
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+{{- if or .MCP.Intents .RecipeIntents}}
 	"{{modulePath}}/internal/mcp/bound"
+{{- end}}
 {{- if .MCP.Intents}}
 	"{{modulePath}}/internal/client"
 {{- end}}
@@ -64,6 +70,9 @@ func RegisterIntents(s *server.MCPServer) {
 		),
 		handle{{pascal .Name}},
 	)
+{{- end}}
+{{- if and .PreserveMCPIntentRegistration (not .PreserveMCPIntentFile)}}
+	RegisterRecipeIntents(s)
 {{- end}}
 }
 

--- a/internal/pipeline/mcpsync/sync.go
+++ b/internal/pipeline/mcpsync/sync.go
@@ -287,6 +287,7 @@ func Sync(cliDir string, opts Options) (Result, error) {
 	gen := generator.New(parsed, cliDir)
 	gen.NovelFeatures = features
 	gen.ModulePath = modulePath
+	gen.PreserveMCPIntentRegistration = hasMCPRecipeIntentRegistration(cliDir)
 	if err := gen.GenerateMCPSurface(); err != nil {
 		return Result{}, fmt.Errorf("rendering MCP surface: %w", err)
 	}
@@ -320,6 +321,15 @@ func Sync(cliDir string, opts Options) (Result, error) {
 		detail = "refreshed MCP surface, manifest.json, and tools-manifest.json from current spec / .printing-press.json / mcp-descriptions.json"
 	}
 	return Result{Changed: true, Detail: detail, UnmatchedOverrideKeys: unmatched}, nil
+}
+
+func hasMCPRecipeIntentRegistration(cliDir string) bool {
+	data, err := os.ReadFile(filepath.Join(cliDir, "internal", "mcp", "intents.go"))
+	if err != nil {
+		return false
+	}
+	source := string(data)
+	return strings.Contains(source, "func RegisterIntents(") && strings.Contains(source, "recipeCLIPath")
 }
 
 func loadArchivedSpec(cliDir string) (*spec.APISpec, error) {

--- a/internal/pipeline/mcpsync/sync.go
+++ b/internal/pipeline/mcpsync/sync.go
@@ -1,9 +1,14 @@
 package mcpsync
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -161,6 +166,10 @@ func Sync(cliDir string, opts Options) (Result, error) {
 	if state.State == pipeline.MCPSurfaceHandEdited && !opts.Force {
 		return Result{}, fmt.Errorf("%w: tools.go appears hand-edited; refusing to overwrite. Use --force to override at your own risk", ErrHandEdited)
 	}
+	preserveRecipeIntents, err := hasMCPRecipeIntentRegistration(cliDir)
+	if err != nil {
+		return Result{}, fmt.Errorf("checking MCP intent registration: %w", err)
+	}
 	if err := ensureMCPClientSurfaceCompatible(cliDir); err != nil {
 		return Result{}, err
 	}
@@ -284,10 +293,39 @@ func Sync(cliDir string, opts Options) (Result, error) {
 	// Surface regen runs every sync — overrides applied above must reach
 	// tools.go, and WriteToolsManifest below rewrites the manifest
 	// unconditionally, so keeping tools.go in lockstep avoids drift.
+	preserveLegacyIntentFile := false
+	if preserveRecipeIntents {
+		legacyIntentsPath := filepath.Join(cliDir, "internal", "mcp", "intents.go")
+		recipeFilePath := filepath.Join(cliDir, "internal", "mcp", "recipe_intents.go")
+		_, recipeFileErr := os.Stat(recipeFilePath)
+		legacyRecipeFile := errors.Is(recipeFileErr, os.ErrNotExist)
+		if recipeFileErr != nil && !legacyRecipeFile {
+			return Result{}, fmt.Errorf("checking %s: %w", recipeFilePath, recipeFileErr)
+		}
+		preserveLegacyFile := false
+		if legacyRecipeFile && len(parsed.MCP.Intents) == 0 {
+			data, readErr := os.ReadFile(legacyIntentsPath)
+			if readErr != nil {
+				return Result{}, fmt.Errorf("reading %s: %w", legacyIntentsPath, readErr)
+			}
+			hasExplicit, parseErr := mcpIntentFileHasExplicitRegistration(string(data))
+			if parseErr != nil {
+				return Result{}, fmt.Errorf("checking explicit intents in %s: %w", legacyIntentsPath, parseErr)
+			}
+			preserveLegacyFile = !hasExplicit
+		}
+		if !preserveLegacyFile {
+			if err := preserveMCPRecipeIntentFile(cliDir, modulePath); err != nil {
+				return Result{}, fmt.Errorf("preserving MCP recipe intents: %w", err)
+			}
+		}
+		preserveLegacyIntentFile = preserveLegacyFile
+	}
 	gen := generator.New(parsed, cliDir)
 	gen.NovelFeatures = features
 	gen.ModulePath = modulePath
-	gen.PreserveMCPIntentRegistration = hasMCPRecipeIntentRegistration(cliDir)
+	gen.PreserveMCPIntentRegistration = preserveRecipeIntents
+	gen.PreserveMCPIntentFile = preserveLegacyIntentFile
 	if err := gen.GenerateMCPSurface(); err != nil {
 		return Result{}, fmt.Errorf("rendering MCP surface: %w", err)
 	}
@@ -323,13 +361,183 @@ func Sync(cliDir string, opts Options) (Result, error) {
 	return Result{Changed: true, Detail: detail, UnmatchedOverrideKeys: unmatched}, nil
 }
 
-func hasMCPRecipeIntentRegistration(cliDir string) bool {
-	data, err := os.ReadFile(filepath.Join(cliDir, "internal", "mcp", "intents.go"))
+func hasMCPRecipeIntentRegistration(cliDir string) (bool, error) {
+	recipePath := filepath.Join(cliDir, "internal", "mcp", "recipe_intents.go")
+	data, err := os.ReadFile(recipePath)
+	if err == nil {
+		return strings.Contains(string(data), "func RegisterRecipeIntents(") && strings.Contains(string(data), "recipeCLIPath"), nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("reading %s: %w", recipePath, err)
+	}
+
+	intentsPath := filepath.Join(cliDir, "internal", "mcp", "intents.go")
+	data, err = os.ReadFile(intentsPath)
 	if err != nil {
-		return false
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("reading %s: %w", intentsPath, err)
 	}
 	source := string(data)
-	return strings.Contains(source, "func RegisterIntents(") && strings.Contains(source, "recipeCLIPath")
+	return strings.Contains(source, "func RegisterIntents(") && strings.Contains(source, "recipeCLIPath"), nil
+}
+
+func preserveMCPRecipeIntentFile(cliDir, modulePath string) error {
+	recipePath := filepath.Join(cliDir, "internal", "mcp", "recipe_intents.go")
+	if _, err := os.Stat(recipePath); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("checking %s: %w", recipePath, err)
+	}
+
+	intentsPath := filepath.Join(cliDir, "internal", "mcp", "intents.go")
+	data, err := os.ReadFile(intentsPath)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", intentsPath, err)
+	}
+	recipeSource, err := extractMCPRecipeIntentSource(string(data), modulePath)
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic(recipePath, recipeSource)
+}
+
+func extractMCPRecipeIntentSource(source, modulePath string) ([]byte, error) {
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, "intents.go", source, parser.ParseComments)
+	if err != nil {
+		return nil, fmt.Errorf("parsing intents.go: %w", err)
+	}
+
+	recipeHandlers := make(map[string]bool)
+	var registerIntents *ast.FuncDecl
+	var recipeDecls []ast.Decl
+	for _, decl := range file.Decls {
+		switch node := decl.(type) {
+		case *ast.FuncDecl:
+			if node.Name.Name == "RegisterIntents" {
+				registerIntents = node
+			}
+			if node.Body == nil {
+				continue
+			}
+			if containsMCPIntentIdentifier(node.Body, "recipeCLIPathErr") {
+				recipeHandlers[node.Name.Name] = true
+				recipeDecls = append(recipeDecls, node)
+			}
+			if node.Name.Name == "init" || strings.HasPrefix(node.Name.Name, "appendRecipe") || node.Name.Name == "recipeValueString" {
+				recipeDecls = append(recipeDecls, node)
+			}
+		case *ast.GenDecl:
+			if node.Tok != token.VAR {
+				continue
+			}
+			if containsMCPIntentIdentifier(node, "recipeCLIPath") || containsMCPIntentIdentifier(node, "recipeCLIPathErr") {
+				recipeDecls = append(recipeDecls, node)
+			}
+		}
+	}
+	if registerIntents == nil || len(recipeHandlers) == 0 {
+		return nil, fmt.Errorf("intents.go contains recipe markers but no extractable recipe handlers")
+	}
+
+	var registration bytes.Buffer
+	for _, stmt := range registerIntents.Body.List {
+		handler, ok := mcpIntentRegistrationHandler(stmt)
+		if !ok || !recipeHandlers[handler] {
+			continue
+		}
+		if err := format.Node(&registration, fileSet, stmt); err != nil {
+			return nil, fmt.Errorf("formatting recipe registration: %w", err)
+		}
+		registration.WriteByte('\n')
+	}
+	if registration.Len() == 0 {
+		return nil, fmt.Errorf("intents.go contains recipe handlers but no recipe registrations")
+	}
+
+	header := "// Generated by CLI Printing Press (https://github.com/mvanhorn/cli-printing-press). DO NOT EDIT.\n"
+	if prefix, _, ok := strings.Cut(source, "package mcp"); ok {
+		header = prefix
+	}
+	var out bytes.Buffer
+	fmt.Fprintf(&out, "%spackage mcp\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\t\"strings\"\n\n\tmcplib \"github.com/mark3labs/mcp-go/mcp\"\n\t\"github.com/mark3labs/mcp-go/server\"\n\t%q\n\t%q\n)\n\nfunc RegisterRecipeIntents(s *server.MCPServer) {\n", header, modulePath+"/internal/mcp/bound", modulePath+"/internal/mcp/cobratree")
+	out.Write(registration.Bytes())
+	out.WriteString("}\n\n")
+	for _, decl := range recipeDecls {
+		if err := format.Node(&out, fileSet, decl); err != nil {
+			return nil, fmt.Errorf("formatting recipe declaration: %w", err)
+		}
+		out.WriteString("\n\n")
+	}
+	formatted, err := format.Source(out.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("formatting recipe_intents.go: %w", err)
+	}
+	return formatted, nil
+}
+
+func containsMCPIntentIdentifier(node ast.Node, name string) bool {
+	found := false
+	ast.Inspect(node, func(node ast.Node) bool {
+		ident, ok := node.(*ast.Ident)
+		if ok && ident.Name == name {
+			found = true
+			return false
+		}
+		return !found
+	})
+	return found
+}
+
+func mcpIntentRegistrationHandler(stmt ast.Stmt) (string, bool) {
+	exprStmt, ok := stmt.(*ast.ExprStmt)
+	if !ok {
+		return "", false
+	}
+	call, ok := exprStmt.X.(*ast.CallExpr)
+	if !ok || len(call.Args) == 0 {
+		return "", false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "AddTool" {
+		return "", false
+	}
+	handler, ok := call.Args[len(call.Args)-1].(*ast.Ident)
+	return handler.Name, ok
+}
+
+func mcpIntentFileHasExplicitRegistration(source string) (bool, error) {
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, "intents.go", source, 0)
+	if err != nil {
+		return false, err
+	}
+	var registerIntents *ast.FuncDecl
+	recipeHandlers := make(map[string]bool)
+	for _, decl := range file.Decls {
+		node, ok := decl.(*ast.FuncDecl)
+		if !ok || node.Body == nil {
+			continue
+		}
+		if node.Name.Name == "RegisterIntents" {
+			registerIntents = node
+		}
+		if containsMCPIntentIdentifier(node.Body, "recipeCLIPathErr") {
+			recipeHandlers[node.Name.Name] = true
+		}
+	}
+	if registerIntents == nil {
+		return false, fmt.Errorf("missing RegisterIntents function")
+	}
+	for _, stmt := range registerIntents.Body.List {
+		handler, ok := mcpIntentRegistrationHandler(stmt)
+		if ok && !recipeHandlers[handler] {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func loadArchivedSpec(cliDir string) (*spec.APISpec, error) {

--- a/internal/pipeline/mcpsync/sync_test.go
+++ b/internal/pipeline/mcpsync/sync_test.go
@@ -71,6 +71,47 @@ func RegisterNovelFeatureTools() { shellOutToCLI("items list") }
 	assert.Equal(t, legacyTools, after, "compatibility refusal must happen before tools.go is rewritten")
 }
 
+func TestSyncPreservesGeneratedRecipeIntentRegistration(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := spec.Parse(filepath.Join("..", "..", "..", "testdata", "loops.yaml"))
+	require.NoError(t, err)
+	cliDir := filepath.Join(t.TempDir(), "loops")
+	gen := generator.New(apiSpec, cliDir)
+	gen.VisionSet = generator.VisionTemplateSet{MCP: true}
+	gen.Narrative = &generator.ReadmeNarrative{
+		Recipes: []generator.Recipe{{
+			Title:       "List contacts with a limit",
+			Command:     "loops-pp-cli contacts list --limit=<limit> --json",
+			Explanation: "Fetch a bounded contact list.",
+		}},
+	}
+	require.NoError(t, gen.Generate())
+
+	specData, err := yaml.Marshal(apiSpec)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "spec.yaml"), specData, 0o644))
+
+	toolsPath := filepath.Join(cliDir, "internal", "mcp", "tools.go")
+	intentsPath := filepath.Join(cliDir, "internal", "mcp", "intents.go")
+	toolsBefore, err := os.ReadFile(toolsPath)
+	require.NoError(t, err)
+	intentsBefore, err := os.ReadFile(intentsPath)
+	require.NoError(t, err)
+	require.Contains(t, string(toolsBefore), "RegisterIntents(s)")
+	require.Contains(t, string(intentsBefore), "list_contacts_with_a_limit")
+
+	_, err = Sync(cliDir, Options{})
+	require.NoError(t, err)
+
+	toolsAfter, err := os.ReadFile(toolsPath)
+	require.NoError(t, err)
+	intentsAfter, err := os.ReadFile(intentsPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(toolsAfter), "RegisterIntents(s)", "same-version mcp-sync must preserve the generated RegisterTools intent registration")
+	assert.Equal(t, string(intentsBefore), string(intentsAfter), "mcp-sync must not rewrite recipe-lifted intent handlers without their narrative source")
+}
+
 func TestEnsureMCPClientSurfaceCompatibleChecksConditionalRequestTypes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/mcpsync/sync_test.go
+++ b/internal/pipeline/mcpsync/sync_test.go
@@ -3,6 +3,7 @@ package mcpsync
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -76,6 +77,12 @@ func TestSyncPreservesGeneratedRecipeIntentRegistration(t *testing.T) {
 
 	apiSpec, err := spec.Parse(filepath.Join("..", "..", "..", "testdata", "loops.yaml"))
 	require.NoError(t, err)
+	apiSpec.MCP.Intents = []spec.Intent{{
+		Name:        "old_explicit_intent",
+		Description: "The old explicit intent.",
+		Steps:       []spec.IntentStep{{Endpoint: "contacts.list", Capture: "contacts"}},
+		Returns:     "contacts",
+	}}
 	cliDir := filepath.Join(t.TempDir(), "loops")
 	gen := generator.New(apiSpec, cliDir)
 	gen.VisionSet = generator.VisionTemplateSet{MCP: true}
@@ -100,6 +107,17 @@ func TestSyncPreservesGeneratedRecipeIntentRegistration(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(toolsBefore), "RegisterIntents(s)")
 	require.Contains(t, string(intentsBefore), "list_contacts_with_a_limit")
+	require.Contains(t, string(intentsBefore), "old_explicit_intent")
+
+	apiSpec.MCP.Intents = []spec.Intent{{
+		Name:        "new_explicit_intent",
+		Description: "The new explicit intent.",
+		Steps:       []spec.IntentStep{{Endpoint: "contacts.list", Capture: "contacts"}},
+		Returns:     "contacts",
+	}}
+	specData, err = yaml.Marshal(apiSpec)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "spec.yaml"), specData, 0o644))
 
 	_, err = Sync(cliDir, Options{})
 	require.NoError(t, err)
@@ -108,8 +126,63 @@ func TestSyncPreservesGeneratedRecipeIntentRegistration(t *testing.T) {
 	require.NoError(t, err)
 	intentsAfter, err := os.ReadFile(intentsPath)
 	require.NoError(t, err)
+	recipeAfter, err := os.ReadFile(filepath.Join(cliDir, "internal", "mcp", "recipe_intents.go"))
+	require.NoError(t, err)
 	assert.Contains(t, string(toolsAfter), "RegisterIntents(s)", "same-version mcp-sync must preserve the generated RegisterTools intent registration")
-	assert.Equal(t, string(intentsBefore), string(intentsAfter), "mcp-sync must not rewrite recipe-lifted intent handlers without their narrative source")
+	assert.Contains(t, string(intentsAfter), "new_explicit_intent", "mcp-sync must regenerate explicit intent declarations from the archived spec")
+	assert.NotContains(t, string(intentsAfter), "old_explicit_intent", "removed explicit intents must not remain registered")
+	assert.Contains(t, string(intentsAfter), "RegisterRecipeIntents(s)", "mcp-sync must retain the preserved recipe registration call")
+	assert.Contains(t, string(recipeAfter), "list_contacts_with_a_limit", "recipe intent registration must survive without the narrative source")
+	assert.Contains(t, string(recipeAfter), "cobratree.RunCLICommand(ctx, recipeCLIPath, args)")
+	cmd := exec.Command("go", "test", "-mod=mod", "./internal/mcp")
+	cmd.Dir = cliDir
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "post-sync MCP package must compile and test: %s", output)
+}
+
+func TestSyncLeavesRecipeOnlyIntentFileUnchanged(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := spec.Parse(filepath.Join("..", "..", "..", "testdata", "loops.yaml"))
+	require.NoError(t, err)
+	cliDir := filepath.Join(t.TempDir(), "loops")
+	gen := generator.New(apiSpec, cliDir)
+	gen.VisionSet = generator.VisionTemplateSet{MCP: true}
+	gen.Narrative = &generator.ReadmeNarrative{
+		Recipes: []generator.Recipe{{
+			Title:       "List contacts with a limit",
+			Command:     "loops-pp-cli contacts list --limit=<limit> --json",
+			Explanation: "Fetch a bounded contact list.",
+		}},
+	}
+	require.NoError(t, gen.Generate())
+	specData, err := yaml.Marshal(apiSpec)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "spec.yaml"), specData, 0o644))
+
+	intentsPath := filepath.Join(cliDir, "internal", "mcp", "intents.go")
+	before, err := os.ReadFile(intentsPath)
+	require.NoError(t, err)
+	_, err = Sync(cliDir, Options{})
+	require.NoError(t, err)
+	after, err := os.ReadFile(intentsPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after), "recipe-only mcp-sync must preserve the combined intent file when no explicit intents need refresh")
+	_, err = os.Stat(filepath.Join(cliDir, "internal", "mcp", "recipe_intents.go"))
+	assert.Error(t, err, "recipe-only mcp-sync should not create a compatibility split file")
+}
+
+func TestHasMCPRecipeIntentRegistrationFailsClosedOnReadError(t *testing.T) {
+	t.Parallel()
+
+	cliDir := filepath.Join(t.TempDir(), "broken")
+	intentsDir := filepath.Join(cliDir, "internal", "mcp", "intents.go")
+	require.NoError(t, os.MkdirAll(intentsDir, 0o755))
+
+	got, err := hasMCPRecipeIntentRegistration(cliDir)
+	require.Error(t, err)
+	assert.False(t, got)
+	assert.Contains(t, err.Error(), "intents.go")
 }
 
 func TestEnsureMCPClientSurfaceCompatibleChecksConditionalRequestTypes(t *testing.T) {


### PR DESCRIPTION
## Summary

- Preserve recipe-lifted `RegisterIntents` wiring when same-version `mcp-sync` regenerates the MCP surface without the original narrative source.
- Refuse `mcp-sync` when the running cli-printing-press minor version differs from the target CLI manifest, preventing a half-migrated print and providing actionable reprint guidance.
- Add generator/pipeline parity and CLI version-skew regression coverage.

## Tests

- Focused generator, CLI version-skew, and `pipeline/mcpsync` tests passed.
- `scripts/golden.sh verify` passed.
- `scripts/verify-generator-output.sh` passed.
- `golangci-lint run ./...` passed.
- `go test ./...` reached the known unrelated verify-mode baseline failures; affected packages passed.

Closes #4134