### PR TITLE
fix(cli): disable sqlite mmap to stop SIGBUS store corruption

### DIFF
--- a/docs/solutions/runtime-errors/modernc-sqlite-dsn-pragma-syntax-silently-ignored.md
+++ b/docs/solutions/runtime-errors/modernc-sqlite-dsn-pragma-syntax-silently-ignored.md
@@ -51,10 +51,10 @@ Switch both opens to the `_pragma=` form (verify with the pinned driver version,
 
 ```go
 // read-only
-sql.Open("sqlite", "file:"+dbPath+"?mode=ro&_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)")
+sql.Open("sqlite", "file:"+dbPath+"?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)")
 
 // read-write (adds synchronous)
-sql.Open("sqlite", dbPath+"?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)")
+sql.Open("sqlite", dbPath+"?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)")
 ```
 
 Empirical proof with the pinned driver — the mattn-style DSN is byte-for-byte equivalent to passing no parameters:
@@ -95,7 +95,7 @@ defer conn.Close()
 
 - **Two SQLite drivers, two DSN dialects.** When the driver is `modernc.org/sqlite`, pragmas are `_pragma=name(value)`. When it is `mattn/go-sqlite3` (CGO), they are `_journal_mode=…` etc. The two are not interchangeable and the wrong one fails silently. Printed CLIs use modernc (pure Go, no CGO) — see `store.go.tmpl`'s import.
 - **A config string that is silently a no-op can mask a latent bug.** The store had concurrency-hardening machinery (`retryOnBusy`, `BEGIN IMMEDIATE`) that only had to cover statement-level contention because WAL was never actually on. Turning WAL on exposed a connect-time conversion race the no-op had hidden. When you fix a setting that was previously inert, re-test the paths that setting touches — the "fix" can reveal bugs the broken state was suppressing.
-- **Verify pragmas by reading them back, never by trusting the DSN or a comment.** `TestOpenAppliesPragmas` (in `store_schema_version_test.go.tmpl`) opens the store, then asserts `PRAGMA journal_mode == wal` and `PRAGMA busy_timeout == 5000` on both the read-write and read-only handles, so the DSN cannot silently regress:
+- **Verify pragmas by reading them back, never by trusting the DSN or a comment.** `TestOpenAppliesPragmas` (in `store_schema_version_test.go.tmpl`) opens the store, then asserts the expected `journal_mode`, `PRAGMA busy_timeout == 5000`, and `PRAGMA mmap_size == 0` on both the read-write and read-only handles, so the DSN cannot silently regress:
 
 ```go
 func requirePragma(t *testing.T, db *sql.DB, name, want string) {
@@ -110,7 +110,7 @@ func requirePragma(t *testing.T, db *sql.DB, name, want string) {
 }
 ```
 
-  (Reading the value as text covers both string pragmas like `journal_mode` and integer pragmas like `busy_timeout`.)
+  (Reading the value as text covers both string pragmas like `journal_mode` and integer pragmas like `busy_timeout` or `mmap_size`.)
 
 ## Related Issues
 

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -118,7 +118,7 @@ func OpenReadOnly(dbPath string) (*Store, error) {
 // OpenReadOnlyContext is OpenReadOnly with a caller-supplied context honored by
 // the driver-init SQLITE_BUSY retry.
 func OpenReadOnlyContext(ctx context.Context, dbPath string) (*Store, error) {
-	dsn := "file:" + dbPath + "?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
+	dsn := "file:" + dbPath + "?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}
@@ -155,9 +155,9 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	// teardown races between short-lived processes. Other store profiles keep
 	// WAL for concurrent analytical reads.
 	{{- if .Cache.Enabled}}
-	dsn := dbPath + "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(TRUNCATE)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
+	dsn := dbPath + "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(TRUNCATE)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
 	{{- else}}
-	dsn := dbPath + "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
+	dsn := dbPath + "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
 	{{- end}}
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err

--- a/internal/generator/templates/store_schema_version_test.go.tmpl
+++ b/internal/generator/templates/store_schema_version_test.go.tmpl
@@ -161,10 +161,10 @@ func TestSchemaVersion_StampedOnFreshDB(t *testing.T) {
 }
 
 // TestOpenAppliesPragmas pins the connection-string contract: the store
-// must use the profile-selected journal mode with a non-zero busy_timeout so
-// concurrent opens wait on the lock instead of failing immediately with
-// SQLITE_BUSY. It fails the instant the DSN regresses to the mattn-style
-// pragma form, which modernc.org/sqlite silently drops.
+// must use the profile-selected journal mode with a non-zero busy_timeout and
+// disabled mmap so concurrent cross-process access stays pread-based. It fails
+// the instant the DSN regresses to the mattn-style pragma form, which
+// modernc.org/sqlite silently drops.
 func TestOpenAppliesPragmas(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "data.db")
 	s, err := Open(dbPath)
@@ -179,10 +179,11 @@ func TestOpenAppliesPragmas(t *testing.T) {
 	requirePragma(t, s.DB(), "journal_mode", "wal")
 	{{- end}}
 	requirePragma(t, s.DB(), "busy_timeout", "5000")
+	requirePragma(t, s.DB(), "mmap_size", "0")
 
 	// The read-only handle (MCP sql/search, analytics) must retain its
-	// profile-compatible journal mode and carry the busy_timeout so it waits
-	// on a concurrent writer rather than erroring.
+	// profile-compatible journal mode, carry the busy_timeout so it waits on a
+	// concurrent writer rather than erroring, and keep mmap disabled.
 	ro, err := OpenReadOnly(dbPath)
 	if err != nil {
 		t.Fatalf("open read-only: %v", err)
@@ -198,6 +199,7 @@ func TestOpenAppliesPragmas(t *testing.T) {
 	requirePragma(t, ro.DB(), "journal_mode", "wal")
 	{{- end}}
 	requirePragma(t, ro.DB(), "busy_timeout", "5000")
+	requirePragma(t, ro.DB(), "mmap_size", "0")
 }
 
 // requirePragma fails the test unless `PRAGMA <name>` reports want. It reads

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -113,7 +113,7 @@ func OpenReadOnly(dbPath string) (*Store, error) {
 // OpenReadOnlyContext is OpenReadOnly with a caller-supplied context honored by
 // the driver-init SQLITE_BUSY retry.
 func OpenReadOnlyContext(ctx context.Context, dbPath string) (*Store, error) {
-	dsn := "file:" + dbPath + "?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
+	dsn := "file:" + dbPath + "?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	// state during reads, so they use a rollback journal and avoid WAL sidecar
 	// teardown races between short-lived processes. Other store profiles keep
 	// WAL for concurrent analytical reads.
-	dsn := dbPath + "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
+	dsn := dbPath + "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -117,7 +117,7 @@ func OpenReadOnly(dbPath string) (*Store, error) {
 // OpenReadOnlyContext is OpenReadOnly with a caller-supplied context honored by
 // the driver-init SQLITE_BUSY retry.
 func OpenReadOnlyContext(ctx context.Context, dbPath string) (*Store, error) {
-	dsn := "file:" + dbPath + "?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
+	dsn := "file:" + dbPath + "?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}
@@ -150,7 +150,7 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	// state during reads, so they use a rollback journal and avoid WAL sidecar
 	// teardown races between short-lived processes. Other store profiles keep
 	// WAL for concurrent analytical reads.
-	dsn := dbPath + "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
+	dsn := dbPath + "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -117,7 +117,7 @@ func OpenReadOnly(dbPath string) (*Store, error) {
 // OpenReadOnlyContext is OpenReadOnly with a caller-supplied context honored by
 // the driver-init SQLITE_BUSY retry.
 func OpenReadOnlyContext(ctx context.Context, dbPath string) (*Store, error) {
-	dsn := "file:" + dbPath + "?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
+	dsn := "file:" + dbPath + "?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}
@@ -150,7 +150,7 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	// state during reads, so they use a rollback journal and avoid WAL sidecar
 	// teardown races between short-lived processes. Other store profiles keep
 	// WAL for concurrent analytical reads.
-	dsn := dbPath + "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
+	dsn := dbPath + "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -117,7 +117,7 @@ func OpenReadOnly(dbPath string) (*Store, error) {
 // OpenReadOnlyContext is OpenReadOnly with a caller-supplied context honored by
 // the driver-init SQLITE_BUSY retry.
 func OpenReadOnlyContext(ctx context.Context, dbPath string) (*Store, error) {
-	dsn := "file:" + dbPath + "?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
+	dsn := "file:" + dbPath + "?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}
@@ -150,7 +150,7 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 	// state during reads, so they use a rollback journal and avoid WAL sidecar
 	// teardown races between short-lived processes. Other store profiles keep
 	// WAL for concurrent analytical reads.
-	dsn := dbPath + "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)"
+	dsn := dbPath + "?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Closes #3739.

Generated stores should avoid SQLite mmap because modernc.org/sqlite can fault mmap'd pages with SIGBUS when another process grows or checkpoints the local store.

## Approach

Emit `_pragma=mmap_size(0)` on both read-write and read-only store DSNs so generated CLIs use pread-based access. Extend the emitted store pragma regression test to assert `PRAGMA mmap_size` is `0` on both handles.

## Scope

Primary area: generator store template.

Why this belongs in this repo: every printed CLI inherits `internal/store/store.go` from the Printing Press generator, so the fix belongs in the reusable template instead of a single generated CLI.

## Risk

Read performance may give up the mmap optimization, but store access remains semantically equivalent and safer for the advertised multi-process sync plus MCP/read workflows.

## Output Contract

Generated store output now ships mmap disabled. The emitted `TestOpenAppliesPragmas` test pins the read-write and read-only `PRAGMA mmap_size` value, and the generated store golden fixtures now carry `mmap_size(0)`.

## Verification

- `go test ./internal/generator -run '^TestGenerateStoreExtrasHook$' -count=1`
- `GOTOOLCHAIN=go1.26.6 scripts/golden.sh verify`
- `GOTOOLCHAIN=go1.26.6 go test ./... -timeout 30m`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92066919-9862-41bf-b1a9-d332be05115c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92066919-9862-41bf-b1a9-d332be05115c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

