### PR TITLE
fix(cli): preserve .git on lock promote in-place

### DIFF
--- a/internal/pipeline/lock.go
+++ b/internal/pipeline/lock.go
@@ -254,6 +254,13 @@ func promoteWorkingCLI(cliName, workingDir string, state *PipelineState) (*Promo
 	if err := os.MkdirAll(filepath.Dir(libraryDir), 0o755); err != nil {
 		return nil, fmt.Errorf("creating library parent directory: %w", err)
 	}
+	sameTarget, err := sameDirectory(workingDir, libraryDir)
+	if err != nil {
+		return nil, err
+	}
+	if sameTarget {
+		return promoteWorkingCLIInPlace(cliName, libraryDir, backupDir, state)
+	}
 
 	// If a previous promote died after moving the live library to backup but
 	// before swapping in staging, restore that backup before attempting a retry.
@@ -352,7 +359,49 @@ func promoteWorkingCLI(cliName, workingDir string, state *PipelineState) (*Promo
 	// Swap succeeded — remove the backup.
 	_ = os.RemoveAll(backupDir)
 
-	// Update current run pointer so working_dir reflects library path.
+	return finishPromote(cliName, libraryDir, state, preservedPatches)
+}
+
+func sameDirectory(a, b string) (bool, error) {
+	aInfo, err := os.Stat(a)
+	if err != nil {
+		return false, fmt.Errorf("checking working directory: %w", err)
+	}
+	bInfo, err := os.Stat(b)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("checking library directory before promote: %w", err)
+	}
+	return os.SameFile(aInfo, bInfo), nil
+}
+
+func promoteWorkingCLIInPlace(cliName, libraryDir, backupDir string, state *PipelineState) (*PromoteResult, error) {
+	state.PublishedDir = libraryDir
+	if err := stageRunstateManuscripts(libraryDir, state); err != nil {
+		return nil, fmt.Errorf("staging runstate manuscripts: %w", err)
+	}
+	if err := writeCLIManifestForPublish(state, libraryDir); err != nil {
+		return nil, fmt.Errorf("writing CLI manifest: %w", err)
+	}
+	if err := WriteMCPBManifest(libraryDir); err != nil {
+		return nil, fmt.Errorf("writing MCPB manifest: %w", err)
+	}
+	if _, err := syncPromoteBundle(libraryDir, cliName); err != nil {
+		return nil, fmt.Errorf("syncing MCPB bundle: %w", err)
+	}
+	if _, err := os.Stat(backupDir); err == nil {
+		if err := os.RemoveAll(backupDir); err != nil {
+			return nil, fmt.Errorf("removing stale backup directory: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("checking stale backup directory: %w", err)
+	}
+	return finishPromote(cliName, libraryDir, state, []string{})
+}
+
+func finishPromote(cliName, libraryDir string, state *PipelineState, preservedPatches []string) (*PromoteResult, error) {
 	state.WorkingDir = libraryDir
 	saveErr := state.Save()
 	releaseErr := ReleaseLock(cliName)

--- a/internal/pipeline/lock.go
+++ b/internal/pipeline/lock.go
@@ -241,9 +241,6 @@ func promoteWorkingCLI(cliName, workingDir string, state *PipelineState) (*Promo
 	if err := validatePIIGateForPromote(workingDir, state); err != nil {
 		return nil, err
 	}
-	if _, err := refreshPromoteArtifacts(workingDir, cliName); err != nil {
-		return nil, fmt.Errorf("refreshing staged artifacts: %w", err)
-	}
 
 	slug := naming.TrimCLISuffix(cliName)
 	libraryDir := filepath.Join(PublishedLibraryRoot(), slug)
@@ -258,8 +255,10 @@ func promoteWorkingCLI(cliName, workingDir string, state *PipelineState) (*Promo
 	if err != nil {
 		return nil, err
 	}
-	if sameTarget {
-		return promoteWorkingCLIInPlace(cliName, libraryDir, backupDir, state)
+	if !sameTarget {
+		if _, err := refreshPromoteArtifacts(workingDir, cliName); err != nil {
+			return nil, fmt.Errorf("refreshing staged artifacts: %w", err)
+		}
 	}
 
 	// If a previous promote died after moving the live library to backup but
@@ -280,7 +279,13 @@ func promoteWorkingCLI(cliName, workingDir string, state *PipelineState) (*Promo
 	// Copy working dir to staging.
 	if err := CopyDir(workingDir, stagingDir); err != nil {
 		_ = os.RemoveAll(stagingDir)
-		return nil, fmt.Errorf("copying to staging directory: %w", err)
+		return failPromoteBeforeSwap(cliName, sameTarget, fmt.Errorf("copying to staging directory: %w", err))
+	}
+	if sameTarget {
+		if _, err := refreshPromoteArtifacts(stagingDir, cliName); err != nil {
+			_ = os.RemoveAll(stagingDir)
+			return failPromoteBeforeSwap(cliName, sameTarget, fmt.Errorf("refreshing staged artifacts: %w", err))
+		}
 	}
 
 	// The library may contain hand-authored patch records that were created
@@ -289,14 +294,14 @@ func promoteWorkingCLI(cliName, workingDir string, state *PipelineState) (*Promo
 	preservedPatches, err := preserveLibraryOnlyPatches(libraryDir, stagingDir)
 	if err != nil {
 		_ = os.RemoveAll(stagingDir)
-		return nil, fmt.Errorf("preserving library-only patches: %w", err)
+		return failPromoteBeforeSwap(cliName, sameTarget, fmt.Errorf("preserving library-only patches: %w", err))
 	}
 
 	// Phase 5 writes acceptance markers to the runstate, but the published
 	// copy is the path downstream consumers see — embed them before the swap.
 	if err := stageRunstateManuscripts(stagingDir, state); err != nil {
 		_ = os.RemoveAll(stagingDir)
-		return nil, fmt.Errorf("staging runstate manuscripts: %w", err)
+		return failPromoteBeforeSwap(cliName, sameTarget, fmt.Errorf("staging runstate manuscripts: %w", err))
 	}
 
 	// Update state to reflect promotion.
@@ -305,11 +310,11 @@ func promoteWorkingCLI(cliName, workingDir string, state *PipelineState) (*Promo
 	// Write CLI manifest into the staging copy.
 	if err := writeCLIManifestForPublish(state, stagingDir); err != nil {
 		_ = os.RemoveAll(stagingDir)
-		return nil, fmt.Errorf("writing CLI manifest: %w", err)
+		return failPromoteBeforeSwap(cliName, sameTarget, fmt.Errorf("writing CLI manifest: %w", err))
 	}
 	if err := restorePermanentCreatorForPromote(stagingDir, libraryDir, state.APIName); err != nil {
 		_ = os.RemoveAll(stagingDir)
-		return nil, fmt.Errorf("restoring permanent creator: %w", err)
+		return failPromoteBeforeSwap(cliName, sameTarget, fmt.Errorf("restoring permanent creator: %w", err))
 	}
 
 	// Refresh the MCPB manifest.json in the staging dir so the lock-and-promote
@@ -321,11 +326,11 @@ func promoteWorkingCLI(cliName, workingDir string, state *PipelineState) (*Promo
 	// fields, which is the exact bug class this writer chain exists to prevent.
 	if err := WriteMCPBManifest(stagingDir); err != nil {
 		_ = os.RemoveAll(stagingDir)
-		return nil, fmt.Errorf("writing MCPB manifest to staging: %w", err)
+		return failPromoteBeforeSwap(cliName, sameTarget, fmt.Errorf("writing MCPB manifest to staging: %w", err))
 	}
 	if _, err := syncPromoteBundle(stagingDir, cliName); err != nil {
 		_ = os.RemoveAll(stagingDir)
-		return nil, fmt.Errorf("syncing MCPB bundle in staging: %w", err)
+		return failPromoteBeforeSwap(cliName, sameTarget, fmt.Errorf("syncing MCPB bundle in staging: %w", err))
 	}
 
 	// Remove any stale backup from a prior successful swap before we create a
@@ -333,7 +338,7 @@ func promoteWorkingCLI(cliName, workingDir string, state *PipelineState) (*Promo
 	if _, err := os.Stat(backupDir); err == nil {
 		if err := os.RemoveAll(backupDir); err != nil {
 			_ = os.RemoveAll(stagingDir)
-			return nil, fmt.Errorf("removing stale backup directory: %w", err)
+			return failPromoteBeforeSwap(cliName, sameTarget, fmt.Errorf("removing stale backup directory: %w", err))
 		}
 	}
 
@@ -341,11 +346,11 @@ func promoteWorkingCLI(cliName, workingDir string, state *PipelineState) (*Promo
 	if _, err := os.Stat(libraryDir); err == nil {
 		if err := os.Rename(libraryDir, backupDir); err != nil {
 			_ = os.RemoveAll(stagingDir)
-			return nil, fmt.Errorf("backing up existing library directory: %w", err)
+			return failPromoteBeforeSwap(cliName, sameTarget, fmt.Errorf("backing up existing library directory: %w", err))
 		}
 	} else if !os.IsNotExist(err) {
 		_ = os.RemoveAll(stagingDir)
-		return nil, fmt.Errorf("checking library directory before promote: %w", err)
+		return failPromoteBeforeSwap(cliName, sameTarget, fmt.Errorf("checking library directory before promote: %w", err))
 	}
 
 	if err := os.Rename(stagingDir, libraryDir); err != nil {
@@ -353,7 +358,17 @@ func promoteWorkingCLI(cliName, workingDir string, state *PipelineState) (*Promo
 		if _, statErr := os.Stat(backupDir); statErr == nil {
 			_ = os.Rename(backupDir, libraryDir)
 		}
-		return nil, fmt.Errorf("promoting staging to library: %w", err)
+		return failPromoteBeforeSwap(cliName, sameTarget, fmt.Errorf("promoting staging to library: %w", err))
+	}
+
+	if sameTarget {
+		if err := moveGitMetadataIntoPromotedLibrary(backupDir, libraryDir); err != nil {
+			_ = os.RemoveAll(libraryDir)
+			if _, statErr := os.Stat(backupDir); statErr == nil {
+				_ = os.Rename(backupDir, libraryDir)
+			}
+			return failPromoteBeforeSwap(cliName, sameTarget, err)
+		}
 	}
 
 	// Swap succeeded — remove the backup.
@@ -377,28 +392,34 @@ func sameDirectory(a, b string) (bool, error) {
 	return os.SameFile(aInfo, bInfo), nil
 }
 
-func promoteWorkingCLIInPlace(cliName, libraryDir, backupDir string, state *PipelineState) (*PromoteResult, error) {
-	state.PublishedDir = libraryDir
-	if err := stageRunstateManuscripts(libraryDir, state); err != nil {
-		return nil, fmt.Errorf("staging runstate manuscripts: %w", err)
-	}
-	if err := writeCLIManifestForPublish(state, libraryDir); err != nil {
-		return nil, fmt.Errorf("writing CLI manifest: %w", err)
-	}
-	if err := WriteMCPBManifest(libraryDir); err != nil {
-		return nil, fmt.Errorf("writing MCPB manifest: %w", err)
-	}
-	if _, err := syncPromoteBundle(libraryDir, cliName); err != nil {
-		return nil, fmt.Errorf("syncing MCPB bundle: %w", err)
-	}
-	if _, err := os.Stat(backupDir); err == nil {
-		if err := os.RemoveAll(backupDir); err != nil {
-			return nil, fmt.Errorf("removing stale backup directory: %w", err)
+func moveGitMetadataIntoPromotedLibrary(backupDir, libraryDir string) error {
+	src := filepath.Join(backupDir, ".git")
+	dst := filepath.Join(libraryDir, ".git")
+	if _, err := os.Lstat(src); err != nil {
+		if os.IsNotExist(err) {
+			return nil
 		}
-	} else if !os.IsNotExist(err) {
-		return nil, fmt.Errorf("checking stale backup directory: %w", err)
+		return fmt.Errorf("checking backup git metadata: %w", err)
 	}
-	return finishPromote(cliName, libraryDir, state, []string{})
+	if _, err := os.Lstat(dst); err == nil {
+		return fmt.Errorf("staged git metadata unexpectedly exists: %s", dst)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("checking staged git metadata: %w", err)
+	}
+	if err := os.Rename(src, dst); err != nil {
+		return fmt.Errorf("moving git metadata into promoted library: %w", err)
+	}
+	return nil
+}
+
+func failPromoteBeforeSwap(cliName string, releaseLock bool, promoteErr error) (*PromoteResult, error) {
+	if !releaseLock {
+		return nil, promoteErr
+	}
+	if releaseErr := ReleaseLock(cliName); releaseErr != nil {
+		return nil, fmt.Errorf("%w; lock release failed: %v", promoteErr, releaseErr)
+	}
+	return nil, promoteErr
 }
 
 func finishPromote(cliName, libraryDir string, state *PipelineState, preservedPatches []string) (*PromoteResult, error) {

--- a/internal/pipeline/lock_test.go
+++ b/internal/pipeline/lock_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -20,6 +21,28 @@ func setupLockTest(t *testing.T) (cleanup func()) {
 	tmpDir := t.TempDir()
 	t.Setenv("PRINTING_PRESS_HOME", tmpDir)
 	return func() {}
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for this test")
+	}
+	cmdArgs := append([]string{"-C", dir}, args...)
+	cmd := exec.Command("git", cmdArgs...)
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %s failed: %s", strings.Join(args, " "), output)
+	return strings.TrimSpace(string(output))
+}
+
+func initGitRepository(t *testing.T, dir string) string {
+	t.Helper()
+	runGit(t, dir, "init", "-q")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test User")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-qm", "initial")
+	return runGit(t, dir, "rev-parse", "HEAD")
 }
 
 func TestAcquireLock_NoExistingLock(t *testing.T) {
@@ -425,6 +448,75 @@ func TestPromoteWorkingCLI_ReplacesExistingLibrary(t *testing.T) {
 	// New file should exist.
 	_, err = os.Stat(filepath.Join(libDir, "new-file.txt"))
 	assert.NoError(t, err)
+}
+
+func TestPromoteWorkingCLI_InPlacePreservesGitRepository(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	libDir := filepath.Join(PublishedLibraryRoot(), "test")
+	require.NoError(t, os.MkdirAll(libDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(libDir, "go.mod"), []byte("module test-pp-cli\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(libDir, "main.go"), []byte("package main\nfunc main() {}\n"), 0o644))
+	require.NoError(t, WriteCLIManifest(libDir, CLIManifest{
+		SchemaVersion: CurrentCLIManifestSchemaVersion,
+		APIName:       "test",
+		CLIName:       "test-pp-cli",
+		MCPReady:      "none",
+	}))
+	beforeHead := initGitRepository(t, libDir)
+
+	_, err := AcquireLock("test-pp-cli", "test-scope", false)
+	require.NoError(t, err)
+
+	state := NewMinimalState("test-pp-cli", libDir)
+	result, err := PromoteWorkingCLIWithResult("test-pp-cli", libDir, state)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.PreservedPatches)
+
+	assert.DirExists(t, filepath.Join(libDir, ".git"))
+	assert.Equal(t, beforeHead, runGit(t, libDir, "rev-parse", "HEAD"))
+
+	manifest := readManifest(t, libDir)
+	assert.Equal(t, "test", manifest.APIName)
+	assert.Equal(t, "test-pp-cli", manifest.CLIName)
+	assert.Equal(t, libDir, state.PublishedDir)
+	assert.Equal(t, libDir, state.WorkingDir)
+
+	pointer, err := loadCurrentRunPointer("test")
+	require.NoError(t, err)
+	assert.Equal(t, libDir, pointer.WorkingDir)
+
+	_, err = os.Stat(LockFilePath("test-pp-cli"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestPromoteWorkingCLI_WorkingDirWithoutGitStillReplacesLibraryGit(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	libDir := filepath.Join(PublishedLibraryRoot(), "test")
+	require.NoError(t, os.MkdirAll(libDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(libDir, "go.mod"), []byte("module old\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(libDir, "old-file.txt"), []byte("old\n"), 0o644))
+	initGitRepository(t, libDir)
+
+	workDir := filepath.Join(tmp, "working", "test-pp-cli")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module test-pp-cli\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "new-file.txt"), []byte("new\n"), 0o644))
+
+	_, err := PromoteWorkingCLIWithResult("test-pp-cli", workDir, NewMinimalState("test-pp-cli", workDir))
+	require.NoError(t, err)
+
+	assert.NoDirExists(t, filepath.Join(libDir, ".git"))
+	assert.NoFileExists(t, filepath.Join(libDir, "old-file.txt"))
+	assert.FileExists(t, filepath.Join(libDir, "new-file.txt"))
 }
 
 func TestPromoteWorkingCLI_PreservesPatchAndManifestUnion(t *testing.T) {

--- a/internal/pipeline/lock_test.go
+++ b/internal/pipeline/lock_test.go
@@ -494,6 +494,59 @@ func TestPromoteWorkingCLI_InPlacePreservesGitRepository(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+func TestPromoteWorkingCLI_InPlaceStagingFailureLeavesLibraryAndReleasesLock(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	libDir := filepath.Join(PublishedLibraryRoot(), "test")
+	require.NoError(t, os.MkdirAll(libDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(libDir, "go.mod"), []byte("module test-pp-cli\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(libDir, "sentinel.txt"), []byte("published\n"), 0o644))
+	require.NoError(t, WriteCLIManifest(libDir, CLIManifest{
+		SchemaVersion: CurrentCLIManifestSchemaVersion,
+		APIName:       "test",
+		CLIName:       "test-pp-cli",
+		MCPReady:      "none",
+		Description:   "published metadata",
+	}))
+	beforeHead := initGitRepository(t, libDir)
+	beforeManifest, err := os.ReadFile(filepath.Join(libDir, CLIManifestFilename))
+	require.NoError(t, err)
+
+	_, err = AcquireLock("test-pp-cli", "test-scope", false)
+	require.NoError(t, err)
+
+	state := NewStateWithRun("test", libDir, "run-in-place-failure", "test-scope")
+	writePhase5PassForState(t, state, "none")
+	outside := filepath.Join(tmp, "outside.txt")
+	require.NoError(t, os.WriteFile(outside, []byte("outside\n"), 0o644))
+	require.NoError(t, os.MkdirAll(state.ResearchDir(), 0o755))
+	require.NoError(t, os.Symlink(outside, filepath.Join(state.ResearchDir(), "external-link.txt")))
+
+	_, err = PromoteWorkingCLIWithResult("test-pp-cli", libDir, state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "staging runstate manuscripts")
+
+	assert.DirExists(t, filepath.Join(libDir, ".git"))
+	assert.Equal(t, beforeHead, runGit(t, libDir, "rev-parse", "HEAD"))
+	data, err := os.ReadFile(filepath.Join(libDir, "sentinel.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "published\n", string(data))
+	afterManifest, err := os.ReadFile(filepath.Join(libDir, CLIManifestFilename))
+	require.NoError(t, err)
+	assert.JSONEq(t, string(beforeManifest), string(afterManifest))
+	assert.NoDirExists(t, libDir+".promoting")
+	assert.NoDirExists(t, libDir+".old")
+
+	_, err = os.Stat(LockFilePath("test-pp-cli"))
+	assert.True(t, os.IsNotExist(err))
+	_, err = AcquireLock("test-pp-cli", "test-scope", false)
+	require.NoError(t, err)
+	require.NoError(t, ReleaseLock("test-pp-cli"))
+}
+
 func TestPromoteWorkingCLI_WorkingDirWithoutGitStillReplacesLibraryGit(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("PRINTING_PRESS_HOME", tmp)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Issue: Closes #4038

Fix `cli-printing-press lock promote --dir <library>` so promoting an already-published git-backed CLI in place does not delete the target repository metadata or change its HEAD.

## Approach

Detect when the promote source resolves to the same directory as the target library path. In that case, artifact refreshes happen in the staging tree instead of the live library, the existing atomic staging and swap flow remains in use, and `.git` is moved from the backup into the promoted tree before the backup is deleted.

Same-target failures before completion clean up staging and release the lock so a retry can proceed. The separate working-dir path still uses the existing pre-copy artifact refresh plus staging and swap flow, so a working directory without `.git` promotes the same way it did before.

## Scope

Primary area: pipeline lock promote behavior.

Why this belongs in this repo: this is a Printing Press promote-path bug that can affect every printed CLI workflow using promote-in-place.

## Risk

The in-place path now preserves atomicity while carrying git metadata through the swap. The normal working-dir to library promotion path remains on the existing behavior.

## Output Contract

N/A

## Verification

- `go test ./internal/pipeline -run 'TestPromoteWorkingCLI_(InPlacePreservesGitRepository|InPlaceStagingFailureLeavesLibraryAndReleasesLock|WorkingDirWithoutGitStillReplacesLibraryGit)'`
- `go test -timeout 30m ./...`

Note: `go test ./...` with the default timeout hit the `internal/generator` package timeout at 10 minutes on the previous run; the same suite passed with `-timeout 30m`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56611667-5359-43a7-8291-ee205ae3d328?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56611667-5359-43a7-8291-ee205ae3d328&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

