### PR TITLE
fix(cli): decouple agent mode from yes

### DIFF
--- a/internal/generator/agent_yes_contract_test.go
+++ b/internal/generator/agent_yes_contract_test.go
@@ -1,0 +1,124 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedAgentModeDoesNotGrantYes(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("agent-yes")
+	outputDir := filepath.Join(t.TempDir(), "agent-yes-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "agent_yes_contract_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestAgentModeDoesNotSetYes(t *testing.T) {
+	got := runFlagProbe(t, "--agent")
+
+	if !got.agent {
+		t.Fatalf("--agent should record agent mode")
+	}
+	if !got.asJSON || !got.compact || !got.noInput {
+		t.Fatalf("--agent should set output and interaction defaults, got asJSON=%v compact=%v noInput=%v", got.asJSON, got.compact, got.noInput)
+	}
+	if got.yes {
+		t.Fatalf("--agent must not grant explicit confirmation")
+	}
+}
+
+func TestExplicitYesStillSetsYes(t *testing.T) {
+	got := runFlagProbe(t, "--yes")
+
+	if got.agent {
+		t.Fatalf("--yes alone must not imply --agent")
+	}
+	if !got.yes {
+		t.Fatalf("explicit --yes should still grant confirmation")
+	}
+}
+
+func runFlagProbe(t *testing.T, args ...string) rootFlags {
+	t.Helper()
+
+	oldNoColor, oldHumanFriendly := noColor, humanFriendly
+	noColor, humanFriendly = false, false
+	t.Cleanup(func() {
+		noColor, humanFriendly = oldNoColor, oldHumanFriendly
+	})
+
+	var flags rootFlags
+	var captured rootFlags
+	root := newRootCmd(&flags)
+	root.AddCommand(&cobra.Command{
+		Use: "probe",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			captured = flags
+			return nil
+		},
+	})
+	root.SetArgs(append([]string{"probe"}, args...))
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("root Execute returned error: %v", err)
+	}
+	return captured
+}
+`), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestAgentModeDoesNotSetYes|TestExplicitYesStillSetsYes", "-count=1")
+}
+
+func TestGeneratedDocsKeepAgentAndYesContractsSeparate(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("agent-docs")
+	items := apiSpec.Resources["items"]
+	items.Endpoints["create"] = spec.Endpoint{
+		Method:      "POST",
+		Path:        "/items",
+		Description: "Create item",
+	}
+	apiSpec.Resources["items"] = items
+	outputDir := filepath.Join(t.TempDir(), "agent-docs-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	rootGo := readAgentContractGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	assert.Contains(t, rootGo, "Set agent-friendly output defaults (--json --compact --no-input --no-color)")
+	assert.NotContains(t, rootGo, "Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)")
+	assert.NotContains(t, rootGo, `flags.yes = true`)
+
+	readme := readAgentContractGeneratedFile(t, outputDir, "README.md")
+	assert.Contains(t, readme, "`--agent` does not imply `--yes`; pass `--yes` separately")
+	assert.NotContains(t, readme, "**Confirmable** - `--yes` for explicit confirmation of destructive actions")
+
+	skill := readAgentContractGeneratedFile(t, outputDir, "SKILL.md")
+	assert.Contains(t, skill, "Expands to: `--json --compact --no-input --no-color`.")
+	assert.Contains(t, skill, "`--agent` does not imply `--yes`; pass `--yes` separately")
+	assert.NotContains(t, skill, "Expands to: `--json --compact --no-input --no-color --yes`.")
+
+	agents := readAgentContractGeneratedFile(t, outputDir, "AGENTS.md")
+	assert.Contains(t, agents, "`--agent` does not imply `--yes`.")
+	assert.NotContains(t, agents, "confirmation-safe scripting")
+}
+
+func readAgentContractGeneratedFile(t *testing.T, outputDir string, parts ...string) string {
+	t.Helper()
+
+	body, err := os.ReadFile(filepath.Join(append([]string{outputDir}, parts...)...))
+	require.NoError(t, err)
+	return string(body)
+}

--- a/internal/generator/templates/agents.md.tmpl
+++ b/internal/generator/templates/agents.md.tmpl
@@ -18,7 +18,7 @@ Use runtime discovery instead of relying on a copied command list:
 {{.Name}}-pp-cli <command> --help
 ```
 
-Add `--agent` to command invocations for JSON, compact output, non-interactive defaults, no color, and confirmation-safe scripting:
+Add `--agent` to command invocations for JSON, compact output, non-interactive defaults, and no color:
 
 ```bash
 {{.Name}}-pp-cli <command> --agent
@@ -31,7 +31,7 @@ Before running an unfamiliar command that may mutate remote state, inspect its h
 {{.Name}}-pp-cli <command> --dry-run --agent
 ```
 
-Use `--yes --no-input` only after the target, arguments, and side effects are clear.
+When a command requires confirmation, pass `--yes` explicitly only after the target, arguments, and side effects are clear. `--agent` does not imply `--yes`.
 
 ## Novel Command Data Sources
 

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -555,7 +555,7 @@ This CLI is designed for AI agent consumption:
 {{- if or .HasCreateCommands .HasDelete}}
 - **Explicit retries** - {{if .HasCreateCommands}}add `--idempotent` to create retries{{if .HasDelete}} and {{end}}{{end}}{{if .HasDelete}}add `--ignore-missing` to delete retries{{end}} when a no-op success is acceptable
 {{- end}}
-- **Confirmable** - `--yes` for explicit confirmation of destructive actions
+- **Explicit confirmation** - `--agent` does not imply `--yes`; pass `--yes` separately only after the target, arguments, and side effects are clear
 - **Piped input** - write commands can accept structured input when their help lists `--stdin`
 {{- else}}
 - **Read-only by default** - this CLI does not create, update, delete, publish, send, or mutate remote resources

--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -366,10 +366,10 @@ Run '{{.Name}}-pp-cli doctor' to verify auth and connectivity.{{backtick}},
 	rootCmd.PersistentFlags().BoolVar(&flags.ignoreMissing, "ignore-missing", false, "Treat missing delete targets as a successful no-op")
 {{- end}}
 	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output{{if .SelectExample}} (e.g. --select {{.SelectExample}}){{end}}")
-	rootCmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Skip confirmation prompts (for agents and scripts)")
+	rootCmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Skip confirmation prompts (explicit confirmation for scripts)")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colored output")
 	rootCmd.PersistentFlags().BoolVar(&humanFriendly, "human-friendly", false, "Enable colored output and rich formatting")
-	rootCmd.PersistentFlags().BoolVar(&flags.agent, "agent", false, "Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)")
+	rootCmd.PersistentFlags().BoolVar(&flags.agent, "agent", false, "Set agent-friendly output defaults (--json --compact --no-input --no-color)")
 {{- if .Learn.Enabled}}
 	rootCmd.PersistentFlags().BoolVar(&flags.noLearn, "no-learn", false, "Disable the teach/recall learning loop for this invocation")
 {{- end}}
@@ -484,9 +484,6 @@ Run '{{.Name}}-pp-cli doctor' to verify auth and connectivity.{{backtick}},
 			}
 			if !cmd.Flags().Changed("no-input") {
 				flags.noInput = true
-			}
-			if !cmd.Flags().Changed("yes") {
-				flags.yes = true
 			}
 			if !cmd.Flags().Changed("no-color") {
 				noColor = true

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -308,7 +308,7 @@ Run `{{.Name}}-pp-cli doctor` to verify setup.
 
 ## Agent Mode
 
-Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color`.
 
 - **Pipeable** — JSON on stdout, errors on stderr
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
@@ -329,6 +329,7 @@ Add `--agent` to any command. Expands to: `--json --compact --no-input --no-colo
 {{- if not .HasWriteCommands}}
 - **Read-only** — do not use this CLI for create, update, delete, publish, comment, upvote, invite, order, send, or other mutating requests
 {{- else}}
+- **Explicit confirmation** — `--agent` does not imply `--yes`; pass `--yes` separately only after the target, arguments, and side effects are clear
 {{- if or .HasCreateCommands .HasDelete}}
 - **Explicit retries** — {{if .HasCreateCommands}}use `--idempotent` only when an already-existing create should count as success{{if .HasDelete}}, and {{end}}{{end}}{{if .HasDelete}}use `--ignore-missing` only when a missing delete target should count as success{{end}}
 {{- end}}

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/root.go
@@ -242,10 +242,10 @@ Run 'fastapi-operationids-golden-pp-cli doctor' to verify auth and connectivity.
 	rootCmd.PersistentFlags().BoolVar(&flags.idempotent, "idempotent", false, "Treat already-existing create results as a successful no-op")
 	rootCmd.PersistentFlags().BoolVar(&flags.ignoreMissing, "ignore-missing", false, "Treat missing delete targets as a successful no-op")
 	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output")
-	rootCmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Skip confirmation prompts (for agents and scripts)")
+	rootCmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Skip confirmation prompts (explicit confirmation for scripts)")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colored output")
 	rootCmd.PersistentFlags().BoolVar(&humanFriendly, "human-friendly", false, "Enable colored output and rich formatting")
-	rootCmd.PersistentFlags().BoolVar(&flags.agent, "agent", false, "Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)")
+	rootCmd.PersistentFlags().BoolVar(&flags.agent, "agent", false, "Set agent-friendly output defaults (--json --compact --no-input --no-color)")
 	rootCmd.PersistentFlags().BoolVar(&flags.noLearn, "no-learn", false, "Disable the teach/recall learning loop for this invocation")
 	rootCmd.PersistentFlags().BoolVar(&flags.allowPartialFailure, "allow-partial-failure", false, "Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit")
 	rootCmd.PersistentFlags().StringVar(&flags.dataSource, "data-source", "auto", "Data source for read commands: auto (live with local fallback), live (API only), local (synced data only)")
@@ -326,9 +326,6 @@ Run 'fastapi-operationids-golden-pp-cli doctor' to verify auth and connectivity.
 			}
 			if !cmd.Flags().Changed("no-input") {
 				flags.noInput = true
-			}
-			if !cmd.Flags().Changed("yes") {
-				flags.yes = true
 			}
 			if !cmd.Flags().Changed("no-color") {
 				noColor = true

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/SKILL.md
@@ -67,7 +67,7 @@ Run `printing-press-oauth2-pp-cli doctor` to verify setup.
 
 ## Agent Mode
 
-Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color`.
 
 - **Pipeable** — JSON on stdout, errors on stderr
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/AGENTS.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/AGENTS.md
@@ -18,7 +18,7 @@ printing-press-rich-pp-cli which "<capability>" --json
 printing-press-rich-pp-cli <command> --help
 ```
 
-Add `--agent` to command invocations for JSON, compact output, non-interactive defaults, no color, and confirmation-safe scripting:
+Add `--agent` to command invocations for JSON, compact output, non-interactive defaults, and no color:
 
 ```bash
 printing-press-rich-pp-cli <command> --agent
@@ -31,7 +31,7 @@ printing-press-rich-pp-cli <command> --help
 printing-press-rich-pp-cli <command> --dry-run --agent
 ```
 
-Use `--yes --no-input` only after the target, arguments, and side effects are clear.
+When a command requires confirmation, pass `--yes` explicitly only after the target, arguments, and side effects are clear. `--agent` does not imply `--yes`.
 
 ## Novel Command Data Sources
 

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/SKILL.md
@@ -65,7 +65,7 @@ Run `printing-press-rich-pp-cli doctor` to verify setup.
 
 ## Agent Mode
 
-Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color`.
 
 - **Pipeable** — JSON on stdout, errors on stderr
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/AGENTS.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/AGENTS.md
@@ -18,7 +18,7 @@ printing-press-golden-pp-cli which "<capability>" --json
 printing-press-golden-pp-cli <command> --help
 ```
 
-Add `--agent` to command invocations for JSON, compact output, non-interactive defaults, no color, and confirmation-safe scripting:
+Add `--agent` to command invocations for JSON, compact output, non-interactive defaults, and no color:
 
 ```bash
 printing-press-golden-pp-cli <command> --agent
@@ -31,7 +31,7 @@ printing-press-golden-pp-cli <command> --help
 printing-press-golden-pp-cli <command> --dry-run --agent
 ```
 
-Use `--yes --no-input` only after the target, arguments, and side effects are clear.
+When a command requires confirmation, pass `--yes` explicitly only after the target, arguments, and side effects are clear. `--agent` does not imply `--yes`.
 
 ## Novel Command Data Sources
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
@@ -265,7 +265,7 @@ This CLI is designed for AI agent consumption:
 - **Filterable** - `--select <field>[,<field>...]` returns only fields you need
 - **Previewable** - `--dry-run` shows the request without sending
 - **Explicit retries** - add `--idempotent` to create retries when a no-op success is acceptable
-- **Confirmable** - `--yes` for explicit confirmation of destructive actions
+- **Explicit confirmation** - `--agent` does not imply `--yes`; pass `--yes` separately only after the target, arguments, and side effects are clear
 - **Piped input** - write commands can accept structured input when their help lists `--stdin`
 - **Offline-friendly** - sync/search commands can use the local SQLite store when available
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
@@ -91,7 +91,7 @@ Run `printing-press-golden-pp-cli doctor` to verify setup.
 
 ## Agent Mode
 
-Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color`.
 
 - **Pipeable** — JSON on stdout, errors on stderr
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
@@ -102,6 +102,7 @@ Add `--agent` to any command. Expands to: `--json --compact --no-input --no-colo
 - **Previewable** — `--dry-run` shows the request without sending
 - **Offline-friendly** — sync/search commands can use the local SQLite store when available
 - **Non-interactive** — never prompts, every input is a flag
+- **Explicit confirmation** — `--agent` does not imply `--yes`; pass `--yes` separately only after the target, arguments, and side effects are clear
 - **Explicit retries** — use `--idempotent` only when an already-existing create should count as success
 
 ### Response envelope

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
@@ -269,10 +269,10 @@ Run 'printing-press-golden-pp-cli doctor' to verify auth and connectivity.`,
 	rootCmd.PersistentFlags().BoolVar(&flags.noInput, "no-input", false, "Disable all interactive prompts (for CI/agents)")
 	rootCmd.PersistentFlags().BoolVar(&flags.idempotent, "idempotent", false, "Treat already-existing create results as a successful no-op")
 	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output (e.g. --select code,decimals,symbol)")
-	rootCmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Skip confirmation prompts (for agents and scripts)")
+	rootCmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Skip confirmation prompts (explicit confirmation for scripts)")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colored output")
 	rootCmd.PersistentFlags().BoolVar(&humanFriendly, "human-friendly", false, "Enable colored output and rich formatting")
-	rootCmd.PersistentFlags().BoolVar(&flags.agent, "agent", false, "Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)")
+	rootCmd.PersistentFlags().BoolVar(&flags.agent, "agent", false, "Set agent-friendly output defaults (--json --compact --no-input --no-color)")
 	rootCmd.PersistentFlags().BoolVar(&flags.noLearn, "no-learn", false, "Disable the teach/recall learning loop for this invocation")
 	rootCmd.PersistentFlags().BoolVar(&flags.allowPartialFailure, "allow-partial-failure", false, "Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit")
 	rootCmd.PersistentFlags().StringVar(&flags.dataSource, "data-source", "auto", "Data source for read commands: auto (live with local fallback), live (API only), local (synced data only)")
@@ -353,9 +353,6 @@ Run 'printing-press-golden-pp-cli doctor' to verify auth and connectivity.`,
 			}
 			if !cmd.Flags().Changed("no-input") {
 				flags.noInput = true
-			}
-			if !cmd.Flags().Changed("yes") {
-				flags.yes = true
 			}
 			if !cmd.Flags().Changed("no-color") {
 				noColor = true

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/AGENTS.md
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/AGENTS.md
@@ -18,7 +18,7 @@ learn-disabled-example-pp-cli which "<capability>" --json
 learn-disabled-example-pp-cli <command> --help
 ```
 
-Add `--agent` to command invocations for JSON, compact output, non-interactive defaults, no color, and confirmation-safe scripting:
+Add `--agent` to command invocations for JSON, compact output, non-interactive defaults, and no color:
 
 ```bash
 learn-disabled-example-pp-cli <command> --agent
@@ -31,7 +31,7 @@ learn-disabled-example-pp-cli <command> --help
 learn-disabled-example-pp-cli <command> --dry-run --agent
 ```
 
-Use `--yes --no-input` only after the target, arguments, and side effects are clear.
+When a command requires confirmation, pass `--yes` explicitly only after the target, arguments, and side effects are clear. `--agent` does not imply `--yes`.
 
 ## Novel Command Data Sources
 

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/SKILL.md
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/SKILL.md
@@ -74,7 +74,7 @@ Run `learn-disabled-example-pp-cli doctor` to verify setup.
 
 ## Agent Mode
 
-Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color`.
 
 - **Pipeable** — JSON on stdout, errors on stderr
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/cli/root.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/cli/root.go
@@ -243,10 +243,10 @@ Run 'learn-disabled-example-pp-cli doctor' to verify auth and connectivity.`,
 	rootCmd.PersistentFlags().StringVar(&flags.auditDir, "audit-dir", "", "Aggregate the receipt and index under this audit directory")
 	rootCmd.PersistentFlags().BoolVar(&flags.noInput, "no-input", false, "Disable all interactive prompts (for CI/agents)")
 	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output")
-	rootCmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Skip confirmation prompts (for agents and scripts)")
+	rootCmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Skip confirmation prompts (explicit confirmation for scripts)")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colored output")
 	rootCmd.PersistentFlags().BoolVar(&humanFriendly, "human-friendly", false, "Enable colored output and rich formatting")
-	rootCmd.PersistentFlags().BoolVar(&flags.agent, "agent", false, "Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)")
+	rootCmd.PersistentFlags().BoolVar(&flags.agent, "agent", false, "Set agent-friendly output defaults (--json --compact --no-input --no-color)")
 	rootCmd.PersistentFlags().StringVar(&flags.dataSource, "data-source", "auto", "Data source for read commands: auto (live with local fallback), live (API only), local (synced data only)")
 	rootCmd.PersistentFlags().DurationVar(&flags.maxAge, "max-age", 30*time.Minute, "Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables")
 	rootCmd.PersistentFlags().StringVar(&flags.runProfileName, "profile", "", "Apply values from a saved run profile; this does not select a client (see 'learn-disabled-example-pp-cli profile list')")
@@ -325,9 +325,6 @@ Run 'learn-disabled-example-pp-cli doctor' to verify auth and connectivity.`,
 			}
 			if !cmd.Flags().Changed("no-input") {
 				flags.noInput = true
-			}
-			if !cmd.Flags().Changed("yes") {
-				flags.yes = true
 			}
 			if !cmd.Flags().Changed("no-color") {
 				noColor = true

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/AGENTS.md
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/AGENTS.md
@@ -18,7 +18,7 @@ learn-loop-example-pp-cli which "<capability>" --json
 learn-loop-example-pp-cli <command> --help
 ```
 
-Add `--agent` to command invocations for JSON, compact output, non-interactive defaults, no color, and confirmation-safe scripting:
+Add `--agent` to command invocations for JSON, compact output, non-interactive defaults, and no color:
 
 ```bash
 learn-loop-example-pp-cli <command> --agent
@@ -31,7 +31,7 @@ learn-loop-example-pp-cli <command> --help
 learn-loop-example-pp-cli <command> --dry-run --agent
 ```
 
-Use `--yes --no-input` only after the target, arguments, and side effects are clear.
+When a command requires confirmation, pass `--yes` explicitly only after the target, arguments, and side effects are clear. `--agent` does not imply `--yes`.
 
 ## Novel Command Data Sources
 

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/SKILL.md
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/SKILL.md
@@ -81,7 +81,7 @@ Run `learn-loop-example-pp-cli doctor` to verify setup.
 
 ## Agent Mode
 
-Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color`.
 
 - **Pipeable** — JSON on stdout, errors on stderr
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/root.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/root.go
@@ -262,10 +262,10 @@ Run 'learn-loop-example-pp-cli doctor' to verify auth and connectivity.`,
 	rootCmd.PersistentFlags().StringVar(&flags.auditDir, "audit-dir", "", "Aggregate the receipt and index under this audit directory")
 	rootCmd.PersistentFlags().BoolVar(&flags.noInput, "no-input", false, "Disable all interactive prompts (for CI/agents)")
 	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output")
-	rootCmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Skip confirmation prompts (for agents and scripts)")
+	rootCmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Skip confirmation prompts (explicit confirmation for scripts)")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colored output")
 	rootCmd.PersistentFlags().BoolVar(&humanFriendly, "human-friendly", false, "Enable colored output and rich formatting")
-	rootCmd.PersistentFlags().BoolVar(&flags.agent, "agent", false, "Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)")
+	rootCmd.PersistentFlags().BoolVar(&flags.agent, "agent", false, "Set agent-friendly output defaults (--json --compact --no-input --no-color)")
 	rootCmd.PersistentFlags().BoolVar(&flags.noLearn, "no-learn", false, "Disable the teach/recall learning loop for this invocation")
 	rootCmd.PersistentFlags().StringVar(&flags.dataSource, "data-source", "auto", "Data source for read commands: auto (live with local fallback), live (API only), local (synced data only)")
 	rootCmd.PersistentFlags().DurationVar(&flags.maxAge, "max-age", 30*time.Minute, "Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables")
@@ -345,9 +345,6 @@ Run 'learn-loop-example-pp-cli doctor' to verify auth and connectivity.`,
 			}
 			if !cmd.Flags().Changed("no-input") {
 				flags.noInput = true
-			}
-			if !cmd.Flags().Changed("yes") {
-				flags.yes = true
 			}
 			if !cmd.Flags().Changed("no-color") {
 				noColor = true

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/README.md
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/README.md
@@ -233,7 +233,7 @@ This CLI is designed for AI agent consumption:
 - **Filterable** - `--select <field>[,<field>...]` returns only fields you need
 - **Previewable** - `--dry-run` shows the request without sending
 - **Explicit retries** - add `--idempotent` to create retries when a no-op success is acceptable
-- **Confirmable** - `--yes` for explicit confirmation of destructive actions
+- **Explicit confirmation** - `--agent` does not imply `--yes`; pass `--yes` separately only after the target, arguments, and side effects are clear
 - **Piped input** - write commands can accept structured input when their help lists `--stdin`
 - **Offline-friendly** - sync/search commands can use the local SQLite store when available
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/SKILL.md
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/SKILL.md
@@ -57,7 +57,7 @@ Run `public-param-golden-pp-cli doctor` to verify setup.
 
 ## Agent Mode
 
-Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color`.
 
 - **Pipeable** — JSON on stdout, errors on stderr
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
@@ -68,6 +68,7 @@ Add `--agent` to any command. Expands to: `--json --compact --no-input --no-colo
 - **Previewable** — `--dry-run` shows the request without sending
 - **Offline-friendly** — sync/search commands can use the local SQLite store when available
 - **Non-interactive** — never prompts, every input is a flag
+- **Explicit confirmation** — `--agent` does not imply `--yes`; pass `--yes` separately only after the target, arguments, and side effects are clear
 - **Explicit retries** — use `--idempotent` only when an already-existing create should count as success
 
 ### Response envelope


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Issue: Closes #3794

`--agent` was silently granting `--yes`, while generated docs described `--yes` as explicit confirmation. This PR makes agent mode output/interaction-only so callers must pass `--yes` explicitly when they intend to skip confirmation.

## Approach

Remove `--yes` from the generated `--agent` expansion and update generated README/SKILL/AGENTS wording to describe the explicit confirmation boundary. Add generated-output tests that execute the emitted root command and assert `--agent` does not set `flags.yes`, while `--yes` still does.

## Scope

Primary area: generator templates

Why this belongs in this repo: the behavior and docs are emitted into every printed CLI by the Printing Press generator.

## Risk

Existing automation that relied on `--agent` to imply `--yes` must pass `--yes` explicitly. `--agent` still sets `--no-input`, so agent flows remain non-interactive and do not hang on prompts.

## Output Contract

Generated root behavior and docs change: `--agent` expands to `--json --compact --no-input --no-color`; explicit confirmation remains `--yes`. Golden fixtures were updated for the intentional root.go/README/SKILL/AGENTS emitted-output changes.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates
- `go test ./internal/generator -run 'TestGeneratedAgentModeDoesNotGrantYes|TestGeneratedDocsKeepAgentAndYesContractsSeparate|TestGeneratedAgentsGuideRendersPortableAgentContract|TestSkillRendersFrontmatterAndCapabilities|TestReadmeRendersNovelFeaturesGrouped|TestRootLongIncludesAllNovelFeatures|TestRootLongFallsBackWhenNoNarrative|TestRootLongCarriesHeadlineWithoutNovelFeatures' -count=1`
- `GOTOOLCHAIN=go1.26.6 scripts/golden.sh verify`
- `GOTOOLCHAIN=go1.26.6 scripts/verify-generator-output.sh`
- `GOTOOLCHAIN=go1.26.6 go test ./... -timeout 20m`

Note: plain `go test ./...` hit Go's default 10-minute package timeout in `internal/generator`; the suite passed with `-timeout 20m`.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d48f64c-c4b2-4a7a-9371-12f67fd55793?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d48f64c-c4b2-4a7a-9371-12f67fd55793&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

