### PR TITLE
docs(cli): teach agents goldens and record-id contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,8 @@ Always use relative paths for build output. Never build to `/tmp` or another sha
 Run `scripts/golden.sh verify` whenever a change may affect CLI command output, browser-sniff or crowd-sniff output, generated specs or generated printed CLI files, templates under `internal/generator/templates/`, naming, endpoint derivation, auth emission, manifest generation, scorecard output, or pipeline artifacts.
 Never update goldens just to make a failing check pass. Run `scripts/golden.sh update` only when the behavior change is intentional, then inspect the diff and explain it in your final response. See [`docs/GOLDEN.md`](docs/GOLDEN.md) for the decision rubric, fixture conventions, and failure handling.
 When adding a new deterministic CLI behavior or generated artifact contract, explicitly decide whether the golden suite needs a new or expanded fixture. A passing `scripts/golden.sh verify` on existing cases does not prove coverage for new auth, pagination, MCP, manifest, naming, or similar deterministic generation behavior.
+For PRs targeting `main`, the same golden set Mergify waits on is Main CI's `full-golden` job, which runs `bash scripts/golden.sh verify`; the separate `Golden` workflow delegates `main`-targeted PRs to that job. A template/generator PR is incomplete until the fixture updates for that full set are committed. Do not open the PR or call it ready when only a cheaper `golden` signal is green and `full-golden` would fail.
+Do not open a PR that touches `internal/generator/templates/**` or parser-emitted contracts without the matching golden or generated-output fixture updates in the same commit set. Use `scripts/verify-generator-output.sh` for template/generator changes that can alter emitted Go, as described below.
 
 ### Generator fixes require generated-output proof
 When touching `internal/generator/**`, `internal/openapi/**`, generator templates, parser-derived fields, MCP descriptions, naming, auth emission, or SKILL.md skeletons, verify the generated CLI behavior, not only the Printing Press source or template text.
@@ -219,6 +221,8 @@ When implementation or generation is blocked, report the exact blocker and stop.
 ## Automated code review with Greptile
 
 Every PR gets automated Greptile review alongside CI. Resolve every Greptile finding before calling a PR ready: P0 and P1 comments block merge, and P2 comments need either a fix or a concrete reply explaining why the deferral is intentional. Do not use the score alone as the gate.
+If a Greptile finding argues against a stated issue or PR contract, do not change the contract just to appease the finding; leave the intended behavior in place and reply with the concrete contract. For example, when a contract says URL-valued path params must reduce to the trailing segment so dependent fetches do not 404, do not "restore" URL components.
+After required CI is green or `ready-to-merge` is on the PR, do not push comment-only, formatting-only, or Greptile-appeasement commits. Those pushes reset required checks and dequeue Mergify; use concrete replies or review-thread resolution for non-blocking nits.
 
 Greptile feedback is not limited to GitHub review threads. It also edits top-level PR summary comments, and those summaries can contain actionable issue blocks, including `Comments Outside Diff`, even when the thread list has zero unresolved comments. Before saying a PR is ready, run the repo-owned review-state helper:
 

--- a/docs/GOLDEN.md
+++ b/docs/GOLDEN.md
@@ -12,11 +12,15 @@ Passing `scripts/golden.sh verify` only proves existing fixtures did not drift. 
 
 Golden verification is byte-level, not compile-level. It can miss generator bugs where a template emits a call without its matching definition, or where the changed branch is not captured by the expected artifact subset. For generator/template changes that can alter emitted Go, also run `scripts/verify-generator-output.sh` so representative generated CLIs are built with `go build ./...`. Pass the specific golden case names that cover the touched variant when the default case set is not enough.
 
+For PRs targeting `main`, `.github/workflows/golden.yml` delegates golden verification to Main CI's `full-golden` job. That job runs `bash scripts/golden.sh verify` and is the golden fixture set Mergify waits on through the aggregate `build-and-test` check. Do not open or mark a generator/template PR ready when only a cheaper `golden` signal is green and `full-golden` would fail; update and commit the matching fixture set first.
+
 ## Decision rubric
 
 - **No golden update:** code changed but the captured external behavior is intentionally identical. Run `scripts/golden.sh verify`; it should pass unchanged.
 - **Update an existing fixture:** the behavior already covered by a golden case intentionally changed. Run `scripts/golden.sh update`, then inspect and explain the exact expected diff.
 - **Add or expand a fixture:** the change creates a new deterministic command output or persisted artifact contract that existing cases do not exercise. Add the smallest fixture that proves that contract.
+
+Template changes under `internal/generator/templates/**` and parser changes that alter emitted contracts must carry their fixture updates in the same commit set. A PR that changes the generator contract but leaves stale goldens for a later push is incomplete.
 
 ## Fixture authoring
 

--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -1355,8 +1355,22 @@ Rules:
 - Must be a string.
 - Leading and trailing whitespace is trimmed.
 - Non-string values emit a warning and are ignored.
-- An empty or missing value falls through to the parser's response-schema
-  fallback chain: `id`, then `name`, then the first required scalar field.
+- A non-empty `x-resource-id` wins over every automatic response-schema
+  fallback.
+- An empty or missing value falls through to the parser's automatic
+  `resolveIDFieldFromResponseSchema` chain: bare `id`; then a resource-derived
+  singular key ending in `_id`, `_uuid`, or `_guid` (matched through
+  snake-case normalization, so camelCase and PascalCase spellings such as
+  `widgetId` are preserved when emitted); then vendor identifier keys `gid`,
+  `sid`, `uid`, `uuid`, and `guid`; then URL-shaped identifier keys `uri`,
+  `self`, `selfLink`, `href`, and `url`; then `name`; then the first plausible
+  required scalar field.
+- URL-shaped keys intentionally trail id-shaped keys, so APIs that expose both
+  `id` and `self` keep the compact primary key.
+- URL-shaped keys intentionally win over display `name` when no id-shaped key
+  is available. A resource URL or URI is usually record-unique, while display
+  names can collide; keying on `name` would collapse two records with the same
+  display label into one local row.
 - Applies to every operation on the path item.
 
 Example:
@@ -1371,6 +1385,20 @@ paths:
         "200":
           description: OK
 ```
+
+Generated dependent sync uses the resolved resource ID field when substituting
+parent IDs into child path parameters. When the resolved ID field is URL-shaped
+(`uri`, `self`, `selfLink`, `href`, or `url`), generated
+`replaceURLIDPathParam` reduces a full URL value to its trailing path segment
+before normal path escaping. This is intentional: dependent fetches whose
+upstream path expects `{id}` must not send a full URL as that path segment. Do
+not restore scheme, host, query, or earlier path components in generated path
+params.
+
+`store.BareResourceID` is a separate storage-key helper for stripping the
+NUL-delimited parent suffix from composite dependent-resource storage IDs. It is
+not part of response-schema identity selection and should not be changed to
+alter URL-shaped record identity behavior.
 
 ### `x-critical`
 

--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -1364,13 +1364,16 @@ Rules:
   `widgetId` are preserved when emitted); then vendor identifier keys `gid`,
   `sid`, `uid`, `uuid`, and `guid`; then URL-shaped identifier keys `uri`,
   `self`, `selfLink`, `href`, and `url`; then `name`; then the first plausible
-  required scalar field.
+  required scalar field. URL-shaped keys qualify only when the field schema is a
+  plausible ID and either the field is required or its name, title, description,
+  or format carries an identifier hint; an optional generic `url` therefore
+  falls through to `name`.
 - URL-shaped keys intentionally trail id-shaped keys, so APIs that expose both
   `id` and `self` keep the compact primary key.
-- URL-shaped keys intentionally win over display `name` when no id-shaped key
-  is available. A resource URL or URI is usually record-unique, while display
-  names can collide; keying on `name` would collapse two records with the same
-  display label into one local row.
+- Qualified URL-shaped keys intentionally win over display `name` when no
+  id-shaped key is available. A resource URL or URI is usually record-unique,
+  while display names can collide; keying on `name` would collapse two records
+  with the same display label into one local row.
 - Applies to every operation on the path item.
 
 Example:

--- a/greptile.json
+++ b/greptile.json
@@ -18,6 +18,14 @@
       {
         "scope": ["internal/**/*.go", "cmd/**/*.go"],
         "rule": "Judge whether the generator's purpose plausibly explains any credential-path read. Patterns to weigh: literal strings or os.Getenv calls for ~/.aws, ~/.ssh, ~/.kube, ~/.claude, ~/.vscode (the node-ipc and TanStack persistence/exfil paths), or env vars AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, ACTIONS_ID_TOKEN_REQUEST_URL, GITHUB_TOKEN, NPM_TOKEN. The generator's own code reads specs and writes generated CLIs; it does not normally read user credentials. Flag P0 when a credential-path read is added unless the PR clearly justifies it. The generator must never write to ~/.claude/ or ~/.vscode/ — those were the TanStack persistence sinks."
+      },
+      {
+        "scope": ["internal/openapi/parser.go"],
+        "rule": "The record-identity contract is intentional: x-resource-id wins; resolveIDFieldFromResponseSchema falls back through id-shaped keys first (id, resource-derived _id/_uuid/_guid spellings, then gid/sid/uid/uuid/guid), then URL-shaped keys (uri, self, selfLink, href, url), then name, then the first plausible required scalar. Do not file a P1 claiming URL-shaped keys should come after name, or claiming self/url should beat id when both exist."
+      },
+      {
+        "scope": ["internal/generator/templates/helpers.go.tmpl", "internal/generator/templates/sync.go.tmpl"],
+        "rule": "Generated dependent path-param substitution intentionally reduces URL-valued resource IDs to the trailing path segment before escaping. Do not file a P1 asking replaceURLIDPathParam/pathParamSegmentValue or replaceDependentPathParam to preserve scheme, host, query, or earlier URL path components; APIs whose child paths take {id} must not receive a full URL as that segment. store.BareResourceID remains only the composite-storage-key suffix stripper, not a replacement for this URL-segment behavior."
       }
     ]
   }

--- a/greptile.json
+++ b/greptile.json
@@ -21,7 +21,7 @@
       },
       {
         "scope": ["internal/openapi/parser.go"],
-        "rule": "The record-identity contract is intentional: x-resource-id wins; resolveIDFieldFromResponseSchema falls back through id-shaped keys first (id, resource-derived _id/_uuid/_guid spellings, then gid/sid/uid/uuid/guid), then URL-shaped keys (uri, self, selfLink, href, url), then name, then the first plausible required scalar. Do not file a P1 claiming URL-shaped keys should come after name, or claiming self/url should beat id when both exist."
+        "rule": "The record-identity contract is intentional: x-resource-id wins; resolveIDFieldFromResponseSchema falls back through id-shaped keys first (id, resource-derived _id/_uuid/_guid spellings, then gid/sid/uid/uuid/guid), then URL-shaped keys (uri, self, selfLink, href, url), then name, then the first plausible required scalar. URL-shaped keys are not unconditional winners: urlShapedIDField also requires a plausible ID schema and urlFieldLooksIdentifier, so required URL-shaped fields qualify automatically but optional generic url fields without unique/identifier/permalink/canonical/resource uri/resource url hints fall through to name. Do not file a P1 claiming qualified URL-shaped keys should come after name, or claiming self/url should beat id when both exist."
       },
       {
         "scope": ["internal/generator/templates/helpers.go.tmpl", "internal/generator/templates/sync.go.tmpl"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Issue: N/A

Teach agents and Greptile the existing full-golden and record-identity contracts so docs-only guidance matches the behavior currently implemented in this repo.

## Approach

Documented the merge-relevant `full-golden` gate in AGENTS.md and docs/GOLDEN.md, recorded the intended `x-resource-id` / automatic ID fallback / URL path-param contract in docs/SPEC-EXTENSIONS.md, and added scoped Greptile rules for the parser and generated helper templates.

## Scope

Primary area: docs and review configuration

Why this belongs in this repo: these are Printing Press contributor and reviewer instructions for this repository's generator/parser contracts. No generator, parser, template, or fixture behavior changes are included.

## Risk

Low; docs/config-only. The Greptile additions are scoped to `internal/openapi/parser.go` and the helper/sync templates and leave the existing supply-chain P0 rules untouched.

## Output Contract

N/A. This PR does not change templates, generated files, manifests, command output, MCP schemas, scorecard output, or pipeline artifacts.

## Verification

- [x] `python3 -m json.tool greptile.json >/dev/null`
- [x] `git diff --check`
- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates

Generator/template verification is not applicable; this is a docs-only change.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a56f96f0-8101-48a1-b1f4-d9f13914039f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a56f96f0-8101-48a1-b1f4-d9f13914039f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

