### PR TITLE
fix(cli): fail sync integrity and hydration aliasing

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -5559,8 +5559,11 @@ func TestExtractPageItemsJSendNullDataEnvelope(t *testing.T) {
 	if len(items) != 0 || cursor != "" || hasMore {
 		t.Fatalf("null data envelope = %d/%q/%v, want empty cursorless page", len(items), cursor, hasMore)
 	}
-	if !isEmptyPageResponse(json.RawMessage(body)) {
-		t.Fatalf("failed JSend null data envelope should be treated as an empty page")
+	if isEmptyPageResponse(json.RawMessage(body)) {
+		t.Fatalf("failed JSend null data envelope should not be treated as an empty page")
+	}
+	if !responseDeclaresFailure(json.RawMessage(body)) {
+		t.Fatalf("failed JSend null data envelope should be detected as a declared failure")
 	}
 
 	withErrors := json.RawMessage(` + "`" + `{"success": false, "errors": [{"code": "bad"}], "data": null}` + "`" + `)
@@ -5570,8 +5573,11 @@ func TestExtractPageItemsJSendNullDataEnvelope(t *testing.T) {
 	}
 
 	statusFail := json.RawMessage(` + "`" + `{"status": "fail", "data": null}` + "`" + `)
-	if !isEmptyPageResponse(statusFail) {
-		t.Fatalf("status=fail null data envelope should be treated as an empty page")
+	if isEmptyPageResponse(statusFail) {
+		t.Fatalf("status=fail null data envelope should not be treated as an empty page")
+	}
+	if !responseDeclaresFailure(statusFail) {
+		t.Fatalf("status=fail null data envelope should be detected as a declared failure")
 	}
 
 	emptyResultSibling := json.RawMessage(` + "`" + `{"data": null, "result": {"orders": []}}` + "`" + `)
@@ -5584,13 +5590,19 @@ func TestExtractPageItemsJSendNullDataEnvelope(t *testing.T) {
 	if len(items) != 0 || cursor != "" || hasMore {
 		t.Fatalf("PascalCase failed JSend null data envelope = %d/%q/%v, want empty cursorless page", len(items), cursor, hasMore)
 	}
-	if !isEmptyPageResponse(pascalSuccessFalse) {
-		t.Fatalf("PascalCase failed JSend null data envelope should be treated as an empty page")
+	if isEmptyPageResponse(pascalSuccessFalse) {
+		t.Fatalf("PascalCase failed JSend null data envelope should not be treated as an empty page")
+	}
+	if !responseDeclaresFailure(pascalSuccessFalse) {
+		t.Fatalf("PascalCase failed JSend null data envelope should be detected as a declared failure")
 	}
 
 	pascalStatusFail := json.RawMessage(` + "`" + `{"Status": "Failed", "Data": null}` + "`" + `)
-	if !isEmptyPageResponse(pascalStatusFail) {
-		t.Fatalf("PascalCase status=Failed null data envelope should be treated as an empty page")
+	if isEmptyPageResponse(pascalStatusFail) {
+		t.Fatalf("PascalCase status=Failed null data envelope should not be treated as an empty page")
+	}
+	if !responseDeclaresFailure(pascalStatusFail) {
+		t.Fatalf("PascalCase status=Failed null data envelope should be detected as a declared failure")
 	}
 
 	statusSuccess := json.RawMessage(` + "`" + `{"status": "success", "data": null}` + "`" + `)
@@ -13362,7 +13374,7 @@ func TestGeneratedSyncTreatsAccessDeniedAsWarning(t *testing.T) {
 	syncContent := string(syncGo)
 
 	// Sync emits the structured warn event and routes to the warn-aware exit branch.
-	assert.Contains(t, syncContent, `Warn     error`)
+	assert.Contains(t, syncContent, `Warn             error`)
 	// The access-denied warning is marshaled via syncWarningJSON (escaping the
 	// embedded upstream error body) rather than raw fmt.Fprintf interpolation.
 	assert.Contains(t, syncContent, `syncWarningJSON(resource, "", w.Status, w.Reason, w.Message)`)

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -6995,12 +6995,12 @@ func TestUpsertResourceBatchRoutesDiscriminatorItems(t *testing.T) {
 		json.RawMessage(`+"`"+`{"type":"collection","id":"c1","name":"Collection","created_at":"2026-01-01T00:00:00Z"}`+"`"+`),
 		json.RawMessage(`+"`"+`{"type":"team","id":"t1","name":"Team","created_at":"2026-01-01T00:00:00Z"}`+"`"+`),
 	}
-	stored, extractFailures, err := upsertResourceBatch(s, "network_entities", items)
+	stored, extractFailures, typedFailures, err := upsertResourceBatch(s, "network_entities", items)
 	if err != nil {
 		t.Fatalf("upsertResourceBatch: %%v", err)
 	}
-	if stored != len(items) || extractFailures != 0 {
-		t.Fatalf("stored/extractFailures = %%d/%%d, want %%d/0", stored, extractFailures, len(items))
+	if stored != len(items) || extractFailures != 0 || typedFailures != 0 {
+		t.Fatalf("stored/extractFailures/typedFailures = %%d/%%d/%%d, want %%d/0/0", stored, extractFailures, typedFailures, len(items))
 	}
 
 	for _, table := range []string{"workspaces", "collections", "teams"} {
@@ -15903,11 +15903,11 @@ func TestGeneratedSyncIDFieldOverridesAndProbes(t *testing.T) {
 		`"reason":"all_items_failed_id_extraction"`,
 		"sync.go must preserve the all_items_failed_id_extraction roll-up event")
 	assert.Contains(t, syncContent,
-		`warn := fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", resource, consumedTotal)`,
-		"sync.go must surface all-items-failed ID extraction as a warning result, not a success")
+		`err := fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", resource, consumedTotal)`,
+		"sync.go must surface all-items-failed ID extraction as an integrity error, not a success")
 	assert.Contains(t, syncContent,
-		`Warn:     warn`,
-		"sync.go must return the all-items-failed warning result, not a success")
+		`IntegrityFailure: true`,
+		"sync.go must mark all-items-failed and typed projection failures as integrity failures")
 	assert.Contains(t, syncContent,
 		`completed with warnings but no successful syncs`,
 		"sync.go all-warned summary must not claim the warning was only access-related")
@@ -15924,15 +15924,14 @@ func TestGeneratedSyncIDFieldOverridesAndProbes(t *testing.T) {
 		`{"event":"sync_anomaly","resource":"%s","consumed":%d,"stored":0,"extract_failures":%d,"reason":"stored_count_zero_after_extraction"}`,
 		"F4b probe must use the literal %s interpolation pattern")
 
-	// UpsertBatch's signature is (int, int, error) — sync.go must consume
-	// all three return values. Without this contract, extractFailures would
-	// not be observable from sync's per-item warning code.
+	// upsertResourceBatch's signature is (int, int, int, error) — sync.go must
+	// consume the typed-projection failure count as well as ID extraction misses.
 	assert.Contains(t, syncContent,
-		`stored, extractFailures, err := upsertResourceBatch(db, resource, items)`,
-		"sync.go syncResource must consume the three-tuple batch upsert return")
+		`stored, extractFailures, typedFailures, err := upsertResourceBatch(db, resource, items)`,
+		"sync.go syncResource must consume the four-tuple batch upsert return")
 	assert.Contains(t, syncContent,
-		`stored, extractFailures, err := upsertResourceBatch(db, dep.Name, items)`,
-		"sync.go syncDependentResource must consume the three-tuple batch upsert return")
+		`stored, extractFailures, typedFailures, err := upsertResourceBatch(db, dep.Name, items)`,
+		"sync.go syncDependentResource must consume the four-tuple batch upsert return")
 
 	// store.go's UpsertBatch declaration matches the new signature.
 	assert.Contains(t, storeContent,

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -20686,17 +20686,17 @@ components:
 	defaultResources := regexp.MustCompile(`(?s)func defaultSyncResources\(\) \[\]string \{(.*?)\n\}`).FindStringSubmatch(src)
 	require.Len(t, defaultResources, 2)
 	assert.Contains(t, defaultResources[1], `"usercollection",`)
-	assert.Contains(t, defaultResources[1], `"usercollection-daily-sleep",`)
+	assert.Contains(t, defaultResources[1], `"usercollection-heartrate",`)
 	assert.Contains(t, defaultResources[1], `"usercollection-personal-info",`)
-	assert.NotContains(t, defaultResources[1], `"usercollection-heartrate",`,
-		"heartrate should stay absorbed by the canonical usercollection resource")
+	assert.NotContains(t, defaultResources[1], `"usercollection-daily-sleep",`,
+		"daily_sleep should stay absorbed by the canonical usercollection resource")
 	assert.NotContains(t, defaultResources[1], `"webhook",`,
 		"auth-tagged webhook resources must stay out of the default sync set")
 
 	paginationSwitch := regexp.MustCompile(`(?s)func resourceSupportsPagination\(resource string\) bool \{(.*?)\n\}`).FindStringSubmatch(src)
 	require.Len(t, paginationSwitch, 2)
 	assert.Contains(t, paginationSwitch[1], `case "usercollection":`)
-	assert.Contains(t, paginationSwitch[1], `case "usercollection-daily-sleep":`)
+	assert.Contains(t, paginationSwitch[1], `case "usercollection-heartrate":`)
 	assert.NotContains(t, paginationSwitch[1], `case "usercollection-personal-info":`,
 		"single-object resources without cursor params must not be marked paginated")
 	assert.Contains(t, src, `cursorParam:    "next_token"`,
@@ -20707,11 +20707,11 @@ components:
 import "testing"
 
 func TestSyncSinceParamFormatForDateOnlyResources(t *testing.T) {
-	if got := syncResourceSinceParamFormat("usercollection-daily-sleep"); got != "date" {
+	if got := syncResourceSinceParamFormat("usercollection"); got != "date" {
 		t.Fatalf("daily sleep since format = %q, want date", got)
 	}
-	// The canonical usercollection endpoint is heartrate because it has the shortest shared-prefix path.
-	if got := syncResourceSinceParamFormat("usercollection"); got != "date-time" {
+	// The canonical usercollection endpoint is daily_sleep because no endpoint is named list and get_daily_sleep sorts before get_heartrate.
+	if got := syncResourceSinceParamFormat("usercollection-heartrate"); got != "date-time" {
 		t.Fatalf("heartrate since format = %q, want date-time", got)
 	}
 	if got := formatSyncSinceValue("2026-06-07T12:34:56Z", "date"); got != "2026-06-07" {

--- a/internal/generator/read_search_extraction_test.go
+++ b/internal/generator/read_search_extraction_test.go
@@ -325,6 +325,115 @@ func TestSyncResourceAllHydrationFailedIsIntegrityFailure(t *testing.T) {
 	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "Test(HydrateScalarItems|SyncResource)", "-count=1")
 }
 
+func TestGeneratedSyncHydrationPathsStayResourceSpecific(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("specific-hydration")
+	apiSpec.Resources = map[string]spec.Resource{
+		"agents": {
+			Description: "Agents",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/get-agent/{agent_id}",
+					Description: "Get agent",
+					Response:    spec.ResponseDef{Type: "object", Item: "Agent"},
+					IDField:     "agent_id",
+				},
+			},
+		},
+		"batch-tests": {
+			Description: "Batch tests",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/get-batch-test/{test_case_batch_job_id}",
+					Description: "Get batch test",
+					Response:    spec.ResponseDef{Type: "object", Item: "BatchTest"},
+					IDField:     "test_case_batch_job_id",
+				},
+			},
+		},
+		"conversation-flow-components": {
+			Description: "Conversation flow components",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/get-conversation-flow-component/{conversation_flow_component_id}",
+					Description: "Get conversation flow component",
+					Response:    spec.ResponseDef{Type: "object", Item: "ConversationFlowComponent"},
+					IDField:     "conversation_flow_component_id",
+				},
+			},
+		},
+		"list-batch-tests": {
+			Description: "Batch test IDs",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/list-batch-tests",
+					Description: "List batch test IDs",
+					Response:    spec.ResponseDef{Type: "array", Item: "string"},
+				},
+			},
+		},
+		"list-conversation-flow-components": {
+			Description: "Conversation flow component IDs",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/list-conversation-flow-components",
+					Description: "List conversation flow component IDs",
+					Response:    spec.ResponseDef{Type: "array", Item: "string"},
+				},
+			},
+		},
+		"list-export-requests": {
+			Description: "Export request IDs",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/list-export-requests",
+					Description: "List export request IDs",
+					Response:    spec.ResponseDef{Type: "array", Item: "string"},
+				},
+			},
+		},
+		"retell-llms": {
+			Description: "Retell LLMs",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/get-retell-llm/{llm_id}",
+					Description: "Get Retell LLM",
+					Response:    spec.ResponseDef{Type: "object", Item: "RetellLLM"},
+					IDField:     "llm_id",
+				},
+				"list": {
+					Method:      "GET",
+					Path:        "/list-retell-llms",
+					Description: "List Retell LLM IDs",
+					Response:    spec.ResponseDef{Type: "array", Item: "string"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	require.Contains(t, syncSrc, `"list-batch-tests": {path: "/get-batch-test/{test_case_batch_job_id}", idParam: "test_case_batch_job_id"}`)
+	require.Contains(t, syncSrc, `"list-conversation-flow-components": {path: "/get-conversation-flow-component/{conversation_flow_component_id}", idParam: "conversation_flow_component_id"}`)
+	require.Contains(t, syncSrc, `"retell-llms": {path: "/get-retell-llm/{llm_id}", idParam: "llm_id"}`)
+	require.NotContains(t, syncSrc, `"list-export-requests": {path:`)
+	require.NotContains(t, syncSrc, `"list-batch-tests": {path: "/get-agent/{agent_id}"`)
+	require.NotContains(t, syncSrc, `"list-conversation-flow-components": {path: "/get-agent/{agent_id}"`)
+	require.NotContains(t, syncSrc, `"retell-llms": {path: "/get-agent/{agent_id}"`)
+}
+
 func TestGeneratedSearchExtractionHonorsResponsePaths(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/read_search_extraction_test.go
+++ b/internal/generator/read_search_extraction_test.go
@@ -425,13 +425,26 @@ func TestGeneratedSyncHydrationPathsStayResourceSpecific(t *testing.T) {
 	require.NoError(t, gen.Generate())
 
 	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
-	require.Contains(t, syncSrc, `"list-batch-tests": {path: "/get-batch-test/{test_case_batch_job_id}", idParam: "test_case_batch_job_id"}`)
-	require.Contains(t, syncSrc, `"list-conversation-flow-components": {path: "/get-conversation-flow-component/{conversation_flow_component_id}", idParam: "conversation_flow_component_id"}`)
-	require.Contains(t, syncSrc, `"retell-llms": {path: "/get-retell-llm/{llm_id}", idParam: "llm_id"}`)
-	require.NotContains(t, syncSrc, `"list-export-requests": {path:`)
+	hydrationMap := generatedHydrationMapSection(syncSrc)
+	require.Contains(t, syncSrc, `"list-batch-tests": {path: "/get-batch-test/{test_case_batch_job_id}", idParam: "test_case_batch_job_id"}`, hydrationMap)
+	require.Contains(t, syncSrc, `"list-conversation-flow-components": {path: "/get-conversation-flow-component/{conversation_flow_component_id}", idParam: "conversation_flow_component_id"}`, hydrationMap)
+	require.Contains(t, syncSrc, `"retell-llms": {path: "/get-retell-llm/{llm_id}", idParam: "llm_id"}`, hydrationMap)
+	require.NotContains(t, syncSrc, `"list-export-requests": {path:`, hydrationMap)
 	require.NotContains(t, syncSrc, `"list-batch-tests": {path: "/get-agent/{agent_id}"`)
 	require.NotContains(t, syncSrc, `"list-conversation-flow-components": {path: "/get-agent/{agent_id}"`)
 	require.NotContains(t, syncSrc, `"retell-llms": {path: "/get-agent/{agent_id}"`)
+}
+
+func generatedHydrationMapSection(syncSrc string) string {
+	start := strings.Index(syncSrc, "var itemHydrationPaths")
+	if start < 0 {
+		return syncSrc
+	}
+	end := strings.Index(syncSrc[start:], "func hydrateScalarItems")
+	if end < 0 {
+		return syncSrc[start:]
+	}
+	return syncSrc[start : start+end]
 }
 
 func TestGeneratedSearchExtractionHonorsResponsePaths(t *testing.T) {

--- a/internal/generator/read_search_extraction_test.go
+++ b/internal/generator/read_search_extraction_test.go
@@ -293,7 +293,7 @@ func TestSyncResourceWarnsOnPartialHydrationFailure(t *testing.T) {
 	}
 }
 
-func TestSyncResourceUsesFetchedPageForHydrationCapWarning(t *testing.T) {
+func TestSyncResourceAllHydrationFailedIsIntegrityFailure(t *testing.T) {
 	db := openHydrationTestStore(t)
 	client := &fakeHydrateClient{
 		responses: map[string]json.RawMessage{
@@ -307,14 +307,14 @@ func TestSyncResourceUsesFetchedPageForHydrationCapWarning(t *testing.T) {
 	var events bytes.Buffer
 
 	res := syncResource(context.Background(), client, db, "stories", "", true, 1, false, false, nil, &events)
-	if res.Err != nil {
-		t.Fatalf("syncResource error: %v", res.Err)
+	if res.Err == nil {
+		t.Fatalf("syncResource returned clean success for all-failed hydration; events: %s", events.String())
 	}
-	if res.Warn == nil || !strings.Contains(res.Warn.Error(), "scalar item hydration failed") {
-		t.Fatalf("syncResource warning = %v, want hydration failure", res.Warn)
+	if !res.IntegrityFailure {
+		t.Fatalf("IntegrityFailure = false, want true")
 	}
 	got := events.String()
-	for _, want := range []string{`+"`"+`"reason":"all_items_failed_hydration"`+"`"+`, `+"`"+`"reason":"max_pages_cap_hit"`+"`"+`} {
+	for _, want := range []string{`+"`"+`"reason":"all_items_failed_hydration"`+"`"+`, `+"`"+`"error":"stories consumed 2 item(s) but stored 0"`+"`"+`} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("sync events missing %s:\n%s", want, got)
 		}

--- a/internal/generator/read_search_extraction_test.go
+++ b/internal/generator/read_search_extraction_test.go
@@ -426,13 +426,20 @@ func TestGeneratedSyncHydrationPathsStayResourceSpecific(t *testing.T) {
 
 	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
 	hydrationMap := generatedHydrationMapSection(syncSrc)
-	require.Contains(t, syncSrc, `"list-batch-tests": {path: "/get-batch-test/{test_case_batch_job_id}", idParam: "test_case_batch_job_id"}`, hydrationMap)
-	require.Contains(t, syncSrc, `"list-conversation-flow-components": {path: "/get-conversation-flow-component/{conversation_flow_component_id}", idParam: "conversation_flow_component_id"}`, hydrationMap)
-	require.Contains(t, syncSrc, `"retell-llms": {path: "/get-retell-llm/{llm_id}", idParam: "llm_id"}`, hydrationMap)
-	require.NotContains(t, syncSrc, `"list-export-requests": {path:`, hydrationMap)
-	require.NotContains(t, syncSrc, `"list-batch-tests": {path: "/get-agent/{agent_id}"`)
-	require.NotContains(t, syncSrc, `"list-conversation-flow-components": {path: "/get-agent/{agent_id}"`)
-	require.NotContains(t, syncSrc, `"retell-llms": {path: "/get-agent/{agent_id}"`)
+	for _, want := range []string{
+		`"list-batch-tests":`,
+		`path: "/get-batch-test/{test_case_batch_job_id}", idParam: "test_case_batch_job_id"`,
+		`"list-conversation-flow-components":`,
+		`path: "/get-conversation-flow-component/{conversation_flow_component_id}", idParam: "conversation_flow_component_id"`,
+		`"retell-llms":`,
+		`path: "/get-retell-llm/{llm_id}", idParam: "llm_id"`,
+	} {
+		require.Contains(t, hydrationMap, want, hydrationMap)
+	}
+	require.NotContains(t, hydrationMap, `"list-export-requests": {path:`, hydrationMap)
+	require.NotContains(t, hydrationMap, `"list-batch-tests":                  {path: "/get-agent/{agent_id}"`)
+	require.NotContains(t, hydrationMap, `"list-conversation-flow-components": {path: "/get-agent/{agent_id}"`)
+	require.NotContains(t, hydrationMap, `"retell-llms":                       {path: "/get-agent/{agent_id}"`)
 }
 
 func generatedHydrationMapSection(syncSrc string) string {

--- a/internal/generator/store_derive_scope_test.go
+++ b/internal/generator/store_derive_scope_test.go
@@ -118,12 +118,15 @@ func TestUpsertBatch_NoFabricatedScopeWhenSourceAbsent(t *testing.T) {
 	items := []json.RawMessage{
 		json.RawMessage(` + "`" + `{"id":"orphan-001","name":"No Parent"}` + "`" + `),
 	}
-	stored, _, err := s.UpsertBatch("modules", items)
+	stored, _, typedFailures, err := s.UpsertBatchDetailed("modules", items)
 	if err != nil {
-		t.Fatalf("UpsertBatch must not error on typed-table NOT NULL failure: %v", err)
+		t.Fatalf("UpsertBatchDetailed must not error on typed-table NOT NULL failure: %v", err)
 	}
 	if stored != 1 {
 		t.Fatalf("stored = %d, want 1 (generic row must land)", stored)
+	}
+	if typedFailures != 1 {
+		t.Fatalf("typedFailures = %d, want 1", typedFailures)
 	}
 	var typed int
 	s.DB().QueryRow(` + "`" + `SELECT COUNT(*) FROM "modules" WHERE id = 'orphan-001'` + "`" + `).Scan(&typed)
@@ -135,8 +138,43 @@ func TestUpsertBatch_NoFabricatedScopeWhenSourceAbsent(t *testing.T) {
 	testPath := filepath.Join(outputDir, "internal", "store", "derive_scope_test.go")
 	require.NoError(t, os.WriteFile(testPath, []byte(testSrc), 0o644))
 
+	cliTestSrc := `package cli
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"derive-scope-pp-cli/internal/store"
+)
+
+func TestUpsertResourceBatchReportsTypedProjectionFailure(t *testing.T) {
+	s, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	items := []json.RawMessage{
+		json.RawMessage(` + "`" + `{"id":"orphan-001","name":"No Parent"}` + "`" + `),
+	}
+	stored, extractFailures, typedFailures, err := upsertResourceBatch(s, "modules", items)
+	if err != nil {
+		t.Fatalf("upsertResourceBatch: %v", err)
+	}
+	if stored != 1 || extractFailures != 0 || typedFailures != 1 {
+		t.Fatalf("stored/extractFailures/typedFailures = %d/%d/%d, want 1/0/1", stored, extractFailures, typedFailures)
+	}
+}
+`
+	cliTestPath := filepath.Join(outputDir, "internal", "cli", "derive_scope_sync_test.go")
+	require.NoError(t, os.WriteFile(cliTestPath, []byte(cliTestSrc), 0o644))
+
 	runGoCommandRequired(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "test", "./internal/store",
 		"-run", "TestUpsertBatch_DerivesChildScopeFromProjectField|TestUpsertBatch_NoFabricatedScopeWhenSourceAbsent",
 		"-count=1", "-v")
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli",
+		"-run", "TestUpsertResourceBatchReportsTypedProjectionFailure",
+		"-count=1")
 }

--- a/internal/generator/sync_store_template_fixes_test.go
+++ b/internal/generator/sync_store_template_fixes_test.go
@@ -369,6 +369,29 @@ func TestSyncResourceDeclaredFailureIsIntegrityFailure(t *testing.T) {
 	}
 }
 
+func TestSyncResourceDeclaredFailureWithItemsIsIntegrityFailure(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	var events bytes.Buffer
+	res := syncResource(context.Background(), fixedBodyClient{body: json.RawMessage(` + "`" + `{"success":false,"data":[{"id":"bad"}],"next_cursor":"still-more"}` + "`" + `)}, db, "things", "", false, 1, false, false, nil, &events)
+	if res.Err == nil {
+		t.Fatalf("syncResource returned clean success for declared-failure body with items; events: %s", events.String())
+	}
+	if !res.IntegrityFailure {
+		t.Fatalf("IntegrityFailure = false, want true")
+	}
+	if res.Count != 0 {
+		t.Fatalf("Count = %d, want 0", res.Count)
+	}
+	if !strings.Contains(events.String(), "response declared failure") {
+		t.Fatalf("events did not contain declared-failure sync error: %s", events.String())
+	}
+}
+
 func TestSyncDependentResourceNonJSONBodyEmitsAnomaly(t *testing.T) {
 	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
 	if err != nil {
@@ -395,9 +418,42 @@ func TestSyncDependentResourceNonJSONBodyEmitsAnomaly(t *testing.T) {
 		t.Fatalf("events did not contain dependent non_json_200_body anomaly: %s", events.String())
 	}
 }
+
+func TestSyncDependentResourceDeclaredFailureWithItemsIsIntegrityFailure(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Upsert("parents", "p1", []byte(` + "`" + `{"id":"p1"}` + "`" + `)); err != nil {
+		t.Fatalf("insert parent: %v", err)
+	}
+
+	var events bytes.Buffer
+	res := syncDependentResource(
+		context.Background(),
+		fixedBodyClient{body: json.RawMessage(` + "`" + `{"success":false,"data":[{"id":"c1"}],"next_cursor":"still-more"}` + "`" + `)},
+		db,
+		dependentResourceDef{Name: "children", ParentTable: "parents", ParentIDParam: "parentId", PathTemplate: "/parents/{parentId}/children"},
+		"", false, 1, false, false, nil, &events, 1,
+	)
+	if res.Err == nil {
+		t.Fatalf("syncDependentResource returned clean success for declared-failure body with items; events: %s", events.String())
+	}
+	if !res.IntegrityFailure {
+		t.Fatalf("IntegrityFailure = false, want true")
+	}
+	if res.Count != 0 {
+		t.Fatalf("Count = %d, want 0", res.Count)
+	}
+	if !strings.Contains(events.String(), "response declared failure") {
+		t.Fatalf("events did not contain dependent declared-failure sync error: %s", events.String())
+	}
+}
 `
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "batch4_sync_test.go"), []byte(cliTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "test", "./internal/store", "-run", "TestCurrencyCodeSuffixExtractsResourceID", "-count=1")
-	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "Test(SyncExtractIDSuffixFallbackIsGuarded|ExtractPageItemsDRFTopLevelNextURL|ExtractPageItemsDRFTopLevelRelativeNextURL|ExtractPageItemsBareTokenCursorUnaffected|SyncResourceNonJSONBodyEmitsAnomaly|SyncResourceValidEmptyJSONDoesNotEmitNonJSONAnomaly|SyncResourceZeroStoredIsIntegrityFailure|SyncResourceDeclaredFailureIsIntegrityFailure|SyncDependentResourceNonJSONBodyEmitsAnomaly)", "-count=1")
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "Test(SyncExtractIDSuffixFallbackIsGuarded|ExtractPageItemsDRFTopLevelNextURL|ExtractPageItemsDRFTopLevelRelativeNextURL|ExtractPageItemsBareTokenCursorUnaffected|SyncResourceNonJSONBodyEmitsAnomaly|SyncResourceValidEmptyJSONDoesNotEmitNonJSONAnomaly|SyncResourceZeroStoredIsIntegrityFailure|SyncResourceDeclaredFailure|SyncDependentResourceNonJSONBodyEmitsAnomaly|SyncDependentResourceDeclaredFailure)", "-count=1")
 }

--- a/internal/generator/sync_store_template_fixes_test.go
+++ b/internal/generator/sync_store_template_fixes_test.go
@@ -329,6 +329,46 @@ func TestSyncResourceValidEmptyJSONDoesNotEmitNonJSONAnomaly(t *testing.T) {
 	}
 }
 
+func TestSyncResourceZeroStoredIsIntegrityFailure(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	var events bytes.Buffer
+	res := syncResource(context.Background(), fixedBodyClient{body: json.RawMessage(` + "`" + `[{"metadata":{"nested":true}}]` + "`" + `)}, db, "things", "", false, 1, false, false, nil, &events)
+	if res.Err == nil {
+		t.Fatalf("syncResource returned clean success for consumed-but-zero-stored page; events: %s", events.String())
+	}
+	if !res.IntegrityFailure {
+		t.Fatalf("IntegrityFailure = false, want true")
+	}
+	if !strings.Contains(events.String(), "\"reason\":\"all_items_failed_id_extraction\"") {
+		t.Fatalf("events did not contain all_items_failed_id_extraction anomaly: %s", events.String())
+	}
+}
+
+func TestSyncResourceDeclaredFailureIsIntegrityFailure(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	var events bytes.Buffer
+	res := syncResource(context.Background(), fixedBodyClient{body: json.RawMessage(` + "`" + `{"success":false,"data":null}` + "`" + `)}, db, "things", "", false, 1, false, false, nil, &events)
+	if res.Err == nil {
+		t.Fatalf("syncResource returned clean success for declared-failure body; events: %s", events.String())
+	}
+	if !res.IntegrityFailure {
+		t.Fatalf("IntegrityFailure = false, want true")
+	}
+	if !strings.Contains(events.String(), "response declared failure") {
+		t.Fatalf("events did not contain declared-failure sync error: %s", events.String())
+	}
+}
+
 func TestSyncDependentResourceNonJSONBodyEmitsAnomaly(t *testing.T) {
 	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
 	if err != nil {
@@ -359,5 +399,5 @@ func TestSyncDependentResourceNonJSONBodyEmitsAnomaly(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "batch4_sync_test.go"), []byte(cliTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "test", "./internal/store", "-run", "TestCurrencyCodeSuffixExtractsResourceID", "-count=1")
-	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "Test(SyncExtractIDSuffixFallbackIsGuarded|ExtractPageItemsDRFTopLevelNextURL|ExtractPageItemsDRFTopLevelRelativeNextURL|ExtractPageItemsBareTokenCursorUnaffected|SyncResourceNonJSONBodyEmitsAnomaly|SyncResourceValidEmptyJSONDoesNotEmitNonJSONAnomaly|SyncDependentResourceNonJSONBodyEmitsAnomaly)", "-count=1")
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "Test(SyncExtractIDSuffixFallbackIsGuarded|ExtractPageItemsDRFTopLevelNextURL|ExtractPageItemsDRFTopLevelRelativeNextURL|ExtractPageItemsBareTokenCursorUnaffected|SyncResourceNonJSONBodyEmitsAnomaly|SyncResourceValidEmptyJSONDoesNotEmitNonJSONAnomaly|SyncResourceZeroStoredIsIntegrityFailure|SyncResourceDeclaredFailureIsIntegrityFailure|SyncDependentResourceNonJSONBodyEmitsAnomaly)", "-count=1")
 }

--- a/internal/generator/sync_store_template_fixes_test.go
+++ b/internal/generator/sync_store_template_fixes_test.go
@@ -392,6 +392,29 @@ func TestSyncResourceDeclaredFailureWithItemsIsIntegrityFailure(t *testing.T) {
 	}
 }
 
+func TestSyncResourceStatusErrorWithItemsIsIntegrityFailure(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	var events bytes.Buffer
+	res := syncResource(context.Background(), fixedBodyClient{body: json.RawMessage(` + "`" + `{"status":"error","items":[{"id":"bad"}],"next_cursor":"still-more"}` + "`" + `)}, db, "things", "", false, 1, false, false, nil, &events)
+	if res.Err == nil {
+		t.Fatalf("syncResource returned clean success for status=error body with items; events: %s", events.String())
+	}
+	if !res.IntegrityFailure {
+		t.Fatalf("IntegrityFailure = false, want true")
+	}
+	if res.Count != 0 {
+		t.Fatalf("Count = %d, want 0", res.Count)
+	}
+	if !strings.Contains(events.String(), "response declared failure") {
+		t.Fatalf("events did not contain status=error sync error: %s", events.String())
+	}
+}
+
 func TestSyncDependentResourceNonJSONBodyEmitsAnomaly(t *testing.T) {
 	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
 	if err != nil {

--- a/internal/generator/templates/channel_workflow.go.tmpl
+++ b/internal/generator/templates/channel_workflow.go.tmpl
@@ -308,6 +308,7 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 				}
 			}
 
+			resourcesSynced := 0
 			for _, resource := range resources {
 {{- if eq .Name "substack"}}
 				if resource == "drafts" {
@@ -319,7 +320,7 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 {{- end}}
 				res := syncResource(cmd.Context(), {{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, s, resource, "", full, archiveMaxPages, false{{if not (isGraphQL .APISpec)}}, false{{end}}{{if .Pagination.DateRangeParam}}, ""{{end}}{{if not (isGraphQL .APISpec)}}, nil, syncEventWriter{{end}})
 				if res.Err != nil {
-					if isSyncStatePersistenceError(res.Err) {
+					if res.IntegrityFailure || isSyncStatePersistenceError(res.Err) {
 						return fmt.Errorf("archiving %s: %w", resource, res.Err)
 					}
 					fmt.Fprintf(cmd.ErrOrStderr(), "  %s: error: %v\n", resource, res.Err)
@@ -330,6 +331,7 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 					continue
 				}
 				totalSynced += res.Count
+				resourcesSynced++
 				fmt.Fprintf(cmd.ErrOrStderr(), "  %s: %d synced\n", resource, res.Count)
 			}
 
@@ -337,14 +339,14 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 				enc := json.NewEncoder(cmd.OutOrStdout())
 				enc.SetIndent("", "  ")
 				return enc.Encode(map[string]any{
-					"resources_synced": len(resources),
+					"resources_synced": resourcesSynced,
 					"total_items":      totalSynced,
 					"store_path":       dbPath,
 					"timestamp":        time.Now().UTC().Format(time.RFC3339),
 				})
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Archived %d items across %d resources to %s\n", totalSynced, len(resources), dbPath)
+			fmt.Fprintf(cmd.OutOrStdout(), "Archived %d items across %d resources to %s\n", totalSynced, resourcesSynced, dbPath)
 			return nil
 		},
 	}

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -25,11 +25,12 @@ import (
 
 // syncResult holds the outcome of syncing a single resource.
 type syncResult struct {
-	Resource string
-	Count    int
-	Err      error
-	Warn     error
-	Duration time.Duration
+	Resource         string
+	Count            int
+	Err              error
+	Warn             error
+	IntegrityFailure bool
+	Duration         time.Duration
 }
 
 func newSyncCmd(flags *rootFlags) *cobra.Command {
@@ -698,5 +699,5 @@ func parseSinceDuration(s string) (time.Time, error) {
 // isSyncStatePersistenceError reports failures to persist sync checkpoints.
 // Shared with workflow archive and the primary sync command's exit policy.
 func isSyncStatePersistenceError(err error) bool {
-	return err != nil && strings.HasPrefix(err.Error(), "saving sync state for ")
+	return err != nil && (strings.HasPrefix(err.Error(), "saving sync state for ") || strings.HasPrefix(err.Error(), "saving sync progress for "))
 }

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1799,13 +1799,9 @@ func deriveScopeColumns(obj map[string]any) {
 	}
 }
 
-// UpsertBatch inserts or replaces multiple records in a single transaction
-// and returns (stored, extractFailures, err). stored counts rows landed in
-// the generic resources table; extractFailures counts items that survived
-// JSON unmarshal but had no extractable primary key (templated IDField AND
-// generic fallback both missed). callers (sync.go.tmpl) compare these
-// against len(items) to emit the per-item primary_key_unresolved warning
-// and the F4b stored_count_zero_after_extraction probe.
+// UpsertBatch inserts or replaces multiple records in a single transaction.
+// The detailed variant also reports typed-table projection failures so sync can
+// treat a generic-only write as an incomplete local mirror.
 //
 // For resource types that have a domain-specific typed table, the per-item
 // generic insert is followed by a dispatch to the matching upsert<Pascal>Tx
@@ -1818,22 +1814,26 @@ func deriveScopeColumns(obj map[string]any) {
 // didn't populate the parent path placeholder) rolls back only that typed
 // upsert. The generic resources row inserted just above it survives the
 // rollback, so successful API fetches never strand in memory because one
-// downstream typed table is misconfigured. Failures are surfaced via a
-// trailing stderr warning rather than aborting the batch.
+// downstream typed table is misconfigured.
 {{- $hasDomainTable := false }}
 {{- range .Tables}}
 {{- if emitsDomainTable .}}{{$hasDomainTable = true}}{{end}}
 {{- end}}
 func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, int, error) {
+	stored, extractFailures, _, err := s.UpsertBatchDetailed(resourceType, items)
+	return stored, extractFailures, err
+}
+
+func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage) (int, int, int, error) {
 	s.lockForWrite()
 	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
-		return 0, 0, fmt.Errorf("starting batch transaction: %w", err)
+		return 0, 0, 0, fmt.Errorf("starting batch transaction: %w", err)
 	}
 	defer tx.Rollback()
 
-	var stored, skippedCount, extractFailures{{if $hasDomainTable}}, typedFailures{{end}} int
+	var stored, skippedCount, extractFailures, typedFailures int
 	for {{if $hasDomainTable}}i, {{else}}_, {{end}}item := range items {
 		obj, err := DecodeJSONObject(item)
 		if err != nil {
@@ -1863,7 +1863,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 			// Return the running stored count rather than zero so callers
 			// inspecting partial progress on failure see what already
 			// landed in earlier loop iterations.
-			return stored, extractFailures, fmt.Errorf("upserting %s/%s: %w", resourceType, storageID, err)
+			return stored, extractFailures, typedFailures, fmt.Errorf("upserting %s/%s: %w", resourceType, storageID, err)
 		}
 		stored++
 {{- if $hasDomainTable}}
@@ -1875,7 +1875,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 
 		savepoint := fmt.Sprintf("pp_typed_%d", i)
 		if _, err := tx.Exec("SAVEPOINT " + savepoint); err != nil {
-			return stored, extractFailures, fmt.Errorf("savepoint begin for %s/%s: %w", resourceType, storageID, err)
+			return stored, extractFailures, typedFailures, fmt.Errorf("savepoint begin for %s/%s: %w", resourceType, storageID, err)
 		}
 
 		var typedErr error
@@ -1890,16 +1890,16 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 
 		if typedErr != nil {
 			if _, rbErr := tx.Exec("ROLLBACK TO SAVEPOINT " + savepoint); rbErr != nil {
-				return stored, extractFailures, fmt.Errorf("rollback to savepoint for %s/%s (typed err: %v): %w", resourceType, storageID, typedErr, rbErr)
+				return stored, extractFailures, typedFailures, fmt.Errorf("rollback to savepoint for %s/%s (typed err: %v): %w", resourceType, storageID, typedErr, rbErr)
 			}
 			if _, relErr := tx.Exec("RELEASE SAVEPOINT " + savepoint); relErr != nil {
-				return stored, extractFailures, fmt.Errorf("release savepoint after rollback for %s/%s: %w", resourceType, storageID, relErr)
+				return stored, extractFailures, typedFailures, fmt.Errorf("release savepoint after rollback for %s/%s: %w", resourceType, storageID, relErr)
 			}
 			typedFailures++
 			continue
 		}
 		if _, err := tx.Exec("RELEASE SAVEPOINT " + savepoint); err != nil {
-			return stored, extractFailures, fmt.Errorf("release savepoint for %s/%s: %w", resourceType, storageID, err)
+			return stored, extractFailures, typedFailures, fmt.Errorf("release savepoint for %s/%s: %w", resourceType, storageID, err)
 		}
 {{- end}}
 	}
@@ -1921,9 +1921,9 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 {{- end}}
 
 	if err := tx.Commit(); err != nil {
-		return 0, extractFailures, err
+		return 0, extractFailures, typedFailures, err
 	}
-	return stored, extractFailures, nil
+	return stored, extractFailures, typedFailures, nil
 }
 
 func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, json.RawMessage, bool) {

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -78,11 +78,12 @@ var endpointTemplateVarSet = map[string]bool{
 
 // syncResult holds the outcome of syncing a single resource.
 type syncResult struct {
-	Resource string
-	Count    int
-	Err      error
-	Warn     error
-	Duration time.Duration
+	Resource         string
+	Count            int
+	Err              error
+	Warn             error
+	IntegrityFailure bool
+	Duration         time.Duration
 }
 
 const syncWatermarkOverlap = time.Second
@@ -429,7 +430,7 @@ Resource scoping:
 						firstPlaceholderErr = res.Err
 					}
 {{- end}}
-					if isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
+					if res.IntegrityFailure || isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
 						criticalErrCount++
 						criticalFailedResources = append(criticalFailedResources, res.Resource)
 					}
@@ -466,7 +467,7 @@ Resource scoping:
 						firstPlaceholderErr = res.Err
 					}
 {{- end}}
-					if isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
+					if res.IntegrityFailure || isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
 						criticalErrCount++
 						criticalFailedResources = append(criticalFailedResources, res.Resource)
 					}
@@ -955,6 +956,13 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
+		if responseDeclaresFailure(data) {
+			err := fmt.Errorf("%s response declared failure without items", resource)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+			}
+			return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
+		}
 		if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 			// Natural end: the API legitimately returned an empty page.
 			outcome.complete = true
@@ -977,9 +985,9 @@ func syncResource(ctx context.Context, c interface {
 		_, hydrationEnabled := itemHydrationPaths[resource]
 		items, hydrateFailures := hydrateScalarItems(ctx, c, resource, items)
 
-	// Batch upsert all items from this page. UpsertBatch returns
-	// (stored, extractFailures, err): stored counts rows actually
-	// landed; extractFailures counts items that survived JSON
+	// Batch upsert all items from this page. upsertResourceBatch returns
+	// stored rows plus extraction and typed-projection failures. stored counts
+	// generic rows actually landed; extractFailures counts items that survived JSON
 	// unmarshal but had no extractable primary key (templated
 	// IDField AND generic fallback both missed). Tracking these
 	// separately lets us emit precise sync_anomaly events: a
@@ -988,7 +996,7 @@ func syncResource(ctx context.Context, c interface {
 	// "primary_key_unresolved" the first time any single item
 	// fails, and the F4b "stored_count_zero_after_extraction"
 	// probe when extraction succeeded but rows still didn't land.
-	stored, extractFailures, err := upsertResourceBatch(db, resource, items)
+	stored, extractFailures, typedFailures, err := upsertResourceBatch(db, resource, items)
 	if err != nil {
 		if !humanFriendly {
 			fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
@@ -1005,6 +1013,13 @@ func syncResource(ctx context.Context, c interface {
 			// advance the incremental watermark past that item.
 			timestampOrderSafe = false
 		}
+		if typedFailures > 0 {
+			err := fmt.Errorf("%s stored %d generic row(s) but %d typed-table projection(s) failed", resource, stored, typedFailures)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+			}
+			return syncResult{Resource: resource, Count: totalCount + stored, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
+		}
 
 		if fetchedThisPage > 0 && stored == 0 {
 			reason := "all_items_failed_id_extraction"
@@ -1018,7 +1033,11 @@ func syncResource(ctx context.Context, c interface {
 			} else {
 				fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","consumed":%d,"stored":0,"reason":"%s"}`+"\n", resource, fetchedThisPage, reason)
 			}
-			anomalyEmitted = true
+			err := fmt.Errorf("%s consumed %d item(s) but stored 0", resource, fetchedThisPage)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+			}
+			return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
 		} else if pageFailureCount > 0 && !anomalyEmitted {
 			reason := "primary_key_unresolved"
 			message := fmt.Sprintf("%s had %d item(s) on this page with no extractable primary key — those rows were not stored. Annotate the spec with x-resource-id to fix.", resource, extractFailures)
@@ -1321,6 +1340,11 @@ func syncResource(ctx context.Context, c interface {
 		} else {
 			fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","consumed":%d,"stored":0,"extract_failures":%d,"reason":"stored_count_zero_after_extraction"}`+"\n", resource, consumedTotal, extractFailureTotal)
 		}
+		err := fmt.Errorf("%s consumed %d item(s) but stored 0 after primary-key extraction", resource, consumedTotal)
+		if !humanFriendly {
+			fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+		}
+		return syncResult{Resource: resource, Count: 0, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
 	}
 
 	if !humanFriendly {
@@ -1328,15 +1352,16 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	if consumedTotal > 0 && totalCount == 0 && extractFailureTotal >= consumedTotal {
-		warn := fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", resource, consumedTotal)
+		err := fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", resource, consumedTotal)
 		if hydrateFailureTotal > 0 {
-			warn = fmt.Errorf("%s consumed %d items but stored 0 because scalar item hydration failed", resource, consumedTotal)
+			err = fmt.Errorf("%s consumed %d items but stored 0 because scalar item hydration failed", resource, consumedTotal)
 		}
 		return syncResult{
-			Resource: resource,
-			Count:    0,
-			Warn:     warn,
-			Duration: time.Since(started),
+			Resource:         resource,
+			Count:            0,
+			Err:              err,
+			IntegrityFailure: true,
+			Duration:         time.Since(started),
 		}
 	}
 
@@ -2088,9 +2113,6 @@ func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 			continue
 		}
 		if isJSONNull(pathData) {
-			if envelopeReportsFailure(envelope) {
-				return true
-			}
 			continue
 		}
 		var direct []json.RawMessage
@@ -2109,9 +2131,6 @@ func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 			continue
 		}
 		if isJSONNull(raw) {
-			if envelopeReportsFailure(envelope) {
-				return true
-			}
 			continue
 		}
 		var inner map[string]json.RawMessage
@@ -2121,6 +2140,14 @@ func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 	}
 
 	return false
+}
+
+func responseDeclaresFailure(data json.RawMessage) bool {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return false
+	}
+	return envelopeReportsFailure(envelope)
 }
 
 func envelopeReportsFailure(envelope map[string]json.RawMessage) bool {
@@ -2562,9 +2589,9 @@ var discriminatorDispatchers = map[string]discriminatorDispatch{
 {{- end}}
 }
 
-func upsertResourceBatch(db *store.Store, resource string, items []json.RawMessage) (int, int, error) {
+func upsertResourceBatch(db *store.Store, resource string, items []json.RawMessage) (int, int, int, error) {
 	if _, ok := discriminatorDispatchers[resource]; !ok {
-		return db.UpsertBatch(resource, items)
+		return db.UpsertBatchDetailed(resource, items)
 	}
 
 	grouped := map[string][]json.RawMessage{}
@@ -2580,16 +2607,17 @@ func upsertResourceBatch(db *store.Store, resource string, items []json.RawMessa
 		grouped[target] = append(grouped[target], item)
 	}
 
-	var stored, extractFailures int
+	var stored, extractFailures, typedFailures int
 	for _, target := range order {
-		targetStored, targetExtractFailures, err := db.UpsertBatch(target, grouped[target])
+		targetStored, targetExtractFailures, targetTypedFailures, err := db.UpsertBatchDetailed(target, grouped[target])
 		if err != nil {
-			return stored, extractFailures + targetExtractFailures, err
+			return stored, extractFailures + targetExtractFailures, typedFailures + targetTypedFailures, err
 		}
 		stored += targetStored
 		extractFailures += targetExtractFailures
+		typedFailures += targetTypedFailures
 	}
-	return stored, extractFailures, nil
+	return stored, extractFailures, typedFailures, nil
 }
 
 func resolveDiscriminatedResource(resource string, obj map[string]any) string {
@@ -3166,6 +3194,7 @@ type parentReport struct {
 	consumed        int
 	extractFailures int
 	failure         error          // non-nil when this parent's batch upsert failed
+	integrityFailure bool
 	denied          bool
 	firstDenial     *accessWarning
 	anomaly         *parentAnomaly // nil unless this parent hit an extraction anomaly
@@ -3410,6 +3439,15 @@ func syncOneParent(
 		}
 
 		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
+			if responseDeclaresFailure(data) {
+				outcome.reason = "response_declared_failure"
+				rep.integrityFailure = true
+				rep.failure = fmt.Errorf("%s parent %s response declared failure without items", dep.Name, parentID)
+				if !humanFriendly {
+					fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, rep.failure))
+				}
+				break
+			}
 			if isEmptyPageResponse(data, responsePathForResource(dep.Name, path)...) {
 				outcome.complete = true // parent legitimately has zero children
 			} else {
@@ -3441,7 +3479,7 @@ func syncOneParent(
 			}
 		}
 
-		stored, extractFailures, err := upsertResourceBatch(db, dep.Name, items)
+		stored, extractFailures, typedFailures, err := upsertResourceBatch(db, dep.Name, items)
 		if err != nil {
 			outcome.reason = "upsert_error"
 			rep.failure = fmt.Errorf("upserting batch for %s parent %s: %w", dep.Name, parentID, err)
@@ -3455,11 +3493,26 @@ func syncOneParent(
 
 		rep.consumed += len(items)
 		rep.extractFailures += extractFailures
+		if typedFailures > 0 {
+			outcome.reason = "typed_projection_failed"
+			rep.integrityFailure = true
+			rep.failure = fmt.Errorf("%s parent %s stored %d generic row(s) but %d typed-table projection(s) failed", dep.Name, parentID, stored, typedFailures)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, rep.failure))
+			}
+			break
+		}
 		// Order matches the flat path (syncResource): all-fail first, then
 		// partial-fail. The all-fail case dominates. Record (first wins within
 		// this parent) and let the aggregator emit.
 		if len(items) > 0 && stored == 0 && rep.anomaly == nil {
 			rep.anomaly = &parentAnomaly{parent: parentID, consumed: len(items), stored: 0, count: len(items), reason: "all_items_failed_id_extraction"}
+			rep.integrityFailure = true
+			rep.failure = fmt.Errorf("%s parent %s consumed %d item(s) but stored 0", dep.Name, parentID, len(items))
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, rep.failure))
+			}
+			break
 		} else if extractFailures > 0 && stored > 0 && rep.anomaly == nil {
 			rep.anomaly = &parentAnomaly{parent: parentID, consumed: len(items), stored: stored, count: extractFailures, reason: "primary_key_unresolved"}
 		}
@@ -3729,6 +3782,7 @@ func syncDependentResource(ctx context.Context, c interface {
 	// "first parent" is inherently nondeterministic under concurrency.
 	dryRunHit := false
 	failedParents := 0
+	integrityFailedParents := 0
 	var firstFailure error
 	for rep := range reports {
 		if rep.dryRun {
@@ -3740,6 +3794,9 @@ func syncDependentResource(ctx context.Context, c interface {
 		depExtractFailureTotal += rep.extractFailures
 		if rep.failure != nil {
 			failedParents++
+			if rep.integrityFailure {
+				integrityFailedParents++
+			}
 			if firstFailure == nil {
 				firstFailure = rep.failure
 			}
@@ -3769,6 +3826,9 @@ func syncDependentResource(ctx context.Context, c interface {
 	}
 	if failedParents > 0 {
 		failure := fmt.Errorf("%s failed to store data for %d of %d parents: %w", dep.Name, failedParents, len(parentRows), firstFailure)
+		if integrityFailedParents > 0 {
+			return syncResult{Resource: dep.Name, Count: totalCount, Err: failure, IntegrityFailure: true, Duration: time.Since(started)}
+		}
 		if failedParents == len(parentRows) && totalCount == 0 {
 			return syncResult{Resource: dep.Name, Count: 0, Err: failure, Duration: time.Since(started)}
 		}
@@ -3787,13 +3847,19 @@ func syncDependentResource(ctx context.Context, c interface {
 		} else {
 			fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","consumed":%d,"stored":0,"extract_failures":%d,"reason":"stored_count_zero_after_extraction"}`+"\n", dep.Name, depConsumedTotal, depExtractFailureTotal)
 		}
+		err := fmt.Errorf("%s consumed %d item(s) but stored 0 after primary-key extraction", dep.Name, depConsumedTotal)
+		if !humanFriendly {
+			fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, "", err))
+		}
+		return syncResult{Resource: dep.Name, Count: 0, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
 	}
 	if depConsumedTotal > 0 && totalCount == 0 && depExtractFailureTotal >= depConsumedTotal {
 		return syncResult{
-			Resource: dep.Name,
-			Count:    0,
-			Warn:     fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", dep.Name, depConsumedTotal),
-			Duration: time.Since(started),
+			Resource:         dep.Name,
+			Count:            0,
+			Err:              fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", dep.Name, depConsumedTotal),
+			IntegrityFailure: true,
+			Duration:         time.Since(started),
 		}
 	}
 
@@ -4068,7 +4134,7 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 // These are always treated as critical because a silent exit 0 would leave
 // resume cursors inconsistent with stored data.
 func isSyncStatePersistenceError(err error) bool {
-	return err != nil && strings.HasPrefix(err.Error(), "saving sync state for ")
+	return err != nil && (strings.HasPrefix(err.Error(), "saving sync state for ") || strings.HasPrefix(err.Error(), "saving sync progress for "))
 }
 
 // criticalResources is the template-time projection of per-resource Critical

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -985,17 +985,10 @@ func syncResource(ctx context.Context, c interface {
 		_, hydrationEnabled := itemHydrationPaths[resource]
 		items, hydrateFailures := hydrateScalarItems(ctx, c, resource, items)
 
-	// Batch upsert all items from this page. upsertResourceBatch returns
-	// stored rows plus extraction and typed-projection failures. stored counts
-	// generic rows actually landed; extractFailures counts items that survived JSON
-	// unmarshal but had no extractable primary key (templated
-	// IDField AND generic fallback both missed). Tracking these
-	// separately lets us emit precise sync_anomaly events: a
-	// roll-up "all_items_failed_id_extraction" when an entire
-	// page yields zero stored, a per-resource
-	// "primary_key_unresolved" the first time any single item
-	// fails, and the F4b "stored_count_zero_after_extraction"
-	// probe when extraction succeeded but rows still didn't land.
+	// Keep page consumption separate from stored rows so integrity-loss
+	// outcomes are classified precisely: all items rejected by ID extraction,
+	// partial primary-key misses, typed projection failures, and rows that
+	// extracted cleanly but still failed to land.
 	stored, extractFailures, typedFailures, err := upsertResourceBatch(db, resource, items)
 	if err != nil {
 		if !humanFriendly {

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -864,6 +864,13 @@ func syncResource(ctx context.Context, c interface {
 	// Try to extract items from the response.
 	// Strategy: try array first, then common wrapper keys.
 	items, nextCursor, hasMore := extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(resource, path)...)
+	if responseDeclaresFailure(data) {
+		err := fmt.Errorf("%s response declared failure", resource)
+		if !humanFriendly {
+			fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+		}
+		return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
+	}
 	if sortEffective && maxPages > 0 {
 		for _, item := range items {
 			itemTimestamp, ok := restSyncTimestamp(item, sortField)
@@ -956,13 +963,6 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
-		if responseDeclaresFailure(data) {
-			err := fmt.Errorf("%s response declared failure without items", resource)
-			if !humanFriendly {
-				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
-			}
-			return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
-		}
 		if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 			// Natural end: the API legitimately returned an empty page.
 			outcome.complete = true
@@ -3393,6 +3393,15 @@ func syncOneParent(
 
 {{ end}}
 		items, nextCursor, hasMore := extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(dep.Name, path)...)
+		if responseDeclaresFailure(data) {
+			outcome.reason = "response_declared_failure"
+			rep.integrityFailure = true
+			rep.failure = fmt.Errorf("%s parent %s response declared failure", dep.Name, parentID)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, rep.failure))
+			}
+			break
+		}
 
 		// Page-int paginator fallback: mirrors syncResource so dependent
 		// resources on integer ?page=N APIs also advance past page 1.
@@ -3439,15 +3448,6 @@ func syncOneParent(
 		}
 
 		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
-			if responseDeclaresFailure(data) {
-				outcome.reason = "response_declared_failure"
-				rep.integrityFailure = true
-				rep.failure = fmt.Errorf("%s parent %s response declared failure without items", dep.Name, parentID)
-				if !humanFriendly {
-					fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, rep.failure))
-				}
-				break
-			}
 			if isEmptyPageResponse(data, responsePathForResource(dep.Name, path)...) {
 				outcome.complete = true // parent legitimately has zero children
 			} else {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -349,14 +349,15 @@ func Profile(s *spec.APISpec) *APIProfile {
 	syncable := make(map[string]syncableMeta) // resource name -> chosen list endpoint metadata
 	syncCandidates := make(map[string][]syncableCandidate)
 	pathDerivedIDFields := make(map[string]string)
-	addSyncCandidate := func(resourceName string, meta syncableMeta) {
+	addSyncCandidate := func(resourceName string, endpointName string, meta syncableMeta) {
 		for _, candidate := range syncCandidates[resourceName] {
 			if candidate.meta.Path == meta.Path {
 				return
 			}
 		}
 		syncCandidates[resourceName] = append(syncCandidates[resourceName], syncableCandidate{
-			meta: meta,
+			endpointName: endpointName,
+			meta:         meta,
 		})
 	}
 	// Keyed by "<parent>/<leaf>" so the same leaf under multiple parents
@@ -522,7 +523,7 @@ func Profile(s *spec.APISpec) *APIProfile {
 					if requiredScope && !endpoint.Syncable {
 						meta.SkipDefaultSync = true
 					}
-					addSyncCandidate(resourceName, meta)
+					addSyncCandidate(resourceName, endpointName, meta)
 				}
 
 				if endpoint.Pagination != nil {
@@ -583,7 +584,7 @@ func Profile(s *spec.APISpec) *APIProfile {
 				if hasRequiredScopeParams(endpoint) && !endpoint.Syncable {
 					meta.SkipDefaultSync = true
 				}
-				addSyncCandidate(resourceName, meta)
+				addSyncCandidate(resourceName, endpointName, meta)
 			}
 
 			if endpoint.Pagination != nil {
@@ -1384,13 +1385,13 @@ func findEntityTypeEnum(endpoint spec.Endpoint) *spec.Param {
 // the catch-all syncable-resource heuristic so that singleton getters like
 // "get" or "show" are excluded.
 func looksLikeCollectionEndpoint(nameLower string) bool {
-	return containsAny(nameLower, collectionEndpointTerms)
+	return nameHasAnyToken(nameLower, collectionEndpointTerms)
 }
 
 var collectionEndpointTerms = []string{"list", "all", "index", "search", "query", "browse", "find"}
 
 func looksLikeBasicGetListEndpoint(nameLower string) bool {
-	return containsAny(nameLower, basicGetListEndpointTerms)
+	return nameHasAnyToken(nameLower, basicGetListEndpointTerms)
 }
 
 var basicGetListEndpointTerms = []string{"list", "all"}
@@ -1555,6 +1556,16 @@ func hasChronologicalParams(params []spec.Param) bool {
 func containsAny(s string, needles []string) bool {
 	for _, needle := range needles {
 		if strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func nameHasAnyToken(name string, needles []string) bool {
+	tokens := nameTokens(name)
+	for _, needle := range needles {
+		if slices.Contains(tokens, normalizeName(needle)) {
 			return true
 		}
 	}
@@ -2339,7 +2350,8 @@ type syncableMeta struct {
 }
 
 type syncableCandidate struct {
-	meta syncableMeta
+	endpointName string
+	meta         syncableMeta
 }
 
 // parameterizedEntry pairs a parameterized list endpoint with the parent
@@ -3118,10 +3130,18 @@ func applySyncCandidates(syncable map[string]syncableMeta, candidates map[string
 	for _, resourceName := range resourceNames {
 		entries := candidates[resourceName]
 		sort.SliceStable(entries, func(i, j int) bool {
-			if len(entries[i].meta.Path) != len(entries[j].meta.Path) {
-				return len(entries[i].meta.Path) < len(entries[j].meta.Path)
+			iRank := syncCandidateRank(entries[i])
+			jRank := syncCandidateRank(entries[j])
+			if iRank != jRank {
+				return iRank < jRank
 			}
-			return entries[i].meta.Path < entries[j].meta.Path
+			if entries[i].endpointName != entries[j].endpointName {
+				return entries[i].endpointName < entries[j].endpointName
+			}
+			if entries[i].meta.Path != entries[j].meta.Path {
+				return entries[i].meta.Path < entries[j].meta.Path
+			}
+			return entries[i].meta.Method < entries[j].meta.Method
 		})
 		if len(entries) == 0 {
 			continue
@@ -3142,6 +3162,16 @@ func applySyncCandidates(syncable map[string]syncableMeta, candidates map[string
 			addSyncableIfUnique(syncable, name, entry.meta)
 		}
 	}
+}
+
+func syncCandidateRank(candidate syncableCandidate) int {
+	if strings.EqualFold(strings.TrimSpace(candidate.endpointName), "list") {
+		return 0
+	}
+	if candidate.meta.SkipDefaultSync {
+		return 2
+	}
+	return 1
 }
 
 func applyPathDerivedIDFields(syncable map[string]syncableMeta, pathDerivedIDFields map[string]string, types map[string]spec.TypeDef) {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -2501,10 +2501,9 @@ func scalarIDHydrationTarget(s *spec.APISpec, resourceName string, endpoint spec
 		return "", ""
 	}
 	type candidate struct {
-		path    string
-		param   string
-		score   int
-		pathLen int
+		path  string
+		param string
+		score int
 	}
 	var candidates []candidate
 	walkResources(s.Resources, func(name string, resource spec.Resource) {
@@ -2522,10 +2521,9 @@ func scalarIDHydrationTarget(s *spec.APISpec, resourceName string, endpoint spec
 				continue
 			}
 			candidates = append(candidates, candidate{
-				path:    ep.Path,
-				param:   placeholders[0],
-				score:   score,
-				pathLen: len(ep.Path),
+				path:  ep.Path,
+				param: placeholders[0],
+				score: score,
 			})
 		}
 	})
@@ -2535,9 +2533,6 @@ func scalarIDHydrationTarget(s *spec.APISpec, resourceName string, endpoint spec
 	sort.SliceStable(candidates, func(i, j int) bool {
 		if candidates[i].score != candidates[j].score {
 			return candidates[i].score > candidates[j].score
-		}
-		if candidates[i].pathLen != candidates[j].pathLen {
-			return candidates[i].pathLen < candidates[j].pathLen
 		}
 		return candidates[i].path < candidates[j].path
 	})
@@ -2568,25 +2563,68 @@ func isScalarIDListShape(endpoint spec.Endpoint, types map[string]spec.TypeDef) 
 
 func hydrationTargetScore(listResourceName, targetResourceName, endpointName string, endpoint spec.Endpoint) int {
 	score := 0
-	targetNames := append(nameVariants(listResourceName), "item")
+	targetNames := append(hydrationNameVariants(listResourceName), "item")
 	for _, segment := range staticPathSegments(endpoint.Path) {
-		if slices.Contains(targetNames, normalizeSyncResourceSegment(segment)) || segment == "item" {
+		pathMatched := false
+		for _, variant := range hydrationNameVariants(segment) {
+			if slices.Contains(targetNames, variant) || variant == "item" {
+				pathMatched = true
+				break
+			}
+		}
+		if pathMatched {
 			score += 4
 			break
 		}
 	}
 	for _, value := range []string{targetResourceName, endpointName} {
-		for _, variant := range nameVariants(value) {
+		for _, variant := range hydrationNameVariants(value) {
 			if slices.Contains(targetNames, variant) || variant == "item" {
 				score += 2
 				break
 			}
 		}
 	}
-	if endpoint.IDField != "" {
+	if score > 0 && endpoint.IDField != "" {
 		score++
 	}
 	return score
+}
+
+func hydrationNameVariants(name string) []string {
+	seen := map[string]struct{}{}
+	var variants []string
+	for _, variant := range nameVariants(name) {
+		addHydrationVariant(variant, seen, &variants)
+		if stem := stripHydrationVerbPrefix(variant); stem != variant {
+			for _, stemVariant := range nameVariants(stem) {
+				addHydrationVariant(stemVariant, seen, &variants)
+			}
+		}
+	}
+	return variants
+}
+
+func addHydrationVariant(variant string, seen map[string]struct{}, variants *[]string) {
+	normalized := normalizeSyncResourceSegment(variant)
+	if normalized == "" {
+		return
+	}
+	if _, ok := seen[normalized]; ok {
+		return
+	}
+	seen[normalized] = struct{}{}
+	*variants = append(*variants, normalized)
+}
+
+func stripHydrationVerbPrefix(name string) string {
+	normalized := normalizeSyncResourceSegment(name)
+	for _, verb := range []string{"list", "get", "fetch", "find", "search", "query", "browse"} {
+		if after, ok := strings.CutPrefix(normalized, verb+"-"); ok && after != "" {
+			return after
+		}
+	}
+	return normalized
 }
 
 // queryEntityForEndpoint returns the SQL-query entity name for a list endpoint

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -1563,13 +1563,90 @@ func containsAny(s string, needles []string) bool {
 }
 
 func nameHasAnyToken(name string, needles []string) bool {
-	tokens := nameTokens(name)
+	tokens := collectionNameTokens(name)
 	for _, needle := range needles {
-		if slices.Contains(tokens, normalizeName(needle)) {
-			return true
+		needle = normalizeName(needle)
+		for _, token := range tokens {
+			if token == needle || strings.HasPrefix(token, needle) || hasListVerbSuffix(token, needle) {
+				return true
+			}
 		}
 	}
 	return false
+}
+
+func hasListVerbSuffix(token string, needle string) bool {
+	if !strings.HasSuffix(token, needle) || len(token) == len(needle) {
+		return false
+	}
+	prefix := strings.TrimSuffix(token, needle)
+	switch prefix {
+	case "get", "fetch", "find", "list", "search", "query", "browse":
+		return true
+	default:
+		return false
+	}
+}
+
+func collectionNameTokens(name string) []string {
+	var tokens []string
+	seen := map[string]bool{}
+	add := func(token string) {
+		token = normalizeName(token)
+		if token == "" || seen[token] {
+			return
+		}
+		seen[token] = true
+		tokens = append(tokens, token)
+	}
+	for _, part := range splitNameParts(name) {
+		add(part)
+		for _, token := range splitCamelNamePart(part) {
+			add(token)
+		}
+	}
+	return tokens
+}
+
+func splitNameParts(name string) []string {
+	return strings.FieldsFunc(name, func(r rune) bool {
+		return r == '-' || r == '_' || r == ' ' || r == '/' || r == '.'
+	})
+}
+
+func splitCamelNamePart(part string) []string {
+	if part == "" {
+		return nil
+	}
+	var tokens []string
+	start := 0
+	runes := []rune(part)
+	for i := 1; i < len(runes); i++ {
+		prev := runes[i-1]
+		cur := runes[i]
+		var next rune
+		if i+1 < len(runes) {
+			next = runes[i+1]
+		}
+		if isNameUpper(cur) && (isNameLower(prev) || isNameDigit(prev) || (isNameUpper(prev) && next != 0 && isNameLower(next))) {
+			tokens = append(tokens, string(runes[start:i]))
+			start = i
+		}
+	}
+	tokens = append(tokens, string(runes[start:]))
+	return tokens
+}
+
+func isNameUpper(r rune) bool {
+	return r >= 'A' && r <= 'Z'
+}
+
+func isNameLower(r rune) bool {
+	return r >= 'a' && r <= 'z'
+}
+
+func isNameDigit(r rune) bool {
+	return r >= '0' && r <= '9'
 }
 
 func sortedKeys[V any](m map[string]V) []string {

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -2905,30 +2905,28 @@ func TestProfileDependentResourceSinceParamPropagation(t *testing.T) {
 	assert.Equal(t, "modified_since", profile.DependentSyncResources[0].SinceParam)
 }
 
-// TestProfileSyncableResourceShorterPathWinsMetadata asserts that when two
-// candidate endpoints can populate the same syncable resource, the shorter-path
-// rule that already governs the Path field also picks the IDField/Critical
-// values — i.e., the metadata always reflects the endpoint sync will actually
-// call.
-func TestProfileSyncableResourceShorterPathWinsMetadata(t *testing.T) {
+// TestProfileSyncableResourceNamedListWinsMetadata asserts that when two
+// candidate endpoints can populate the same syncable resource, metadata follows
+// the endpoint explicitly named list rather than a shorter sibling path.
+func TestProfileSyncableResourceNamedListWinsMetadata(t *testing.T) {
 	s := &spec.APISpec{
 		Name: "things",
 		Resources: map[string]spec.Resource{
 			"things": {
 				Endpoints: map[string]spec.Endpoint{
-					"longList": {
+					"list": {
 						Method:   "GET",
 						Path:     "/v1/things/all",
 						Response: spec.ResponseDef{Type: "array"},
-						IDField:  "loser",
-						Critical: false,
+						IDField:  "winner",
+						Critical: true,
 					},
-					"shortList": {
+					"shortPicker": {
 						Method:   "GET",
 						Path:     "/v1/things",
 						Response: spec.ResponseDef{Type: "array"},
-						IDField:  "winner",
-						Critical: true,
+						IDField:  "loser",
+						Critical: false,
 					},
 				},
 			},
@@ -2937,7 +2935,7 @@ func TestProfileSyncableResourceShorterPathWinsMetadata(t *testing.T) {
 
 	profile := Profile(s)
 	require.Len(t, profile.SyncableResources, 1)
-	assert.Equal(t, "/v1/things", profile.SyncableResources[0].Path)
+	assert.Equal(t, "/v1/things/all", profile.SyncableResources[0].Path)
 	assert.Equal(t, "winner", profile.SyncableResources[0].IDField)
 	assert.True(t, profile.SyncableResources[0].Critical)
 }

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -206,6 +206,61 @@ func TestProfileSiblingListEndpoints(t *testing.T) {
 	assert.Equal(t, "/portfolio/settlements", syncPaths["portfolio-settlements"])
 }
 
+func TestProfilePrefersNamedListEndpointForCanonicalSyncResource(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "canonical",
+		Resources: map[string]spec.Resource{
+			"computers": {
+				Endpoints: map[string]spec.Endpoint{
+					"picker": {
+						Method:     "GET",
+						Path:       "/Computer/ComputerGetForNewComputer",
+						Response:   spec.ResponseDef{Type: "array"},
+						Pagination: &spec.Pagination{CursorParam: "cursor", LimitParam: "limit"},
+					},
+					"list": {
+						Method:     "GET",
+						Path:       "/Computer/ComputerGetByAllParameters",
+						Response:   spec.ResponseDef{Type: "array"},
+						Pagination: &spec.Pagination{CursorParam: "cursor", LimitParam: "limit"},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+
+	syncPaths := make(map[string]string)
+	for _, resource := range profile.SyncableResources {
+		syncPaths[resource.Name] = resource.Path
+	}
+
+	assert.Equal(t, "/Computer/ComputerGetByAllParameters", syncPaths["computers"])
+	assert.Equal(t, "/Computer/ComputerGetForNewComputer", syncPaths["computers-computer-get-for-new-computer"])
+}
+
+func TestProfileInstallInfoEndpointNameIsNotAList(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "installer",
+		Resources: map[string]spec.Resource{
+			"computers": {
+				Endpoints: map[string]spec.Endpoint{
+					"install-info": {
+						Method:   "GET",
+						Path:     "/Computer/install-info",
+						Response: spec.ResponseDef{Type: "object"},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+
+	assert.Empty(t, profile.SyncableResources)
+}
+
 func TestProfileScalarIDListsUseHydrationTarget(t *testing.T) {
 	s := &spec.APISpec{
 		Name: "hydrate",

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -320,6 +320,103 @@ func TestProfileScalarIDListsUseHydrationTarget(t *testing.T) {
 	assert.Equal(t, "id", byName["updates"].HydrateIDParam)
 }
 
+func TestProfileScalarIDListsUseOwnHydrationTargets(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "hydrate-multiple",
+		Resources: map[string]spec.Resource{
+			"agents": {
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method:   "GET",
+						Path:     "/get-agent/{agent_id}",
+						Response: spec.ResponseDef{Type: "object", Item: "Agent"},
+						IDField:  "agent_id",
+					},
+				},
+			},
+			"batch-tests": {
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method:   "GET",
+						Path:     "/get-batch-test/{test_case_batch_job_id}",
+						Response: spec.ResponseDef{Type: "object", Item: "BatchTest"},
+						IDField:  "test_case_batch_job_id",
+					},
+				},
+			},
+			"conversation-flow-components": {
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method:   "GET",
+						Path:     "/get-conversation-flow-component/{conversation_flow_component_id}",
+						Response: spec.ResponseDef{Type: "object", Item: "ConversationFlowComponent"},
+						IDField:  "conversation_flow_component_id",
+					},
+				},
+			},
+			"list-batch-tests": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/list-batch-tests",
+						Response: spec.ResponseDef{Type: "array", Item: "string"},
+					},
+				},
+			},
+			"list-conversation-flow-components": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/list-conversation-flow-components",
+						Response: spec.ResponseDef{Type: "array", Item: "string"},
+					},
+				},
+			},
+			"list-export-requests": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/list-export-requests",
+						Response: spec.ResponseDef{Type: "array", Item: "string"},
+					},
+				},
+			},
+			"retell-llms": {
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method:   "GET",
+						Path:     "/get-retell-llm/{llm_id}",
+						Response: spec.ResponseDef{Type: "object", Item: "RetellLLM"},
+						IDField:  "llm_id",
+					},
+					"list": {
+						Method:   "GET",
+						Path:     "/list-retell-llms",
+						Response: spec.ResponseDef{Type: "array", Item: "string"},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+
+	byName := map[string]SyncableResource{}
+	for _, resource := range profile.SyncableResources {
+		byName[resource.Name] = resource
+	}
+	require.Contains(t, byName, "list-batch-tests")
+	assert.Equal(t, "/get-batch-test/{test_case_batch_job_id}", byName["list-batch-tests"].HydratePath)
+	assert.Equal(t, "test_case_batch_job_id", byName["list-batch-tests"].HydrateIDParam)
+	require.Contains(t, byName, "list-conversation-flow-components")
+	assert.Equal(t, "/get-conversation-flow-component/{conversation_flow_component_id}", byName["list-conversation-flow-components"].HydratePath)
+	assert.Equal(t, "conversation_flow_component_id", byName["list-conversation-flow-components"].HydrateIDParam)
+	require.Contains(t, byName, "retell-llms")
+	assert.Equal(t, "/get-retell-llm/{llm_id}", byName["retell-llms"].HydratePath)
+	assert.Equal(t, "llm_id", byName["retell-llms"].HydrateIDParam)
+	assert.NotContains(t, byName, "list-export-requests")
+}
+
 func TestProfileScalarIDListsWithoutHydrationTargetStayUnsyncable(t *testing.T) {
 	s := &spec.APISpec{
 		Name: "scalar-list",

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -40,11 +40,12 @@ const dogfoodMaxParentRows = 2
 
 // syncResult holds the outcome of syncing a single resource.
 type syncResult struct {
-	Resource string
-	Count    int
-	Err      error
-	Warn     error
-	Duration time.Duration
+	Resource         string
+	Count            int
+	Err              error
+	Warn             error
+	IntegrityFailure bool
+	Duration         time.Duration
 }
 
 const syncWatermarkOverlap = time.Second
@@ -279,7 +280,7 @@ Resource scoping:
 					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
 						firstPlaceholderErr = res.Err
 					}
-					if isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
+					if res.IntegrityFailure || isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
 						criticalErrCount++
 						criticalFailedResources = append(criticalFailedResources, res.Resource)
 					}
@@ -312,7 +313,7 @@ Resource scoping:
 					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
 						firstPlaceholderErr = res.Err
 					}
-					if isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
+					if res.IntegrityFailure || isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
 						criticalErrCount++
 						criticalFailedResources = append(criticalFailedResources, res.Resource)
 					}
@@ -668,6 +669,13 @@ func syncResource(ctx context.Context, c interface {
 		}
 
 		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
+			if responseDeclaresFailure(data) {
+				err := fmt.Errorf("%s response declared failure without items", resource)
+				if !humanFriendly {
+					fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+				}
+				return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
+			}
 			if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 				// Natural end: the API legitimately returned an empty page.
 				outcome.complete = true
@@ -690,9 +698,9 @@ func syncResource(ctx context.Context, c interface {
 		_, hydrationEnabled := itemHydrationPaths[resource]
 		items, hydrateFailures := hydrateScalarItems(ctx, c, resource, items)
 
-		// Batch upsert all items from this page. UpsertBatch returns
-		// (stored, extractFailures, err): stored counts rows actually
-		// landed; extractFailures counts items that survived JSON
+		// Batch upsert all items from this page. upsertResourceBatch returns
+		// stored rows plus extraction and typed-projection failures. stored counts
+		// generic rows actually landed; extractFailures counts items that survived JSON
 		// unmarshal but had no extractable primary key (templated
 		// IDField AND generic fallback both missed). Tracking these
 		// separately lets us emit precise sync_anomaly events: a
@@ -701,7 +709,7 @@ func syncResource(ctx context.Context, c interface {
 		// "primary_key_unresolved" the first time any single item
 		// fails, and the F4b "stored_count_zero_after_extraction"
 		// probe when extraction succeeded but rows still didn't land.
-		stored, extractFailures, err := upsertResourceBatch(db, resource, items)
+		stored, extractFailures, typedFailures, err := upsertResourceBatch(db, resource, items)
 		if err != nil {
 			if !humanFriendly {
 				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
@@ -718,6 +726,13 @@ func syncResource(ctx context.Context, c interface {
 			// advance the incremental watermark past that item.
 			timestampOrderSafe = false
 		}
+		if typedFailures > 0 {
+			err := fmt.Errorf("%s stored %d generic row(s) but %d typed-table projection(s) failed", resource, stored, typedFailures)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+			}
+			return syncResult{Resource: resource, Count: totalCount + stored, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
+		}
 
 		if fetchedThisPage > 0 && stored == 0 {
 			reason := "all_items_failed_id_extraction"
@@ -731,7 +746,11 @@ func syncResource(ctx context.Context, c interface {
 			} else {
 				fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","consumed":%d,"stored":0,"reason":"%s"}`+"\n", resource, fetchedThisPage, reason)
 			}
-			anomalyEmitted = true
+			err := fmt.Errorf("%s consumed %d item(s) but stored 0", resource, fetchedThisPage)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+			}
+			return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
 		} else if pageFailureCount > 0 && !anomalyEmitted {
 			reason := "primary_key_unresolved"
 			message := fmt.Sprintf("%s had %d item(s) on this page with no extractable primary key — those rows were not stored. Annotate the spec with x-resource-id to fix.", resource, extractFailures)
@@ -964,6 +983,11 @@ func syncResource(ctx context.Context, c interface {
 		} else {
 			fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","consumed":%d,"stored":0,"extract_failures":%d,"reason":"stored_count_zero_after_extraction"}`+"\n", resource, consumedTotal, extractFailureTotal)
 		}
+		err := fmt.Errorf("%s consumed %d item(s) but stored 0 after primary-key extraction", resource, consumedTotal)
+		if !humanFriendly {
+			fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+		}
+		return syncResult{Resource: resource, Count: 0, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
 	}
 
 	if !humanFriendly {
@@ -971,15 +995,16 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	if consumedTotal > 0 && totalCount == 0 && extractFailureTotal >= consumedTotal {
-		warn := fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", resource, consumedTotal)
+		err := fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", resource, consumedTotal)
 		if hydrateFailureTotal > 0 {
-			warn = fmt.Errorf("%s consumed %d items but stored 0 because scalar item hydration failed", resource, consumedTotal)
+			err = fmt.Errorf("%s consumed %d items but stored 0 because scalar item hydration failed", resource, consumedTotal)
 		}
 		return syncResult{
-			Resource: resource,
-			Count:    0,
-			Warn:     warn,
-			Duration: time.Since(started),
+			Resource:         resource,
+			Count:            0,
+			Err:              err,
+			IntegrityFailure: true,
+			Duration:         time.Since(started),
 		}
 	}
 
@@ -1318,9 +1343,6 @@ func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 			continue
 		}
 		if isJSONNull(pathData) {
-			if envelopeReportsFailure(envelope) {
-				return true
-			}
 			continue
 		}
 		var direct []json.RawMessage
@@ -1339,9 +1361,6 @@ func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 			continue
 		}
 		if isJSONNull(raw) {
-			if envelopeReportsFailure(envelope) {
-				return true
-			}
 			continue
 		}
 		var inner map[string]json.RawMessage
@@ -1351,6 +1370,14 @@ func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 	}
 
 	return false
+}
+
+func responseDeclaresFailure(data json.RawMessage) bool {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return false
+	}
+	return envelopeReportsFailure(envelope)
 }
 
 func envelopeReportsFailure(envelope map[string]json.RawMessage) bool {
@@ -1767,9 +1794,9 @@ type discriminatorDispatch struct {
 
 var discriminatorDispatchers = map[string]discriminatorDispatch{}
 
-func upsertResourceBatch(db *store.Store, resource string, items []json.RawMessage) (int, int, error) {
+func upsertResourceBatch(db *store.Store, resource string, items []json.RawMessage) (int, int, int, error) {
 	if _, ok := discriminatorDispatchers[resource]; !ok {
-		return db.UpsertBatch(resource, items)
+		return db.UpsertBatchDetailed(resource, items)
 	}
 
 	grouped := map[string][]json.RawMessage{}
@@ -1785,16 +1812,17 @@ func upsertResourceBatch(db *store.Store, resource string, items []json.RawMessa
 		grouped[target] = append(grouped[target], item)
 	}
 
-	var stored, extractFailures int
+	var stored, extractFailures, typedFailures int
 	for _, target := range order {
-		targetStored, targetExtractFailures, err := db.UpsertBatch(target, grouped[target])
+		targetStored, targetExtractFailures, targetTypedFailures, err := db.UpsertBatchDetailed(target, grouped[target])
 		if err != nil {
-			return stored, extractFailures + targetExtractFailures, err
+			return stored, extractFailures + targetExtractFailures, typedFailures + targetTypedFailures, err
 		}
 		stored += targetStored
 		extractFailures += targetExtractFailures
+		typedFailures += targetTypedFailures
 	}
-	return stored, extractFailures, nil
+	return stored, extractFailures, typedFailures, nil
 }
 
 func resolveDiscriminatedResource(resource string, obj map[string]any) string {
@@ -2135,14 +2163,15 @@ func syncDependentResources(ctx context.Context, c interface {
 // reconcile and returns this; the aggregator sums the counters AFTER a full
 // barrier and resolves the one-shot anomaly / first-denial deterministically.
 type parentReport struct {
-	stored          int
-	consumed        int
-	extractFailures int
-	failure         error // non-nil when this parent's batch upsert failed
-	denied          bool
-	firstDenial     *accessWarning
-	anomaly         *parentAnomaly // nil unless this parent hit an extraction anomaly
-	dryRun          bool           // true if a dry-run sentinel was seen — caller short-circuits
+	stored           int
+	consumed         int
+	extractFailures  int
+	failure          error // non-nil when this parent's batch upsert failed
+	integrityFailure bool
+	denied           bool
+	firstDenial      *accessWarning
+	anomaly          *parentAnomaly // nil unless this parent hit an extraction anomaly
+	dryRun           bool           // true if a dry-run sentinel was seen — caller short-circuits
 }
 
 // parentAnomaly carries the fields the two sync_anomaly event shapes need so
@@ -2320,6 +2349,15 @@ func syncOneParent(
 		}
 
 		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
+			if responseDeclaresFailure(data) {
+				outcome.reason = "response_declared_failure"
+				rep.integrityFailure = true
+				rep.failure = fmt.Errorf("%s parent %s response declared failure without items", dep.Name, parentID)
+				if !humanFriendly {
+					fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, rep.failure))
+				}
+				break
+			}
 			if isEmptyPageResponse(data, responsePathForResource(dep.Name, path)...) {
 				outcome.complete = true // parent legitimately has zero children
 			} else {
@@ -2351,7 +2389,7 @@ func syncOneParent(
 			}
 		}
 
-		stored, extractFailures, err := upsertResourceBatch(db, dep.Name, items)
+		stored, extractFailures, typedFailures, err := upsertResourceBatch(db, dep.Name, items)
 		if err != nil {
 			outcome.reason = "upsert_error"
 			rep.failure = fmt.Errorf("upserting batch for %s parent %s: %w", dep.Name, parentID, err)
@@ -2365,11 +2403,26 @@ func syncOneParent(
 
 		rep.consumed += len(items)
 		rep.extractFailures += extractFailures
+		if typedFailures > 0 {
+			outcome.reason = "typed_projection_failed"
+			rep.integrityFailure = true
+			rep.failure = fmt.Errorf("%s parent %s stored %d generic row(s) but %d typed-table projection(s) failed", dep.Name, parentID, stored, typedFailures)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, rep.failure))
+			}
+			break
+		}
 		// Order matches the flat path (syncResource): all-fail first, then
 		// partial-fail. The all-fail case dominates. Record (first wins within
 		// this parent) and let the aggregator emit.
 		if len(items) > 0 && stored == 0 && rep.anomaly == nil {
 			rep.anomaly = &parentAnomaly{parent: parentID, consumed: len(items), stored: 0, count: len(items), reason: "all_items_failed_id_extraction"}
+			rep.integrityFailure = true
+			rep.failure = fmt.Errorf("%s parent %s consumed %d item(s) but stored 0", dep.Name, parentID, len(items))
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, rep.failure))
+			}
+			break
 		} else if extractFailures > 0 && stored > 0 && rep.anomaly == nil {
 			rep.anomaly = &parentAnomaly{parent: parentID, consumed: len(items), stored: stored, count: extractFailures, reason: "primary_key_unresolved"}
 		}
@@ -2603,6 +2656,7 @@ func syncDependentResource(ctx context.Context, c interface {
 	// "first parent" is inherently nondeterministic under concurrency.
 	dryRunHit := false
 	failedParents := 0
+	integrityFailedParents := 0
 	var firstFailure error
 	for rep := range reports {
 		if rep.dryRun {
@@ -2614,6 +2668,9 @@ func syncDependentResource(ctx context.Context, c interface {
 		depExtractFailureTotal += rep.extractFailures
 		if rep.failure != nil {
 			failedParents++
+			if rep.integrityFailure {
+				integrityFailedParents++
+			}
 			if firstFailure == nil {
 				firstFailure = rep.failure
 			}
@@ -2643,6 +2700,9 @@ func syncDependentResource(ctx context.Context, c interface {
 	}
 	if failedParents > 0 {
 		failure := fmt.Errorf("%s failed to store data for %d of %d parents: %w", dep.Name, failedParents, len(parentRows), firstFailure)
+		if integrityFailedParents > 0 {
+			return syncResult{Resource: dep.Name, Count: totalCount, Err: failure, IntegrityFailure: true, Duration: time.Since(started)}
+		}
 		if failedParents == len(parentRows) && totalCount == 0 {
 			return syncResult{Resource: dep.Name, Count: 0, Err: failure, Duration: time.Since(started)}
 		}
@@ -2661,13 +2721,19 @@ func syncDependentResource(ctx context.Context, c interface {
 		} else {
 			fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","consumed":%d,"stored":0,"extract_failures":%d,"reason":"stored_count_zero_after_extraction"}`+"\n", dep.Name, depConsumedTotal, depExtractFailureTotal)
 		}
+		err := fmt.Errorf("%s consumed %d item(s) but stored 0 after primary-key extraction", dep.Name, depConsumedTotal)
+		if !humanFriendly {
+			fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, "", err))
+		}
+		return syncResult{Resource: dep.Name, Count: 0, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
 	}
 	if depConsumedTotal > 0 && totalCount == 0 && depExtractFailureTotal >= depConsumedTotal {
 		return syncResult{
-			Resource: dep.Name,
-			Count:    0,
-			Warn:     fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", dep.Name, depConsumedTotal),
-			Duration: time.Since(started),
+			Resource:         dep.Name,
+			Count:            0,
+			Err:              fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", dep.Name, depConsumedTotal),
+			IntegrityFailure: true,
+			Duration:         time.Since(started),
 		}
 	}
 
@@ -2873,7 +2939,7 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 // These are always treated as critical because a silent exit 0 would leave
 // resume cursors inconsistent with stored data.
 func isSyncStatePersistenceError(err error) bool {
-	return err != nil && strings.HasPrefix(err.Error(), "saving sync state for ")
+	return err != nil && (strings.HasPrefix(err.Error(), "saving sync state for ") || strings.HasPrefix(err.Error(), "saving sync progress for "))
 }
 
 // criticalResources is the template-time projection of per-resource Critical

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -604,6 +604,13 @@ func syncResource(ctx context.Context, c interface {
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(resource, path)...)
+		if responseDeclaresFailure(data) {
+			err := fmt.Errorf("%s response declared failure", resource)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+			}
+			return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
+		}
 		if sortEffective && maxPages > 0 {
 			for _, item := range items {
 				itemTimestamp, ok := restSyncTimestamp(item, sortField)
@@ -669,13 +676,6 @@ func syncResource(ctx context.Context, c interface {
 		}
 
 		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
-			if responseDeclaresFailure(data) {
-				err := fmt.Errorf("%s response declared failure without items", resource)
-				if !humanFriendly {
-					fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
-				}
-				return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
-			}
 			if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 				// Natural end: the API legitimately returned an empty page.
 				outcome.complete = true
@@ -2308,6 +2308,15 @@ func syncOneParent(
 		}
 
 		items, nextCursor, hasMore := extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(dep.Name, path)...)
+		if responseDeclaresFailure(data) {
+			outcome.reason = "response_declared_failure"
+			rep.integrityFailure = true
+			rep.failure = fmt.Errorf("%s parent %s response declared failure", dep.Name, parentID)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, rep.failure))
+			}
+			break
+		}
 
 		// Page-int paginator fallback: mirrors syncResource so dependent
 		// resources on integer ?page=N APIs also advance past page 1.
@@ -2349,15 +2358,6 @@ func syncOneParent(
 		}
 
 		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
-			if responseDeclaresFailure(data) {
-				outcome.reason = "response_declared_failure"
-				rep.integrityFailure = true
-				rep.failure = fmt.Errorf("%s parent %s response declared failure without items", dep.Name, parentID)
-				if !humanFriendly {
-					fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, rep.failure))
-				}
-				break
-			}
 			if isEmptyPageResponse(data, responsePathForResource(dep.Name, path)...) {
 				outcome.complete = true // parent legitimately has zero children
 			} else {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -698,17 +698,10 @@ func syncResource(ctx context.Context, c interface {
 		_, hydrationEnabled := itemHydrationPaths[resource]
 		items, hydrateFailures := hydrateScalarItems(ctx, c, resource, items)
 
-		// Batch upsert all items from this page. upsertResourceBatch returns
-		// stored rows plus extraction and typed-projection failures. stored counts
-		// generic rows actually landed; extractFailures counts items that survived JSON
-		// unmarshal but had no extractable primary key (templated
-		// IDField AND generic fallback both missed). Tracking these
-		// separately lets us emit precise sync_anomaly events: a
-		// roll-up "all_items_failed_id_extraction" when an entire
-		// page yields zero stored, a per-resource
-		// "primary_key_unresolved" the first time any single item
-		// fails, and the F4b "stored_count_zero_after_extraction"
-		// probe when extraction succeeded but rows still didn't land.
+		// Keep page consumption separate from stored rows so integrity-loss
+		// outcomes are classified precisely: all items rejected by ID extraction,
+		// partial primary-key misses, typed projection failures, and rows that
+		// extracted cleanly but still failed to land.
 		stored, extractFailures, typedFailures, err := upsertResourceBatch(db, resource, items)
 		if err != nil {
 			if !humanFriendly {

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -1417,13 +1417,9 @@ func deriveScopeColumns(obj map[string]any) {
 	}
 }
 
-// UpsertBatch inserts or replaces multiple records in a single transaction
-// and returns (stored, extractFailures, err). stored counts rows landed in
-// the generic resources table; extractFailures counts items that survived
-// JSON unmarshal but had no extractable primary key (templated IDField AND
-// generic fallback both missed). callers (sync.go.tmpl) compare these
-// against len(items) to emit the per-item primary_key_unresolved warning
-// and the F4b stored_count_zero_after_extraction probe.
+// UpsertBatch inserts or replaces multiple records in a single transaction.
+// The detailed variant also reports typed-table projection failures so sync can
+// treat a generic-only write as an incomplete local mirror.
 //
 // For resource types that have a domain-specific typed table, the per-item
 // generic insert is followed by a dispatch to the matching upsert<Pascal>Tx
@@ -1436,18 +1432,22 @@ func deriveScopeColumns(obj map[string]any) {
 // didn't populate the parent path placeholder) rolls back only that typed
 // upsert. The generic resources row inserted just above it survives the
 // rollback, so successful API fetches never strand in memory because one
-// downstream typed table is misconfigured. Failures are surfaced via a
-// trailing stderr warning rather than aborting the batch.
+// downstream typed table is misconfigured.
 func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, int, error) {
+	stored, extractFailures, _, err := s.UpsertBatchDetailed(resourceType, items)
+	return stored, extractFailures, err
+}
+
+func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage) (int, int, int, error) {
 	s.lockForWrite()
 	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
-		return 0, 0, fmt.Errorf("starting batch transaction: %w", err)
+		return 0, 0, 0, fmt.Errorf("starting batch transaction: %w", err)
 	}
 	defer tx.Rollback()
 
-	var stored, skippedCount, extractFailures int
+	var stored, skippedCount, extractFailures, typedFailures int
 	for _, item := range items {
 		obj, err := DecodeJSONObject(item)
 		if err != nil {
@@ -1477,7 +1477,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 			// Return the running stored count rather than zero so callers
 			// inspecting partial progress on failure see what already
 			// landed in earlier loop iterations.
-			return stored, extractFailures, fmt.Errorf("upserting %s/%s: %w", resourceType, storageID, err)
+			return stored, extractFailures, typedFailures, fmt.Errorf("upserting %s/%s: %w", resourceType, storageID, err)
 		}
 		stored++
 	}
@@ -1492,9 +1492,9 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 	}
 
 	if err := tx.Commit(); err != nil {
-		return 0, extractFailures, err
+		return 0, extractFailures, typedFailures, err
 	}
-	return stored, extractFailures, nil
+	return stored, extractFailures, typedFailures, nil
 }
 
 func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, json.RawMessage, bool) {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1637,13 +1637,9 @@ func deriveScopeColumns(obj map[string]any) {
 	}
 }
 
-// UpsertBatch inserts or replaces multiple records in a single transaction
-// and returns (stored, extractFailures, err). stored counts rows landed in
-// the generic resources table; extractFailures counts items that survived
-// JSON unmarshal but had no extractable primary key (templated IDField AND
-// generic fallback both missed). callers (sync.go.tmpl) compare these
-// against len(items) to emit the per-item primary_key_unresolved warning
-// and the F4b stored_count_zero_after_extraction probe.
+// UpsertBatch inserts or replaces multiple records in a single transaction.
+// The detailed variant also reports typed-table projection failures so sync can
+// treat a generic-only write as an incomplete local mirror.
 //
 // For resource types that have a domain-specific typed table, the per-item
 // generic insert is followed by a dispatch to the matching upsert<Pascal>Tx
@@ -1656,14 +1652,18 @@ func deriveScopeColumns(obj map[string]any) {
 // didn't populate the parent path placeholder) rolls back only that typed
 // upsert. The generic resources row inserted just above it survives the
 // rollback, so successful API fetches never strand in memory because one
-// downstream typed table is misconfigured. Failures are surfaced via a
-// trailing stderr warning rather than aborting the batch.
+// downstream typed table is misconfigured.
 func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, int, error) {
+	stored, extractFailures, _, err := s.UpsertBatchDetailed(resourceType, items)
+	return stored, extractFailures, err
+}
+
+func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage) (int, int, int, error) {
 	s.lockForWrite()
 	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
-		return 0, 0, fmt.Errorf("starting batch transaction: %w", err)
+		return 0, 0, 0, fmt.Errorf("starting batch transaction: %w", err)
 	}
 	defer tx.Rollback()
 
@@ -1697,7 +1697,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 			// Return the running stored count rather than zero so callers
 			// inspecting partial progress on failure see what already
 			// landed in earlier loop iterations.
-			return stored, extractFailures, fmt.Errorf("upserting %s/%s: %w", resourceType, storageID, err)
+			return stored, extractFailures, typedFailures, fmt.Errorf("upserting %s/%s: %w", resourceType, storageID, err)
 		}
 		stored++
 
@@ -1708,7 +1708,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 
 		savepoint := fmt.Sprintf("pp_typed_%d", i)
 		if _, err := tx.Exec("SAVEPOINT " + savepoint); err != nil {
-			return stored, extractFailures, fmt.Errorf("savepoint begin for %s/%s: %w", resourceType, storageID, err)
+			return stored, extractFailures, typedFailures, fmt.Errorf("savepoint begin for %s/%s: %w", resourceType, storageID, err)
 		}
 
 		var typedErr error
@@ -1719,16 +1719,16 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 
 		if typedErr != nil {
 			if _, rbErr := tx.Exec("ROLLBACK TO SAVEPOINT " + savepoint); rbErr != nil {
-				return stored, extractFailures, fmt.Errorf("rollback to savepoint for %s/%s (typed err: %v): %w", resourceType, storageID, typedErr, rbErr)
+				return stored, extractFailures, typedFailures, fmt.Errorf("rollback to savepoint for %s/%s (typed err: %v): %w", resourceType, storageID, typedErr, rbErr)
 			}
 			if _, relErr := tx.Exec("RELEASE SAVEPOINT " + savepoint); relErr != nil {
-				return stored, extractFailures, fmt.Errorf("release savepoint after rollback for %s/%s: %w", resourceType, storageID, relErr)
+				return stored, extractFailures, typedFailures, fmt.Errorf("release savepoint after rollback for %s/%s: %w", resourceType, storageID, relErr)
 			}
 			typedFailures++
 			continue
 		}
 		if _, err := tx.Exec("RELEASE SAVEPOINT " + savepoint); err != nil {
-			return stored, extractFailures, fmt.Errorf("release savepoint for %s/%s: %w", resourceType, storageID, err)
+			return stored, extractFailures, typedFailures, fmt.Errorf("release savepoint for %s/%s: %w", resourceType, storageID, err)
 		}
 	}
 
@@ -1747,9 +1747,9 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 	}
 
 	if err := tx.Commit(); err != nil {
-		return 0, extractFailures, err
+		return 0, extractFailures, typedFailures, err
 	}
-	return stored, extractFailures, nil
+	return stored, extractFailures, typedFailures, nil
 }
 
 func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, json.RawMessage, bool) {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -38,11 +38,12 @@ var unresolvedPathKeyRE = regexp.MustCompile(`\{[a-zA-Z_][a-zA-Z0-9_]*\}`)
 
 // syncResult holds the outcome of syncing a single resource.
 type syncResult struct {
-	Resource string
-	Count    int
-	Err      error
-	Warn     error
-	Duration time.Duration
+	Resource         string
+	Count            int
+	Err              error
+	Warn             error
+	IntegrityFailure bool
+	Duration         time.Duration
 }
 
 const syncWatermarkOverlap = time.Second
@@ -273,7 +274,7 @@ Resource scoping:
 					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
 						firstPlaceholderErr = res.Err
 					}
-					if isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
+					if res.IntegrityFailure || isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
 						criticalErrCount++
 						criticalFailedResources = append(criticalFailedResources, res.Resource)
 					}
@@ -672,6 +673,13 @@ func syncResource(ctx context.Context, c interface {
 		}
 
 		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
+			if responseDeclaresFailure(data) {
+				err := fmt.Errorf("%s response declared failure without items", resource)
+				if !humanFriendly {
+					fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+				}
+				return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
+			}
 			if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 				// Natural end: the API legitimately returned an empty page.
 				outcome.complete = true
@@ -694,9 +702,9 @@ func syncResource(ctx context.Context, c interface {
 		_, hydrationEnabled := itemHydrationPaths[resource]
 		items, hydrateFailures := hydrateScalarItems(ctx, c, resource, items)
 
-		// Batch upsert all items from this page. UpsertBatch returns
-		// (stored, extractFailures, err): stored counts rows actually
-		// landed; extractFailures counts items that survived JSON
+		// Batch upsert all items from this page. upsertResourceBatch returns
+		// stored rows plus extraction and typed-projection failures. stored counts
+		// generic rows actually landed; extractFailures counts items that survived JSON
 		// unmarshal but had no extractable primary key (templated
 		// IDField AND generic fallback both missed). Tracking these
 		// separately lets us emit precise sync_anomaly events: a
@@ -705,7 +713,7 @@ func syncResource(ctx context.Context, c interface {
 		// "primary_key_unresolved" the first time any single item
 		// fails, and the F4b "stored_count_zero_after_extraction"
 		// probe when extraction succeeded but rows still didn't land.
-		stored, extractFailures, err := upsertResourceBatch(db, resource, items)
+		stored, extractFailures, typedFailures, err := upsertResourceBatch(db, resource, items)
 		if err != nil {
 			if !humanFriendly {
 				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
@@ -722,6 +730,13 @@ func syncResource(ctx context.Context, c interface {
 			// advance the incremental watermark past that item.
 			timestampOrderSafe = false
 		}
+		if typedFailures > 0 {
+			err := fmt.Errorf("%s stored %d generic row(s) but %d typed-table projection(s) failed", resource, stored, typedFailures)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+			}
+			return syncResult{Resource: resource, Count: totalCount + stored, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
+		}
 
 		if fetchedThisPage > 0 && stored == 0 {
 			reason := "all_items_failed_id_extraction"
@@ -735,7 +750,11 @@ func syncResource(ctx context.Context, c interface {
 			} else {
 				fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","consumed":%d,"stored":0,"reason":"%s"}`+"\n", resource, fetchedThisPage, reason)
 			}
-			anomalyEmitted = true
+			err := fmt.Errorf("%s consumed %d item(s) but stored 0", resource, fetchedThisPage)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+			}
+			return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
 		} else if pageFailureCount > 0 && !anomalyEmitted {
 			reason := "primary_key_unresolved"
 			message := fmt.Sprintf("%s had %d item(s) on this page with no extractable primary key — those rows were not stored. Annotate the spec with x-resource-id to fix.", resource, extractFailures)
@@ -987,6 +1006,11 @@ func syncResource(ctx context.Context, c interface {
 		} else {
 			fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","consumed":%d,"stored":0,"extract_failures":%d,"reason":"stored_count_zero_after_extraction"}`+"\n", resource, consumedTotal, extractFailureTotal)
 		}
+		err := fmt.Errorf("%s consumed %d item(s) but stored 0 after primary-key extraction", resource, consumedTotal)
+		if !humanFriendly {
+			fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+		}
+		return syncResult{Resource: resource, Count: 0, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
 	}
 
 	if !humanFriendly {
@@ -994,15 +1018,16 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	if consumedTotal > 0 && totalCount == 0 && extractFailureTotal >= consumedTotal {
-		warn := fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", resource, consumedTotal)
+		err := fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", resource, consumedTotal)
 		if hydrateFailureTotal > 0 {
-			warn = fmt.Errorf("%s consumed %d items but stored 0 because scalar item hydration failed", resource, consumedTotal)
+			err = fmt.Errorf("%s consumed %d items but stored 0 because scalar item hydration failed", resource, consumedTotal)
 		}
 		return syncResult{
-			Resource: resource,
-			Count:    0,
-			Warn:     warn,
-			Duration: time.Since(started),
+			Resource:         resource,
+			Count:            0,
+			Err:              err,
+			IntegrityFailure: true,
+			Duration:         time.Since(started),
 		}
 	}
 
@@ -1321,9 +1346,6 @@ func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 			continue
 		}
 		if isJSONNull(pathData) {
-			if envelopeReportsFailure(envelope) {
-				return true
-			}
 			continue
 		}
 		var direct []json.RawMessage
@@ -1342,9 +1364,6 @@ func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 			continue
 		}
 		if isJSONNull(raw) {
-			if envelopeReportsFailure(envelope) {
-				return true
-			}
 			continue
 		}
 		var inner map[string]json.RawMessage
@@ -1354,6 +1373,14 @@ func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 	}
 
 	return false
+}
+
+func responseDeclaresFailure(data json.RawMessage) bool {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return false
+	}
+	return envelopeReportsFailure(envelope)
 }
 
 func envelopeReportsFailure(envelope map[string]json.RawMessage) bool {
@@ -1770,9 +1797,9 @@ type discriminatorDispatch struct {
 
 var discriminatorDispatchers = map[string]discriminatorDispatch{}
 
-func upsertResourceBatch(db *store.Store, resource string, items []json.RawMessage) (int, int, error) {
+func upsertResourceBatch(db *store.Store, resource string, items []json.RawMessage) (int, int, int, error) {
 	if _, ok := discriminatorDispatchers[resource]; !ok {
-		return db.UpsertBatch(resource, items)
+		return db.UpsertBatchDetailed(resource, items)
 	}
 
 	grouped := map[string][]json.RawMessage{}
@@ -1788,16 +1815,17 @@ func upsertResourceBatch(db *store.Store, resource string, items []json.RawMessa
 		grouped[target] = append(grouped[target], item)
 	}
 
-	var stored, extractFailures int
+	var stored, extractFailures, typedFailures int
 	for _, target := range order {
-		targetStored, targetExtractFailures, err := db.UpsertBatch(target, grouped[target])
+		targetStored, targetExtractFailures, targetTypedFailures, err := db.UpsertBatchDetailed(target, grouped[target])
 		if err != nil {
-			return stored, extractFailures + targetExtractFailures, err
+			return stored, extractFailures + targetExtractFailures, typedFailures + targetTypedFailures, err
 		}
 		stored += targetStored
 		extractFailures += targetExtractFailures
+		typedFailures += targetTypedFailures
 	}
-	return stored, extractFailures, nil
+	return stored, extractFailures, typedFailures, nil
 }
 
 func resolveDiscriminatedResource(resource string, obj map[string]any) string {
@@ -2212,7 +2240,7 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 // These are always treated as critical because a silent exit 0 would leave
 // resume cursors inconsistent with stored data.
 func isSyncStatePersistenceError(err error) bool {
-	return err != nil && strings.HasPrefix(err.Error(), "saving sync state for ")
+	return err != nil && (strings.HasPrefix(err.Error(), "saving sync state for ") || strings.HasPrefix(err.Error(), "saving sync progress for "))
 }
 
 // criticalResources is the template-time projection of per-resource Critical

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -588,6 +588,13 @@ func syncResource(ctx context.Context, c interface {
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(resource, path)...)
+		if responseDeclaresFailure(data) {
+			err := fmt.Errorf("%s response declared failure", resource)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+			}
+			return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
+		}
 		if sortEffective && maxPages > 0 {
 			for _, item := range items {
 				itemTimestamp, ok := restSyncTimestamp(item, sortField)
@@ -673,13 +680,6 @@ func syncResource(ctx context.Context, c interface {
 		}
 
 		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
-			if responseDeclaresFailure(data) {
-				err := fmt.Errorf("%s response declared failure without items", resource)
-				if !humanFriendly {
-					fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
-				}
-				return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
-			}
 			if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 				// Natural end: the API legitimately returned an empty page.
 				outcome.complete = true

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -702,17 +702,10 @@ func syncResource(ctx context.Context, c interface {
 		_, hydrationEnabled := itemHydrationPaths[resource]
 		items, hydrateFailures := hydrateScalarItems(ctx, c, resource, items)
 
-		// Batch upsert all items from this page. upsertResourceBatch returns
-		// stored rows plus extraction and typed-projection failures. stored counts
-		// generic rows actually landed; extractFailures counts items that survived JSON
-		// unmarshal but had no extractable primary key (templated
-		// IDField AND generic fallback both missed). Tracking these
-		// separately lets us emit precise sync_anomaly events: a
-		// roll-up "all_items_failed_id_extraction" when an entire
-		// page yields zero stored, a per-resource
-		// "primary_key_unresolved" the first time any single item
-		// fails, and the F4b "stored_count_zero_after_extraction"
-		// probe when extraction succeeded but rows still didn't land.
+		// Keep page consumption separate from stored rows so integrity-loss
+		// outcomes are classified precisely: all items rejected by ID extraction,
+		// partial primary-key misses, typed projection failures, and rows that
+		// extracted cleanly but still failed to land.
 		stored, extractFailures, typedFailures, err := upsertResourceBatch(db, resource, items)
 		if err != nil {
 			if !humanFriendly {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1687,13 +1687,9 @@ func deriveScopeColumns(obj map[string]any) {
 	}
 }
 
-// UpsertBatch inserts or replaces multiple records in a single transaction
-// and returns (stored, extractFailures, err). stored counts rows landed in
-// the generic resources table; extractFailures counts items that survived
-// JSON unmarshal but had no extractable primary key (templated IDField AND
-// generic fallback both missed). callers (sync.go.tmpl) compare these
-// against len(items) to emit the per-item primary_key_unresolved warning
-// and the F4b stored_count_zero_after_extraction probe.
+// UpsertBatch inserts or replaces multiple records in a single transaction.
+// The detailed variant also reports typed-table projection failures so sync can
+// treat a generic-only write as an incomplete local mirror.
 //
 // For resource types that have a domain-specific typed table, the per-item
 // generic insert is followed by a dispatch to the matching upsert<Pascal>Tx
@@ -1706,14 +1702,18 @@ func deriveScopeColumns(obj map[string]any) {
 // didn't populate the parent path placeholder) rolls back only that typed
 // upsert. The generic resources row inserted just above it survives the
 // rollback, so successful API fetches never strand in memory because one
-// downstream typed table is misconfigured. Failures are surfaced via a
-// trailing stderr warning rather than aborting the batch.
+// downstream typed table is misconfigured.
 func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, int, error) {
+	stored, extractFailures, _, err := s.UpsertBatchDetailed(resourceType, items)
+	return stored, extractFailures, err
+}
+
+func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage) (int, int, int, error) {
 	s.lockForWrite()
 	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
-		return 0, 0, fmt.Errorf("starting batch transaction: %w", err)
+		return 0, 0, 0, fmt.Errorf("starting batch transaction: %w", err)
 	}
 	defer tx.Rollback()
 
@@ -1747,7 +1747,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 			// Return the running stored count rather than zero so callers
 			// inspecting partial progress on failure see what already
 			// landed in earlier loop iterations.
-			return stored, extractFailures, fmt.Errorf("upserting %s/%s: %w", resourceType, storageID, err)
+			return stored, extractFailures, typedFailures, fmt.Errorf("upserting %s/%s: %w", resourceType, storageID, err)
 		}
 		stored++
 
@@ -1758,7 +1758,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 
 		savepoint := fmt.Sprintf("pp_typed_%d", i)
 		if _, err := tx.Exec("SAVEPOINT " + savepoint); err != nil {
-			return stored, extractFailures, fmt.Errorf("savepoint begin for %s/%s: %w", resourceType, storageID, err)
+			return stored, extractFailures, typedFailures, fmt.Errorf("savepoint begin for %s/%s: %w", resourceType, storageID, err)
 		}
 
 		var typedErr error
@@ -1771,16 +1771,16 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 
 		if typedErr != nil {
 			if _, rbErr := tx.Exec("ROLLBACK TO SAVEPOINT " + savepoint); rbErr != nil {
-				return stored, extractFailures, fmt.Errorf("rollback to savepoint for %s/%s (typed err: %v): %w", resourceType, storageID, typedErr, rbErr)
+				return stored, extractFailures, typedFailures, fmt.Errorf("rollback to savepoint for %s/%s (typed err: %v): %w", resourceType, storageID, typedErr, rbErr)
 			}
 			if _, relErr := tx.Exec("RELEASE SAVEPOINT " + savepoint); relErr != nil {
-				return stored, extractFailures, fmt.Errorf("release savepoint after rollback for %s/%s: %w", resourceType, storageID, relErr)
+				return stored, extractFailures, typedFailures, fmt.Errorf("release savepoint after rollback for %s/%s: %w", resourceType, storageID, relErr)
 			}
 			typedFailures++
 			continue
 		}
 		if _, err := tx.Exec("RELEASE SAVEPOINT " + savepoint); err != nil {
-			return stored, extractFailures, fmt.Errorf("release savepoint for %s/%s: %w", resourceType, storageID, err)
+			return stored, extractFailures, typedFailures, fmt.Errorf("release savepoint for %s/%s: %w", resourceType, storageID, err)
 		}
 	}
 
@@ -1799,9 +1799,9 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 	}
 
 	if err := tx.Commit(); err != nil {
-		return 0, extractFailures, err
+		return 0, extractFailures, typedFailures, err
 	}
-	return stored, extractFailures, nil
+	return stored, extractFailures, typedFailures, nil
 }
 
 func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, json.RawMessage, bool) {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -604,6 +604,13 @@ func syncResource(ctx context.Context, c interface {
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(resource, path)...)
+		if responseDeclaresFailure(data) {
+			err := fmt.Errorf("%s response declared failure", resource)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+			}
+			return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
+		}
 		if sortEffective && maxPages > 0 {
 			for _, item := range items {
 				itemTimestamp, ok := restSyncTimestamp(item, sortField)
@@ -669,13 +676,6 @@ func syncResource(ctx context.Context, c interface {
 		}
 
 		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
-			if responseDeclaresFailure(data) {
-				err := fmt.Errorf("%s response declared failure without items", resource)
-				if !humanFriendly {
-					fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
-				}
-				return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
-			}
 			if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 				// Natural end: the API legitimately returned an empty page.
 				outcome.complete = true
@@ -2277,6 +2277,15 @@ func syncOneParent(
 		}
 
 		items, nextCursor, hasMore := extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(dep.Name, path)...)
+		if responseDeclaresFailure(data) {
+			outcome.reason = "response_declared_failure"
+			rep.integrityFailure = true
+			rep.failure = fmt.Errorf("%s parent %s response declared failure", dep.Name, parentID)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, rep.failure))
+			}
+			break
+		}
 
 		// Page-int paginator fallback: mirrors syncResource so dependent
 		// resources on integer ?page=N APIs also advance past page 1.
@@ -2318,15 +2327,6 @@ func syncOneParent(
 		}
 
 		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
-			if responseDeclaresFailure(data) {
-				outcome.reason = "response_declared_failure"
-				rep.integrityFailure = true
-				rep.failure = fmt.Errorf("%s parent %s response declared failure without items", dep.Name, parentID)
-				if !humanFriendly {
-					fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, rep.failure))
-				}
-				break
-			}
 			if isEmptyPageResponse(data, responsePathForResource(dep.Name, path)...) {
 				outcome.complete = true // parent legitimately has zero children
 			} else {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -40,11 +40,12 @@ const dogfoodMaxParentRows = 2
 
 // syncResult holds the outcome of syncing a single resource.
 type syncResult struct {
-	Resource string
-	Count    int
-	Err      error
-	Warn     error
-	Duration time.Duration
+	Resource         string
+	Count            int
+	Err              error
+	Warn             error
+	IntegrityFailure bool
+	Duration         time.Duration
 }
 
 const syncWatermarkOverlap = time.Second
@@ -279,7 +280,7 @@ Resource scoping:
 					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
 						firstPlaceholderErr = res.Err
 					}
-					if isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
+					if res.IntegrityFailure || isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
 						criticalErrCount++
 						criticalFailedResources = append(criticalFailedResources, res.Resource)
 					}
@@ -312,7 +313,7 @@ Resource scoping:
 					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
 						firstPlaceholderErr = res.Err
 					}
-					if isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
+					if res.IntegrityFailure || isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
 						criticalErrCount++
 						criticalFailedResources = append(criticalFailedResources, res.Resource)
 					}
@@ -668,6 +669,13 @@ func syncResource(ctx context.Context, c interface {
 		}
 
 		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
+			if responseDeclaresFailure(data) {
+				err := fmt.Errorf("%s response declared failure without items", resource)
+				if !humanFriendly {
+					fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+				}
+				return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
+			}
 			if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 				// Natural end: the API legitimately returned an empty page.
 				outcome.complete = true
@@ -690,9 +698,9 @@ func syncResource(ctx context.Context, c interface {
 		_, hydrationEnabled := itemHydrationPaths[resource]
 		items, hydrateFailures := hydrateScalarItems(ctx, c, resource, items)
 
-		// Batch upsert all items from this page. UpsertBatch returns
-		// (stored, extractFailures, err): stored counts rows actually
-		// landed; extractFailures counts items that survived JSON
+		// Batch upsert all items from this page. upsertResourceBatch returns
+		// stored rows plus extraction and typed-projection failures. stored counts
+		// generic rows actually landed; extractFailures counts items that survived JSON
 		// unmarshal but had no extractable primary key (templated
 		// IDField AND generic fallback both missed). Tracking these
 		// separately lets us emit precise sync_anomaly events: a
@@ -701,7 +709,7 @@ func syncResource(ctx context.Context, c interface {
 		// "primary_key_unresolved" the first time any single item
 		// fails, and the F4b "stored_count_zero_after_extraction"
 		// probe when extraction succeeded but rows still didn't land.
-		stored, extractFailures, err := upsertResourceBatch(db, resource, items)
+		stored, extractFailures, typedFailures, err := upsertResourceBatch(db, resource, items)
 		if err != nil {
 			if !humanFriendly {
 				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
@@ -718,6 +726,13 @@ func syncResource(ctx context.Context, c interface {
 			// advance the incremental watermark past that item.
 			timestampOrderSafe = false
 		}
+		if typedFailures > 0 {
+			err := fmt.Errorf("%s stored %d generic row(s) but %d typed-table projection(s) failed", resource, stored, typedFailures)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+			}
+			return syncResult{Resource: resource, Count: totalCount + stored, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
+		}
 
 		if fetchedThisPage > 0 && stored == 0 {
 			reason := "all_items_failed_id_extraction"
@@ -731,7 +746,11 @@ func syncResource(ctx context.Context, c interface {
 			} else {
 				fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","consumed":%d,"stored":0,"reason":"%s"}`+"\n", resource, fetchedThisPage, reason)
 			}
-			anomalyEmitted = true
+			err := fmt.Errorf("%s consumed %d item(s) but stored 0", resource, fetchedThisPage)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+			}
+			return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
 		} else if pageFailureCount > 0 && !anomalyEmitted {
 			reason := "primary_key_unresolved"
 			message := fmt.Sprintf("%s had %d item(s) on this page with no extractable primary key — those rows were not stored. Annotate the spec with x-resource-id to fix.", resource, extractFailures)
@@ -964,6 +983,11 @@ func syncResource(ctx context.Context, c interface {
 		} else {
 			fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","consumed":%d,"stored":0,"extract_failures":%d,"reason":"stored_count_zero_after_extraction"}`+"\n", resource, consumedTotal, extractFailureTotal)
 		}
+		err := fmt.Errorf("%s consumed %d item(s) but stored 0 after primary-key extraction", resource, consumedTotal)
+		if !humanFriendly {
+			fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+		}
+		return syncResult{Resource: resource, Count: 0, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
 	}
 
 	if !humanFriendly {
@@ -971,15 +995,16 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	if consumedTotal > 0 && totalCount == 0 && extractFailureTotal >= consumedTotal {
-		warn := fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", resource, consumedTotal)
+		err := fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", resource, consumedTotal)
 		if hydrateFailureTotal > 0 {
-			warn = fmt.Errorf("%s consumed %d items but stored 0 because scalar item hydration failed", resource, consumedTotal)
+			err = fmt.Errorf("%s consumed %d items but stored 0 because scalar item hydration failed", resource, consumedTotal)
 		}
 		return syncResult{
-			Resource: resource,
-			Count:    0,
-			Warn:     warn,
-			Duration: time.Since(started),
+			Resource:         resource,
+			Count:            0,
+			Err:              err,
+			IntegrityFailure: true,
+			Duration:         time.Since(started),
 		}
 	}
 
@@ -1298,9 +1323,6 @@ func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 			continue
 		}
 		if isJSONNull(pathData) {
-			if envelopeReportsFailure(envelope) {
-				return true
-			}
 			continue
 		}
 		var direct []json.RawMessage
@@ -1319,9 +1341,6 @@ func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 			continue
 		}
 		if isJSONNull(raw) {
-			if envelopeReportsFailure(envelope) {
-				return true
-			}
 			continue
 		}
 		var inner map[string]json.RawMessage
@@ -1331,6 +1350,14 @@ func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 	}
 
 	return false
+}
+
+func responseDeclaresFailure(data json.RawMessage) bool {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return false
+	}
+	return envelopeReportsFailure(envelope)
 }
 
 func envelopeReportsFailure(envelope map[string]json.RawMessage) bool {
@@ -1747,9 +1774,9 @@ type discriminatorDispatch struct {
 
 var discriminatorDispatchers = map[string]discriminatorDispatch{}
 
-func upsertResourceBatch(db *store.Store, resource string, items []json.RawMessage) (int, int, error) {
+func upsertResourceBatch(db *store.Store, resource string, items []json.RawMessage) (int, int, int, error) {
 	if _, ok := discriminatorDispatchers[resource]; !ok {
-		return db.UpsertBatch(resource, items)
+		return db.UpsertBatchDetailed(resource, items)
 	}
 
 	grouped := map[string][]json.RawMessage{}
@@ -1765,16 +1792,17 @@ func upsertResourceBatch(db *store.Store, resource string, items []json.RawMessa
 		grouped[target] = append(grouped[target], item)
 	}
 
-	var stored, extractFailures int
+	var stored, extractFailures, typedFailures int
 	for _, target := range order {
-		targetStored, targetExtractFailures, err := db.UpsertBatch(target, grouped[target])
+		targetStored, targetExtractFailures, targetTypedFailures, err := db.UpsertBatchDetailed(target, grouped[target])
 		if err != nil {
-			return stored, extractFailures + targetExtractFailures, err
+			return stored, extractFailures + targetExtractFailures, typedFailures + targetTypedFailures, err
 		}
 		stored += targetStored
 		extractFailures += targetExtractFailures
+		typedFailures += targetTypedFailures
 	}
-	return stored, extractFailures, nil
+	return stored, extractFailures, typedFailures, nil
 }
 
 func resolveDiscriminatedResource(resource string, obj map[string]any) string {
@@ -2104,14 +2132,15 @@ func syncDependentResources(ctx context.Context, c interface {
 // reconcile and returns this; the aggregator sums the counters AFTER a full
 // barrier and resolves the one-shot anomaly / first-denial deterministically.
 type parentReport struct {
-	stored          int
-	consumed        int
-	extractFailures int
-	failure         error // non-nil when this parent's batch upsert failed
-	denied          bool
-	firstDenial     *accessWarning
-	anomaly         *parentAnomaly // nil unless this parent hit an extraction anomaly
-	dryRun          bool           // true if a dry-run sentinel was seen — caller short-circuits
+	stored           int
+	consumed         int
+	extractFailures  int
+	failure          error // non-nil when this parent's batch upsert failed
+	integrityFailure bool
+	denied           bool
+	firstDenial      *accessWarning
+	anomaly          *parentAnomaly // nil unless this parent hit an extraction anomaly
+	dryRun           bool           // true if a dry-run sentinel was seen — caller short-circuits
 }
 
 // parentAnomaly carries the fields the two sync_anomaly event shapes need so
@@ -2289,6 +2318,15 @@ func syncOneParent(
 		}
 
 		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
+			if responseDeclaresFailure(data) {
+				outcome.reason = "response_declared_failure"
+				rep.integrityFailure = true
+				rep.failure = fmt.Errorf("%s parent %s response declared failure without items", dep.Name, parentID)
+				if !humanFriendly {
+					fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, rep.failure))
+				}
+				break
+			}
 			if isEmptyPageResponse(data, responsePathForResource(dep.Name, path)...) {
 				outcome.complete = true // parent legitimately has zero children
 			} else {
@@ -2320,7 +2358,7 @@ func syncOneParent(
 			}
 		}
 
-		stored, extractFailures, err := upsertResourceBatch(db, dep.Name, items)
+		stored, extractFailures, typedFailures, err := upsertResourceBatch(db, dep.Name, items)
 		if err != nil {
 			outcome.reason = "upsert_error"
 			rep.failure = fmt.Errorf("upserting batch for %s parent %s: %w", dep.Name, parentID, err)
@@ -2334,11 +2372,26 @@ func syncOneParent(
 
 		rep.consumed += len(items)
 		rep.extractFailures += extractFailures
+		if typedFailures > 0 {
+			outcome.reason = "typed_projection_failed"
+			rep.integrityFailure = true
+			rep.failure = fmt.Errorf("%s parent %s stored %d generic row(s) but %d typed-table projection(s) failed", dep.Name, parentID, stored, typedFailures)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, rep.failure))
+			}
+			break
+		}
 		// Order matches the flat path (syncResource): all-fail first, then
 		// partial-fail. The all-fail case dominates. Record (first wins within
 		// this parent) and let the aggregator emit.
 		if len(items) > 0 && stored == 0 && rep.anomaly == nil {
 			rep.anomaly = &parentAnomaly{parent: parentID, consumed: len(items), stored: 0, count: len(items), reason: "all_items_failed_id_extraction"}
+			rep.integrityFailure = true
+			rep.failure = fmt.Errorf("%s parent %s consumed %d item(s) but stored 0", dep.Name, parentID, len(items))
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, rep.failure))
+			}
+			break
 		} else if extractFailures > 0 && stored > 0 && rep.anomaly == nil {
 			rep.anomaly = &parentAnomaly{parent: parentID, consumed: len(items), stored: stored, count: extractFailures, reason: "primary_key_unresolved"}
 		}
@@ -2572,6 +2625,7 @@ func syncDependentResource(ctx context.Context, c interface {
 	// "first parent" is inherently nondeterministic under concurrency.
 	dryRunHit := false
 	failedParents := 0
+	integrityFailedParents := 0
 	var firstFailure error
 	for rep := range reports {
 		if rep.dryRun {
@@ -2583,6 +2637,9 @@ func syncDependentResource(ctx context.Context, c interface {
 		depExtractFailureTotal += rep.extractFailures
 		if rep.failure != nil {
 			failedParents++
+			if rep.integrityFailure {
+				integrityFailedParents++
+			}
 			if firstFailure == nil {
 				firstFailure = rep.failure
 			}
@@ -2612,6 +2669,9 @@ func syncDependentResource(ctx context.Context, c interface {
 	}
 	if failedParents > 0 {
 		failure := fmt.Errorf("%s failed to store data for %d of %d parents: %w", dep.Name, failedParents, len(parentRows), firstFailure)
+		if integrityFailedParents > 0 {
+			return syncResult{Resource: dep.Name, Count: totalCount, Err: failure, IntegrityFailure: true, Duration: time.Since(started)}
+		}
 		if failedParents == len(parentRows) && totalCount == 0 {
 			return syncResult{Resource: dep.Name, Count: 0, Err: failure, Duration: time.Since(started)}
 		}
@@ -2630,13 +2690,19 @@ func syncDependentResource(ctx context.Context, c interface {
 		} else {
 			fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","consumed":%d,"stored":0,"extract_failures":%d,"reason":"stored_count_zero_after_extraction"}`+"\n", dep.Name, depConsumedTotal, depExtractFailureTotal)
 		}
+		err := fmt.Errorf("%s consumed %d item(s) but stored 0 after primary-key extraction", dep.Name, depConsumedTotal)
+		if !humanFriendly {
+			fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, "", err))
+		}
+		return syncResult{Resource: dep.Name, Count: 0, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
 	}
 	if depConsumedTotal > 0 && totalCount == 0 && depExtractFailureTotal >= depConsumedTotal {
 		return syncResult{
-			Resource: dep.Name,
-			Count:    0,
-			Warn:     fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", dep.Name, depConsumedTotal),
-			Duration: time.Since(started),
+			Resource:         dep.Name,
+			Count:            0,
+			Err:              fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", dep.Name, depConsumedTotal),
+			IntegrityFailure: true,
+			Duration:         time.Since(started),
 		}
 	}
 
@@ -2837,7 +2903,7 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 // These are always treated as critical because a silent exit 0 would leave
 // resume cursors inconsistent with stored data.
 func isSyncStatePersistenceError(err error) bool {
-	return err != nil && strings.HasPrefix(err.Error(), "saving sync state for ")
+	return err != nil && (strings.HasPrefix(err.Error(), "saving sync state for ") || strings.HasPrefix(err.Error(), "saving sync progress for "))
 }
 
 // criticalResources is the template-time projection of per-resource Critical

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -698,17 +698,10 @@ func syncResource(ctx context.Context, c interface {
 		_, hydrationEnabled := itemHydrationPaths[resource]
 		items, hydrateFailures := hydrateScalarItems(ctx, c, resource, items)
 
-		// Batch upsert all items from this page. upsertResourceBatch returns
-		// stored rows plus extraction and typed-projection failures. stored counts
-		// generic rows actually landed; extractFailures counts items that survived JSON
-		// unmarshal but had no extractable primary key (templated
-		// IDField AND generic fallback both missed). Tracking these
-		// separately lets us emit precise sync_anomaly events: a
-		// roll-up "all_items_failed_id_extraction" when an entire
-		// page yields zero stored, a per-resource
-		// "primary_key_unresolved" the first time any single item
-		// fails, and the F4b "stored_count_zero_after_extraction"
-		// probe when extraction succeeded but rows still didn't land.
+		// Keep page consumption separate from stored rows so integrity-loss
+		// outcomes are classified precisely: all items rejected by ID extraction,
+		// partial primary-key misses, typed projection failures, and rows that
+		// extracted cleanly but still failed to land.
 		stored, extractFailures, typedFailures, err := upsertResourceBatch(db, resource, items)
 		if err != nil {
 			if !humanFriendly {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1637,13 +1637,9 @@ func deriveScopeColumns(obj map[string]any) {
 	}
 }
 
-// UpsertBatch inserts or replaces multiple records in a single transaction
-// and returns (stored, extractFailures, err). stored counts rows landed in
-// the generic resources table; extractFailures counts items that survived
-// JSON unmarshal but had no extractable primary key (templated IDField AND
-// generic fallback both missed). callers (sync.go.tmpl) compare these
-// against len(items) to emit the per-item primary_key_unresolved warning
-// and the F4b stored_count_zero_after_extraction probe.
+// UpsertBatch inserts or replaces multiple records in a single transaction.
+// The detailed variant also reports typed-table projection failures so sync can
+// treat a generic-only write as an incomplete local mirror.
 //
 // For resource types that have a domain-specific typed table, the per-item
 // generic insert is followed by a dispatch to the matching upsert<Pascal>Tx
@@ -1656,14 +1652,18 @@ func deriveScopeColumns(obj map[string]any) {
 // didn't populate the parent path placeholder) rolls back only that typed
 // upsert. The generic resources row inserted just above it survives the
 // rollback, so successful API fetches never strand in memory because one
-// downstream typed table is misconfigured. Failures are surfaced via a
-// trailing stderr warning rather than aborting the batch.
+// downstream typed table is misconfigured.
 func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, int, error) {
+	stored, extractFailures, _, err := s.UpsertBatchDetailed(resourceType, items)
+	return stored, extractFailures, err
+}
+
+func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage) (int, int, int, error) {
 	s.lockForWrite()
 	defer s.unlockAfterWrite()
 	tx, err := s.db.Begin()
 	if err != nil {
-		return 0, 0, fmt.Errorf("starting batch transaction: %w", err)
+		return 0, 0, 0, fmt.Errorf("starting batch transaction: %w", err)
 	}
 	defer tx.Rollback()
 
@@ -1697,7 +1697,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 			// Return the running stored count rather than zero so callers
 			// inspecting partial progress on failure see what already
 			// landed in earlier loop iterations.
-			return stored, extractFailures, fmt.Errorf("upserting %s/%s: %w", resourceType, storageID, err)
+			return stored, extractFailures, typedFailures, fmt.Errorf("upserting %s/%s: %w", resourceType, storageID, err)
 		}
 		stored++
 
@@ -1708,7 +1708,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 
 		savepoint := fmt.Sprintf("pp_typed_%d", i)
 		if _, err := tx.Exec("SAVEPOINT " + savepoint); err != nil {
-			return stored, extractFailures, fmt.Errorf("savepoint begin for %s/%s: %w", resourceType, storageID, err)
+			return stored, extractFailures, typedFailures, fmt.Errorf("savepoint begin for %s/%s: %w", resourceType, storageID, err)
 		}
 
 		var typedErr error
@@ -1719,16 +1719,16 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 
 		if typedErr != nil {
 			if _, rbErr := tx.Exec("ROLLBACK TO SAVEPOINT " + savepoint); rbErr != nil {
-				return stored, extractFailures, fmt.Errorf("rollback to savepoint for %s/%s (typed err: %v): %w", resourceType, storageID, typedErr, rbErr)
+				return stored, extractFailures, typedFailures, fmt.Errorf("rollback to savepoint for %s/%s (typed err: %v): %w", resourceType, storageID, typedErr, rbErr)
 			}
 			if _, relErr := tx.Exec("RELEASE SAVEPOINT " + savepoint); relErr != nil {
-				return stored, extractFailures, fmt.Errorf("release savepoint after rollback for %s/%s: %w", resourceType, storageID, relErr)
+				return stored, extractFailures, typedFailures, fmt.Errorf("release savepoint after rollback for %s/%s: %w", resourceType, storageID, relErr)
 			}
 			typedFailures++
 			continue
 		}
 		if _, err := tx.Exec("RELEASE SAVEPOINT " + savepoint); err != nil {
-			return stored, extractFailures, fmt.Errorf("release savepoint for %s/%s: %w", resourceType, storageID, err)
+			return stored, extractFailures, typedFailures, fmt.Errorf("release savepoint for %s/%s: %w", resourceType, storageID, err)
 		}
 	}
 
@@ -1747,9 +1747,9 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 	}
 
 	if err := tx.Commit(); err != nil {
-		return 0, extractFailures, err
+		return 0, extractFailures, typedFailures, err
 	}
-	return stored, extractFailures, nil
+	return stored, extractFailures, typedFailures, nil
 }
 
 func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, json.RawMessage, bool) {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -565,6 +565,13 @@ func syncResource(ctx context.Context, c interface {
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(resource, path)...)
+		if responseDeclaresFailure(data) {
+			err := fmt.Errorf("%s response declared failure", resource)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+			}
+			return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
+		}
 		if sortEffective && maxPages > 0 {
 			for _, item := range items {
 				itemTimestamp, ok := restSyncTimestamp(item, sortField)
@@ -630,13 +637,6 @@ func syncResource(ctx context.Context, c interface {
 		}
 
 		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
-			if responseDeclaresFailure(data) {
-				err := fmt.Errorf("%s response declared failure without items", resource)
-				if !humanFriendly {
-					fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
-				}
-				return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
-			}
 			if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 				// Natural end: the API legitimately returned an empty page.
 				outcome.complete = true

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -659,17 +659,10 @@ func syncResource(ctx context.Context, c interface {
 		_, hydrationEnabled := itemHydrationPaths[resource]
 		items, hydrateFailures := hydrateScalarItems(ctx, c, resource, items)
 
-		// Batch upsert all items from this page. upsertResourceBatch returns
-		// stored rows plus extraction and typed-projection failures. stored counts
-		// generic rows actually landed; extractFailures counts items that survived JSON
-		// unmarshal but had no extractable primary key (templated
-		// IDField AND generic fallback both missed). Tracking these
-		// separately lets us emit precise sync_anomaly events: a
-		// roll-up "all_items_failed_id_extraction" when an entire
-		// page yields zero stored, a per-resource
-		// "primary_key_unresolved" the first time any single item
-		// fails, and the F4b "stored_count_zero_after_extraction"
-		// probe when extraction succeeded but rows still didn't land.
+		// Keep page consumption separate from stored rows so integrity-loss
+		// outcomes are classified precisely: all items rejected by ID extraction,
+		// partial primary-key misses, typed projection failures, and rows that
+		// extracted cleanly but still failed to land.
 		stored, extractFailures, typedFailures, err := upsertResourceBatch(db, resource, items)
 		if err != nil {
 			if !humanFriendly {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -38,11 +38,12 @@ var unresolvedPathKeyRE = regexp.MustCompile(`\{[a-zA-Z_][a-zA-Z0-9_]*\}`)
 
 // syncResult holds the outcome of syncing a single resource.
 type syncResult struct {
-	Resource string
-	Count    int
-	Err      error
-	Warn     error
-	Duration time.Duration
+	Resource         string
+	Count            int
+	Err              error
+	Warn             error
+	IntegrityFailure bool
+	Duration         time.Duration
 }
 
 const syncWatermarkOverlap = time.Second
@@ -273,7 +274,7 @@ Resource scoping:
 					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
 						firstPlaceholderErr = res.Err
 					}
-					if isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
+					if res.IntegrityFailure || isSyncStatePersistenceError(res.Err) || criticalResources[res.Resource] {
 						criticalErrCount++
 						criticalFailedResources = append(criticalFailedResources, res.Resource)
 					}
@@ -629,6 +630,13 @@ func syncResource(ctx context.Context, c interface {
 		}
 
 		if len(items) == 0 && !cursorPageHasContinuation(pageSize.cursorType, hasMore, nextCursor) {
+			if responseDeclaresFailure(data) {
+				err := fmt.Errorf("%s response declared failure without items", resource)
+				if !humanFriendly {
+					fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+				}
+				return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
+			}
 			if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 				// Natural end: the API legitimately returned an empty page.
 				outcome.complete = true
@@ -651,9 +659,9 @@ func syncResource(ctx context.Context, c interface {
 		_, hydrationEnabled := itemHydrationPaths[resource]
 		items, hydrateFailures := hydrateScalarItems(ctx, c, resource, items)
 
-		// Batch upsert all items from this page. UpsertBatch returns
-		// (stored, extractFailures, err): stored counts rows actually
-		// landed; extractFailures counts items that survived JSON
+		// Batch upsert all items from this page. upsertResourceBatch returns
+		// stored rows plus extraction and typed-projection failures. stored counts
+		// generic rows actually landed; extractFailures counts items that survived JSON
 		// unmarshal but had no extractable primary key (templated
 		// IDField AND generic fallback both missed). Tracking these
 		// separately lets us emit precise sync_anomaly events: a
@@ -662,7 +670,7 @@ func syncResource(ctx context.Context, c interface {
 		// "primary_key_unresolved" the first time any single item
 		// fails, and the F4b "stored_count_zero_after_extraction"
 		// probe when extraction succeeded but rows still didn't land.
-		stored, extractFailures, err := upsertResourceBatch(db, resource, items)
+		stored, extractFailures, typedFailures, err := upsertResourceBatch(db, resource, items)
 		if err != nil {
 			if !humanFriendly {
 				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
@@ -679,6 +687,13 @@ func syncResource(ctx context.Context, c interface {
 			// advance the incremental watermark past that item.
 			timestampOrderSafe = false
 		}
+		if typedFailures > 0 {
+			err := fmt.Errorf("%s stored %d generic row(s) but %d typed-table projection(s) failed", resource, stored, typedFailures)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+			}
+			return syncResult{Resource: resource, Count: totalCount + stored, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
+		}
 
 		if fetchedThisPage > 0 && stored == 0 {
 			reason := "all_items_failed_id_extraction"
@@ -692,7 +707,11 @@ func syncResource(ctx context.Context, c interface {
 			} else {
 				fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","consumed":%d,"stored":0,"reason":"%s"}`+"\n", resource, fetchedThisPage, reason)
 			}
-			anomalyEmitted = true
+			err := fmt.Errorf("%s consumed %d item(s) but stored 0", resource, fetchedThisPage)
+			if !humanFriendly {
+				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+			}
+			return syncResult{Resource: resource, Count: totalCount, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
 		} else if pageFailureCount > 0 && !anomalyEmitted {
 			reason := "primary_key_unresolved"
 			message := fmt.Sprintf("%s had %d item(s) on this page with no extractable primary key — those rows were not stored. Annotate the spec with x-resource-id to fix.", resource, extractFailures)
@@ -925,6 +944,11 @@ func syncResource(ctx context.Context, c interface {
 		} else {
 			fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","consumed":%d,"stored":0,"extract_failures":%d,"reason":"stored_count_zero_after_extraction"}`+"\n", resource, consumedTotal, extractFailureTotal)
 		}
+		err := fmt.Errorf("%s consumed %d item(s) but stored 0 after primary-key extraction", resource, consumedTotal)
+		if !humanFriendly {
+			fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+		}
+		return syncResult{Resource: resource, Count: 0, Err: err, IntegrityFailure: true, Duration: time.Since(started)}
 	}
 
 	if !humanFriendly {
@@ -932,15 +956,16 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	if consumedTotal > 0 && totalCount == 0 && extractFailureTotal >= consumedTotal {
-		warn := fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", resource, consumedTotal)
+		err := fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", resource, consumedTotal)
 		if hydrateFailureTotal > 0 {
-			warn = fmt.Errorf("%s consumed %d items but stored 0 because scalar item hydration failed", resource, consumedTotal)
+			err = fmt.Errorf("%s consumed %d items but stored 0 because scalar item hydration failed", resource, consumedTotal)
 		}
 		return syncResult{
-			Resource: resource,
-			Count:    0,
-			Warn:     warn,
-			Duration: time.Since(started),
+			Resource:         resource,
+			Count:            0,
+			Err:              err,
+			IntegrityFailure: true,
+			Duration:         time.Since(started),
 		}
 	}
 
@@ -1269,9 +1294,6 @@ func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 			continue
 		}
 		if isJSONNull(pathData) {
-			if envelopeReportsFailure(envelope) {
-				return true
-			}
 			continue
 		}
 		var direct []json.RawMessage
@@ -1290,9 +1312,6 @@ func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 			continue
 		}
 		if isJSONNull(raw) {
-			if envelopeReportsFailure(envelope) {
-				return true
-			}
 			continue
 		}
 		var inner map[string]json.RawMessage
@@ -1302,6 +1321,14 @@ func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 	}
 
 	return false
+}
+
+func responseDeclaresFailure(data json.RawMessage) bool {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return false
+	}
+	return envelopeReportsFailure(envelope)
 }
 
 func envelopeReportsFailure(envelope map[string]json.RawMessage) bool {
@@ -1718,9 +1745,9 @@ type discriminatorDispatch struct {
 
 var discriminatorDispatchers = map[string]discriminatorDispatch{}
 
-func upsertResourceBatch(db *store.Store, resource string, items []json.RawMessage) (int, int, error) {
+func upsertResourceBatch(db *store.Store, resource string, items []json.RawMessage) (int, int, int, error) {
 	if _, ok := discriminatorDispatchers[resource]; !ok {
-		return db.UpsertBatch(resource, items)
+		return db.UpsertBatchDetailed(resource, items)
 	}
 
 	grouped := map[string][]json.RawMessage{}
@@ -1736,16 +1763,17 @@ func upsertResourceBatch(db *store.Store, resource string, items []json.RawMessa
 		grouped[target] = append(grouped[target], item)
 	}
 
-	var stored, extractFailures int
+	var stored, extractFailures, typedFailures int
 	for _, target := range order {
-		targetStored, targetExtractFailures, err := db.UpsertBatch(target, grouped[target])
+		targetStored, targetExtractFailures, targetTypedFailures, err := db.UpsertBatchDetailed(target, grouped[target])
 		if err != nil {
-			return stored, extractFailures + targetExtractFailures, err
+			return stored, extractFailures + targetExtractFailures, typedFailures + targetTypedFailures, err
 		}
 		stored += targetStored
 		extractFailures += targetExtractFailures
+		typedFailures += targetTypedFailures
 	}
-	return stored, extractFailures, nil
+	return stored, extractFailures, typedFailures, nil
 }
 
 func resolveDiscriminatedResource(resource string, obj map[string]any) string {
@@ -2137,7 +2165,7 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 // These are always treated as critical because a silent exit 0 would leave
 // resume cursors inconsistent with stored data.
 func isSyncStatePersistenceError(err error) bool {
-	return err != nil && strings.HasPrefix(err.Error(), "saving sync state for ")
+	return err != nil && (strings.HasPrefix(err.Error(), "saving sync state for ") || strings.HasPrefix(err.Error(), "saving sync progress for "))
 }
 
 // criticalResources is the template-time projection of per-resource Critical


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Issue: Closes #4163, Closes #4165, and Closes #4159

Fix the scoped sync silent-success / wrong-canonical-resource cluster: canonical sync resource selection, collection endpoint detection, sync outcomes that previously looked successful despite losing local-store integrity, and scalar ID hydration paths aliasing unrelated detail endpoints.

## Approach

- Prefer an endpoint explicitly named `list` when choosing the canonical sync resource for a resource with multiple list-like endpoints; use deterministic endpoint/path tie-breakers for fallback cases rather than shortest path.
- Match collection/list endpoint names by normalized boundary terms, including camelCase/PascalCase list verbs, so names like `install-info` do not match `all` as a raw substring.
- Surface sync integrity-loss outcomes as non-success results: consumed-but-zero-stored pages, typed-table projection failures, and 200 responses whose body declares failure, including failure envelopes that also include items or continuation metadata.
- Preserve the existing `UpsertBatch` API while adding a detailed generated-store path for sync to observe typed projection failures.
- Keep scalar ID hydration target selection resource-specific by requiring name/path affinity, treating `IDField` as a bonus rather than standalone evidence, and omitting resources with no resolvable detail endpoint.
- Make `workflow archive` stop on these integrity failures instead of reporting requested resources as synced.

## Scope

Primary area: generated sync/store templates and profiler sync-candidate/hydration selection.

#4165 findings 3, 5, 6, 7, and 8 remain out of scope for this PR.

Why this belongs in this repo: these are generator/profiler behaviors that affect every future printed CLI, not a one-off printed-CLI fix.

## Risk

Generated sync output changes. Runs that previously exited 0 while failing to populate the local mirror now fail, including `workflow archive` for the same integrity-loss outcomes. Scalar-ID list resources with no matching detail endpoint now skip unsafe hydration rather than calling an unrelated endpoint.

## Output Contract

Generated-output coverage added/updated for:
- canonical sync resource ranking and boundary-based list detection in profiler tests
- generated sync zero-stored and declared-failure integrity errors, including failure envelopes with items
- generated store detailed typed-projection failure reporting consumed by sync helper code
- resource-specific scalar ID hydration path derivation and omission of no-detail resources
- emitted-code assertions and golden fixtures for the four-value sync batch helper and integrity result field

## Verification

- [x] `go test ./internal/profiler ./internal/generator -run 'TestProfile(PrefersNamedListEndpointForCanonicalSyncResource|InstallInfoEndpointNameIsNotAList|SiblingListEndpoints)|TestGeneratedSyncStoreBatch4TemplateFixes|TestGenerate_EmitsDeriveScope|TestUpsertResourceBatchRoutesDiscriminatorItems|TestGeneratedSyncIDFieldOverridesAndProbes' -count=1`
- [x] `go test ./internal/profiler ./internal/generator -run 'TestProfileScalarIDListsUseOwnHydrationTargets|TestGeneratedSyncHydrationPathsStayResourceSpecific|TestGeneratedSyncHydratesScalarIDListItems|TestGeneratedSyncStoreBatch4TemplateFixes' -count=1`
- [x] `go test ./internal/profiler ./internal/generator -count=1 -timeout 20m`
- [x] `go test ./... -timeout 20m`
- [x] `scripts/verify-generator-output.sh`
- [x] `scripts/golden.sh verify` for generated CLI cases after updating intentional `sync.go` goldens. The only remaining local failures are unrelated dogfood verdict fixture build/toolchain output (`example check skipped: could not build CLI binary: exit status 1`) plus the pre-existing missing `verify-runtime-matrix` artifact `structural-fail.json` in this VM.

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41039b6c-134a-466d-94ae-07e25e9969be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41039b6c-134a-466d-94ae-07e25e9969be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

