### PR TITLE
fix(cli): bound workflow archive and keep the store crash-safe

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10795,7 +10795,105 @@ func TestWorkflowArchiveTimeoutFailsFast(t *testing.T) {
 `
 	testPath := filepath.Join(outputDir, "internal", "cli", "workflow_boundary_runtime_test.go")
 	require.NoError(t, os.WriteFile(testPath, []byte(behaviorTest), 0o644))
+	storeCrashTest := `package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStoreWrite_KilledProcessLeavesDatabaseIntegral(t *testing.T) {
+	if os.Getenv("PP_STORE_KILL_HELPER") == "1" {
+		runStoreKillHelper()
+		return
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open seed db: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close seed db: %v", err)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestStoreWrite_KilledProcessLeavesDatabaseIntegral$", "-test.count=1")
+	cmd.Env = append(os.Environ(),
+		"PP_STORE_KILL_HELPER=1",
+		"PP_STORE_KILL_DB="+dbPath,
+	)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start kill helper: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill helper: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		_ = cmd.Process.Kill()
+		<-done
+	}
+
+	ro, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open killed db read-only: %v", err)
+	}
+	defer ro.Close()
+	var integrity string
+	if err := ro.DB().QueryRow("PRAGMA integrity_check").Scan(&integrity); err != nil {
+		t.Fatalf("integrity_check killed db: %v", err)
+	}
+	if integrity != "ok" {
+		t.Fatalf("integrity_check = %q, want ok", integrity)
+	}
+}
+
+func runStoreKillHelper() {
+	dbPath := os.Getenv("PP_STORE_KILL_DB")
+	if dbPath == "" {
+		fmt.Fprintln(os.Stderr, "PP_STORE_KILL_DB is required")
+		os.Exit(2)
+	}
+	s, err := Open(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "open helper db: %v\n", err)
+		os.Exit(3)
+	}
+	defer s.Close()
+
+	items := make([]json.RawMessage, 0, 100)
+	payload := strings.Repeat("x", 1024)
+	for i := 0; i < cap(items); i++ {
+		items = append(items, json.RawMessage(fmt.Sprintf(` + "`" + `{"id":"kill-%d","payload":%q}` + "`" + `, i, payload)))
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, _, err := s.UpsertBatch("kill_items", items); err != nil {
+			fmt.Fprintf(os.Stderr, "upsert helper batch: %v\n", err)
+			os.Exit(4)
+		}
+	}
+}
+`
+	storeCrashPath := filepath.Join(outputDir, "internal", "store", "killed_writer_integrity_test.go")
+	require.NoError(t, os.WriteFile(storeCrashPath, []byte(storeCrashTest), 0o644))
 	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestWorkflow(Status|Archive)")
+	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "TestStoreWrite_KilledProcessLeavesDatabaseIntegral", "-count=1")
 	requireGeneratedCompiles(t, outputDir)
 }
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10560,6 +10560,10 @@ func TestGeneratedOutput_WorkflowBoundaries(t *testing.T) {
 		"workflow archive must leave normal archive pagination unlimited unless the operator sets a cap")
 	assert.Contains(t, src, `cmd.Flags().DurationVar(&timeout, "timeout", 30*time.Minute`,
 		"workflow archive must expose a wall-clock bound with an operator escape hatch")
+	assert.Contains(t, src, `if maxPages < 0`,
+		"workflow archive must reject negative page limits instead of treating them as unlimited")
+	assert.Contains(t, src, `if timeout < 0`,
+		"workflow archive must reject negative timeouts instead of treating them as no timeout")
 	assert.Contains(t, src, `context.WithTimeout(archiveCtx, archiveTimeout)`,
 		"workflow archive must pass a timeout-bound context through store open and sync")
 	assert.Contains(t, src, `if cliutil.IsDogfoodEnv()`,
@@ -10572,6 +10576,17 @@ func TestGeneratedOutput_WorkflowBoundaries(t *testing.T) {
 		"workflow archive must cap the resource list under dogfood")
 	assert.Contains(t, src, `archiveMaxPages, false`,
 		"workflow archive must pass the dogfood-aware page limit to syncResource")
+
+	substackSpec := minimalSpec("substack")
+	substackDir := filepath.Join(t.TempDir(), naming.CLI(substackSpec.Name))
+	substackGen := New(substackSpec, substackDir)
+	substackGen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, substackGen.Generate())
+	substackWorkflow := readGeneratedFile(t, substackDir, "internal", "cli", "channel_workflow.go")
+	assert.Contains(t, substackWorkflow, `resolveSubstackPublicationIDTemplate(archiveCtx, c, flags)`,
+		"Substack archive publication preflight must share the bounded archive context")
+	assert.NotContains(t, substackWorkflow, `resolveSubstackPublicationIDTemplate(cmd.Context(), c, flags)`,
+		"Substack archive publication preflight must not bypass the archive timeout")
 
 	syncDisabledDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name)+"-nosync")
 	syncDisabledGen := New(apiSpec, syncDisabledDir)
@@ -10790,6 +10805,32 @@ func TestWorkflowArchiveTimeoutFailsFast(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "workflow archive timed out after 1ms") {
 		t.Fatalf("timeout archive error = %v; stderr=%s", err, stderr)
+	}
+}
+
+func TestWorkflowArchiveRejectsNegativeBounds(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		flag string
+		value string
+		want string
+	}{
+		{name: "max pages", flag: "--max-pages", value: "-1", want: "--max-pages must be greater than or equal to 0"},
+		{name: "timeout", flag: "--timeout", value: "-1s", want: "--timeout must be greater than or equal to 0"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dbPath := filepath.Join(t.TempDir(), "negative.db")
+			stdout, stderr, err := runWorkflowBoundaryCommand("workflow", "archive", "--db", dbPath, tc.flag, tc.value)
+			if err == nil {
+				t.Fatalf("negative %s unexpectedly succeeded; stdout=%s stderr=%s", tc.flag, stdout, stderr)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("negative %s error = %v; stderr=%s", tc.flag, err, stderr)
+			}
+			if _, statErr := os.Stat(dbPath); !os.IsNotExist(statErr) {
+				t.Fatalf("negative %s created db path: stat err=%v", tc.flag, statErr)
+			}
+		})
 	}
 }
 `

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10556,10 +10556,18 @@ func TestGeneratedOutput_WorkflowBoundaries(t *testing.T) {
 		"workflow status must reject stores newer than the generated schema")
 	assert.Contains(t, src, `"workflowboundary-pp-cli/internal/cliutil"`,
 		"workflow archive must import the generated dogfood environment helper")
-	assert.Contains(t, src, `archiveMaxPages := 100`,
-		"workflow archive must keep its normal page limit explicit")
+	assert.Contains(t, src, `cmd.Flags().IntVar(&maxPages, "max-pages", 0`,
+		"workflow archive must leave normal archive pagination unlimited unless the operator sets a cap")
+	assert.Contains(t, src, `cmd.Flags().DurationVar(&timeout, "timeout", 30*time.Minute`,
+		"workflow archive must expose a wall-clock bound with an operator escape hatch")
+	assert.Contains(t, src, `context.WithTimeout(archiveCtx, archiveTimeout)`,
+		"workflow archive must pass a timeout-bound context through store open and sync")
 	assert.Contains(t, src, `if cliutil.IsDogfoodEnv()`,
 		"workflow archive must enter its bounded dogfood path")
+	assert.Contains(t, src, `if !cmd.Flags().Changed("max-pages")`,
+		"dogfood must not override an explicit archive page cap")
+	assert.Contains(t, src, `if !cmd.Flags().Changed("timeout")`,
+		"dogfood must not override an explicit archive timeout")
 	assert.Contains(t, src, `resources = resources[:3]`,
 		"workflow archive must cap the resource list under dogfood")
 	assert.Contains(t, src, `archiveMaxPages, false`,
@@ -10591,6 +10599,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"workflowboundary-pp-cli/internal/store"
 )
@@ -10744,8 +10753,17 @@ func TestWorkflowArchiveCurtailsOnlyUnderDogfood(t *testing.T) {
 	}
 
 	atomic.StoreInt32(&requests, 0)
+	stdout, stderr, err = runWorkflowBoundaryCommand("workflow", "archive", "--db", filepath.Join(t.TempDir(), "dogfood-unlimited.db"), "--max-pages", "0", "--timeout", "0")
+	if err != nil {
+		t.Fatalf("dogfood archive with explicit escape: %v; stdout=%s stderr=%s", err, stdout, stderr)
+	}
+	if got := atomic.LoadInt32(&requests); got != 6 {
+		t.Fatalf("dogfood archive with explicit escape requests = %d, want two pages for each of 3 resources", got)
+	}
+
+	atomic.StoreInt32(&requests, 0)
 	t.Setenv("PRINTING_PRESS_DOGFOOD", "")
-	stdout, stderr, err = runWorkflowBoundaryCommand("workflow", "archive", "--db", filepath.Join(t.TempDir(), "normal.db"))
+	stdout, stderr, err = runWorkflowBoundaryCommand("workflow", "archive", "--db", filepath.Join(t.TempDir(), "normal.db"), "--timeout", "0")
 	if err != nil {
 		t.Fatalf("normal archive: %v; stdout=%s stderr=%s", err, stdout, stderr)
 	}
@@ -10754,6 +10772,24 @@ func TestWorkflowArchiveCurtailsOnlyUnderDogfood(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "across 4 resources") {
 		t.Fatalf("normal archive stdout = %q, want all-resource count", stdout)
+	}
+}
+
+func TestWorkflowArchiveTimeoutFailsFast(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"items\":[{\"id\":\"item-1\"}],\"has_more\":false,\"next_cursor\":\"\"}"))
+	}))
+	defer server.Close()
+	t.Setenv("WORKFLOWBOUNDARY_BASE_URL", server.URL)
+
+	stdout, stderr, err := runWorkflowBoundaryCommand("workflow", "archive", "--db", filepath.Join(t.TempDir(), "timeout.db"), "--timeout", "1ms")
+	if err == nil {
+		t.Fatalf("timeout archive unexpectedly succeeded; stdout=%s stderr=%s", stdout, stderr)
+	}
+	if !strings.Contains(err.Error(), "workflow archive timed out after 1ms") {
+		t.Fatalf("timeout archive error = %v; stderr=%s", err, stderr)
 	}
 }
 `

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10585,6 +10585,10 @@ func TestGeneratedOutput_WorkflowBoundaries(t *testing.T) {
 	substackWorkflow := readGeneratedFile(t, substackDir, "internal", "cli", "channel_workflow.go")
 	assert.Contains(t, substackWorkflow, `resolveSubstackPublicationIDTemplate(archiveCtx, c, flags)`,
 		"Substack archive publication preflight must share the bounded archive context")
+	assert.Contains(t, substackWorkflow, `err = workflowArchiveTimeoutError(archiveTimeout, err)`,
+		"Substack archive publication preflight must convert deadline errors into actionable archive timeout errors")
+	assert.Contains(t, substackWorkflow, `return fmt.Errorf("archiving %s: %w", resource, err)`,
+		"Substack archive publication preflight timeout must hard-fail instead of continuing")
 	assert.NotContains(t, substackWorkflow, `resolveSubstackPublicationIDTemplate(cmd.Context(), c, flags)`,
 		"Substack archive publication preflight must not bypass the archive timeout")
 

--- a/internal/generator/templates/channel_workflow.go.tmpl
+++ b/internal/generator/templates/channel_workflow.go.tmpl
@@ -4,6 +4,10 @@
 package cli
 
 import (
+{{- if .SyncEnabled}}
+	"context"
+	"errors"
+{{- end}}
 {{- if .AgentMoneyWorkflow.Enabled}}
 	"crypto/rand"
 	"encoding/hex"
@@ -253,6 +257,8 @@ func workflowAmountArg(amount float64, integer bool) (string, error) {
 func newWorkflowArchiveCmd(flags *rootFlags) *cobra.Command {
 	var dbPath string
 	var full bool
+	var maxPages int
+	var timeout time.Duration
 
 	cmd := &cobra.Command{
 		Use:   "archive",
@@ -264,8 +270,28 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
   {{.Name}}-pp-cli workflow archive
 
   # Full re-archive (ignore previous sync state)
-  {{.Name}}-pp-cli workflow archive --full`,
+  {{.Name}}-pp-cli workflow archive --full
+
+  # Archive without a wall-clock timeout
+  {{.Name}}-pp-cli workflow archive --timeout 0`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			archiveTimeout := timeout
+			archiveMaxPages := maxPages
+			if cliutil.IsDogfoodEnv() {
+				if !cmd.Flags().Changed("max-pages") {
+					archiveMaxPages = 1
+				}
+				if !cmd.Flags().Changed("timeout") {
+					archiveTimeout = 10 * time.Second
+				}
+			}
+			archiveCtx := cmd.Context()
+			var cancel context.CancelFunc
+			if archiveTimeout > 0 {
+				archiveCtx, cancel = context.WithTimeout(archiveCtx, archiveTimeout)
+				defer cancel()
+			}
+
 			c, err := flags.newClient()
 			if err != nil {
 				return err
@@ -275,16 +301,14 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 			if dbPath == "" {
 				dbPath = defaultDBPath("{{.Name}}-pp-cli")
 			}
-			s, err := store.OpenWithContext(cmd.Context(), dbPath)
+			s, err := store.OpenWithContext(archiveCtx, dbPath)
 			if err != nil {
-				return fmt.Errorf("opening store: %w", err)
+				return workflowArchiveTimeoutError(archiveTimeout, fmt.Errorf("opening store: %w", err))
 			}
 			defer s.Close()
 
 			resources := []string{ {{- range .SyncableResources}}{{if not .SkipDefaultSync}}"{{.Name}}", {{end}}{{end}} }
-			archiveMaxPages := 100
 			if cliutil.IsDogfoodEnv() {
-				archiveMaxPages = 1
 				if len(resources) > 3 {
 					resources = resources[:3]
 				}
@@ -318,9 +342,13 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 					}
 				}
 {{- end}}
-				res := syncResource(cmd.Context(), {{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, s, resource, "", full, archiveMaxPages, false{{if not (isGraphQL .APISpec)}}, false{{end}}{{if .Pagination.DateRangeParam}}, ""{{end}}{{if not (isGraphQL .APISpec)}}, nil, syncEventWriter{{end}})
+				res := syncResource(archiveCtx, {{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, s, resource, "", full, archiveMaxPages, false{{if not (isGraphQL .APISpec)}}, false{{end}}{{if .Pagination.DateRangeParam}}, ""{{end}}{{if not (isGraphQL .APISpec)}}, nil, syncEventWriter{{end}})
 				if res.Err != nil {
+					res.Err = workflowArchiveTimeoutError(archiveTimeout, res.Err)
 					if res.IntegrityFailure || isSyncStatePersistenceError(res.Err) {
+						return fmt.Errorf("archiving %s: %w", resource, res.Err)
+					}
+					if errors.Is(res.Err, context.DeadlineExceeded) {
 						return fmt.Errorf("archiving %s: %w", resource, res.Err)
 					}
 					fmt.Fprintf(cmd.ErrOrStderr(), "  %s: error: %v\n", resource, res.Err)
@@ -353,8 +381,17 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 
 	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database file path (default: resolved data directory data.db)")
 	cmd.Flags().BoolVar(&full, "full", false, "Full re-archive (ignore previous sync state)")
+	cmd.Flags().IntVar(&maxPages, "max-pages", 0, "Maximum pages to fetch per resource (0 = unlimited; cap-hit emits a sync_warning event)")
+	cmd.Flags().DurationVar(&timeout, "timeout", 30*time.Minute, "Maximum time to spend archiving (0 = no timeout)")
 
 	return cmd
+}
+
+func workflowArchiveTimeoutError(timeout time.Duration, err error) error {
+	if timeout <= 0 || !errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	return fmt.Errorf("workflow archive timed out after %s; rerun with --timeout 0 or a larger value to continue: %w", timeout, err)
 }
 {{- end}}
 

--- a/internal/generator/templates/channel_workflow.go.tmpl
+++ b/internal/generator/templates/channel_workflow.go.tmpl
@@ -343,6 +343,10 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 {{- if eq .Name "substack"}}
 				if resource == "drafts" {
 					if err := resolveSubstackPublicationIDTemplate(archiveCtx, c, flags); err != nil {
+						err = workflowArchiveTimeoutError(archiveTimeout, err)
+						if errors.Is(err, context.DeadlineExceeded) {
+							return fmt.Errorf("archiving %s: %w", resource, err)
+						}
 						fmt.Fprintf(cmd.ErrOrStderr(), "  %s: error: %v\n", resource, err)
 						continue
 					}

--- a/internal/generator/templates/channel_workflow.go.tmpl
+++ b/internal/generator/templates/channel_workflow.go.tmpl
@@ -275,6 +275,12 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
   # Archive without a wall-clock timeout
   {{.Name}}-pp-cli workflow archive --timeout 0`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if maxPages < 0 {
+				return fmt.Errorf("--max-pages must be greater than or equal to 0 (0 = unlimited)")
+			}
+			if timeout < 0 {
+				return fmt.Errorf("--timeout must be greater than or equal to 0 (0 = no timeout)")
+			}
 			archiveTimeout := timeout
 			archiveMaxPages := maxPages
 			if cliutil.IsDogfoodEnv() {
@@ -336,7 +342,7 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 			for _, resource := range resources {
 {{- if eq .Name "substack"}}
 				if resource == "drafts" {
-					if err := resolveSubstackPublicationIDTemplate(cmd.Context(), c, flags); err != nil {
+					if err := resolveSubstackPublicationIDTemplate(archiveCtx, c, flags); err != nil {
 						fmt.Fprintf(cmd.ErrOrStderr(), "  %s: error: %v\n", resource, err)
 						continue
 					}

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -6,14 +6,11 @@ package store
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -126,88 +123,6 @@ func TestStoreWrite_PanicReleasesLock(t *testing.T) {
 		close(done)
 	}()
 	<-done
-}
-
-func TestStoreWrite_KilledProcessLeavesDatabaseIntegral(t *testing.T) {
-	if os.Getenv("PP_STORE_KILL_HELPER") == "1" {
-		runStoreKillHelper()
-		return
-	}
-
-	dbPath := filepath.Join(t.TempDir(), "data.db")
-	s, err := Open(dbPath)
-	if err != nil {
-		t.Fatalf("open seed db: %v", err)
-	}
-	if err := s.Close(); err != nil {
-		t.Fatalf("close seed db: %v", err)
-	}
-
-	cmd := exec.Command(os.Args[0], "-test.run=^TestStoreWrite_KilledProcessLeavesDatabaseIntegral$", "-test.count=1")
-	cmd.Env = append(os.Environ(),
-		"PP_STORE_KILL_HELPER=1",
-		"PP_STORE_KILL_DB="+dbPath,
-	)
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start kill helper: %v", err)
-	}
-
-	time.Sleep(200 * time.Millisecond)
-	if err := cmd.Process.Kill(); err != nil {
-		t.Fatalf("kill helper: %v", err)
-	}
-
-	done := make(chan error, 1)
-	go func() {
-		done <- cmd.Wait()
-	}()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		_ = cmd.Process.Kill()
-		<-done
-	}
-
-	ro, err := OpenReadOnly(dbPath)
-	if err != nil {
-		t.Fatalf("open killed db read-only: %v", err)
-	}
-	defer ro.Close()
-	var integrity string
-	if err := ro.DB().QueryRow("PRAGMA integrity_check").Scan(&integrity); err != nil {
-		t.Fatalf("integrity_check killed db: %v", err)
-	}
-	if integrity != "ok" {
-		t.Fatalf("integrity_check = %q, want ok", integrity)
-	}
-}
-
-func runStoreKillHelper() {
-	dbPath := os.Getenv("PP_STORE_KILL_DB")
-	if dbPath == "" {
-		fmt.Fprintln(os.Stderr, "PP_STORE_KILL_DB is required")
-		os.Exit(2)
-	}
-	s, err := Open(dbPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "open helper db: %v\n", err)
-		os.Exit(3)
-	}
-	defer s.Close()
-
-	items := make([]json.RawMessage, 0, 250)
-	payload := strings.Repeat("x", 4096)
-	for i := 0; i < cap(items); i++ {
-		items = append(items, json.RawMessage(fmt.Sprintf(`{"id":"sigterm-%d","payload":%q}`, i, payload)))
-	}
-
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, _, err := s.UpsertBatch("sigterm_items", items); err != nil {
-			fmt.Fprintf(os.Stderr, "upsert helper batch: %v\n", err)
-			os.Exit(4)
-		}
-	}
 }
 
 // TestUpsertBatch_TemplatedIDFieldOverrideWins exercises the

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -6,11 +6,14 @@ package store
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -123,6 +126,88 @@ func TestStoreWrite_PanicReleasesLock(t *testing.T) {
 		close(done)
 	}()
 	<-done
+}
+
+func TestStoreWrite_KilledProcessLeavesDatabaseIntegral(t *testing.T) {
+	if os.Getenv("PP_STORE_KILL_HELPER") == "1" {
+		runStoreKillHelper()
+		return
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open seed db: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close seed db: %v", err)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestStoreWrite_KilledProcessLeavesDatabaseIntegral$", "-test.count=1")
+	cmd.Env = append(os.Environ(),
+		"PP_STORE_KILL_HELPER=1",
+		"PP_STORE_KILL_DB="+dbPath,
+	)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start kill helper: %v", err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill helper: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		_ = cmd.Process.Kill()
+		<-done
+	}
+
+	ro, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open killed db read-only: %v", err)
+	}
+	defer ro.Close()
+	var integrity string
+	if err := ro.DB().QueryRow("PRAGMA integrity_check").Scan(&integrity); err != nil {
+		t.Fatalf("integrity_check killed db: %v", err)
+	}
+	if integrity != "ok" {
+		t.Fatalf("integrity_check = %q, want ok", integrity)
+	}
+}
+
+func runStoreKillHelper() {
+	dbPath := os.Getenv("PP_STORE_KILL_DB")
+	if dbPath == "" {
+		fmt.Fprintln(os.Stderr, "PP_STORE_KILL_DB is required")
+		os.Exit(2)
+	}
+	s, err := Open(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "open helper db: %v\n", err)
+		os.Exit(3)
+	}
+	defer s.Close()
+
+	items := make([]json.RawMessage, 0, 250)
+	payload := strings.Repeat("x", 4096)
+	for i := 0; i < cap(items); i++ {
+		items = append(items, json.RawMessage(fmt.Sprintf(`{"id":"sigterm-%d","payload":%q}`, i, payload)))
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, _, err := s.UpsertBatch("sigterm_items", items); err != nil {
+			fmt.Fprintf(os.Stderr, "upsert helper batch: %v\n", err)
+			os.Exit(4)
+		}
+	}
 }
 
 // TestUpsertBatch_TemplatedIDFieldOverrideWins exercises the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Closes #4094.

`workflow archive` needs an operator-visible bound without silently truncating normal archive runs, and the emitted store should prove that an abruptly killed writer leaves SQLite integrity intact.

## Approach

- Add `workflow archive --max-pages` with a default of `0`, so normal archives are not page-capped unless the operator asks for it.
- Add `workflow archive --timeout` with a default wall-clock budget and `--timeout 0` as the escape hatch.
- Reject negative `--max-pages` and `--timeout` values before archive opens the store or starts network work.
- Keep dogfood bounded by default, but honor explicit `--max-pages` and `--timeout` values.
- Pass the archive context through store open, Substack publication preflight, and sync, and surface timeout failures as actionable errors.
- Add a generated-output store crash-safety proof that kills a writer subprocess and checks `PRAGMA integrity_check`.

## Scope

Primary area: generator templates for emitted workflow and store behavior.

Why this belongs in this repo: the issue reproduced in printed CLIs, but the archive command and SQLite store path are generated for every future printed CLI.

## Risk

This changes generated command flags and MCP workflow_archive arguments through the Cobra walker. Existing archive invocations still work, but normal runs are no longer silently capped at 100 pages and can now fail after the timeout unless operators pass `--timeout 0` or a larger duration. Negative bound values now fail fast instead of behaving like the unlimited escape hatch.

## Output Contract

Generated-output assertions and generated CLI runtime tests cover archive flags, dogfood behavior, timeout behavior, negative-bound rejection, Substack preflight context, and store kill integrity.

## Verification

- [x] `go fmt ./...`
- [x] `go test ./internal/generator -run TestGeneratedOutput_WorkflowBoundaries -count=1`
- [x] `go test ./internal/generator -run TestGenerateZeroSyncableAPIOmitsSyncAndDoctorCache -count=1`
- [x] `go test -timeout 20m ./...`
- [x] `GOTOOLCHAIN=go1.26.6 scripts/golden.sh verify`
- [x] `scripts/verify-generator-output.sh`

Note: plain `go test ./...` hit Go's default 10 minute timeout while `internal/generator` was still running on this machine. The same suite passed with a 20 minute package timeout. Plain `scripts/golden.sh verify` tried to download an unavailable fixture toolchain `go1.24`; pinning `GOTOOLCHAIN=go1.26.6` made the same golden suite pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c2d8382-eb0b-4f30-9918-7ca174fc04bb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c2d8382-eb0b-4f30-9918-7ca174fc04bb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

