### PR TITLE
fix(cli): preserve null analytics groups

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -19674,6 +19674,8 @@ func TestAnalyticsCommandWritesToConfiguredOutput(t *testing.T) {
 	for _, raw := range []string{
 		` + "`" + `{"id":"issue-1","status":"open","stage_id":"qualified"}` + "`" + `,
 		` + "`" + `{"id":"issue-2","status":"open","stage_id":"qualified"}` + "`" + `,
+		` + "`" + `{"id":"issue-3","status":"closed","stage_id":null}` + "`" + `,
+		` + "`" + `{"id":"issue-4","status":"closed"}` + "`" + `,
 	} {
 		var payload json.RawMessage = []byte(raw)
 		var obj map[string]any
@@ -19690,14 +19692,14 @@ func TestAnalyticsCommandWritesToConfiguredOutput(t *testing.T) {
 	}
 
 	stdout, _ := runPMCommand(t, dbPath, false, "analytics")
-	for _, want := range []string{"Resource Type\tCount", "issues\t2"} {
+	for _, want := range []string{"Resource Type\tCount", "issues\t4"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("analytics text summary stdout = %q, want %q in configured output", stdout, want)
 		}
 	}
 
 	stdout, _ = runPMCommand(t, dbPath, false, "analytics", "--type", "issues")
-	if !strings.Contains(stdout, "issues: 2 records") {
+	if !strings.Contains(stdout, "issues: 4 records") {
 		t.Fatalf("analytics text count stdout = %q, want issues count in configured output", stdout)
 	}
 
@@ -19709,7 +19711,7 @@ func TestAnalyticsCommandWritesToConfiguredOutput(t *testing.T) {
 	}
 
 	stdout, _ = runPMCommand(t, dbPath, false, "analytics", "--type", "issues", "--group-by", "stage")
-	for _, want := range []string{"stage\tCount", "qualified\t2"} {
+	for _, want := range []string{"stage\tCount", "qualified\t2", "(none)\t2"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("analytics friendly group-by stdout = %q, want %q in configured output", stdout, want)
 		}
@@ -19729,7 +19731,7 @@ func TestAnalyticsCommandWritesToConfiguredOutput(t *testing.T) {
 	}
 
 	stdout, _ = runPMHintCommand(t, dbPath, "analytics")
-	if !strings.Contains(stdout, ` + "`" + `"issues": 2` + "`" + `) {
+	if !strings.Contains(stdout, ` + "`" + `"issues": 4` + "`" + `) {
 		t.Fatalf("analytics summary stdout = %q, want issues count in configured output", stdout)
 	}
 
@@ -19737,6 +19739,13 @@ func TestAnalyticsCommandWritesToConfiguredOutput(t *testing.T) {
 	for _, want := range []string{` + "`" + `"value": "open"` + "`" + `, ` + "`" + `"count": 2` + "`" + `} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("analytics group-by stdout = %q, want %q in configured output", stdout, want)
+		}
+	}
+
+	stdout, _ = runPMHintCommand(t, dbPath, "analytics", "--type", "issues", "--group-by", "stage")
+	for _, want := range []string{` + "`" + `"value": null` + "`" + `, ` + "`" + `"count": 2` + "`" + `} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("analytics null group stdout = %q, want %q in configured output", stdout, want)
 		}
 	}
 }

--- a/internal/generator/templates/analytics.go.tmpl
+++ b/internal/generator/templates/analytics.go.tmpl
@@ -117,6 +117,7 @@ func runGroupBy(out io.Writer, db *store.Store, resourceType, field string, limi
 	}
 
 	counts := make(map[string]int)
+	nullCount := 0
 	validFields := make(map[string]struct{})
 	matchedAny := false
 	missingFieldCount := 0
@@ -133,6 +134,10 @@ func runGroupBy(out io.Writer, db *store.Store, resourceType, field string, limi
 		raw, ok := resolvedGroupValue(obj, field)
 		if ok {
 			matchedAny = true
+			if raw == nil {
+				nullCount++
+				continue
+			}
 			val := fmt.Sprintf("%v", raw)
 			counts[val]++
 		} else {
@@ -143,16 +148,19 @@ func runGroupBy(out io.Writer, db *store.Store, resourceType, field string, limi
 		return fmt.Errorf("group-by field %q was not found in any %s record; valid group-by fields: %s", field, resourceType, formatGroupByFields(validFields))
 	}
 	if missingFieldCount > 0 {
-		counts["<nil>"] += missingFieldCount
+		nullCount += missingFieldCount
 	}
 
 	type kv struct {
-		Key   string `json:"value"`
+		Value any `json:"value"`
 		Count int    `json:"count"`
 	}
 	var sorted []kv
 	for k, v := range counts {
 		sorted = append(sorted, kv{k, v})
+	}
+	if nullCount > 0 {
+		sorted = append(sorted, kv{Value: nil, Count: nullCount})
 	}
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Count > sorted[j].Count })
 	if limit > 0 && len(sorted) > limit {
@@ -166,7 +174,11 @@ func runGroupBy(out io.Writer, db *store.Store, resourceType, field string, limi
 	fmt.Fprintf(out, "%s\tCount\n", field)
 	fmt.Fprintln(out, "---\t-----")
 	for _, kv := range sorted {
-		fmt.Fprintf(out, "%s\t%d\n", kv.Key, kv.Count)
+		value := fmt.Sprint(kv.Value)
+		if kv.Value == nil {
+			value = "(none)"
+		}
+		fmt.Fprintf(out, "%s\t%d\n", value, kv.Count)
 	}
 	return nil
 }


### PR DESCRIPTION
## Intent

Preserve null semantics in generated `analytics --group-by` output. Explicit null values and missing fields currently become the string `"<nil>"`, so agents can mistake absent data for a real category.

Issue: Fixes #4098

## Approach

Track null and missing values in a separate count instead of passing them through the string-keyed group map. Generated machine output now encodes that group as JSON `null`, while text output labels it `(none)`. The generated-CLI regression covers both an explicit null field and an absent field.

## Scope

Primary area: generated analytics command

Why this belongs in this repo: `analytics.go.tmpl` is the shared Printing Press template that emits this behavior into every store-enabled printed CLI.

## Risk

Low. Non-null group values retain their existing string representation and sorting behavior. The only output-contract change is the null bucket: JSON `"<nil>"` becomes `null`, and text `<nil>` becomes `(none)`.

## Output Contract

Generated-output evidence: `TestProjectManagementWorkflowsEmitSyncHints` generates and compiles a CLI, seeds both explicit-null and missing-field rows, and asserts JSON `null` plus the `(none)` text label. The full golden suite and generated-output compile suite also pass without fixture changes.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

- `go test ./internal/generator -run '^TestProjectManagementWorkflowsEmitSyncHints$' -count=1`
- `go test -timeout 30m -p 1 ./...`
- `go fmt ./...`
- `scripts/golden.sh verify` (32 cases)
- `scripts/verify-generator-output.sh` (10 cases)
- `GOTOOLCHAIN=go1.26.6 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run ./...` (0 issues)

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change
