### PR TITLE
fix(cli): surface success-path CLI stderr to MCP clients

### DIFF
--- a/internal/generator/cobratree_shellout_test.go
+++ b/internal/generator/cobratree_shellout_test.go
@@ -24,5 +24,5 @@ func TestGeneratedWindowsShelloutLargeOutputUsesPowerShell(t *testing.T) {
 	assert.NotContains(t, source, "for /L %%i in (1,1,70000)")
 
 	requireGeneratedCompiles(t, outputDir)
-	runGoCommandRequired(t, outputDir, "test", "./internal/mcp/cobratree", "-run", "^Test(ShellOutBoundsFinalError|RunCLICommandBoundsFailureOutput)$", "-count=1")
+	runGoCommandRequired(t, outputDir, "test", "./internal/mcp/cobratree", "-run", "^Test(ShellOutBoundsFinalError|ShellOutSurfacesSuccessStderrHintsSeparateFromJSON|RunCLICommandBoundsFailureOutput|RunCLICommandFiltersSuccessStderrHints)$", "-count=1")
 }

--- a/internal/generator/mcp_bound_package_test.go
+++ b/internal/generator/mcp_bound_package_test.go
@@ -72,7 +72,8 @@ func TestGenerateMCPSharedBoundPackageAndConsumers(t *testing.T) {
 	require.NoError(t, err)
 	shelloutCode := stripGoComments(string(shelloutSrc))
 	assert.Contains(t, shelloutCode, `/internal/mcp/bound"`)
-	assert.Contains(t, shelloutCode, "bound.Text(out)")
+	assert.Contains(t, shelloutCode, "bound.Text(result.Stdout)")
+	assert.Contains(t, shelloutCode, "bound.Text(strings.Join(result.StderrHints")
 	assert.NotContains(t, shelloutCode, "NewToolResultText(out)")
 
 	requireGeneratedCompiles(t, outputDir)

--- a/internal/generator/recipe_intents_test.go
+++ b/internal/generator/recipe_intents_test.go
@@ -54,6 +54,7 @@ func TestRecipeNarrativeEmitsMCPIntentTools(t *testing.T) {
 	require.Contains(t, intents, `mcplib.NewTool("rank_with_numeric_limit"`)
 	require.Contains(t, intents, `mcplib.WithNumber("limit"`)
 	require.Contains(t, intents, `cobratree.RunCLICommand(ctx, recipeCLIPath, args)`)
+	require.Contains(t, intents, `cobratree.ToolResultFromCLICommand(out)`)
 	require.NotContains(t, intents, "CombinedOutput")
 	require.Contains(t, intents, `mcplib.NewTool("plain_lookup"`)
 	require.Contains(t, intents, `mcplib.WithString("id"`)

--- a/internal/generator/templates/cobratree/shellout.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout.go.tmpl
@@ -76,7 +76,7 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, blocked
 		if err != nil {
 			return boundedToolResultError(err.Error()), nil
 		}
-		return mcplib.NewToolResultText(bound.Text(out)), nil
+		return ToolResultFromCLICommand(out), nil
 	}
 }
 
@@ -299,10 +299,28 @@ func SplitShellArgs(s string) []string {
 	return tokens
 }
 
+// CLICommandResult carries the machine-readable stdout separately from
+// operator-facing stderr hints.
+type CLICommandResult struct {
+	Stdout      string
+	StderrHints []string
+}
+
+// ToolResultFromCLICommand keeps stdout in the first content block and places
+// filtered CLI hints in a separate block for clients that display auxiliary
+// content.
+func ToolResultFromCLICommand(result CLICommandResult) *mcplib.CallToolResult {
+	toolResult := mcplib.NewToolResultText(bound.Text(result.Stdout))
+	if len(result.StderrHints) > 0 {
+		toolResult.Content = append(toolResult.Content, mcplib.NewTextContent(bound.Text(strings.Join(result.StderrHints, "\n"))))
+	}
+	return toolResult
+}
+
 // RunCLICommand executes the companion CLI while preserving stdout as the
-// machine-readable channel. Stderr is included only in error text so post-run
-// telemetry or quota output cannot corrupt JSON results.
-func RunCLICommand(ctx context.Context, binPath string, args []string) (string, error) {
+// machine-readable channel. Hint and warning stderr lines are returned
+// separately on success so they cannot corrupt JSON results.
+func RunCLICommand(ctx context.Context, binPath string, args []string) (CLICommandResult, error) {
 	cmd := exec.CommandContext(ctx, binPath, args...) // #nosec G204 -- trusted companion CLI path, args pre-tokenized.
 	stdout := newCappedCapture()
 	stderr := newCappedCapture()
@@ -310,6 +328,10 @@ func RunCLICommand(ctx context.Context, binPath string, args []string) (string, 
 	cmd.Stderr = stderr
 	err := cmd.Run()
 	stdoutText := stdout.String()
+	result := CLICommandResult{
+		Stdout:      stdoutText,
+		StderrHints: stderrHintLines(stderr.String()),
+	}
 	if err != nil {
 		stderrText := strings.TrimSpace(stderr.String())
 		msg := stderrText
@@ -321,9 +343,23 @@ func RunCLICommand(ctx context.Context, binPath string, args []string) (string, 
 			if stderrText == "" {
 				label = "output"
 			}
-			return stdoutText, fmt.Errorf("cli %s: %w (%s: %s)", binPath, err, label, bound.Text(msg))
+			return result, fmt.Errorf("cli %s: %w (%s: %s)", binPath, err, label, bound.Text(msg))
 		}
-		return stdoutText, fmt.Errorf("cli %s: %w", binPath, err)
+		return result, fmt.Errorf("cli %s: %w", binPath, err)
 	}
-	return stdoutText, nil
+	return result, nil
+}
+
+func stderrHintLines(stderr string) []string {
+	var hints []string
+	for _, rawLine := range strings.Split(stderr, "\n") {
+		for _, segment := range strings.Split(rawLine, "\r") {
+			line := strings.TrimSpace(segment)
+			lower := strings.ToLower(line)
+			if strings.HasPrefix(lower, "hint:") || strings.HasPrefix(lower, "warning:") {
+				hints = append(hints, line)
+			}
+		}
+	}
+	return hints
 }

--- a/internal/generator/templates/cobratree/shellout_test.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout_test.go.tmpl
@@ -691,6 +691,49 @@ func TestShellOutBoundsFinalError(t *testing.T) {
 	}
 }
 
+func TestShellOutSurfacesSuccessStderrHintsSeparateFromJSON(t *testing.T) {
+	bin := writeShelloutHelper(t, "success-hints")
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		nil,
+		map[string]bool{},
+		map[string]bool{},
+		nil,
+		false,
+		nil,
+	)
+
+	result, err := handler(context.Background(), mcplib.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned tool error: %s", toolResultText(result))
+	}
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(toolResultText(result)), &payload); err != nil {
+		t.Fatalf("stdout content is not parseable JSON: %v; text=%q", err, toolResultText(result))
+	}
+	if payload["args"] != "" {
+		t.Fatalf("stdout payload args = %q, want empty", payload["args"])
+	}
+	if strings.Contains(toolResultText(result), "hint:") || strings.Contains(toolResultText(result), "warning:") {
+		t.Fatalf("stderr hints leaked into JSON stdout content: %q", toolResultText(result))
+	}
+	hints := toolResultContentText(result, 1)
+	if !strings.Contains(hints, "hint: local store is empty; run sync") {
+		t.Fatalf("MCP result hints missing hint line: %q", hints)
+	}
+	if !strings.Contains(hints, "warning: result was truncated") {
+		t.Fatalf("MCP result hints missing warning line: %q", hints)
+	}
+	for _, noise := range []string{"telemetry", "progress"} {
+		if strings.Contains(hints, noise) {
+			t.Fatalf("MCP result hints included filtered stderr noise %q: %q", noise, hints)
+		}
+	}
+}
+
 func TestCappedCaptureDrainsWithoutRetainingFullInput(t *testing.T) {
 	capture := newCappedCapture()
 	input := strings.Repeat("x", shelloutCaptureLimit+100)
@@ -712,11 +755,29 @@ func TestRunCLICommandKeepsStdoutSeparateFromStderr(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunCLICommand success returned error: %v", err)
 	}
-	if !strings.Contains(got, `{"args":"alpha beta"}`) {
-		t.Fatalf("stdout result missing JSON payload: %q", got)
+	if !strings.Contains(got.Stdout, `{"args":"alpha beta"}`) {
+		t.Fatalf("stdout result missing JSON payload: %q", got.Stdout)
 	}
-	if strings.Contains(got, "telemetry") {
-		t.Fatalf("stderr telemetry leaked into stdout: %q", got)
+	if strings.Contains(got.Stdout, "telemetry") {
+		t.Fatalf("stderr telemetry leaked into stdout: %q", got.Stdout)
+	}
+}
+
+func TestRunCLICommandFiltersSuccessStderrHints(t *testing.T) {
+	bin := writeShelloutHelper(t, "success-hints")
+	got, err := RunCLICommand(context.Background(), bin, nil)
+	if err != nil {
+		t.Fatalf("RunCLICommand success-hints returned error: %v", err)
+	}
+	if !strings.Contains(got.Stdout, `{"args":""}`) {
+		t.Fatalf("stdout result missing JSON payload: %q", got.Stdout)
+	}
+	want := []string{
+		"hint: local store is empty; run sync",
+		"warning: result was truncated",
+	}
+	if !reflect.DeepEqual(got.StderrHints, want) {
+		t.Fatalf("stderr hints = %#v, want %#v", got.StderrHints, want)
 	}
 }
 
@@ -775,6 +836,8 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		switch mode {
 		case "success":
 			body = "@echo off\r\necho telemetry 1>&2\r\necho {\"args\":\"%*\"}\r\n"
+		case "success-hints":
+			body = "@echo off\r\necho telemetry 1>&2\r\n<nul set /p \"=progress 50%%\" 1>&2\r\necho. 1>&2\r\necho hint: local store is empty; run sync 1>&2\r\necho warning: result was truncated 1>&2\r\necho {\"args\":\"%*\"}\r\n"
 		case "fail-stderr":
 			body = "@echo off\r\necho boom from stderr 1>&2\r\nexit /b 7\r\n"
 		case "fail-stdout":
@@ -796,6 +859,8 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 	switch mode {
 	case "success":
 		body = "#!/bin/sh\necho telemetry >&2\nprintf '{\"args\":\"%s\"}\\n' \"$*\"\n"
+	case "success-hints":
+		body = "#!/bin/sh\nprintf 'telemetry\\nprogress 50%%\\rhint: local store is empty; run sync\\nwarning: result was truncated\\n' >&2\nprintf '{\"args\":\"%s\"}\\n' \"$*\"\n"
 	case "fail-stderr":
 		body = "#!/bin/sh\necho boom from stderr >&2\nexit 7\n"
 	case "fail-stdout":
@@ -852,10 +917,17 @@ func decodeArgvResult(t *testing.T, result *mcplib.CallToolResult) []string {
 }
 
 func toolResultText(result *mcplib.CallToolResult) string {
+	return toolResultContentText(result, 0)
+}
+
+func toolResultContentText(result *mcplib.CallToolResult, index int) string {
 	if result == nil || len(result.Content) == 0 {
 		return ""
 	}
-	text, ok := result.Content[0].(mcplib.TextContent)
+	if index >= len(result.Content) {
+		return ""
+	}
+	text, ok := result.Content[index].(mcplib.TextContent)
 	if !ok {
 		return ""
 	}

--- a/internal/generator/templates/mcp_intents.go.tmpl
+++ b/internal/generator/templates/mcp_intents.go.tmpl
@@ -29,7 +29,7 @@ import (
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-{{- if or .MCP.Intents .RecipeIntents}}
+{{- if .MCP.Intents}}
 	"{{modulePath}}/internal/mcp/bound"
 {{- end}}
 {{- if .MCP.Intents}}
@@ -187,7 +187,7 @@ func handle{{pascal .Name}}(ctx context.Context, req mcplib.CallToolRequest) (*m
 	if err != nil {
 		return mcplib.NewToolResultError(err.Error()), nil
 	}
-	return mcplib.NewToolResultText(bound.Text(out)), nil
+	return cobratree.ToolResultFromCLICommand(out), nil
 }
 {{end}}
 

--- a/internal/pipeline/mcpsync/sync.go
+++ b/internal/pipeline/mcpsync/sync.go
@@ -462,7 +462,11 @@ func extractMCPRecipeIntentSource(source, modulePath string) ([]byte, error) {
 		header = prefix
 	}
 	var out bytes.Buffer
-	fmt.Fprintf(&out, "%spackage mcp\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\t\"strings\"\n\n\tmcplib \"github.com/mark3labs/mcp-go/mcp\"\n\t\"github.com/mark3labs/mcp-go/server\"\n\t%q\n\t%q\n)\n\nfunc RegisterRecipeIntents(s *server.MCPServer) {\n", header, modulePath+"/internal/mcp/bound", modulePath+"/internal/mcp/cobratree")
+	fmt.Fprintf(&out, "%spackage mcp\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\t\"strings\"\n\n\tmcplib \"github.com/mark3labs/mcp-go/mcp\"\n\t\"github.com/mark3labs/mcp-go/server\"\n", header)
+	if declsContainIdentifier(recipeDecls, "bound") {
+		fmt.Fprintf(&out, "\t%q\n", modulePath+"/internal/mcp/bound")
+	}
+	fmt.Fprintf(&out, "\t%q\n)\n\nfunc RegisterRecipeIntents(s *server.MCPServer) {\n", modulePath+"/internal/mcp/cobratree")
 	out.Write(registration.Bytes())
 	out.WriteString("}\n\n")
 	for _, decl := range recipeDecls {
@@ -476,6 +480,15 @@ func extractMCPRecipeIntentSource(source, modulePath string) ([]byte, error) {
 		return nil, fmt.Errorf("formatting recipe_intents.go: %w", err)
 	}
 	return formatted, nil
+}
+
+func declsContainIdentifier(decls []ast.Decl, name string) bool {
+	for _, decl := range decls {
+		if containsMCPIntentIdentifier(decl, name) {
+			return true
+		}
+	}
+	return false
 }
 
 func containsMCPIntentIdentifier(node ast.Node, name string) bool {

--- a/internal/pipeline/mcpsync/sync_test.go
+++ b/internal/pipeline/mcpsync/sync_test.go
@@ -134,6 +134,7 @@ func TestSyncPreservesGeneratedRecipeIntentRegistration(t *testing.T) {
 	assert.Contains(t, string(intentsAfter), "RegisterRecipeIntents(s)", "mcp-sync must retain the preserved recipe registration call")
 	assert.Contains(t, string(recipeAfter), "list_contacts_with_a_limit", "recipe intent registration must survive without the narrative source")
 	assert.Contains(t, string(recipeAfter), "cobratree.RunCLICommand(ctx, recipeCLIPath, args)")
+	assert.Contains(t, string(recipeAfter), "cobratree.ToolResultFromCLICommand(out)")
 	cmd := exec.Command("go", "test", "-mod=mod", "./internal/mcp")
 	cmd.Dir = cliDir
 	output, err := cmd.CombinedOutput()

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
@@ -76,7 +76,7 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, blocked
 		if err != nil {
 			return boundedToolResultError(err.Error()), nil
 		}
-		return mcplib.NewToolResultText(bound.Text(out)), nil
+		return ToolResultFromCLICommand(out), nil
 	}
 }
 
@@ -299,10 +299,28 @@ func SplitShellArgs(s string) []string {
 	return tokens
 }
 
+// CLICommandResult carries the machine-readable stdout separately from
+// operator-facing stderr hints.
+type CLICommandResult struct {
+	Stdout      string
+	StderrHints []string
+}
+
+// ToolResultFromCLICommand keeps stdout in the first content block and places
+// filtered CLI hints in a separate block for clients that display auxiliary
+// content.
+func ToolResultFromCLICommand(result CLICommandResult) *mcplib.CallToolResult {
+	toolResult := mcplib.NewToolResultText(bound.Text(result.Stdout))
+	if len(result.StderrHints) > 0 {
+		toolResult.Content = append(toolResult.Content, mcplib.NewTextContent(bound.Text(strings.Join(result.StderrHints, "\n"))))
+	}
+	return toolResult
+}
+
 // RunCLICommand executes the companion CLI while preserving stdout as the
-// machine-readable channel. Stderr is included only in error text so post-run
-// telemetry or quota output cannot corrupt JSON results.
-func RunCLICommand(ctx context.Context, binPath string, args []string) (string, error) {
+// machine-readable channel. Hint and warning stderr lines are returned
+// separately on success so they cannot corrupt JSON results.
+func RunCLICommand(ctx context.Context, binPath string, args []string) (CLICommandResult, error) {
 	cmd := exec.CommandContext(ctx, binPath, args...) // #nosec G204 -- trusted companion CLI path, args pre-tokenized.
 	stdout := newCappedCapture()
 	stderr := newCappedCapture()
@@ -310,6 +328,10 @@ func RunCLICommand(ctx context.Context, binPath string, args []string) (string, 
 	cmd.Stderr = stderr
 	err := cmd.Run()
 	stdoutText := stdout.String()
+	result := CLICommandResult{
+		Stdout:      stdoutText,
+		StderrHints: stderrHintLines(stderr.String()),
+	}
 	if err != nil {
 		stderrText := strings.TrimSpace(stderr.String())
 		msg := stderrText
@@ -321,9 +343,23 @@ func RunCLICommand(ctx context.Context, binPath string, args []string) (string, 
 			if stderrText == "" {
 				label = "output"
 			}
-			return stdoutText, fmt.Errorf("cli %s: %w (%s: %s)", binPath, err, label, bound.Text(msg))
+			return result, fmt.Errorf("cli %s: %w (%s: %s)", binPath, err, label, bound.Text(msg))
 		}
-		return stdoutText, fmt.Errorf("cli %s: %w", binPath, err)
+		return result, fmt.Errorf("cli %s: %w", binPath, err)
 	}
-	return stdoutText, nil
+	return result, nil
+}
+
+func stderrHintLines(stderr string) []string {
+	var hints []string
+	for _, rawLine := range strings.Split(stderr, "\n") {
+		for _, segment := range strings.Split(rawLine, "\r") {
+			line := strings.TrimSpace(segment)
+			lower := strings.ToLower(line)
+			if strings.HasPrefix(lower, "hint:") || strings.HasPrefix(lower, "warning:") {
+				hints = append(hints, line)
+			}
+		}
+	}
+	return hints
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
@@ -691,6 +691,49 @@ func TestShellOutBoundsFinalError(t *testing.T) {
 	}
 }
 
+func TestShellOutSurfacesSuccessStderrHintsSeparateFromJSON(t *testing.T) {
+	bin := writeShelloutHelper(t, "success-hints")
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		nil,
+		map[string]bool{},
+		map[string]bool{},
+		nil,
+		false,
+		nil,
+	)
+
+	result, err := handler(context.Background(), mcplib.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned tool error: %s", toolResultText(result))
+	}
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(toolResultText(result)), &payload); err != nil {
+		t.Fatalf("stdout content is not parseable JSON: %v; text=%q", err, toolResultText(result))
+	}
+	if payload["args"] != "" {
+		t.Fatalf("stdout payload args = %q, want empty", payload["args"])
+	}
+	if strings.Contains(toolResultText(result), "hint:") || strings.Contains(toolResultText(result), "warning:") {
+		t.Fatalf("stderr hints leaked into JSON stdout content: %q", toolResultText(result))
+	}
+	hints := toolResultContentText(result, 1)
+	if !strings.Contains(hints, "hint: local store is empty; run sync") {
+		t.Fatalf("MCP result hints missing hint line: %q", hints)
+	}
+	if !strings.Contains(hints, "warning: result was truncated") {
+		t.Fatalf("MCP result hints missing warning line: %q", hints)
+	}
+	for _, noise := range []string{"telemetry", "progress"} {
+		if strings.Contains(hints, noise) {
+			t.Fatalf("MCP result hints included filtered stderr noise %q: %q", noise, hints)
+		}
+	}
+}
+
 func TestCappedCaptureDrainsWithoutRetainingFullInput(t *testing.T) {
 	capture := newCappedCapture()
 	input := strings.Repeat("x", shelloutCaptureLimit+100)
@@ -712,11 +755,29 @@ func TestRunCLICommandKeepsStdoutSeparateFromStderr(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunCLICommand success returned error: %v", err)
 	}
-	if !strings.Contains(got, `{"args":"alpha beta"}`) {
-		t.Fatalf("stdout result missing JSON payload: %q", got)
+	if !strings.Contains(got.Stdout, `{"args":"alpha beta"}`) {
+		t.Fatalf("stdout result missing JSON payload: %q", got.Stdout)
 	}
-	if strings.Contains(got, "telemetry") {
-		t.Fatalf("stderr telemetry leaked into stdout: %q", got)
+	if strings.Contains(got.Stdout, "telemetry") {
+		t.Fatalf("stderr telemetry leaked into stdout: %q", got.Stdout)
+	}
+}
+
+func TestRunCLICommandFiltersSuccessStderrHints(t *testing.T) {
+	bin := writeShelloutHelper(t, "success-hints")
+	got, err := RunCLICommand(context.Background(), bin, nil)
+	if err != nil {
+		t.Fatalf("RunCLICommand success-hints returned error: %v", err)
+	}
+	if !strings.Contains(got.Stdout, `{"args":""}`) {
+		t.Fatalf("stdout result missing JSON payload: %q", got.Stdout)
+	}
+	want := []string{
+		"hint: local store is empty; run sync",
+		"warning: result was truncated",
+	}
+	if !reflect.DeepEqual(got.StderrHints, want) {
+		t.Fatalf("stderr hints = %#v, want %#v", got.StderrHints, want)
 	}
 }
 
@@ -775,6 +836,8 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		switch mode {
 		case "success":
 			body = "@echo off\r\necho telemetry 1>&2\r\necho {\"args\":\"%*\"}\r\n"
+		case "success-hints":
+			body = "@echo off\r\necho telemetry 1>&2\r\n<nul set /p \"=progress 50%%\" 1>&2\r\necho. 1>&2\r\necho hint: local store is empty; run sync 1>&2\r\necho warning: result was truncated 1>&2\r\necho {\"args\":\"%*\"}\r\n"
 		case "fail-stderr":
 			body = "@echo off\r\necho boom from stderr 1>&2\r\nexit /b 7\r\n"
 		case "fail-stdout":
@@ -796,6 +859,8 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 	switch mode {
 	case "success":
 		body = "#!/bin/sh\necho telemetry >&2\nprintf '{\"args\":\"%s\"}\\n' \"$*\"\n"
+	case "success-hints":
+		body = "#!/bin/sh\nprintf 'telemetry\\nprogress 50%%\\rhint: local store is empty; run sync\\nwarning: result was truncated\\n' >&2\nprintf '{\"args\":\"%s\"}\\n' \"$*\"\n"
 	case "fail-stderr":
 		body = "#!/bin/sh\necho boom from stderr >&2\nexit 7\n"
 	case "fail-stdout":
@@ -852,10 +917,17 @@ func decodeArgvResult(t *testing.T, result *mcplib.CallToolResult) []string {
 }
 
 func toolResultText(result *mcplib.CallToolResult) string {
+	return toolResultContentText(result, 0)
+}
+
+func toolResultContentText(result *mcplib.CallToolResult, index int) string {
 	if result == nil || len(result.Content) == 0 {
 		return ""
 	}
-	text, ok := result.Content[0].(mcplib.TextContent)
+	if index >= len(result.Content) {
+		return ""
+	}
+	text, ok := result.Content[index].(mcplib.TextContent)
 	if !ok {
 		return ""
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Issue: Closes #3941

Surface useful CLI stderr hints and warnings to MCP clients on successful cobratree shell-outs without corrupting machine-readable stdout payloads.

## Approach

`RunCLICommand` now returns stdout separately from filtered success-path stderr hints. `shellOutToCLI` and recipe MCP handlers render stdout as the first MCP text content block and append hint/warning stderr lines as a second content block. Progress/noise stderr is filtered out, and the existing failure-path error text continues to own stderr/stdout diagnostics for non-zero exits.

## Scope

Primary area: generated MCP cobratree shell-out and recipe MCP handlers.

Why this belongs in this repo: this is generator/template behavior that affects every printed CLI using the cobratree MCP mirror, not a one-off printed-CLI fix.

## Risk

MCP clients that only read the first content block keep receiving the same stdout payload. Clients that render all content now see an additional hint/warning block on successful commands. The `RunCLICommand` return type changes inside generated cobratree internals, so recipe call sites and mcp-sync preservation were updated with it.

## Output Contract

Generated-output evidence covers emitted cobratree shellout code, compiled generated CLI cases, and the checked-in `generate-golden-api` fixture. New generated tests assert a successful CLI hint on stderr appears in the MCP result, JSON stdout remains parseable, progress/noise stderr is filtered, and failure-path stderr behavior is unchanged.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:
- `go test ./internal/generator -run 'TestGeneratedWindowsShelloutLargeOutputUsesPowerShell|TestRecipeNarrativeEmitsMCPIntentTools' -count=1`
- `GOTOOLCHAIN=go1.26.6 GOLDEN_ALLOW_DIRTY=1 scripts/golden.sh update`
- `scripts/verify-generator-output.sh`
- `go fmt ./...`
- `go test ./...` (attempted twice; `internal/generator` exceeded Go's default 10m package timeout after other packages passed)
- `go test -timeout 20m ./...`
- `GOTOOLCHAIN=go1.26.6 scripts/golden.sh verify`

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91fd7a7a-c650-4f76-ae95-6b0f4a0cb0cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91fd7a7a-c650-4f76-ae95-6b0f4a0cb0cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

