### PR TITLE
fix(cli): validate composed-auth login --chrome sessions

### DIFF
--- a/internal/generator/composed_auth_jwt_validation_test.go
+++ b/internal/generator/composed_auth_jwt_validation_test.go
@@ -135,7 +135,7 @@ func composedAuthTestJWT(t *testing.T, expiry time.Time) string {
 	t.Helper()
 
 	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
-	payload := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"sub":"test","exp":%d}`, expiry.Unix())))
+	payload := base64.RawURLEncoding.EncodeToString(fmt.Appendf(nil, `{"sub":"test","exp":%d}`, expiry.Unix()))
 	signature := base64.RawURLEncoding.EncodeToString([]byte("signature"))
 	return header + "." + payload + "." + signature
 }

--- a/internal/generator/composed_auth_jwt_validation_test.go
+++ b/internal/generator/composed_auth_jwt_validation_test.go
@@ -1,0 +1,125 @@
+package generator
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedComposedAuthValidatesJWTExpLocally(t *testing.T) {
+	t.Parallel()
+
+	expiredJWT := composedAuthTestJWT(t, time.Now().Add(-time.Hour))
+	validJWT := composedAuthTestJWT(t, time.Now().Add(time.Hour))
+
+	var mu sync.Mutex
+	calls := map[string]int{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		mu.Lock()
+		calls[auth]++
+		mu.Unlock()
+
+		switch auth {
+		case "Bearer " + expiredJWT:
+			w.WriteHeader(http.StatusNoContent)
+		case "Bearer " + validJWT, "opaque-session":
+			w.WriteHeader(http.StatusUnauthorized)
+		default:
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer server.Close()
+
+	apiSpec := &spec.APISpec{
+		Name:    "composed-jwt-validation",
+		Version: "0.1.0",
+		BaseURL: server.URL,
+		Auth: spec.AuthConfig{
+			Type:         "composed",
+			Header:       "Authorization",
+			Format:       "Bearer {session}",
+			CookieDomain: "example.com",
+			Cookies:      []string{"session"},
+		},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/composed-jwt-validation-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Description: "Manage items",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/items", Description: "List items"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "composed-jwt-validation-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	requireGeneratedCompiles(t, outputDir)
+
+	testSrc := fmt.Sprintf(`package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+const expiredJWT = %q
+const validJWT = %q
+
+func TestValidateComposedAuthRejectsExpiredJWTBeforeProbe(t *testing.T) {
+	err := validateComposedAuth("Bearer " + expiredJWT)
+	if err == nil {
+		t.Fatal("validateComposedAuth() error = nil, want expired JWT error")
+	}
+	if !strings.Contains(err.Error(), "JWT expired") {
+		t.Fatalf("validateComposedAuth() error = %%q, want JWT expired", err)
+	}
+}
+
+func TestValidateComposedAuthAcceptsValidJWTWithoutProbe(t *testing.T) {
+	if err := validateComposedAuth("Bearer " + validJWT); err != nil {
+		t.Fatalf("validateComposedAuth() error = %%v, want nil", err)
+	}
+}
+
+func TestValidateComposedAuthFallsBackForOpaqueCredential(t *testing.T) {
+	err := validateComposedAuth("opaque-session")
+	if err == nil {
+		t.Fatal("validateComposedAuth() error = nil, want probe error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 401") {
+		t.Fatalf("validateComposedAuth() error = %%q, want HTTP 401", err)
+	}
+}
+`, expiredJWT, validJWT)
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "composed_auth_jwt_validation_test.go"), []byte(testSrc), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestValidateComposedAuth", "-count=1")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Zero(t, calls["Bearer "+expiredJWT], "expired JWT must fail locally even when the probe would accept it")
+	require.Zero(t, calls["Bearer "+validJWT], "valid JWT with exp must not be rejected by a hostile probe")
+	require.Positive(t, calls["opaque-session"], "opaque composed credentials must still use the existing probe")
+}
+
+func composedAuthTestJWT(t *testing.T, expiry time.Time) string {
+	t.Helper()
+
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"sub":"test","exp":%d}`, expiry.Unix())))
+	signature := base64.RawURLEncoding.EncodeToString([]byte("signature"))
+	return header + "." + payload + "." + signature
+}

--- a/internal/generator/composed_auth_jwt_validation_test.go
+++ b/internal/generator/composed_auth_jwt_validation_test.go
@@ -24,15 +24,21 @@ func TestGeneratedComposedAuthValidatesJWTExpLocally(t *testing.T) {
 	var mu sync.Mutex
 	calls := map[string]int{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		auth := r.Header.Get("Authorization")
+		authHeader := r.Header.Get("Authorization")
+		cookieHeader := r.Header.Get("Cookie")
+		callKey := "Authorization:" + authHeader + "|Cookie:" + cookieHeader
 		mu.Lock()
-		calls[auth]++
+		calls[callKey]++
 		mu.Unlock()
 
-		switch auth {
-		case "Bearer " + expiredJWT:
-			w.WriteHeader(http.StatusNoContent)
-		case "Bearer " + validJWT, "opaque-session":
+		if authHeader != "" {
+			w.WriteHeader(http.StatusTeapot)
+			return
+		}
+		switch cookieHeader {
+		case "session=" + validJWT:
+			w.WriteHeader(http.StatusUnauthorized)
+		case "session=opaque-session":
 			w.WriteHeader(http.StatusUnauthorized)
 		default:
 			w.WriteHeader(http.StatusNoContent)
@@ -79,8 +85,15 @@ import (
 const expiredJWT = %q
 const validJWT = %q
 
+func TestComposeAuthFromCookiesReplacesTokenPlaceholder(t *testing.T) {
+	got := composeAuthFromCookies("Bearer {token}", []string{"session"}, map[string]string{"session": "captured-cookie"})
+	if got != "Bearer captured-cookie" {
+		t.Fatalf("composeAuthFromCookies() = %%q, want %%q", got, "Bearer captured-cookie")
+	}
+}
+
 func TestValidateComposedAuthRejectsExpiredJWTBeforeProbe(t *testing.T) {
-	err := validateComposedAuth("Bearer " + expiredJWT)
+	err := validateComposedAuth("Bearer " + expiredJWT, "session=" + expiredJWT)
 	if err == nil {
 		t.Fatal("validateComposedAuth() error = nil, want expired JWT error")
 	}
@@ -90,13 +103,13 @@ func TestValidateComposedAuthRejectsExpiredJWTBeforeProbe(t *testing.T) {
 }
 
 func TestValidateComposedAuthAcceptsValidJWTWithoutProbe(t *testing.T) {
-	if err := validateComposedAuth("Bearer " + validJWT); err != nil {
+	if err := validateComposedAuth("Bearer " + validJWT, "session=" + validJWT); err != nil {
 		t.Fatalf("validateComposedAuth() error = %%v, want nil", err)
 	}
 }
 
 func TestValidateComposedAuthFallsBackForOpaqueCredential(t *testing.T) {
-	err := validateComposedAuth("opaque-session")
+	err := validateComposedAuth("Bearer opaque-session", "session=opaque-session")
 	if err == nil {
 		t.Fatal("validateComposedAuth() error = nil, want probe error")
 	}
@@ -110,9 +123,12 @@ func TestValidateComposedAuthFallsBackForOpaqueCredential(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
-	require.Zero(t, calls["Bearer "+expiredJWT], "expired JWT must fail locally even when the probe would accept it")
-	require.Zero(t, calls["Bearer "+validJWT], "valid JWT with exp must not be rejected by a hostile probe")
-	require.Positive(t, calls["opaque-session"], "opaque composed credentials must still use the existing probe")
+	require.Zero(t, calls["Authorization:Bearer "+expiredJWT+"|Cookie:session="+expiredJWT], "expired JWT must fail locally even when the probe would accept it")
+	require.Zero(t, calls["Authorization:|Cookie:session="+expiredJWT], "expired JWT must fail locally before any cookie probe")
+	require.Zero(t, calls["Authorization:Bearer "+validJWT+"|Cookie:session="+validJWT], "valid JWT with exp must not be rejected by a hostile probe")
+	require.Zero(t, calls["Authorization:|Cookie:session="+validJWT], "valid JWT with exp must not be rejected by a hostile cookie probe")
+	require.Positive(t, calls["Authorization:|Cookie:session=opaque-session"], "opaque composed credentials must still use the existing cookie probe")
+	require.Zero(t, calls["Authorization:Bearer opaque-session|Cookie:session=opaque-session"], "cookie-session validation must not send the bearer Authorization header")
 }
 
 func composedAuthTestJWT(t *testing.T, expiry time.Time) string {

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -365,15 +365,13 @@ profile by name when the installed backend supports it.`,
 				fmt.Fprintf(w, "%s Found session cookies via live Chrome.\n", green("OK"))
 			}
 
-			composed := "{{.Auth.Format}}"
-			for _, name := range requiredCookies {
-				composed = strings.ReplaceAll(composed, "{"+name+"}", cookieMap[name])
-			}
+			composed := composeAuthFromCookies("{{.Auth.Format}}", requiredCookies, cookieMap)
+			validationCookies := composeCookieHeader(requiredCookies, cookieMap)
 
 {{- if not .Auth.RequiresBrowserSession}}
 			// Validate the composed auth before saving — catch stale/expired sessions
 			fmt.Fprintf(w, "Validating session...")
-			if err := validateComposedAuth(composed); err != nil {
+			if err := validateComposedAuth(composed, validationCookies); err != nil {
 				loginURL := "https://" + strings.TrimPrefix(domain, ".")
 				fmt.Fprintf(w, " %s\n", red("expired"))
 				fmt.Fprintln(w, "")
@@ -1034,10 +1032,7 @@ func refreshStoredBrowserCookies(cfg *config.Config, w io.Writer) error {
 			return fmt.Errorf("cookie %q not found for %s", name, domain)
 		}
 	}
-	composed := "{{.Auth.Format}}"
-	for _, name := range requiredCookies {
-		composed = strings.ReplaceAll(composed, "{"+name+"}", cookieMap[name])
-	}
+	composed := composeAuthFromCookies("{{.Auth.Format}}", requiredCookies, cookieMap)
 	cfg.CredentialDomain = "{{.Auth.CookieDomain}}"
 	if err := cfg.SaveTokens("", "", composed, "", time.Time{}); err != nil {
 		return configErr(fmt.Errorf("saving auth: %w", err))
@@ -2226,14 +2221,40 @@ func extractViaCookieScoop(domain, profileDir string) (string, error) {
 {{- end}}
 
 {{- if eq .Auth.Type "composed"}}
+func composeAuthFromCookies(format string, requiredCookies []string, cookieMap map[string]string) string {
+	composed := format
+	if len(requiredCookies) > 0 {
+		if value, ok := cookieMap[requiredCookies[0]]; ok {
+			composed = strings.ReplaceAll(composed, "{token}", value)
+			composed = strings.ReplaceAll(composed, "{access_token}", value)
+		}
+	}
+	for _, name := range requiredCookies {
+		composed = strings.ReplaceAll(composed, "{"+name+"}", cookieMap[name])
+	}
+	return composed
+}
+
+func composeCookieHeader(requiredCookies []string, cookieMap map[string]string) string {
+	parts := make([]string, 0, len(requiredCookies))
+	for _, name := range requiredCookies {
+		if value, ok := cookieMap[name]; ok {
+			parts = append(parts, name+"="+value)
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
 // validateComposedAuth rejects expired JWTs locally before falling back to a
 // lightweight probe for opaque composed credentials.
-func validateComposedAuth(authHeader string) error {
-	if expiry, ok := composedAuthJWTExpiry(authHeader); ok {
-		if !time.Now().Before(expiry) {
-			return fmt.Errorf("JWT expired at %s", expiry.Format(time.RFC3339))
+func validateComposedAuth(authHeader, cookieHeader string) error {
+	for _, credential := range []string{authHeader, cookieHeader} {
+		if expiry, ok := composedAuthJWTExpiry(credential); ok {
+			if !time.Now().Before(expiry) {
+				return fmt.Errorf("JWT expired at %s", expiry.Format(time.RFC3339))
+			}
+			return nil
 		}
-		return nil
 	}
 
 	testURL := "{{.BaseURL}}"
@@ -2241,7 +2262,11 @@ func validateComposedAuth(authHeader string) error {
 	if err != nil {
 		return nil // can't validate, assume OK
 	}
-	req.Header.Set("{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}", authHeader)
+	if strings.TrimSpace(cookieHeader) != "" {
+		req.Header.Set("Cookie", cookieHeader)
+	} else {
+		req.Header.Set("{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}", authHeader)
+	}
 {{- range .RequiredHeaders}}
 	req.Header.Set("{{.Name}}", "{{.Value}}")
 {{- end}}

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -23,6 +23,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 {{- end}}
+{{- if eq .Auth.Type "composed"}}
+	"encoding/base64"
+{{- end}}
 {{- if or $hasCookieBrowserAuth $hasBrowserCapture}}
 	"encoding/json"
 {{- end}}
@@ -2223,11 +2226,16 @@ func extractViaCookieScoop(domain, profileDir string) (string, error) {
 {{- end}}
 
 {{- if eq .Auth.Type "composed"}}
-// validateComposedAuth makes a lightweight test request to verify the session is still active.
-// Uses the API base URL — any authenticated endpoint returning 401/403 indicates expiry.
-// A non-auth error (404, 500, timeout) is treated as "can't validate, assume OK" to avoid
-// blocking auth on unrelated API issues.
+// validateComposedAuth rejects expired JWTs locally before falling back to a
+// lightweight probe for opaque composed credentials.
 func validateComposedAuth(authHeader string) error {
+	if expiry, ok := composedAuthJWTExpiry(authHeader); ok {
+		if !time.Now().Before(expiry) {
+			return fmt.Errorf("JWT expired at %s", expiry.Format(time.RFC3339))
+		}
+		return nil
+	}
+
 	testURL := "{{.BaseURL}}"
 	req, err := http.NewRequest("HEAD", testURL, nil)
 	if err != nil {
@@ -2269,6 +2277,61 @@ func validateComposedAuth(authHeader string) error {
 		return fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
 	return nil
+}
+
+func composedAuthJWTExpiry(authHeader string) (time.Time, bool) {
+	for _, candidate := range strings.FieldsFunc(authHeader, func(r rune) bool {
+		isAlnum := (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		return !isAlnum && r != '-' && r != '_' && r != '.'
+	}) {
+		if strings.Count(candidate, ".") != 2 {
+			continue
+		}
+		expiry, ok := decodeJWTExpiry(candidate)
+		if ok {
+			return expiry, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func decodeJWTExpiry(candidate string) (time.Time, bool) {
+	parts := strings.Split(candidate, ".")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return time.Time{}, false
+	}
+	header, err := decodeBase64URLSegment(parts[0])
+	if err != nil {
+		return time.Time{}, false
+	}
+	var headerClaims map[string]any
+	if err := json.Unmarshal(header, &headerClaims); err != nil {
+		return time.Time{}, false
+	}
+	payload, err := decodeBase64URLSegment(parts[1])
+	if err != nil {
+		return time.Time{}, false
+	}
+	var claims struct {
+		Exp json.Number `json:"exp"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.UseNumber()
+	if err := decoder.Decode(&claims); err != nil {
+		return time.Time{}, false
+	}
+	expUnix, err := claims.Exp.Int64()
+	if err != nil {
+		return time.Time{}, false
+	}
+	return time.Unix(expUnix, 0), true
+}
+
+func decodeBase64URLSegment(segment string) ([]byte, error) {
+	if decoded, err := base64.RawURLEncoding.DecodeString(segment); err == nil {
+		return decoded, nil
+	}
+	return base64.URLEncoding.DecodeString(segment)
 }
 {{- end}}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Closes #4105.
Closes #4148.

Generated composed-auth `auth login --chrome` validation could accept expired JWT session cookies when a probe endpoint returned non-401/403, and could also reject valid captured cookies when the composed format used `{token}` or when the validation request sent the cookie credential as an Authorization bearer header.

## Approach

- Decode JWT-shaped segments in composed auth credentials and captured cookie headers during Chrome login validation.
- If a JWT payload has `exp`, reject expired tokens locally before saving and skip the probe for unexpired tokens.
- Compose Chrome-captured credentials with the same primary credential alias used elsewhere: `{token}` and `{access_token}` map to the first required captured cookie, while named cookie placeholders still work.
- Validate captured cookie sessions with a filtered `Cookie` header built from required cookies, while keeping the existing probe fallback for opaque credentials.

## Output Contract

- Added a generated-output runtime test that compiles a composed-auth CLI and covers expired JWT rejection, valid JWT acceptance, `{token}` substitution from captured cookies, opaque credential probe fallback, and Cookie-header validation without an Authorization bearer header.

## Verification

- `go fmt ./...`
- `GOTOOLCHAIN=go1.26.6 go test ./internal/generator -run TestGeneratedComposedAuthValidatesJWTExpLocally -count=1`
- `GOTOOLCHAIN=go1.26.6 scripts/golden.sh verify`
- `GOTOOLCHAIN=go1.26.6 scripts/verify-generator-output.sh`
- `GOTOOLCHAIN=go1.26.6 go test ./... -timeout 20m`
- `GOTOOLCHAIN=go1.26.6 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fba7babf-bdbd-47ed-bd33-1bdc579a7b67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fba7babf-bdbd-47ed-bd33-1bdc579a7b67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

