### PR TITLE
fix(cli): clamp MCP code-orch search limit before slice. Closes #3742.

### DIFF
--- a/internal/generator/code_orch_limit_test.go
+++ b/internal/generator/code_orch_limit_test.go
@@ -1,0 +1,98 @@
+package generator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodeOrchestrationSearchLimitClamp(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("code-orch-limit")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.MCP = spec.MCPConfig{Orchestration: "code"}
+
+	endpoints := make(map[string]spec.Endpoint, 125)
+	for i := 0; i < 125; i++ {
+		name := fmt.Sprintf("list-%03d", i)
+		endpoints[name] = spec.Endpoint{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/items/%03d", i),
+			Description: fmt.Sprintf("List searchable items %03d", i),
+		}
+	}
+	apiSpec.Resources = map[string]spec.Resource{
+		"items": {
+			Description: "Searchable items",
+			Endpoints:   endpoints,
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	runtimeTest := `package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestCodeOrchestrationSearchLimitClamp(t *testing.T) {
+	tests := map[string]struct {
+		limit any
+		want  int
+	}{
+		"default": {want: codeOrchSearchDefaultLimit},
+		"negative": {limit: -5.0, want: codeOrchSearchDefaultLimit},
+		"normal": {limit: 3.0, want: 3},
+		"huge": {limit: 1e19, want: codeOrchSearchMaxLimit},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			args := map[string]any{"query": "searchable items"}
+			if test.limit != nil {
+				args["limit"] = test.limit
+			}
+
+			result, err := handleCodeOrchSearch(context.Background(), mcplib.CallToolRequest{
+				Params: mcplib.CallToolParams{Arguments: args},
+			})
+			if err != nil || result == nil || result.IsError {
+				t.Fatalf("search failed: result=%#v err=%v", result, err)
+			}
+			if len(result.Content) != 1 {
+				t.Fatalf("content length = %d, want 1", len(result.Content))
+			}
+			text, ok := result.Content[0].(mcplib.TextContent)
+			if !ok {
+				t.Fatalf("content type = %T, want TextContent", result.Content[0])
+			}
+			var envelope struct {
+				Count   int              ` + "`json:\"count\"`" + `
+				Results []map[string]any ` + "`json:\"results\"`" + `
+			}
+			if err := json.Unmarshal([]byte(text.Text), &envelope); err != nil {
+				t.Fatalf("decode search result: %v", err)
+			}
+			if envelope.Count != test.want || len(envelope.Results) != test.want {
+				t.Fatalf("result count = %d/%d, want %d", envelope.Count, len(envelope.Results), test.want)
+			}
+		})
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "mcp", "code_orch_limit_runtime_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/mcp", "-run", "^TestCodeOrchestrationSearchLimitClamp$", "-count=1")
+	requireGeneratedCompiles(t, outputDir)
+}

--- a/internal/generator/code_orch_limit_test.go
+++ b/internal/generator/code_orch_limit_test.go
@@ -19,7 +19,7 @@ func TestCodeOrchestrationSearchLimitClamp(t *testing.T) {
 	apiSpec.MCP = spec.MCPConfig{Orchestration: "code"}
 
 	endpoints := make(map[string]spec.Endpoint, 125)
-	for i := 0; i < 125; i++ {
+	for i := range 125 {
 		name := fmt.Sprintf("list-%03d", i)
 		endpoints[name] = spec.Endpoint{
 			Method:      "GET",

--- a/internal/generator/templates/mcp_code_orch.go.tmpl
+++ b/internal/generator/templates/mcp_code_orch.go.tmpl
@@ -40,7 +40,7 @@ func RegisterCodeOrchestrationTools(s *server.MCPServer) {
 		mcplib.NewTool("{{snake .Name}}_search",
 			mcplib.WithDescription("Search the {{.Name}} API for endpoints matching a natural-language query. Returns a ranked list of {{if hasRawRequest .APISpec}}endpoint metadata, including request_body instructions for raw uploads{{else}}{endpoint_id, method, path, summary} entries{{end}}. Call this first to find the endpoint to execute."),
 			mcplib.WithString("query", mcplib.Required(), mcplib.Description("Natural-language description of what you want to do.")),
-			mcplib.WithNumber("limit", mcplib.Description("Max endpoints to return (default 10).")),
+			mcplib.WithNumber("limit", mcplib.Description("Max endpoints to return (default 10, max 100).")),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(false),

--- a/internal/generator/templates/mcp_code_orch.go.tmpl
+++ b/internal/generator/templates/mcp_code_orch.go.tmpl
@@ -282,16 +282,28 @@ func findCodeOrchEndpoint(id string) *codeOrchEndpoint {
 	return nil
 }
 
+const (
+	codeOrchSearchDefaultLimit = 10
+	codeOrchSearchMaxLimit     = 100
+)
+
+func codeOrchSearchLimit(args map[string]any) int {
+	if v, ok := args["limit"].(float64); ok && v > 0 {
+		if v > float64(codeOrchSearchMaxLimit) {
+			return codeOrchSearchMaxLimit
+		}
+		return int(v)
+	}
+	return codeOrchSearchDefaultLimit
+}
+
 func handleCodeOrchSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	args := req.GetArguments()
 	query, ok := args["query"].(string)
 	if !ok || strings.TrimSpace(query) == "" {
 		return mcplib.NewToolResultError("query is required"), nil
 	}
-	limit := 10
-	if v, ok := args["limit"].(float64); ok && v > 0 {
-		limit = int(v)
-	}
+	limit := codeOrchSearchLimit(args)
 
 	terms := codeOrchKeywords("", "", query, "")
 	type scored struct {

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/code_orch.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/code_orch.go
@@ -185,16 +185,28 @@ func findCodeOrchEndpoint(id string) *codeOrchEndpoint {
 	return nil
 }
 
+const (
+	codeOrchSearchDefaultLimit = 10
+	codeOrchSearchMaxLimit     = 100
+)
+
+func codeOrchSearchLimit(args map[string]any) int {
+	if v, ok := args["limit"].(float64); ok && v > 0 {
+		if v > float64(codeOrchSearchMaxLimit) {
+			return codeOrchSearchMaxLimit
+		}
+		return int(v)
+	}
+	return codeOrchSearchDefaultLimit
+}
+
 func handleCodeOrchSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	args := req.GetArguments()
 	query, ok := args["query"].(string)
 	if !ok || strings.TrimSpace(query) == "" {
 		return mcplib.NewToolResultError("query is required"), nil
 	}
-	limit := 10
-	if v, ok := args["limit"].(float64); ok && v > 0 {
-		limit = int(v)
-	}
+	limit := codeOrchSearchLimit(args)
 
 	terms := codeOrchKeywords("", "", query, "")
 	type scored struct {

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/code_orch.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/code_orch.go
@@ -37,7 +37,7 @@ func RegisterCodeOrchestrationTools(s *server.MCPServer) {
 		mcplib.NewTool("mcp-cloudflare_search",
 			mcplib.WithDescription("Search the mcp-cloudflare API for endpoints matching a natural-language query. Returns a ranked list of {endpoint_id, method, path, summary} entries. Call this first to find the endpoint to execute."),
 			mcplib.WithString("query", mcplib.Required(), mcplib.Description("Natural-language description of what you want to do.")),
-			mcplib.WithNumber("limit", mcplib.Description("Max endpoints to return (default 10).")),
+			mcplib.WithNumber("limit", mcplib.Description("Max endpoints to return (default 10, max 100).")),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(false),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Issue: Closes #3742

Fixes only the MCP code-orch search limit-cast panic. The registry-drift portion of the issue is intentionally out of scope.

## Approach

Clamp the generated code-orch search `limit` argument before converting from `float64` to `int`, preserving the default and small positive-limit behavior while bounding huge values at a sane maximum. The generated MCP `limit` parameter metadata now also documents the `max 100` cap so agents know requests above that value are clamped.

## Scope

Primary area: generator template for MCP code orchestration.

Why this belongs in this repo: the panic and MCP tool metadata are emitted into printed CLIs from `internal/generator/templates/mcp_code_orch.go.tmpl`, so the Printing Press should generate safe and accurate handler metadata for all future code-orch CLIs.

## Risk

Low. The behavior change affects only the MCP code-orch search result cap. The metadata follow-up only documents the generated cap. Very large limits now return at most the generated maximum instead of attempting an overflowing conversion; normal positive limits and the default remain unchanged.

## Output Contract

The generated `generate-mcp-api` golden updates `internal/mcp/code_orch.go` with the new limit helper and the `limit` metadata description (`default 10, max 100`). `TestCodeOrchestrationSearchLimitClamp` generates and compiles a code-orch CLI with more matching endpoints than the clamp and invokes the compiled handler to prove `1e19` returns bounded results without panic while default, negative, and normal limits remain correct.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:
- `GOTOOLCHAIN=go1.26.6 go test ./internal/generator -run '^TestCodeOrchestrationSearchLimitClamp$' -count=1`
- `GOTOOLCHAIN=go1.26.6 GOLDEN_ALLOW_DIRTY=1 scripts/golden.sh update`
- `GOTOOLCHAIN=go1.26.6 go fmt ./...`
- `GOTOOLCHAIN=go1.26.6 scripts/verify-generator-output.sh`
- `GOTOOLCHAIN=go1.26.6 GOFLAGS='-timeout=30m' go test ./...`
- `GOTOOLCHAIN=go1.26.6 scripts/golden.sh verify`
- `GOTOOLCHAIN=go1.26.6 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run ./internal/generator/...`

Follow-up metadata-cap verification:
- `GOTOOLCHAIN=go1.26.6 GOLDEN_ALLOW_DIRTY=1 scripts/golden.sh update`
- `GOTOOLCHAIN=go1.26.6 scripts/golden.sh verify`
- `GOTOOLCHAIN=go1.26.6 scripts/verify-generator-output.sh generate-mcp-api`
- `GOTOOLCHAIN=go1.26.6 GOFLAGS='-timeout=30m' go test ./...`

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-026ae054-43cf-48bc-ac4b-28d364d3ba85?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-026ae054-43cf-48bc-ac4b-28d364d3ba85&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

