### PR TITLE
fix(cli): block MCP filesystem destination flags

### DIFF
--- a/internal/generator/mcp_destination_flags_test.go
+++ b/internal/generator/mcp_destination_flags_test.go
@@ -1,0 +1,72 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedMCPExportBlocksFilesystemDestinationFlags(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("mcpdest")
+	outputDir := filepath.Join(t.TempDir(), "mcpdest-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Export: true, MCP: true}
+	require.NoError(t, gen.Generate())
+
+	const runtimeTest = `package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func TestMCPExportDestinationFlagsBlocked(t *testing.T) {
+	t.Setenv("MCPDEST_CLI_PATH", "fixture-cli")
+
+	s := server.NewMCPServer("mcpdest", "test")
+	RegisterTools(s)
+	tools := s.ListTools()
+	entry, ok := tools["export"]
+	if !ok {
+		t.Fatalf("export tool missing from tools/list: %#v", tools)
+	}
+	props := entry.Tool.InputSchema.Properties
+	for _, want := range []string{"resource", "id", "format", "limit", "no-cache"} {
+		if _, ok := props[want]; !ok {
+			t.Fatalf("export tool schema missing %q: %#v", want, props)
+		}
+	}
+	for _, hidden := range []string{"audit-dir", "o", "output", "receipt-file"} {
+		if _, ok := props[hidden]; ok {
+			t.Fatalf("filesystem destination %q leaked into export tool schema: %#v", hidden, props)
+		}
+		result, err := entry.Handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+			Name:      "export",
+			Arguments: map[string]any{"resource": "items", hidden: "/tmp/evil"},
+		}})
+		if err != nil {
+			t.Fatalf("export handler returned transport error for %q: %v", hidden, err)
+		}
+		if result == nil || !result.IsError {
+			t.Fatalf("export handler accepted filesystem destination %q: %#v", hidden, result)
+		}
+		text := mcpTextContent(t, result)
+		if !strings.Contains(text, "unknown MCP parameter") || !strings.Contains(text, hidden) {
+			t.Fatalf("export handler error for %q = %q", hidden, text)
+		}
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "mcp", "export_destination_flags_test.go"), []byte(runtimeTest), 0o644))
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommandRequired(t, outputDir, "test", "./internal/mcp", "-run", "^TestMCPExportDestinationFlagsBlocked$", "-count=1")
+}

--- a/internal/generator/templates/cobratree/shellout.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout.go.tmpl
@@ -189,21 +189,35 @@ var reservedStructuredArgs = map[string]bool{
 	"args": true,
 }
 
+// blockedDestinationFlags are filesystem destination selectors that an MCP
+// client must not choose. The server account owns command execution, so
+// letting the client pick paths would let a tool write or truncate anything
+// that account can reach.
+var blockedDestinationFlags = map[string]bool{
+	"audit-dir":    true,
+	"o":            true,
+	"output":       true,
+	"receipt-file": true,
+}
+
 // blockedRootFlags are root-level CLI flags that an MCP client must not be
 // able to override via structured tool parameters. Allowing them lets a
 // caller swap auth credentials, redirect the API base URL, select a different
 // per-client filesystem, relocate the config/data/state/cache roots, load a
-// malicious config file, or change the delivery target, all of which sit
-// outside the per-command surface the agent is supposed to be calling.
+// malicious config file, change receipt destinations, or change the delivery
+// target, all of which sit outside the per-command surface the agent is
+// supposed to be calling.
 var blockedRootFlags = map[string]bool{
-	"base-url": true,
-	"client":   true,
-	"config":   true,
-	"deliver":  true,
-	"home":     true,
-	"insecure": true,
-	"profile":  true,
-	"token":    true,
+	"audit-dir":    true,
+	"base-url":     true,
+	"client":       true,
+	"config":       true,
+	"deliver":      true,
+	"home":         true,
+	"insecure":     true,
+	"profile":      true,
+	"receipt-file": true,
+	"token":        true,
 }
 
 func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {

--- a/internal/generator/templates/cobratree/shellout.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout.go.tmpl
@@ -189,10 +189,9 @@ var reservedStructuredArgs = map[string]bool{
 	"args": true,
 }
 
-// blockedDestinationFlags are filesystem destination selectors that an MCP
-// client must not choose. The server account owns command execution, so
-// letting the client pick paths would let a tool write or truncate anything
-// that account can reach.
+// MCP runs commands as the server account. Letting clients choose filesystem
+// destinations would let a tool write or truncate anything that account can
+// reach.
 var blockedDestinationFlags = map[string]bool{
 	"audit-dir":    true,
 	"o":            true,

--- a/internal/generator/templates/cobratree/shellout_test.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout_test.go.tmpl
@@ -58,18 +58,23 @@ func TestSplitShellArgs(t *testing.T) {
 // before they reach exec.CommandContext. A regression here would let a
 // caller redirect --base-url, swap --token, switch --client filesystems,
 // relocate the CLI's filesystem roots via --home, or load a malicious
-// --config.
+// --config. Filesystem destination flags must also be dropped even when they
+// are local command flags, because MCP clients do not get to choose disk paths.
 func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 	in := map[string]any{
-		"args":     "contacts",
-		"base-url": "https://evil.example.com",
-		"client":   "attacker-client",
-		"config":   "/tmp/evil.yaml",
-		"deliver":  "fd:3",
-		"home":     "/tmp/evil-home",
-		"insecure": true,
-		"profile":  "attacker",
-		"token":    "stolen-token",
+		"args":         "contacts",
+		"audit-dir":    "/tmp/evil-audit",
+		"base-url":     "https://evil.example.com",
+		"client":       "attacker-client",
+		"config":       "/tmp/evil.yaml",
+		"deliver":      "fd:3",
+		"home":         "/tmp/evil-home",
+		"insecure":     true,
+		"o":            "/tmp/evil-short.json",
+		"output":       "/tmp/evil.json",
+		"profile":      "attacker",
+		"receipt-file": "/tmp/evil-receipt.json",
+		"token":        "stolen-token",
 		// Keys containing "=" must not be emitted verbatim as flag=value.
 		"base-url=https://evil.example.com": true,
 		"config=/tmp/evil.yaml":             true,
@@ -79,21 +84,25 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in, map[string]bool{
-		"args":     true,
-		"base-url": true,
-		"client":   true,
-		"config":   true,
-		"deliver":  true,
-		"home":     true,
-		"insecure": true,
-		"profile":  true,
-		"token":    true,
+		"args":         true,
+		"audit-dir":    true,
+		"base-url":     true,
+		"client":       true,
+		"config":       true,
+		"deliver":      true,
+		"home":         true,
+		"insecure":     true,
+		"o":            true,
+		"output":       true,
+		"profile":      true,
+		"receipt-file": true,
+		"token":        true,
 	})
 	want := []string{"--limit", "10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
-	for _, blocked := range []string{"--base-url", "--client", "--config", "--deliver", "--home", "--insecure", "--profile", "--token", "--args"} {
+	for _, blocked := range []string{"--audit-dir", "--base-url", "--client", "--config", "--deliver", "--home", "--insecure", "--o", "--output", "--profile", "--receipt-file", "--token", "--args"} {
 		for _, tok := range got {
 			if tok == blocked {
 				t.Errorf("blocked flag %q leaked through cliArgsFromMCP", blocked)
@@ -149,11 +158,14 @@ func TestValidateMCPArgumentNamesQuotesEachUnknownArg(t *testing.T) {
 
 func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("audit-dir", "", "root audit dir")
 	root.PersistentFlags().String("profile", "", "root profile")
+	root.PersistentFlags().String("receipt-file", "", "root receipt file")
 	root.PersistentFlags().String("config", "", "root config")
 	root.PersistentFlags().String("json", "", "format output")
 
 	child := &cobra.Command{Use: "child"}
+	child.Flags().StringP("output", "o", "", "local output")
 	child.Flags().String("profile", "", "command profile")
 	root.AddCommand(child)
 
@@ -164,6 +176,11 @@ func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 	if !blocked["config"] {
 		t.Fatalf("inherited root --config was not blocked: %#v", blocked)
 	}
+	for _, destination := range []string{"audit-dir", "o", "output", "receipt-file"} {
+		if !blocked[destination] {
+			t.Fatalf("destination flag %q was not blocked: %#v", destination, blocked)
+		}
+	}
 	if blocked["json"] {
 		t.Fatalf("non-sensitive inherited --json should remain available: %#v", blocked)
 	}
@@ -173,6 +190,7 @@ func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 		"profile": "local-profile",
 		"config":  "/tmp/evil.yaml",
 		"json":    "true",
+		"output":  "/tmp/evil.json",
 	}, blocked)
 	want := []string{"--json", "true", "--profile", "local-profile"}
 	if !reflect.DeepEqual(got, want) {
@@ -400,11 +418,14 @@ func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
 
 func TestToolOptionsHideBlockedRootFlagsButKeepLocalCollisions(t *testing.T) {
 	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("audit-dir", "", "root audit dir")
 	root.PersistentFlags().String("config", "", "root config")
 	root.PersistentFlags().Bool("json", false, "json output")
+	root.PersistentFlags().String("receipt-file", "", "root receipt file")
 
 	child := &cobra.Command{Use: "child <query>"}
 	child.Flags().String("config", "", "local config")
+	child.Flags().StringP("output", "o", "", "local output")
 	child.Flags().String("args", "", "reserved local args")
 	root.AddCommand(child)
 
@@ -421,8 +442,16 @@ func TestToolOptionsHideBlockedRootFlagsButKeepLocalCollisions(t *testing.T) {
 	if _, ok := props["query"]; !ok {
 		t.Fatalf("positional <query> missing from schema: %#v", props)
 	}
-	if _, ok := props["args"]; ok {
-		t.Fatalf("reserved args parameter should not be exposed as a flag schema: %#v", props)
+	for _, hidden := range []string{"args", "audit-dir", "o", "output", "receipt-file"} {
+		if _, ok := props[hidden]; ok {
+			t.Fatalf("blocked parameter %q should not be exposed as a flag schema: %#v", hidden, props)
+		}
+	}
+	allowed := allowedStructuredArgsForCommand(child, blocked, positionals, true)
+	for _, hidden := range []string{"audit-dir", "o", "output", "receipt-file"} {
+		if allowed[hidden] {
+			t.Fatalf("blocked parameter %q should not be accepted by structured args: %#v", hidden, allowed)
+		}
 	}
 }
 

--- a/internal/generator/templates/cobratree/typemap.go.tmpl
+++ b/internal/generator/templates/cobratree/typemap.go.tmpl
@@ -31,6 +31,9 @@ func toolOptionsForFlags(cmd *cobra.Command, blocked map[string]bool, positional
 		if reservedStructuredArgs[flag.Name] {
 			return
 		}
+		if blocked[flag.Name] {
+			return
+		}
 		if seen[flag.Name] {
 			return
 		}
@@ -188,6 +191,9 @@ func positionalArgsForCommand(cmd *cobra.Command, blocked map[string]bool) []pos
 func blockedStructuredArgsForCommand(cmd *cobra.Command) map[string]bool {
 	blocked := map[string]bool{}
 	for name := range reservedStructuredArgs {
+		blocked[name] = true
+	}
+	for name := range blockedDestinationFlags {
 		blocked[name] = true
 	}
 	if cmd == nil {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
@@ -189,21 +189,35 @@ var reservedStructuredArgs = map[string]bool{
 	"args": true,
 }
 
+// blockedDestinationFlags are filesystem destination selectors that an MCP
+// client must not choose. The server account owns command execution, so
+// letting the client pick paths would let a tool write or truncate anything
+// that account can reach.
+var blockedDestinationFlags = map[string]bool{
+	"audit-dir":    true,
+	"o":            true,
+	"output":       true,
+	"receipt-file": true,
+}
+
 // blockedRootFlags are root-level CLI flags that an MCP client must not be
 // able to override via structured tool parameters. Allowing them lets a
 // caller swap auth credentials, redirect the API base URL, select a different
 // per-client filesystem, relocate the config/data/state/cache roots, load a
-// malicious config file, or change the delivery target, all of which sit
-// outside the per-command surface the agent is supposed to be calling.
+// malicious config file, change receipt destinations, or change the delivery
+// target, all of which sit outside the per-command surface the agent is
+// supposed to be calling.
 var blockedRootFlags = map[string]bool{
-	"base-url": true,
-	"client":   true,
-	"config":   true,
-	"deliver":  true,
-	"home":     true,
-	"insecure": true,
-	"profile":  true,
-	"token":    true,
+	"audit-dir":    true,
+	"base-url":     true,
+	"client":       true,
+	"config":       true,
+	"deliver":      true,
+	"home":         true,
+	"insecure":     true,
+	"profile":      true,
+	"receipt-file": true,
+	"token":        true,
 }
 
 func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
@@ -189,10 +189,9 @@ var reservedStructuredArgs = map[string]bool{
 	"args": true,
 }
 
-// blockedDestinationFlags are filesystem destination selectors that an MCP
-// client must not choose. The server account owns command execution, so
-// letting the client pick paths would let a tool write or truncate anything
-// that account can reach.
+// MCP runs commands as the server account. Letting clients choose filesystem
+// destinations would let a tool write or truncate anything that account can
+// reach.
 var blockedDestinationFlags = map[string]bool{
 	"audit-dir":    true,
 	"o":            true,

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
@@ -58,18 +58,23 @@ func TestSplitShellArgs(t *testing.T) {
 // before they reach exec.CommandContext. A regression here would let a
 // caller redirect --base-url, swap --token, switch --client filesystems,
 // relocate the CLI's filesystem roots via --home, or load a malicious
-// --config.
+// --config. Filesystem destination flags must also be dropped even when they
+// are local command flags, because MCP clients do not get to choose disk paths.
 func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 	in := map[string]any{
-		"args":     "contacts",
-		"base-url": "https://evil.example.com",
-		"client":   "attacker-client",
-		"config":   "/tmp/evil.yaml",
-		"deliver":  "fd:3",
-		"home":     "/tmp/evil-home",
-		"insecure": true,
-		"profile":  "attacker",
-		"token":    "stolen-token",
+		"args":         "contacts",
+		"audit-dir":    "/tmp/evil-audit",
+		"base-url":     "https://evil.example.com",
+		"client":       "attacker-client",
+		"config":       "/tmp/evil.yaml",
+		"deliver":      "fd:3",
+		"home":         "/tmp/evil-home",
+		"insecure":     true,
+		"o":            "/tmp/evil-short.json",
+		"output":       "/tmp/evil.json",
+		"profile":      "attacker",
+		"receipt-file": "/tmp/evil-receipt.json",
+		"token":        "stolen-token",
 		// Keys containing "=" must not be emitted verbatim as flag=value.
 		"base-url=https://evil.example.com": true,
 		"config=/tmp/evil.yaml":             true,
@@ -79,21 +84,25 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in, map[string]bool{
-		"args":     true,
-		"base-url": true,
-		"client":   true,
-		"config":   true,
-		"deliver":  true,
-		"home":     true,
-		"insecure": true,
-		"profile":  true,
-		"token":    true,
+		"args":         true,
+		"audit-dir":    true,
+		"base-url":     true,
+		"client":       true,
+		"config":       true,
+		"deliver":      true,
+		"home":         true,
+		"insecure":     true,
+		"o":            true,
+		"output":       true,
+		"profile":      true,
+		"receipt-file": true,
+		"token":        true,
 	})
 	want := []string{"--limit", "10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
-	for _, blocked := range []string{"--base-url", "--client", "--config", "--deliver", "--home", "--insecure", "--profile", "--token", "--args"} {
+	for _, blocked := range []string{"--audit-dir", "--base-url", "--client", "--config", "--deliver", "--home", "--insecure", "--o", "--output", "--profile", "--receipt-file", "--token", "--args"} {
 		for _, tok := range got {
 			if tok == blocked {
 				t.Errorf("blocked flag %q leaked through cliArgsFromMCP", blocked)
@@ -149,11 +158,14 @@ func TestValidateMCPArgumentNamesQuotesEachUnknownArg(t *testing.T) {
 
 func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("audit-dir", "", "root audit dir")
 	root.PersistentFlags().String("profile", "", "root profile")
+	root.PersistentFlags().String("receipt-file", "", "root receipt file")
 	root.PersistentFlags().String("config", "", "root config")
 	root.PersistentFlags().String("json", "", "format output")
 
 	child := &cobra.Command{Use: "child"}
+	child.Flags().StringP("output", "o", "", "local output")
 	child.Flags().String("profile", "", "command profile")
 	root.AddCommand(child)
 
@@ -164,6 +176,11 @@ func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 	if !blocked["config"] {
 		t.Fatalf("inherited root --config was not blocked: %#v", blocked)
 	}
+	for _, destination := range []string{"audit-dir", "o", "output", "receipt-file"} {
+		if !blocked[destination] {
+			t.Fatalf("destination flag %q was not blocked: %#v", destination, blocked)
+		}
+	}
 	if blocked["json"] {
 		t.Fatalf("non-sensitive inherited --json should remain available: %#v", blocked)
 	}
@@ -173,6 +190,7 @@ func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 		"profile": "local-profile",
 		"config":  "/tmp/evil.yaml",
 		"json":    "true",
+		"output":  "/tmp/evil.json",
 	}, blocked)
 	want := []string{"--json", "true", "--profile", "local-profile"}
 	if !reflect.DeepEqual(got, want) {
@@ -400,11 +418,14 @@ func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
 
 func TestToolOptionsHideBlockedRootFlagsButKeepLocalCollisions(t *testing.T) {
 	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("audit-dir", "", "root audit dir")
 	root.PersistentFlags().String("config", "", "root config")
 	root.PersistentFlags().Bool("json", false, "json output")
+	root.PersistentFlags().String("receipt-file", "", "root receipt file")
 
 	child := &cobra.Command{Use: "child <query>"}
 	child.Flags().String("config", "", "local config")
+	child.Flags().StringP("output", "o", "", "local output")
 	child.Flags().String("args", "", "reserved local args")
 	root.AddCommand(child)
 
@@ -421,8 +442,16 @@ func TestToolOptionsHideBlockedRootFlagsButKeepLocalCollisions(t *testing.T) {
 	if _, ok := props["query"]; !ok {
 		t.Fatalf("positional <query> missing from schema: %#v", props)
 	}
-	if _, ok := props["args"]; ok {
-		t.Fatalf("reserved args parameter should not be exposed as a flag schema: %#v", props)
+	for _, hidden := range []string{"args", "audit-dir", "o", "output", "receipt-file"} {
+		if _, ok := props[hidden]; ok {
+			t.Fatalf("blocked parameter %q should not be exposed as a flag schema: %#v", hidden, props)
+		}
+	}
+	allowed := allowedStructuredArgsForCommand(child, blocked, positionals, true)
+	for _, hidden := range []string{"audit-dir", "o", "output", "receipt-file"} {
+		if allowed[hidden] {
+			t.Fatalf("blocked parameter %q should not be accepted by structured args: %#v", hidden, allowed)
+		}
 	}
 }
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/typemap.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/typemap.go
@@ -31,6 +31,9 @@ func toolOptionsForFlags(cmd *cobra.Command, blocked map[string]bool, positional
 		if reservedStructuredArgs[flag.Name] {
 			return
 		}
+		if blocked[flag.Name] {
+			return
+		}
 		if seen[flag.Name] {
 			return
 		}
@@ -188,6 +191,9 @@ func positionalArgsForCommand(cmd *cobra.Command, blocked map[string]bool) []pos
 func blockedStructuredArgsForCommand(cmd *cobra.Command) map[string]bool {
 	blocked := map[string]bool{}
 	for name := range reservedStructuredArgs {
+		blocked[name] = true
+	}
+	for name := range blockedDestinationFlags {
 		blocked[name] = true
 	}
 	if cmd == nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Issue: Closes #4167

Generated MCP shell-out tools should not let MCP clients select filesystem destinations that can write or truncate arbitrary paths owned by the server account.

## Approach

Add a shared generated Cobra-tree blocklist for filesystem destination parameters (`output`, `o`, `audit-dir`, `receipt-file`) and apply it consistently to MCP schema generation, structured-argument validation, and CLI argument forwarding. Existing sensitive root flags remain blocked, while non-destination command-local flags continue to pass through.

## Scope

Primary area: generated MCP Cobra-tree shell-out tools.

Why this belongs in this repo: the unsafe surface is emitted into printed CLIs by the Printing Press generator, so the fix belongs in the reusable generator templates and generated-output tests.

## Risk

MCP clients can no longer use structured parameters to set destination file paths for mirrored commands. Human CLI usage, including `export --output`, remains unchanged.

## Output Contract

Updated the generated MCP cobratree golden fixture. Added generated-output coverage that registers the emitted MCP `export` tool, asserts `output`/`o`/`audit-dir`/`receipt-file` are absent from the tool schema, and verifies sending those names is rejected by the handler before shell-out.

## Verification

- [x] `go fmt ./...`
- [x] `go test ./internal/generator -run 'TestGeneratedMCPExportBlocksFilesystemDestinationFlags|TestGeneratedResourceCommandsUseAuthoritativePaths|TestGeneratedWindowsShelloutLargeOutputUsesPowerShell' -count=1`
- [x] `GOTOOLCHAIN=go1.26.6 scripts/golden.sh verify`
- [x] `GOTOOLCHAIN=go1.26.6 scripts/verify-generator-output.sh`
- [x] `GOTOOLCHAIN=go1.26.6 go test -timeout 20m ./...`
- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Note: `GOTOOLCHAIN=go1.26.6 go test ./...` was attempted and hit Go's default 10-minute timeout in `internal/generator`; the same suite passed with `-timeout 20m` (`internal/generator` took ~13m12s in this environment).

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f78cc4d4-8f05-451e-ba13-c80fb42e9d23?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f78cc4d4-8f05-451e-ba13-c80fb42e9d23&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

