### PR TITLE
fix(cli): skip MCP tools for sub-resource parent groups.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ The runtime walker in `internal/mcp/cobratree/` mirrors the Cobra tree at server
 1. Commands annotated `cmd.Annotations["pp:endpoint"] = "<resource>.<endpoint>"` already have typed tools and are skipped to avoid duplicates.
 2. Framework commands listed in `cobratree/classify.go.tmpl`'s `frameworkCommands` set are skipped because a typed equivalent is better (`sql`, `search`, `context`) or the command is non-functional via MCP (`auth`, `completion`, `doctor`, `version`, `feedback`, `profile`, `which`, `help`).
 3. `cmd.Annotations["mcp:hidden"] = "true"` opts out a domain command that needs human-in-the-loop input.
+4. Commands annotated `cmd.Annotations["pp:api-resource"] = "true"` or `cmd.Annotations["pp:parent-group"] = "true"` are grouping parents whose only behavior is printing help; they are skipped so they do not register as runnable MCP tools. Endpoint leaves stay exposed.
 Store-population commands stay exposed: `sync`, `stale`, `orphans`, `reconcile`, `load`, `export`, `import`, `workflow`, `analytics`. `sql` and `search` return empty until `sync` populates the store. When in doubt, leave it exposed.
 
 ### Tool safety annotations

--- a/internal/generator/mcp_parent_group_test.go
+++ b/internal/generator/mcp_parent_group_test.go
@@ -1,0 +1,130 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPParentGroupClassifiesAsCommandGroupAndIsSkippedFromToolsList(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("parentgroup")
+	apiSpec.Resources = map[string]spec.Resource{
+		"companies": {
+			Description: "Manage companies",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/companies", Description: "List companies"},
+				"get":  {Method: "GET", Path: "/companies/{id}", Description: "Get a company"},
+			},
+			SubResources: map[string]spec.Resource{
+				"sites": {
+					Description: "Manage company sites",
+					Endpoints: map[string]spec.Endpoint{
+						"list": {Method: "GET", Path: "/companies/{company_id}/sites", Description: "List company sites"},
+						"get":  {Method: "GET", Path: "/companies/{company_id}/sites/{id}", Description: "Get a company site"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "parentgroup-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	classifySrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "mcp", "cobratree", "classify.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(classifySrc), `ParentGroupAnnotation = "pp:parent-group"`)
+	assert.Contains(t, string(classifySrc), "func isGroupingParent(cmd *cobra.Command) bool")
+	assert.Contains(t, string(classifySrc), "annotationIsTrue(cmd, ParentGroupAnnotation)")
+
+	subParentSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "companies_sites.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(subParentSrc), `"pp:parent-group": "true"`)
+	assert.NotContains(t, string(subParentSrc), `"pp:api-resource"`)
+	assert.Regexp(t, `RunE:\s+parentNoSubcommandRunE\(flags\)`, string(subParentSrc))
+
+	topParentSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "companies.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(topParentSrc), `"pp:api-resource": "true"`)
+	assert.Contains(t, string(topParentSrc), `"pp:parent-group": "true"`)
+
+	const classifyTest = `package cobratree
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestParentGroupAnnotationClassifiesAsCommandGroup(t *testing.T) {
+	parent := &cobra.Command{
+		Use: "sites",
+		Annotations: map[string]string{"pp:parent-group": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	leaf := &cobra.Command{
+		Use: "list",
+		Annotations: map[string]string{"pp:endpoint": "sites.list"},
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	parent.AddCommand(leaf)
+
+	if got := classify(parent); got != commandGroup {
+		t.Fatalf("pp:parent-group classify() = %v, want commandGroup", got)
+	}
+	if got := classify(leaf); got != commandEndpoint {
+		t.Fatalf("endpoint leaf classify() = %v, want commandEndpoint", got)
+	}
+
+	apiParent := &cobra.Command{
+		Use: "companies",
+		Annotations: map[string]string{"pp:api-resource": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	if got := classify(apiParent); got != commandGroup {
+		t.Fatalf("pp:api-resource classify() = %v, want commandGroup", got)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "mcp", "cobratree", "parent_group_classify_test.go"), []byte(classifyTest), 0o644))
+
+	const toolsListTest = `package mcp
+
+import (
+	"testing"
+
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func TestParentGroupSkippedFromToolsList(t *testing.T) {
+	s := server.NewMCPServer("test", "0.0.0")
+	RegisterTools(s)
+	tools := s.ListTools()
+
+	if _, ok := tools["companies_sites"]; ok {
+		t.Fatalf("sub-resource parent leaked into MCP tools/list: %#v", tools)
+	}
+	if _, ok := tools["companies"]; ok {
+		t.Fatalf("API resource grouping command leaked into MCP tools/list: %#v", tools)
+	}
+	for _, leaf := range []string{"companies_list", "companies_get", "companies_sites_list", "companies_sites_get"} {
+		entry, ok := tools[leaf]
+		if !ok {
+			t.Fatalf("leaf tool %q missing from MCP tools/list: %#v", leaf, tools)
+		}
+		if entry.Tool.Annotations.ReadOnlyHint == nil || !*entry.Tool.Annotations.ReadOnlyHint {
+			t.Fatalf("leaf tool %q readOnlyHint = %v, want true", leaf, entry.Tool.Annotations.ReadOnlyHint)
+		}
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "mcp", "parent_group_tools_list_test.go"), []byte(toolsListTest), 0o644))
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommandRequired(t, outputDir, "test", "./internal/mcp/...", "-run", "TestParentGroup(AnnotationClassifiesAsCommandGroup|SkippedFromToolsList)", "-count", "1")
+}

--- a/internal/generator/templates/cobratree/classify.go.tmpl
+++ b/internal/generator/templates/cobratree/classify.go.tmpl
@@ -11,9 +11,12 @@ import (
 )
 
 const (
-	EndpointAnnotation = "pp:endpoint"
-	HiddenAnnotation   = "mcp:hidden"
+	EndpointAnnotation    = "pp:endpoint"
+	HiddenAnnotation      = "mcp:hidden"
 	APIResourceAnnotation = "pp:api-resource"
+	// Sub-resource parents set this without APIResourceAnnotation; both
+	// classify as commandGroup so help-only parents are not MCP tools.
+	ParentGroupAnnotation = "pp:parent-group"
 	// ReadOnlyAnnotation, when set on a Cobra command to "true"/"1"/"yes",
 	// causes the runtime walker to register the resulting MCP tool with
 	// readOnlyHint=true. Use for novel CLI commands that don't mutate
@@ -91,7 +94,7 @@ func classify(cmd *cobra.Command) commandKind {
 	if endpointID(cmd) != "" {
 		return commandEndpoint
 	}
-	if annotationIsTrue(cmd, APIResourceAnnotation) {
+	if isGroupingParent(cmd) {
 		return commandGroup
 	}
 	if isTopLevelFrameworkCommand(cmd) {
@@ -113,6 +116,10 @@ func endpointID(cmd *cobra.Command) string {
 		return ""
 	}
 	return strings.TrimSpace(cmd.Annotations[EndpointAnnotation])
+}
+
+func isGroupingParent(cmd *cobra.Command) bool {
+	return annotationIsTrue(cmd, APIResourceAnnotation) || annotationIsTrue(cmd, ParentGroupAnnotation)
 }
 
 func isMCPHidden(cmd *cobra.Command) bool {

--- a/internal/pipeline/mcp_size.go
+++ b/internal/pipeline/mcp_size.go
@@ -435,7 +435,7 @@ func cobratreeCommandKind(cmd cobraCommandLiteral, depth int) mcpCobraCommandKin
 	if strings.TrimSpace(cmd.annotations["pp:endpoint"]) != "" {
 		return mcpCobraEndpoint
 	}
-	if annotationIsTrueValue(cmd.annotations["pp:api-resource"]) {
+	if annotationIsTrueValue(cmd.annotations["pp:api-resource"]) || annotationIsTrueValue(cmd.annotations["pp:parent-group"]) {
 		return mcpCobraGroup
 	}
 	if depth == 1 && cobratreeFrameworkCommands[name] {

--- a/internal/pipeline/mcp_size_test.go
+++ b/internal/pipeline/mcp_size_test.go
@@ -300,6 +300,62 @@ func newAPIResourceChildCmd() *cobra.Command {
 	assert.NotContains(t, names, "cobratree:catalog")
 }
 
+func TestEstimateMCPTokens_SkipsParentGroupCommands(t *testing.T) {
+	dir := writeMCPTools(t, `
+	s.AddTool(mcplib.NewTool("typed_get", mcplib.WithDescription("Typed endpoint.")), nil)
+	cobratree.RegisterAll(s, cli.RootCmd(), cobratree.SiblingCLIPath)
+`)
+	writeMCPCLISource(t, dir, "root.go", `package cli
+
+import "github.com/spf13/cobra"
+
+func RootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "demo-pp-cli"}
+	rootCmd.AddCommand(newCompaniesCmd())
+	return rootCmd
+}
+
+func newCompaniesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         "companies",
+		Annotations: map[string]string{"pp:api-resource": "true", "pp:parent-group": "true"},
+		RunE:        func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	cmd.AddCommand(newCompaniesSitesCmd())
+	return cmd
+}
+
+func newCompaniesSitesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         "sites",
+		Annotations: map[string]string{"pp:parent-group": "true"},
+		RunE:        func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	cmd.AddCommand(newCompaniesSitesListCmd())
+	return cmd
+}
+
+func newCompaniesSitesListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List company sites.",
+		RunE:  func(cmd *cobra.Command, args []string) error { return nil },
+	}
+}
+`)
+
+	est := estimateMCPTokens(dir)
+	require.Equal(t, 2, est.ToolCount, "typed tool plus the novel leaf under a parent-group should count")
+	names := make([]string, 0, len(est.PerTool))
+	for _, tool := range est.PerTool {
+		names = append(names, tool.Name)
+	}
+	assert.Contains(t, names, "typed_get")
+	assert.Contains(t, names, "cobratree:companies_sites_list")
+	assert.NotContains(t, names, "cobratree:companies")
+	assert.NotContains(t, names, "cobratree:companies_sites")
+}
+
 func TestEstimateMCPTokens_CountsSharedConstructorsAtDistinctPaths(t *testing.T) {
 	dir := writeMCPTools(t, `
 	cobratree.RegisterAll(s, cli.RootCmd(), cobratree.SiblingCLIPath)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/classify.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/classify.go
@@ -14,6 +14,9 @@ const (
 	EndpointAnnotation    = "pp:endpoint"
 	HiddenAnnotation      = "mcp:hidden"
 	APIResourceAnnotation = "pp:api-resource"
+	// Sub-resource parents set this without APIResourceAnnotation; both
+	// classify as commandGroup so help-only parents are not MCP tools.
+	ParentGroupAnnotation = "pp:parent-group"
 	// ReadOnlyAnnotation, when set on a Cobra command to "true"/"1"/"yes",
 	// causes the runtime walker to register the resulting MCP tool with
 	// readOnlyHint=true. Use for novel CLI commands that don't mutate
@@ -91,7 +94,7 @@ func classify(cmd *cobra.Command) commandKind {
 	if endpointID(cmd) != "" {
 		return commandEndpoint
 	}
-	if annotationIsTrue(cmd, APIResourceAnnotation) {
+	if isGroupingParent(cmd) {
 		return commandGroup
 	}
 	if isTopLevelFrameworkCommand(cmd) {
@@ -113,6 +116,10 @@ func endpointID(cmd *cobra.Command) string {
 		return ""
 	}
 	return strings.TrimSpace(cmd.Annotations[EndpointAnnotation])
+}
+
+func isGroupingParent(cmd *cobra.Command) bool {
+	return annotationIsTrue(cmd, APIResourceAnnotation) || annotationIsTrue(cmd, ParentGroupAnnotation)
 }
 
 func isMCPHidden(cmd *cobra.Command) bool {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #4240.

`classify()` treated a node as `commandGroup` only when `pp:api-resource` was true. Sub-resource parents always set `pp:parent-group` and only set `pp:api-resource` when `.APIResource`. Combined with 4.30 no longer hiding those parents, they classified as `commandNovel`, registered as runnable MCP tools, and `tools/call` returned the parent's Cobra help with `isError` unset.

This change treats `pp:parent-group` the same as `pp:api-resource` when deciding `commandGroup`. Help-only parents (`parentNoSubcommandRunE`) are not MCP tools. Endpoint leaves stay registered. Tenant-gate and `readOnlyHint` behavior is unchanged.

The MCP token estimator in `internal/pipeline/mcp_size.go` mirrors the same skip so static tool counts stay aligned with the runtime walker.

Proof: generated/compiled `tools/list` omits a sub-resource parent that has children and no own endpoint; remaining leaf tools still list. A compiled classify test asserts `pp:parent-group` => `commandGroup`.

Verified: `go test ./... -timeout 30m`, `scripts/golden.sh update` (full set; only `generate-golden-api` classify.go changed), `scripts/verify-generator-output.sh`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7764489-6ba2-49ad-8a58-912f5e361974?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7764489-6ba2-49ad-8a58-912f5e361974&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

