### PR TITLE
fix(cli): stop storing nested objects as sync rows

### DIFF
--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1847,10 +1847,10 @@ func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage
 		// spec declares x-resource-id).
 		id := ExtractResourceID(resourceType, obj)
 		if id == "" {
-			if unwrappedObj, unwrappedItem, ok := unwrapIDBearingEnvelopeItem(resourceType, item, obj); ok {
-				obj = unwrappedObj
-				item = unwrappedItem
-				id = ExtractResourceID(resourceType, obj)
+			if keyObj, rowObj, rowItem, ok := unwrapIDBearingEnvelopeItem(resourceType, item, obj); ok {
+				id = ExtractResourceID(resourceType, keyObj)
+				obj = rowObj
+				item = rowItem
 			}
 		}
 		if id == "" {
@@ -1927,33 +1927,38 @@ func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage
 	return stored, extractFailures, typedFailures, nil
 }
 
-func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, json.RawMessage, bool) {
+// Multi-field wrappers keep their outer row because scalar siblings may be
+// resource data; true single-field envelopes unwrap to the inner object.
+func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, map[string]any, json.RawMessage, bool) {
 	var candidate map[string]any
 	candidateKey := ""
-	objectFields := 0
+	candidates := 0
 	for key, value := range obj {
 		inner, ok := value.(map[string]any)
 		if !ok {
 			continue
 		}
-		objectFields++
 		if ExtractResourceID(resourceType, inner) != "" {
 			candidate = inner
 			candidateKey = key
+			candidates++
 		}
 	}
-	if objectFields != 1 || candidate == nil || candidateKey == "" {
-		return nil, nil, false
+	if candidates != 1 || candidate == nil || candidateKey == "" {
+		return nil, nil, nil, false
+	}
+	if len(obj) != 1 {
+		return candidate, obj, item, true
 	}
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(item, &raw); err != nil {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
 	data, ok := raw[candidateKey]
 	if !ok {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
-	return candidate, data, true
+	return candidate, candidate, data, true
 }
 
 {{- range .Tables}}

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -273,9 +273,11 @@ func TestUpsertBatch_UnwrapsIDBearingEnvelopeItems(t *testing.T) {
 	defer s.Close()
 
 	items := []json.RawMessage{
-		json.RawMessage(`{"customer":{"id":"cust-1","name":"Ada"}}`),
+		json.RawMessage(`{"result":{"id":"cust-1","name":"Ada"}}`),
 		json.RawMessage(`{"kind":"customer","data":{"id":"cust-2","name":"Grace"}}`),
 		json.RawMessage(`{"customer":{"id":"cust-large","external_id":9007199254740993,"name":"Big"}}`),
+		json.RawMessage(`{"a":1,"metadata":{"uuid":"meta-1"}}`),
+		json.RawMessage(`{"id":"cust-top","name":"Top","metadata":{"uuid":"ignored"}}`),
 		json.RawMessage(`{"kind":"customer","data":{"description":"missing-id"}}`),
 		json.RawMessage(`{"kind":"customer","data":{"id":"cust-3"},"alternate":{"id":"other-1"}}`),
 	}
@@ -283,15 +285,15 @@ func TestUpsertBatch_UnwrapsIDBearingEnvelopeItems(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UpsertBatch: %v", err)
 	}
-	if stored != 3 || extractFailures != 2 {
-		t.Fatalf("envelope unwrap stored=%d extractFailures=%d, want stored=3 extractFailures=2", stored, extractFailures)
+	if stored != 5 || extractFailures != 2 {
+		t.Fatalf("envelope unwrap stored=%d extractFailures=%d, want stored=5 extractFailures=2", stored, extractFailures)
 	}
 
 	row, err := s.Get("customers", "cust-1")
 	if err != nil {
 		t.Fatalf("Get cust-1: %v", err)
 	}
-	if strings.Contains(string(row), `"customer"`) || !strings.Contains(string(row), `"name":"Ada"`) {
+	if strings.Contains(string(row), `"result"`) || !strings.Contains(string(row), `"name":"Ada"`) {
 		t.Fatalf("single-key envelope should store the flat inner object, got %s", row)
 	}
 
@@ -299,8 +301,8 @@ func TestUpsertBatch_UnwrapsIDBearingEnvelopeItems(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get cust-2: %v", err)
 	}
-	if strings.Contains(string(row), `"kind"`) || !strings.Contains(string(row), `"name":"Grace"`) {
-		t.Fatalf("tagged envelope should store the flat inner object, got %s", row)
+	if !strings.Contains(string(row), `"kind":"customer"`) || !strings.Contains(string(row), `"data"`) || !strings.Contains(string(row), `"name":"Grace"`) {
+		t.Fatalf("tagged envelope should keep the outer row while deriving the ID from data, got %s", row)
 	}
 
 	row, err = s.Get("customers", "cust-large")
@@ -309,6 +311,22 @@ func TestUpsertBatch_UnwrapsIDBearingEnvelopeItems(t *testing.T) {
 	}
 	if !strings.Contains(string(row), `"external_id":9007199254740993`) || strings.Contains(string(row), `9007199254740992`) {
 		t.Fatalf("envelope unwrap should preserve original large integer bytes, got %s", row)
+	}
+
+	row, err = s.Get("customers", "meta-1")
+	if err != nil {
+		t.Fatalf("Get meta-1: %v", err)
+	}
+	if !strings.Contains(string(row), `"a":1`) || !strings.Contains(string(row), `"metadata"`) || !strings.Contains(string(row), `"uuid":"meta-1"`) {
+		t.Fatalf("nested metadata ID should keep the outer row, got %s", row)
+	}
+
+	row, err = s.Get("customers", "cust-top")
+	if err != nil {
+		t.Fatalf("Get cust-top: %v", err)
+	}
+	if !strings.Contains(string(row), `"id":"cust-top"`) || !strings.Contains(string(row), `"metadata"`) {
+		t.Fatalf("top-level ID item should remain unchanged, got %s", row)
 	}
 }
 

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -1461,10 +1461,10 @@ func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage
 		// spec declares x-resource-id).
 		id := ExtractResourceID(resourceType, obj)
 		if id == "" {
-			if unwrappedObj, unwrappedItem, ok := unwrapIDBearingEnvelopeItem(resourceType, item, obj); ok {
-				obj = unwrappedObj
-				item = unwrappedItem
-				id = ExtractResourceID(resourceType, obj)
+			if keyObj, rowObj, rowItem, ok := unwrapIDBearingEnvelopeItem(resourceType, item, obj); ok {
+				id = ExtractResourceID(resourceType, keyObj)
+				obj = rowObj
+				item = rowItem
 			}
 		}
 		if id == "" {
@@ -1498,33 +1498,38 @@ func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage
 	return stored, extractFailures, typedFailures, nil
 }
 
-func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, json.RawMessage, bool) {
+// Multi-field wrappers keep their outer row because scalar siblings may be
+// resource data; true single-field envelopes unwrap to the inner object.
+func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, map[string]any, json.RawMessage, bool) {
 	var candidate map[string]any
 	candidateKey := ""
-	objectFields := 0
+	candidates := 0
 	for key, value := range obj {
 		inner, ok := value.(map[string]any)
 		if !ok {
 			continue
 		}
-		objectFields++
 		if ExtractResourceID(resourceType, inner) != "" {
 			candidate = inner
 			candidateKey = key
+			candidates++
 		}
 	}
-	if objectFields != 1 || candidate == nil || candidateKey == "" {
-		return nil, nil, false
+	if candidates != 1 || candidate == nil || candidateKey == "" {
+		return nil, nil, nil, false
+	}
+	if len(obj) != 1 {
+		return candidate, obj, item, true
 	}
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(item, &raw); err != nil {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
 	data, ok := raw[candidateKey]
 	if !ok {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
-	return candidate, data, true
+	return candidate, candidate, data, true
 }
 
 func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1681,10 +1681,10 @@ func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage
 		// spec declares x-resource-id).
 		id := ExtractResourceID(resourceType, obj)
 		if id == "" {
-			if unwrappedObj, unwrappedItem, ok := unwrapIDBearingEnvelopeItem(resourceType, item, obj); ok {
-				obj = unwrappedObj
-				item = unwrappedItem
-				id = ExtractResourceID(resourceType, obj)
+			if keyObj, rowObj, rowItem, ok := unwrapIDBearingEnvelopeItem(resourceType, item, obj); ok {
+				id = ExtractResourceID(resourceType, keyObj)
+				obj = rowObj
+				item = rowItem
 			}
 		}
 		if id == "" {
@@ -1753,33 +1753,38 @@ func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage
 	return stored, extractFailures, typedFailures, nil
 }
 
-func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, json.RawMessage, bool) {
+// Multi-field wrappers keep their outer row because scalar siblings may be
+// resource data; true single-field envelopes unwrap to the inner object.
+func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, map[string]any, json.RawMessage, bool) {
 	var candidate map[string]any
 	candidateKey := ""
-	objectFields := 0
+	candidates := 0
 	for key, value := range obj {
 		inner, ok := value.(map[string]any)
 		if !ok {
 			continue
 		}
-		objectFields++
 		if ExtractResourceID(resourceType, inner) != "" {
 			candidate = inner
 			candidateKey = key
+			candidates++
 		}
 	}
-	if objectFields != 1 || candidate == nil || candidateKey == "" {
-		return nil, nil, false
+	if candidates != 1 || candidate == nil || candidateKey == "" {
+		return nil, nil, nil, false
+	}
+	if len(obj) != 1 {
+		return candidate, obj, item, true
 	}
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(item, &raw); err != nil {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
 	data, ok := raw[candidateKey]
 	if !ok {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
-	return candidate, data, true
+	return candidate, candidate, data, true
 }
 
 func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1731,10 +1731,10 @@ func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage
 		// spec declares x-resource-id).
 		id := ExtractResourceID(resourceType, obj)
 		if id == "" {
-			if unwrappedObj, unwrappedItem, ok := unwrapIDBearingEnvelopeItem(resourceType, item, obj); ok {
-				obj = unwrappedObj
-				item = unwrappedItem
-				id = ExtractResourceID(resourceType, obj)
+			if keyObj, rowObj, rowItem, ok := unwrapIDBearingEnvelopeItem(resourceType, item, obj); ok {
+				id = ExtractResourceID(resourceType, keyObj)
+				obj = rowObj
+				item = rowItem
 			}
 		}
 		if id == "" {
@@ -1805,33 +1805,38 @@ func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage
 	return stored, extractFailures, typedFailures, nil
 }
 
-func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, json.RawMessage, bool) {
+// Multi-field wrappers keep their outer row because scalar siblings may be
+// resource data; true single-field envelopes unwrap to the inner object.
+func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, map[string]any, json.RawMessage, bool) {
 	var candidate map[string]any
 	candidateKey := ""
-	objectFields := 0
+	candidates := 0
 	for key, value := range obj {
 		inner, ok := value.(map[string]any)
 		if !ok {
 			continue
 		}
-		objectFields++
 		if ExtractResourceID(resourceType, inner) != "" {
 			candidate = inner
 			candidateKey = key
+			candidates++
 		}
 	}
-	if objectFields != 1 || candidate == nil || candidateKey == "" {
-		return nil, nil, false
+	if candidates != 1 || candidate == nil || candidateKey == "" {
+		return nil, nil, nil, false
+	}
+	if len(obj) != 1 {
+		return candidate, obj, item, true
 	}
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(item, &raw); err != nil {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
 	data, ok := raw[candidateKey]
 	if !ok {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
-	return candidate, data, true
+	return candidate, candidate, data, true
 }
 
 func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1681,10 +1681,10 @@ func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage
 		// spec declares x-resource-id).
 		id := ExtractResourceID(resourceType, obj)
 		if id == "" {
-			if unwrappedObj, unwrappedItem, ok := unwrapIDBearingEnvelopeItem(resourceType, item, obj); ok {
-				obj = unwrappedObj
-				item = unwrappedItem
-				id = ExtractResourceID(resourceType, obj)
+			if keyObj, rowObj, rowItem, ok := unwrapIDBearingEnvelopeItem(resourceType, item, obj); ok {
+				id = ExtractResourceID(resourceType, keyObj)
+				obj = rowObj
+				item = rowItem
 			}
 		}
 		if id == "" {
@@ -1753,33 +1753,38 @@ func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage
 	return stored, extractFailures, typedFailures, nil
 }
 
-func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, json.RawMessage, bool) {
+// Multi-field wrappers keep their outer row because scalar siblings may be
+// resource data; true single-field envelopes unwrap to the inner object.
+func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, map[string]any, json.RawMessage, bool) {
 	var candidate map[string]any
 	candidateKey := ""
-	objectFields := 0
+	candidates := 0
 	for key, value := range obj {
 		inner, ok := value.(map[string]any)
 		if !ok {
 			continue
 		}
-		objectFields++
 		if ExtractResourceID(resourceType, inner) != "" {
 			candidate = inner
 			candidateKey = key
+			candidates++
 		}
 	}
-	if objectFields != 1 || candidate == nil || candidateKey == "" {
-		return nil, nil, false
+	if candidates != 1 || candidate == nil || candidateKey == "" {
+		return nil, nil, nil, false
+	}
+	if len(obj) != 1 {
+		return candidate, obj, item, true
 	}
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(item, &raw); err != nil {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
 	data, ok := raw[candidateKey]
 	if !ok {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
-	return candidate, data, true
+	return candidate, candidate, data, true
 }
 
 func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Issue: Closes #3790

Fixes the store-template envelope heuristic so a nested ID-bearing object can supply the persisted key without replacing the resource row payload.

## Approach

When a batch item has no top-level ID, `unwrapIDBearingEnvelopeItem` now returns both the key source and the row to cache. True single-field envelopes such as `{"result":{"id":"..."}}` still unwrap to the inner entity, while multi-field wrappers such as tagged envelopes or `metadata.uuid` rows keep the outer JSON object as the cached row.

## Scope

Primary area: generator store template / generated store output

Why this belongs in this repo: this is generated `UpsertBatch` behavior shared by printed CLIs, not an API-specific printed-CLI patch.

## Risk

Low-to-moderate generated-output risk: multi-field envelopes that previously cached only the nested object now cache the full outer row. Key derivation remains limited to exactly one nested ID-bearing object; ambiguous multi-ID wrappers continue to skip.

## Output Contract

Updated generated store tests prove:
- nested metadata IDs keep the full outer item as the cached row
- tagged envelopes keep the full outer item while deriving the ID from `data`
- true single-key envelopes still unwrap
- top-level-ID items remain unchanged

Refreshed generated `store.go` golden fixtures for the store-template helper change.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:
- `go fmt ./...`
- `go test ./internal/generator -run TestGeneratedSyncIDFieldOverridesAndProbes -count=1`
- `scripts/golden.sh update` (first attempt hit unavailable auto-download for fixture Go 1.24; rerun successfully with `GOTOOLCHAIN=go1.26.6`)
- `GOTOOLCHAIN=go1.26.6 scripts/golden.sh verify`
- `GOTOOLCHAIN=go1.26.6 scripts/verify-generator-output.sh`
- `GOTOOLCHAIN=go1.26.6 GOFLAGS='-timeout=30m' go test ./...`

Note: a plain default-timeout `go test ./...` attempt reached the Go test runner's 10-minute timeout in `internal/generator`; the final full run above passed with the same command and an extended timeout via `GOFLAGS`.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ba0f481-8586-4782-b288-189d658a0796?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ba0f481-8586-4782-b288-189d658a0796&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

