### PR TITLE
fix(cli): bind MCP HTTP to loopback by default

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -17857,6 +17857,25 @@ func TestGenerateMCPMainLargeAPIExplicitEndpointMirrorHonored(t *testing.T) {
 	assert.NotContains(t, body, "NewStreamableHTTPServer")
 }
 
+func TestGenerateMCPMainRemoteOptInDefaultsHTTPAddrToLoopback(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := spec.Parse(filepath.Join("..", "..", "testdata", "loops.yaml"))
+	require.NoError(t, err)
+	apiSpec.MCP = spec.MCPConfig{
+		Transport: []string{"stdio", "http"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+	requireGeneratedCompiles(t, outputDir)
+
+	body := readGeneratedMCPMain(t, outputDir, apiSpec.Name)
+	assert.Contains(t, body, `defaultHTTPAddr = "127.0.0.1:7777"`)
+	assert.NotContains(t, body, `defaultHTTPAddr = ":7777"`)
+}
+
 // TestGenerateMCPMainRemoteOptIn confirms that declaring mcp.transport: [stdio, http]
 // emits a flag-aware main with both transport branches, including the env-based
 // default and the custom --addr. Uses a byte-level check on the template
@@ -17868,22 +17887,19 @@ func TestGenerateMCPMainRemoteOptIn(t *testing.T) {
 	require.NoError(t, err)
 	apiSpec.MCP = spec.MCPConfig{
 		Transport: []string{"stdio", "http"},
-		Addr:      ":8123",
+		Addr:      "0.0.0.0:7777",
 	}
 
 	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
 	gen := New(apiSpec, outputDir)
 	require.NoError(t, gen.Generate())
 
-	mainPath := filepath.Join(outputDir, "cmd", naming.MCP(apiSpec.Name), "main.go")
-	data, err := os.ReadFile(mainPath)
-	require.NoError(t, err)
-	body := string(data)
+	body := readGeneratedMCPMain(t, outputDir, apiSpec.Name)
 
 	for _, want := range []string{
 		`"flag"`,
 		`"strings"`,
-		`defaultHTTPAddr = ":8123"`,
+		`defaultHTTPAddr = "0.0.0.0:7777"`,
 		`flag.String("transport"`,
 		`flag.String("addr"`,
 		`server.ServeStdio(s)`,
@@ -17894,6 +17910,15 @@ func TestGenerateMCPMainRemoteOptIn(t *testing.T) {
 		assert.Contains(t, body, want, "remote-opt-in main should contain %q", want)
 	}
 	assertMCPMainUsesVersionVar(t, body)
+}
+
+func readGeneratedMCPMain(t *testing.T, outputDir, apiName string) string {
+	t.Helper()
+
+	mainPath := filepath.Join(outputDir, "cmd", naming.MCP(apiName), "main.go")
+	data, err := os.ReadFile(mainPath)
+	require.NoError(t, err)
+	return string(data)
 }
 
 func assertMCPMainUsesVersionVar(t *testing.T, body string) {

--- a/internal/generator/templates/main_mcp.go.tmpl
+++ b/internal/generator/templates/main_mcp.go.tmpl
@@ -23,7 +23,7 @@ import (
 // guidance that production agents need a remote option.
 
 const (
-	defaultHTTPAddr = "{{if .MCP.Addr}}{{.MCP.Addr}}{{else}}:7777{{end}}"
+	defaultHTTPAddr = "{{if .MCP.Addr}}{{.MCP.Addr}}{{else}}127.0.0.1:7777{{end}}"
 )
 
 // version is the printed MCP server's version, overridable at build time via ldflags.

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -2817,17 +2817,16 @@ emits the thin search+execute pair that covers the typed-endpoint surface in
 `mcp.endpoint_tools: hidden` removes the raw per-endpoint tools that would
 otherwise still show up alongside the orchestration pair.
 
-**HTTP transport security default — read before enabling `http`.** The emitted
-MCP server binds its HTTP listener to all interfaces by default
-(`defaultHTTPAddr = ":7777"`) and does not authenticate reachable callers, so
-any client that can reach the port can invoke tools with the process's bound
-API credentials. The public library's Greptile review has flagged this on new
-CLI prints. If the CLI needs HTTP transport, either ship the `--addr` flag with
-a loopback default (`127.0.0.1:<port>`) so operators opt into exposure, or —
-for CLIs whose MCP surface is only consumed locally — remove HTTP transport
-entirely and keep the server stdio-only, which keeps the credential boundary at
-process ownership. Decide this before generation; changing it after the PR
-opens costs review cycles.
+**HTTP transport security default - read before enabling `http`.** The emitted
+MCP server binds its HTTP listener to loopback by default
+(`defaultHTTPAddr = "127.0.0.1:7777"`) and does not authenticate reachable
+callers. Any client that can reach a deliberately non-loopback `mcp.addr` or
+`--addr` value can invoke tools with the process's bound API credentials. If the
+CLI needs HTTP transport for local agents, rely on the loopback default. Only
+configure a non-loopback address when the exposure is deliberate; for CLIs whose
+MCP surface is only consumed locally, keep the server stdio-only when HTTP is
+not needed. Decide this before generation; changing it after the PR opens costs
+review cycles.
 
 For command-dominant CLIs where cobratree-walked tools greatly outnumber typed
 endpoints, do not present code orchestration as the context-reduction remedy for

--- a/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/cmd/cafe-bistro-pp-mcp/main.go
+++ b/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/cmd/cafe-bistro-pp-mcp/main.go
@@ -21,7 +21,7 @@ import (
 // guidance that production agents need a remote option.
 
 const (
-	defaultHTTPAddr = ":7777"
+	defaultHTTPAddr = "127.0.0.1:7777"
 )
 
 // version is the printed MCP server's version, overridable at build time via ldflags.

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/cmd/printing-press-golden-pp-mcp/main.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/cmd/printing-press-golden-pp-mcp/main.go
@@ -21,7 +21,7 @@ import (
 // guidance that production agents need a remote option.
 
 const (
-	defaultHTTPAddr = ":7777"
+	defaultHTTPAddr = "127.0.0.1:7777"
 )
 
 // version is the printed MCP server's version, overridable at build time via ldflags.

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/cmd/mcp-cloudflare-pp-mcp/main.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/cmd/mcp-cloudflare-pp-mcp/main.go
@@ -21,7 +21,7 @@ import (
 // guidance that production agents need a remote option.
 
 const (
-	defaultHTTPAddr = ":7777"
+	defaultHTTPAddr = "127.0.0.1:7777"
 )
 
 // version is the printed MCP server's version, overridable at build time via ldflags.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Closes #3737

Generated MCP binaries that opt into streamable HTTP should not listen on all interfaces when no address is configured.

## Approach

The MCP main template now emits `127.0.0.1:7777` as the fallback `defaultHTTPAddr`. Specs that set `mcp.addr` still render that configured value unchanged, including non-loopback binds such as `0.0.0.0:7777`.

Updated the Printing Press skill guidance so agents no longer treat the wildcard bind as the generator default.

## Output Contract

Added and updated generated-output coverage for both paths:

- omitted `mcp.addr` emits `defaultHTTPAddr = "127.0.0.1:7777"` and compiles the generated CLI
- explicit `mcp.addr: 0.0.0.0:7777` is preserved in the emitted MCP binary source
- golden generated MCP main artifacts now capture the loopback fallback

## Verification

- `go fmt ./...`
- `go test ./internal/generator -run 'TestGenerateMCPMainRemoteOptIn' -count=1`
- `go test ./... -timeout 20m`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify` confirms the affected generated MCP artifacts after the expected updates; the command still exits nonzero on unrelated dogfood/runtime-matrix fixture issues (`dogfood-verdict-matrix` fixture build and missing `verify-runtime-matrix` structural artifact).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39d09959-3455-4faf-ab57-10187ec8cf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39d09959-3455-4faf-ab57-10187ec8cf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

