### PR TITLE
fix(cli): bump Go floor to 1.26.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You need both the **binary** and the **Printing Press skills**. The skills (`/pr
 
 The binary alone works (research, generation, verification, scoring) but skips the curated agent loop. The skills alone have nothing to call. Install both.
 
-**Prerequisites:** [Go 1.26.5 or newer](https://go.dev/dl/), [Claude Code](https://claude.ai/code) or another `skills`-supported agent, and Node/npm for `npx`. The skills are tested with Claude Code; install for Codex with `--agent codex` when you want to try the same slash-command workflow there. **Use Claude Code for the best-tested experience.**
+**Prerequisites:** [Go 1.26.6 or newer](https://go.dev/dl/), [Claude Code](https://claude.ai/code) or another `skills`-supported agent, and Node/npm for `npx`. The skills are tested with Claude Code; install for Codex with `--agent codex` when you want to try the same slash-command workflow there. **Use Claude Code for the best-tested experience.**
 
 ### 1. Install
 
@@ -54,7 +54,7 @@ npx -y skills@latest list -g -a codex --json
 
 See [docs/CODEX.md](docs/CODEX.md) for the Codex-specific notes.
 
-Verify with `cli-printing-press --version`. If install fails, confirm Go 1.26.5 or newer is installed, Node/npm is installed for `npx`, and `$GOPATH/bin` is on your `PATH`.
+Verify with `cli-printing-press --version`. If install fails, confirm Go 1.26.6 or newer is installed, Node/npm is installed for `npx`, and `$GOPATH/bin` is on your `PATH`.
 
 Older releases installed a generator binary named `printing-press`. That legacy
 entrypoint still works for compatibility, but the canonical generator command is
@@ -529,7 +529,7 @@ Each newly published CLI ships a root `AGENTS.md` operating guide, a research ma
 ## Limitations
 
 - **Technical capability is not legal permission.** Before generating a CLI for any service, review its Terms of Service. Many services explicitly prohibit automated access. Using this tool against such services may violate their terms or applicable law. You are responsible for ensuring your use is authorized.
-- **Requires Go 1.26.5 or newer and an agent that can load open-agent-skills.** Claude Code is the tested path; Codex installation is documented but may lag Claude Code behavior. No standalone distribution today; the slash command is the supported entry point for Claude Code.
+- **Requires Go 1.26.6 or newer and an agent that can load open-agent-skills.** Claude Code is the tested path; Codex installation is documented but may lag Claude Code behavior. No standalone distribution today; the slash command is the supported entry point for Claude Code.
 - **Generated CLIs are domain-shaped, not vendor-replacements.** A `<api>-pp-cli` covers the agent power-user surface, not every back-office knob a vendor's official CLI ships.
 - **Browser-sniff requires manual capture.** You point a browser at the site (or import a HAR); the press doesn't crawl autonomously.
 - **Live verify is read-only.** Phase 5 runs GET only and never mutates. Real write-path coverage lives in unit tests and the dogfood structural checks.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mvanhorn/cli-printing-press/v4
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/chromedp/chromedp v0.15.1

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -263,7 +263,7 @@ resources:
 
 	const modulePath = "github.com/mvanhorn/printing-press-library/library/sales-and-crm/tenderned"
 	require.NoError(t, os.MkdirAll(outputDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "go.mod"), []byte("module "+modulePath+"\n\ngo 1.26.5\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "go.mod"), []byte("module "+modulePath+"\n\ngo 1.26.6\n"), 0o644))
 
 	cmd := newGenerateCmd()
 	cmd.SetArgs([]string{

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -679,7 +679,7 @@ func TestRunGoVulnCheckUsesPinnedDefaultCommandWithModuleToolchain(t *testing.T)
 		t.Skip("fake shell go binary is Unix-only")
 	}
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.26.5\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.26.6\n"), 0o644))
 
 	fakeBin := t.TempDir()
 	callsPath := filepath.Join(t.TempDir(), "go-calls.txt")
@@ -701,7 +701,7 @@ exit 42
 
 	calls, err := os.ReadFile(callsPath)
 	require.NoError(t, err)
-	assert.Equal(t, "args=run "+govulncheck.ToolModule+" ./...\ntoolchain=go1.26.5\n", string(calls))
+	assert.Equal(t, "args=run "+govulncheck.ToolModule+" ./...\ntoolchain=go1.26.6\n", string(calls))
 	assert.NotContains(t, string(calls), "-show")
 	assert.NotContains(t, string(calls), "verbose")
 }
@@ -2395,7 +2395,7 @@ func TestCheckModulePath(t *testing.T) {
 
 	t.Run("canonical prefix passes", func(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
-			[]byte("module github.com/mvanhorn/printing-press-library/library/ai/exa\n\ngo 1.26.5\n"), 0o644))
+			[]byte("module github.com/mvanhorn/printing-press-library/library/ai/exa\n\ngo 1.26.6\n"), 0o644))
 		res := checkModulePath(dir)
 		assert.True(t, res.Passed, res.Error)
 		assert.Equal(t, "module path", res.Name)
@@ -2403,7 +2403,7 @@ func TestCheckModulePath(t *testing.T) {
 
 	t.Run("bare CLI name fails", func(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
-			[]byte("module exa-pp-cli\n\ngo 1.26.5\n"), 0o644))
+			[]byte("module exa-pp-cli\n\ngo 1.26.6\n"), 0o644))
 		res := checkModulePath(dir)
 		assert.False(t, res.Passed)
 		assert.Contains(t, res.Error, "does not start with the canonical library prefix")
@@ -2417,7 +2417,7 @@ func TestCheckModulePath(t *testing.T) {
 
 	t.Run("no module line fails", func(t *testing.T) {
 		emptyDir := t.TempDir()
-		require.NoError(t, os.WriteFile(filepath.Join(emptyDir, "go.mod"), []byte("go 1.26.5\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(emptyDir, "go.mod"), []byte("go 1.26.6\n"), 0o644))
 		res := checkModulePath(emptyDir)
 		assert.False(t, res.Passed)
 		assert.Contains(t, res.Error, "declares no module line")
@@ -2430,7 +2430,7 @@ func TestPublishValidateModulePathCheckWired(t *testing.T) {
 	writePublishableTestCLI(t, cliDir)
 	// Force a bare module path to exercise the new check end-to-end.
 	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "go.mod"),
-		[]byte("module test-pp-cli\n\ngo 1.26.5\n"), 0o644))
+		[]byte("module test-pp-cli\n\ngo 1.26.6\n"), 0o644))
 
 	cmd := newPublishCmd()
 	cmd.SetArgs([]string{"validate", "--dir", cliDir, "--json"})

--- a/internal/cli/verify_skill_test.go
+++ b/internal/cli/verify_skill_test.go
@@ -815,7 +815,7 @@ func Execute() error { return (&cobra.Command{Use: "`+name+`-pp-cli"}).Execute()
 `), 0o644))
 
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
-		[]byte("module github.com/example/"+name+"-pp-cli\n\ngo 1.26.5\n"), 0o644))
+		[]byte("module github.com/example/"+name+"-pp-cli\n\ngo 1.26.6\n"), 0o644))
 
 	manifest := fmt.Sprintf(`{"api_name":%q,"cli_name":%q,"category":%q}`,
 		name, name+"-pp-cli", category)

--- a/internal/generator/install_section.go
+++ b/internal/generator/install_section.go
@@ -38,7 +38,7 @@ const canonicalSkillInstallSectionStartFormat = "## Prerequisites: Install the C
 // canonicalSkillInstallSectionGoFallbackFormat is appended only once the
 // public-library category is known. Before publish, the category-agnostic installer is
 // the only canonical path; emitting library/other/<slug> creates drift.
-const canonicalSkillInstallSectionGoFallbackFormat = "If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.5 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:\n" +
+const canonicalSkillInstallSectionGoFallbackFormat = "If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.6 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:\n" +
 	"\n" +
 	"```bash\n" +
 	"go install github.com/mvanhorn/printing-press-library/library/%[2]s/%[1]s/cmd/%[1]s-pp-cli@latest\n" +

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -53,7 +53,7 @@ npx -y @mvanhorn/printing-press-library install {{.Name}} --agent claude-code --
 {{ if .Category}}
 ### Without Node (Go fallback)
 
-If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.5 or newer):
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.6 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/{{.Category}}/{{.Name}}/cmd/{{.Name}}-pp-cli@latest

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -34,7 +34,7 @@ This skill drives the `{{.Name}}-pp-cli` binary. **You must verify the CLI is in
 2. Verify: `{{.Name}}-pp-cli --version`
 3. Ensure the reported install directory is on `$PATH` for the agent/runtime that will invoke this skill.
 {{ if .Category}}
-If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.5 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.6 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/{{.Category}}/{{.Name}}/cmd/{{.Name}}-pp-cli@latest

--- a/internal/govulncheck/govulncheck_test.go
+++ b/internal/govulncheck/govulncheck_test.go
@@ -25,16 +25,16 @@ func TestGoRunArgsUsesDefaultMode(t *testing.T) {
 
 func TestToolchainEnvPrefersToolchainDirective(t *testing.T) {
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.25.0\ntoolchain go1.26.5\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.25.0\ntoolchain go1.26.6\n"), 0o644))
 
-	assert.Equal(t, []string{"GOTOOLCHAIN=go1.26.5"}, ToolchainEnv(dir))
+	assert.Equal(t, []string{"GOTOOLCHAIN=go1.26.6"}, ToolchainEnv(dir))
 }
 
 func TestToolchainEnvFallsBackToPatchLevelGoDirective(t *testing.T) {
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.26.5\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.26.6\n"), 0o644))
 
-	assert.Equal(t, []string{"GOTOOLCHAIN=go1.26.5"}, ToolchainEnv(dir))
+	assert.Equal(t, []string{"GOTOOLCHAIN=go1.26.6"}, ToolchainEnv(dir))
 }
 
 func TestToolchainEnvIgnoresLanguageOnlyGoDirective(t *testing.T) {

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -326,8 +326,8 @@ func TestSetupContractsStayQuietInHealthyEnvironment(t *testing.T) {
 
 			output, err := runSkillSetupContract(t, skill, setupContractOptions{
 				includeGo:       true,
-				goInstalled:     "1.26.5",
-				goBinary:        "1.26.5",
+				goInstalled:     "1.26.6",
+				goBinary:        "1.26.6",
 				diskAvailableKB: "4194304",
 			})
 
@@ -349,14 +349,14 @@ func TestSetupContractsWarnOnOldGoToolchain(t *testing.T) {
 			output, err := runSkillSetupContract(t, skill, setupContractOptions{
 				includeGo:       true,
 				goInstalled:     "1.25.0",
-				goBinary:        "1.26.5",
+				goBinary:        "1.26.6",
 				diskAvailableKB: "4194304",
 			})
 
 			require.NoError(t, err, output)
 			assert.Contains(t, output, "[go-toolchain-old]")
 			assert.Contains(t, output, "PRESS_GO_INSTALLED=1.25.0")
-			assert.Contains(t, output, "PRESS_GO_REQUIRED=1.26.5")
+			assert.Contains(t, output, "PRESS_GO_REQUIRED=1.26.6")
 		})
 	}
 }
@@ -371,13 +371,13 @@ func TestSetupContractsBlockOldGoWhenToolchainLocal(t *testing.T) {
 			output, err := runSkillSetupContract(t, skill, setupContractOptions{
 				includeGo:       true,
 				goInstalled:     "1.25.0",
-				goBinary:        "1.26.5",
+				goBinary:        "1.26.6",
 				goToolchain:     "local",
 				diskAvailableKB: "4194304",
 			})
 
 			require.Error(t, err, output)
-			assert.Contains(t, output, "[setup-error] Go 1.26.5 or newer is required")
+			assert.Contains(t, output, "[setup-error] Go 1.26.6 or newer is required")
 			assert.NotContains(t, output, "[go-toolchain-old]")
 		})
 	}
@@ -392,8 +392,8 @@ func TestSetupContractsWarnOnLowDisk(t *testing.T) {
 
 			output, err := runSkillSetupContract(t, skill, setupContractOptions{
 				includeGo:       true,
-				goInstalled:     "1.26.5",
-				goBinary:        "1.26.5",
+				goInstalled:     "1.26.6",
+				goBinary:        "1.26.6",
 				diskAvailableKB: "1048576",
 			})
 
@@ -414,8 +414,8 @@ func TestSetupContractsBlockCriticallyLowDisk(t *testing.T) {
 
 			output, err := runSkillSetupContract(t, skill, setupContractOptions{
 				includeGo:       true,
-				goInstalled:     "1.26.5",
-				goBinary:        "1.26.5",
+				goInstalled:     "1.26.6",
+				goBinary:        "1.26.6",
 				diskAvailableKB: "1024",
 			})
 
@@ -944,7 +944,7 @@ func TestImportRewriteHandlesCRLFGoMod(t *testing.T) {
 	t.Parallel()
 
 	staging := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(staging, "go.mod"), []byte("module github.com/mvanhorn/printing-press-library/library/productivity/sample\r\n\r\ngo 1.26.5\r\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(staging, "go.mod"), []byte("module github.com/mvanhorn/printing-press-library/library/productivity/sample\r\n\r\ngo 1.26.6\r\n"), 0o644))
 	require.NoError(t, os.MkdirAll(filepath.Join(staging, "internal", "cli"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(staging, "internal", "cli", "root.go"), []byte("package cli\r\n\r\nimport \"github.com/mvanhorn/printing-press-library/library/productivity/sample/internal/client\"\r\n\r\nvar _ = client.New\r\n"), 0o644))
 
@@ -1580,7 +1580,7 @@ func runSkillSetupContract(t *testing.T, skill setupSkill, opts setupContractOpt
 	t.Helper()
 
 	if opts.goInstalled == "" {
-		opts.goInstalled = "1.26.5"
+		opts.goInstalled = "1.26.6"
 	}
 	if opts.goBinary == "" {
 		opts.goBinary = opts.goInstalled
@@ -1616,16 +1616,16 @@ echo "fake 9999999 0 ${PP_FAKE_DF_AVAIL_KB:-4194304} 0% /"
 case "$1" in
   env)
     if [ "$2" = "GOVERSION" ]; then
-      echo "go${PP_FAKE_GO_INSTALLED:-1.26.5}"
+      echo "go${PP_FAKE_GO_INSTALLED:-1.26.6}"
       exit 0
     fi
     exit 0
     ;;
   version)
     if [ "$#" -ge 2 ]; then
-      echo "$2: go${PP_FAKE_GO_BINARY:-1.26.5}"
+      echo "$2: go${PP_FAKE_GO_BINARY:-1.26.6}"
     else
-      echo "go version go${PP_FAKE_GO_INSTALLED:-1.26.5} test/amd64"
+      echo "go version go${PP_FAKE_GO_INSTALLED:-1.26.6} test/amd64"
     fi
     exit 0
     ;;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,7 +20,7 @@ umask 022
 
 readonly PROJECT_NAME="CLI Printing Press"
 readonly BINARY_NAME="cli-printing-press"
-readonly GO_MIN_VERSION="1.26.5"
+readonly GO_MIN_VERSION="1.26.6"
 readonly GO_INSTALL_TARGET="github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest"
 readonly SKILL_SOURCE="mvanhorn/cli-printing-press/skills"
 readonly SKILLS_PACKAGE="skills@latest"

--- a/skills/printing-press-amend/SKILL.md
+++ b/skills/printing-press-amend/SKILL.md
@@ -88,7 +88,7 @@ if ! command -v go >/dev/null 2>&1; then
   echo "[setup-error] Go toolchain not found."
   echo ""
   echo "This Printing Press flow runs Go-based build or validation commands."
-  echo "Install Go 1.26.5 or newer from https://go.dev/dl/, then verify with:"
+  echo "Install Go 1.26.6 or newer from https://go.dev/dl/, then verify with:"
   echo "  go version"
   echo "Then re-run this skill."
   echo ""

--- a/skills/printing-press-import/SKILL.md
+++ b/skills/printing-press-import/SKILL.md
@@ -56,7 +56,7 @@ if ! command -v go >/dev/null 2>&1; then
   echo "[setup-error] Go toolchain not found."
   echo ""
   echo "This Printing Press flow runs Go-based build or validation commands."
-  echo "Install Go 1.26.5 or newer from https://go.dev/dl/, then verify with:"
+  echo "Install Go 1.26.6 or newer from https://go.dev/dl/, then verify with:"
   echo "  go version"
   echo "Then re-run this skill."
   echo ""

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -116,7 +116,7 @@ if ! command -v go >/dev/null 2>&1; then
   echo "[setup-error] Go toolchain not found."
   echo ""
   echo "This Printing Press flow runs Go-based build or validation commands."
-  echo "Install Go 1.26.5 or newer from https://go.dev/dl/, then verify with:"
+  echo "Install Go 1.26.6 or newer from https://go.dev/dl/, then verify with:"
   echo "  go version"
   echo "Then re-run this skill."
   echo ""

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -216,7 +216,7 @@ if ! command -v go >/dev/null 2>&1; then
   echo "[setup-error] Go toolchain not found."
   echo ""
   echo "This Printing Press flow runs Go-based build or validation commands."
-  echo "Install Go 1.26.5 or newer from https://go.dev/dl/, then verify with:"
+  echo "Install Go 1.26.6 or newer from https://go.dev/dl/, then verify with:"
   echo "  go version"
   echo "Then re-run this skill."
   echo ""

--- a/skills/printing-press-score/SKILL.md
+++ b/skills/printing-press-score/SKILL.md
@@ -27,7 +27,7 @@ Score generated CLIs against the Steinberger bar. Supports rescoring, scoring by
 
 ## Prerequisites
 
-- Go 1.26.5 or newer installed
+- Go 1.26.6 or newer installed
 - `cli-printing-press` binary on PATH (install with `go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest`)
 
 ## Step 0: Setup

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -223,7 +223,7 @@ elif ! _resolve_press_bin >/dev/null; then
       echo "Install it in your terminal:"
       echo "  go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest"
     else
-      echo "Go 1.26.5 or newer is also not installed. Install Go from https://go.dev/dl/, then:"
+      echo "Go 1.26.6 or newer is also not installed. Install Go from https://go.dev/dl/, then:"
       echo "  go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest"
     fi
     echo ""
@@ -243,7 +243,7 @@ if ! command -v go >/dev/null 2>&1; then
   echo "[setup-error] Go toolchain not found."
   echo ""
   echo "The Printing Press generator runs Go-based quality gates after generation."
-  echo "Install Go 1.26.5 or newer from https://go.dev/dl/, then verify with:"
+  echo "Install Go 1.26.6 or newer from https://go.dev/dl/, then verify with:"
   echo "  go version"
   echo "Then re-run /printing-press."
   echo ""

--- a/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/go.mod
+++ b/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/go.mod
@@ -1,8 +1,8 @@
 module ble-desk-lamp-pp-cli
 
-go 1.26.5
+go 1.26.6
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/mark3labs/mcp-go v0.57.0

--- a/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/go.mod
+++ b/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/go.mod
@@ -1,8 +1,8 @@
 module ble-opaque-binary-pp-cli
 
-go 1.26.5
+go 1.26.6
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/mark3labs/mcp-go v0.57.0

--- a/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/go.mod
+++ b/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/go.mod
@@ -1,8 +1,8 @@
 module ble-session-appliance-pp-cli
 
-go 1.26.5
+go 1.26.6
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/mark3labs/mcp-go v0.57.0

--- a/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/go.mod
+++ b/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/go.mod
@@ -1,8 +1,8 @@
 module ble-temperature-sensor-pp-cli
 
-go 1.26.5
+go 1.26.6
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/mark3labs/mcp-go v0.57.0

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
@@ -1,8 +1,8 @@
 module golden-api-cookie-auth-pp-cli
 
-go 1.26.5
+go 1.26.6
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/gorilla/websocket v1.5.3

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/go.mod
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/go.mod
@@ -1,8 +1,8 @@
 module printing-press-golden-pp-cli
 
-go 1.26.5
+go 1.26.6
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/spf13/cobra v1.9.1


### PR DESCRIPTION
## Intent

Closes #4149. PR #4146 is blocked because generated-output validation runs `govulncheck` under Go 1.26.5, which is affected by standard-library advisories fixed in Go 1.26.6.

## Approach

Raise the repository floor in `go.mod` to 1.26.6 and update the verifier-tracked installer guidance, setup contracts, govulncheck toolchain tests, generated CLI guidance, and generated `go.mod` goldens. Workflows continue to use `go-version-file: go.mod`; this adds no vulnerability suppression or validation bypass.

## Scope

Primary area: generator verification and Go toolchain floor.

This belongs in the Printing Press because the shared floor controls both the generator’s validation toolchain and every newly generated CLI’s install guidance and module contract.

## Risk

Generated CLI module and install guidance now require Go 1.26.6. No runtime, API, MCP, auth, or workflow behavior changes are intended.

## Output Contract

Generated README/SKILL fallback guidance and expected generated `go.mod` files use Go 1.26.6. The generated-output verifier passed 10 cases.

## Verification

- `python3 scripts/verify-go-floor.py` — passed.
- Focused `go test ./internal/govulncheck ./internal/cli ./internal/pipeline` — passed.
- Targeted generator floor/install-section tests — passed.
- `scripts/golden.sh verify` — passed, 32 cases.
- `scripts/verify-generator-output.sh` — passed, 10 cases.
- `go test ./...` — all packages passed except the existing `internal/generator` live HTML integration failures: `TestGenerateHTMLExtractionEndpoint`, `TestGenerateHTMLExtractionEmbeddedJSONMode`, and `TestGeneratedPaginatedReadHonorsResponseFormat/{nested_live,nested_auto,promoted_live,promoted_auto}`, all reporting `invalid character 'w' looking for beginning of value`.

These changes make PR #4146 pick up Go 1.26.6 through the existing `go.mod`-based setup, so its generated-output `govulncheck` gate runs with the advisory-fixed standard library.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
