### PR TITLE
fix(cli): allow ungated MCP tenant gate

### DIFF
--- a/internal/generator/mcp_tenant_gate_test.go
+++ b/internal/generator/mcp_tenant_gate_test.go
@@ -28,6 +28,8 @@ func TestGeneratedMCPEveryToolUsesExactlyOneFreshTenantGate(t *testing.T) {
 	gateTest := readGeneratedFile(t, outputDir, "internal", "mcp", "platform_gate_test.go")
 	require.Contains(t, gateTest, "TestMCPEveryRegisteredToolHasFreshTenantGate")
 	require.Contains(t, gateTest, "TestMCPTypedInvocationUsesSingleFreshTenantGate")
+	require.Contains(t, gateTest, "TestMCPUngatedInvocationUsesRealVerifier")
+	require.Contains(t, gateTest, "verifyFreshMCPInvocation = cli.VerifyMCPInvocation")
 
 	walker := readGeneratedFile(t, outputDir, "internal", "mcp", "cobratree", "walker.go")
 	require.Contains(t, walker, `tool.Meta.AdditionalFields["pp:tenant-gate"] = "child-cli"`)

--- a/internal/generator/templates/mcp_platform_gate.go.tmpl
+++ b/internal/generator/templates/mcp_platform_gate.go.tmpl
@@ -38,7 +38,7 @@ func requireFreshTenantGate(s *server.MCPServer, next server.ToolHandlerFunc) se
 			return mcplib.NewToolResultError(err.Error()), nil
 		}
 		if session == nil {
-			return mcplib.NewToolResultError("MCP tenant gate is not configured"), nil
+			return next(ctx, request)
 		}
 		defer session.ZeroCredentials()
 		return next(platform.ContextWithSession(ctx, session), request)

--- a/internal/generator/templates/mcp_platform_gate_test.go.tmpl
+++ b/internal/generator/templates/mcp_platform_gate_test.go.tmpl
@@ -121,3 +121,36 @@ func TestMCPTypedInvocationUsesSingleFreshTenantGate(t *testing.T) {
 		t.Fatalf("typed handler calls = %d, want 1", handlerCalls)
 	}
 }
+
+func TestMCPUngatedInvocationUsesRealVerifier(t *testing.T) {
+	originalVerify := verifyFreshMCPInvocation
+	t.Cleanup(func() { verifyFreshMCPInvocation = originalVerify })
+	verifyFreshMCPInvocation = cli.VerifyMCPInvocation
+
+	session, err := cli.VerifyMCPInvocation(context.Background())
+	if err != nil {
+		t.Fatalf("real MCP verifier returned an error: %v", err)
+	}
+	if session != nil {
+		session.ZeroCredentials()
+		t.Skip("this CLI registers a platform source")
+	}
+
+	handlerCalls := 0
+	s := server.NewMCPServer("tenant-gate-conformance", "test")
+	result, err := requireFreshTenantGate(s, func(context.Context, mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+		handlerCalls++
+		return mcplib.NewToolResultText("ok"), nil
+	})(context.Background(), mcplib.CallToolRequest{
+		Params: mcplib.CallToolParams{Name: "ungated-conformance", Arguments: map[string]any{}},
+	})
+	if err != nil {
+		t.Fatalf("ungated wrapper returned protocol error: %v", err)
+	}
+	if handlerCalls != 1 {
+		t.Fatalf("ungated handler calls = %d, want 1", handlerCalls)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("ungated handler was blocked by the tenant gate: %#v", result)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Issue: Closes #4157

Fix generated MCP tenant-gate middleware so printed CLIs with no tenant-gated platform source can use in-process MCP tools instead of receiving `MCP tenant gate is not configured`.

## Approach

`cli.VerifyMCPInvocation` already uses `(nil, nil)` to mean there is no registered platform source and therefore nothing to gate. The middleware now treats that pair as an ungated pass-through while still returning verifier errors and binding verified sessions when present.

Generated conformance now includes a regression that resets the verifier hook to the real `cli.VerifyMCPInvocation`, asserts the ungated `(nil, nil)` path, and drives the real wrapper through a handler.

## Scope

Primary area: generator templates / MCP tenant gate

Why this belongs in this repo: the broken behavior is emitted into printed CLIs by the Printing Press generator, so the fix must live in the reusable template and generated-output tests.

## Risk

Low-to-moderate: this changes generated MCP middleware behavior. Gated CLIs still deny verifier errors and still bind verified sessions; ungated CLIs now bypass only when the real verifier reports no registered source.

## Output Contract

Generated output is covered by `TestGeneratedMCPEveryToolUsesExactlyOneFreshTenantGate`, which asserts the emitted real-verifier regression and compiles/runs the generated `internal/mcp` tests. `scripts/verify-generator-output.sh` also passed its default generated compile cases, and `scripts/golden.sh verify` passed the generated CLI fixture cases relevant to MCP output. No checked-in golden fixture changed because the golden expected set does not include `internal/mcp/platform_gate.go` or its generated tests.

## Verification

- [x] `go test ./internal/generator -run '^TestGeneratedMCPEveryToolUsesExactlyOneFreshTenantGate$' -count=1`
- [x] `scripts/verify-generator-output.sh`
- [x] `go test ./... -timeout 30m`
- [x] `go fmt ./...`
- [x] `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- [ ] `scripts/golden.sh verify` (fails in existing/unrelated dogfood verdict fixtures: `dogfood-verdict-matrix/{pass,fail-path-auth-dead,warn-priority}.json` due example-check build failure diffs, plus missing `verify-runtime-matrix: structural-fail.json`; all generated CLI cases including `generate-mcp-api` passed)
- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ff62d87-d103-4ff6-be93-c32bc385065e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ff62d87-d103-4ff6-be93-c32bc385065e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

