### PR TITLE
fix(cli): stop name-keying records when a real identifier exists

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -16231,6 +16231,83 @@ func TestGeneratedSyncIDFieldOverridesAndProbes(t *testing.T) {
 	runGoCommand(t, outputDir, "test", "./internal/cli/...", "-run", "TestSyncSingleObject_PreservesLargeIntegerResourceIDs")
 }
 
+func TestGeneratedStoreIDFieldOverrideKeepsDuplicateNames(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("idfieldrows")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"scheduled-events": {
+			Description: "Manage scheduled events",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/scheduled_events",
+					Description: "List scheduled events",
+					Response:    spec.ResponseDef{Type: "array"},
+					Pagination:  &spec.Pagination{CursorParam: "page_token", LimitParam: "count"},
+					IDField:     "uri",
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	storeGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(storeGo), `"scheduled-events": "uri",`)
+
+	storeTest := `package store
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+func TestURIOverrideKeepsDuplicateDisplayNames(t *testing.T) {
+	db, err := OpenWithContext(context.Background(), filepath.Join(t.TempDir(), "store.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	items := []json.RawMessage{
+		json.RawMessage(` + "`" + `{"uri":"https://api.example.com/scheduled_events/event-a","name":"Weekly review"}` + "`" + `),
+		json.RawMessage(` + "`" + `{"uri":"https://api.example.com/scheduled_events/event-b","name":"Weekly review"}` + "`" + `),
+	}
+	stored, extractFailures, typedFailures, err := db.UpsertBatchDetailed("scheduled-events", items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored != 2 || extractFailures != 0 || typedFailures != 0 {
+		t.Fatalf("UpsertBatchDetailed stored=%d extractFailures=%d typedFailures=%d, want 2/0/0", stored, extractFailures, typedFailures)
+	}
+	count, err := db.Count("scheduled-events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("Count = %d, want 2", count)
+	}
+	for _, id := range []string{
+		"https://api.example.com/scheduled_events/event-a",
+		"https://api.example.com/scheduled_events/event-b",
+	} {
+		if _, err := db.Get("scheduled-events", id); err != nil {
+			t.Fatalf("Get(%q): %v", id, err)
+		}
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "store", "id_override_test.go"), []byte(storeTest), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/store", "-run", "TestURIOverrideKeepsDuplicateDisplayNames")
+	requireGeneratedCompiles(t, outputDir)
+}
+
 func TestGeneratedSyncIDFieldOverridesFromMemberPathParam(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/path_param_encoding_test.go
+++ b/internal/generator/path_param_encoding_test.go
@@ -63,8 +63,8 @@ func TestReplacePathParamPercentEncodesValue(t *testing.T) {
 	assert.Contains(t, src, "/internal/cliutil",
 		"helpers.go must import cliutil when replacePathParam is emitted")
 	assert.Contains(t, src,
-		`return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(value))`,
-		"replacePathParam must use the shared path-param escaper")
+		`return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(pathParamSegmentValue(value)))`,
+		"replacePathParam must normalize URL IDs before using the shared path-param escaper")
 
 	cliutilPath := filepath.Join(outputDir, "internal", "cliutil", "text.go")
 	cliutilGo, err := os.ReadFile(cliutilPath)
@@ -94,7 +94,8 @@ func TestReplacePathParamEncodesSingleSegment(t *testing.T) {
 	tests := map[string]string{
 		"opaque-id": "opaque-id",
 		"sc-domain:example.com": "sc-domain:example.com",
-		"https://example.com/foo": "https:%2F%2Fexample.com%2Ffoo",
+		"https://example.com/foo": "foo",
+		"https://example.com/foo/bar/": "bar",
 		"allenai/c4": "allenai%2Fc4",
 		"src/main file.go": "src%2Fmain%20file.go",
 		"../secret": "..%2Fsecret",

--- a/internal/generator/path_param_encoding_test.go
+++ b/internal/generator/path_param_encoding_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -63,8 +64,11 @@ func TestReplacePathParamPercentEncodesValue(t *testing.T) {
 	assert.Contains(t, src, "/internal/cliutil",
 		"helpers.go must import cliutil when replacePathParam is emitted")
 	assert.Contains(t, src,
-		`return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(pathParamSegmentValue(value)))`,
-		"replacePathParam must normalize URL IDs before using the shared path-param escaper")
+		`return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(value))`,
+		"replacePathParam must preserve ordinary path params while using the shared path-param escaper")
+	assert.Contains(t, src,
+		`return replacePathParam(path, name, pathParamSegmentValue(value))`,
+		"replaceURLIDPathParam must normalize URL-backed resource IDs before escaping")
 
 	cliutilPath := filepath.Join(outputDir, "internal", "cliutil", "text.go")
 	cliutilGo, err := os.ReadFile(cliutilPath)
@@ -94,8 +98,7 @@ func TestReplacePathParamEncodesSingleSegment(t *testing.T) {
 	tests := map[string]string{
 		"opaque-id": "opaque-id",
 		"sc-domain:example.com": "sc-domain:example.com",
-		"https://example.com/foo": "foo",
-		"https://example.com/foo/bar/": "bar",
+		"https://example.com/foo?version=2": "https:%2F%2Fexample.com%2Ffoo%3Fversion=2",
 		"allenai/c4": "allenai%2Fc4",
 		"src/main file.go": "src%2Fmain%20file.go",
 		"../secret": "..%2Fsecret",
@@ -105,6 +108,21 @@ func TestReplacePathParamEncodesSingleSegment(t *testing.T) {
 	for input, want := range tests {
 		if got := replacePathParam("/datasets/{id}", "id", input); got != "/datasets/"+want {
 			t.Fatalf("replacePathParam(%q) = %q, want %q", input, got, "/datasets/"+want)
+		}
+	}
+}
+
+func TestReplaceURLIDPathParamUsesTrailingSegment(t *testing.T) {
+	tests := map[string]string{
+		"https://example.com/foo": "foo",
+		"https://example.com/foo/bar/": "bar",
+		"https://example.com/foo?version=2": "foo",
+		"opaque-id": "opaque-id",
+		"allenai/c4": "allenai%2Fc4",
+	}
+	for input, want := range tests {
+		if got := replaceURLIDPathParam("/datasets/{id}", "id", input); got != "/datasets/"+want {
+			t.Fatalf("replaceURLIDPathParam(%q) = %q, want %q", input, got, "/datasets/"+want)
 		}
 	}
 }
@@ -216,10 +234,123 @@ func TestDependentPathParamStripsCompositeStorageID(t *testing.T) {
 	src := string(syncGo)
 
 	assert.Contains(t, src,
-		`path = replacePathParam(path, pathParam.Param, store.BareResourceID(parentRow[pathParam.Field]))`,
+		`path = replaceDependentPathParam(path, pathParam.Param, dep.ParentTable, pathParam.Field, parentRow[pathParam.Field])`,
 		"the dependent fan-out must strip the NUL-composite parent storage id via "+
 			"store.BareResourceID before substituting it into the path, so a parent-keyed "+
 			"parent (composite id) never leaks a %00 into the request URL (nginx 400)")
+	assert.Contains(t, src,
+		`bareValue := store.BareResourceID(value)`,
+		"replaceDependentPathParam must still strip composite storage IDs before path substitution")
+}
+
+func TestDependentURLIDPathParamUsesTrailingSegment(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("urlidpath")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"scheduled-events": {
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:   "GET",
+					Path:     "/scheduled_events",
+					Response: spec.ResponseDef{Type: "array"},
+					IDField:  "uri",
+				},
+			},
+		},
+		"invitees": {
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:   "GET",
+					Path:     "/scheduled_events/{event_uuid}/invitees",
+					Response: spec.ResponseDef{Type: "array"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	gen.profile = &profiler.APIProfile{
+		SyncableResources: []profiler.SyncableResource{
+			{Name: "scheduled-events", Path: "/scheduled_events", Method: "GET", IDField: "uri"},
+		},
+		DependentSyncResources: []profiler.DependentResource{
+			{
+				Name:           "invitees",
+				ParentResource: "scheduled-events",
+				ParentIDParam:  "event_uuid",
+				Path:           "/scheduled_events/{event_uuid}/invitees",
+				Method:         "GET",
+				PathParams:     []profiler.DependentPathParam{{Param: "event_uuid", Field: "uri"}},
+			},
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	inlineTest := `package cli
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"` + naming.CLI(apiSpec.Name) + `/internal/store"
+)
+
+type dependentURLIDClient struct {
+	t *testing.T
+}
+
+func (c dependentURLIDClient) Get(_ context.Context, path string, _ map[string]string) (json.RawMessage, error) {
+	if path != "/scheduled_events/event-a/invitees" {
+		c.t.Fatalf("path = %q, want /scheduled_events/event-a/invitees", path)
+	}
+	return json.RawMessage(` + "`" + `[{"id":"invitee-1"}]` + "`" + `), nil
+}
+
+func (dependentURLIDClient) RateLimit() float64 {
+	return 0
+}
+
+func TestDependentURLIDPathParamUsesTrailingSegment(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	eventURI := "https://api.example.com/scheduled_events/event-a?version=2"
+	if err := db.Upsert("scheduled-events", eventURI, []byte(` + "`" + `{"uri":"https://api.example.com/scheduled_events/event-a?version=2","name":"Weekly review"}` + "`" + `)); err != nil {
+		t.Fatalf("insert scheduled event: %v", err)
+	}
+
+	res := syncDependentResource(
+		context.Background(),
+		dependentURLIDClient{t: t},
+		db,
+		dependentResourceDef{
+			Name: "invitees",
+			ParentTable: "scheduled-events",
+			ParentIDParam: "event_uuid",
+			PathTemplate: "/scheduled_events/{event_uuid}/invitees",
+			PathParams: []dependentPathParamDef{{Param: "event_uuid", Field: "uri"}},
+		},
+		"", false, 1, false, false, nil, nil, 1,
+	)
+	if res.Err != nil {
+		t.Fatalf("syncDependentResource error: %v", res.Err)
+	}
+	if res.Count != 1 {
+		t.Fatalf("synced count = %d, want 1", res.Count)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "dependent_url_id_path_test.go"), []byte(inlineTest), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "TestDependentURLIDPathParamUsesTrailingSegment")
 }
 
 // TestPathParamEscapeBehaviorPinsContract is a stdlib-behavior pin for

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-{{- if or .HasEmbeddedPaged (hasIndexedOrArrayQueryParams .APISpec)}}
+{{- if or .HasEmbeddedPaged (hasIndexedOrArrayQueryParams .APISpec) .HasPathParams}}
 	"net/url"
 {{- end}}
 	"os"
@@ -1267,7 +1267,29 @@ func newTabWriter(w io.Writer) *tabwriter.Writer {
 // replacePathParam escapes path-param values before substituting them so
 // reserved characters within each segment remain safe in the request URL.
 func replacePathParam(path, name, value string) string {
-	return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(value))
+	return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(pathParamSegmentValue(value)))
+}
+
+func pathParamSegmentValue(value string) string {
+	parsed, err := url.Parse(strings.TrimSpace(value))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return value
+	}
+	escapedPath := strings.TrimRight(parsed.EscapedPath(), "/")
+	if escapedPath == "" {
+		return value
+	}
+	segment := escapedPath
+	if i := strings.LastIndex(segment, "/"); i >= 0 {
+		segment = segment[i+1:]
+	}
+	if segment == "" {
+		return value
+	}
+	if decoded, err := url.PathUnescape(segment); err == nil {
+		return decoded
+	}
+	return segment
 }
 {{- end}}
 

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1267,7 +1267,11 @@ func newTabWriter(w io.Writer) *tabwriter.Writer {
 // replacePathParam escapes path-param values before substituting them so
 // reserved characters within each segment remain safe in the request URL.
 func replacePathParam(path, name, value string) string {
-	return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(pathParamSegmentValue(value)))
+	return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(value))
+}
+
+func replaceURLIDPathParam(path, name, value string) string {
+	return replacePathParam(path, name, pathParamSegmentValue(value))
 }
 
 func pathParamSegmentValue(value string) string {

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -3045,6 +3045,29 @@ type dependentPathParamDef struct {
 	Field string
 }
 
+func replaceDependentPathParam(path, name, parentResource, field, value string) string {
+	bareValue := store.BareResourceID(value)
+	if resourceURLIDPathParam(parentResource, field) {
+		return replaceURLIDPathParam(path, name, bareValue)
+	}
+	return replacePathParam(path, name, bareValue)
+}
+
+func resourceURLIDPathParam(resource, field string) bool {
+	idField, ok := resourceIDFieldOverrides[resource]
+	return ok && idField == field && urlIDFieldName(field)
+}
+
+func urlIDFieldName(field string) bool {
+	normalized := strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(field))
+	switch normalized {
+	case "uri", "self", "selflink", "href", "url":
+		return true
+	default:
+		return false
+	}
+}
+
 func dependentResourceDefs() []dependentResourceDef {
 	return []dependentResourceDef{
 {{- range .DependentSyncResources}}
@@ -3266,13 +3289,7 @@ func syncOneParent(
 	parentFKKey := dep.ParentTable + "_id"
 	path := dep.PathTemplate
 	for _, pathParam := range pathParams {
-		// Strip the NUL-composite parent suffix that resourceStorageID builds
-		// for parent-keyed parents: the path needs the BARE entity id. Leaving
-		// the composite in routes a "%00" through replacePathParam's
-		// url.PathEscape into the URL, which nginx rejects with HTTP 400.
-		// BareResourceID is a no-op on non-composite ids, so this is safe for
-		// every path param (plain parents are unaffected).
-		path = replacePathParam(path, pathParam.Param, store.BareResourceID(parentRow[pathParam.Field]))
+		path = replaceDependentPathParam(path, pathParam.Param, dep.ParentTable, pathParam.Field, parentRow[pathParam.Field])
 	}
 {{- if $hasIDWalk}}
 	idWalk, usesIDWalk := syncResourceIDWalkConfig(dep.Name)

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -3706,6 +3706,9 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) error {
 				endpoint.IDFieldFromPathParam = true
 			} else {
 				endpoint.IDField = resolveIDFieldFromResponseSchema(op, targetResourceName)
+				if endpoint.IDField == "name" {
+					warnf("%s %q: response-schema ID fallback chose display field \"name\"; add x-resource-id if the API exposes a stable identifier", strings.ToUpper(method), path)
+				}
 			}
 			if strings.ToUpper(method) == "POST" {
 				endpoint.Pagination = detectPostQueryIDWalkPagination(endpoint.Body, op, endpoint.IDField)
@@ -6165,11 +6168,12 @@ func responseItemSchema(op *openapi3.Operation) *openapi3.Schema {
 	return unwrapItemSchema(schemaRef.Value)
 }
 
-// resolveIDFieldFromResponseSchema implements tiers 2-5 of the IDField fallback
+// resolveIDFieldFromResponseSchema implements tiers 2-6 of the IDField fallback
 // chain: prefer "id", then a resource-prefixed key (`<singular>_id` /
 // `_uuid` / `_guid`), then a vendor identifier (`gid` / `sid` / `uid` /
-// `uuid` / `guid`), then "name", then the first scalar field listed in the
-// response schema's `required:` array (walking properties in their schema order).
+// `uuid` / `guid`), then a URL-shaped identifier (`uri` / `self` /
+// `selfLink` / `href` / `url`), then "name", then the first scalar field listed
+// in the response schema's `required:` array (walking properties in their schema order).
 // Returns "" when no field qualifies; templates fall through to runtime list
 // scanning. Tier 1 (`x-resource-id` extension) is handled separately by the
 // caller — it overrides every tier here.
@@ -6214,12 +6218,18 @@ func resolveIDFieldFromResponseSchema(op *openapi3.Operation, resourceName strin
 		}
 	}
 
-	// Tier 4: explicit `name`
+	// Tier 4: URL-shaped identifiers. These trail id-shaped keys so APIs that
+	// expose both `id` and `self` keep keying on the compact primary key.
+	if id := urlShapedIDField(itemSchema); id != "" {
+		return id
+	}
+
+	// Tier 5: explicit `name`
 	if _, ok := itemSchema.Properties["name"]; ok {
 		return "name"
 	}
 
-	// Tier 5: first plausible-PK scalar field appearing in the schema's
+	// Tier 6: first plausible-PK scalar field appearing in the schema's
 	// required[] array, matched against properties in their schema-declared
 	// order. kin-openapi preserves YAML/JSON property order in MapKeys/Extensions
 	// but not via range over Properties (it's a Go map). Fall back to iterating
@@ -6295,13 +6305,13 @@ func collectIDSchemaFieldsInto(schemaRef *openapi3.SchemaRef, fields *idSchemaFi
 }
 
 // resourcePrefixedIDField returns the first property whose snake-cased name
-// matches `<singular_resource>_id`, then `_uuid`, then `_guid`. Returns "" when
-// the resource name is empty or no property matches. Property names are
-// returned verbatim so callers preserve the spec's original casing (e.g.
-// `categoryId` rather than `category_id`).
+// matches a resource-derived base plus `_id`, then `_uuid`, then `_guid`.
+// Composed resource names also probe their leaf segment so child collections
+// like `projects_tasks` can key on `taskId`. Property names are returned
+// verbatim so callers preserve the spec's original casing.
 func resourcePrefixedIDField(schema *openapi3.Schema, resourceName string) string {
-	singular := singularizeIdentifier(toSnakeCase(resourceName))
-	if singular == "" {
+	bases := resourceIDBaseCandidates(resourceName)
+	if len(bases) == 0 {
 		return ""
 	}
 	// Sort property names so behavior is deterministic across Go map
@@ -6313,9 +6323,56 @@ func resourcePrefixedIDField(schema *openapi3.Schema, resourceName string) strin
 	}
 	sort.Strings(propNames)
 	for _, suffix := range []string{"_id", "_uuid", "_guid"} {
-		target := singular + suffix
+		for _, base := range bases {
+			target := base + suffix
+			for _, propName := range propNames {
+				if toSnakeCase(propName) == target {
+					return propName
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func resourceIDBaseCandidates(resourceName string) []string {
+	snake := strings.Trim(toSnakeCase(resourceName), "_")
+	if snake == "" {
+		return nil
+	}
+	candidates := []string{}
+	seen := map[string]bool{}
+	add := func(s string) {
+		s = strings.Trim(s, "_")
+		if s == "" || seen[s] {
+			return
+		}
+		seen[s] = true
+		candidates = append(candidates, s)
+	}
+	add(singularizeIdentifier(snake))
+	if i := strings.LastIndex(snake, "_"); i >= 0 && i+1 < len(snake) {
+		add(singularizeIdentifier(snake[i+1:]))
+	}
+	return candidates
+}
+
+func urlShapedIDField(schema *openapi3.Schema) string {
+	if schema == nil {
+		return ""
+	}
+	propNames := make([]string, 0, len(schema.Properties))
+	for name := range schema.Properties {
+		propNames = append(propNames, name)
+	}
+	sort.Strings(propNames)
+	for _, key := range []string{"uri", "self", "selfLink", "href", "url"} {
+		keySnake := toSnakeCase(key)
 		for _, propName := range propNames {
-			if toSnakeCase(propName) == target {
+			if propName != key && toSnakeCase(propName) != keySnake {
+				continue
+			}
+			if propRef := schema.Properties[propName]; propRef != nil && isPlausibleIDFieldSchema(schemaRefValue(propRef)) {
 				return propName
 			}
 		}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -6220,7 +6220,7 @@ func resolveIDFieldFromResponseSchema(op *openapi3.Operation, resourceName strin
 
 	// Tier 4: URL-shaped identifiers. These trail id-shaped keys so APIs that
 	// expose both `id` and `self` keep keying on the compact primary key.
-	if id := urlShapedIDField(itemSchema); id != "" {
+	if id := urlShapedIDField(itemSchema, itemFields.required); id != "" {
 		return id
 	}
 
@@ -6357,9 +6357,13 @@ func resourceIDBaseCandidates(resourceName string) []string {
 	return candidates
 }
 
-func urlShapedIDField(schema *openapi3.Schema) string {
+func urlShapedIDField(schema *openapi3.Schema, required []string) string {
 	if schema == nil {
 		return ""
+	}
+	requiredSet := map[string]struct{}{}
+	for _, name := range required {
+		requiredSet[name] = struct{}{}
 	}
 	propNames := make([]string, 0, len(schema.Properties))
 	for name := range schema.Properties {
@@ -6372,12 +6376,30 @@ func urlShapedIDField(schema *openapi3.Schema) string {
 			if propName != key && toSnakeCase(propName) != keySnake {
 				continue
 			}
-			if propRef := schema.Properties[propName]; propRef != nil && isPlausibleIDFieldSchema(schemaRefValue(propRef)) {
+			propRef := schema.Properties[propName]
+			propSchema := schemaRefValue(propRef)
+			if propRef != nil && isPlausibleIDFieldSchema(propSchema) && urlFieldLooksIdentifier(propName, propSchema, isRequired(requiredSet, propName)) {
 				return propName
 			}
 		}
 	}
 	return ""
+}
+
+func urlFieldLooksIdentifier(name string, schema *openapi3.Schema, required bool) bool {
+	if required {
+		return true
+	}
+	if schema == nil {
+		return false
+	}
+	text := strings.ToLower(strings.Join([]string{name, schema.Title, schema.Description, schema.Format}, " "))
+	for _, token := range []string{"unique", "identifier", "permalink", "canonical", "resource uri", "resource url"} {
+		if strings.Contains(text, token) {
+			return true
+		}
+	}
+	return false
 }
 
 // singularizeIdentifier returns a simple singular form of a snake-cased

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -8603,8 +8603,9 @@ func TestParseIDFieldFallbackChain(t *testing.T) {
 			wantID: "id",
 		},
 		{
-			name: "tier 4: uri wins over name (Calendly shape)",
+			name: "tier 4: required uri wins over name (Calendly shape)",
 			schemaYAML: `                  type: object
+                  required: [uri]
                   properties:
                     uri: {type: string}
                     name: {type: string}
@@ -8612,13 +8613,34 @@ func TestParseIDFieldFallbackChain(t *testing.T) {
 			wantID: "uri",
 		},
 		{
-			name: "tier 4: selfLink casing is preserved",
+			name: "tier 4: required selfLink casing is preserved",
 			schemaYAML: `                  type: object
+                  required: [selfLink]
                   properties:
                     selfLink: {type: string}
                     name: {type: string}
 `,
 			wantID: "selfLink",
+		},
+		{
+			name: "tier 4: optional identifier-looking url wins over name",
+			schemaYAML: `                  type: object
+                  properties:
+                    url:
+                      type: string
+                      description: Unique resource URL for this object.
+                    name: {type: string}
+`,
+			wantID: "url",
+		},
+		{
+			name: "tier 5: optional generic url falls through to name",
+			schemaYAML: `                  type: object
+                  properties:
+                    url: {type: string}
+                    name: {type: string}
+`,
+			wantID: "name",
 		},
 		{
 			name: "tier 4: id wins over self (compact id precedence)",

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -8603,7 +8603,35 @@ func TestParseIDFieldFallbackChain(t *testing.T) {
 			wantID: "id",
 		},
 		{
-			name: "tier 3: name when id absent",
+			name: "tier 4: uri wins over name (Calendly shape)",
+			schemaYAML: `                  type: object
+                  properties:
+                    uri: {type: string}
+                    name: {type: string}
+`,
+			wantID: "uri",
+		},
+		{
+			name: "tier 4: selfLink casing is preserved",
+			schemaYAML: `                  type: object
+                  properties:
+                    selfLink: {type: string}
+                    name: {type: string}
+`,
+			wantID: "selfLink",
+		},
+		{
+			name: "tier 4: id wins over self (compact id precedence)",
+			schemaYAML: `                  type: object
+                  properties:
+                    id: {type: string}
+                    self: {type: string}
+                    name: {type: string}
+`,
+			wantID: "id",
+		},
+		{
+			name: "tier 5: name when no stable identifier is present",
 			schemaYAML: `                  type: object
                   properties:
                     name: {type: string}
@@ -8612,7 +8640,7 @@ func TestParseIDFieldFallbackChain(t *testing.T) {
 			wantID: "name",
 		},
 		{
-			name: "tier 4: first required scalar when id and name absent",
+			name: "tier 6: first required scalar when id and name absent",
 			schemaYAML: `                  type: object
                   required: [ticker, market]
                   properties:
@@ -8623,7 +8651,7 @@ func TestParseIDFieldFallbackChain(t *testing.T) {
 			wantID: "ticker",
 		},
 		{
-			name: "tier 4: required scalar inside anyOf is considered",
+			name: "tier 6: required scalar inside anyOf is considered",
 			schemaYAML: `                  anyOf:
                     - type: object
                       required: [ticker]
@@ -8639,7 +8667,7 @@ func TestParseIDFieldFallbackChain(t *testing.T) {
 			wantID: "ticker",
 		},
 		{
-			name: "tier 4: object-typed required field is skipped, next scalar wins",
+			name: "tier 6: object-typed required field is skipped, next scalar wins",
 			schemaYAML: `                  type: object
                   required: [meta, code]
                   properties:
@@ -8768,6 +8796,42 @@ paths:
 			assert.False(t, ep.Critical)
 		})
 	}
+}
+
+func TestParseIDFieldNameFallbackWarns(t *testing.T) {
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /things:
+    get:
+      operationId: listThings
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name: {type: string}
+                    description: {type: string}
+`)
+	var parsed *spec.APISpec
+	var err error
+	warnings := captureWarnings(t, func() {
+		parsed, err = Parse(yamlSpec)
+	})
+	require.NoError(t, err)
+
+	ep := findEndpoint(t, parsed, "/things")
+	assert.Equal(t, "name", ep.IDField)
+	assert.Contains(t, warnings, `GET "/things": response-schema ID fallback chose display field "name"`)
 }
 
 func TestParseScalarUnionArrayDoesNotRegisterEmptyInlineType(t *testing.T) {
@@ -9025,6 +9089,27 @@ func TestParseIDFieldResourcePrefixedHeuristic(t *testing.T) {
 			wantID: "categoryId",
 		},
 		{
+			name: "composed resource leaf picks camelCase child id before name",
+			path: "/days/{dayId}/activities",
+			schemaYAML: `                  type: object
+                  properties:
+                    activityId: {type: string}
+                    name: {type: string}
+                    title: {type: string}
+`,
+			wantID: "activityId",
+		},
+		{
+			name: "composed resource leaf picks PascalCase child id before title",
+			path: "/projects/{projectId}/tasks",
+			schemaYAML: `                  type: object
+                  properties:
+                    TaskId: {type: string}
+                    title: {type: string}
+`,
+			wantID: "TaskId",
+		},
+		{
 			name: "kebab-case path resource singularizes correctly",
 			path: "/auth-tokens",
 			schemaYAML: `                  type: object
@@ -9220,6 +9305,8 @@ paths:
                 properties:
                   widgetId: {type: string}
                   canonical_id: {type: string}
+                  uri: {type: string}
+                  name: {type: string}
 `)
 	parsed, err := Parse(yamlSpec)
 	require.NoError(t, err)

--- a/internal/pipeline/dead_code_allowlist.go
+++ b/internal/pipeline/dead_code_allowlist.go
@@ -31,8 +31,12 @@ func isAllowedDeadHelper(name string) bool {
 		"paginatedItemsEqual",
 		"paginationCursorToken",
 		"pathParamSegmentValue",
+		"replaceDependentPathParam",
 		"replacePathParam",
+		"replaceURLIDPathParam",
+		"resourceURLIDPathParam",
 		"responsePayloadParentAtPath",
+		"urlIDFieldName",
 		"writeNoop":
 		return true
 	default:

--- a/internal/pipeline/dead_code_allowlist.go
+++ b/internal/pipeline/dead_code_allowlist.go
@@ -30,6 +30,7 @@ func isAllowedDeadHelper(name string) bool {
 		"paginatedCollectionEnvelopeField",
 		"paginatedItemsEqual",
 		"paginationCursorToken",
+		"pathParamSegmentValue",
 		"replacePathParam",
 		"responsePayloadParentAtPath",
 		"writeNoop":

--- a/internal/pipeline/polish_test.go
+++ b/internal/pipeline/polish_test.go
@@ -232,6 +232,7 @@ func boundCtx() {}
 func writeHarnessRefusal() {}
 func declarePlatformAnalytics() {}
 func resolvePlatformWindow() {}
+func pathParamSegmentValue() {}
 
 func deadHelper() {}
 `), 0o644)

--- a/internal/pipeline/polish_test.go
+++ b/internal/pipeline/polish_test.go
@@ -233,6 +233,10 @@ func writeHarnessRefusal() {}
 func declarePlatformAnalytics() {}
 func resolvePlatformWindow() {}
 func pathParamSegmentValue() {}
+func replaceDependentPathParam() {}
+func replaceURLIDPathParam() {}
+func resourceURLIDPathParam() {}
+func urlIDFieldName() {}
 
 func deadHelper() {}
 `), 0o644)

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -657,7 +657,29 @@ func newTabWriter(w io.Writer) *tabwriter.Writer {
 // replacePathParam escapes path-param values before substituting them so
 // reserved characters within each segment remain safe in the request URL.
 func replacePathParam(path, name, value string) string {
-	return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(value))
+	return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(pathParamSegmentValue(value)))
+}
+
+func pathParamSegmentValue(value string) string {
+	parsed, err := url.Parse(strings.TrimSpace(value))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return value
+	}
+	escapedPath := strings.TrimRight(parsed.EscapedPath(), "/")
+	if escapedPath == "" {
+		return value
+	}
+	segment := escapedPath
+	if i := strings.LastIndex(segment, "/"); i >= 0 {
+		segment = segment[i+1:]
+	}
+	if segment == "" {
+		return value
+	}
+	if decoded, err := url.PathUnescape(segment); err == nil {
+		return decoded
+	}
+	return segment
 }
 
 const responsePathItemsKey = "__printing_press_response_path_items"

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -657,7 +657,11 @@ func newTabWriter(w io.Writer) *tabwriter.Writer {
 // replacePathParam escapes path-param values before substituting them so
 // reserved characters within each segment remain safe in the request URL.
 func replacePathParam(path, name, value string) string {
-	return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(pathParamSegmentValue(value)))
+	return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(value))
+}
+
+func replaceURLIDPathParam(path, name, value string) string {
+	return replacePathParam(path, name, pathParamSegmentValue(value))
 }
 
 func pathParamSegmentValue(value string) string {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -740,7 +740,11 @@ func newTabWriter(w io.Writer) *tabwriter.Writer {
 // replacePathParam escapes path-param values before substituting them so
 // reserved characters within each segment remain safe in the request URL.
 func replacePathParam(path, name, value string) string {
-	return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(pathParamSegmentValue(value)))
+	return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(value))
+}
+
+func replaceURLIDPathParam(path, name, value string) string {
+	return replacePathParam(path, name, pathParamSegmentValue(value))
 }
 
 func pathParamSegmentValue(value string) string {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -739,7 +740,29 @@ func newTabWriter(w io.Writer) *tabwriter.Writer {
 // replacePathParam escapes path-param values before substituting them so
 // reserved characters within each segment remain safe in the request URL.
 func replacePathParam(path, name, value string) string {
-	return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(value))
+	return strings.ReplaceAll(path, "{"+name+"}", cliutil.EscapePathParam(pathParamSegmentValue(value)))
+}
+
+func pathParamSegmentValue(value string) string {
+	parsed, err := url.Parse(strings.TrimSpace(value))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return value
+	}
+	escapedPath := strings.TrimRight(parsed.EscapedPath(), "/")
+	if escapedPath == "" {
+		return value
+	}
+	segment := escapedPath
+	if i := strings.LastIndex(segment, "/"); i >= 0 {
+		segment = segment[i+1:]
+	}
+	if segment == "" {
+		return value
+	}
+	if decoded, err := url.PathUnescape(segment); err == nil {
+		return decoded
+	}
+	return segment
 }
 
 const responsePathItemsKey = "__printing_press_response_path_items"

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -2121,6 +2121,29 @@ type dependentPathParamDef struct {
 	Field string
 }
 
+func replaceDependentPathParam(path, name, parentResource, field, value string) string {
+	bareValue := store.BareResourceID(value)
+	if resourceURLIDPathParam(parentResource, field) {
+		return replaceURLIDPathParam(path, name, bareValue)
+	}
+	return replacePathParam(path, name, bareValue)
+}
+
+func resourceURLIDPathParam(resource, field string) bool {
+	idField, ok := resourceIDFieldOverrides[resource]
+	return ok && idField == field && urlIDFieldName(field)
+}
+
+func urlIDFieldName(field string) bool {
+	normalized := strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(field))
+	switch normalized {
+	case "uri", "self", "selflink", "href", "url":
+		return true
+	default:
+		return false
+	}
+}
+
 func dependentResourceDefs() []dependentResourceDef {
 	return []dependentResourceDef{
 		{Name: "tasks", ParentTable: "projects", ParentIDParam: "projectId", PathTemplate: "/projects/{projectId}/tasks", KeyField: "", ReconcileMode: "per_parent", GenericScopeJSONPath: "$.project", PathParams: []dependentPathParamDef{
@@ -2228,13 +2251,7 @@ func syncOneParent(
 	parentFKKey := dep.ParentTable + "_id"
 	path := dep.PathTemplate
 	for _, pathParam := range pathParams {
-		// Strip the NUL-composite parent suffix that resourceStorageID builds
-		// for parent-keyed parents: the path needs the BARE entity id. Leaving
-		// the composite in routes a "%00" through replacePathParam's
-		// url.PathEscape into the URL, which nginx rejects with HTTP 400.
-		// BareResourceID is a no-op on non-composite ids, so this is safe for
-		// every path param (plain parents are unaffected).
-		path = replacePathParam(path, pathParam.Param, store.BareResourceID(parentRow[pathParam.Field]))
+		path = replaceDependentPathParam(path, pathParam.Param, dep.ParentTable, pathParam.Field, parentRow[pathParam.Field])
 	}
 
 	cursor := ""

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -2090,6 +2090,29 @@ type dependentPathParamDef struct {
 	Field string
 }
 
+func replaceDependentPathParam(path, name, parentResource, field, value string) string {
+	bareValue := store.BareResourceID(value)
+	if resourceURLIDPathParam(parentResource, field) {
+		return replaceURLIDPathParam(path, name, bareValue)
+	}
+	return replacePathParam(path, name, bareValue)
+}
+
+func resourceURLIDPathParam(resource, field string) bool {
+	idField, ok := resourceIDFieldOverrides[resource]
+	return ok && idField == field && urlIDFieldName(field)
+}
+
+func urlIDFieldName(field string) bool {
+	normalized := strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(field))
+	switch normalized {
+	case "uri", "self", "selflink", "href", "url":
+		return true
+	default:
+		return false
+	}
+}
+
 func dependentResourceDefs() []dependentResourceDef {
 	return []dependentResourceDef{
 		{Name: "leagues", ParentTable: "games", ParentIDParam: "game_key", PathTemplate: "/games/{game_key}/leagues", KeyField: "game_key", ReconcileMode: "none", GenericScopeJSONPath: "", PathParams: []dependentPathParamDef{
@@ -2197,13 +2220,7 @@ func syncOneParent(
 	parentFKKey := dep.ParentTable + "_id"
 	path := dep.PathTemplate
 	for _, pathParam := range pathParams {
-		// Strip the NUL-composite parent suffix that resourceStorageID builds
-		// for parent-keyed parents: the path needs the BARE entity id. Leaving
-		// the composite in routes a "%00" through replacePathParam's
-		// url.PathEscape into the URL, which nginx rejects with HTTP 400.
-		// BareResourceID is a no-op on non-composite ids, so this is safe for
-		// every path param (plain parents are unaffected).
-		path = replacePathParam(path, pathParam.Param, store.BareResourceID(parentRow[pathParam.Field]))
+		path = replaceDependentPathParam(path, pathParam.Param, dep.ParentTable, pathParam.Field, parentRow[pathParam.Field])
 	}
 
 	cursor := ""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Issue: Closes #4170

Fix bug 1 only: OpenAPI response-schema ID inference could choose display field `name` before stable camel/Pascal resource identifiers or safe URL-shaped identifiers, causing sync rows to collapse under duplicate display names.

## Approach

Add parser fallback tiers before `name` for resource-derived camel/Pascal identifiers and URL-shaped keys (`uri`, `self`, `selfLink`, `href`, `url`), while preserving `id` precedence over URL self links. URL-shaped fields now win over `name` only when they are required or schema text identifies them as unique/canonical identifiers.

Generated path-param substitution now preserves ordinary full-URL path parameter values as one encoded path segment. Dependent sync uses a separate URL-ID path helper only when the parent resource's selected ID field is URL-shaped, reducing those URL-backed resource IDs to their trailing path segment before escaping so Calendly-style child fetches do not send full URLs as path params. The parser also warns when automatic response-schema inference falls back to `name`.

Greptile leftovers addressed as valid:
- Scoped URL trailing-segment extraction away from all path params and into URL-backed dependent resource IDs only.
- Gated URL-shaped ID fallback so optional/shared URL fields do not automatically become store keys.

## Scope

Primary area: OpenAPI parser and generated CLI helpers/store identity behavior.

Why this belongs in this repo: the failure is generated into printed CLIs from OpenAPI schemas, so the Printing Press generator/parser must select stable IDs before emitting `resourceIDFieldOverrides`.

## Risk

Low-to-moderate: changes generated helper/sync output for CLIs with path params and dependent sync, and changes parse-time ID selection for schemas that expose URL-shaped identifiers. `id`, explicit `x-resource-id`, and resource-shaped IDs remain higher precedence.

## Output Contract

Generated-output evidence added:
- parser fallback tests for URL-shaped IDs, `id`+`self`, resource leaf camel/Pascal IDs, `x-resource-id`, optional URL fallthrough, and `name` warnings
- generated helper test proving ordinary URL path params remain fully encoded
- generated dependent-sync test proving URL-backed parent IDs use trailing segments for child fetches
- generated store test proving two same-name rows with different `uri` values remain separate
- golden fixture updates for emitted `replacePathParam` and dependent sync helper output

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates
- [x] `go fmt ./internal/openapi ./internal/generator ./internal/pipeline`
- [x] `go test ./internal/openapi -run 'TestParseIDField(FallbackChain|NameFallbackWarns|ResourcePrefixedHeuristic|ExplicitResourceIDWinsOverPathParamHeuristic)$'`
- [x] `go test ./internal/generator -run 'Test(ReplacePathParamPercentEncodesValue|DependentPathParamStripsCompositeStorageID|DependentURLIDPathParamUsesTrailingSegment|GeneratedStoreIDFieldOverrideKeepsDuplicateNames)$'`
- [x] `go test ./internal/pipeline -run TestFindAllDeadFunctions/keeps_generated_extension_point_helpers`
- [x] `go test -timeout 30m ./...`
- [x] `GOTOOLCHAIN=go1.26.6 scripts/golden.sh verify`
- [x] `GOTOOLCHAIN=go1.26.6 scripts/verify-generator-output.sh`

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c3764f9-4a61-4b31-a14d-9d32ee726ed3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c3764f9-4a61-4b31-a14d-9d32ee726ed3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

