### PR TITLE
fix(cli): collapse html error bodies

### DIFF
--- a/internal/generator/client_apierror_empty_body_test.go
+++ b/internal/generator/client_apierror_empty_body_test.go
@@ -92,6 +92,15 @@ func TestAPIErrorHTMLTitleSanitizesDecodedControls(t *testing.T) {
 	if !strings.Contains(collapsed, "Tenant [2J Missing") {
 		t.Fatalf("collapsed body = %q, want sanitized title text", collapsed)
 	}
+
+	unicodeBody := []byte(` + "`" + `<!doctype html><html><head><title>Tenant &#x202E;Split&#x2028;Missing</title></head><body>Denied</body></html>` + "`" + `)
+	unicodeCollapsed := truncateBody(unicodeBody)
+	if strings.ContainsRune(unicodeCollapsed, '\u202e') || strings.ContainsRune(unicodeCollapsed, '\u2028') {
+		t.Fatalf("collapsed body contains decoded unicode formatting controls: %q", unicodeCollapsed)
+	}
+	if !strings.Contains(unicodeCollapsed, "Tenant Split Missing") {
+		t.Fatalf("collapsed body = %q, want unicode controls sanitized", unicodeCollapsed)
+	}
 }
 
 func TestAPIErrorHTMLTitleUsesOriginalOffsets(t *testing.T) {

--- a/internal/generator/client_apierror_empty_body_test.go
+++ b/internal/generator/client_apierror_empty_body_test.go
@@ -135,7 +135,7 @@ func TestAPIErrorHTMLTitleIgnoresScriptAndStyleBlocks(t *testing.T) {
 func TestAPIErrorHTMLTitleSkipsRepeatedBlocks(t *testing.T) {
 	var body strings.Builder
 	body.WriteString(` + "`" + `<!doctype html><html><head>` + "`" + `)
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 10; i++ {
 		body.WriteString(` + "`" + `<script><title>Script Secret</title></script>` + "`" + `)
 	}
 	body.WriteString(` + "`" + `<title>Real Title</title></head></html>` + "`" + `)

--- a/internal/generator/client_apierror_empty_body_test.go
+++ b/internal/generator/client_apierror_empty_body_test.go
@@ -77,10 +77,56 @@ func TestAPIErrorHTMLBodyCollapsed(t *testing.T) {
 		t.Fatalf("APIError.Error emitted raw HTML: %q", errText)
 	}
 }
+
+func TestAPIErrorHTMLTitleSanitizesDecodedControls(t *testing.T) {
+	body := []byte(` + "`" + `<!doctype html><html><head><title>Tenant &#27;[2J Missing</title></head><body>Denied</body></html>` + "`" + `)
+
+	collapsed := truncateBody(body)
+	if strings.ContainsRune(collapsed, '\x1b') {
+		t.Fatalf("collapsed body contains decoded ESC control: %q", collapsed)
+	}
+	errText := (&APIError{Method: "GET", Path: "/items", StatusCode: 403, Body: collapsed}).Error()
+	if strings.ContainsRune(errText, '\x1b') {
+		t.Fatalf("APIError.Error contains decoded ESC control: %q", errText)
+	}
+	if !strings.Contains(collapsed, "Tenant [2J Missing") {
+		t.Fatalf("collapsed body = %q, want sanitized title text", collapsed)
+	}
+}
+
+func TestAPIErrorHTMLTitleUsesOriginalOffsets(t *testing.T) {
+	body := []byte(` + "`" + `<!doctype html><html><head><title>Tenant İ Missing</title></head><body>Denied</body></html>` + "`" + `)
+
+	collapsed := truncateBody(body)
+	if !strings.Contains(collapsed, "Tenant İ Missing") {
+		t.Fatalf("collapsed body = %q, want non-ASCII title preserved", collapsed)
+	}
+}
+
+func TestAPIErrorHTMLTitleIgnoresScriptAndStyleBlocks(t *testing.T) {
+	closedBlock := []byte(` + "`" + `<!doctype html><html><head><script><title>Script Secret</title></script><title>Real Title</title></head></html>` + "`" + `)
+	closedCollapsed := truncateBody(closedBlock)
+	if strings.Contains(closedCollapsed, "Script Secret") {
+		t.Fatalf("closed script block leaked into title summary: %q", closedCollapsed)
+	}
+	if !strings.Contains(closedCollapsed, "Real Title") {
+		t.Fatalf("closed script block summary = %q, want real title", closedCollapsed)
+	}
+
+	unclosedBlock := []byte(` + "`" + `<!doctype html><html><head><style><title>Style Secret</title></head><body>Denied</body></html>` + "`" + `)
+	unclosedCollapsed := truncateBody(unclosedBlock)
+	if strings.Contains(unclosedCollapsed, "Style Secret") || strings.Contains(unclosedCollapsed, "Denied") {
+		t.Fatalf("unclosed style block leaked body content into summary: %q", unclosedCollapsed)
+	}
+	if !strings.Contains(unclosedCollapsed, "HTML error page") {
+		t.Fatalf("unclosed style block summary = %q, want HTML summary", unclosedCollapsed)
+	}
+}
 `
 	require.NoError(t, os.WriteFile(
 		filepath.Join(outputDir, "internal", "client", "apierror_empty_body_test.go"),
 		[]byte(clientTest), 0o644))
 
+	requireGeneratedCompiles(t, outputDir)
 	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "TestAPIError", "-count=1")
 }

--- a/internal/generator/client_apierror_empty_body_test.go
+++ b/internal/generator/client_apierror_empty_body_test.go
@@ -148,6 +148,21 @@ func TestAPIErrorHTMLTitleSkipsRepeatedBlocks(t *testing.T) {
 		t.Fatalf("repeated script block summary = %q, want real title", collapsed)
 	}
 }
+
+func TestAPIErrorHTMLTitleScanIsCapped(t *testing.T) {
+	var body strings.Builder
+	body.WriteString(` + "`" + `<!doctype html><html><head>` + "`" + `)
+	body.WriteString(strings.Repeat("x", 5000))
+	body.WriteString(` + "`" + `<title>Late Title</title></head></html>` + "`" + `)
+
+	collapsed := truncateBody([]byte(body.String()))
+	if strings.Contains(collapsed, "Late Title") {
+		t.Fatalf("title beyond capped scan window leaked into summary: %q", collapsed)
+	}
+	if !strings.Contains(collapsed, "HTML error page") {
+		t.Fatalf("capped scan summary = %q, want HTML summary", collapsed)
+	}
+}
 `
 	require.NoError(t, os.WriteFile(
 		filepath.Join(outputDir, "internal", "client", "apierror_empty_body_test.go"),

--- a/internal/generator/client_apierror_empty_body_test.go
+++ b/internal/generator/client_apierror_empty_body_test.go
@@ -122,6 +122,23 @@ func TestAPIErrorHTMLTitleIgnoresScriptAndStyleBlocks(t *testing.T) {
 		t.Fatalf("unclosed style block summary = %q, want HTML summary", unclosedCollapsed)
 	}
 }
+
+func TestAPIErrorHTMLTitleSkipsRepeatedBlocks(t *testing.T) {
+	var body strings.Builder
+	body.WriteString(` + "`" + `<!doctype html><html><head>` + "`" + `)
+	for i := 0; i < 100; i++ {
+		body.WriteString(` + "`" + `<script><title>Script Secret</title></script>` + "`" + `)
+	}
+	body.WriteString(` + "`" + `<title>Real Title</title></head></html>` + "`" + `)
+
+	collapsed := truncateBody([]byte(body.String()))
+	if strings.Contains(collapsed, "Script Secret") {
+		t.Fatalf("repeated script blocks leaked into title summary: %q", collapsed)
+	}
+	if !strings.Contains(collapsed, "Real Title") {
+		t.Fatalf("repeated script block summary = %q, want real title", collapsed)
+	}
+}
 `
 	require.NoError(t, os.WriteFile(
 		filepath.Join(outputDir, "internal", "client", "apierror_empty_body_test.go"),

--- a/internal/generator/client_apierror_empty_body_test.go
+++ b/internal/generator/client_apierror_empty_body_test.go
@@ -21,7 +21,10 @@ func TestGeneratedAPIErrorOmitsSeparatorOnEmptyBody(t *testing.T) {
 
 	const clientTest = `package client
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestAPIErrorSeparatorGuardOnEmptyBody(t *testing.T) {
 	cases := []struct {
@@ -43,10 +46,41 @@ func TestAPIErrorSeparatorGuardOnEmptyBody(t *testing.T) {
 		})
 	}
 }
+
+func TestAPIErrorHTMLBodyCollapsed(t *testing.T) {
+	body := []byte(` + "`" + `<!doctype html>
+<html>
+<head>
+<title>Tenant Missing</title>
+<style>body{color:red}</style>
+</head>
+<body>
+<h1>Tenant Missing</h1>
+<script>alert("x")</script>
+<p>Use the right host.</p>
+</body>
+</html>` + "`" + `)
+
+	collapsed := truncateBody(body)
+	if strings.Contains(collapsed, "<html") || strings.Contains(collapsed, "<script") || strings.Contains(collapsed, "body{color:red}") {
+		t.Fatalf("HTML body was emitted verbatim: %q", collapsed)
+	}
+	if !strings.Contains(collapsed, "HTML error page") {
+		t.Fatalf("collapsed body = %q, want HTML error page summary", collapsed)
+	}
+	if !strings.Contains(collapsed, "Tenant Missing") {
+		t.Fatalf("collapsed body = %q, want title excerpt", collapsed)
+	}
+
+	errText := (&APIError{Method: "GET", Path: "/items", StatusCode: 404, Body: collapsed}).Error()
+	if strings.Contains(errText, "<html") || strings.Contains(errText, "<script") || strings.Contains(errText, "alert(") {
+		t.Fatalf("APIError.Error emitted raw HTML: %q", errText)
+	}
+}
 `
 	require.NoError(t, os.WriteFile(
 		filepath.Join(outputDir, "internal", "client", "apierror_empty_body_test.go"),
 		[]byte(clientTest), 0o644))
 
-	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "TestAPIErrorSeparatorGuardOnEmptyBody", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "TestAPIError", "-count=1")
 }

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -56,6 +56,7 @@ const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
 {{- if .HasTextResponse}}
 const TextResponseHeader = "X-Printing-Press-Text-Response"
 {{- end}}
+const maxErrorBodyBytes = 4096
 
 {{- if and .Auth.Type (ne .Auth.Type "none")}}
 var ErrPlaceholderCredential = errors.New("auth placeholder credential")
@@ -3270,18 +3271,21 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 }
 
 func truncateBody(b []byte) string {
-	const maxBytes = 4096
 	if summary, ok := collapseHTMLErrorBody(b); ok {
 		return summary
 	}
-	if len(b) <= maxBytes {
+	if len(b) <= maxErrorBodyBytes {
 		return string(b)
 	}
-	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+	return strings.ToValidUTF8(string(b[:maxErrorBodyBytes]), "") + "..."
 }
 
 func collapseHTMLErrorBody(b []byte) (string, bool) {
-	body := strings.ToValidUTF8(string(b), "")
+	scanBytes := b
+	if len(scanBytes) > maxErrorBodyBytes {
+		scanBytes = scanBytes[:maxErrorBodyBytes]
+	}
+	body := strings.ToValidUTF8(string(scanBytes), "")
 	trimmed := strings.TrimSpace(body)
 	if trimmed == "" || !looksLikeHTMLBody(trimmed) {
 		return "", false

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -3307,84 +3307,66 @@ func looksLikeHTMLBody(body string) bool {
 }
 
 func extractHTMLTitle(body string) string {
-	searchFrom := 0
-	for searchFrom < len(body) {
-		titleStart := indexHTMLTag(body[searchFrom:], "title")
-		if titleStart < 0 {
+	pos := 0
+	ignoredBlock := ""
+	for pos < len(body) {
+		tagStartRel := strings.IndexByte(body[pos:], '<')
+		if tagStartRel < 0 {
 			return ""
 		}
-		if blockStart, blockTag := nextHTMLBlockTag(body[searchFrom:titleStart+searchFrom], "script", "style"); blockStart >= 0 {
-			blockStart += searchFrom
-			blockOpenEnd := htmlTagEnd(body, blockStart)
-			if blockOpenEnd < 0 {
-				return ""
-			}
-			blockCloseStart := indexHTMLCloseTag(body[blockOpenEnd+1:], blockTag)
-			if blockCloseStart < 0 {
-				return ""
-			}
-			searchFrom = blockOpenEnd + 1 + blockCloseStart + len("</"+blockTag+">")
+		tagStart := pos + tagStartRel
+		tagEnd := htmlTagEnd(body, tagStart)
+		if tagEnd < 0 {
+			return ""
+		}
+		tagName, closing := htmlTagName(body[tagStart+1 : tagEnd])
+		pos = tagEnd + 1
+		if tagName == "" {
 			continue
 		}
-		titleStart += searchFrom
-		openEnd := htmlTagEnd(body, titleStart)
-		if openEnd < 0 {
+		if ignoredBlock != "" {
+			if closing && tagName == ignoredBlock {
+				ignoredBlock = ""
+			}
+			continue
+		}
+		if closing {
+			continue
+		}
+		if tagName == "script" || tagName == "style" {
+			ignoredBlock = tagName
+			continue
+		}
+		if tagName != "title" {
+			continue
+		}
+		titleEnd := findHTMLCloseTag(body, pos, "title")
+		if titleEnd < 0 {
 			return ""
 		}
-		contentStart := openEnd + 1
-		end := indexHTMLCloseTag(body[contentStart:], "title")
-		if end < 0 {
-			return ""
-		}
-		title := stripHTMLTags(body[contentStart : contentStart+end])
+		title := stripHTMLTags(body[pos:titleEnd])
 		return strings.Join(strings.Fields(stripControlCharacters(html.UnescapeString(title))), " ")
 	}
 	return ""
 }
 
-func indexHTMLTag(body, tag string) int {
-	needle := "<" + tag
-	offset := 0
-	for offset < len(body) {
-		idx := indexCaseInsensitive(body[offset:], needle)
-		if idx < 0 {
+func findHTMLCloseTag(body string, from int, tag string) int {
+	pos := from
+	for pos < len(body) {
+		tagStartRel := strings.IndexByte(body[pos:], '<')
+		if tagStartRel < 0 {
 			return -1
 		}
-		start := offset + idx
-		after := start + len(needle)
-		if after >= len(body) || isHTMLTagNameBoundary(body[after]) {
-			return start
+		tagStart := pos + tagStartRel
+		tagEnd := htmlTagEnd(body, tagStart)
+		if tagEnd < 0 {
+			return -1
 		}
-		offset = after
-	}
-	return -1
-}
-
-func nextHTMLBlockTag(body string, tags ...string) (int, string) {
-	best := -1
-	bestTag := ""
-	for _, tag := range tags {
-		idx := indexHTMLTag(body, tag)
-		if idx >= 0 && (best < 0 || idx < best) {
-			best = idx
-			bestTag = tag
+		tagName, closing := htmlTagName(body[tagStart+1 : tagEnd])
+		if closing && tagName == tag {
+			return tagStart
 		}
-	}
-	return best, bestTag
-}
-
-func indexHTMLCloseTag(body, tag string) int {
-	return indexCaseInsensitive(body, "</"+tag+">")
-}
-
-func indexCaseInsensitive(body, needle string) int {
-	if needle == "" {
-		return 0
-	}
-	for idx := 0; idx+len(needle) <= len(body); idx++ {
-		if strings.EqualFold(body[idx:idx+len(needle)], needle) {
-			return idx
-		}
+		pos = tagEnd + 1
 	}
 	return -1
 }
@@ -3397,8 +3379,32 @@ func htmlTagEnd(body string, start int) int {
 	return start + end
 }
 
-func isHTMLTagNameBoundary(b byte) bool {
-	return b == '>' || b == '/' || b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f'
+func htmlTagName(raw string) (string, bool) {
+	raw = strings.TrimLeftFunc(raw, isHTMLSpace)
+	closing := false
+	if strings.HasPrefix(raw, "/") {
+		closing = true
+		raw = strings.TrimLeftFunc(raw[1:], isHTMLSpace)
+	}
+	if raw == "" || strings.HasPrefix(raw, "!") || strings.HasPrefix(raw, "?") {
+		return "", closing
+	}
+	end := 0
+	for end < len(raw) && isHTMLTagNameByte(raw[end]) {
+		end++
+	}
+	if end == 0 {
+		return "", closing
+	}
+	return strings.ToLower(raw[:end]), closing
+}
+
+func isHTMLTagNameByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '-' || b == ':'
+}
+
+func isHTMLSpace(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\n' || r == '\r' || r == '\f'
 }
 
 func stripHTMLTags(body string) string {

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -3286,18 +3286,9 @@ func collapseHTMLErrorBody(b []byte) (string, bool) {
 		return "", false
 	}
 
-	title := extractHTMLTitle(trimmed)
-	excerpt := collapseHTMLVisibleText(trimmed)
-	detail := title
-	if detail == "" {
-		detail = excerpt
-	} else if excerpt != "" && !strings.Contains(strings.ToLower(excerpt), strings.ToLower(title)) {
-		detail += ": " + excerpt
-	}
-
 	summary := fmt.Sprintf("HTML error page (%d bytes)", len(b))
-	if detail != "" {
-		summary += ": " + truncateRunes(detail, 240)
+	if title := extractHTMLTitle(trimmed); title != "" {
+		summary += ": " + truncateRunes(title, 160)
 	}
 	return summary, true
 }
@@ -3311,7 +3302,7 @@ func looksLikeHTMLBody(body string) bool {
 	if len(sample) > 2048 {
 		sample = sample[:2048]
 	}
-	return strings.Contains(sample, "<body") || strings.Contains(sample, "<script") || (strings.Contains(sample, "<head") && strings.Contains(sample, "</html>"))
+	return strings.HasPrefix(sample, "<") && (strings.Contains(sample, "<body") || strings.Contains(sample, "<head") || strings.Contains(sample, "<title") || strings.Contains(sample, "<script"))
 }
 
 func extractHTMLTitle(body string) string {
@@ -3329,43 +3320,8 @@ func extractHTMLTitle(body string) string {
 	if end < 0 {
 		return ""
 	}
-	return collapsePlainText(stripHTMLTags(body[contentStart : contentStart+end]))
-}
-
-func collapseHTMLVisibleText(body string) string {
-	body = removeHTMLBlocks(body, "script", "style", "svg")
-	return collapsePlainText(stripHTMLTags(body))
-}
-
-func removeHTMLBlocks(body string, tags ...string) string {
-	lower := strings.ToLower(body)
-	for _, tag := range tags {
-		open := "<" + tag
-		close := "</" + tag + ">"
-		for {
-			start := strings.Index(lower, open)
-			if start < 0 {
-				break
-			}
-			openEnd := strings.Index(lower[start:], ">")
-			if openEnd < 0 {
-				body = body[:start]
-				lower = lower[:start]
-				break
-			}
-			contentStart := start + openEnd + 1
-			closeStart := strings.Index(lower[contentStart:], close)
-			if closeStart < 0 {
-				body = body[:start] + " " + body[contentStart:]
-				lower = lower[:start] + " " + lower[contentStart:]
-				continue
-			}
-			end := contentStart + closeStart + len(close)
-			body = body[:start] + " " + body[end:]
-			lower = lower[:start] + " " + lower[end:]
-		}
-	}
-	return body
+	title := stripHTMLTags(body[contentStart : contentStart+end])
+	return strings.Join(strings.Fields(html.UnescapeString(title)), " ")
 }
 
 func stripHTMLTags(body string) string {
@@ -3385,10 +3341,6 @@ func stripHTMLTags(body string) string {
 		}
 	}
 	return out.String()
-}
-
-func collapsePlainText(text string) string {
-	return strings.Join(strings.Fields(html.UnescapeString(text)), " ")
 }
 
 func truncateRunes(text string, maxRunes int) string {

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"math"
 {{- if .HasMultipartRequest}}
@@ -3269,10 +3270,136 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 
 func truncateBody(b []byte) string {
 	const maxBytes = 4096
+	if summary, ok := collapseHTMLErrorBody(b); ok {
+		return summary
+	}
 	if len(b) <= maxBytes {
 		return string(b)
 	}
 	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+}
+
+func collapseHTMLErrorBody(b []byte) (string, bool) {
+	body := strings.ToValidUTF8(string(b), "")
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" || !looksLikeHTMLBody(trimmed) {
+		return "", false
+	}
+
+	title := extractHTMLTitle(trimmed)
+	excerpt := collapseHTMLVisibleText(trimmed)
+	detail := title
+	if detail == "" {
+		detail = excerpt
+	} else if excerpt != "" && !strings.Contains(strings.ToLower(excerpt), strings.ToLower(title)) {
+		detail += ": " + excerpt
+	}
+
+	summary := fmt.Sprintf("HTML error page (%d bytes)", len(b))
+	if detail != "" {
+		summary += ": " + truncateRunes(detail, 240)
+	}
+	return summary, true
+}
+
+func looksLikeHTMLBody(body string) bool {
+	lower := strings.ToLower(body)
+	if strings.HasPrefix(lower, "<!doctype html") || strings.HasPrefix(lower, "<html") {
+		return true
+	}
+	sample := lower
+	if len(sample) > 2048 {
+		sample = sample[:2048]
+	}
+	return strings.Contains(sample, "<body") || strings.Contains(sample, "<script") || (strings.Contains(sample, "<head") && strings.Contains(sample, "</html>"))
+}
+
+func extractHTMLTitle(body string) string {
+	lower := strings.ToLower(body)
+	start := strings.Index(lower, "<title")
+	if start < 0 {
+		return ""
+	}
+	openEnd := strings.Index(lower[start:], ">")
+	if openEnd < 0 {
+		return ""
+	}
+	contentStart := start + openEnd + 1
+	end := strings.Index(lower[contentStart:], "</title>")
+	if end < 0 {
+		return ""
+	}
+	return collapsePlainText(stripHTMLTags(body[contentStart : contentStart+end]))
+}
+
+func collapseHTMLVisibleText(body string) string {
+	body = removeHTMLBlocks(body, "script", "style", "svg")
+	return collapsePlainText(stripHTMLTags(body))
+}
+
+func removeHTMLBlocks(body string, tags ...string) string {
+	lower := strings.ToLower(body)
+	for _, tag := range tags {
+		open := "<" + tag
+		close := "</" + tag + ">"
+		for {
+			start := strings.Index(lower, open)
+			if start < 0 {
+				break
+			}
+			openEnd := strings.Index(lower[start:], ">")
+			if openEnd < 0 {
+				body = body[:start]
+				lower = lower[:start]
+				break
+			}
+			contentStart := start + openEnd + 1
+			closeStart := strings.Index(lower[contentStart:], close)
+			if closeStart < 0 {
+				body = body[:start] + " " + body[contentStart:]
+				lower = lower[:start] + " " + lower[contentStart:]
+				continue
+			}
+			end := contentStart + closeStart + len(close)
+			body = body[:start] + " " + body[end:]
+			lower = lower[:start] + " " + lower[end:]
+		}
+	}
+	return body
+}
+
+func stripHTMLTags(body string) string {
+	var out strings.Builder
+	inTag := false
+	for _, r := range body {
+		switch r {
+		case '<':
+			inTag = true
+			out.WriteByte(' ')
+		case '>':
+			inTag = false
+		default:
+			if !inTag {
+				out.WriteRune(r)
+			}
+		}
+	}
+	return out.String()
+}
+
+func collapsePlainText(text string) string {
+	return strings.Join(strings.Fields(html.UnescapeString(text)), " ")
+}
+
+func truncateRunes(text string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return text
+	}
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return text
+	}
+	return string(runes[:maxRunes]) + "..."
 }
 
 func clientMaxRetries() int {

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 {{- if eq .Auth.Subtype "google_service_account"}}
 	"golang.org/x/oauth2/google"
@@ -3306,22 +3307,98 @@ func looksLikeHTMLBody(body string) bool {
 }
 
 func extractHTMLTitle(body string) string {
-	lower := strings.ToLower(body)
-	start := strings.Index(lower, "<title")
-	if start < 0 {
-		return ""
+	searchFrom := 0
+	for searchFrom < len(body) {
+		titleStart := indexHTMLTag(body[searchFrom:], "title")
+		if titleStart < 0 {
+			return ""
+		}
+		if blockStart, blockTag := nextHTMLBlockTag(body[searchFrom:titleStart+searchFrom], "script", "style"); blockStart >= 0 {
+			blockStart += searchFrom
+			blockOpenEnd := htmlTagEnd(body, blockStart)
+			if blockOpenEnd < 0 {
+				return ""
+			}
+			blockCloseStart := indexHTMLCloseTag(body[blockOpenEnd+1:], blockTag)
+			if blockCloseStart < 0 {
+				return ""
+			}
+			searchFrom = blockOpenEnd + 1 + blockCloseStart + len("</"+blockTag+">")
+			continue
+		}
+		titleStart += searchFrom
+		openEnd := htmlTagEnd(body, titleStart)
+		if openEnd < 0 {
+			return ""
+		}
+		contentStart := openEnd + 1
+		end := indexHTMLCloseTag(body[contentStart:], "title")
+		if end < 0 {
+			return ""
+		}
+		title := stripHTMLTags(body[contentStart : contentStart+end])
+		return strings.Join(strings.Fields(stripControlCharacters(html.UnescapeString(title))), " ")
 	}
-	openEnd := strings.Index(lower[start:], ">")
-	if openEnd < 0 {
-		return ""
+	return ""
+}
+
+func indexHTMLTag(body, tag string) int {
+	needle := "<" + tag
+	offset := 0
+	for offset < len(body) {
+		idx := indexCaseInsensitive(body[offset:], needle)
+		if idx < 0 {
+			return -1
+		}
+		start := offset + idx
+		after := start + len(needle)
+		if after >= len(body) || isHTMLTagNameBoundary(body[after]) {
+			return start
+		}
+		offset = after
 	}
-	contentStart := start + openEnd + 1
-	end := strings.Index(lower[contentStart:], "</title>")
+	return -1
+}
+
+func nextHTMLBlockTag(body string, tags ...string) (int, string) {
+	best := -1
+	bestTag := ""
+	for _, tag := range tags {
+		idx := indexHTMLTag(body, tag)
+		if idx >= 0 && (best < 0 || idx < best) {
+			best = idx
+			bestTag = tag
+		}
+	}
+	return best, bestTag
+}
+
+func indexHTMLCloseTag(body, tag string) int {
+	return indexCaseInsensitive(body, "</"+tag+">")
+}
+
+func indexCaseInsensitive(body, needle string) int {
+	if needle == "" {
+		return 0
+	}
+	for idx := 0; idx+len(needle) <= len(body); idx++ {
+		if strings.EqualFold(body[idx:idx+len(needle)], needle) {
+			return idx
+		}
+	}
+	return -1
+}
+
+func htmlTagEnd(body string, start int) int {
+	end := strings.IndexByte(body[start:], '>')
 	if end < 0 {
-		return ""
+		return -1
 	}
-	title := stripHTMLTags(body[contentStart : contentStart+end])
-	return strings.Join(strings.Fields(html.UnescapeString(title)), " ")
+	return start + end
+}
+
+func isHTMLTagNameBoundary(b byte) bool {
+	return b == '>' || b == '/' || b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f'
 }
 
 func stripHTMLTags(body string) string {
@@ -3341,6 +3418,18 @@ func stripHTMLTags(body string) string {
 		}
 	}
 	return out.String()
+}
+
+func stripControlCharacters(text string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' || r == '\r' {
+			return ' '
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, text)
 }
 
 func truncateRunes(text string, maxRunes int) string {

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -3431,6 +3431,12 @@ func stripControlCharacters(text string) string {
 		if r == '\t' || r == '\n' || r == '\r' {
 			return ' '
 		}
+		if unicode.Is(unicode.Zl, r) || unicode.Is(unicode.Zp, r) {
+			return ' '
+		}
+		if unicode.Is(unicode.Cf, r) {
+			return -1
+		}
 		if unicode.IsControl(r) {
 			return -1
 		}

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -1645,6 +1645,12 @@ func stripControlCharacters(text string) string {
 		if r == '\t' || r == '\n' || r == '\r' {
 			return ' '
 		}
+		if unicode.Is(unicode.Zl, r) || unicode.Is(unicode.Zp, r) {
+			return ' '
+		}
+		if unicode.Is(unicode.Cf, r) {
+			return -1
+		}
 		if unicode.IsControl(r) {
 			return -1
 		}

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -33,6 +33,7 @@ import (
 )
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
+const maxErrorBodyBytes = 4096
 
 var ErrPlaceholderCredential = errors.New("auth placeholder credential")
 
@@ -1484,18 +1485,21 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 }
 
 func truncateBody(b []byte) string {
-	const maxBytes = 4096
 	if summary, ok := collapseHTMLErrorBody(b); ok {
 		return summary
 	}
-	if len(b) <= maxBytes {
+	if len(b) <= maxErrorBodyBytes {
 		return string(b)
 	}
-	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+	return strings.ToValidUTF8(string(b[:maxErrorBodyBytes]), "") + "..."
 }
 
 func collapseHTMLErrorBody(b []byte) (string, bool) {
-	body := strings.ToValidUTF8(string(b), "")
+	scanBytes := b
+	if len(scanBytes) > maxErrorBodyBytes {
+		scanBytes = scanBytes[:maxErrorBodyBytes]
+	}
+	body := strings.ToValidUTF8(string(scanBytes), "")
 	trimmed := strings.TrimSpace(body)
 	if trimmed == "" || !looksLikeHTMLBody(trimmed) {
 		return "", false

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -1521,84 +1521,66 @@ func looksLikeHTMLBody(body string) bool {
 }
 
 func extractHTMLTitle(body string) string {
-	searchFrom := 0
-	for searchFrom < len(body) {
-		titleStart := indexHTMLTag(body[searchFrom:], "title")
-		if titleStart < 0 {
+	pos := 0
+	ignoredBlock := ""
+	for pos < len(body) {
+		tagStartRel := strings.IndexByte(body[pos:], '<')
+		if tagStartRel < 0 {
 			return ""
 		}
-		if blockStart, blockTag := nextHTMLBlockTag(body[searchFrom:titleStart+searchFrom], "script", "style"); blockStart >= 0 {
-			blockStart += searchFrom
-			blockOpenEnd := htmlTagEnd(body, blockStart)
-			if blockOpenEnd < 0 {
-				return ""
-			}
-			blockCloseStart := indexHTMLCloseTag(body[blockOpenEnd+1:], blockTag)
-			if blockCloseStart < 0 {
-				return ""
-			}
-			searchFrom = blockOpenEnd + 1 + blockCloseStart + len("</"+blockTag+">")
+		tagStart := pos + tagStartRel
+		tagEnd := htmlTagEnd(body, tagStart)
+		if tagEnd < 0 {
+			return ""
+		}
+		tagName, closing := htmlTagName(body[tagStart+1 : tagEnd])
+		pos = tagEnd + 1
+		if tagName == "" {
 			continue
 		}
-		titleStart += searchFrom
-		openEnd := htmlTagEnd(body, titleStart)
-		if openEnd < 0 {
+		if ignoredBlock != "" {
+			if closing && tagName == ignoredBlock {
+				ignoredBlock = ""
+			}
+			continue
+		}
+		if closing {
+			continue
+		}
+		if tagName == "script" || tagName == "style" {
+			ignoredBlock = tagName
+			continue
+		}
+		if tagName != "title" {
+			continue
+		}
+		titleEnd := findHTMLCloseTag(body, pos, "title")
+		if titleEnd < 0 {
 			return ""
 		}
-		contentStart := openEnd + 1
-		end := indexHTMLCloseTag(body[contentStart:], "title")
-		if end < 0 {
-			return ""
-		}
-		title := stripHTMLTags(body[contentStart : contentStart+end])
+		title := stripHTMLTags(body[pos:titleEnd])
 		return strings.Join(strings.Fields(stripControlCharacters(html.UnescapeString(title))), " ")
 	}
 	return ""
 }
 
-func indexHTMLTag(body, tag string) int {
-	needle := "<" + tag
-	offset := 0
-	for offset < len(body) {
-		idx := indexCaseInsensitive(body[offset:], needle)
-		if idx < 0 {
+func findHTMLCloseTag(body string, from int, tag string) int {
+	pos := from
+	for pos < len(body) {
+		tagStartRel := strings.IndexByte(body[pos:], '<')
+		if tagStartRel < 0 {
 			return -1
 		}
-		start := offset + idx
-		after := start + len(needle)
-		if after >= len(body) || isHTMLTagNameBoundary(body[after]) {
-			return start
+		tagStart := pos + tagStartRel
+		tagEnd := htmlTagEnd(body, tagStart)
+		if tagEnd < 0 {
+			return -1
 		}
-		offset = after
-	}
-	return -1
-}
-
-func nextHTMLBlockTag(body string, tags ...string) (int, string) {
-	best := -1
-	bestTag := ""
-	for _, tag := range tags {
-		idx := indexHTMLTag(body, tag)
-		if idx >= 0 && (best < 0 || idx < best) {
-			best = idx
-			bestTag = tag
+		tagName, closing := htmlTagName(body[tagStart+1 : tagEnd])
+		if closing && tagName == tag {
+			return tagStart
 		}
-	}
-	return best, bestTag
-}
-
-func indexHTMLCloseTag(body, tag string) int {
-	return indexCaseInsensitive(body, "</"+tag+">")
-}
-
-func indexCaseInsensitive(body, needle string) int {
-	if needle == "" {
-		return 0
-	}
-	for idx := 0; idx+len(needle) <= len(body); idx++ {
-		if strings.EqualFold(body[idx:idx+len(needle)], needle) {
-			return idx
-		}
+		pos = tagEnd + 1
 	}
 	return -1
 }
@@ -1611,8 +1593,32 @@ func htmlTagEnd(body string, start int) int {
 	return start + end
 }
 
-func isHTMLTagNameBoundary(b byte) bool {
-	return b == '>' || b == '/' || b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f'
+func htmlTagName(raw string) (string, bool) {
+	raw = strings.TrimLeftFunc(raw, isHTMLSpace)
+	closing := false
+	if strings.HasPrefix(raw, "/") {
+		closing = true
+		raw = strings.TrimLeftFunc(raw[1:], isHTMLSpace)
+	}
+	if raw == "" || strings.HasPrefix(raw, "!") || strings.HasPrefix(raw, "?") {
+		return "", closing
+	}
+	end := 0
+	for end < len(raw) && isHTMLTagNameByte(raw[end]) {
+		end++
+	}
+	if end == 0 {
+		return "", closing
+	}
+	return strings.ToLower(raw[:end]), closing
+}
+
+func isHTMLTagNameByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '-' || b == ':'
+}
+
+func isHTMLSpace(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\n' || r == '\r' || r == '\f'
 }
 
 func stripHTMLTags(body string) string {

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 )
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
@@ -1520,22 +1521,98 @@ func looksLikeHTMLBody(body string) bool {
 }
 
 func extractHTMLTitle(body string) string {
-	lower := strings.ToLower(body)
-	start := strings.Index(lower, "<title")
-	if start < 0 {
-		return ""
+	searchFrom := 0
+	for searchFrom < len(body) {
+		titleStart := indexHTMLTag(body[searchFrom:], "title")
+		if titleStart < 0 {
+			return ""
+		}
+		if blockStart, blockTag := nextHTMLBlockTag(body[searchFrom:titleStart+searchFrom], "script", "style"); blockStart >= 0 {
+			blockStart += searchFrom
+			blockOpenEnd := htmlTagEnd(body, blockStart)
+			if blockOpenEnd < 0 {
+				return ""
+			}
+			blockCloseStart := indexHTMLCloseTag(body[blockOpenEnd+1:], blockTag)
+			if blockCloseStart < 0 {
+				return ""
+			}
+			searchFrom = blockOpenEnd + 1 + blockCloseStart + len("</"+blockTag+">")
+			continue
+		}
+		titleStart += searchFrom
+		openEnd := htmlTagEnd(body, titleStart)
+		if openEnd < 0 {
+			return ""
+		}
+		contentStart := openEnd + 1
+		end := indexHTMLCloseTag(body[contentStart:], "title")
+		if end < 0 {
+			return ""
+		}
+		title := stripHTMLTags(body[contentStart : contentStart+end])
+		return strings.Join(strings.Fields(stripControlCharacters(html.UnescapeString(title))), " ")
 	}
-	openEnd := strings.Index(lower[start:], ">")
-	if openEnd < 0 {
-		return ""
+	return ""
+}
+
+func indexHTMLTag(body, tag string) int {
+	needle := "<" + tag
+	offset := 0
+	for offset < len(body) {
+		idx := indexCaseInsensitive(body[offset:], needle)
+		if idx < 0 {
+			return -1
+		}
+		start := offset + idx
+		after := start + len(needle)
+		if after >= len(body) || isHTMLTagNameBoundary(body[after]) {
+			return start
+		}
+		offset = after
 	}
-	contentStart := start + openEnd + 1
-	end := strings.Index(lower[contentStart:], "</title>")
+	return -1
+}
+
+func nextHTMLBlockTag(body string, tags ...string) (int, string) {
+	best := -1
+	bestTag := ""
+	for _, tag := range tags {
+		idx := indexHTMLTag(body, tag)
+		if idx >= 0 && (best < 0 || idx < best) {
+			best = idx
+			bestTag = tag
+		}
+	}
+	return best, bestTag
+}
+
+func indexHTMLCloseTag(body, tag string) int {
+	return indexCaseInsensitive(body, "</"+tag+">")
+}
+
+func indexCaseInsensitive(body, needle string) int {
+	if needle == "" {
+		return 0
+	}
+	for idx := 0; idx+len(needle) <= len(body); idx++ {
+		if strings.EqualFold(body[idx:idx+len(needle)], needle) {
+			return idx
+		}
+	}
+	return -1
+}
+
+func htmlTagEnd(body string, start int) int {
+	end := strings.IndexByte(body[start:], '>')
 	if end < 0 {
-		return ""
+		return -1
 	}
-	title := stripHTMLTags(body[contentStart : contentStart+end])
-	return strings.Join(strings.Fields(html.UnescapeString(title)), " ")
+	return start + end
+}
+
+func isHTMLTagNameBoundary(b byte) bool {
+	return b == '>' || b == '/' || b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f'
 }
 
 func stripHTMLTags(body string) string {
@@ -1555,6 +1632,18 @@ func stripHTMLTags(body string) string {
 		}
 	}
 	return out.String()
+}
+
+func stripControlCharacters(text string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' || r == '\r' {
+			return ' '
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, text)
 }
 
 func truncateRunes(text string, maxRunes int) string {

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -16,6 +16,7 @@ import (
 	"golden-api-cookie-auth-pp-cli/internal/cliutil"
 	"golden-api-cookie-auth-pp-cli/internal/config"
 	"golden-api-cookie-auth-pp-cli/internal/platform"
+	"html"
 	"io"
 	"math"
 	"net"
@@ -1483,10 +1484,88 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 
 func truncateBody(b []byte) string {
 	const maxBytes = 4096
+	if summary, ok := collapseHTMLErrorBody(b); ok {
+		return summary
+	}
 	if len(b) <= maxBytes {
 		return string(b)
 	}
 	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+}
+
+func collapseHTMLErrorBody(b []byte) (string, bool) {
+	body := strings.ToValidUTF8(string(b), "")
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" || !looksLikeHTMLBody(trimmed) {
+		return "", false
+	}
+
+	summary := fmt.Sprintf("HTML error page (%d bytes)", len(b))
+	if title := extractHTMLTitle(trimmed); title != "" {
+		summary += ": " + truncateRunes(title, 160)
+	}
+	return summary, true
+}
+
+func looksLikeHTMLBody(body string) bool {
+	lower := strings.ToLower(body)
+	if strings.HasPrefix(lower, "<!doctype html") || strings.HasPrefix(lower, "<html") {
+		return true
+	}
+	sample := lower
+	if len(sample) > 2048 {
+		sample = sample[:2048]
+	}
+	return strings.HasPrefix(sample, "<") && (strings.Contains(sample, "<body") || strings.Contains(sample, "<head") || strings.Contains(sample, "<title") || strings.Contains(sample, "<script"))
+}
+
+func extractHTMLTitle(body string) string {
+	lower := strings.ToLower(body)
+	start := strings.Index(lower, "<title")
+	if start < 0 {
+		return ""
+	}
+	openEnd := strings.Index(lower[start:], ">")
+	if openEnd < 0 {
+		return ""
+	}
+	contentStart := start + openEnd + 1
+	end := strings.Index(lower[contentStart:], "</title>")
+	if end < 0 {
+		return ""
+	}
+	title := stripHTMLTags(body[contentStart : contentStart+end])
+	return strings.Join(strings.Fields(html.UnescapeString(title)), " ")
+}
+
+func stripHTMLTags(body string) string {
+	var out strings.Builder
+	inTag := false
+	for _, r := range body {
+		switch r {
+		case '<':
+			inTag = true
+			out.WriteByte(' ')
+		case '>':
+			inTag = false
+		default:
+			if !inTag {
+				out.WriteRune(r)
+			}
+		}
+	}
+	return out.String()
+}
+
+func truncateRunes(text string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return text
+	}
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return text
+	}
+	return string(runes[:maxRunes]) + "..."
 }
 
 func clientMaxRetries() int {

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -32,6 +32,7 @@ import (
 )
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
+const maxErrorBodyBytes = 4096
 
 var ErrPlaceholderCredential = errors.New("auth placeholder credential")
 
@@ -1512,18 +1513,21 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 }
 
 func truncateBody(b []byte) string {
-	const maxBytes = 4096
 	if summary, ok := collapseHTMLErrorBody(b); ok {
 		return summary
 	}
-	if len(b) <= maxBytes {
+	if len(b) <= maxErrorBodyBytes {
 		return string(b)
 	}
-	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+	return strings.ToValidUTF8(string(b[:maxErrorBodyBytes]), "") + "..."
 }
 
 func collapseHTMLErrorBody(b []byte) (string, bool) {
-	body := strings.ToValidUTF8(string(b), "")
+	scanBytes := b
+	if len(scanBytes) > maxErrorBodyBytes {
+		scanBytes = scanBytes[:maxErrorBodyBytes]
+	}
+	body := strings.ToValidUTF8(string(scanBytes), "")
 	trimmed := strings.TrimSpace(body)
 	if trimmed == "" || !looksLikeHTMLBody(trimmed) {
 		return "", false

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 )
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
@@ -1548,22 +1549,98 @@ func looksLikeHTMLBody(body string) bool {
 }
 
 func extractHTMLTitle(body string) string {
-	lower := strings.ToLower(body)
-	start := strings.Index(lower, "<title")
-	if start < 0 {
-		return ""
+	searchFrom := 0
+	for searchFrom < len(body) {
+		titleStart := indexHTMLTag(body[searchFrom:], "title")
+		if titleStart < 0 {
+			return ""
+		}
+		if blockStart, blockTag := nextHTMLBlockTag(body[searchFrom:titleStart+searchFrom], "script", "style"); blockStart >= 0 {
+			blockStart += searchFrom
+			blockOpenEnd := htmlTagEnd(body, blockStart)
+			if blockOpenEnd < 0 {
+				return ""
+			}
+			blockCloseStart := indexHTMLCloseTag(body[blockOpenEnd+1:], blockTag)
+			if blockCloseStart < 0 {
+				return ""
+			}
+			searchFrom = blockOpenEnd + 1 + blockCloseStart + len("</"+blockTag+">")
+			continue
+		}
+		titleStart += searchFrom
+		openEnd := htmlTagEnd(body, titleStart)
+		if openEnd < 0 {
+			return ""
+		}
+		contentStart := openEnd + 1
+		end := indexHTMLCloseTag(body[contentStart:], "title")
+		if end < 0 {
+			return ""
+		}
+		title := stripHTMLTags(body[contentStart : contentStart+end])
+		return strings.Join(strings.Fields(stripControlCharacters(html.UnescapeString(title))), " ")
 	}
-	openEnd := strings.Index(lower[start:], ">")
-	if openEnd < 0 {
-		return ""
+	return ""
+}
+
+func indexHTMLTag(body, tag string) int {
+	needle := "<" + tag
+	offset := 0
+	for offset < len(body) {
+		idx := indexCaseInsensitive(body[offset:], needle)
+		if idx < 0 {
+			return -1
+		}
+		start := offset + idx
+		after := start + len(needle)
+		if after >= len(body) || isHTMLTagNameBoundary(body[after]) {
+			return start
+		}
+		offset = after
 	}
-	contentStart := start + openEnd + 1
-	end := strings.Index(lower[contentStart:], "</title>")
+	return -1
+}
+
+func nextHTMLBlockTag(body string, tags ...string) (int, string) {
+	best := -1
+	bestTag := ""
+	for _, tag := range tags {
+		idx := indexHTMLTag(body, tag)
+		if idx >= 0 && (best < 0 || idx < best) {
+			best = idx
+			bestTag = tag
+		}
+	}
+	return best, bestTag
+}
+
+func indexHTMLCloseTag(body, tag string) int {
+	return indexCaseInsensitive(body, "</"+tag+">")
+}
+
+func indexCaseInsensitive(body, needle string) int {
+	if needle == "" {
+		return 0
+	}
+	for idx := 0; idx+len(needle) <= len(body); idx++ {
+		if strings.EqualFold(body[idx:idx+len(needle)], needle) {
+			return idx
+		}
+	}
+	return -1
+}
+
+func htmlTagEnd(body string, start int) int {
+	end := strings.IndexByte(body[start:], '>')
 	if end < 0 {
-		return ""
+		return -1
 	}
-	title := stripHTMLTags(body[contentStart : contentStart+end])
-	return strings.Join(strings.Fields(html.UnescapeString(title)), " ")
+	return start + end
+}
+
+func isHTMLTagNameBoundary(b byte) bool {
+	return b == '>' || b == '/' || b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f'
 }
 
 func stripHTMLTags(body string) string {
@@ -1583,6 +1660,18 @@ func stripHTMLTags(body string) string {
 		}
 	}
 	return out.String()
+}
+
+func stripControlCharacters(text string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' || r == '\r' {
+			return ' '
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, text)
 }
 
 func truncateRunes(text string, maxRunes int) string {

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -1673,6 +1673,12 @@ func stripControlCharacters(text string) string {
 		if r == '\t' || r == '\n' || r == '\r' {
 			return ' '
 		}
+		if unicode.Is(unicode.Zl, r) || unicode.Is(unicode.Zp, r) {
+			return ' '
+		}
+		if unicode.Is(unicode.Cf, r) {
+			return -1
+		}
 		if unicode.IsControl(r) {
 			return -1
 		}

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"math"
 	"net"
@@ -1511,10 +1512,88 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 
 func truncateBody(b []byte) string {
 	const maxBytes = 4096
+	if summary, ok := collapseHTMLErrorBody(b); ok {
+		return summary
+	}
 	if len(b) <= maxBytes {
 		return string(b)
 	}
 	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+}
+
+func collapseHTMLErrorBody(b []byte) (string, bool) {
+	body := strings.ToValidUTF8(string(b), "")
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" || !looksLikeHTMLBody(trimmed) {
+		return "", false
+	}
+
+	summary := fmt.Sprintf("HTML error page (%d bytes)", len(b))
+	if title := extractHTMLTitle(trimmed); title != "" {
+		summary += ": " + truncateRunes(title, 160)
+	}
+	return summary, true
+}
+
+func looksLikeHTMLBody(body string) bool {
+	lower := strings.ToLower(body)
+	if strings.HasPrefix(lower, "<!doctype html") || strings.HasPrefix(lower, "<html") {
+		return true
+	}
+	sample := lower
+	if len(sample) > 2048 {
+		sample = sample[:2048]
+	}
+	return strings.HasPrefix(sample, "<") && (strings.Contains(sample, "<body") || strings.Contains(sample, "<head") || strings.Contains(sample, "<title") || strings.Contains(sample, "<script"))
+}
+
+func extractHTMLTitle(body string) string {
+	lower := strings.ToLower(body)
+	start := strings.Index(lower, "<title")
+	if start < 0 {
+		return ""
+	}
+	openEnd := strings.Index(lower[start:], ">")
+	if openEnd < 0 {
+		return ""
+	}
+	contentStart := start + openEnd + 1
+	end := strings.Index(lower[contentStart:], "</title>")
+	if end < 0 {
+		return ""
+	}
+	title := stripHTMLTags(body[contentStart : contentStart+end])
+	return strings.Join(strings.Fields(html.UnescapeString(title)), " ")
+}
+
+func stripHTMLTags(body string) string {
+	var out strings.Builder
+	inTag := false
+	for _, r := range body {
+		switch r {
+		case '<':
+			inTag = true
+			out.WriteByte(' ')
+		case '>':
+			inTag = false
+		default:
+			if !inTag {
+				out.WriteRune(r)
+			}
+		}
+	}
+	return out.String()
+}
+
+func truncateRunes(text string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return text
+	}
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return text
+	}
+	return string(runes[:maxRunes]) + "..."
 }
 
 func clientMaxRetries() int {

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -1549,84 +1549,66 @@ func looksLikeHTMLBody(body string) bool {
 }
 
 func extractHTMLTitle(body string) string {
-	searchFrom := 0
-	for searchFrom < len(body) {
-		titleStart := indexHTMLTag(body[searchFrom:], "title")
-		if titleStart < 0 {
+	pos := 0
+	ignoredBlock := ""
+	for pos < len(body) {
+		tagStartRel := strings.IndexByte(body[pos:], '<')
+		if tagStartRel < 0 {
 			return ""
 		}
-		if blockStart, blockTag := nextHTMLBlockTag(body[searchFrom:titleStart+searchFrom], "script", "style"); blockStart >= 0 {
-			blockStart += searchFrom
-			blockOpenEnd := htmlTagEnd(body, blockStart)
-			if blockOpenEnd < 0 {
-				return ""
-			}
-			blockCloseStart := indexHTMLCloseTag(body[blockOpenEnd+1:], blockTag)
-			if blockCloseStart < 0 {
-				return ""
-			}
-			searchFrom = blockOpenEnd + 1 + blockCloseStart + len("</"+blockTag+">")
+		tagStart := pos + tagStartRel
+		tagEnd := htmlTagEnd(body, tagStart)
+		if tagEnd < 0 {
+			return ""
+		}
+		tagName, closing := htmlTagName(body[tagStart+1 : tagEnd])
+		pos = tagEnd + 1
+		if tagName == "" {
 			continue
 		}
-		titleStart += searchFrom
-		openEnd := htmlTagEnd(body, titleStart)
-		if openEnd < 0 {
+		if ignoredBlock != "" {
+			if closing && tagName == ignoredBlock {
+				ignoredBlock = ""
+			}
+			continue
+		}
+		if closing {
+			continue
+		}
+		if tagName == "script" || tagName == "style" {
+			ignoredBlock = tagName
+			continue
+		}
+		if tagName != "title" {
+			continue
+		}
+		titleEnd := findHTMLCloseTag(body, pos, "title")
+		if titleEnd < 0 {
 			return ""
 		}
-		contentStart := openEnd + 1
-		end := indexHTMLCloseTag(body[contentStart:], "title")
-		if end < 0 {
-			return ""
-		}
-		title := stripHTMLTags(body[contentStart : contentStart+end])
+		title := stripHTMLTags(body[pos:titleEnd])
 		return strings.Join(strings.Fields(stripControlCharacters(html.UnescapeString(title))), " ")
 	}
 	return ""
 }
 
-func indexHTMLTag(body, tag string) int {
-	needle := "<" + tag
-	offset := 0
-	for offset < len(body) {
-		idx := indexCaseInsensitive(body[offset:], needle)
-		if idx < 0 {
+func findHTMLCloseTag(body string, from int, tag string) int {
+	pos := from
+	for pos < len(body) {
+		tagStartRel := strings.IndexByte(body[pos:], '<')
+		if tagStartRel < 0 {
 			return -1
 		}
-		start := offset + idx
-		after := start + len(needle)
-		if after >= len(body) || isHTMLTagNameBoundary(body[after]) {
-			return start
+		tagStart := pos + tagStartRel
+		tagEnd := htmlTagEnd(body, tagStart)
+		if tagEnd < 0 {
+			return -1
 		}
-		offset = after
-	}
-	return -1
-}
-
-func nextHTMLBlockTag(body string, tags ...string) (int, string) {
-	best := -1
-	bestTag := ""
-	for _, tag := range tags {
-		idx := indexHTMLTag(body, tag)
-		if idx >= 0 && (best < 0 || idx < best) {
-			best = idx
-			bestTag = tag
+		tagName, closing := htmlTagName(body[tagStart+1 : tagEnd])
+		if closing && tagName == tag {
+			return tagStart
 		}
-	}
-	return best, bestTag
-}
-
-func indexHTMLCloseTag(body, tag string) int {
-	return indexCaseInsensitive(body, "</"+tag+">")
-}
-
-func indexCaseInsensitive(body, needle string) int {
-	if needle == "" {
-		return 0
-	}
-	for idx := 0; idx+len(needle) <= len(body); idx++ {
-		if strings.EqualFold(body[idx:idx+len(needle)], needle) {
-			return idx
-		}
+		pos = tagEnd + 1
 	}
 	return -1
 }
@@ -1639,8 +1621,32 @@ func htmlTagEnd(body string, start int) int {
 	return start + end
 }
 
-func isHTMLTagNameBoundary(b byte) bool {
-	return b == '>' || b == '/' || b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f'
+func htmlTagName(raw string) (string, bool) {
+	raw = strings.TrimLeftFunc(raw, isHTMLSpace)
+	closing := false
+	if strings.HasPrefix(raw, "/") {
+		closing = true
+		raw = strings.TrimLeftFunc(raw[1:], isHTMLSpace)
+	}
+	if raw == "" || strings.HasPrefix(raw, "!") || strings.HasPrefix(raw, "?") {
+		return "", closing
+	}
+	end := 0
+	for end < len(raw) && isHTMLTagNameByte(raw[end]) {
+		end++
+	}
+	if end == 0 {
+		return "", closing
+	}
+	return strings.ToLower(raw[:end]), closing
+}
+
+func isHTMLTagNameByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '-' || b == ':'
+}
+
+func isHTMLSpace(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\n' || r == '\r' || r == '\f'
 }
 
 func stripHTMLTags(body string) string {

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"math"
 	"net"
@@ -1634,10 +1635,88 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 
 func truncateBody(b []byte) string {
 	const maxBytes = 4096
+	if summary, ok := collapseHTMLErrorBody(b); ok {
+		return summary
+	}
 	if len(b) <= maxBytes {
 		return string(b)
 	}
 	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+}
+
+func collapseHTMLErrorBody(b []byte) (string, bool) {
+	body := strings.ToValidUTF8(string(b), "")
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" || !looksLikeHTMLBody(trimmed) {
+		return "", false
+	}
+
+	summary := fmt.Sprintf("HTML error page (%d bytes)", len(b))
+	if title := extractHTMLTitle(trimmed); title != "" {
+		summary += ": " + truncateRunes(title, 160)
+	}
+	return summary, true
+}
+
+func looksLikeHTMLBody(body string) bool {
+	lower := strings.ToLower(body)
+	if strings.HasPrefix(lower, "<!doctype html") || strings.HasPrefix(lower, "<html") {
+		return true
+	}
+	sample := lower
+	if len(sample) > 2048 {
+		sample = sample[:2048]
+	}
+	return strings.HasPrefix(sample, "<") && (strings.Contains(sample, "<body") || strings.Contains(sample, "<head") || strings.Contains(sample, "<title") || strings.Contains(sample, "<script"))
+}
+
+func extractHTMLTitle(body string) string {
+	lower := strings.ToLower(body)
+	start := strings.Index(lower, "<title")
+	if start < 0 {
+		return ""
+	}
+	openEnd := strings.Index(lower[start:], ">")
+	if openEnd < 0 {
+		return ""
+	}
+	contentStart := start + openEnd + 1
+	end := strings.Index(lower[contentStart:], "</title>")
+	if end < 0 {
+		return ""
+	}
+	title := stripHTMLTags(body[contentStart : contentStart+end])
+	return strings.Join(strings.Fields(html.UnescapeString(title)), " ")
+}
+
+func stripHTMLTags(body string) string {
+	var out strings.Builder
+	inTag := false
+	for _, r := range body {
+		switch r {
+		case '<':
+			inTag = true
+			out.WriteByte(' ')
+		case '>':
+			inTag = false
+		default:
+			if !inTag {
+				out.WriteRune(r)
+			}
+		}
+	}
+	return out.String()
+}
+
+func truncateRunes(text string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return text
+	}
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return text
+	}
+	return string(runes[:maxRunes]) + "..."
 }
 
 func clientMaxRetries() int {

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 )
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
@@ -1671,22 +1672,98 @@ func looksLikeHTMLBody(body string) bool {
 }
 
 func extractHTMLTitle(body string) string {
-	lower := strings.ToLower(body)
-	start := strings.Index(lower, "<title")
-	if start < 0 {
-		return ""
+	searchFrom := 0
+	for searchFrom < len(body) {
+		titleStart := indexHTMLTag(body[searchFrom:], "title")
+		if titleStart < 0 {
+			return ""
+		}
+		if blockStart, blockTag := nextHTMLBlockTag(body[searchFrom:titleStart+searchFrom], "script", "style"); blockStart >= 0 {
+			blockStart += searchFrom
+			blockOpenEnd := htmlTagEnd(body, blockStart)
+			if blockOpenEnd < 0 {
+				return ""
+			}
+			blockCloseStart := indexHTMLCloseTag(body[blockOpenEnd+1:], blockTag)
+			if blockCloseStart < 0 {
+				return ""
+			}
+			searchFrom = blockOpenEnd + 1 + blockCloseStart + len("</"+blockTag+">")
+			continue
+		}
+		titleStart += searchFrom
+		openEnd := htmlTagEnd(body, titleStart)
+		if openEnd < 0 {
+			return ""
+		}
+		contentStart := openEnd + 1
+		end := indexHTMLCloseTag(body[contentStart:], "title")
+		if end < 0 {
+			return ""
+		}
+		title := stripHTMLTags(body[contentStart : contentStart+end])
+		return strings.Join(strings.Fields(stripControlCharacters(html.UnescapeString(title))), " ")
 	}
-	openEnd := strings.Index(lower[start:], ">")
-	if openEnd < 0 {
-		return ""
+	return ""
+}
+
+func indexHTMLTag(body, tag string) int {
+	needle := "<" + tag
+	offset := 0
+	for offset < len(body) {
+		idx := indexCaseInsensitive(body[offset:], needle)
+		if idx < 0 {
+			return -1
+		}
+		start := offset + idx
+		after := start + len(needle)
+		if after >= len(body) || isHTMLTagNameBoundary(body[after]) {
+			return start
+		}
+		offset = after
 	}
-	contentStart := start + openEnd + 1
-	end := strings.Index(lower[contentStart:], "</title>")
+	return -1
+}
+
+func nextHTMLBlockTag(body string, tags ...string) (int, string) {
+	best := -1
+	bestTag := ""
+	for _, tag := range tags {
+		idx := indexHTMLTag(body, tag)
+		if idx >= 0 && (best < 0 || idx < best) {
+			best = idx
+			bestTag = tag
+		}
+	}
+	return best, bestTag
+}
+
+func indexHTMLCloseTag(body, tag string) int {
+	return indexCaseInsensitive(body, "</"+tag+">")
+}
+
+func indexCaseInsensitive(body, needle string) int {
+	if needle == "" {
+		return 0
+	}
+	for idx := 0; idx+len(needle) <= len(body); idx++ {
+		if strings.EqualFold(body[idx:idx+len(needle)], needle) {
+			return idx
+		}
+	}
+	return -1
+}
+
+func htmlTagEnd(body string, start int) int {
+	end := strings.IndexByte(body[start:], '>')
 	if end < 0 {
-		return ""
+		return -1
 	}
-	title := stripHTMLTags(body[contentStart : contentStart+end])
-	return strings.Join(strings.Fields(html.UnescapeString(title)), " ")
+	return start + end
+}
+
+func isHTMLTagNameBoundary(b byte) bool {
+	return b == '>' || b == '/' || b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f'
 }
 
 func stripHTMLTags(body string) string {
@@ -1706,6 +1783,18 @@ func stripHTMLTags(body string) string {
 		}
 	}
 	return out.String()
+}
+
+func stripControlCharacters(text string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' || r == '\r' {
+			return ' '
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, text)
 }
 
 func truncateRunes(text string, maxRunes int) string {

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -1672,84 +1672,66 @@ func looksLikeHTMLBody(body string) bool {
 }
 
 func extractHTMLTitle(body string) string {
-	searchFrom := 0
-	for searchFrom < len(body) {
-		titleStart := indexHTMLTag(body[searchFrom:], "title")
-		if titleStart < 0 {
+	pos := 0
+	ignoredBlock := ""
+	for pos < len(body) {
+		tagStartRel := strings.IndexByte(body[pos:], '<')
+		if tagStartRel < 0 {
 			return ""
 		}
-		if blockStart, blockTag := nextHTMLBlockTag(body[searchFrom:titleStart+searchFrom], "script", "style"); blockStart >= 0 {
-			blockStart += searchFrom
-			blockOpenEnd := htmlTagEnd(body, blockStart)
-			if blockOpenEnd < 0 {
-				return ""
-			}
-			blockCloseStart := indexHTMLCloseTag(body[blockOpenEnd+1:], blockTag)
-			if blockCloseStart < 0 {
-				return ""
-			}
-			searchFrom = blockOpenEnd + 1 + blockCloseStart + len("</"+blockTag+">")
+		tagStart := pos + tagStartRel
+		tagEnd := htmlTagEnd(body, tagStart)
+		if tagEnd < 0 {
+			return ""
+		}
+		tagName, closing := htmlTagName(body[tagStart+1 : tagEnd])
+		pos = tagEnd + 1
+		if tagName == "" {
 			continue
 		}
-		titleStart += searchFrom
-		openEnd := htmlTagEnd(body, titleStart)
-		if openEnd < 0 {
+		if ignoredBlock != "" {
+			if closing && tagName == ignoredBlock {
+				ignoredBlock = ""
+			}
+			continue
+		}
+		if closing {
+			continue
+		}
+		if tagName == "script" || tagName == "style" {
+			ignoredBlock = tagName
+			continue
+		}
+		if tagName != "title" {
+			continue
+		}
+		titleEnd := findHTMLCloseTag(body, pos, "title")
+		if titleEnd < 0 {
 			return ""
 		}
-		contentStart := openEnd + 1
-		end := indexHTMLCloseTag(body[contentStart:], "title")
-		if end < 0 {
-			return ""
-		}
-		title := stripHTMLTags(body[contentStart : contentStart+end])
+		title := stripHTMLTags(body[pos:titleEnd])
 		return strings.Join(strings.Fields(stripControlCharacters(html.UnescapeString(title))), " ")
 	}
 	return ""
 }
 
-func indexHTMLTag(body, tag string) int {
-	needle := "<" + tag
-	offset := 0
-	for offset < len(body) {
-		idx := indexCaseInsensitive(body[offset:], needle)
-		if idx < 0 {
+func findHTMLCloseTag(body string, from int, tag string) int {
+	pos := from
+	for pos < len(body) {
+		tagStartRel := strings.IndexByte(body[pos:], '<')
+		if tagStartRel < 0 {
 			return -1
 		}
-		start := offset + idx
-		after := start + len(needle)
-		if after >= len(body) || isHTMLTagNameBoundary(body[after]) {
-			return start
+		tagStart := pos + tagStartRel
+		tagEnd := htmlTagEnd(body, tagStart)
+		if tagEnd < 0 {
+			return -1
 		}
-		offset = after
-	}
-	return -1
-}
-
-func nextHTMLBlockTag(body string, tags ...string) (int, string) {
-	best := -1
-	bestTag := ""
-	for _, tag := range tags {
-		idx := indexHTMLTag(body, tag)
-		if idx >= 0 && (best < 0 || idx < best) {
-			best = idx
-			bestTag = tag
+		tagName, closing := htmlTagName(body[tagStart+1 : tagEnd])
+		if closing && tagName == tag {
+			return tagStart
 		}
-	}
-	return best, bestTag
-}
-
-func indexHTMLCloseTag(body, tag string) int {
-	return indexCaseInsensitive(body, "</"+tag+">")
-}
-
-func indexCaseInsensitive(body, needle string) int {
-	if needle == "" {
-		return 0
-	}
-	for idx := 0; idx+len(needle) <= len(body); idx++ {
-		if strings.EqualFold(body[idx:idx+len(needle)], needle) {
-			return idx
-		}
+		pos = tagEnd + 1
 	}
 	return -1
 }
@@ -1762,8 +1744,32 @@ func htmlTagEnd(body string, start int) int {
 	return start + end
 }
 
-func isHTMLTagNameBoundary(b byte) bool {
-	return b == '>' || b == '/' || b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f'
+func htmlTagName(raw string) (string, bool) {
+	raw = strings.TrimLeftFunc(raw, isHTMLSpace)
+	closing := false
+	if strings.HasPrefix(raw, "/") {
+		closing = true
+		raw = strings.TrimLeftFunc(raw[1:], isHTMLSpace)
+	}
+	if raw == "" || strings.HasPrefix(raw, "!") || strings.HasPrefix(raw, "?") {
+		return "", closing
+	}
+	end := 0
+	for end < len(raw) && isHTMLTagNameByte(raw[end]) {
+		end++
+	}
+	if end == 0 {
+		return "", closing
+	}
+	return strings.ToLower(raw[:end]), closing
+}
+
+func isHTMLTagNameByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '-' || b == ':'
+}
+
+func isHTMLSpace(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\n' || r == '\r' || r == '\f'
 }
 
 func stripHTMLTags(body string) string {

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -1796,6 +1796,12 @@ func stripControlCharacters(text string) string {
 		if r == '\t' || r == '\n' || r == '\r' {
 			return ' '
 		}
+		if unicode.Is(unicode.Zl, r) || unicode.Is(unicode.Zp, r) {
+			return ' '
+		}
+		if unicode.Is(unicode.Cf, r) {
+			return -1
+		}
 		if unicode.IsControl(r) {
 			return -1
 		}

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -32,6 +32,7 @@ import (
 )
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
+const maxErrorBodyBytes = 4096
 
 var ErrPlaceholderCredential = errors.New("auth placeholder credential")
 
@@ -1635,18 +1636,21 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 }
 
 func truncateBody(b []byte) string {
-	const maxBytes = 4096
 	if summary, ok := collapseHTMLErrorBody(b); ok {
 		return summary
 	}
-	if len(b) <= maxBytes {
+	if len(b) <= maxErrorBodyBytes {
 		return string(b)
 	}
-	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+	return strings.ToValidUTF8(string(b[:maxErrorBodyBytes]), "") + "..."
 }
 
 func collapseHTMLErrorBody(b []byte) (string, bool) {
-	body := strings.ToValidUTF8(string(b), "")
+	scanBytes := b
+	if len(scanBytes) > maxErrorBodyBytes {
+		scanBytes = scanBytes[:maxErrorBodyBytes]
+	}
+	body := strings.ToValidUTF8(string(scanBytes), "")
 	trimmed := strings.TrimSpace(body)
 	if trimmed == "" || !looksLikeHTMLBody(trimmed) {
 		return "", false

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 )
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
@@ -1547,22 +1548,98 @@ func looksLikeHTMLBody(body string) bool {
 }
 
 func extractHTMLTitle(body string) string {
-	lower := strings.ToLower(body)
-	start := strings.Index(lower, "<title")
-	if start < 0 {
-		return ""
+	searchFrom := 0
+	for searchFrom < len(body) {
+		titleStart := indexHTMLTag(body[searchFrom:], "title")
+		if titleStart < 0 {
+			return ""
+		}
+		if blockStart, blockTag := nextHTMLBlockTag(body[searchFrom:titleStart+searchFrom], "script", "style"); blockStart >= 0 {
+			blockStart += searchFrom
+			blockOpenEnd := htmlTagEnd(body, blockStart)
+			if blockOpenEnd < 0 {
+				return ""
+			}
+			blockCloseStart := indexHTMLCloseTag(body[blockOpenEnd+1:], blockTag)
+			if blockCloseStart < 0 {
+				return ""
+			}
+			searchFrom = blockOpenEnd + 1 + blockCloseStart + len("</"+blockTag+">")
+			continue
+		}
+		titleStart += searchFrom
+		openEnd := htmlTagEnd(body, titleStart)
+		if openEnd < 0 {
+			return ""
+		}
+		contentStart := openEnd + 1
+		end := indexHTMLCloseTag(body[contentStart:], "title")
+		if end < 0 {
+			return ""
+		}
+		title := stripHTMLTags(body[contentStart : contentStart+end])
+		return strings.Join(strings.Fields(stripControlCharacters(html.UnescapeString(title))), " ")
 	}
-	openEnd := strings.Index(lower[start:], ">")
-	if openEnd < 0 {
-		return ""
+	return ""
+}
+
+func indexHTMLTag(body, tag string) int {
+	needle := "<" + tag
+	offset := 0
+	for offset < len(body) {
+		idx := indexCaseInsensitive(body[offset:], needle)
+		if idx < 0 {
+			return -1
+		}
+		start := offset + idx
+		after := start + len(needle)
+		if after >= len(body) || isHTMLTagNameBoundary(body[after]) {
+			return start
+		}
+		offset = after
 	}
-	contentStart := start + openEnd + 1
-	end := strings.Index(lower[contentStart:], "</title>")
+	return -1
+}
+
+func nextHTMLBlockTag(body string, tags ...string) (int, string) {
+	best := -1
+	bestTag := ""
+	for _, tag := range tags {
+		idx := indexHTMLTag(body, tag)
+		if idx >= 0 && (best < 0 || idx < best) {
+			best = idx
+			bestTag = tag
+		}
+	}
+	return best, bestTag
+}
+
+func indexHTMLCloseTag(body, tag string) int {
+	return indexCaseInsensitive(body, "</"+tag+">")
+}
+
+func indexCaseInsensitive(body, needle string) int {
+	if needle == "" {
+		return 0
+	}
+	for idx := 0; idx+len(needle) <= len(body); idx++ {
+		if strings.EqualFold(body[idx:idx+len(needle)], needle) {
+			return idx
+		}
+	}
+	return -1
+}
+
+func htmlTagEnd(body string, start int) int {
+	end := strings.IndexByte(body[start:], '>')
 	if end < 0 {
-		return ""
+		return -1
 	}
-	title := stripHTMLTags(body[contentStart : contentStart+end])
-	return strings.Join(strings.Fields(html.UnescapeString(title)), " ")
+	return start + end
+}
+
+func isHTMLTagNameBoundary(b byte) bool {
+	return b == '>' || b == '/' || b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f'
 }
 
 func stripHTMLTags(body string) string {
@@ -1582,6 +1659,18 @@ func stripHTMLTags(body string) string {
 		}
 	}
 	return out.String()
+}
+
+func stripControlCharacters(text string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' || r == '\r' {
+			return ' '
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, text)
 }
 
 func truncateRunes(text string, maxRunes int) string {

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -32,6 +32,7 @@ import (
 )
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
+const maxErrorBodyBytes = 4096
 
 var ErrPlaceholderCredential = errors.New("auth placeholder credential")
 
@@ -1511,18 +1512,21 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 }
 
 func truncateBody(b []byte) string {
-	const maxBytes = 4096
 	if summary, ok := collapseHTMLErrorBody(b); ok {
 		return summary
 	}
-	if len(b) <= maxBytes {
+	if len(b) <= maxErrorBodyBytes {
 		return string(b)
 	}
-	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+	return strings.ToValidUTF8(string(b[:maxErrorBodyBytes]), "") + "..."
 }
 
 func collapseHTMLErrorBody(b []byte) (string, bool) {
-	body := strings.ToValidUTF8(string(b), "")
+	scanBytes := b
+	if len(scanBytes) > maxErrorBodyBytes {
+		scanBytes = scanBytes[:maxErrorBodyBytes]
+	}
+	body := strings.ToValidUTF8(string(scanBytes), "")
 	trimmed := strings.TrimSpace(body)
 	if trimmed == "" || !looksLikeHTMLBody(trimmed) {
 		return "", false

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -1672,6 +1672,12 @@ func stripControlCharacters(text string) string {
 		if r == '\t' || r == '\n' || r == '\r' {
 			return ' '
 		}
+		if unicode.Is(unicode.Zl, r) || unicode.Is(unicode.Zp, r) {
+			return ' '
+		}
+		if unicode.Is(unicode.Cf, r) {
+			return -1
+		}
 		if unicode.IsControl(r) {
 			return -1
 		}

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -1548,84 +1548,66 @@ func looksLikeHTMLBody(body string) bool {
 }
 
 func extractHTMLTitle(body string) string {
-	searchFrom := 0
-	for searchFrom < len(body) {
-		titleStart := indexHTMLTag(body[searchFrom:], "title")
-		if titleStart < 0 {
+	pos := 0
+	ignoredBlock := ""
+	for pos < len(body) {
+		tagStartRel := strings.IndexByte(body[pos:], '<')
+		if tagStartRel < 0 {
 			return ""
 		}
-		if blockStart, blockTag := nextHTMLBlockTag(body[searchFrom:titleStart+searchFrom], "script", "style"); blockStart >= 0 {
-			blockStart += searchFrom
-			blockOpenEnd := htmlTagEnd(body, blockStart)
-			if blockOpenEnd < 0 {
-				return ""
-			}
-			blockCloseStart := indexHTMLCloseTag(body[blockOpenEnd+1:], blockTag)
-			if blockCloseStart < 0 {
-				return ""
-			}
-			searchFrom = blockOpenEnd + 1 + blockCloseStart + len("</"+blockTag+">")
+		tagStart := pos + tagStartRel
+		tagEnd := htmlTagEnd(body, tagStart)
+		if tagEnd < 0 {
+			return ""
+		}
+		tagName, closing := htmlTagName(body[tagStart+1 : tagEnd])
+		pos = tagEnd + 1
+		if tagName == "" {
 			continue
 		}
-		titleStart += searchFrom
-		openEnd := htmlTagEnd(body, titleStart)
-		if openEnd < 0 {
+		if ignoredBlock != "" {
+			if closing && tagName == ignoredBlock {
+				ignoredBlock = ""
+			}
+			continue
+		}
+		if closing {
+			continue
+		}
+		if tagName == "script" || tagName == "style" {
+			ignoredBlock = tagName
+			continue
+		}
+		if tagName != "title" {
+			continue
+		}
+		titleEnd := findHTMLCloseTag(body, pos, "title")
+		if titleEnd < 0 {
 			return ""
 		}
-		contentStart := openEnd + 1
-		end := indexHTMLCloseTag(body[contentStart:], "title")
-		if end < 0 {
-			return ""
-		}
-		title := stripHTMLTags(body[contentStart : contentStart+end])
+		title := stripHTMLTags(body[pos:titleEnd])
 		return strings.Join(strings.Fields(stripControlCharacters(html.UnescapeString(title))), " ")
 	}
 	return ""
 }
 
-func indexHTMLTag(body, tag string) int {
-	needle := "<" + tag
-	offset := 0
-	for offset < len(body) {
-		idx := indexCaseInsensitive(body[offset:], needle)
-		if idx < 0 {
+func findHTMLCloseTag(body string, from int, tag string) int {
+	pos := from
+	for pos < len(body) {
+		tagStartRel := strings.IndexByte(body[pos:], '<')
+		if tagStartRel < 0 {
 			return -1
 		}
-		start := offset + idx
-		after := start + len(needle)
-		if after >= len(body) || isHTMLTagNameBoundary(body[after]) {
-			return start
+		tagStart := pos + tagStartRel
+		tagEnd := htmlTagEnd(body, tagStart)
+		if tagEnd < 0 {
+			return -1
 		}
-		offset = after
-	}
-	return -1
-}
-
-func nextHTMLBlockTag(body string, tags ...string) (int, string) {
-	best := -1
-	bestTag := ""
-	for _, tag := range tags {
-		idx := indexHTMLTag(body, tag)
-		if idx >= 0 && (best < 0 || idx < best) {
-			best = idx
-			bestTag = tag
+		tagName, closing := htmlTagName(body[tagStart+1 : tagEnd])
+		if closing && tagName == tag {
+			return tagStart
 		}
-	}
-	return best, bestTag
-}
-
-func indexHTMLCloseTag(body, tag string) int {
-	return indexCaseInsensitive(body, "</"+tag+">")
-}
-
-func indexCaseInsensitive(body, needle string) int {
-	if needle == "" {
-		return 0
-	}
-	for idx := 0; idx+len(needle) <= len(body); idx++ {
-		if strings.EqualFold(body[idx:idx+len(needle)], needle) {
-			return idx
-		}
+		pos = tagEnd + 1
 	}
 	return -1
 }
@@ -1638,8 +1620,32 @@ func htmlTagEnd(body string, start int) int {
 	return start + end
 }
 
-func isHTMLTagNameBoundary(b byte) bool {
-	return b == '>' || b == '/' || b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f'
+func htmlTagName(raw string) (string, bool) {
+	raw = strings.TrimLeftFunc(raw, isHTMLSpace)
+	closing := false
+	if strings.HasPrefix(raw, "/") {
+		closing = true
+		raw = strings.TrimLeftFunc(raw[1:], isHTMLSpace)
+	}
+	if raw == "" || strings.HasPrefix(raw, "!") || strings.HasPrefix(raw, "?") {
+		return "", closing
+	}
+	end := 0
+	for end < len(raw) && isHTMLTagNameByte(raw[end]) {
+		end++
+	}
+	if end == 0 {
+		return "", closing
+	}
+	return strings.ToLower(raw[:end]), closing
+}
+
+func isHTMLTagNameByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '-' || b == ':'
+}
+
+func isHTMLSpace(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\n' || r == '\r' || r == '\f'
 }
 
 func stripHTMLTags(body string) string {

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"math"
 	"net"
@@ -1510,10 +1511,88 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 
 func truncateBody(b []byte) string {
 	const maxBytes = 4096
+	if summary, ok := collapseHTMLErrorBody(b); ok {
+		return summary
+	}
 	if len(b) <= maxBytes {
 		return string(b)
 	}
 	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+}
+
+func collapseHTMLErrorBody(b []byte) (string, bool) {
+	body := strings.ToValidUTF8(string(b), "")
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" || !looksLikeHTMLBody(trimmed) {
+		return "", false
+	}
+
+	summary := fmt.Sprintf("HTML error page (%d bytes)", len(b))
+	if title := extractHTMLTitle(trimmed); title != "" {
+		summary += ": " + truncateRunes(title, 160)
+	}
+	return summary, true
+}
+
+func looksLikeHTMLBody(body string) bool {
+	lower := strings.ToLower(body)
+	if strings.HasPrefix(lower, "<!doctype html") || strings.HasPrefix(lower, "<html") {
+		return true
+	}
+	sample := lower
+	if len(sample) > 2048 {
+		sample = sample[:2048]
+	}
+	return strings.HasPrefix(sample, "<") && (strings.Contains(sample, "<body") || strings.Contains(sample, "<head") || strings.Contains(sample, "<title") || strings.Contains(sample, "<script"))
+}
+
+func extractHTMLTitle(body string) string {
+	lower := strings.ToLower(body)
+	start := strings.Index(lower, "<title")
+	if start < 0 {
+		return ""
+	}
+	openEnd := strings.Index(lower[start:], ">")
+	if openEnd < 0 {
+		return ""
+	}
+	contentStart := start + openEnd + 1
+	end := strings.Index(lower[contentStart:], "</title>")
+	if end < 0 {
+		return ""
+	}
+	title := stripHTMLTags(body[contentStart : contentStart+end])
+	return strings.Join(strings.Fields(html.UnescapeString(title)), " ")
+}
+
+func stripHTMLTags(body string) string {
+	var out strings.Builder
+	inTag := false
+	for _, r := range body {
+		switch r {
+		case '<':
+			inTag = true
+			out.WriteByte(' ')
+		case '>':
+			inTag = false
+		default:
+			if !inTag {
+				out.WriteRune(r)
+			}
+		}
+	}
+	return out.String()
+}
+
+func truncateRunes(text string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return text
+	}
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return text
+	}
+	return string(runes[:maxRunes]) + "..."
 }
 
 func clientMaxRetries() int {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 )
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
@@ -1567,22 +1568,98 @@ func looksLikeHTMLBody(body string) bool {
 }
 
 func extractHTMLTitle(body string) string {
-	lower := strings.ToLower(body)
-	start := strings.Index(lower, "<title")
-	if start < 0 {
-		return ""
+	searchFrom := 0
+	for searchFrom < len(body) {
+		titleStart := indexHTMLTag(body[searchFrom:], "title")
+		if titleStart < 0 {
+			return ""
+		}
+		if blockStart, blockTag := nextHTMLBlockTag(body[searchFrom:titleStart+searchFrom], "script", "style"); blockStart >= 0 {
+			blockStart += searchFrom
+			blockOpenEnd := htmlTagEnd(body, blockStart)
+			if blockOpenEnd < 0 {
+				return ""
+			}
+			blockCloseStart := indexHTMLCloseTag(body[blockOpenEnd+1:], blockTag)
+			if blockCloseStart < 0 {
+				return ""
+			}
+			searchFrom = blockOpenEnd + 1 + blockCloseStart + len("</"+blockTag+">")
+			continue
+		}
+		titleStart += searchFrom
+		openEnd := htmlTagEnd(body, titleStart)
+		if openEnd < 0 {
+			return ""
+		}
+		contentStart := openEnd + 1
+		end := indexHTMLCloseTag(body[contentStart:], "title")
+		if end < 0 {
+			return ""
+		}
+		title := stripHTMLTags(body[contentStart : contentStart+end])
+		return strings.Join(strings.Fields(stripControlCharacters(html.UnescapeString(title))), " ")
 	}
-	openEnd := strings.Index(lower[start:], ">")
-	if openEnd < 0 {
-		return ""
+	return ""
+}
+
+func indexHTMLTag(body, tag string) int {
+	needle := "<" + tag
+	offset := 0
+	for offset < len(body) {
+		idx := indexCaseInsensitive(body[offset:], needle)
+		if idx < 0 {
+			return -1
+		}
+		start := offset + idx
+		after := start + len(needle)
+		if after >= len(body) || isHTMLTagNameBoundary(body[after]) {
+			return start
+		}
+		offset = after
 	}
-	contentStart := start + openEnd + 1
-	end := strings.Index(lower[contentStart:], "</title>")
+	return -1
+}
+
+func nextHTMLBlockTag(body string, tags ...string) (int, string) {
+	best := -1
+	bestTag := ""
+	for _, tag := range tags {
+		idx := indexHTMLTag(body, tag)
+		if idx >= 0 && (best < 0 || idx < best) {
+			best = idx
+			bestTag = tag
+		}
+	}
+	return best, bestTag
+}
+
+func indexHTMLCloseTag(body, tag string) int {
+	return indexCaseInsensitive(body, "</"+tag+">")
+}
+
+func indexCaseInsensitive(body, needle string) int {
+	if needle == "" {
+		return 0
+	}
+	for idx := 0; idx+len(needle) <= len(body); idx++ {
+		if strings.EqualFold(body[idx:idx+len(needle)], needle) {
+			return idx
+		}
+	}
+	return -1
+}
+
+func htmlTagEnd(body string, start int) int {
+	end := strings.IndexByte(body[start:], '>')
 	if end < 0 {
-		return ""
+		return -1
 	}
-	title := stripHTMLTags(body[contentStart : contentStart+end])
-	return strings.Join(strings.Fields(html.UnescapeString(title)), " ")
+	return start + end
+}
+
+func isHTMLTagNameBoundary(b byte) bool {
+	return b == '>' || b == '/' || b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f'
 }
 
 func stripHTMLTags(body string) string {
@@ -1602,6 +1679,18 @@ func stripHTMLTags(body string) string {
 		}
 	}
 	return out.String()
+}
+
+func stripControlCharacters(text string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' || r == '\r' {
+			return ' '
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, text)
 }
 
 func truncateRunes(text string, maxRunes int) string {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"math"
 	"mime/multipart"
@@ -1530,10 +1531,88 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 
 func truncateBody(b []byte) string {
 	const maxBytes = 4096
+	if summary, ok := collapseHTMLErrorBody(b); ok {
+		return summary
+	}
 	if len(b) <= maxBytes {
 		return string(b)
 	}
 	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+}
+
+func collapseHTMLErrorBody(b []byte) (string, bool) {
+	body := strings.ToValidUTF8(string(b), "")
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" || !looksLikeHTMLBody(trimmed) {
+		return "", false
+	}
+
+	summary := fmt.Sprintf("HTML error page (%d bytes)", len(b))
+	if title := extractHTMLTitle(trimmed); title != "" {
+		summary += ": " + truncateRunes(title, 160)
+	}
+	return summary, true
+}
+
+func looksLikeHTMLBody(body string) bool {
+	lower := strings.ToLower(body)
+	if strings.HasPrefix(lower, "<!doctype html") || strings.HasPrefix(lower, "<html") {
+		return true
+	}
+	sample := lower
+	if len(sample) > 2048 {
+		sample = sample[:2048]
+	}
+	return strings.HasPrefix(sample, "<") && (strings.Contains(sample, "<body") || strings.Contains(sample, "<head") || strings.Contains(sample, "<title") || strings.Contains(sample, "<script"))
+}
+
+func extractHTMLTitle(body string) string {
+	lower := strings.ToLower(body)
+	start := strings.Index(lower, "<title")
+	if start < 0 {
+		return ""
+	}
+	openEnd := strings.Index(lower[start:], ">")
+	if openEnd < 0 {
+		return ""
+	}
+	contentStart := start + openEnd + 1
+	end := strings.Index(lower[contentStart:], "</title>")
+	if end < 0 {
+		return ""
+	}
+	title := stripHTMLTags(body[contentStart : contentStart+end])
+	return strings.Join(strings.Fields(html.UnescapeString(title)), " ")
+}
+
+func stripHTMLTags(body string) string {
+	var out strings.Builder
+	inTag := false
+	for _, r := range body {
+		switch r {
+		case '<':
+			inTag = true
+			out.WriteByte(' ')
+		case '>':
+			inTag = false
+		default:
+			if !inTag {
+				out.WriteRune(r)
+			}
+		}
+	}
+	return out.String()
+}
+
+func truncateRunes(text string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return text
+	}
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return text
+	}
+	return string(runes[:maxRunes]) + "..."
 }
 
 func clientMaxRetries() int {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -1568,84 +1568,66 @@ func looksLikeHTMLBody(body string) bool {
 }
 
 func extractHTMLTitle(body string) string {
-	searchFrom := 0
-	for searchFrom < len(body) {
-		titleStart := indexHTMLTag(body[searchFrom:], "title")
-		if titleStart < 0 {
+	pos := 0
+	ignoredBlock := ""
+	for pos < len(body) {
+		tagStartRel := strings.IndexByte(body[pos:], '<')
+		if tagStartRel < 0 {
 			return ""
 		}
-		if blockStart, blockTag := nextHTMLBlockTag(body[searchFrom:titleStart+searchFrom], "script", "style"); blockStart >= 0 {
-			blockStart += searchFrom
-			blockOpenEnd := htmlTagEnd(body, blockStart)
-			if blockOpenEnd < 0 {
-				return ""
-			}
-			blockCloseStart := indexHTMLCloseTag(body[blockOpenEnd+1:], blockTag)
-			if blockCloseStart < 0 {
-				return ""
-			}
-			searchFrom = blockOpenEnd + 1 + blockCloseStart + len("</"+blockTag+">")
+		tagStart := pos + tagStartRel
+		tagEnd := htmlTagEnd(body, tagStart)
+		if tagEnd < 0 {
+			return ""
+		}
+		tagName, closing := htmlTagName(body[tagStart+1 : tagEnd])
+		pos = tagEnd + 1
+		if tagName == "" {
 			continue
 		}
-		titleStart += searchFrom
-		openEnd := htmlTagEnd(body, titleStart)
-		if openEnd < 0 {
+		if ignoredBlock != "" {
+			if closing && tagName == ignoredBlock {
+				ignoredBlock = ""
+			}
+			continue
+		}
+		if closing {
+			continue
+		}
+		if tagName == "script" || tagName == "style" {
+			ignoredBlock = tagName
+			continue
+		}
+		if tagName != "title" {
+			continue
+		}
+		titleEnd := findHTMLCloseTag(body, pos, "title")
+		if titleEnd < 0 {
 			return ""
 		}
-		contentStart := openEnd + 1
-		end := indexHTMLCloseTag(body[contentStart:], "title")
-		if end < 0 {
-			return ""
-		}
-		title := stripHTMLTags(body[contentStart : contentStart+end])
+		title := stripHTMLTags(body[pos:titleEnd])
 		return strings.Join(strings.Fields(stripControlCharacters(html.UnescapeString(title))), " ")
 	}
 	return ""
 }
 
-func indexHTMLTag(body, tag string) int {
-	needle := "<" + tag
-	offset := 0
-	for offset < len(body) {
-		idx := indexCaseInsensitive(body[offset:], needle)
-		if idx < 0 {
+func findHTMLCloseTag(body string, from int, tag string) int {
+	pos := from
+	for pos < len(body) {
+		tagStartRel := strings.IndexByte(body[pos:], '<')
+		if tagStartRel < 0 {
 			return -1
 		}
-		start := offset + idx
-		after := start + len(needle)
-		if after >= len(body) || isHTMLTagNameBoundary(body[after]) {
-			return start
+		tagStart := pos + tagStartRel
+		tagEnd := htmlTagEnd(body, tagStart)
+		if tagEnd < 0 {
+			return -1
 		}
-		offset = after
-	}
-	return -1
-}
-
-func nextHTMLBlockTag(body string, tags ...string) (int, string) {
-	best := -1
-	bestTag := ""
-	for _, tag := range tags {
-		idx := indexHTMLTag(body, tag)
-		if idx >= 0 && (best < 0 || idx < best) {
-			best = idx
-			bestTag = tag
+		tagName, closing := htmlTagName(body[tagStart+1 : tagEnd])
+		if closing && tagName == tag {
+			return tagStart
 		}
-	}
-	return best, bestTag
-}
-
-func indexHTMLCloseTag(body, tag string) int {
-	return indexCaseInsensitive(body, "</"+tag+">")
-}
-
-func indexCaseInsensitive(body, needle string) int {
-	if needle == "" {
-		return 0
-	}
-	for idx := 0; idx+len(needle) <= len(body); idx++ {
-		if strings.EqualFold(body[idx:idx+len(needle)], needle) {
-			return idx
-		}
+		pos = tagEnd + 1
 	}
 	return -1
 }
@@ -1658,8 +1640,32 @@ func htmlTagEnd(body string, start int) int {
 	return start + end
 }
 
-func isHTMLTagNameBoundary(b byte) bool {
-	return b == '>' || b == '/' || b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f'
+func htmlTagName(raw string) (string, bool) {
+	raw = strings.TrimLeftFunc(raw, isHTMLSpace)
+	closing := false
+	if strings.HasPrefix(raw, "/") {
+		closing = true
+		raw = strings.TrimLeftFunc(raw[1:], isHTMLSpace)
+	}
+	if raw == "" || strings.HasPrefix(raw, "!") || strings.HasPrefix(raw, "?") {
+		return "", closing
+	}
+	end := 0
+	for end < len(raw) && isHTMLTagNameByte(raw[end]) {
+		end++
+	}
+	if end == 0 {
+		return "", closing
+	}
+	return strings.ToLower(raw[:end]), closing
+}
+
+func isHTMLTagNameByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '-' || b == ':'
+}
+
+func isHTMLSpace(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\n' || r == '\r' || r == '\f'
 }
 
 func stripHTMLTags(body string) string {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -1692,6 +1692,12 @@ func stripControlCharacters(text string) string {
 		if r == '\t' || r == '\n' || r == '\r' {
 			return ' '
 		}
+		if unicode.Is(unicode.Zl, r) || unicode.Is(unicode.Zp, r) {
+			return ' '
+		}
+		if unicode.Is(unicode.Cf, r) {
+			return -1
+		}
 		if unicode.IsControl(r) {
 			return -1
 		}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -33,6 +33,7 @@ import (
 )
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
+const maxErrorBodyBytes = 4096
 
 var ErrPlaceholderCredential = errors.New("auth placeholder credential")
 
@@ -1531,18 +1532,21 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 }
 
 func truncateBody(b []byte) string {
-	const maxBytes = 4096
 	if summary, ok := collapseHTMLErrorBody(b); ok {
 		return summary
 	}
-	if len(b) <= maxBytes {
+	if len(b) <= maxErrorBodyBytes {
 		return string(b)
 	}
-	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+	return strings.ToValidUTF8(string(b[:maxErrorBodyBytes]), "") + "..."
 }
 
 func collapseHTMLErrorBody(b []byte) (string, bool) {
-	body := strings.ToValidUTF8(string(b), "")
+	scanBytes := b
+	if len(scanBytes) > maxErrorBodyBytes {
+		scanBytes = scanBytes[:maxErrorBodyBytes]
+	}
+	body := strings.ToValidUTF8(string(scanBytes), "")
 	trimmed := strings.TrimSpace(body)
 	if trimmed == "" || !looksLikeHTMLBody(trimmed) {
 		return "", false

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -32,6 +32,7 @@ import (
 )
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
+const maxErrorBodyBytes = 4096
 
 var ErrPlaceholderCredential = errors.New("auth placeholder credential")
 
@@ -1540,18 +1541,21 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 }
 
 func truncateBody(b []byte) string {
-	const maxBytes = 4096
 	if summary, ok := collapseHTMLErrorBody(b); ok {
 		return summary
 	}
-	if len(b) <= maxBytes {
+	if len(b) <= maxErrorBodyBytes {
 		return string(b)
 	}
-	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+	return strings.ToValidUTF8(string(b[:maxErrorBodyBytes]), "") + "..."
 }
 
 func collapseHTMLErrorBody(b []byte) (string, bool) {
-	body := strings.ToValidUTF8(string(b), "")
+	scanBytes := b
+	if len(scanBytes) > maxErrorBodyBytes {
+		scanBytes = scanBytes[:maxErrorBodyBytes]
+	}
+	body := strings.ToValidUTF8(string(scanBytes), "")
 	trimmed := strings.TrimSpace(body)
 	if trimmed == "" || !looksLikeHTMLBody(trimmed) {
 		return "", false

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -1577,84 +1577,66 @@ func looksLikeHTMLBody(body string) bool {
 }
 
 func extractHTMLTitle(body string) string {
-	searchFrom := 0
-	for searchFrom < len(body) {
-		titleStart := indexHTMLTag(body[searchFrom:], "title")
-		if titleStart < 0 {
+	pos := 0
+	ignoredBlock := ""
+	for pos < len(body) {
+		tagStartRel := strings.IndexByte(body[pos:], '<')
+		if tagStartRel < 0 {
 			return ""
 		}
-		if blockStart, blockTag := nextHTMLBlockTag(body[searchFrom:titleStart+searchFrom], "script", "style"); blockStart >= 0 {
-			blockStart += searchFrom
-			blockOpenEnd := htmlTagEnd(body, blockStart)
-			if blockOpenEnd < 0 {
-				return ""
-			}
-			blockCloseStart := indexHTMLCloseTag(body[blockOpenEnd+1:], blockTag)
-			if blockCloseStart < 0 {
-				return ""
-			}
-			searchFrom = blockOpenEnd + 1 + blockCloseStart + len("</"+blockTag+">")
+		tagStart := pos + tagStartRel
+		tagEnd := htmlTagEnd(body, tagStart)
+		if tagEnd < 0 {
+			return ""
+		}
+		tagName, closing := htmlTagName(body[tagStart+1 : tagEnd])
+		pos = tagEnd + 1
+		if tagName == "" {
 			continue
 		}
-		titleStart += searchFrom
-		openEnd := htmlTagEnd(body, titleStart)
-		if openEnd < 0 {
+		if ignoredBlock != "" {
+			if closing && tagName == ignoredBlock {
+				ignoredBlock = ""
+			}
+			continue
+		}
+		if closing {
+			continue
+		}
+		if tagName == "script" || tagName == "style" {
+			ignoredBlock = tagName
+			continue
+		}
+		if tagName != "title" {
+			continue
+		}
+		titleEnd := findHTMLCloseTag(body, pos, "title")
+		if titleEnd < 0 {
 			return ""
 		}
-		contentStart := openEnd + 1
-		end := indexHTMLCloseTag(body[contentStart:], "title")
-		if end < 0 {
-			return ""
-		}
-		title := stripHTMLTags(body[contentStart : contentStart+end])
+		title := stripHTMLTags(body[pos:titleEnd])
 		return strings.Join(strings.Fields(stripControlCharacters(html.UnescapeString(title))), " ")
 	}
 	return ""
 }
 
-func indexHTMLTag(body, tag string) int {
-	needle := "<" + tag
-	offset := 0
-	for offset < len(body) {
-		idx := indexCaseInsensitive(body[offset:], needle)
-		if idx < 0 {
+func findHTMLCloseTag(body string, from int, tag string) int {
+	pos := from
+	for pos < len(body) {
+		tagStartRel := strings.IndexByte(body[pos:], '<')
+		if tagStartRel < 0 {
 			return -1
 		}
-		start := offset + idx
-		after := start + len(needle)
-		if after >= len(body) || isHTMLTagNameBoundary(body[after]) {
-			return start
+		tagStart := pos + tagStartRel
+		tagEnd := htmlTagEnd(body, tagStart)
+		if tagEnd < 0 {
+			return -1
 		}
-		offset = after
-	}
-	return -1
-}
-
-func nextHTMLBlockTag(body string, tags ...string) (int, string) {
-	best := -1
-	bestTag := ""
-	for _, tag := range tags {
-		idx := indexHTMLTag(body, tag)
-		if idx >= 0 && (best < 0 || idx < best) {
-			best = idx
-			bestTag = tag
+		tagName, closing := htmlTagName(body[tagStart+1 : tagEnd])
+		if closing && tagName == tag {
+			return tagStart
 		}
-	}
-	return best, bestTag
-}
-
-func indexHTMLCloseTag(body, tag string) int {
-	return indexCaseInsensitive(body, "</"+tag+">")
-}
-
-func indexCaseInsensitive(body, needle string) int {
-	if needle == "" {
-		return 0
-	}
-	for idx := 0; idx+len(needle) <= len(body); idx++ {
-		if strings.EqualFold(body[idx:idx+len(needle)], needle) {
-			return idx
-		}
+		pos = tagEnd + 1
 	}
 	return -1
 }
@@ -1667,8 +1649,32 @@ func htmlTagEnd(body string, start int) int {
 	return start + end
 }
 
-func isHTMLTagNameBoundary(b byte) bool {
-	return b == '>' || b == '/' || b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f'
+func htmlTagName(raw string) (string, bool) {
+	raw = strings.TrimLeftFunc(raw, isHTMLSpace)
+	closing := false
+	if strings.HasPrefix(raw, "/") {
+		closing = true
+		raw = strings.TrimLeftFunc(raw[1:], isHTMLSpace)
+	}
+	if raw == "" || strings.HasPrefix(raw, "!") || strings.HasPrefix(raw, "?") {
+		return "", closing
+	}
+	end := 0
+	for end < len(raw) && isHTMLTagNameByte(raw[end]) {
+		end++
+	}
+	if end == 0 {
+		return "", closing
+	}
+	return strings.ToLower(raw[:end]), closing
+}
+
+func isHTMLTagNameByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '-' || b == ':'
+}
+
+func isHTMLSpace(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\n' || r == '\r' || r == '\f'
 }
 
 func stripHTMLTags(body string) string {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"math"
 	"net"
@@ -1539,10 +1540,88 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 
 func truncateBody(b []byte) string {
 	const maxBytes = 4096
+	if summary, ok := collapseHTMLErrorBody(b); ok {
+		return summary
+	}
 	if len(b) <= maxBytes {
 		return string(b)
 	}
 	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+}
+
+func collapseHTMLErrorBody(b []byte) (string, bool) {
+	body := strings.ToValidUTF8(string(b), "")
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" || !looksLikeHTMLBody(trimmed) {
+		return "", false
+	}
+
+	summary := fmt.Sprintf("HTML error page (%d bytes)", len(b))
+	if title := extractHTMLTitle(trimmed); title != "" {
+		summary += ": " + truncateRunes(title, 160)
+	}
+	return summary, true
+}
+
+func looksLikeHTMLBody(body string) bool {
+	lower := strings.ToLower(body)
+	if strings.HasPrefix(lower, "<!doctype html") || strings.HasPrefix(lower, "<html") {
+		return true
+	}
+	sample := lower
+	if len(sample) > 2048 {
+		sample = sample[:2048]
+	}
+	return strings.HasPrefix(sample, "<") && (strings.Contains(sample, "<body") || strings.Contains(sample, "<head") || strings.Contains(sample, "<title") || strings.Contains(sample, "<script"))
+}
+
+func extractHTMLTitle(body string) string {
+	lower := strings.ToLower(body)
+	start := strings.Index(lower, "<title")
+	if start < 0 {
+		return ""
+	}
+	openEnd := strings.Index(lower[start:], ">")
+	if openEnd < 0 {
+		return ""
+	}
+	contentStart := start + openEnd + 1
+	end := strings.Index(lower[contentStart:], "</title>")
+	if end < 0 {
+		return ""
+	}
+	title := stripHTMLTags(body[contentStart : contentStart+end])
+	return strings.Join(strings.Fields(html.UnescapeString(title)), " ")
+}
+
+func stripHTMLTags(body string) string {
+	var out strings.Builder
+	inTag := false
+	for _, r := range body {
+		switch r {
+		case '<':
+			inTag = true
+			out.WriteByte(' ')
+		case '>':
+			inTag = false
+		default:
+			if !inTag {
+				out.WriteRune(r)
+			}
+		}
+	}
+	return out.String()
+}
+
+func truncateRunes(text string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return text
+	}
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return text
+	}
+	return string(runes[:maxRunes]) + "..."
 }
 
 func clientMaxRetries() int {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -1701,6 +1701,12 @@ func stripControlCharacters(text string) string {
 		if r == '\t' || r == '\n' || r == '\r' {
 			return ' '
 		}
+		if unicode.Is(unicode.Zl, r) || unicode.Is(unicode.Zp, r) {
+			return ' '
+		}
+		if unicode.Is(unicode.Cf, r) {
+			return -1
+		}
 		if unicode.IsControl(r) {
 			return -1
 		}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -28,6 +28,7 @@ import (
 	"tier-routing-golden-pp-cli/internal/config"
 	"tier-routing-golden-pp-cli/internal/platform"
 	"time"
+	"unicode"
 )
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
@@ -1576,22 +1577,98 @@ func looksLikeHTMLBody(body string) bool {
 }
 
 func extractHTMLTitle(body string) string {
-	lower := strings.ToLower(body)
-	start := strings.Index(lower, "<title")
-	if start < 0 {
-		return ""
+	searchFrom := 0
+	for searchFrom < len(body) {
+		titleStart := indexHTMLTag(body[searchFrom:], "title")
+		if titleStart < 0 {
+			return ""
+		}
+		if blockStart, blockTag := nextHTMLBlockTag(body[searchFrom:titleStart+searchFrom], "script", "style"); blockStart >= 0 {
+			blockStart += searchFrom
+			blockOpenEnd := htmlTagEnd(body, blockStart)
+			if blockOpenEnd < 0 {
+				return ""
+			}
+			blockCloseStart := indexHTMLCloseTag(body[blockOpenEnd+1:], blockTag)
+			if blockCloseStart < 0 {
+				return ""
+			}
+			searchFrom = blockOpenEnd + 1 + blockCloseStart + len("</"+blockTag+">")
+			continue
+		}
+		titleStart += searchFrom
+		openEnd := htmlTagEnd(body, titleStart)
+		if openEnd < 0 {
+			return ""
+		}
+		contentStart := openEnd + 1
+		end := indexHTMLCloseTag(body[contentStart:], "title")
+		if end < 0 {
+			return ""
+		}
+		title := stripHTMLTags(body[contentStart : contentStart+end])
+		return strings.Join(strings.Fields(stripControlCharacters(html.UnescapeString(title))), " ")
 	}
-	openEnd := strings.Index(lower[start:], ">")
-	if openEnd < 0 {
-		return ""
+	return ""
+}
+
+func indexHTMLTag(body, tag string) int {
+	needle := "<" + tag
+	offset := 0
+	for offset < len(body) {
+		idx := indexCaseInsensitive(body[offset:], needle)
+		if idx < 0 {
+			return -1
+		}
+		start := offset + idx
+		after := start + len(needle)
+		if after >= len(body) || isHTMLTagNameBoundary(body[after]) {
+			return start
+		}
+		offset = after
 	}
-	contentStart := start + openEnd + 1
-	end := strings.Index(lower[contentStart:], "</title>")
+	return -1
+}
+
+func nextHTMLBlockTag(body string, tags ...string) (int, string) {
+	best := -1
+	bestTag := ""
+	for _, tag := range tags {
+		idx := indexHTMLTag(body, tag)
+		if idx >= 0 && (best < 0 || idx < best) {
+			best = idx
+			bestTag = tag
+		}
+	}
+	return best, bestTag
+}
+
+func indexHTMLCloseTag(body, tag string) int {
+	return indexCaseInsensitive(body, "</"+tag+">")
+}
+
+func indexCaseInsensitive(body, needle string) int {
+	if needle == "" {
+		return 0
+	}
+	for idx := 0; idx+len(needle) <= len(body); idx++ {
+		if strings.EqualFold(body[idx:idx+len(needle)], needle) {
+			return idx
+		}
+	}
+	return -1
+}
+
+func htmlTagEnd(body string, start int) int {
+	end := strings.IndexByte(body[start:], '>')
 	if end < 0 {
-		return ""
+		return -1
 	}
-	title := stripHTMLTags(body[contentStart : contentStart+end])
-	return strings.Join(strings.Fields(html.UnescapeString(title)), " ")
+	return start + end
+}
+
+func isHTMLTagNameBoundary(b byte) bool {
+	return b == '>' || b == '/' || b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f'
 }
 
 func stripHTMLTags(body string) string {
@@ -1611,6 +1688,18 @@ func stripHTMLTags(body string) string {
 		}
 	}
 	return out.String()
+}
+
+func stripControlCharacters(text string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' || r == '\r' {
+			return ' '
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, text)
 }
 
 func truncateRunes(text string, maxRunes int) string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Issue: Closes #3465

Collapse generated-client HTML error bodies so upstream gateway/framework error pages do not get dumped verbatim into CLI error output.

Note: #3465 also covered dry-run store write-through. That half is already fixed on current main via `isDryRunResponse(...)` returning before `writeThroughCache(...)`; this PR intentionally leaves `data_source.go.tmpl` unchanged.

## Approach

`truncateBody` now detects HTML-shaped error bodies, emits a compact `HTML error page (N bytes)` summary, and appends a stripped `<title>` excerpt when present. JSON/plain-text error bodies keep the existing bounded path.

Review hardening addressed:

- HTML detection/title scanning is capped to the same 4096-byte error-body bound before any tag scan
- decoded HTML entities are sanitized before reaching `APIError.Error()` / Cobra stderr, including Cc controls, Unicode format controls, and Unicode line/paragraph separators
- title extraction scans the original response string instead of slicing with offsets from a lowercased copy
- `script` / `style` blocks are skipped with a single-pass tag scanner; unclosed blocks do not leak the rest of the body
- generated-output tests now compile the generated module with `requireGeneratedCompiles(t, outputDir)`
- generated client goldens were refreshed for the final helper shape

## Scope

Primary area: generator client template

Why this belongs in this repo: the raw HTML dump is emitted into every printed CLI from `internal/generator/templates/client.go.tmpl`, so the Printing Press should fix future generated clients rather than patching individual CLIs.

## Risk

Low. The change is limited to API error-body display; successful HTML responses are not routed through this helper. Plain text and JSON error bodies still use the existing truncation path.

## Output Contract

Generated client output changes: emitted `internal/client/client.go` now imports `html`/`unicode` and includes bounded HTML error-body collapse helpers. Coverage is added through a generated `internal/client` test that calls the emitted helper, verifies raw HTML is suppressed, verifies decoded terminal controls and Unicode formatting/separator controls are removed or collapsed, verifies non-ASCII title content is preserved, verifies script/style title leakage is blocked, verifies repeated script/style blocks are skipped, verifies titles beyond the capped scan window are not extracted, and compiles the generated module.

## Verification

- `go test ./internal/generator -run TestGeneratedAPIErrorOmitsSeparatorOnEmptyBody -count=1` ✅
- `scripts/verify-generator-output.sh` ✅
- `scripts/golden.sh verify` ⚠️ generated client cases pass after intentional fixture updates; remaining unrelated `dogfood-verdict-matrix` diffs come from fixture example-check builds failing in this runner (`go1.24` toolchain unavailable / fixture module deps missing), not from this PR
- `go test ./... -timeout=30m` ✅
- `go fmt ./...` ✅

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e965a1af-0b85-4e19-a87a-a71990f65aa9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e965a1af-0b85-4e19-a87a-a71990f65aa9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

