### PR TITLE
fix(cli): sanitize insights similar FTS queries

### DIFF
--- a/internal/generator/insights_similar_fts_test.go
+++ b/internal/generator/insights_similar_fts_test.go
@@ -1,0 +1,177 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateInsightsSimilarSanitizesSourceTitleForFTSMatch(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("similar-fts-sanitize")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{
+		Store:    true,
+		Insights: []string{"insights/similar.go.tmpl"},
+	}
+	require.NoError(t, gen.Generate())
+
+	similarSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "similar.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(similarSrc), "matchQuery := store.FTSMatchQuery(searchText)")
+	require.Contains(t, string(similarSrc), "db.DB().Query(query, matchQuery, itemID, sourceType, limit)")
+
+	inlineTest := `package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"` + naming.CLI(apiSpec.Name) + `/internal/store"
+)
+
+func TestSimilarSanitizesSourceTitleForFTSMatch(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		sourceID    string
+		peerID      string
+		title       string
+		peerTitle   string
+		wantSimilar bool
+	}{
+		{
+			name:        "comma and parens",
+			sourceID:    "comma-source",
+			peerID:      "comma-peer",
+			title:       "Well drilling, Phase 2 (residential)",
+			peerTitle:   "Well drilling Phase 2 residential followup",
+			wantSimilar: true,
+		},
+		{
+			name:        "embedded quote",
+			sourceID:    "quote-source",
+			peerID:      "quote-peer",
+			title:       "Alpha \"quoted\" beta",
+			peerTitle:   "Alpha quoted beta followup",
+			wantSimilar: true,
+		},
+		{
+			name:        "leading hyphen",
+			sourceID:    "hyphen-source",
+			peerID:      "hyphen-peer",
+			title:       "-Draft- proposal",
+			peerTitle:   "Draft proposal review",
+			wantSimilar: true,
+		},
+		{
+			name:        "bare operators",
+			sourceID:    "operators-source",
+			peerID:      "operators-peer",
+			title:       "AND OR NOT",
+			peerTitle:   "AND OR NOT checklist",
+			wantSimilar: true,
+		},
+		{
+			name:        "punctuation only",
+			sourceID:    "punctuation-source",
+			title:       "!!! , -- ()",
+			wantSimilar: false,
+		},
+	}
+
+	for _, tt := range tests {
+		upsertSimilarRecord(t, db, tt.sourceID, tt.title)
+		if tt.wantSimilar {
+			upsertSimilarRecord(t, db, tt.peerID, tt.peerTitle)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := runSimilarJSON(t, dbPath, tt.sourceID)
+			if got.ResultCount != len(got.Similar) {
+				t.Fatalf("result_count = %d, len(similar) = %d", got.ResultCount, len(got.Similar))
+			}
+			if !tt.wantSimilar {
+				if len(got.Similar) != 0 {
+					t.Fatalf("punctuation-only title returned similar rows: %+v", got.Similar)
+				}
+				return
+			}
+			if !similarContainsID(got.Similar, tt.peerID) {
+				t.Fatalf("similar results missing %q: %+v", tt.peerID, got.Similar)
+			}
+		})
+	}
+}
+
+type similarOutput struct {
+	Similar []struct {
+		ID string ` + "`" + `json:"id"` + "`" + `
+	} ` + "`" + `json:"similar"` + "`" + `
+	ResultCount int ` + "`" + `json:"result_count"` + "`" + `
+}
+
+func upsertSimilarRecord(t *testing.T, db *store.Store, id, title string) {
+	t.Helper()
+	data, err := json.Marshal(map[string]string{
+		"id":    id,
+		"title": title,
+	})
+	if err != nil {
+		t.Fatalf("marshal record: %v", err)
+	}
+	if err := db.Upsert("tickets", id, data); err != nil {
+		t.Fatalf("upsert %s: %v", id, err)
+	}
+}
+
+func runSimilarJSON(t *testing.T, dbPath, sourceID string) similarOutput {
+	t.Helper()
+	cmd := newSimilarCmd(&rootFlags{asJSON: true})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{sourceID, "--db", dbPath, "--type", "tickets", "--limit", "10"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("similar %s: %v", sourceID, err)
+	}
+	var got similarOutput
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("parse similar output: %v\n%s", err, out.String())
+	}
+	return got
+}
+
+func similarContainsID(rows []struct {
+	ID string ` + "`" + `json:"id"` + "`" + `
+}, id string) bool {
+	for _, row := range rows {
+		if row.ID == id {
+			return true
+		}
+	}
+	return false
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "similar_fts_sanitize_test.go"), []byte(inlineTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "mod", "tidy")
+	runGoCommandRequired(t, outputDir, "test", "./internal/store", "-run", "^TestFTSMatchQuerySanitizesPunctuation$", "-count=1")
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "^TestSimilarSanitizesSourceTitleForFTSMatch$", "-count=1")
+}

--- a/internal/generator/templates/insights/similar.go.tmpl
+++ b/internal/generator/templates/insights/similar.go.tmpl
@@ -96,21 +96,6 @@ work items, tickets, or tasks.`,
 				return fmt.Errorf("item %q has no searchable title or name", itemID)
 			}
 
-			// Use FTS5 to find similar items (exclude the source item)
-			query := `SELECT r.id, r.resource_type, r.data, fts.rank
-				FROM resources_fts fts
-				JOIN resources r ON r.id = fts.id AND r.resource_type = fts.resource_type
-				WHERE resources_fts MATCH ?
-				  AND NOT (r.id = ? AND r.resource_type = ?)
-				ORDER BY fts.rank
-				LIMIT ?`
-
-			rows, err := db.DB().Query(query, searchText, itemID, sourceType, limit)
-			if err != nil {
-				return fmt.Errorf("searching for similar items: %w", err)
-			}
-			defer rows.Close()
-
 			type similarItem struct {
 				ID           string  `json:"id"`
 				ResourceType string  `json:"resource_type"`
@@ -119,33 +104,54 @@ work items, tickets, or tasks.`,
 			}
 
 			var items []similarItem
-			for rows.Next() {
-				var id, resType string
-				var data []byte
-				var rank float64
-				if err := rows.Scan(&id, &resType, &data, &rank); err != nil {
-					continue
-				}
+			matchQuery := store.FTSMatchQuery(searchText)
+			if matchQuery != "" {
+				// Use FTS5 to find similar items (exclude the source item)
+				query := `SELECT r.id, r.resource_type, r.data, fts.rank
+					FROM resources_fts fts
+					JOIN resources r ON r.id = fts.id AND r.resource_type = fts.resource_type
+					WHERE resources_fts MATCH ?
+					  AND NOT (r.id = ? AND r.resource_type = ?)
+					ORDER BY fts.rank
+					LIMIT ?`
 
-				var obj map[string]any
-				if err := json.Unmarshal(data, &obj); err != nil {
-					continue
+				rows, err := db.DB().Query(query, matchQuery, itemID, sourceType, limit)
+				if err != nil {
+					return fmt.Errorf("searching for similar items: %w", err)
 				}
+				defer rows.Close()
 
-				title := ""
-				for _, key := range []string{"title", "name", "subject", "summary"} {
-					if v, ok := obj[key]; ok {
-						title = fmt.Sprintf("%v", v)
-						break
+				for rows.Next() {
+					var id, resType string
+					var data []byte
+					var rank float64
+					if err := rows.Scan(&id, &resType, &data, &rank); err != nil {
+						continue
 					}
-				}
 
-				items = append(items, similarItem{
-					ID:           id,
-					ResourceType: resType,
-					Title:        title,
-					Rank:         rank,
-				})
+					var obj map[string]any
+					if err := json.Unmarshal(data, &obj); err != nil {
+						continue
+					}
+
+					title := ""
+					for _, key := range []string{"title", "name", "subject", "summary"} {
+						if v, ok := obj[key]; ok {
+							title = fmt.Sprintf("%v", v)
+							break
+						}
+					}
+
+					items = append(items, similarItem{
+						ID:           id,
+						ResourceType: resType,
+						Title:        title,
+						Rank:         rank,
+					})
+				}
+				if err := rows.Err(); err != nil {
+					return fmt.Errorf("reading similar items: %w", err)
+				}
 			}
 
 			if flags.asJSON {

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1175,7 +1175,7 @@ func (s *Store) Search(query string, limit int, resourceTypes ...string) ([]json
 	if limit <= 0 {
 		limit = 50
 	}
-	matchQuery := ftsMatchQuery(query)
+	matchQuery := FTSMatchQuery(query)
 	if matchQuery == "" {
 		return nil, nil
 	}
@@ -1295,7 +1295,8 @@ func isIdentifierKey(key string) bool {
 		strings.HasSuffix(key, "ID")
 }
 
-func ftsMatchQuery(query string) string {
+// FTSMatchQuery converts arbitrary text into a safe FTS5 MATCH expression.
+func FTSMatchQuery(query string) string {
 	tokens := ftsQueryTokenRE.FindAllString(query, -1)
 	if len(tokens) == 0 {
 		return ""
@@ -1962,7 +1963,7 @@ func (s *Store) Search{{pascal .Name}}(query string, limit int) ([]json.RawMessa
 	if limit <= 0 {
 		limit = 50
 	}
-	matchQuery := ftsMatchQuery(query)
+	matchQuery := FTSMatchQuery(query)
 	if matchQuery == "" {
 		return nil, nil
 	}

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -444,6 +444,66 @@ func TestSearchQuotesFTSQuerySyntax(t *testing.T) {
 	}
 }
 
+func TestFTSMatchQuerySanitizesPunctuation(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "comma and parens",
+			input: `Well drilling, Phase 2 (residential)`,
+			want:  `"Well" "drilling" "Phase" "2" "residential"`,
+		},
+		{
+			name:  "embedded quote",
+			input: `Alpha "quoted" beta`,
+			want:  `"Alpha" "quoted" "beta"`,
+		},
+		{
+			name:  "leading hyphen",
+			input: `-Draft- proposal`,
+			want:  `"Draft" "proposal"`,
+		},
+		{
+			name:  "bare operators",
+			input: `AND OR NOT`,
+			want:  `"AND" "OR" "NOT"`,
+		},
+		{
+			name:  "punctuation only",
+			input: `!!! , -- () ""`,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matchQuery := FTSMatchQuery(tt.input)
+			if matchQuery != tt.want {
+				t.Fatalf("FTSMatchQuery(%q) = %q, want %q", tt.input, matchQuery, tt.want)
+			}
+			if matchQuery == "" {
+				return
+			}
+			rows, err := s.DB().Query(`SELECT rowid FROM resources_fts WHERE resources_fts MATCH ? LIMIT 1`, matchQuery)
+			if err != nil {
+				t.Fatalf("FTS MATCH rejected sanitized query %q from %q: %v", matchQuery, tt.input, err)
+			}
+			if err := rows.Close(); err != nil {
+				t.Fatalf("close rows: %v", err)
+			}
+		})
+	}
+}
+
 {{- $hasDomainTable := false }}
 {{- range .Tables}}
 {{- if emitsDomainTable .}}

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -887,7 +887,7 @@ func (s *Store) Search(query string, limit int, resourceTypes ...string) ([]json
 	if limit <= 0 {
 		limit = 50
 	}
-	matchQuery := ftsMatchQuery(query)
+	matchQuery := FTSMatchQuery(query)
 	if matchQuery == "" {
 		return nil, nil
 	}
@@ -1007,7 +1007,8 @@ func isIdentifierKey(key string) bool {
 		strings.HasSuffix(key, "ID")
 }
 
-func ftsMatchQuery(query string) string {
+// FTSMatchQuery converts arbitrary text into a safe FTS5 MATCH expression.
+func FTSMatchQuery(query string) string {
 	tokens := ftsQueryTokenRE.FindAllString(query, -1)
 	if len(tokens) == 0 {
 		return ""

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1049,7 +1049,7 @@ func (s *Store) Search(query string, limit int, resourceTypes ...string) ([]json
 	if limit <= 0 {
 		limit = 50
 	}
-	matchQuery := ftsMatchQuery(query)
+	matchQuery := FTSMatchQuery(query)
 	if matchQuery == "" {
 		return nil, nil
 	}
@@ -1169,7 +1169,8 @@ func isIdentifierKey(key string) bool {
 		strings.HasSuffix(key, "ID")
 }
 
-func ftsMatchQuery(query string) string {
+// FTSMatchQuery converts arbitrary text into a safe FTS5 MATCH expression.
+func FTSMatchQuery(query string) string {
 	tokens := ftsQueryTokenRE.FindAllString(query, -1)
 	if len(tokens) == 0 {
 		return ""

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1055,7 +1055,7 @@ func (s *Store) Search(query string, limit int, resourceTypes ...string) ([]json
 	if limit <= 0 {
 		limit = 50
 	}
-	matchQuery := ftsMatchQuery(query)
+	matchQuery := FTSMatchQuery(query)
 	if matchQuery == "" {
 		return nil, nil
 	}
@@ -1175,7 +1175,8 @@ func isIdentifierKey(key string) bool {
 		strings.HasSuffix(key, "ID")
 }
 
-func ftsMatchQuery(query string) string {
+// FTSMatchQuery converts arbitrary text into a safe FTS5 MATCH expression.
+func FTSMatchQuery(query string) string {
 	tokens := ftsQueryTokenRE.FindAllString(query, -1)
 	if len(tokens) == 0 {
 		return ""

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1049,7 +1049,7 @@ func (s *Store) Search(query string, limit int, resourceTypes ...string) ([]json
 	if limit <= 0 {
 		limit = 50
 	}
-	matchQuery := ftsMatchQuery(query)
+	matchQuery := FTSMatchQuery(query)
 	if matchQuery == "" {
 		return nil, nil
 	}
@@ -1169,7 +1169,8 @@ func isIdentifierKey(key string) bool {
 		strings.HasSuffix(key, "ID")
 }
 
-func ftsMatchQuery(query string) string {
+// FTSMatchQuery converts arbitrary text into a safe FTS5 MATCH expression.
+func FTSMatchQuery(query string) string {
 	tokens := ftsQueryTokenRE.FindAllString(query, -1)
 	if len(tokens) == 0 {
 		return ""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Issue: Closes #3943

Fix generated `insights/similar` so API-provided source titles are sanitized before binding into SQLite FTS5 `MATCH`.

## Approach

Export the generated store sanitizer as `store.FTSMatchQuery`, keep generated `Search` and typed `Search<Resource>` helpers on that shared path, and route `insights/similar` through it before querying `resources_fts`. Sanitizer-empty titles, such as punctuation-only titles, now skip the MATCH query and return a clean empty similar-items result.

## Scope

Primary area: generator templates for printed CLI local store/search behavior.

Why this belongs in this repo: the broken behavior is emitted into printed CLIs by the Printing Press generator, so the fix needs to land in the generator templates rather than one printed CLI.

## Risk

Low. This narrows generated FTS MATCH inputs to the same token-quoted form already used by generated store search helpers; punctuation-only titles stop before querying FTS and return no similar items.

## Output Contract

Generated-output evidence is covered by a generator regression that emits a CLI with `insights/similar`, asserts the emitted command uses `store.FTSMatchQuery`, runs the emitted store sanitizer table, and runs the emitted similar command against problematic API titles.

Golden fixture updates are limited to generated `internal/store/store.go` artifacts that now expose `FTSMatchQuery`.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates
- [x] `go fmt ./internal/generator`
- [x] `go fmt ./...`
- [x] `go test ./internal/generator -run 'TestGenerateInsightsSimilarSanitizesSourceTitleForFTSMatch|TestGenerateStoreFTSOrderByRankQualified|TestGenerateInsightsSimilarFTSOrderByRankQualified' -count=1`
- [x] `go test ./... -timeout 30m`
- [x] `scripts/verify-generator-output.sh`
- [x] `scripts/golden.sh verify` confirmed all generated CLI golden cases affected by this change pass after fixture updates
- [ ] `scripts/golden.sh verify` full harness still fails on unrelated existing fixture/harness issues: `dogfood-verdict-matrix` example-check fixture builds report `could not build CLI binary: exit status 1`, and `verify-runtime-matrix` reports missing `structural-fail.json`

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21293f81-0e07-48b1-abd3-5d14638b0cdf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21293f81-0e07-48b1-abd3-5d14638b0cdf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

