### PR TITLE
fix(cli): prune single-tenant mirrors; do not mark truncated walks complete.

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -591,9 +591,9 @@ The value flows into the resource profile and is consumed in two places:
   (`ReconcileMode = "flat"`) when it carries a tenant column, has a
   stable primary key, and is not routed through a discriminator dispatcher.
 - **Single-tenant whole-table reconcile**: when a print has zero
-  tenant-scoped flat resources, eligible flat resources (stable PK, no
+  `TenantScopeColumn` annotations, eligible flat resources (stable PK, no
   discriminator) are classified `ReconcileMode = "flat_global"` and the
-  table is the partition. Resources that fail those gates stay `"none"`.
+  table is the partition. Unscoped resources in a mixed print stay `"none"`.
 
 Rules:
 - Optional. Absence means no tenant scoping is recorded for the collection.

--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -588,9 +588,12 @@ The value flows into the resource profile and is consumed in two places:
   into the generated `parentTenantScopeColumns` map, so dependent fan-out
   targets only rows belonging to the active tenant.
 - **Flat tenant-scoped reconcile**: a flat resource becomes reconcilable
-  (`ReconcileMode = "flat"`) only when it carries a tenant column, has a
-  stable primary key, and is not routed through a discriminator dispatcher;
-  otherwise it stays `"none"`.
+  (`ReconcileMode = "flat"`) when it carries a tenant column, has a
+  stable primary key, and is not routed through a discriminator dispatcher.
+- **Single-tenant whole-table reconcile**: when a print has zero
+  tenant-scoped flat resources, eligible flat resources (stable PK, no
+  discriminator) are classified `ReconcileMode = "flat_global"` and the
+  table is the partition. Resources that fail those gates stay `"none"`.
 
 Rules:
 - Optional. Absence means no tenant scoping is recorded for the collection.

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -506,8 +506,8 @@ func TestGenerateDedupesResourceRegistryMapEntries(t *testing.T) {
 }
 
 // TestGenerate_EmitsReconcile verifies that, for a spec with a single-path-param
-// dependent resource, the generator emits the ReconcilePartition wiring in both
-// store.go and sync.go, and that the generated code compiles successfully.
+// dependent resource, the generator emits ReconcilePartition and ReconcileAll
+// wiring in store.go and sync.go, and that the generated code compiles.
 func TestGenerate_EmitsReconcile(t *testing.T) {
 	t.Parallel()
 	apiSpec := minimalSpec("emits-reconcile")
@@ -537,7 +537,11 @@ func TestGenerate_EmitsReconcile(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, string(storeSrc), "func (s *Store) ReconcilePartition")
+	assert.Contains(t, string(storeSrc), "func (s *Store) ReconcileAll")
 	assert.Contains(t, string(syncSrc), "ReconcilePartition(")
+	assert.Contains(t, string(syncSrc), "ReconcileAll(")
+	assert.Contains(t, string(syncSrc), `"flat_global"`,
+		"no-tenant-scope print must emit a reconcilable whole-table mode")
 	assert.Contains(t, string(syncSrc), "partitionOutcome")
 	assert.Contains(t, string(syncSrc), "reconcile_skipped")
 

--- a/internal/generator/store_reconcile_all_test.go
+++ b/internal/generator/store_reconcile_all_test.go
@@ -1,0 +1,96 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReconcileAll_DeletesUnseenKeepsSeen(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("reconcile-all")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"things": {
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:   "GET",
+					Path:     "/things",
+					Response: spec.ResponseDef{Type: "array", Item: "Thing"},
+					IDField:  "id",
+				},
+				"get": {
+					Method:   "GET",
+					Path:     "/things/{thingId}",
+					Response: spec.ResponseDef{Type: "object", Item: "Thing"},
+					IDField:  "id",
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Thing": {
+			Fields: []spec.TypeField{
+				{Name: "id", Type: "string"},
+				{Name: "name", Type: "string"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "reconcile-all-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	storeSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(storeSrc), "func (s *Store) ReconcileAll")
+
+	inlineTest := `package store
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+func TestReconcileAll_DeletesUnseenKeepsSeen(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	keep, err := json.Marshal(map[string]any{"id": "keep-1", "name": "keep"})
+	if err != nil {
+		t.Fatalf("marshal keep: %v", err)
+	}
+	stale, err := json.Marshal(map[string]any{"id": "stale-1", "name": "stale"})
+	if err != nil {
+		t.Fatalf("marshal stale: %v", err)
+	}
+	if _, _, err := s.UpsertBatch("things", []json.RawMessage{keep, stale}); err != nil {
+		t.Fatalf("UpsertBatch: %v", err)
+	}
+
+	deleted, err := s.ReconcileAll("things", []string{"keep-1"}, "things", nil)
+	if err != nil {
+		t.Fatalf("ReconcileAll: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("ReconcileAll deleted %d, want 1", deleted)
+	}
+	if _, err := s.Get("things", "keep-1"); err != nil {
+		t.Fatalf("keep-1 missing after ReconcileAll: %v", err)
+	}
+	if _, err := s.Get("things", "stale-1"); err == nil {
+		t.Fatal("stale-1 still present after ReconcileAll")
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "store", "reconcile_all_test.go"), []byte(inlineTest), 0o644))
+	runGoCommandRequired(t, outputDir, "mod", "tidy")
+	runGoCommandRequired(t, outputDir, "test", "./internal/store", "-run", "TestReconcileAll_DeletesUnseenKeepsSeen", "-count=1")
+}

--- a/internal/generator/sync_flat_reconcile_test.go
+++ b/internal/generator/sync_flat_reconcile_test.go
@@ -59,10 +59,12 @@ func TestFlatReconcile_SkipOnUnknownTenant(t *testing.T) {
 	syncSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
 	require.NoError(t, err)
 	src := string(syncSrc)
-	require.Contains(t, src, "flatReconcilable := resourceReconcileMode(resource) == \"flat\"",
+	require.Contains(t, src, "flatReconcilable := resourceIsFlatReconcilable(reconcileMode)",
 		"sync.go must declare flatReconcilable in syncResource")
 	require.Contains(t, src, "func resourceReconcileMode(resource string) string",
 		"sync.go must emit the resourceReconcileMode lookup")
+	require.Contains(t, src, "func resourceIsFlatReconcilable(mode string) bool",
+		"sync.go must treat flat and flat_global as reconcilable")
 	require.Contains(t, src, "func flatReconcileDef(resource string)",
 		"sync.go must emit the flatReconcileDef lookup")
 	require.Contains(t, src, `"unknown-tenant"`,

--- a/internal/generator/sync_single_tenant_reconcile_test.go
+++ b/internal/generator/sync_single_tenant_reconcile_test.go
@@ -1,0 +1,175 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSingleTenantReconcile_CompleteWalkPrunes proves the #4239 single-tenant
+// prune / completeness-gate pair: a print with zero tenant-scoped flat
+// resources emits a reconcilable mode, --full deletes local rows absent from a
+// complete walk, and a full page with no followable cursor leaves complete=false
+// so prune does not run.
+func TestSingleTenantReconcile_CompleteWalkPrunes(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("streconcile")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"devices": {
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:     "GET",
+					Path:       "/devices",
+					Response:   spec.ResponseDef{Type: "array", Item: "Device"},
+					Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+					IDField:    "id",
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Device": {
+			Fields: []spec.TypeField{
+				{Name: "id", Type: "string"},
+				{Name: "name", Type: "string"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	syncSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	src := string(syncSrc)
+	require.Contains(t, src, `"devices": "flat_global"`,
+		"no-tenant-scope resource must get a reconcilable whole-table mode")
+	require.Contains(t, src, "db.ReconcileAll(",
+		"sync.go must call ReconcileAll for single-tenant whole-table prune")
+	require.Contains(t, src, "func paginationEndUnprovable(",
+		"sync.go must gate completeness on an unprovable full-page-with-no-cursor")
+	require.Contains(t, src, "after a complete walk",
+		"--no-prune help must describe prune-after-complete-walk, not a parent partition")
+	require.NotContains(t, src, "fully-enumerated parent partition",
+		"--no-prune help must not claim parent-partition prune on a single-tenant print")
+
+	storeSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(storeSrc), "func (s *Store) ReconcileAll",
+		"store.go must emit ReconcileAll")
+
+	inlineTest := `package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"` + naming.CLI(apiSpec.Name) + `/internal/store"
+)
+
+type stubDeviceClient struct {
+	items []json.RawMessage
+}
+
+func (s *stubDeviceClient) Get(_ context.Context, _ string, _ map[string]string) (json.RawMessage, error) {
+	payload, _ := json.Marshal(s.items)
+	return json.RawMessage(payload), nil
+}
+
+func (s *stubDeviceClient) RateLimit() float64 { return 0 }
+
+func seedDevices(t *testing.T, db *store.Store, ids ...string) {
+	t.Helper()
+	var batch []json.RawMessage
+	for _, id := range ids {
+		raw, err := json.Marshal(map[string]any{"id": id, "name": "device-" + id})
+		if err != nil {
+			t.Fatalf("marshal device %s: %v", id, err)
+		}
+		batch = append(batch, raw)
+	}
+	if _, _, err := db.UpsertBatch("devices", batch); err != nil {
+		t.Fatalf("UpsertBatch: %v", err)
+	}
+}
+
+func deviceExists(t *testing.T, db *store.Store, id string) bool {
+	t.Helper()
+	_, err := db.Get("devices", id)
+	return err == nil
+}
+
+func TestSingleTenantReconcile_CompleteWalkDeletesAbsentRows(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	seedDevices(t, db, "keep-1", "ghost-1", "ghost-2")
+
+	keep, _ := json.Marshal(map[string]any{"id": "keep-1", "name": "device-keep-1"})
+	client := &stubDeviceClient{items: []json.RawMessage{json.RawMessage(keep)}}
+	var events bytes.Buffer
+	syncResource(context.Background(), client, db, "devices", "", true, 0, false, true, nil, &events)
+
+	if !deviceExists(t, db, "keep-1") {
+		t.Fatal("keep-1 was pruned; a complete walk must keep rows the API still returns")
+	}
+	if deviceExists(t, db, "ghost-1") {
+		t.Fatal("ghost-1 was NOT pruned; --full must delete local rows absent from a complete walk")
+	}
+	if deviceExists(t, db, "ghost-2") {
+		t.Fatal("ghost-2 was NOT pruned; --full must delete local rows absent from a complete walk")
+	}
+	if !strings.Contains(events.String(), "\"event\":\"reconcile\"") {
+		t.Fatalf("expected reconcile event after a complete single-tenant walk, got %s", events.String())
+	}
+}
+
+func TestSingleTenantReconcile_FullPageNoCursorSkipsPrune(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	seedDevices(t, db, "page-1", "ghost-beyond-page")
+
+	limit := determinePaginationDefaults("devices").limit
+	page := make([]json.RawMessage, 0, limit)
+	for i := 0; i < limit; i++ {
+		id := "page-item-" + strconv.Itoa(i)
+		if i == 0 {
+			id = "page-1"
+		}
+		raw, _ := json.Marshal(map[string]any{"id": id, "name": "device-" + id})
+		page = append(page, json.RawMessage(raw))
+	}
+	client := &stubDeviceClient{items: page}
+	var events bytes.Buffer
+	syncResource(context.Background(), client, db, "devices", "", true, 0, false, true, nil, &events)
+
+	if !deviceExists(t, db, "ghost-beyond-page") {
+		t.Fatal("ghost-beyond-page was pruned; a full page with no followable cursor must leave complete=false and skip prune")
+	}
+	if !strings.Contains(events.String(), "\"event\":\"reconcile_skipped\"") || !strings.Contains(events.String(), "\"reason\":\"cursor_unavailable\"") {
+		t.Fatalf("expected reconcile_skipped with cursor_unavailable, got %s", events.String())
+	}
+}
+`
+	testPath := filepath.Join(outputDir, "internal", "cli", "single_tenant_reconcile_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommandRequired(t, outputDir, "test", "-run", "TestSingleTenantReconcile", "./internal/cli")
+}

--- a/internal/generator/sync_single_tenant_reconcile_test.go
+++ b/internal/generator/sync_single_tenant_reconcile_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSingleTenantReconcile_CompleteWalkPrunes proves the #4239 single-tenant
-// prune / completeness-gate pair: a print with zero tenant-scoped flat
+// TestSingleTenantReconcile_CompleteWalkPrunes proves the single-tenant
+// prune and completeness-gate pair: a print with zero tenant-scoped flat
 // resources emits a reconcilable mode, --full deletes local rows absent from a
 // complete walk, and a full page with no followable cursor leaves complete=false
 // so prune does not run.

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -2490,10 +2490,8 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 		resourceType, genericScopeJSONPath, scopeValue)
 }
 
-// ReconcileAll hard-deletes local rows of resourceType whose primary key is NOT
-// in seenIDs. It is the single-tenant counterpart of ReconcilePartition: the
-// table is the partition. The caller must pass the COMPLETE seen-ID set from a
-// proven-complete walk.
+// Whole-table reconciliation is safe only when the caller supplies the complete
+// seen-ID set from a proven-complete walk.
 func (s *Store) ReconcileAll(resourceType string, seenIDs []string, typedTable string, cascades []CascadeJunction) (int, error) {
 	return s.reconcileUnseen(resourceType, seenIDs, typedTable, cascades,
 		`SELECT id FROM resources WHERE resource_type = ?`, resourceType)

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -2483,6 +2483,23 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	if genericScopeJSONPath == "" || scopeValue == "" {
 		return 0, fmt.Errorf("reconcile %s: empty partition scope", resourceType)
 	}
+	return s.reconcileUnseen(resourceType, seenIDs, typedTable, cascades,
+		`SELECT id FROM resources
+		 WHERE resource_type = ?
+		   AND (CASE WHEN json_valid(data) THEN json_extract(data, ?) END) = ?`,
+		resourceType, genericScopeJSONPath, scopeValue)
+}
+
+// ReconcileAll hard-deletes local rows of resourceType whose primary key is NOT
+// in seenIDs. It is the single-tenant counterpart of ReconcilePartition: the
+// table is the partition. The caller must pass the COMPLETE seen-ID set from a
+// proven-complete walk.
+func (s *Store) ReconcileAll(resourceType string, seenIDs []string, typedTable string, cascades []CascadeJunction) (int, error) {
+	return s.reconcileUnseen(resourceType, seenIDs, typedTable, cascades,
+		`SELECT id FROM resources WHERE resource_type = ?`, resourceType)
+}
+
+func (s *Store) reconcileUnseen(resourceType string, seenIDs []string, typedTable string, cascades []CascadeJunction, query string, args ...any) (int, error) {
 	s.lockForWrite()
 	defer s.unlockAfterWrite()
 
@@ -2507,12 +2524,7 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 
 	// CASE guards against a malformed-JSON row aborting the victim scan:
 	// a row we cannot parse is never a victim — it is skipped (never deleted).
-	rows, err := tx.Query(
-		`SELECT id FROM resources
-		 WHERE resource_type = ?
-		   AND (CASE WHEN json_valid(data) THEN json_extract(data, ?) END) = ?`,
-		resourceType, genericScopeJSONPath, scopeValue,
-	)
+	rows, err := tx.Query(query, args...)
 	if err != nil {
 		return 0, fmt.Errorf("reconcile %s: select victims: %w", resourceType, err)
 	}

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -373,9 +373,9 @@ Resource scoping:
 {{- end}}
 			started := time.Now()
 			// prune gates deletion reconciliation: a full sync prunes local rows
-			// the API no longer returns within a fully-enumerated partition, unless
-			// --no-prune disables it. Flat tenant-scoped reconcile (per resource)
-			// and dependent per-parent reconcile share this gate.
+			// the API no longer returns after a complete walk, unless --no-prune
+			// disables it. Flat tenant-scoped / single-tenant reconcile (per
+			// resource) and dependent per-parent reconcile share this gate.
 			prune := full && !noPrune
 			work := make(chan string, len(resources))
 			results := make(chan syncResult, len(resources))
@@ -559,7 +559,7 @@ Resource scoping:
 
 	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync. Naming a parent also runs its parent-keyed dependents (see Long help for scoping).")
 	cmd.Flags().BoolVar(&full, "full", false, "Full resync (ignore previous checkpoint)")
-	cmd.Flags().BoolVar(&noPrune, "no-prune", false, "Disable deletion reconciliation on --full (by default a full sync prunes local rows the API no longer returns for a fully-enumerated parent partition)")
+	cmd.Flags().BoolVar(&noPrune, "no-prune", false, "Disable deletion reconciliation on --full (by default a full sync prunes local rows the API no longer returns after a complete walk)")
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", {{.SyncDefaultConcurrency}}, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database file path (default: resolved data directory data.db)")
@@ -734,12 +734,14 @@ func syncResource(ctx context.Context, c interface {
 		var consumedTotal int
 	anomalyEmitted := false
 
-	// Flat tenant-scoped reconcile bookkeeping (mirrors the dependent loop's
-	// partitionOutcome machinery). flatReconcilable gates all of it: only
-	// resources classified reconcileMode=="flat" collect seen IDs and prune.
-	// outcome.complete is set ONLY at proven natural ends; any abnormal break
-	// sets outcome.reason and leaves complete=false so the reconcile SKIPS.
-	flatReconcilable := resourceReconcileMode(resource) == "flat"
+	// Flat reconcile bookkeeping (mirrors the dependent loop's partitionOutcome
+	// machinery). flatReconcilable gates all of it: only resources classified
+	// "flat" (tenant partition) or "flat_global" (whole table) collect seen IDs
+	// and prune. outcome.complete is set ONLY at proven natural ends; any
+	// abnormal break sets outcome.reason and leaves complete=false so the
+	// reconcile SKIPS.
+	reconcileMode := resourceReconcileMode(resource)
+	flatReconcilable := resourceIsFlatReconcilable(reconcileMode)
 	outcome := partitionOutcome{}
 	var seenIDs []string
 
@@ -1163,6 +1165,8 @@ func syncResource(ctx context.Context, c interface {
 			// the operator's page ceiling fired on that same request.
 			if capResumed {
 				outcome.reason = "max_pages_cap"
+			} else if paginationEndUnprovable(resourceSupportsPagination(resource), nextCursor, fetchedThisPage, capPageLimit, data, responsePathForResource(resource, path)...) {
+				outcome.reason = "cursor_unavailable"
 			} else if !hasMore ||
 {{- if .QuerySync}}
 				(path != queryPath && shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, capPageLimit)) {
@@ -1206,6 +1210,14 @@ func syncResource(ctx context.Context, c interface {
 			outcome.complete = true // resource declares no pagination: one page is the whole set
 			break
 		}
+{{- if $hasIDWalk}}
+		if paginationEndUnprovable(resourceSupportsPagination(resource), nextCursor, fetchedThisPage, activePageLimit, data, responsePathForResource(resource, path)...) {
+{{- else}}
+		if paginationEndUnprovable(resourceSupportsPagination(resource), nextCursor, fetchedThisPage, pageSize.limit, data, responsePathForResource(resource, path)...) {
+{{- end}}
+			outcome.reason = "cursor_unavailable"
+			break
+		}
 		if !hasMore {
 			outcome.complete = true
 			break
@@ -1224,8 +1236,16 @@ func syncResource(ctx context.Context, c interface {
 			break
 		}
 {{- if $hasIDWalk}}
+		if paginationEndUnprovable(true, nextCursor, fetchedThisPage, activePageLimit, data, responsePathForResource(resource, path)...) {
+			outcome.reason = "cursor_unavailable"
+			break
+		}
 		if !hasMore || shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, activePageLimit) {
 {{- else}}
+		if paginationEndUnprovable(true, nextCursor, fetchedThisPage, pageSize.limit, data, responsePathForResource(resource, path)...) {
+			outcome.reason = "cursor_unavailable"
+			break
+		}
 		if !hasMore || shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit) {
 {{- end}}
 			outcome.complete = true
@@ -1254,36 +1274,54 @@ func syncResource(ctx context.Context, c interface {
 		cursor = nextCursor
 	}
 
-	// Flat tenant-scoped reconcile: prune local rows the API no longer returns
-	// within THIS tenant's partition, gated on a proven-complete sync.
-	//   - Unknown tenant (resolveTenantID()=="") ⇒ SKIP, zero deletes. This is
-	//     the OPPOSITE of the dependent fan-out fallback (which enumerates
-	//     unscoped): a flat delete cannot be safely scoped without a tenant, so
-	//     we never delete on unknown.
+	// Flat reconcile: prune local rows the API no longer returns, gated on a
+	// proven-complete sync.
+	//   - flat_global (single-tenant): the table is the partition. No tenant
+	//     resolver is required.
+	//   - flat (tenant-scoped): unknown tenant (resolveTenantID()=="") ⇒ SKIP,
+	//     zero deletes. This is the OPPOSITE of the dependent fan-out fallback
+	//     (which enumerates unscoped): a tenant-scoped delete cannot be safely
+	//     scoped without a tenant, so we never delete on unknown.
 	//   - Incomplete sync (outcome.complete==false) ⇒ SKIP with the recorded
-	//     reason; an abnormal break never proves the partition was enumerated.
+	//     reason; an abnormal or unprovable end never proves the partition was
+	//     enumerated.
 	if prune && flatReconcilable {
-		def := flatReconcileDef(resource)
-		tenantUUID := resolveTenantID()
-		if tenantUUID == "" {
-			fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unknown-tenant"}`+"\n", resource)
-		} else if outcome.complete {
-			deleted, rerr := db.ReconcilePartition(
-				resource, "$."+def.BodyField, tenantUUID,
-				seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
-			)
-			if rerr != nil {
-				fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", resource, tenantUUID, rerr.Error())
+		if reconcileMode == "flat_global" {
+			if outcome.complete {
+				deleted, rerr := db.ReconcileAll(
+					resource, seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
+				)
+				if rerr != nil {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"*","error":%q}`+"\n", resource, rerr.Error())
+				} else {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"*","deleted":%d}`+"\n", resource, deleted)
+				}
 			} else {
-				fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"%s","deleted":%d}`+"\n", resource, tenantUUID, deleted)
+				fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","scope":"*","reason":%q}`+"\n", resource, outcome.reason)
 			}
 		} else {
-			fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","scope":"%s","reason":%q}`+"\n", resource, tenantUUID, outcome.reason)
+			def := flatReconcileDef(resource)
+			tenantUUID := resolveTenantID()
+			if tenantUUID == "" {
+				fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unknown-tenant"}`+"\n", resource)
+			} else if outcome.complete {
+				deleted, rerr := db.ReconcilePartition(
+					resource, "$."+def.BodyField, tenantUUID,
+					seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
+				)
+				if rerr != nil {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", resource, tenantUUID, rerr.Error())
+				} else {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"%s","deleted":%d}`+"\n", resource, tenantUUID, deleted)
+				}
+			} else {
+				fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","scope":"%s","reason":%q}`+"\n", resource, tenantUUID, outcome.reason)
+			}
 		}
 	} else if prune {
-		// Unpartitioned resources cannot be reconciled safely: the generated
-		// store only supports scoped mark-and-sweep deletion. Emit the decision
-		// so --full never implies that unsupported rows were pruned.
+		// Resources that are not flat-reconcilable (no PK, discriminator, or
+		// unscoped in a tenant-scoped print) cannot be pruned safely. Emit the
+		// decision so --full never implies that unsupported rows were pruned.
 		fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unsupported-resource-shape"}`+"\n", resource)
 	}
 
@@ -1372,6 +1410,17 @@ type paginationDefaults struct {
 
 func shortPageEndsPagination(cursorType string, fetched, limit int) bool {
 	return cursorType != "cursor" && cursorType != "page_token" && fetched < limit
+}
+
+// paginationEndUnprovable is true when pagination is declared, the page is
+// full, there is no followable cursor, and the API did not explicitly say
+// has_more=false. extractPageItemsWithPagination reports hasMore=false for a
+// bare array, which is not a proven end — prune must skip.
+func paginationEndUnprovable(declared bool, nextCursor string, fetched, limit int, data json.RawMessage, responsePaths ...string) bool {
+	if !declared || nextCursor != "" || fetched < limit {
+		return false
+	}
+	return pageMayHaveMore(data, responsePaths...)
 }
 
 func syncPageItemsEqual(previous, current []json.RawMessage) bool {
@@ -3579,9 +3628,17 @@ func syncOneParent(
 			break
 		}
 {{- if $hasIDWalk}}
+		if paginationEndUnprovable(true, nextCursor, len(items), activePageLimit, data, responsePathForResource(dep.Name, path)...) {
+			outcome.reason = "cursor_unavailable"
+			break
+		}
 		if !hasMore || shortPageEndsPagination(pageSize.cursorType, len(items), activePageLimit) {
 			outcome.complete = true
 {{- else}}
+		if paginationEndUnprovable(true, nextCursor, len(items), pageSize.limit, data, responsePathForResource(dep.Name, path)...) {
+			outcome.reason = "cursor_unavailable"
+			break
+		}
 		if !hasMore || shortPageEndsPagination(pageSize.cursorType, len(items), pageSize.limit) {
 			outcome.complete = true
 {{- end}}
@@ -3947,11 +4004,12 @@ var resourceIDFieldOverrides = map[string]string{
 {{- end}}
 }
 
-// partitionOutcome tracks whether a sync loop (flat tenant-scoped OR dependent
-// per-parent) enumerated its partition completely. complete is set ONLY at
-// proven natural ends; any abnormal break records a reason and leaves
-// complete=false so the gated reconcile SKIPS. scopeVal carries the dependent
-// loop's parent scope value (unused by the flat path).
+// partitionOutcome tracks whether a sync loop (flat tenant-scoped, single-tenant
+// whole-table, OR dependent per-parent) enumerated its partition completely.
+// complete is set ONLY at proven natural ends; any abnormal or unprovable break
+// records a reason and leaves complete=false so the gated reconcile SKIPS.
+// scopeVal carries the dependent loop's parent scope value (unused by the flat
+// path).
 type partitionOutcome struct {
 	complete bool
 	reason   string
@@ -3959,14 +4017,13 @@ type partitionOutcome struct {
 }
 
 // flatReconcileModes maps a flat resource to its reconcile mode classification
-// (from SyncableResource.ReconcileMode, set by the profiler when a flat resource
-// carries a tenant scope column AND an extractable IDField AND no discriminator).
-// Only "flat" resources are emitted; resourceReconcileMode returns "" for any
-// resource absent here, which is all the flat reconcile gate checks for.
+// (from SyncableResource.ReconcileMode). "flat" is a tenant-scoped partition;
+// "flat_global" is a single-tenant whole-table partition. resourceReconcileMode
+// returns "" for any resource absent here.
 var flatReconcileModes = map[string]string{
 {{- range .SyncableResources}}
-{{- if eq .ReconcileMode "flat"}}
-	{{printf "%q" .Name}}: "flat",
+{{- if or (eq .ReconcileMode "flat") (eq .ReconcileMode "flat_global")}}
+	{{printf "%q" .Name}}: {{printf "%q" .ReconcileMode}},
 {{- end}}
 {{- end}}
 }
@@ -3975,6 +4032,10 @@ var flatReconcileModes = map[string]string{
 // or "" when it is not a flat-reconcilable resource.
 func resourceReconcileMode(resource string) string {
 	return flatReconcileModes[resource]
+}
+
+func resourceIsFlatReconcilable(mode string) bool {
+	return mode == "flat" || mode == "flat_global"
 }
 
 // flatReconcileDefT carries the per-resource metadata the flat reconcile call

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -708,7 +708,7 @@ func Profile(s *spec.APISpec) *APIProfile {
 	sortDependentResources(p.DependentSyncResources, nil)
 	addUnresolvedPathTemplateCollections(syncable, parameterized, p.DependentSyncResources)
 	p.SyncableResources = sortedSyncableResources(syncable)
-	classifyFlatReconcileModes(p.SyncableResources)
+	classifyFlatReconcileModes(p.SyncableResources, specHasTenantScopeColumn(s))
 	// Populate reconcile metadata for each dependent resource.
 	// per_parent is safe only for a single-path-param dependent with a PK.
 	for i := range p.DependentSyncResources {
@@ -747,21 +747,35 @@ func flatResourceReconcilable(sr SyncableResource) bool {
 	return sr.IDField != "" && sr.Discriminator.Field == ""
 }
 
+func specHasTenantScopeColumn(s *spec.APISpec) bool {
+	if s == nil {
+		return false
+	}
+	return resourceTreeHasTenantScopeColumn(s.Resources)
+}
+
+func resourceTreeHasTenantScopeColumn(resources map[string]spec.Resource) bool {
+	for _, resource := range resources {
+		for _, endpoint := range resource.Endpoints {
+			if endpoint.TenantScopeColumn != "" {
+				return true
+			}
+		}
+		if resourceTreeHasTenantScopeColumn(resource.SubResources) {
+			return true
+		}
+	}
+	return false
+}
+
 // classifyFlatReconcileModes assigns ReconcileMode for each flat resource.
 // Tenant-discriminated resources with a stable PK and no discriminator are
 // "flat". flat_global (whole table is the partition) is emitted only when
 // the print has zero TenantScopeColumn annotations anywhere — a mixed print
-// that carries any tenant column keeps unscoped siblings at "none", even if
-// no tenant-scoped resource itself qualifies as reconcilable. Everything
-// else stays "none".
-func classifyFlatReconcileModes(resources []SyncableResource) {
-	hasTenantScope := false
-	for _, sr := range resources {
-		if sr.TenantScopeColumn != "" {
-			hasTenantScope = true
-			break
-		}
-	}
+// that carries any tenant column (flat or parameterized/dependent) keeps
+// unscoped siblings at "none", even if no tenant-scoped flat resource
+// itself qualifies as reconcilable. Everything else stays "none".
+func classifyFlatReconcileModes(resources []SyncableResource, hasTenantScope bool) {
 	for i := range resources {
 		sr := &resources[i]
 		switch {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -749,14 +749,16 @@ func flatResourceReconcilable(sr SyncableResource) bool {
 
 // classifyFlatReconcileModes assigns ReconcileMode for each flat resource.
 // Tenant-discriminated resources with a stable PK and no discriminator are
-// "flat". When the print has zero such tenant-scoped resources, the same
-// PK/discriminator gates classify eligible resources as "flat_global" (the
-// table is the partition). Everything else stays "none".
+// "flat". flat_global (whole table is the partition) is emitted only when
+// the print has zero TenantScopeColumn annotations anywhere — a mixed print
+// that carries any tenant column keeps unscoped siblings at "none", even if
+// no tenant-scoped resource itself qualifies as reconcilable. Everything
+// else stays "none".
 func classifyFlatReconcileModes(resources []SyncableResource) {
-	hasTenantFlat := false
+	hasTenantScope := false
 	for _, sr := range resources {
-		if sr.TenantScopeColumn != "" && flatResourceReconcilable(sr) {
-			hasTenantFlat = true
+		if sr.TenantScopeColumn != "" {
+			hasTenantScope = true
 			break
 		}
 	}
@@ -765,7 +767,7 @@ func classifyFlatReconcileModes(resources []SyncableResource) {
 		switch {
 		case sr.TenantScopeColumn != "" && flatResourceReconcilable(*sr):
 			sr.ReconcileMode = ReconcileModeFlat
-		case !hasTenantFlat && flatResourceReconcilable(*sr):
+		case !hasTenantScope && flatResourceReconcilable(*sr):
 			sr.ReconcileMode = ReconcileModeFlatGlobal
 		default:
 			sr.ReconcileMode = ReconcileModeNone

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -27,6 +27,13 @@ const (
 	ArchetypeGeneric           DomainArchetype = "generic"
 )
 
+const (
+	ReconcileModeNone       = "none"
+	ReconcileModeFlat       = "flat"
+	ReconcileModeFlatGlobal = "flat_global"
+	ReconcileModePerParent  = "per_parent"
+)
+
 type DomainSignals struct {
 	Archetype        DomainArchetype
 	HasAssignees     bool
@@ -184,9 +191,9 @@ type SyncableResource struct {
 	// that carry it.
 	QueryEntity string
 
-	// ReconcileMode mirrors DependentResource.ReconcileMode for flat resources.
-	// Always "none" this round — forward-looking metadata reserved for a
-	// follow-up flat/tenant reconcile pass; no sync logic consumes it yet.
+	// ReconcileMode classifies how sync can prune this flat resource:
+	// "flat" (tenant-scoped partition), "flat_global" (whole table is the
+	// partition), or "none".
 	ReconcileMode string
 
 	// TenantScopeColumn is the resource's own tenant discriminator column
@@ -701,28 +708,17 @@ func Profile(s *spec.APISpec) *APIProfile {
 	sortDependentResources(p.DependentSyncResources, nil)
 	addUnresolvedPathTemplateCollections(syncable, parameterized, p.DependentSyncResources)
 	p.SyncableResources = sortedSyncableResources(syncable)
-	// Flat tenant-scoped reconcile: a flat resource is reconcilable only when it
-	// is tenant-discriminated (its rows carry a tenant column) AND has a stable
-	// PK AND will not mis-route items through a discriminator dispatcher. All
-	// other flat resources stay "none". flat_global is intentionally unreachable.
-	for i := range p.SyncableResources {
-		sr := &p.SyncableResources[i]
-		if sr.TenantScopeColumn != "" && sr.IDField != "" && sr.Discriminator.Field == "" {
-			sr.ReconcileMode = "flat"
-		} else {
-			sr.ReconcileMode = "none"
-		}
-	}
+	classifyFlatReconcileModes(p.SyncableResources)
 	// Populate reconcile metadata for each dependent resource.
 	// per_parent is safe only for a single-path-param dependent with a PK.
 	for i := range p.DependentSyncResources {
 		dep := &p.DependentSyncResources[i]
 		if len(dep.PathParams) == 1 && dep.IDField != "" {
-			dep.ReconcileMode = "per_parent"
+			dep.ReconcileMode = ReconcileModePerParent
 			dep.ParentScopeColumn = dep.ParentResource + "_id"
 			dep.GenericScopeJSONPath = "$." + singularParentField(dep.ParentResource)
 		} else {
-			dep.ReconcileMode = "none"
+			dep.ReconcileMode = ReconcileModeNone
 		}
 	}
 	for resource, fields := range searchable {
@@ -745,6 +741,36 @@ func Profile(s *spec.APISpec) *APIProfile {
 	}
 
 	return p
+}
+
+func flatResourceReconcilable(sr SyncableResource) bool {
+	return sr.IDField != "" && sr.Discriminator.Field == ""
+}
+
+// classifyFlatReconcileModes assigns ReconcileMode for each flat resource.
+// Tenant-discriminated resources with a stable PK and no discriminator are
+// "flat". When the print has zero such tenant-scoped resources, the same
+// PK/discriminator gates classify eligible resources as "flat_global" (the
+// table is the partition). Everything else stays "none".
+func classifyFlatReconcileModes(resources []SyncableResource) {
+	hasTenantFlat := false
+	for _, sr := range resources {
+		if sr.TenantScopeColumn != "" && flatResourceReconcilable(sr) {
+			hasTenantFlat = true
+			break
+		}
+	}
+	for i := range resources {
+		sr := &resources[i]
+		switch {
+		case sr.TenantScopeColumn != "" && flatResourceReconcilable(*sr):
+			sr.ReconcileMode = ReconcileModeFlat
+		case !hasTenantFlat && flatResourceReconcilable(*sr):
+			sr.ReconcileMode = ReconcileModeFlatGlobal
+		default:
+			sr.ReconcileMode = ReconcileModeNone
+		}
+	}
 }
 
 func (p *APIProfile) ToVisionaryPlan(apiName string) *vision.VisionaryPlan {

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -4421,3 +4421,90 @@ func TestProfiler_FlatReconcileClassification(t *testing.T) {
 		t.Fatalf("mixed_items.ReconcileMode = %q, want none (discriminator-dispatched)", mixed.ReconcileMode)
 	}
 }
+
+func TestProfiler_SingleTenantFlatGlobal(t *testing.T) {
+	prof := Profile(&spec.APISpec{
+		Name: "single-tenant-fixture",
+		Resources: map[string]spec.Resource{
+			"devices": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:     "GET",
+						Path:       "/devices",
+						Response:   spec.ResponseDef{Type: "array", Item: "Device"},
+						Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+						IDField:    "id",
+					},
+				},
+			},
+			"invoices": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/invoices",
+						Response: spec.ResponseDef{Type: "array"},
+						// IDField intentionally omitted — no stable PK.
+					},
+				},
+			},
+			"mixed_items": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/mixed-items",
+						Response: spec.ResponseDef{Type: "array", Item: "MixedItem"},
+						IDField:  "id",
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Device": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "string"},
+					{Name: "name", Type: "string"},
+				},
+			},
+			"MixedItem": {
+				Fields: []spec.TypeField{
+					{Name: "type", Type: "string", Enum: []string{"devices", "invoices"}},
+					{Name: "id", Type: "string"},
+				},
+			},
+		},
+	})
+
+	var devices, invoices, mixed SyncableResource
+	var foundDevices, foundInvoices, foundMixed bool
+	for _, sr := range prof.SyncableResources {
+		switch sr.Name {
+		case "devices":
+			devices, foundDevices = sr, true
+		case "invoices":
+			invoices, foundInvoices = sr, true
+		case "mixed_items":
+			mixed, foundMixed = sr, true
+		}
+		if sr.TenantScopeColumn != "" {
+			t.Fatalf("%s unexpectedly carries a tenant scope column", sr.Name)
+		}
+	}
+	if !foundDevices {
+		t.Fatal("devices resource not found in SyncableResources")
+	}
+	if devices.ReconcileMode != ReconcileModeFlatGlobal {
+		t.Fatalf("devices.ReconcileMode = %q, want %q (single-tenant whole-table)", devices.ReconcileMode, ReconcileModeFlatGlobal)
+	}
+	if foundInvoices && invoices.ReconcileMode != ReconcileModeNone {
+		t.Fatalf("invoices.ReconcileMode = %q, want none (no IDField)", invoices.ReconcileMode)
+	}
+	if !foundMixed {
+		t.Fatal("mixed_items resource not found in SyncableResources")
+	}
+	if mixed.Discriminator.Field == "" {
+		t.Fatal("mixed_items fixture is not discriminator-dispatched; negative case is ineffective")
+	}
+	if mixed.ReconcileMode != ReconcileModeNone {
+		t.Fatalf("mixed_items.ReconcileMode = %q, want none (discriminator-dispatched)", mixed.ReconcileMode)
+	}
+}

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -4581,3 +4581,90 @@ func TestProfiler_MixedPrintUnscopedStaysNone(t *testing.T) {
 		t.Fatalf("devices.ReconcileMode = %q, want none (unscoped sibling in a print that has any TenantScopeColumn)", devices.ReconcileMode)
 	}
 }
+
+func TestProfiler_DependentTenantScopeKeepsUnscopedNone(t *testing.T) {
+	prof := Profile(&spec.APISpec{
+		Name: "dependent-tenant-scope-fixture",
+		Resources: map[string]spec.Resource{
+			"projects": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/projects",
+						Response: spec.ResponseDef{Type: "array", Item: "Project"},
+						IDField:  "id",
+					},
+					"get": {
+						Method:   "GET",
+						Path:     "/projects/{project_id}",
+						Response: spec.ResponseDef{Type: "object", Item: "Project"},
+					},
+				},
+			},
+			"modules": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:            "GET",
+						Path:              "/projects/{project_id}/modules",
+						Response:          spec.ResponseDef{Type: "array", Item: "Module"},
+						Pagination:        &spec.Pagination{CursorParam: "cursor", LimitParam: "limit"},
+						IDField:           "id",
+						TenantScopeColumn: "workspace",
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Project": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "string"},
+					{Name: "name", Type: "string"},
+				},
+			},
+			"Module": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "string"},
+					{Name: "workspace", Type: "string"},
+				},
+			},
+		},
+	})
+
+	for _, sr := range prof.SyncableResources {
+		if sr.Name == "modules" {
+			t.Fatal("modules landed in SyncableResources; test must cover a DependentSyncResources-only tenant column")
+		}
+		if sr.TenantScopeColumn != "" {
+			t.Fatalf("%s unexpectedly carries a tenant scope column on the flat slice", sr.Name)
+		}
+	}
+
+	var foundDependent bool
+	for _, dep := range prof.DependentSyncResources {
+		if dep.Name == "modules" {
+			foundDependent = true
+			break
+		}
+	}
+	if !foundDependent {
+		t.Fatal("modules did not land in DependentSyncResources; test does not cover the dependent-scope hole")
+	}
+
+	var projects SyncableResource
+	var foundProjects bool
+	for _, sr := range prof.SyncableResources {
+		if sr.Name == "projects" {
+			projects, foundProjects = sr, true
+			break
+		}
+	}
+	if !foundProjects {
+		t.Fatal("projects resource not found in SyncableResources")
+	}
+	if projects.IDField == "" || projects.Discriminator.Field != "" {
+		t.Fatalf("projects fixture is not reconcilable (id=%q discriminator=%q); dependent-scope case is ineffective", projects.IDField, projects.Discriminator.Field)
+	}
+	if projects.ReconcileMode != ReconcileModeNone {
+		t.Fatalf("projects.ReconcileMode = %q, want none (unscoped flat sibling when the only TenantScopeColumn is on a dependent)", projects.ReconcileMode)
+	}
+}

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -4508,3 +4508,76 @@ func TestProfiler_SingleTenantFlatGlobal(t *testing.T) {
 		t.Fatalf("mixed_items.ReconcileMode = %q, want none (discriminator-dispatched)", mixed.ReconcileMode)
 	}
 }
+
+func TestProfiler_MixedPrintUnscopedStaysNone(t *testing.T) {
+	prof := Profile(&spec.APISpec{
+		Name: "mixed-unscoped-fixture",
+		Resources: map[string]spec.Resource{
+			"invoices": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:            "GET",
+						Path:              "/invoices",
+						Response:          spec.ResponseDef{Type: "array"},
+						TenantScopeColumn: "workspace",
+						// IDField intentionally omitted — tenant-scoped but not reconcilable.
+					},
+				},
+			},
+			"devices": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:     "GET",
+						Path:       "/devices",
+						Response:   spec.ResponseDef{Type: "array", Item: "Device"},
+						Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+						IDField:    "id",
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Device": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "string"},
+					{Name: "name", Type: "string"},
+				},
+			},
+		},
+	})
+
+	var invoices, devices SyncableResource
+	var foundInvoices, foundDevices bool
+	for _, sr := range prof.SyncableResources {
+		switch sr.Name {
+		case "invoices":
+			invoices, foundInvoices = sr, true
+		case "devices":
+			devices, foundDevices = sr, true
+		}
+	}
+	if !foundInvoices {
+		t.Fatal("invoices resource not found in SyncableResources")
+	}
+	if invoices.TenantScopeColumn == "" {
+		t.Fatal("invoices fixture lost its tenant column; mixed-print case is ineffective")
+	}
+	if invoices.IDField != "" {
+		t.Fatal("invoices fixture gained an IDField; mixed-print case needs a non-reconcilable tenant resource")
+	}
+	if invoices.ReconcileMode != ReconcileModeNone {
+		t.Fatalf("invoices.ReconcileMode = %q, want none (tenant-scoped without IDField)", invoices.ReconcileMode)
+	}
+	if !foundDevices {
+		t.Fatal("devices resource not found in SyncableResources")
+	}
+	if devices.TenantScopeColumn != "" {
+		t.Fatal("devices fixture unexpectedly carries a tenant scope column")
+	}
+	if devices.IDField == "" || devices.Discriminator.Field != "" {
+		t.Fatalf("devices fixture is not reconcilable (id=%q discriminator=%q); mixed-print case is ineffective", devices.IDField, devices.Discriminator.Field)
+	}
+	if devices.ReconcileMode != ReconcileModeNone {
+		t.Fatalf("devices.ReconcileMode = %q, want none (unscoped sibling in a print that has any TenantScopeColumn)", devices.ReconcileMode)
+	}
+}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -227,9 +227,9 @@ Resource scoping:
 
 			started := time.Now()
 			// prune gates deletion reconciliation: a full sync prunes local rows
-			// the API no longer returns within a fully-enumerated partition, unless
-			// --no-prune disables it. Flat tenant-scoped reconcile (per resource)
-			// and dependent per-parent reconcile share this gate.
+			// the API no longer returns after a complete walk, unless --no-prune
+			// disables it. Flat tenant-scoped / single-tenant reconcile (per
+			// resource) and dependent per-parent reconcile share this gate.
 			prune := full && !noPrune
 			work := make(chan string, len(resources))
 			results := make(chan syncResult, len(resources))
@@ -399,7 +399,7 @@ Resource scoping:
 
 	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync. Naming a parent also runs its parent-keyed dependents (see Long help for scoping).")
 	cmd.Flags().BoolVar(&full, "full", false, "Full resync (ignore previous checkpoint)")
-	cmd.Flags().BoolVar(&noPrune, "no-prune", false, "Disable deletion reconciliation on --full (by default a full sync prunes local rows the API no longer returns for a fully-enumerated parent partition)")
+	cmd.Flags().BoolVar(&noPrune, "no-prune", false, "Disable deletion reconciliation on --full (by default a full sync prunes local rows the API no longer returns after a complete walk)")
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database file path (default: resolved data directory data.db)")
@@ -540,12 +540,14 @@ func syncResource(ctx context.Context, c interface {
 	var consumedTotal int
 	anomalyEmitted := false
 
-	// Flat tenant-scoped reconcile bookkeeping (mirrors the dependent loop's
-	// partitionOutcome machinery). flatReconcilable gates all of it: only
-	// resources classified reconcileMode=="flat" collect seen IDs and prune.
-	// outcome.complete is set ONLY at proven natural ends; any abnormal break
-	// sets outcome.reason and leaves complete=false so the reconcile SKIPS.
-	flatReconcilable := resourceReconcileMode(resource) == "flat"
+	// Flat reconcile bookkeeping (mirrors the dependent loop's partitionOutcome
+	// machinery). flatReconcilable gates all of it: only resources classified
+	// "flat" (tenant partition) or "flat_global" (whole table) collect seen IDs
+	// and prune. outcome.complete is set ONLY at proven natural ends; any
+	// abnormal break sets outcome.reason and leaves complete=false so the
+	// reconcile SKIPS.
+	reconcileMode := resourceReconcileMode(resource)
+	flatReconcilable := resourceIsFlatReconcilable(reconcileMode)
 	outcome := partitionOutcome{}
 	var seenIDs []string
 
@@ -838,6 +840,8 @@ func syncResource(ctx context.Context, c interface {
 			// the operator's page ceiling fired on that same request.
 			if capResumed {
 				outcome.reason = "max_pages_cap"
+			} else if paginationEndUnprovable(resourceSupportsPagination(resource), nextCursor, fetchedThisPage, capPageLimit, data, responsePathForResource(resource, path)...) {
+				outcome.reason = "cursor_unavailable"
 			} else if !hasMore ||
 				shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, capPageLimit) {
 				outcome.complete = true
@@ -871,6 +875,10 @@ func syncResource(ctx context.Context, c interface {
 			outcome.complete = true // resource declares no pagination: one page is the whole set
 			break
 		}
+		if paginationEndUnprovable(true, nextCursor, fetchedThisPage, pageSize.limit, data, responsePathForResource(resource, path)...) {
+			outcome.reason = "cursor_unavailable"
+			break
+		}
 		if !hasMore || shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit) {
 			outcome.complete = true
 			break
@@ -897,36 +905,54 @@ func syncResource(ctx context.Context, c interface {
 		cursor = nextCursor
 	}
 
-	// Flat tenant-scoped reconcile: prune local rows the API no longer returns
-	// within THIS tenant's partition, gated on a proven-complete sync.
-	//   - Unknown tenant (resolveTenantID()=="") ⇒ SKIP, zero deletes. This is
-	//     the OPPOSITE of the dependent fan-out fallback (which enumerates
-	//     unscoped): a flat delete cannot be safely scoped without a tenant, so
-	//     we never delete on unknown.
+	// Flat reconcile: prune local rows the API no longer returns, gated on a
+	// proven-complete sync.
+	//   - flat_global (single-tenant): the table is the partition. No tenant
+	//     resolver is required.
+	//   - flat (tenant-scoped): unknown tenant (resolveTenantID()=="") ⇒ SKIP,
+	//     zero deletes. This is the OPPOSITE of the dependent fan-out fallback
+	//     (which enumerates unscoped): a tenant-scoped delete cannot be safely
+	//     scoped without a tenant, so we never delete on unknown.
 	//   - Incomplete sync (outcome.complete==false) ⇒ SKIP with the recorded
-	//     reason; an abnormal break never proves the partition was enumerated.
+	//     reason; an abnormal or unprovable end never proves the partition was
+	//     enumerated.
 	if prune && flatReconcilable {
-		def := flatReconcileDef(resource)
-		tenantUUID := resolveTenantID()
-		if tenantUUID == "" {
-			fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unknown-tenant"}`+"\n", resource)
-		} else if outcome.complete {
-			deleted, rerr := db.ReconcilePartition(
-				resource, "$."+def.BodyField, tenantUUID,
-				seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
-			)
-			if rerr != nil {
-				fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", resource, tenantUUID, rerr.Error())
+		if reconcileMode == "flat_global" {
+			if outcome.complete {
+				deleted, rerr := db.ReconcileAll(
+					resource, seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
+				)
+				if rerr != nil {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"*","error":%q}`+"\n", resource, rerr.Error())
+				} else {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"*","deleted":%d}`+"\n", resource, deleted)
+				}
 			} else {
-				fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"%s","deleted":%d}`+"\n", resource, tenantUUID, deleted)
+				fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","scope":"*","reason":%q}`+"\n", resource, outcome.reason)
 			}
 		} else {
-			fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","scope":"%s","reason":%q}`+"\n", resource, tenantUUID, outcome.reason)
+			def := flatReconcileDef(resource)
+			tenantUUID := resolveTenantID()
+			if tenantUUID == "" {
+				fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unknown-tenant"}`+"\n", resource)
+			} else if outcome.complete {
+				deleted, rerr := db.ReconcilePartition(
+					resource, "$."+def.BodyField, tenantUUID,
+					seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
+				)
+				if rerr != nil {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", resource, tenantUUID, rerr.Error())
+				} else {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"%s","deleted":%d}`+"\n", resource, tenantUUID, deleted)
+				}
+			} else {
+				fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","scope":"%s","reason":%q}`+"\n", resource, tenantUUID, outcome.reason)
+			}
 		}
 	} else if prune {
-		// Unpartitioned resources cannot be reconciled safely: the generated
-		// store only supports scoped mark-and-sweep deletion. Emit the decision
-		// so --full never implies that unsupported rows were pruned.
+		// Resources that are not flat-reconcilable (no PK, discriminator, or
+		// unscoped in a tenant-scoped print) cannot be pruned safely. Emit the
+		// decision so --full never implies that unsupported rows were pruned.
 		fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unsupported-resource-shape"}`+"\n", resource)
 	}
 
@@ -1015,6 +1041,17 @@ type paginationDefaults struct {
 
 func shortPageEndsPagination(cursorType string, fetched, limit int) bool {
 	return cursorType != "cursor" && cursorType != "page_token" && fetched < limit
+}
+
+// paginationEndUnprovable is true when pagination is declared, the page is
+// full, there is no followable cursor, and the API did not explicitly say
+// has_more=false. extractPageItemsWithPagination reports hasMore=false for a
+// bare array, which is not a proven end — prune must skip.
+func paginationEndUnprovable(declared bool, nextCursor string, fetched, limit int, data json.RawMessage, responsePaths ...string) bool {
+	if !declared || nextCursor != "" || fetched < limit {
+		return false
+	}
+	return pageMayHaveMore(data, responsePaths...)
 }
 
 func syncPageItemsEqual(previous, current []json.RawMessage) bool {
@@ -2482,6 +2519,10 @@ func syncOneParent(
 			outcome.complete = true
 			break
 		}
+		if paginationEndUnprovable(true, nextCursor, len(items), pageSize.limit, data, responsePathForResource(dep.Name, path)...) {
+			outcome.reason = "cursor_unavailable"
+			break
+		}
 		if !hasMore || shortPageEndsPagination(pageSize.cursorType, len(items), pageSize.limit) {
 			outcome.complete = true
 			break
@@ -2819,11 +2860,12 @@ var resourceIDFieldOverrides = map[string]string{
 	"tasks":    "id",
 }
 
-// partitionOutcome tracks whether a sync loop (flat tenant-scoped OR dependent
-// per-parent) enumerated its partition completely. complete is set ONLY at
-// proven natural ends; any abnormal break records a reason and leaves
-// complete=false so the gated reconcile SKIPS. scopeVal carries the dependent
-// loop's parent scope value (unused by the flat path).
+// partitionOutcome tracks whether a sync loop (flat tenant-scoped, single-tenant
+// whole-table, OR dependent per-parent) enumerated its partition completely.
+// complete is set ONLY at proven natural ends; any abnormal or unprovable break
+// records a reason and leaves complete=false so the gated reconcile SKIPS.
+// scopeVal carries the dependent loop's parent scope value (unused by the flat
+// path).
 type partitionOutcome struct {
 	complete bool
 	reason   string
@@ -2831,16 +2873,21 @@ type partitionOutcome struct {
 }
 
 // flatReconcileModes maps a flat resource to its reconcile mode classification
-// (from SyncableResource.ReconcileMode, set by the profiler when a flat resource
-// carries a tenant scope column AND an extractable IDField AND no discriminator).
-// Only "flat" resources are emitted; resourceReconcileMode returns "" for any
-// resource absent here, which is all the flat reconcile gate checks for.
-var flatReconcileModes = map[string]string{}
+// (from SyncableResource.ReconcileMode). "flat" is a tenant-scoped partition;
+// "flat_global" is a single-tenant whole-table partition. resourceReconcileMode
+// returns "" for any resource absent here.
+var flatReconcileModes = map[string]string{
+	"projects": "flat_global",
+}
 
 // resourceReconcileMode returns the flat reconcile classification for a resource,
 // or "" when it is not a flat-reconcilable resource.
 func resourceReconcileMode(resource string) string {
 	return flatReconcileModes[resource]
+}
+
+func resourceIsFlatReconcilable(mode string) bool {
+	return mode == "flat" || mode == "flat_global"
 }
 
 // flatReconcileDefT carries the per-resource metadata the flat reconcile call

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -1964,10 +1964,8 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 		resourceType, genericScopeJSONPath, scopeValue)
 }
 
-// ReconcileAll hard-deletes local rows of resourceType whose primary key is NOT
-// in seenIDs. It is the single-tenant counterpart of ReconcilePartition: the
-// table is the partition. The caller must pass the COMPLETE seen-ID set from a
-// proven-complete walk.
+// Whole-table reconciliation is safe only when the caller supplies the complete
+// seen-ID set from a proven-complete walk.
 func (s *Store) ReconcileAll(resourceType string, seenIDs []string, typedTable string, cascades []CascadeJunction) (int, error) {
 	return s.reconcileUnseen(resourceType, seenIDs, typedTable, cascades,
 		`SELECT id FROM resources WHERE resource_type = ?`, resourceType)

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -1957,6 +1957,23 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	if genericScopeJSONPath == "" || scopeValue == "" {
 		return 0, fmt.Errorf("reconcile %s: empty partition scope", resourceType)
 	}
+	return s.reconcileUnseen(resourceType, seenIDs, typedTable, cascades,
+		`SELECT id FROM resources
+		 WHERE resource_type = ?
+		   AND (CASE WHEN json_valid(data) THEN json_extract(data, ?) END) = ?`,
+		resourceType, genericScopeJSONPath, scopeValue)
+}
+
+// ReconcileAll hard-deletes local rows of resourceType whose primary key is NOT
+// in seenIDs. It is the single-tenant counterpart of ReconcilePartition: the
+// table is the partition. The caller must pass the COMPLETE seen-ID set from a
+// proven-complete walk.
+func (s *Store) ReconcileAll(resourceType string, seenIDs []string, typedTable string, cascades []CascadeJunction) (int, error) {
+	return s.reconcileUnseen(resourceType, seenIDs, typedTable, cascades,
+		`SELECT id FROM resources WHERE resource_type = ?`, resourceType)
+}
+
+func (s *Store) reconcileUnseen(resourceType string, seenIDs []string, typedTable string, cascades []CascadeJunction, query string, args ...any) (int, error) {
 	s.lockForWrite()
 	defer s.unlockAfterWrite()
 
@@ -1981,12 +1998,7 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 
 	// CASE guards against a malformed-JSON row aborting the victim scan:
 	// a row we cannot parse is never a victim — it is skipped (never deleted).
-	rows, err := tx.Query(
-		`SELECT id FROM resources
-		 WHERE resource_type = ?
-		   AND (CASE WHEN json_valid(data) THEN json_extract(data, ?) END) = ?`,
-		resourceType, genericScopeJSONPath, scopeValue,
-	)
+	rows, err := tx.Query(query, args...)
 	if err != nil {
 		return 0, fmt.Errorf("reconcile %s: select victims: %w", resourceType, err)
 	}

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -2219,10 +2219,8 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 		resourceType, genericScopeJSONPath, scopeValue)
 }
 
-// ReconcileAll hard-deletes local rows of resourceType whose primary key is NOT
-// in seenIDs. It is the single-tenant counterpart of ReconcilePartition: the
-// table is the partition. The caller must pass the COMPLETE seen-ID set from a
-// proven-complete walk.
+// Whole-table reconciliation is safe only when the caller supplies the complete
+// seen-ID set from a proven-complete walk.
 func (s *Store) ReconcileAll(resourceType string, seenIDs []string, typedTable string, cascades []CascadeJunction) (int, error) {
 	return s.reconcileUnseen(resourceType, seenIDs, typedTable, cascades,
 		`SELECT id FROM resources WHERE resource_type = ?`, resourceType)

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -2212,6 +2212,23 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	if genericScopeJSONPath == "" || scopeValue == "" {
 		return 0, fmt.Errorf("reconcile %s: empty partition scope", resourceType)
 	}
+	return s.reconcileUnseen(resourceType, seenIDs, typedTable, cascades,
+		`SELECT id FROM resources
+		 WHERE resource_type = ?
+		   AND (CASE WHEN json_valid(data) THEN json_extract(data, ?) END) = ?`,
+		resourceType, genericScopeJSONPath, scopeValue)
+}
+
+// ReconcileAll hard-deletes local rows of resourceType whose primary key is NOT
+// in seenIDs. It is the single-tenant counterpart of ReconcilePartition: the
+// table is the partition. The caller must pass the COMPLETE seen-ID set from a
+// proven-complete walk.
+func (s *Store) ReconcileAll(resourceType string, seenIDs []string, typedTable string, cascades []CascadeJunction) (int, error) {
+	return s.reconcileUnseen(resourceType, seenIDs, typedTable, cascades,
+		`SELECT id FROM resources WHERE resource_type = ?`, resourceType)
+}
+
+func (s *Store) reconcileUnseen(resourceType string, seenIDs []string, typedTable string, cascades []CascadeJunction, query string, args ...any) (int, error) {
 	s.lockForWrite()
 	defer s.unlockAfterWrite()
 
@@ -2236,12 +2253,7 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 
 	// CASE guards against a malformed-JSON row aborting the victim scan:
 	// a row we cannot parse is never a victim — it is skipped (never deleted).
-	rows, err := tx.Query(
-		`SELECT id FROM resources
-		 WHERE resource_type = ?
-		   AND (CASE WHEN json_valid(data) THEN json_extract(data, ?) END) = ?`,
-		resourceType, genericScopeJSONPath, scopeValue,
-	)
+	rows, err := tx.Query(query, args...)
 	if err != nil {
 		return 0, fmt.Errorf("reconcile %s: select victims: %w", resourceType, err)
 	}

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -221,9 +221,9 @@ Resource scoping:
 
 			started := time.Now()
 			// prune gates deletion reconciliation: a full sync prunes local rows
-			// the API no longer returns within a fully-enumerated partition, unless
-			// --no-prune disables it. Flat tenant-scoped reconcile (per resource)
-			// and dependent per-parent reconcile share this gate.
+			// the API no longer returns after a complete walk, unless --no-prune
+			// disables it. Flat tenant-scoped / single-tenant reconcile (per
+			// resource) and dependent per-parent reconcile share this gate.
 			prune := full && !noPrune
 			work := make(chan string, len(resources))
 			results := make(chan syncResult, len(resources))
@@ -360,7 +360,7 @@ Resource scoping:
 
 	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync. Naming a parent also runs its parent-keyed dependents (see Long help for scoping).")
 	cmd.Flags().BoolVar(&full, "full", false, "Full resync (ignore previous checkpoint)")
-	cmd.Flags().BoolVar(&noPrune, "no-prune", false, "Disable deletion reconciliation on --full (by default a full sync prunes local rows the API no longer returns for a fully-enumerated parent partition)")
+	cmd.Flags().BoolVar(&noPrune, "no-prune", false, "Disable deletion reconciliation on --full (by default a full sync prunes local rows the API no longer returns after a complete walk)")
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database file path (default: resolved data directory data.db)")
@@ -501,12 +501,14 @@ func syncResource(ctx context.Context, c interface {
 	var consumedTotal int
 	anomalyEmitted := false
 
-	// Flat tenant-scoped reconcile bookkeeping (mirrors the dependent loop's
-	// partitionOutcome machinery). flatReconcilable gates all of it: only
-	// resources classified reconcileMode=="flat" collect seen IDs and prune.
-	// outcome.complete is set ONLY at proven natural ends; any abnormal break
-	// sets outcome.reason and leaves complete=false so the reconcile SKIPS.
-	flatReconcilable := resourceReconcileMode(resource) == "flat"
+	// Flat reconcile bookkeeping (mirrors the dependent loop's partitionOutcome
+	// machinery). flatReconcilable gates all of it: only resources classified
+	// "flat" (tenant partition) or "flat_global" (whole table) collect seen IDs
+	// and prune. outcome.complete is set ONLY at proven natural ends; any
+	// abnormal break sets outcome.reason and leaves complete=false so the
+	// reconcile SKIPS.
+	reconcileMode := resourceReconcileMode(resource)
+	flatReconcilable := resourceIsFlatReconcilable(reconcileMode)
 	outcome := partitionOutcome{}
 	var seenIDs []string
 
@@ -852,6 +854,8 @@ func syncResource(ctx context.Context, c interface {
 			// the operator's page ceiling fired on that same request.
 			if capResumed {
 				outcome.reason = "max_pages_cap"
+			} else if paginationEndUnprovable(resourceSupportsPagination(resource), nextCursor, fetchedThisPage, capPageLimit, data, responsePathForResource(resource, path)...) {
+				outcome.reason = "cursor_unavailable"
 			} else if !hasMore ||
 				(path != queryPath && shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, capPageLimit)) {
 				outcome.complete = true
@@ -890,6 +894,10 @@ func syncResource(ctx context.Context, c interface {
 			outcome.complete = true // resource declares no pagination: one page is the whole set
 			break
 		}
+		if paginationEndUnprovable(resourceSupportsPagination(resource), nextCursor, fetchedThisPage, pageSize.limit, data, responsePathForResource(resource, path)...) {
+			outcome.reason = "cursor_unavailable"
+			break
+		}
 		if !hasMore {
 			outcome.complete = true
 			break
@@ -920,36 +928,54 @@ func syncResource(ctx context.Context, c interface {
 		cursor = nextCursor
 	}
 
-	// Flat tenant-scoped reconcile: prune local rows the API no longer returns
-	// within THIS tenant's partition, gated on a proven-complete sync.
-	//   - Unknown tenant (resolveTenantID()=="") ⇒ SKIP, zero deletes. This is
-	//     the OPPOSITE of the dependent fan-out fallback (which enumerates
-	//     unscoped): a flat delete cannot be safely scoped without a tenant, so
-	//     we never delete on unknown.
+	// Flat reconcile: prune local rows the API no longer returns, gated on a
+	// proven-complete sync.
+	//   - flat_global (single-tenant): the table is the partition. No tenant
+	//     resolver is required.
+	//   - flat (tenant-scoped): unknown tenant (resolveTenantID()=="") ⇒ SKIP,
+	//     zero deletes. This is the OPPOSITE of the dependent fan-out fallback
+	//     (which enumerates unscoped): a tenant-scoped delete cannot be safely
+	//     scoped without a tenant, so we never delete on unknown.
 	//   - Incomplete sync (outcome.complete==false) ⇒ SKIP with the recorded
-	//     reason; an abnormal break never proves the partition was enumerated.
+	//     reason; an abnormal or unprovable end never proves the partition was
+	//     enumerated.
 	if prune && flatReconcilable {
-		def := flatReconcileDef(resource)
-		tenantUUID := resolveTenantID()
-		if tenantUUID == "" {
-			fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unknown-tenant"}`+"\n", resource)
-		} else if outcome.complete {
-			deleted, rerr := db.ReconcilePartition(
-				resource, "$."+def.BodyField, tenantUUID,
-				seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
-			)
-			if rerr != nil {
-				fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", resource, tenantUUID, rerr.Error())
+		if reconcileMode == "flat_global" {
+			if outcome.complete {
+				deleted, rerr := db.ReconcileAll(
+					resource, seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
+				)
+				if rerr != nil {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"*","error":%q}`+"\n", resource, rerr.Error())
+				} else {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"*","deleted":%d}`+"\n", resource, deleted)
+				}
 			} else {
-				fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"%s","deleted":%d}`+"\n", resource, tenantUUID, deleted)
+				fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","scope":"*","reason":%q}`+"\n", resource, outcome.reason)
 			}
 		} else {
-			fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","scope":"%s","reason":%q}`+"\n", resource, tenantUUID, outcome.reason)
+			def := flatReconcileDef(resource)
+			tenantUUID := resolveTenantID()
+			if tenantUUID == "" {
+				fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unknown-tenant"}`+"\n", resource)
+			} else if outcome.complete {
+				deleted, rerr := db.ReconcilePartition(
+					resource, "$."+def.BodyField, tenantUUID,
+					seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
+				)
+				if rerr != nil {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", resource, tenantUUID, rerr.Error())
+				} else {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"%s","deleted":%d}`+"\n", resource, tenantUUID, deleted)
+				}
+			} else {
+				fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","scope":"%s","reason":%q}`+"\n", resource, tenantUUID, outcome.reason)
+			}
 		}
 	} else if prune {
-		// Unpartitioned resources cannot be reconciled safely: the generated
-		// store only supports scoped mark-and-sweep deletion. Emit the decision
-		// so --full never implies that unsupported rows were pruned.
+		// Resources that are not flat-reconcilable (no PK, discriminator, or
+		// unscoped in a tenant-scoped print) cannot be pruned safely. Emit the
+		// decision so --full never implies that unsupported rows were pruned.
 		fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unsupported-resource-shape"}`+"\n", resource)
 	}
 
@@ -1038,6 +1064,17 @@ type paginationDefaults struct {
 
 func shortPageEndsPagination(cursorType string, fetched, limit int) bool {
 	return cursorType != "cursor" && cursorType != "page_token" && fetched < limit
+}
+
+// paginationEndUnprovable is true when pagination is declared, the page is
+// full, there is no followable cursor, and the API did not explicitly say
+// has_more=false. extractPageItemsWithPagination reports hasMore=false for a
+// bare array, which is not a proven end — prune must skip.
+func paginationEndUnprovable(declared bool, nextCursor string, fetched, limit int, data json.RawMessage, responsePaths ...string) bool {
+	if !declared || nextCursor != "" || fetched < limit {
+		return false
+	}
+	return pageMayHaveMore(data, responsePaths...)
 }
 
 func syncPageItemsEqual(previous, current []json.RawMessage) bool {
@@ -2082,11 +2119,12 @@ func isNullOrEmptyJSON(data json.RawMessage) bool {
 // flat paths.
 var resourceIDFieldOverrides = map[string]string{}
 
-// partitionOutcome tracks whether a sync loop (flat tenant-scoped OR dependent
-// per-parent) enumerated its partition completely. complete is set ONLY at
-// proven natural ends; any abnormal break records a reason and leaves
-// complete=false so the gated reconcile SKIPS. scopeVal carries the dependent
-// loop's parent scope value (unused by the flat path).
+// partitionOutcome tracks whether a sync loop (flat tenant-scoped, single-tenant
+// whole-table, OR dependent per-parent) enumerated its partition completely.
+// complete is set ONLY at proven natural ends; any abnormal or unprovable break
+// records a reason and leaves complete=false so the gated reconcile SKIPS.
+// scopeVal carries the dependent loop's parent scope value (unused by the flat
+// path).
 type partitionOutcome struct {
 	complete bool
 	reason   string
@@ -2094,16 +2132,19 @@ type partitionOutcome struct {
 }
 
 // flatReconcileModes maps a flat resource to its reconcile mode classification
-// (from SyncableResource.ReconcileMode, set by the profiler when a flat resource
-// carries a tenant scope column AND an extractable IDField AND no discriminator).
-// Only "flat" resources are emitted; resourceReconcileMode returns "" for any
-// resource absent here, which is all the flat reconcile gate checks for.
+// (from SyncableResource.ReconcileMode). "flat" is a tenant-scoped partition;
+// "flat_global" is a single-tenant whole-table partition. resourceReconcileMode
+// returns "" for any resource absent here.
 var flatReconcileModes = map[string]string{}
 
 // resourceReconcileMode returns the flat reconcile classification for a resource,
 // or "" when it is not a flat-reconcilable resource.
 func resourceReconcileMode(resource string) string {
 	return flatReconcileModes[resource]
+}
+
+func resourceIsFlatReconcilable(mode string) bool {
+	return mode == "flat" || mode == "flat_global"
 }
 
 // flatReconcileDefT carries the per-resource metadata the flat reconcile call

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -2264,6 +2264,23 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	if genericScopeJSONPath == "" || scopeValue == "" {
 		return 0, fmt.Errorf("reconcile %s: empty partition scope", resourceType)
 	}
+	return s.reconcileUnseen(resourceType, seenIDs, typedTable, cascades,
+		`SELECT id FROM resources
+		 WHERE resource_type = ?
+		   AND (CASE WHEN json_valid(data) THEN json_extract(data, ?) END) = ?`,
+		resourceType, genericScopeJSONPath, scopeValue)
+}
+
+// ReconcileAll hard-deletes local rows of resourceType whose primary key is NOT
+// in seenIDs. It is the single-tenant counterpart of ReconcilePartition: the
+// table is the partition. The caller must pass the COMPLETE seen-ID set from a
+// proven-complete walk.
+func (s *Store) ReconcileAll(resourceType string, seenIDs []string, typedTable string, cascades []CascadeJunction) (int, error) {
+	return s.reconcileUnseen(resourceType, seenIDs, typedTable, cascades,
+		`SELECT id FROM resources WHERE resource_type = ?`, resourceType)
+}
+
+func (s *Store) reconcileUnseen(resourceType string, seenIDs []string, typedTable string, cascades []CascadeJunction, query string, args ...any) (int, error) {
 	s.lockForWrite()
 	defer s.unlockAfterWrite()
 
@@ -2288,12 +2305,7 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 
 	// CASE guards against a malformed-JSON row aborting the victim scan:
 	// a row we cannot parse is never a victim — it is skipped (never deleted).
-	rows, err := tx.Query(
-		`SELECT id FROM resources
-		 WHERE resource_type = ?
-		   AND (CASE WHEN json_valid(data) THEN json_extract(data, ?) END) = ?`,
-		resourceType, genericScopeJSONPath, scopeValue,
-	)
+	rows, err := tx.Query(query, args...)
 	if err != nil {
 		return 0, fmt.Errorf("reconcile %s: select victims: %w", resourceType, err)
 	}

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -2271,10 +2271,8 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 		resourceType, genericScopeJSONPath, scopeValue)
 }
 
-// ReconcileAll hard-deletes local rows of resourceType whose primary key is NOT
-// in seenIDs. It is the single-tenant counterpart of ReconcilePartition: the
-// table is the partition. The caller must pass the COMPLETE seen-ID set from a
-// proven-complete walk.
+// Whole-table reconciliation is safe only when the caller supplies the complete
+// seen-ID set from a proven-complete walk.
 func (s *Store) ReconcileAll(resourceType string, seenIDs []string, typedTable string, cascades []CascadeJunction) (int, error) {
 	return s.reconcileUnseen(resourceType, seenIDs, typedTable, cascades,
 		`SELECT id FROM resources WHERE resource_type = ?`, resourceType)

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -227,9 +227,9 @@ Resource scoping:
 
 			started := time.Now()
 			// prune gates deletion reconciliation: a full sync prunes local rows
-			// the API no longer returns within a fully-enumerated partition, unless
-			// --no-prune disables it. Flat tenant-scoped reconcile (per resource)
-			// and dependent per-parent reconcile share this gate.
+			// the API no longer returns after a complete walk, unless --no-prune
+			// disables it. Flat tenant-scoped / single-tenant reconcile (per
+			// resource) and dependent per-parent reconcile share this gate.
 			prune := full && !noPrune
 			work := make(chan string, len(resources))
 			results := make(chan syncResult, len(resources))
@@ -399,7 +399,7 @@ Resource scoping:
 
 	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync. Naming a parent also runs its parent-keyed dependents (see Long help for scoping).")
 	cmd.Flags().BoolVar(&full, "full", false, "Full resync (ignore previous checkpoint)")
-	cmd.Flags().BoolVar(&noPrune, "no-prune", false, "Disable deletion reconciliation on --full (by default a full sync prunes local rows the API no longer returns for a fully-enumerated parent partition)")
+	cmd.Flags().BoolVar(&noPrune, "no-prune", false, "Disable deletion reconciliation on --full (by default a full sync prunes local rows the API no longer returns after a complete walk)")
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database file path (default: resolved data directory data.db)")
@@ -540,12 +540,14 @@ func syncResource(ctx context.Context, c interface {
 	var consumedTotal int
 	anomalyEmitted := false
 
-	// Flat tenant-scoped reconcile bookkeeping (mirrors the dependent loop's
-	// partitionOutcome machinery). flatReconcilable gates all of it: only
-	// resources classified reconcileMode=="flat" collect seen IDs and prune.
-	// outcome.complete is set ONLY at proven natural ends; any abnormal break
-	// sets outcome.reason and leaves complete=false so the reconcile SKIPS.
-	flatReconcilable := resourceReconcileMode(resource) == "flat"
+	// Flat reconcile bookkeeping (mirrors the dependent loop's partitionOutcome
+	// machinery). flatReconcilable gates all of it: only resources classified
+	// "flat" (tenant partition) or "flat_global" (whole table) collect seen IDs
+	// and prune. outcome.complete is set ONLY at proven natural ends; any
+	// abnormal break sets outcome.reason and leaves complete=false so the
+	// reconcile SKIPS.
+	reconcileMode := resourceReconcileMode(resource)
+	flatReconcilable := resourceIsFlatReconcilable(reconcileMode)
 	outcome := partitionOutcome{}
 	var seenIDs []string
 
@@ -838,6 +840,8 @@ func syncResource(ctx context.Context, c interface {
 			// the operator's page ceiling fired on that same request.
 			if capResumed {
 				outcome.reason = "max_pages_cap"
+			} else if paginationEndUnprovable(resourceSupportsPagination(resource), nextCursor, fetchedThisPage, capPageLimit, data, responsePathForResource(resource, path)...) {
+				outcome.reason = "cursor_unavailable"
 			} else if !hasMore ||
 				shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, capPageLimit) {
 				outcome.complete = true
@@ -871,6 +875,10 @@ func syncResource(ctx context.Context, c interface {
 			outcome.complete = true // resource declares no pagination: one page is the whole set
 			break
 		}
+		if paginationEndUnprovable(true, nextCursor, fetchedThisPage, pageSize.limit, data, responsePathForResource(resource, path)...) {
+			outcome.reason = "cursor_unavailable"
+			break
+		}
 		if !hasMore || shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit) {
 			outcome.complete = true
 			break
@@ -897,36 +905,54 @@ func syncResource(ctx context.Context, c interface {
 		cursor = nextCursor
 	}
 
-	// Flat tenant-scoped reconcile: prune local rows the API no longer returns
-	// within THIS tenant's partition, gated on a proven-complete sync.
-	//   - Unknown tenant (resolveTenantID()=="") ⇒ SKIP, zero deletes. This is
-	//     the OPPOSITE of the dependent fan-out fallback (which enumerates
-	//     unscoped): a flat delete cannot be safely scoped without a tenant, so
-	//     we never delete on unknown.
+	// Flat reconcile: prune local rows the API no longer returns, gated on a
+	// proven-complete sync.
+	//   - flat_global (single-tenant): the table is the partition. No tenant
+	//     resolver is required.
+	//   - flat (tenant-scoped): unknown tenant (resolveTenantID()=="") ⇒ SKIP,
+	//     zero deletes. This is the OPPOSITE of the dependent fan-out fallback
+	//     (which enumerates unscoped): a tenant-scoped delete cannot be safely
+	//     scoped without a tenant, so we never delete on unknown.
 	//   - Incomplete sync (outcome.complete==false) ⇒ SKIP with the recorded
-	//     reason; an abnormal break never proves the partition was enumerated.
+	//     reason; an abnormal or unprovable end never proves the partition was
+	//     enumerated.
 	if prune && flatReconcilable {
-		def := flatReconcileDef(resource)
-		tenantUUID := resolveTenantID()
-		if tenantUUID == "" {
-			fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unknown-tenant"}`+"\n", resource)
-		} else if outcome.complete {
-			deleted, rerr := db.ReconcilePartition(
-				resource, "$."+def.BodyField, tenantUUID,
-				seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
-			)
-			if rerr != nil {
-				fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", resource, tenantUUID, rerr.Error())
+		if reconcileMode == "flat_global" {
+			if outcome.complete {
+				deleted, rerr := db.ReconcileAll(
+					resource, seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
+				)
+				if rerr != nil {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"*","error":%q}`+"\n", resource, rerr.Error())
+				} else {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"*","deleted":%d}`+"\n", resource, deleted)
+				}
 			} else {
-				fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"%s","deleted":%d}`+"\n", resource, tenantUUID, deleted)
+				fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","scope":"*","reason":%q}`+"\n", resource, outcome.reason)
 			}
 		} else {
-			fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","scope":"%s","reason":%q}`+"\n", resource, tenantUUID, outcome.reason)
+			def := flatReconcileDef(resource)
+			tenantUUID := resolveTenantID()
+			if tenantUUID == "" {
+				fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unknown-tenant"}`+"\n", resource)
+			} else if outcome.complete {
+				deleted, rerr := db.ReconcilePartition(
+					resource, "$."+def.BodyField, tenantUUID,
+					seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
+				)
+				if rerr != nil {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", resource, tenantUUID, rerr.Error())
+				} else {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"%s","deleted":%d}`+"\n", resource, tenantUUID, deleted)
+				}
+			} else {
+				fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","scope":"%s","reason":%q}`+"\n", resource, tenantUUID, outcome.reason)
+			}
 		}
 	} else if prune {
-		// Unpartitioned resources cannot be reconciled safely: the generated
-		// store only supports scoped mark-and-sweep deletion. Emit the decision
-		// so --full never implies that unsupported rows were pruned.
+		// Resources that are not flat-reconcilable (no PK, discriminator, or
+		// unscoped in a tenant-scoped print) cannot be pruned safely. Emit the
+		// decision so --full never implies that unsupported rows were pruned.
 		fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unsupported-resource-shape"}`+"\n", resource)
 	}
 
@@ -1015,6 +1041,17 @@ type paginationDefaults struct {
 
 func shortPageEndsPagination(cursorType string, fetched, limit int) bool {
 	return cursorType != "cursor" && cursorType != "page_token" && fetched < limit
+}
+
+// paginationEndUnprovable is true when pagination is declared, the page is
+// full, there is no followable cursor, and the API did not explicitly say
+// has_more=false. extractPageItemsWithPagination reports hasMore=false for a
+// bare array, which is not a proven end — prune must skip.
+func paginationEndUnprovable(declared bool, nextCursor string, fetched, limit int, data json.RawMessage, responsePaths ...string) bool {
+	if !declared || nextCursor != "" || fetched < limit {
+		return false
+	}
+	return pageMayHaveMore(data, responsePaths...)
 }
 
 func syncPageItemsEqual(previous, current []json.RawMessage) bool {
@@ -2451,6 +2488,10 @@ func syncOneParent(
 			outcome.complete = true
 			break
 		}
+		if paginationEndUnprovable(true, nextCursor, len(items), pageSize.limit, data, responsePathForResource(dep.Name, path)...) {
+			outcome.reason = "cursor_unavailable"
+			break
+		}
 		if !hasMore || shortPageEndsPagination(pageSize.cursorType, len(items), pageSize.limit) {
 			outcome.complete = true
 			break
@@ -2787,11 +2828,12 @@ var resourceIDFieldOverrides = map[string]string{
 	"games": "game_key",
 }
 
-// partitionOutcome tracks whether a sync loop (flat tenant-scoped OR dependent
-// per-parent) enumerated its partition completely. complete is set ONLY at
-// proven natural ends; any abnormal break records a reason and leaves
-// complete=false so the gated reconcile SKIPS. scopeVal carries the dependent
-// loop's parent scope value (unused by the flat path).
+// partitionOutcome tracks whether a sync loop (flat tenant-scoped, single-tenant
+// whole-table, OR dependent per-parent) enumerated its partition completely.
+// complete is set ONLY at proven natural ends; any abnormal or unprovable break
+// records a reason and leaves complete=false so the gated reconcile SKIPS.
+// scopeVal carries the dependent loop's parent scope value (unused by the flat
+// path).
 type partitionOutcome struct {
 	complete bool
 	reason   string
@@ -2799,16 +2841,21 @@ type partitionOutcome struct {
 }
 
 // flatReconcileModes maps a flat resource to its reconcile mode classification
-// (from SyncableResource.ReconcileMode, set by the profiler when a flat resource
-// carries a tenant scope column AND an extractable IDField AND no discriminator).
-// Only "flat" resources are emitted; resourceReconcileMode returns "" for any
-// resource absent here, which is all the flat reconcile gate checks for.
-var flatReconcileModes = map[string]string{}
+// (from SyncableResource.ReconcileMode). "flat" is a tenant-scoped partition;
+// "flat_global" is a single-tenant whole-table partition. resourceReconcileMode
+// returns "" for any resource absent here.
+var flatReconcileModes = map[string]string{
+	"games": "flat_global",
+}
 
 // resourceReconcileMode returns the flat reconcile classification for a resource,
 // or "" when it is not a flat-reconcilable resource.
 func resourceReconcileMode(resource string) string {
 	return flatReconcileModes[resource]
+}
+
+func resourceIsFlatReconcilable(mode string) bool {
+	return mode == "flat" || mode == "flat_global"
 }
 
 // flatReconcileDefT carries the per-resource metadata the flat reconcile call

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -2219,10 +2219,8 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 		resourceType, genericScopeJSONPath, scopeValue)
 }
 
-// ReconcileAll hard-deletes local rows of resourceType whose primary key is NOT
-// in seenIDs. It is the single-tenant counterpart of ReconcilePartition: the
-// table is the partition. The caller must pass the COMPLETE seen-ID set from a
-// proven-complete walk.
+// Whole-table reconciliation is safe only when the caller supplies the complete
+// seen-ID set from a proven-complete walk.
 func (s *Store) ReconcileAll(resourceType string, seenIDs []string, typedTable string, cascades []CascadeJunction) (int, error) {
 	return s.reconcileUnseen(resourceType, seenIDs, typedTable, cascades,
 		`SELECT id FROM resources WHERE resource_type = ?`, resourceType)

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -2212,6 +2212,23 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	if genericScopeJSONPath == "" || scopeValue == "" {
 		return 0, fmt.Errorf("reconcile %s: empty partition scope", resourceType)
 	}
+	return s.reconcileUnseen(resourceType, seenIDs, typedTable, cascades,
+		`SELECT id FROM resources
+		 WHERE resource_type = ?
+		   AND (CASE WHEN json_valid(data) THEN json_extract(data, ?) END) = ?`,
+		resourceType, genericScopeJSONPath, scopeValue)
+}
+
+// ReconcileAll hard-deletes local rows of resourceType whose primary key is NOT
+// in seenIDs. It is the single-tenant counterpart of ReconcilePartition: the
+// table is the partition. The caller must pass the COMPLETE seen-ID set from a
+// proven-complete walk.
+func (s *Store) ReconcileAll(resourceType string, seenIDs []string, typedTable string, cascades []CascadeJunction) (int, error) {
+	return s.reconcileUnseen(resourceType, seenIDs, typedTable, cascades,
+		`SELECT id FROM resources WHERE resource_type = ?`, resourceType)
+}
+
+func (s *Store) reconcileUnseen(resourceType string, seenIDs []string, typedTable string, cascades []CascadeJunction, query string, args ...any) (int, error) {
 	s.lockForWrite()
 	defer s.unlockAfterWrite()
 
@@ -2236,12 +2253,7 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 
 	// CASE guards against a malformed-JSON row aborting the victim scan:
 	// a row we cannot parse is never a victim — it is skipped (never deleted).
-	rows, err := tx.Query(
-		`SELECT id FROM resources
-		 WHERE resource_type = ?
-		   AND (CASE WHEN json_valid(data) THEN json_extract(data, ?) END) = ?`,
-		resourceType, genericScopeJSONPath, scopeValue,
-	)
+	rows, err := tx.Query(query, args...)
 	if err != nil {
 		return 0, fmt.Errorf("reconcile %s: select victims: %w", resourceType, err)
 	}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -221,9 +221,9 @@ Resource scoping:
 
 			started := time.Now()
 			// prune gates deletion reconciliation: a full sync prunes local rows
-			// the API no longer returns within a fully-enumerated partition, unless
-			// --no-prune disables it. Flat tenant-scoped reconcile (per resource)
-			// and dependent per-parent reconcile share this gate.
+			// the API no longer returns after a complete walk, unless --no-prune
+			// disables it. Flat tenant-scoped / single-tenant reconcile (per
+			// resource) and dependent per-parent reconcile share this gate.
 			prune := full && !noPrune
 			work := make(chan string, len(resources))
 			results := make(chan syncResult, len(resources))
@@ -360,7 +360,7 @@ Resource scoping:
 
 	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync. Naming a parent also runs its parent-keyed dependents (see Long help for scoping).")
 	cmd.Flags().BoolVar(&full, "full", false, "Full resync (ignore previous checkpoint)")
-	cmd.Flags().BoolVar(&noPrune, "no-prune", false, "Disable deletion reconciliation on --full (by default a full sync prunes local rows the API no longer returns for a fully-enumerated parent partition)")
+	cmd.Flags().BoolVar(&noPrune, "no-prune", false, "Disable deletion reconciliation on --full (by default a full sync prunes local rows the API no longer returns after a complete walk)")
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database file path (default: resolved data directory data.db)")
@@ -501,12 +501,14 @@ func syncResource(ctx context.Context, c interface {
 	var consumedTotal int
 	anomalyEmitted := false
 
-	// Flat tenant-scoped reconcile bookkeeping (mirrors the dependent loop's
-	// partitionOutcome machinery). flatReconcilable gates all of it: only
-	// resources classified reconcileMode=="flat" collect seen IDs and prune.
-	// outcome.complete is set ONLY at proven natural ends; any abnormal break
-	// sets outcome.reason and leaves complete=false so the reconcile SKIPS.
-	flatReconcilable := resourceReconcileMode(resource) == "flat"
+	// Flat reconcile bookkeeping (mirrors the dependent loop's partitionOutcome
+	// machinery). flatReconcilable gates all of it: only resources classified
+	// "flat" (tenant partition) or "flat_global" (whole table) collect seen IDs
+	// and prune. outcome.complete is set ONLY at proven natural ends; any
+	// abnormal break sets outcome.reason and leaves complete=false so the
+	// reconcile SKIPS.
+	reconcileMode := resourceReconcileMode(resource)
+	flatReconcilable := resourceIsFlatReconcilable(reconcileMode)
 	outcome := partitionOutcome{}
 	var seenIDs []string
 
@@ -799,6 +801,8 @@ func syncResource(ctx context.Context, c interface {
 			// the operator's page ceiling fired on that same request.
 			if capResumed {
 				outcome.reason = "max_pages_cap"
+			} else if paginationEndUnprovable(resourceSupportsPagination(resource), nextCursor, fetchedThisPage, capPageLimit, data, responsePathForResource(resource, path)...) {
+				outcome.reason = "cursor_unavailable"
 			} else if !hasMore ||
 				shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, capPageLimit) {
 				outcome.complete = true
@@ -832,6 +836,10 @@ func syncResource(ctx context.Context, c interface {
 			outcome.complete = true // resource declares no pagination: one page is the whole set
 			break
 		}
+		if paginationEndUnprovable(true, nextCursor, fetchedThisPage, pageSize.limit, data, responsePathForResource(resource, path)...) {
+			outcome.reason = "cursor_unavailable"
+			break
+		}
 		if !hasMore || shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit) {
 			outcome.complete = true
 			break
@@ -858,36 +866,54 @@ func syncResource(ctx context.Context, c interface {
 		cursor = nextCursor
 	}
 
-	// Flat tenant-scoped reconcile: prune local rows the API no longer returns
-	// within THIS tenant's partition, gated on a proven-complete sync.
-	//   - Unknown tenant (resolveTenantID()=="") ⇒ SKIP, zero deletes. This is
-	//     the OPPOSITE of the dependent fan-out fallback (which enumerates
-	//     unscoped): a flat delete cannot be safely scoped without a tenant, so
-	//     we never delete on unknown.
+	// Flat reconcile: prune local rows the API no longer returns, gated on a
+	// proven-complete sync.
+	//   - flat_global (single-tenant): the table is the partition. No tenant
+	//     resolver is required.
+	//   - flat (tenant-scoped): unknown tenant (resolveTenantID()=="") ⇒ SKIP,
+	//     zero deletes. This is the OPPOSITE of the dependent fan-out fallback
+	//     (which enumerates unscoped): a tenant-scoped delete cannot be safely
+	//     scoped without a tenant, so we never delete on unknown.
 	//   - Incomplete sync (outcome.complete==false) ⇒ SKIP with the recorded
-	//     reason; an abnormal break never proves the partition was enumerated.
+	//     reason; an abnormal or unprovable end never proves the partition was
+	//     enumerated.
 	if prune && flatReconcilable {
-		def := flatReconcileDef(resource)
-		tenantUUID := resolveTenantID()
-		if tenantUUID == "" {
-			fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unknown-tenant"}`+"\n", resource)
-		} else if outcome.complete {
-			deleted, rerr := db.ReconcilePartition(
-				resource, "$."+def.BodyField, tenantUUID,
-				seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
-			)
-			if rerr != nil {
-				fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", resource, tenantUUID, rerr.Error())
+		if reconcileMode == "flat_global" {
+			if outcome.complete {
+				deleted, rerr := db.ReconcileAll(
+					resource, seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
+				)
+				if rerr != nil {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"*","error":%q}`+"\n", resource, rerr.Error())
+				} else {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"*","deleted":%d}`+"\n", resource, deleted)
+				}
 			} else {
-				fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"%s","deleted":%d}`+"\n", resource, tenantUUID, deleted)
+				fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","scope":"*","reason":%q}`+"\n", resource, outcome.reason)
 			}
 		} else {
-			fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","scope":"%s","reason":%q}`+"\n", resource, tenantUUID, outcome.reason)
+			def := flatReconcileDef(resource)
+			tenantUUID := resolveTenantID()
+			if tenantUUID == "" {
+				fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unknown-tenant"}`+"\n", resource)
+			} else if outcome.complete {
+				deleted, rerr := db.ReconcilePartition(
+					resource, "$."+def.BodyField, tenantUUID,
+					seenIDs, reconcileTypedTable(resource), store.CascadeJunctionsFor(resource),
+				)
+				if rerr != nil {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", resource, tenantUUID, rerr.Error())
+				} else {
+					fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"%s","deleted":%d}`+"\n", resource, tenantUUID, deleted)
+				}
+			} else {
+				fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","scope":"%s","reason":%q}`+"\n", resource, tenantUUID, outcome.reason)
+			}
 		}
 	} else if prune {
-		// Unpartitioned resources cannot be reconciled safely: the generated
-		// store only supports scoped mark-and-sweep deletion. Emit the decision
-		// so --full never implies that unsupported rows were pruned.
+		// Resources that are not flat-reconcilable (no PK, discriminator, or
+		// unscoped in a tenant-scoped print) cannot be pruned safely. Emit the
+		// decision so --full never implies that unsupported rows were pruned.
 		fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","reason":"unsupported-resource-shape"}`+"\n", resource)
 	}
 
@@ -976,6 +1002,17 @@ type paginationDefaults struct {
 
 func shortPageEndsPagination(cursorType string, fetched, limit int) bool {
 	return cursorType != "cursor" && cursorType != "page_token" && fetched < limit
+}
+
+// paginationEndUnprovable is true when pagination is declared, the page is
+// full, there is no followable cursor, and the API did not explicitly say
+// has_more=false. extractPageItemsWithPagination reports hasMore=false for a
+// bare array, which is not a proven end — prune must skip.
+func paginationEndUnprovable(declared bool, nextCursor string, fetched, limit int, data json.RawMessage, responsePaths ...string) bool {
+	if !declared || nextCursor != "" || fetched < limit {
+		return false
+	}
+	return pageMayHaveMore(data, responsePaths...)
 }
 
 func syncPageItemsEqual(previous, current []json.RawMessage) bool {
@@ -2034,11 +2071,12 @@ func syncClientForResource(c *client.Client, resource string) *client.Client {
 // flat paths.
 var resourceIDFieldOverrides = map[string]string{}
 
-// partitionOutcome tracks whether a sync loop (flat tenant-scoped OR dependent
-// per-parent) enumerated its partition completely. complete is set ONLY at
-// proven natural ends; any abnormal break records a reason and leaves
-// complete=false so the gated reconcile SKIPS. scopeVal carries the dependent
-// loop's parent scope value (unused by the flat path).
+// partitionOutcome tracks whether a sync loop (flat tenant-scoped, single-tenant
+// whole-table, OR dependent per-parent) enumerated its partition completely.
+// complete is set ONLY at proven natural ends; any abnormal or unprovable break
+// records a reason and leaves complete=false so the gated reconcile SKIPS.
+// scopeVal carries the dependent loop's parent scope value (unused by the flat
+// path).
 type partitionOutcome struct {
 	complete bool
 	reason   string
@@ -2046,16 +2084,19 @@ type partitionOutcome struct {
 }
 
 // flatReconcileModes maps a flat resource to its reconcile mode classification
-// (from SyncableResource.ReconcileMode, set by the profiler when a flat resource
-// carries a tenant scope column AND an extractable IDField AND no discriminator).
-// Only "flat" resources are emitted; resourceReconcileMode returns "" for any
-// resource absent here, which is all the flat reconcile gate checks for.
+// (from SyncableResource.ReconcileMode). "flat" is a tenant-scoped partition;
+// "flat_global" is a single-tenant whole-table partition. resourceReconcileMode
+// returns "" for any resource absent here.
 var flatReconcileModes = map[string]string{}
 
 // resourceReconcileMode returns the flat reconcile classification for a resource,
 // or "" when it is not a flat-reconcilable resource.
 func resourceReconcileMode(resource string) string {
 	return flatReconcileModes[resource]
+}
+
+func resourceIsFlatReconcilable(mode string) bool {
+	return mode == "flat" || mode == "flat_global"
 }
 
 // flatReconcileDefT carries the per-resource metadata the flat reconcile call


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the single-tenant prune / completeness-gate part of #4239.

## Intent

Single-tenant prints generated deletion reconcile as dead code: the profiler only emitted `flat` when a tenant scope column was present, so `flatReconcileModes` / `flatReconcileDefs` were empty, `resolveTenantID` stayed the `""` stub, and `sync --full` never deleted. `--no-prune` help claimed a full sync prunes by default. Wiring prune without a completeness fix would turn silent truncation into data loss: a full page with no followable cursor (bare array → `hasMore=false`) was marked `outcome.complete=true`.

## Approach

- When a print has **zero** `TenantScopeColumn` annotations on any spec endpoint (flat or parameterized/dependent), classify eligible flats (stable PK, no discriminator) as `flat_global`. The table is the partition.
- Any tenant column anywhere — including a child that lands only in `DependentSyncResources` — keeps unscoped flat siblings at `none`, even if no tenant-scoped flat resource itself is reconcilable.
- Tenant-scoped flat resources that pass the PK / no-discriminator gates still get `flat`.
- Store grows `ReconcileAll` for whole-table mark-and-sweep. Same completeness gate as tenant-scoped `ReconcilePartition`.
- `--no-prune` help now matches real behavior: a full sync prunes after a complete walk.
- An unprovable end (pagination declared, full page, no followable cursor, no explicit `has_more=false`) leaves `complete=false` and skips prune.

Proof in generated-output tests:
- no-tenant-scope resource gets a reconcilable mode (`flat_global`)
- `--full` deletes local rows absent from a complete walk
- a full page with no followable cursor sets `complete=false` and does not prune
- mixed print with a non-reconcilable tenant resource plus a reconcilable unscoped sibling keeps the unscoped resource at `none`
- mixed print whose only tenant column is on a parameterized child keeps the unscoped flat sibling at `none`

## Remaining (out of scope — #3649 family)

Do **not** treat this PR as closing #4239. Still open:

3. Bare-array `?after=<last id>` cursor derivation
4. Named server-side cursor objects / sticky-cursor exceptions

## Verification

- `go test ./... -count=1 -timeout 30m` (initial)
- `go test ./internal/profiler ./internal/generator -count=1 -timeout 20m` (follow-ups)
- `GOLDEN_ALLOW_DIRTY=1 bash scripts/golden.sh update` (no generate-* fixture move on the dependent-scope follow-up; dogfood/verify-runtime-matrix fixture CLIs need Go 1.24 and were left unchanged)
- `bash scripts/verify-generator-output.sh generate-golden-api generate-query-endpoint-api generate-sync-walker-api generate-tier-routing-api`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1eb16d21-5e15-4ce4-8aaa-045eb8f46f74?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1eb16d21-5e15-4ce4-8aaa-045eb8f46f74&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

