### PR TITLE
fix(cli): wrap mutation bodies under spec resource root.

### DIFF
--- a/internal/generator/body_map_test.go
+++ b/internal/generator/body_map_test.go
@@ -841,6 +841,134 @@ func TestBodyJSONFallback_BodyMap_TypedPath(t *testing.T) {
 	}
 }
 
+func TestBodyResourceWrapKey(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		endpoint spec.Endpoint
+		want     string
+	}{
+		{
+			name: "single object property wraps",
+			endpoint: spec.Endpoint{Body: []spec.Param{{
+				Name: "issue",
+				Type: "object",
+				Fields: []spec.Param{
+					{Name: "notes", Type: "string"},
+				},
+			}}},
+			want: "issue",
+		},
+		{
+			name: "body_name is the wrap key",
+			endpoint: spec.Endpoint{Body: []spec.Param{{
+				Name:     "Issue",
+				BodyName: "issue",
+				Type:     "object",
+				Fields:   []spec.Param{{Name: "notes", Type: "string"}},
+			}}},
+			want: "issue",
+		},
+		{
+			name:     "flat scalar stays unwrapped",
+			endpoint: spec.Endpoint{Body: []spec.Param{{Name: "user_id", Type: "int"}}},
+		},
+		{
+			name: "flat object-without-fields stays unwrapped",
+			endpoint: spec.Endpoint{Body: []spec.Param{{
+				Name: "metadata",
+				Type: "object",
+			}}},
+		},
+		{
+			name: "multi-key body stays unwrapped",
+			endpoint: spec.Endpoint{Body: []spec.Param{
+				{Name: "notes", Type: "string"},
+				{Name: "notify", Type: "bool"},
+			}},
+		},
+		{
+			name: "object plus sibling stays unwrapped",
+			endpoint: spec.Endpoint{Body: []spec.Param{
+				{
+					Name:   "issue",
+					Type:   "object",
+					Fields: []spec.Param{{Name: "notes", Type: "string"}},
+				},
+				{Name: "notify", Type: "bool"},
+			}},
+		},
+		{
+			name: "body-json fallback stays unwrapped",
+			endpoint: spec.Endpoint{
+				BodyJSONFallback: true,
+				Body: []spec.Param{{
+					Name:   "issue",
+					Type:   "object",
+					Fields: []spec.Param{{Name: "notes", Type: "string"}},
+				}},
+			},
+		},
+		{
+			name: "multipart stays unwrapped",
+			endpoint: spec.Endpoint{
+				RequestContentType: "multipart/form-data",
+				Body: []spec.Param{{
+					Name:   "issue",
+					Type:   "object",
+					Fields: []spec.Param{{Name: "notes", Type: "string"}},
+				}},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, bodyResourceWrapKey(tc.endpoint))
+		})
+	}
+}
+
+func TestAssignJSONBodyMap(t *testing.T) {
+	t.Parallel()
+
+	wrapped := spec.Endpoint{Body: []spec.Param{{
+		Name:   "issue",
+		Type:   "object",
+		Fields: []spec.Param{{Name: "notes", Type: "string"}},
+	}}}
+	require.Equal(t, `body = map[string]any{"issue": bodyMap}`, assignJSONBodyMap(wrapped, "bodyMap", "body"))
+	require.Equal(t, `var body any = map[string]any{"issue": bodyMap}`, declareJSONBodyMap(wrapped, "bodyMap", "body"))
+
+	flat := spec.Endpoint{Body: []spec.Param{{Name: "user_id", Type: "int"}}}
+	require.Equal(t, "body = bodyMap", assignJSONBodyMap(flat, "bodyMap", "body"))
+	require.Equal(t, "var body any = bodyMap", declareJSONBodyMap(flat, "bodyMap", "body"))
+}
+
+func TestBodyMapForEndpointVars_ResourceWrapFillsInnerFields(t *testing.T) {
+	t.Parallel()
+
+	wrapped := spec.Endpoint{Body: []spec.Param{{
+		Name: "issue",
+		Type: "object",
+		Fields: []spec.Param{
+			{Name: "notes", Type: "string"},
+			{Name: "subject", Type: "string"},
+		},
+	}}}
+	got := bodyMapForEndpointVars(wrapped, "\t", "bodyMap", "body")
+	require.Contains(t, got, `bodyMap["notes"] = bodyIssueNotes`)
+	require.Contains(t, got, `bodyMap["subject"] = bodyIssueSubject`)
+	require.NotContains(t, got, `bodyMap["issue"]`)
+	require.NotContains(t, got, "nestedIssue")
+
+	flat := spec.Endpoint{Body: []spec.Param{{Name: "user_id", Type: "int"}}}
+	got = bodyMapForEndpointVars(flat, "\t", "bodyMap", "body")
+	require.Contains(t, got, `bodyMap["user_id"] = bodyUserId`)
+	require.NotContains(t, got, `map[string]any{"`)
+}
+
 func TestBodyHasStringBackedBool(t *testing.T) {
 	t.Parallel()
 	endpoint := spec.Endpoint{Body: []spec.Param{{

--- a/internal/generator/body_resource_wrap_test.go
+++ b/internal/generator/body_resource_wrap_test.go
@@ -1,0 +1,403 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/openapi"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateResourceRootSchemaWrapsMutationBody(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := spec.ParseBytes([]byte(`
+name: resource-wrap
+base_url: https://api.example.com
+auth:
+  type: none
+resources:
+  issues:
+    description: Issues
+    endpoints:
+      list:
+        method: GET
+        path: /issues
+        description: List issues
+      create:
+        method: POST
+        path: /issues
+        description: Create an issue
+        body:
+          properties:
+            issue:
+              type: object
+              properties:
+                notes:
+                  type: string
+                subject:
+                  type: string
+      update:
+        method: PUT
+        path: /issues/{id}
+        description: Update an issue
+        params:
+          - name: id
+            type: string
+            positional: true
+            required: true
+        body:
+          properties:
+            issue:
+              type: object
+              properties:
+                notes:
+                  type: string
+  watchers:
+    description: Watchers
+    endpoints:
+      list:
+        method: GET
+        path: /watchers
+        description: List watchers
+      create:
+        method: POST
+        path: /issues/{id}/watchers
+        description: Add a watcher
+        params:
+          - name: id
+            type: string
+            positional: true
+            required: true
+        body:
+          properties:
+            user_id:
+              type: integer
+  items:
+    description: Items
+    endpoints:
+      list:
+        method: GET
+        path: /items
+        description: List items
+      create:
+        method: POST
+        path: /items
+        description: Create an item
+        body:
+          - name: id
+            type: int
+          - name: name
+            type: string
+`))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	createSrc := readGeneratedFile(t, outputDir, "internal", "cli", "issues_create.go")
+	require.Contains(t, createSrc, `body = map[string]any{"issue": bodyMap}`)
+	require.Contains(t, createSrc, `bodyMap["notes"] = bodyIssueNotes`)
+	require.Contains(t, createSrc, `bodyMap["subject"] = bodyIssueSubject`)
+	require.NotContains(t, createSrc, `bodyMap["issue"]`)
+	require.Contains(t, createSrc, "body = jsonBody")
+	require.NotContains(t, createSrc, `body = map[string]any{"issue": jsonBody}`)
+
+	updateSrc := readGeneratedFile(t, outputDir, "internal", "cli", "issues_update.go")
+	require.Contains(t, updateSrc, `body = map[string]any{"issue": bodyMap}`)
+	require.Contains(t, updateSrc, `bodyMap["notes"] = bodyIssueNotes`)
+
+	watcherSrc := readGeneratedFile(t, outputDir, "internal", "cli", "watchers_create.go")
+	require.Contains(t, watcherSrc, "body = bodyMap")
+	require.NotContains(t, watcherSrc, `body = map[string]any{`)
+	require.Contains(t, watcherSrc, `bodyMap["user_id"] = bodyUserId`)
+
+	itemSrc := readGeneratedFile(t, outputDir, "internal", "cli", "items_create.go")
+	require.Contains(t, itemSrc, "body = bodyMap")
+	require.NotContains(t, itemSrc, `body = map[string]any{`)
+	require.Contains(t, itemSrc, `bodyMap["id"] = bodyId`)
+	require.Contains(t, itemSrc, `bodyMap["name"] = bodyName`)
+	require.Contains(t, itemSrc, "body = jsonBody")
+
+	behaviorTest := `package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func runResourceWrap(t *testing.T, args ...string) error {
+	t.Helper()
+	cmd := newRootCmd(&rootFlags{asJSON: true})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+func TestResourceWrapSendsWrappedIssueBody(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody = nil
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(` + "`" + `{"ok":true}` + "`" + `))
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("RESOURCE_WRAP_BASE_URL", server.URL)
+
+	if err := runResourceWrap(t, "issues", "create", "--issue-notes", "hello"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	issue, ok := gotBody["issue"].(map[string]any)
+	if !ok {
+		t.Fatalf("create body = %#v, want issue wrapper", gotBody)
+	}
+	if issue["notes"] != "hello" {
+		t.Fatalf("create notes = %#v", issue["notes"])
+	}
+	if _, ok := gotBody["notes"]; ok {
+		t.Fatalf("create body leaked flat notes: %#v", gotBody)
+	}
+
+	if err := runResourceWrap(t, "issues", "update", "42", "--issue-notes", "edited"); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	issue, ok = gotBody["issue"].(map[string]any)
+	if !ok || issue["notes"] != "edited" {
+		t.Fatalf("update body = %#v", gotBody)
+	}
+
+	if err := runResourceWrap(t, "watchers", "create", "42", "--user-id", "9"); err != nil {
+		t.Fatalf("watchers: %v", err)
+	}
+	if fmt.Sprint(gotBody["user_id"]) != "9" {
+		t.Fatalf("watchers body = %#v, want flat user_id", gotBody)
+	}
+	if _, ok := gotBody["issue"]; ok {
+		t.Fatalf("watchers body unexpectedly wrapped: %#v", gotBody)
+	}
+
+	if err := runResourceWrap(t, "items", "create", "--id", "7", "--name", "widget"); err != nil {
+		t.Fatalf("items: %v", err)
+	}
+	if fmt.Sprint(gotBody["id"]) != "7" || gotBody["name"] != "widget" {
+		t.Fatalf("items body = %#v, want top-level id and name", gotBody)
+	}
+}
+
+func TestResourceWrapStdinJSONStaysCallerShaped(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody = nil
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(` + "`" + `{"ok":true}` + "`" + `))
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("RESOURCE_WRAP_BASE_URL", server.URL)
+
+	restore := replaceStdin(t, ` + "`" + `{"issue":{"notes":"from-stdin"}}` + "`" + `)
+	defer restore()
+	if err := runResourceWrap(t, "issues", "create", "--stdin"); err != nil {
+		t.Fatalf("stdin wrap: %v", err)
+	}
+	issue, ok := gotBody["issue"].(map[string]any)
+	if !ok || issue["notes"] != "from-stdin" {
+		t.Fatalf("stdin wrapped body = %#v", gotBody)
+	}
+
+	restore = replaceStdin(t, ` + "`" + `{"id":3,"name":"from-stdin"}` + "`" + `)
+	defer restore()
+	if err := runResourceWrap(t, "items", "create", "--stdin"); err != nil {
+		t.Fatalf("stdin id: %v", err)
+	}
+	if fmt.Sprint(gotBody["id"]) != "3" || gotBody["name"] != "from-stdin" {
+		t.Fatalf("stdin top-level id body = %#v", gotBody)
+	}
+}
+
+func replaceStdin(t *testing.T, data string) func() {
+	t.Helper()
+	oldStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdin: %v", err)
+	}
+	if _, err := w.WriteString(data); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdin writer: %v", err)
+	}
+	os.Stdin = r
+	return func() {
+		os.Stdin = oldStdin
+		_ = r.Close()
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "resource_wrap_runtime_test.go"), []byte(behaviorTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestResourceWrap", "-count=1")
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestGeneratePromotedResourceRootWrapsMutationBody(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("promoted-wrap")
+	apiSpec.Resources = map[string]spec.Resource{
+		"tickets": {
+			Description: "Tickets",
+			Endpoints: map[string]spec.Endpoint{
+				"create": {
+					Method:      "POST",
+					Path:        "/tickets",
+					Description: "Create a ticket",
+					Body: []spec.Param{{
+						Name: "ticket",
+						Type: "object",
+						Fields: []spec.Param{
+							{Name: "title", Type: "string"},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	src := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_tickets.go")
+	require.Contains(t, src, `var body any = map[string]any{"ticket": bodyMap}`)
+	require.Contains(t, src, `bodyMap["title"] = bodyTicketTitle`)
+	require.NotContains(t, src, `bodyMap["ticket"]`)
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestGenerateOpenAPIResourceRootWrapsMutationBody(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := openapi.Parse([]byte(`
+openapi: 3.0.3
+info:
+  title: Schema Wrap
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /issues:
+    get:
+      tags: [issues]
+      operationId: listIssues
+      responses:
+        "200":
+          description: ok
+    post:
+      tags: [issues]
+      operationId: createIssue
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                issue:
+                  type: object
+                  properties:
+                    notes:
+                      type: string
+                    subject:
+                      type: string
+      responses:
+        "201":
+          description: created
+  /issues/{id}:
+    put:
+      tags: [issues]
+      operationId: updateIssue
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                issue:
+                  type: object
+                  properties:
+                    notes:
+                      type: string
+      responses:
+        "200":
+          description: ok
+  /issues/{id}/watchers:
+    post:
+      tags: [watchers]
+      operationId: addWatcher
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user_id:
+                  type: integer
+      responses:
+        "201":
+          description: created
+  /watchers:
+    get:
+      tags: [watchers]
+      operationId: listWatchers
+      responses:
+        "200":
+          description: ok
+`))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	createSrc := readGeneratedFile(t, outputDir, "internal", "cli", "issues_create.go")
+	require.Contains(t, createSrc, `body = map[string]any{"issue": bodyMap}`)
+	require.Contains(t, createSrc, `bodyMap["notes"] = bodyIssueNotes`)
+	require.NotContains(t, createSrc, `bodyMap["issue"]`)
+	require.Contains(t, createSrc, "body = jsonBody")
+
+	updateSrc := readGeneratedFile(t, outputDir, "internal", "cli", "issues_update.go")
+	require.Contains(t, updateSrc, `body = map[string]any{"issue": bodyMap}`)
+
+	watcherSrc := readGeneratedCLIFileContaining(t, outputDir, `bodyMap["user_id"]`)
+	require.Contains(t, watcherSrc, "body = bodyMap")
+	require.NotContains(t, watcherSrc, `body = map[string]any{`)
+
+	requireGeneratedCompiles(t, outputDir)
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -406,6 +406,8 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"bodyMap":                      bodyMap,
 		"bodyMapForEndpoint":           bodyMapForEndpoint,
 		"bodyMapForEndpointVars":       bodyMapForEndpointVars,
+		"assignJSONBodyMap":            assignJSONBodyMap,
+		"declareJSONBodyMap":           declareJSONBodyMap,
 		"bodyVarDecls":                 bodyVarDecls,
 		"bodyFlagRegs":                 bodyFlagRegs,
 		"bodyRequiredChecks":           bodyRequiredChecks,
@@ -6922,8 +6924,9 @@ const maxBodyFlagDepth = 3
 // branch in command_promoted.go.tmpl. The four sites generated the
 // same Go code at different indentation levels; this consolidates them
 // and parameterizes the indent. The output is the body of the
-// `body := map[string]any{}` block — callers emit the surrounding
-// declaration and the closing brace themselves.
+// `bodyMap := map[string]any{}` block — callers emit the surrounding
+// declaration (including a resource-root wrap when the schema names one)
+// themselves.
 //
 // When a body Param has Type "object" with non-empty Fields, the block
 // recurses: each leaf field becomes its own flag (parent-prefixed in
@@ -6952,7 +6955,56 @@ func bodyMapForEndpointVars(endpoint spec.Endpoint, indent, mapVar, bodyVar stri
 	if endpoint.BodyJSONFallback {
 		return bodyJSONFallbackMap(endpoint, indent, bodyVar)
 	}
+	if wrapper, ok := bodyResourceWrap(endpoint); ok {
+		// Fill the inner resource fields into mapVar. The template wraps
+		// mapVar under the schema's single object key at assignment
+		// (`body = map[string]any{"issue": bodyMap}`) so we must not
+		// also nest that key here.
+		var b strings.Builder
+		renderBodyMap(&b, wrapper.Fields, 1, indent, mapVar, toCamel(paramIdent(wrapper)), publicFlagName(wrapper))
+		return b.String()
+	}
 	return bodyMapForVar(endpoint.Body, indent, mapVar)
+}
+
+// bodyResourceWrap reports the request-body schema's resource-root
+// wrapper when the body is a single object property whose value is an
+// object (Rails/ActiveModel `{"issue":{...}}`). Flat bodies
+// (`{"user_id": N}`) and multi-key objects stay unwrapped.
+func bodyResourceWrap(endpoint spec.Endpoint) (spec.Param, bool) {
+	if endpoint.BodyJSONFallback || endpoint.BodyIsArray || bodyUsesFlatEmission(endpoint) {
+		return spec.Param{}, false
+	}
+	body := flattenCollidingBodyFields(endpoint.Body)
+	if len(body) != 1 {
+		return spec.Param{}, false
+	}
+	p := body[0]
+	if p.Type != "object" || len(p.Fields) == 0 {
+		return spec.Param{}, false
+	}
+	return p, true
+}
+
+func bodyResourceWrapKey(endpoint spec.Endpoint) string {
+	if p, ok := bodyResourceWrap(endpoint); ok {
+		return p.BodyWireName()
+	}
+	return ""
+}
+
+func assignJSONBodyMap(endpoint spec.Endpoint, mapVar, bodyVar string) string {
+	if key := bodyResourceWrapKey(endpoint); key != "" {
+		return fmt.Sprintf("%s = map[string]any{%q: %s}", bodyVar, key, mapVar)
+	}
+	return fmt.Sprintf("%s = %s", bodyVar, mapVar)
+}
+
+func declareJSONBodyMap(endpoint spec.Endpoint, mapVar, bodyVar string) string {
+	if key := bodyResourceWrapKey(endpoint); key != "" {
+		return fmt.Sprintf("var %s any = map[string]any{%q: %s}", bodyVar, key, mapVar)
+	}
+	return fmt.Sprintf("var %s any = %s", bodyVar, mapVar)
 }
 
 // bodyJSONFallbackMap renders the body-population block used when an

--- a/internal/generator/json_string_validation_test.go
+++ b/internal/generator/json_string_validation_test.go
@@ -260,7 +260,8 @@ func TestHTMLStringBodyParamDoesNotEmitJSONValidation(t *testing.T) {
 	code := string(src)
 
 	require.Contains(t, code, `cmd.Flags().StringVar(&bodyDataHtmlText, "data-html-text"`)
-	require.Contains(t, code, `nestedData["html_text"] = bodyDataHtmlText`)
+	require.Contains(t, code, `body = map[string]any{"data": bodyMap}`)
+	require.Contains(t, code, `bodyMap["html_text"] = bodyDataHtmlText`)
 	require.NotContains(t, code, `parsedDataHtmlText`)
 	require.NotContains(t, code, `parsing --data-html-text JSON`)
 }

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -535,7 +535,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				body = []any{}
 {{bodyMapForEndpointVars .Endpoint "\t\t\t\t" "bodyMap" "body"}}{{- else}}
 				bodyMap := map[string]any{}
-				body = bodyMap
+				{{assignJSONBodyMap .Endpoint "bodyMap" "body"}}
 {{bodyMapForEndpointVars .Endpoint "\t\t\t\t" "bodyMap" "body"}}{{- end}}			}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 {{- if .IsReadOnly}}
@@ -597,7 +597,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				body = []any{}
 {{bodyMapForEndpointVars .Endpoint "\t\t\t\t" "bodyMap" "body"}}{{- else}}
 				bodyMap := map[string]any{}
-				body = bodyMap
+				{{assignJSONBodyMap .Endpoint "bodyMap" "body"}}
 {{bodyMapForEndpointVars .Endpoint "\t\t\t\t" "bodyMap" "body"}}{{- end}}			}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 {{- if endpointHasRequestParams .Endpoint}}
@@ -696,7 +696,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				body = []any{}
 {{bodyMapForEndpointVars .Endpoint "\t\t\t\t" "bodyMap" "body"}}{{- else}}
 				bodyMap := map[string]any{}
-				body = bodyMap
+				{{assignJSONBodyMap .Endpoint "bodyMap" "body"}}
 {{bodyMapForEndpointVars .Endpoint "\t\t\t\t" "bodyMap" "body"}}{{- end}}			}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 {{- if .IsReadOnly}}
@@ -789,7 +789,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				body = []any{}
 {{bodyMapForEndpointVars .Endpoint "\t\t\t\t" "bodyMap" "body"}}{{- else}}
 				bodyMap := map[string]any{}
-				body = bodyMap
+				{{assignJSONBodyMap .Endpoint "bodyMap" "body"}}
 {{bodyMapForEndpointVars .Endpoint "\t\t\t\t" "bodyMap" "body"}}{{- end}}			}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}
 {{- if .IsReadOnly}}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -332,7 +332,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			var body any = []any{}
 {{bodyMapForEndpointVars .Endpoint "\t\t\t" "bodyMap" "body"}}{{else}}
 			bodyMap := map[string]any{}
-			var body any = bodyMap
+			{{declareJSONBodyMap .Endpoint "bodyMap" "body"}}
 {{bodyMapForEndpointVars .Endpoint "\t\t\t" "bodyMap" "body"}}{{end}}{{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}{{if endpointHasRequestParams .Endpoint}}			data, _, err := c.DeleteWithParamsAndBodyAndHeaders(cmd.Context(), path, params, body, headerOverrides)
 {{else}}			data, _, err := c.DeleteWithBodyAndHeaders(cmd.Context(), path, body, headerOverrides)
 {{end}}{{else}}{{if endpointHasRequestParams .Endpoint}}			data, _, err := c.DeleteWithParamsAndBody(cmd.Context(), path, params, body)
@@ -406,7 +406,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			var body any = []any{}
 {{bodyMapForEndpointVars .Endpoint "\t\t\t" "bodyMap" "body"}}{{else}}
 			bodyMap := map[string]any{}
-			var body any = bodyMap
+			{{declareJSONBodyMap .Endpoint "bodyMap" "body"}}
 {{bodyMapForEndpointVars .Endpoint "\t\t\t" "bodyMap" "body"}}{{end}}{{if .IsReadOnly}}{{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}			data, _, err := c.{{pascal (lower .Endpoint.Method)}}QueryWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
 {{else}}			data, _, err := c.{{pascal (lower .Endpoint.Method)}}QueryWithParams(cmd.Context(), path, params, body)
 {{end}}{{else}}{{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.{{pascal (lower .Endpoint.Method)}}WithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)

--- a/skills/printing-press/references/spec-format.md
+++ b/skills/printing-press/references/spec-format.md
@@ -411,6 +411,14 @@ Top-level scalars become typed flags. Object properties with their own
 without expandable scalar children remain JSON-string flags so the command can
 pass nested payloads without hand-written Go.
 
+When the request-body schema is a **single object property whose value is an
+object** (the resource root, e.g. `{"issue":{"notes":"..."}}`), generated
+create/update/patch/post commands wrap the constructed field map under that
+schema key. Keep the wrapper in the schema when the API requires it. A flat
+schema (`{"user_id": 1}` or `{id, name, ...}`) stays a flat body — do not
+invent a wrap key or flatten a named resource root away. `--stdin` still sends
+the caller's JSON as-is.
+
 ## 4. Validation Rules
 
 Validation in `spec.Validate()` enforces:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #4233.

Mutation create/update/patch/post commands now wrap the constructed body map under the request-body schema's resource root when that schema is a single object property whose value is an object (`{"issue":{"notes":"..."}}`). Flat schemas stay flat (`{"user_id": N}`). `--stdin` and top-level `id` fields are unchanged. The wrap key is derived from the existing schema; no new spec extension.

Generated-output proof covers wrapped vs flat emission, OpenAPI schemas, promoted commands, stdin JSON, and compiled generated CLIs. Full `go test ./...` and `scripts/golden.sh update` were run; existing golden fixtures did not change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3c7aedf-16a6-4ff1-b916-5906be7d073f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3c7aedf-16a6-4ff1-b916-5906be7d073f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

