### PR TITLE
fix(cli): treat unclassified dogfood commands as mutating

### DIFF
--- a/internal/cli/dogfood_test.go
+++ b/internal/cli/dogfood_test.go
@@ -185,10 +185,10 @@ if [ "${1:-}" = "agent-context" ]; then
 {
   "commands": [
     {"name":"alpha","subcommands":[
-      {"name":"list"}
+      {"name":"list","annotations":{"pp:method":"GET"}}
     ]},
     {"name":"widgets","subcommands":[
-      {"name":"list"}
+      {"name":"list","annotations":{"pp:method":"GET"}}
     ]}
   ]
 }

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -48,6 +48,7 @@ const reasonDestructiveAtAuth = "destructive-at-auth"
 const reasonMutatingDryRunOnly = "mutating command dry-run only"
 const reasonMutatingErrorPath = "mutating command; error_path would call live API without --dry-run"
 const reasonMutatingRunnableFixture = "blocked-fixture: mutating command requires runnable example"
+const reasonSyncDryRunRequired = "sync command requires --dry-run"
 const reasonUnclassifiedNoMethod = "unclassified: no pp:method"
 const reasonNoLiveSignal = "no live happy/json pass; credential-unavailable skips cannot certify acceptance"
 const reasonUnverifiedNeedsAccess = "unverified-needs-access"
@@ -608,6 +609,10 @@ func isReadLeaf(name string) bool {
 		}
 	}
 	return isCompanionLeaf(name)
+}
+
+func isSyncLeaf(name string) bool {
+	return slices.Contains(commandNameTokens(name), "sync")
 }
 
 func liveDogfoodCommandMutates(command liveDogfoodCommand) bool {
@@ -1579,6 +1584,15 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 		if useDryRun {
 			results = append(results, skippedLiveDogfoodResult(commandName, LiveDogfoodTestErrorReal, tierSkip))
 		}
+		return results
+	}
+
+	if mutating && len(command.Path) > 0 && isSyncLeaf(command.Path[len(command.Path)-1]) && !useDryRun {
+		results = append(results,
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, reasonSyncDryRunRequired),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, reasonSyncDryRunRequired),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestError, reasonSyncDryRunRequired),
+		)
 		return results
 	}
 

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -581,6 +581,7 @@ var mutatingVerbs = map[string]bool{
 	"set": true, "modify": true, "replace": true,
 	"post": true, "put": true, "send": true, "submit": true,
 	"transfer": true, "cancel": true, "freeze": true, "unfreeze": true,
+	"sync": true,
 }
 
 var readVerbs = map[string]bool{
@@ -588,7 +589,7 @@ var readVerbs = map[string]bool{
 	"describe": true, "view": true, "info": true, "lookup": true,
 	"fetch": true, "retrieve": true, "query": true, "find": true,
 	"search": true, "status": true, "stats": true, "history": true,
-	"recent": true, "feed": true, "sync": true,
+	"recent": true, "feed": true,
 }
 
 func isMutatingLeaf(name string) bool {

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -588,7 +588,7 @@ var readVerbs = map[string]bool{
 	"describe": true, "view": true, "info": true, "lookup": true,
 	"fetch": true, "retrieve": true, "query": true, "find": true,
 	"search": true, "status": true, "stats": true, "history": true,
-	"recent": true, "feed": true,
+	"recent": true, "feed": true, "sync": true,
 }
 
 func isMutatingLeaf(name string) bool {

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -1555,14 +1555,6 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 	mutation := liveDogfoodCommandMutation(command)
 	mutating := mutation.mutating
 	useDryRun := mutating && commandSupportsDryRun(command.Help)
-	if mutation.unclassified && !useDryRun {
-		results = append(results,
-			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, reasonUnclassifiedNoMethod),
-			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, reasonUnclassifiedNoMethod),
-			skippedLiveDogfoodResult(commandName, LiveDogfoodTestError, reasonUnclassifiedNoMethod),
-		)
-		return results
-	}
 
 	if annotationIsTrueValue(command.Annotations[interactiveAnnotation]) {
 		results = append(results,
@@ -1668,6 +1660,13 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, syntheticParamSkip),
 			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, syntheticParamSkip),
 		)
+	case mutation.unclassified && !useDryRun:
+		results = append(results,
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, reasonUnclassifiedNoMethod),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, reasonUnclassifiedNoMethod),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestError, reasonUnclassifiedNoMethod),
+		)
+		return results
 	default:
 		happyArgs = resolvedArgs
 

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -48,6 +48,7 @@ const reasonDestructiveAtAuth = "destructive-at-auth"
 const reasonMutatingDryRunOnly = "mutating command dry-run only"
 const reasonMutatingErrorPath = "mutating command; error_path would call live API without --dry-run"
 const reasonMutatingRunnableFixture = "blocked-fixture: mutating command requires runnable example"
+const reasonUnclassifiedNoMethod = "unclassified: no pp:method"
 const reasonNoLiveSignal = "no live happy/json pass; credential-unavailable skips cannot certify acceptance"
 const reasonUnverifiedNeedsAccess = "unverified-needs-access"
 
@@ -596,19 +597,37 @@ func liveDogfoodCommandMutates(command liveDogfoodCommand) bool {
 }
 
 func commandMutates(annotations map[string]string, commandPath []string) bool {
+	return commandMutation(annotations, commandPath).mutating
+}
+
+type commandMutationClassification struct {
+	mutating     bool
+	unclassified bool
+}
+
+func liveDogfoodCommandMutation(command liveDogfoodCommand) commandMutationClassification {
+	return commandMutation(command.Annotations, command.Path)
+}
+
+func commandMutation(annotations map[string]string, commandPath []string) commandMutationClassification {
 	if annotationIsTrueValue(annotations[mcpReadOnlyAnnotation]) {
-		return false
+		return commandMutationClassification{}
 	}
 	if annotationIsTrueValue(annotations[mcpLocalWriteAnnotation]) {
-		return true
+		return commandMutationClassification{mutating: true}
 	}
 	if method := strings.ToUpper(strings.TrimSpace(annotations[endpointMethodAnnotation])); method != "" {
-		return method == "POST" || method == "PUT" || method == "PATCH" || method == "DELETE"
+		return commandMutationClassification{
+			mutating: method == "POST" || method == "PUT" || method == "PATCH" || method == "DELETE",
+		}
 	}
 	if len(commandPath) == 0 {
-		return false
+		return commandMutationClassification{}
 	}
-	return isMutatingLeaf(commandPath[len(commandPath)-1])
+	if isMutatingLeaf(commandPath[len(commandPath)-1]) {
+		return commandMutationClassification{mutating: true}
+	}
+	return commandMutationClassification{mutating: true, unclassified: true}
 }
 
 func commandNameTokens(name string) []string {
@@ -1513,8 +1532,17 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 	// same contract `verify` honors. Commands with no declaration keep the
 	// default {0}, so their happy/json verdicts are unchanged.
 	successCodes := liveDogfoodSuccessExitCodes(command)
-	mutating := liveDogfoodCommandMutates(command)
+	mutation := liveDogfoodCommandMutation(command)
+	mutating := mutation.mutating
 	useDryRun := mutating && commandSupportsDryRun(command.Help)
+	if mutation.unclassified && !useDryRun {
+		results = append(results,
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, reasonUnclassifiedNoMethod),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, reasonUnclassifiedNoMethod),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestError, reasonUnclassifiedNoMethod),
+		)
+		return results
+	}
 
 	if annotationIsTrueValue(command.Annotations[interactiveAnnotation]) {
 		results = append(results,

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -583,6 +583,14 @@ var mutatingVerbs = map[string]bool{
 	"transfer": true, "cancel": true, "freeze": true, "unfreeze": true,
 }
 
+var readVerbs = map[string]bool{
+	"get": true, "list": true, "show": true, "read": true,
+	"describe": true, "view": true, "info": true, "lookup": true,
+	"fetch": true, "retrieve": true, "query": true, "find": true,
+	"search": true, "status": true, "stats": true, "history": true,
+	"recent": true, "feed": true,
+}
+
 func isMutatingLeaf(name string) bool {
 	for _, token := range commandNameTokens(name) {
 		if mutatingVerbs[token] {
@@ -590,6 +598,15 @@ func isMutatingLeaf(name string) bool {
 		}
 	}
 	return false
+}
+
+func isReadLeaf(name string) bool {
+	for _, token := range commandNameTokens(name) {
+		if readVerbs[token] {
+			return true
+		}
+	}
+	return isCompanionLeaf(name)
 }
 
 func liveDogfoodCommandMutates(command liveDogfoodCommand) bool {
@@ -626,6 +643,9 @@ func commandMutation(annotations map[string]string, commandPath []string) comman
 	}
 	if isMutatingLeaf(commandPath[len(commandPath)-1]) {
 		return commandMutationClassification{mutating: true}
+	}
+	if isReadLeaf(commandPath[len(commandPath)-1]) {
+		return commandMutationClassification{}
 	}
 	return commandMutationClassification{mutating: true, unclassified: true}
 }

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -1841,6 +1841,7 @@ func TestLiveDogfoodMutatingLeafDetectionTokenizesCommandNames(t *testing.T) {
 		"request-send-money",
 		"transfer",
 		"set-token",
+		"sync",
 	} {
 		assert.True(t, isMutatingLeaf(name), "%s should be treated as mutating", name)
 	}
@@ -1881,6 +1882,12 @@ func TestLiveDogfoodCommandMutatesPrefersEndpointMethod(t *testing.T) {
 	}).unclassified)
 	assert.True(t, liveDogfoodCommandMutation(liveDogfoodCommand{
 		Path: []string{"courses", "publish"},
+	}).unclassified)
+	assert.True(t, liveDogfoodCommandMutates(liveDogfoodCommand{
+		Path: []string{"sync"},
+	}))
+	assert.False(t, liveDogfoodCommandMutation(liveDogfoodCommand{
+		Path: []string{"sync"},
 	}).unclassified)
 }
 
@@ -6152,6 +6159,8 @@ func TestRunLiveDogfoodSearchErrorPathMutationFallthrough(t *testing.T) {
 //     --dry-run. The matrix must inject --dry-run instead of executing live.
 //   - widgets activate - unclassified no-method command without --dry-run.
 //     The matrix must skip it before invoking the binary.
+//   - sync - unannotated store-population command that advertises --dry-run.
+//     The matrix must treat it as mutating and inject --dry-run.
 func writeLiveDogfoodDryRunFixture(t *testing.T) (dir string, binaryName string) {
 	t.Helper()
 
@@ -6173,6 +6182,7 @@ if [ "$1" = "agent-context" ]; then
   cat <<'JSON'
 {
   "commands": [
+    {"name":"sync"},
     {"name":"widgets","subcommands":[
       {"name":"create"},
       {"name":"destroy"},
@@ -6195,6 +6205,35 @@ for a in "$@"; do
     --dry-run|--dry-run=*) has_dry_run=1 ;;
   esac
 done
+
+# ---------- sync: unannotated store-population command with --dry-run advertised ----------
+if [ "$1" = "sync" ] && [ "${2:-}" = "--help" ]; then
+  cat <<'HELP'
+Sync the source into the local store.
+
+Usage:
+  fixture-pp-cli sync [flags]
+
+Examples:
+  fixture-pp-cli sync
+
+Flags:
+      --json   Output JSON
+
+Global Flags:
+      --dry-run   Show request without sending
+HELP
+  exit 0
+fi
+
+if [ "$1" = "sync" ]; then
+  if [ "$has_dry_run" = "1" ]; then
+    echo '{"action":"sync","status":0,"success":false,"dry_run":true}'
+    exit 0
+  fi
+  echo 'unexpected live sync invocation' >&2
+  exit 99
+fi
 
 # ---------- widgets create: mutator with --dry-run advertised ----------
 if [ "$1" = "widgets" ] && [ "$2" = "create" ] && [ "${3:-}" = "--help" ]; then
@@ -6530,6 +6569,20 @@ func TestRunLiveDogfoodInjectsDryRunForUnclassifiedCommand(t *testing.T) {
 	assert.Equal(t, LiveDogfoodStatusPass, got.Status, got.Reason)
 	assert.Contains(t, got.Args, "--dry-run",
 		"expected matrix to inject --dry-run into unclassified commands that advertise it")
+}
+
+func TestRunLiveDogfoodInjectsDryRunForUnannotatedSync(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+	dir, binaryName := writeLiveDogfoodDryRunFixture(t)
+	report := runDryRunFixtureMatrix(t, dir, binaryName)
+
+	got := findResultByCommandKind(report, "sync", LiveDogfoodTestHappy)
+	require.NotNil(t, got, "expected sync happy_path result in matrix")
+	assert.Equal(t, LiveDogfoodStatusPass, got.Status, got.Reason)
+	assert.Contains(t, got.Args, "--dry-run",
+		"expected matrix to inject --dry-run into unannotated sync")
 }
 
 func TestRunLiveDogfoodSkipsUnclassifiedCommandWithoutDryRun(t *testing.T) {

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -2480,8 +2480,8 @@ if [ "$1" = "agent-context" ]; then
 {
   "commands": [
     {"name":"reports","subcommands":[
-      {"name":"prospects"},
-      {"name":"summary"}
+      {"name":"prospects","annotations":{"pp:method":"GET"}},
+      {"name":"summary","annotations":{"pp:method":"GET"}}
     ]},
     {"name":"events","subcommands":[
       {"name":"list","annotations":{"pp:method":"GET","mcp:read-only":"true"}}
@@ -2654,7 +2654,7 @@ if [ "$1" = "agent-context" ]; then
 {
   "commands": [
     {"name":"reports","subcommands":[
-      {"name":"broken-filter"}
+      {"name":"broken-filter","annotations":{"pp:method":"GET"}}
     ]}
   ]
 }
@@ -4995,7 +4995,7 @@ if [ "$1" = "agent-context" ]; then
 {
   "commands": [
     {"name":"api-keys","subcommands":[
-      {"name":"refresh","annotations":{"pp:endpoint":"api-keys.keys-refresh"}}
+      {"name":"refresh","annotations":{"pp:endpoint":"api-keys.keys-refresh","pp:method":"POST"}}
     ]},
     {"name":"widgets","subcommands":[
       {"name":"list"}
@@ -7027,10 +7027,10 @@ if [ "$1" = "agent-context" ]; then
 {
   "commands": [
     {"name":"records","subcommands":[
-      {"name":"verify","annotations":{"pp:typed-exit-codes":"0,2"}}
+      {"name":"verify","annotations":{"pp:method":"GET","pp:typed-exit-codes":"0,2"}}
     ]},
     {"name":"items","subcommands":[
-      {"name":"verify"}
+      {"name":"verify","annotations":{"pp:method":"GET"}}
     ]}
   ]
 }

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -2211,11 +2211,11 @@ func TestRunLiveDogfoodHappyPathHandlesShellCommentInExample(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	happy := findResultByCommandKind(report, "sync", LiveDogfoodTestHappy)
-	require.NotNil(t, happy, "expected sync happy_path result")
+	happy := findResultByCommandKind(report, "status", LiveDogfoodTestHappy)
+	require.NotNil(t, happy, "expected status happy_path result")
 	assert.Equal(t, LiveDogfoodStatusPass, happy.Status,
 		"trailing '# comment' in Cobra Example must not bleed into happy_path argv (reason=%q)", happy.Reason)
-	assert.Equal(t, []string{"sync"}, happy.Args,
+	assert.Equal(t, []string{"status"}, happy.Args,
 		"happy_path argv must contain only the subcommand path, not the comment text")
 }
 
@@ -2234,22 +2234,22 @@ if [ "$1" = "agent-context" ]; then
   cat <<'JSON'
 {
   "commands": [
-    {"name":"sync"}
+    {"name":"status"}
   ]
 }
 JSON
   exit 0
 fi
 
-if [ "$1" = "sync" ] && [ "${2:-}" = "--help" ]; then
+if [ "$1" = "status" ] && [ "${2:-}" = "--help" ]; then
   cat <<'HELP'
-Refresh local cache.
+Show service status.
 
 Usage:
-  fixture-pp-cli sync [flags]
+  fixture-pp-cli status [flags]
 
 Examples:
-  fixture-pp-cli sync                       # full schema + records refresh
+  fixture-pp-cli status                     # include service health
 
 Flags:
       --json    Output JSON
@@ -2257,18 +2257,18 @@ HELP
   exit 0
 fi
 
-if [ "$1" = "sync" ]; then
-  # Anything past 'sync' means the example's trailing comment leaked into
+if [ "$1" = "status" ]; then
+  # Anything past 'status' means the example's trailing comment leaked into
   # argv — fail loudly so the test catches the regression.
   if [ "$#" -gt 1 ] && [ "${2}" != "--json" ]; then
-    echo "unexpected sync args: $*" >&2
+    echo "unexpected status args: $*" >&2
     exit 4
   fi
   if [ "${2:-}" = "--json" ]; then
-    echo '{"synced":true}'
+    echo '{"ok":true}'
     exit 0
   fi
-  echo 'synced'
+  echo 'ok'
   exit 0
 fi
 
@@ -6462,6 +6462,61 @@ func runDryRunFixtureMatrix(t *testing.T, dir, binaryName string) *LiveDogfoodRe
 	return report
 }
 
+func writeLiveDogfoodSyncNoDryRunFixture(t *testing.T) (dir string, binaryName string, argvLogPath string) {
+	t.Helper()
+
+	dir = t.TempDir()
+	binaryName = "fixture-pp-cli"
+	writeTestManifestForLiveDogfood(t, dir)
+	argvLogPath = filepath.Join(t.TempDir(), "argv.log")
+
+	binPath := filepath.Join(dir, binaryName)
+	script := `#!/bin/sh
+set -u
+
+if [ -n "${PRINTING_PRESS_TEST_ARGV_LOG:-}" ]; then
+  printf '%s\n' "$*" >> "$PRINTING_PRESS_TEST_ARGV_LOG"
+fi
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"sync"}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "sync" ] && [ "${2:-}" = "--help" ]; then
+  cat <<'HELP'
+Sync the source into the local store.
+
+Usage:
+  fixture-pp-cli sync [flags]
+
+Examples:
+  fixture-pp-cli sync
+
+Flags:
+      --json   Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "sync" ]; then
+  echo 'unexpected live sync invocation' >&2
+  exit 99
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`
+	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755))
+	return dir, binaryName, argvLogPath
+}
+
 func TestRunLiveDogfoodInjectsDryRunForMutator(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")
@@ -6583,6 +6638,25 @@ func TestRunLiveDogfoodInjectsDryRunForUnannotatedSync(t *testing.T) {
 	assert.Equal(t, LiveDogfoodStatusPass, got.Status, got.Reason)
 	assert.Contains(t, got.Args, "--dry-run",
 		"expected matrix to inject --dry-run into unannotated sync")
+}
+
+func TestRunLiveDogfoodSkipsUnannotatedSyncWithoutDryRun(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+	dir, binaryName, argvLogPath := writeLiveDogfoodSyncNoDryRunFixture(t)
+	t.Setenv("PRINTING_PRESS_TEST_ARGV_LOG", argvLogPath)
+	report := runDryRunFixtureMatrix(t, dir, binaryName)
+
+	got := findResultByCommandKind(report, "sync", LiveDogfoodTestHappy)
+	require.NotNil(t, got, "expected sync happy_path result in matrix")
+	assert.Equal(t, LiveDogfoodStatusSkip, got.Status, got.Reason)
+	assert.Equal(t, reasonSyncDryRunRequired, got.Reason)
+	assert.Empty(t, got.Args, "skipped sync must not include executable mutation args")
+
+	lines := readArgvLog(t, argvLogPath)
+	assert.Equal(t, 0, countArgvLines(lines, "sync")-countArgvLines(lines, "sync --help"),
+		"sync without --dry-run must not invoke the binary")
 }
 
 func TestRunLiveDogfoodSkipsUnclassifiedCommandWithoutDryRun(t *testing.T) {

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -6655,8 +6655,7 @@ func TestRunLiveDogfoodSkipsUnannotatedSyncWithoutDryRun(t *testing.T) {
 	assert.Empty(t, got.Args, "skipped sync must not include executable mutation args")
 
 	lines := readArgvLog(t, argvLogPath)
-	assert.Equal(t, 0, countArgvLines(lines, "sync")-countArgvLines(lines, "sync --help"),
-		"sync without --dry-run must not invoke the binary")
+	assert.NotContains(t, lines, "sync", "sync without --dry-run must not invoke the binary")
 }
 
 func TestRunLiveDogfoodSkipsUnclassifiedCommandWithoutDryRun(t *testing.T) {

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -6655,7 +6655,13 @@ func TestRunLiveDogfoodSkipsUnannotatedSyncWithoutDryRun(t *testing.T) {
 	assert.Empty(t, got.Args, "skipped sync must not include executable mutation args")
 
 	lines := readArgvLog(t, argvLogPath)
-	assert.NotContains(t, lines, "sync", "sync without --dry-run must not invoke the binary")
+	syncCalls := 0
+	for _, line := range lines {
+		if line == "sync" {
+			syncCalls++
+		}
+	}
+	assert.Equal(t, 1, syncCalls, "only the explicit pre-sync hydration may invoke sync without --dry-run")
 }
 
 func TestRunLiveDogfoodSkipsUnclassifiedCommandWithoutDryRun(t *testing.T) {

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -4361,9 +4361,9 @@ if [ "$1" = "agent-context" ]; then
 {
   "commands": [
     {"name":"widgets","subcommands":[
-      {"name":"list"},
-      {"name":"get"},
-      {"name":"broken"}
+      {"name":"list","annotations":{"pp:method":"GET"}},
+      {"name":"get","annotations":{"pp:method":"GET"}},
+      {"name":"broken","annotations":{"pp:method":"GET"}}
     ]},
     {"name":"completion","subcommands":[{"name":"bash"}]}
   ]
@@ -4674,7 +4674,7 @@ if [ "$1" = "agent-context" ]; then
   cat <<'JSON'
 {
   "commands": [
-    {"name":"widgets","subcommands":[{"name":"large"}]}
+    {"name":"widgets","subcommands":[{"name":"large","annotations":{"pp:method":"GET"}}]}
   ]
 }
 JSON

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -1866,6 +1866,22 @@ func TestLiveDogfoodCommandMutatesPrefersEndpointMethod(t *testing.T) {
 		Path:        []string{"accounts", "plain-name"},
 		Annotations: map[string]string{"pp:method": "POST"},
 	}))
+	assert.True(t, liveDogfoodCommandMutates(liveDogfoodCommand{
+		Path: []string{"courses", "publish"},
+	}))
+	assert.True(t, liveDogfoodCommandMutates(liveDogfoodCommand{
+		Path: []string{"courses", "publish"},
+		Annotations: map[string]string{
+			"mcp:read-only": "false",
+		},
+	}))
+	assert.False(t, liveDogfoodCommandMutation(liveDogfoodCommand{
+		Path:        []string{"courses", "publish"},
+		Annotations: map[string]string{"pp:method": "GET"},
+	}).unclassified)
+	assert.True(t, liveDogfoodCommandMutation(liveDogfoodCommand{
+		Path: []string{"courses", "publish"},
+	}).unclassified)
 }
 
 func TestLiveDogfoodCommandMutatesHonorsLocalWrite(t *testing.T) {
@@ -6122,13 +6138,20 @@ func TestRunLiveDogfoodSearchErrorPathMutationFallthrough(t *testing.T) {
 //     --dry-run, exits 1 (modeling the live-API placeholder-body rejection
 //     class). When PRINTING_PRESS_TEST_DRY_RUN_BROKEN=1, exits 1 even with
 //     --dry-run, modeling a broken dry-run preview (R3).
-//   - widgets destroy — mutator (leaf in mutatingVerbs) that does NOT
+//   - widgets destroy - mutator (leaf in mutatingVerbs) that does NOT
 //     advertise --dry-run (hand-written novel command shape). The matrix
 //     should fail the gate's second leg and keep today behavior: no
 //     --dry-run injection and no error_path_real entry.
-//   - widgets get — non-mutator (read). Advertises --dry-run via the
-//     persistent root flag, but the matrix must not inject because the leaf
-//     is not in mutatingVerbs.
+//   - widgets get - annotated GET read. Advertises --dry-run via the
+//     persistent root flag, but the matrix must not inject because the
+//     endpoint method marks it as read-only.
+//   - widgets lookup - annotated read-only command. Advertises --dry-run via
+//     the persistent root flag, but the matrix must not inject because the
+//     MCP annotation marks it as read-only.
+//   - widgets publish - unclassified no-method command that advertises
+//     --dry-run. The matrix must inject --dry-run instead of executing live.
+//   - widgets activate - unclassified no-method command without --dry-run.
+//     The matrix must skip it before invoking the binary.
 func writeLiveDogfoodDryRunFixture(t *testing.T) (dir string, binaryName string) {
 	t.Helper()
 
@@ -6153,7 +6176,10 @@ if [ "$1" = "agent-context" ]; then
     {"name":"widgets","subcommands":[
       {"name":"create"},
       {"name":"destroy"},
-      {"name":"get"},
+      {"name":"get","annotations":{"pp:method":"GET"}},
+      {"name":"lookup","annotations":{"mcp:read-only":"true"}},
+      {"name":"publish"},
+      {"name":"activate"},
       {"name":"update"}
     ]}
   ]
@@ -6267,6 +6293,86 @@ if [ "$1" = "widgets" ] && [ "$2" = "get" ]; then
   fi
   echo '{"id":"42"}'
   exit 0
+fi
+
+# ---------- widgets lookup: read-only annotated command with --dry-run advertised globally ----------
+if [ "$1" = "widgets" ] && [ "$2" = "lookup" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Look up widgets.
+
+Usage:
+  fixture-pp-cli widgets lookup [flags]
+
+Examples:
+  fixture-pp-cli widgets lookup
+
+Flags:
+      --json   Output JSON
+
+Global Flags:
+      --dry-run   Show request without sending
+HELP
+  exit 0
+fi
+
+if [ "$1" = "widgets" ] && [ "$2" = "lookup" ]; then
+  if [ "$has_dry_run" = "1" ]; then
+    echo 'unexpected --dry-run on read-only command' >&2
+    exit 99
+  fi
+  echo '{"id":"42"}'
+  exit 0
+fi
+
+# ---------- widgets publish: unclassified command with --dry-run advertised ----------
+if [ "$1" = "widgets" ] && [ "$2" = "publish" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Publish widgets.
+
+Usage:
+  fixture-pp-cli widgets publish [flags]
+
+Examples:
+  fixture-pp-cli widgets publish
+
+Flags:
+      --json   Output JSON
+
+Global Flags:
+      --dry-run   Show request without sending
+HELP
+  exit 0
+fi
+
+if [ "$1" = "widgets" ] && [ "$2" = "publish" ]; then
+  if [ "$has_dry_run" = "1" ]; then
+    echo '{"action":"publish","resource":"widgets","status":0,"success":false,"dry_run":true}'
+    exit 0
+  fi
+  echo 'unexpected live publish invocation' >&2
+  exit 99
+fi
+
+# ---------- widgets activate: unclassified command without --dry-run advertised ----------
+if [ "$1" = "widgets" ] && [ "$2" = "activate" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Activate widgets.
+
+Usage:
+  fixture-pp-cli widgets activate [flags]
+
+Examples:
+  fixture-pp-cli widgets activate
+
+Flags:
+      --json   Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "widgets" ] && [ "$2" = "activate" ]; then
+  echo 'unexpected live activate invocation' >&2
+  exit 99
 fi
 
 # ---------- widgets update <id>: mutator with positional + no list companion ----------
@@ -6388,14 +6494,62 @@ func TestRunLiveDogfoodSkipsDryRunInjectionForReadCommand(t *testing.T) {
 	dir, binaryName := writeLiveDogfoodDryRunFixture(t)
 	report := runDryRunFixtureMatrix(t, dir, binaryName)
 
-	// widgets get is a read command. Even though --dry-run is advertised
-	// (as a global flag), the leaf is not in mutatingVerbs, so injection
-	// must not happen. Fixture surfaces a regression as exit 99.
+	// widgets get is a GET endpoint. Even though --dry-run is advertised
+	// (as a global flag), the endpoint method marks it as read-only, so
+	// injection must not happen. Fixture surfaces a regression as exit 99.
 	got := findResultByCommandKind(report, "widgets get", LiveDogfoodTestHappy)
 	require.NotNil(t, got)
 	assert.Equal(t, LiveDogfoodStatusPass, got.Status, got.Reason)
 	assert.NotContains(t, got.Args, "--dry-run",
-		"expected matrix to skip --dry-run injection on non-mutator read commands")
+		"expected matrix to skip --dry-run injection on GET endpoint commands")
+}
+
+func TestRunLiveDogfoodSkipsDryRunInjectionForReadOnlyAnnotatedCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+	dir, binaryName := writeLiveDogfoodDryRunFixture(t)
+	report := runDryRunFixtureMatrix(t, dir, binaryName)
+
+	got := findResultByCommandKind(report, "widgets lookup", LiveDogfoodTestHappy)
+	require.NotNil(t, got)
+	assert.Equal(t, LiveDogfoodStatusPass, got.Status, got.Reason)
+	assert.NotContains(t, got.Args, "--dry-run",
+		"expected matrix to skip --dry-run injection on read-only annotated commands")
+}
+
+func TestRunLiveDogfoodInjectsDryRunForUnclassifiedCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+	dir, binaryName := writeLiveDogfoodDryRunFixture(t)
+	report := runDryRunFixtureMatrix(t, dir, binaryName)
+
+	got := findResultByCommandKind(report, "widgets publish", LiveDogfoodTestHappy)
+	require.NotNil(t, got, "expected widgets publish happy_path result in matrix")
+	assert.Equal(t, LiveDogfoodStatusPass, got.Status, got.Reason)
+	assert.Contains(t, got.Args, "--dry-run",
+		"expected matrix to inject --dry-run into unclassified commands that advertise it")
+}
+
+func TestRunLiveDogfoodSkipsUnclassifiedCommandWithoutDryRun(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+	argvLogPath := filepath.Join(t.TempDir(), "argv.log")
+	t.Setenv("PRINTING_PRESS_TEST_ARGV_LOG", argvLogPath)
+	dir, binaryName := writeLiveDogfoodDryRunFixture(t)
+	report := runDryRunFixtureMatrix(t, dir, binaryName)
+
+	got := findResultByCommandKind(report, "widgets activate", LiveDogfoodTestHappy)
+	require.NotNil(t, got, "expected widgets activate happy_path result in matrix")
+	assert.Equal(t, LiveDogfoodStatusSkip, got.Status, got.Reason)
+	assert.Equal(t, reasonUnclassifiedNoMethod, got.Reason)
+	assert.Empty(t, got.Args, "skipped unclassified command must not include executable mutation args")
+
+	lines := readArgvLog(t, argvLogPath)
+	assert.Equal(t, 0, countArgvLines(lines, "widgets activate")-countArgvLines(lines, "widgets activate --help"),
+		"unclassified command without --dry-run must not invoke the binary")
 }
 
 func TestRunLiveDogfoodSkipsErrorPathRealForMutatorWithDryRun(t *testing.T) {

--- a/testdata/golden/expected/verify-runtime-matrix/mock-pass.json
+++ b/testdata/golden/expected/verify-runtime-matrix/mock-pass.json
@@ -19,7 +19,7 @@
         "dry_run": true,
         "execute": true,
         "help": true,
-        "kind": "read",
+        "kind": "write",
         "score": 3
       }
     ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Closes #3893.

`printing-press dogfood --live` must not execute commands live when the runner cannot prove they are read-only, locally safe, or backed by a typed endpoint method.

## Approach

Commands with `mcp:read-only: "true"` remain non-mutating, and commands with `pp:method: GET` continue to run live as reads. Commands without `pp:method` that are neither recognized read leaves nor recognized mutating leaves now fail closed as unclassified mutating commands. If they advertise `--dry-run`, the matrix injects it. If they do not, the matrix skips happy, JSON, and error probes with `unclassified: no pp:method` instead of invoking the binary.

`sync` is explicitly classified as mutating so generated store-population commands are dry-run protected in the live matrix. If an unannotated sync command does not advertise `--dry-run`, the matrix skips it with `sync command requires --dry-run`. The explicit pre-sync hydration path remains separate and unchanged.

The runtime command matrix now also reports unannotated unknown leaves as `write`, matching the safer classifier.

## Verification

- `go test ./internal/pipeline -run 'TestLiveDogfood(MutatingLeafDetectionTokenizesCommandNames|CommandMutatesPrefersEndpointMethod)|TestRunLiveDogfood(InjectsDryRunForUnannotatedSync|SkipsUnannotatedSyncWithoutDryRun|InjectsDryRunForUnclassifiedCommand|SkipsUnclassifiedCommandWithoutDryRun|HappyPathHandlesShellCommentInExample)'`
- `go test ./internal/pipeline`
- `GOTOOLCHAIN=go1.26.6 scripts/golden.sh verify`
- Earlier full-suite pass on this branch: `GOFLAGS='-timeout=20m' go test ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1589219-de95-4601-ab67-b8642e1d3c9e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1589219-de95-4601-ab67-b8642e1d3c9e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

