### PR TITLE
feat(skills,generator): add native Antigravity environment support

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -10,7 +10,7 @@ This is built as a Claude Code skill. You run `/printing-press Discord` inside C
 
 ## How It's Used
 
-The primary entry point for users is the **`/printing-press` Claude Code skill** (defined in `skills/printing-press/`). A user types `/printing-press <API name>` inside Claude Code and the skill drives the fast path: one research brief, generation, focused build work, then a shipcheck block using `dogfood`, `verify`, and `scorecard`. Everything else in this repo -- the Go binary, the parsers, the templates, the profiler -- exists to serve that skill.
+The primary entry point for users is the **`/printing-press` agent skill** (defined in `skills/printing-press/`, supported in Claude Code, Antigravity, and Codex). A user types `/printing-press <API name>` inside their agent session and the skill drives the fast path: one research brief, generation, focused build work, then a shipcheck block using `dogfood`, `verify`, and `scorecard`. Everything else in this repo -- the Go binary, the parsers, the templates, the profiler -- exists to serve that skill.
 
 Developers working on this codebase build and test the Go binary directly (`go build`, `go test`), but the thing you're ultimately shipping is the skill-driven experience.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Three CLIs printed by the press, installable today:
 
 Browse the full catalog of printed CLIs at [printingpress.dev](https://printingpress.dev) or in the [Printing Press Library](https://github.com/mvanhorn/printing-press-library), organized by category, most with full MCP servers.
 
+**Antigravity users:** see [docs/ANTIGRAVITY.md](docs/ANTIGRAVITY.md) to install the Printing Press skills with `--agent antigravity` into your `~/.gemini/config/skills/` directory and run `/printing-press <api>` natively.
+
 **Codex users:** see [docs/CODEX.md](docs/CODEX.md) to install the Printing Press skills with `--agent codex`, verify the install, and understand how that differs from `/printing-press <api> codex`.
 
 **Cursor users:** see [docs/CURSOR.md](docs/CURSOR.md) for how to install a printed CLI, attach the matching skill, handle auth, and choose CLI vs MCP when your repo does not already document a workflow.

--- a/docs/ANTIGRAVITY.md
+++ b/docs/ANTIGRAVITY.md
@@ -1,0 +1,72 @@
+# Using Printing Press Skills in Antigravity
+
+Antigravity (the Google DeepMind Advanced Agentic Coding environment) supports running Printing Press skills natively.
+
+## 1. Install for Antigravity
+
+Install the generator binary and the skills into your Antigravity environment:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --agent antigravity
+```
+
+If the binary is already current and you only want to refresh skills:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --skills-only --agent antigravity
+```
+
+The installer populates skills directly into your global Antigravity skills directory (`~/.gemini/config/skills/`).
+
+## 2. Verify Skill Discovery
+
+Verify that the skills are installed:
+
+```bash
+ls -d ~/.gemini/config/skills/printing-press*
+```
+
+You should see the 9 Printing Press skills:
+- `printing-press`
+- `printing-press-amend`
+- `printing-press-import`
+- `printing-press-output-review`
+- `printing-press-polish`
+- `printing-press-publish`
+- `printing-press-reprint`
+- `printing-press-retro`
+- `printing-press-score`
+
+## 3. Running Printing Press
+
+Start a conversation with Antigravity and invoke:
+
+```text
+/printing-press <api-slug>
+```
+
+Antigravity will load `~/.gemini/config/skills/printing-press/SKILL.md` and begin the generation pipeline.
+
+## 4. Key Antigravity Tool Conventions
+
+When executing under Antigravity, the skills and generated tools map to native Antigravity primitives:
+
+- **Subagents:** Spawning uses `invoke_subagent` with `TypeName: "research"` or `"self"`. Antigravity operates on a **Reactive Wakeup** model — after dispatching subagents, the parent simply ends its turn and is woken automatically when the subagent responds.
+- **Interactive Questions:** Discrete user choices use `ask_question` (`{questions: [{question, options, is_multi_select}]}`). Open-ended questions are output as regular markdown text.
+- **Terminal Execution:** In Antigravity's `run_command`, directory changes must use subshells `(cd <dir> && <cmd>)` or set the tool's `Cwd` parameter, avoiding bare `cd`.
+- **Code Review & Simplification:** Phase 4.95 runs code review (via reviewer subagents or an installed review skill) and executes a targeted simplification pass to tighten autofix edits.
+- **Transcripts:** The `/printing-press-amend` dogfood flow reads Antigravity session transcripts from `<appDataDir>/brain/<conversation-id>/.system_generated/logs/transcript.jsonl`.
+
+## 5. Using Generated MCP Servers in Antigravity
+
+Every printed CLI ships a companion MCP server (`<name>-pp-mcp`). To register it with Antigravity, add it to your Antigravity `mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "<name>-pp-mcp": {
+      "command": "<name>-pp-mcp"
+    }
+  }
+}
+```

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -4,7 +4,7 @@ Conventions for the skills shipped from this repo (under `skills/`) and any inte
 
 ## Install Targets
 
-The shipped Printing Press skills are installed through the `skills` CLI. Claude Code is the default and tested target (`--agent claude-code`), but the installer can target other supported agents, including Codex (`--agent codex`). Keep install instructions agent-neutral unless the step truly depends on Claude Code behavior, and link Codex-specific setup notes to [CODEX.md](CODEX.md).
+The shipped Printing Press skills are installed through the `skills` CLI or the installer script. Claude Code is the default and tested target (`--agent claude-code`), but the installer supports other agents including Antigravity (`--agent antigravity`) and Codex (`--agent codex`). Keep install instructions agent-neutral unless the step truly depends on Claude Code behavior, and link agent-specific setup notes to [ANTIGRAVITY.md](ANTIGRAVITY.md) and [CODEX.md](CODEX.md).
 
 ## Workflow Parity
 

--- a/internal/artifacts/pii.go
+++ b/internal/artifacts/pii.go
@@ -542,6 +542,9 @@ func isUnderManuscripts(relSlash string) bool {
 // Generated fixture and top-level tooling workspaces are skipped at the root.
 var skippedDirs = map[string]bool{
 	".claude":      true,
+	".gemini":      true,
+	".antigravity": true,
+	".agent":       true,
 	".git":         true,
 	".omc":         true,
 	"testdata":     true,

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -463,6 +463,9 @@ func TestFindPII_SkipsFixtureAndToolingWorkspaces(t *testing.T) {
 	write(t, filepath.Join(root, "testdata", "fixtures", "sample.json"), pii)
 	write(t, filepath.Join(root, ".omc", "state.json"), pii)
 	write(t, filepath.Join(root, ".claude", "scratch.md"), pii)
+	write(t, filepath.Join(root, ".gemini", "state.json"), pii)
+	write(t, filepath.Join(root, ".antigravity", "session.json"), pii)
+	write(t, filepath.Join(root, ".agent", "scratch.md"), pii)
 	write(t, filepath.Join(root, "config.yaml"), pii)
 	write(t, filepath.Join(root, "README.md"), pii)
 
@@ -474,6 +477,9 @@ func TestFindPII_SkipsFixtureAndToolingWorkspaces(t *testing.T) {
 	assert.NotContains(t, files, "testdata/fixtures/sample.json")
 	assert.NotContains(t, files, ".omc/state.json")
 	assert.NotContains(t, files, ".claude/scratch.md")
+	assert.NotContains(t, files, ".gemini/state.json")
+	assert.NotContains(t, files, ".antigravity/session.json")
+	assert.NotContains(t, files, ".agent/scratch.md")
 	assert.Contains(t, files, "config.yaml")
 	assert.Contains(t, files, "README.md")
 }

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -27,7 +27,7 @@ Contributors: {{range $i, $c := .Contributors}}{{if $i}}, {{end}}{{if $c.Handle}
 
 ## Install
 
-The recommended path installs both the `{{.Name}}-pp-cli` binary and the `pp-{{.Name}}` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
+The recommended path installs both the `{{.Name}}-pp-cli` binary and the `pp-{{.Name}}` agent skill (Claude Code, Antigravity, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
 npx -y @mvanhorn/printing-press-library install {{.Name}}

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -671,15 +671,35 @@ Parse `$ARGUMENTS`:
    ```bash
    claude mcp add {{.Name}}-pp-mcp -- {{.Name}}-pp-mcp
    ```
-3. Verify: `claude mcp list`
+   Or add to Antigravity `mcp_config.json`:
+   ```json
+   {
+     "mcpServers": {
+       "{{.Name}}-pp-mcp": {
+         "command": "{{.Name}}-pp-mcp"
+       }
+     }
+   }
+   ```
+3. Verify: `claude mcp list` or inspect Antigravity MCP tool catalog
 {{- else}}
 Install the MCP binary from this CLI's published public-library entry or pre-built release, then register it:
 
 ```bash
 claude mcp add {{.Name}}-pp-mcp -- {{.Name}}-pp-mcp
 ```
+Or add to Antigravity `mcp_config.json`:
+```json
+{
+  "mcpServers": {
+    "{{.Name}}-pp-mcp": {
+      "command": "{{.Name}}-pp-mcp"
+    }
+  }
+}
+```
 
-Verify: `claude mcp list`
+Verify: `claude mcp list` or inspect Antigravity MCP tool catalog
 {{- end}}
 
 ## Direct Use

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -9,14 +9,18 @@ import (
 
 // Available returns true if any supported LLM CLI is installed.
 func Available() bool {
-	_, err1 := exec.LookPath("claude")
-	_, err2 := exec.LookPath("codex")
-	return err1 == nil || err2 == nil
+	for _, name := range []string{"claude", "codex", "gemini", "agentapi"} {
+		if _, err := exec.LookPath(name); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // Run sends a prompt to the best available LLM CLI and returns the response.
-// It tries claude first, then falls back to codex. Long Claude prompts are
-// written to a temp file and passed by reference to avoid ARG_MAX issues.
+// It tries claude first, then falls back to codex, gemini, and agentapi.
+// Long prompts for CLI tools that support file references are written to a
+// temp file to avoid ARG_MAX issues.
 func Run(prompt string) (string, error) {
 	// Try claude first (-p / --print mode, prompt as positional arg)
 	if path, err := exec.LookPath("claude"); err == nil {
@@ -52,10 +56,44 @@ func Run(prompt string) (string, error) {
 		if err == nil {
 			return strings.TrimSpace(string(out)), nil
 		}
-		return "", fmt.Errorf("codex failed: %w", err)
+		fmt.Fprintf(os.Stderr, "warning: codex failed (%v), trying gemini\n", err)
 	}
 
-	return "", fmt.Errorf("no LLM CLI found (install claude or codex)")
+	// Try gemini (-p / --prompt positional)
+	if path, err := exec.LookPath("gemini"); err == nil {
+		var cmd *exec.Cmd
+		if len(prompt) < 100000 {
+			cmd = exec.Command(path, "-p", prompt)
+		} else {
+			tmpFile, cleanup, err := writePromptTempFile(prompt)
+			if err != nil {
+				return "", err
+			}
+			defer cleanup()
+
+			metaPrompt := fmt.Sprintf("Read the file at %s and follow the instructions inside it exactly.", tmpFile)
+			cmd = exec.Command(path, "-p", metaPrompt)
+		}
+		cmd.Stderr = os.Stderr
+		out, err := cmd.Output()
+		if err == nil {
+			return strings.TrimSpace(string(out)), nil
+		}
+		fmt.Fprintf(os.Stderr, "warning: gemini failed (%v), trying agentapi\n", err)
+	}
+
+	// Try agentapi (new-conversation)
+	if path, err := exec.LookPath("agentapi"); err == nil {
+		cmd := exec.Command(path, "new-conversation", prompt)
+		cmd.Stderr = os.Stderr
+		out, err := cmd.Output()
+		if err == nil {
+			return strings.TrimSpace(string(out)), nil
+		}
+		return "", fmt.Errorf("agentapi failed: %w", err)
+	}
+
+	return "", fmt.Errorf("no LLM CLI found (install claude, codex, or gemini)")
 }
 
 func writePromptTempFile(prompt string) (string, func(), error) {

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -18,11 +18,11 @@ func TestAvailable(t *testing.T) {
 }
 
 func TestRunReturnsErrorWhenNoLLM(t *testing.T) {
-	// Only test this if neither CLI is installed
-	_, err1 := exec.LookPath("claude")
-	_, err2 := exec.LookPath("codex")
-	if err1 == nil || err2 == nil {
-		t.Skip("skipping: LLM CLI is installed")
+	// Only test this if none of the CLIs are installed
+	for _, name := range []string{"claude", "codex", "gemini", "agentapi"} {
+		if _, err := exec.LookPath(name); err == nil {
+			t.Skip("skipping: LLM CLI is installed")
+		}
 	}
 
 	_, err := Run("test prompt")
@@ -93,4 +93,40 @@ printf ok
 	response, err := Run(strings.Repeat("x", 100001))
 	require.NoError(t, err)
 	assert.Equal(t, "ok", response)
+}
+
+func TestRunGeminiFallback(t *testing.T) {
+	binDir := t.TempDir()
+	tmpDir := t.TempDir()
+	geminiPath := filepath.Join(binDir, "gemini")
+	script := `#!/bin/sh
+printf "gemini response"
+`
+	require.NoError(t, os.WriteFile(geminiPath, []byte(script), 0700))
+	t.Setenv("PATH", binDir)
+	t.Setenv("TMPDIR", tmpDir)
+
+	response, err := Run("test gemini prompt")
+	require.NoError(t, err)
+	assert.Equal(t, "gemini response", response)
+}
+
+func TestRunAgentAPIFallback(t *testing.T) {
+	binDir := t.TempDir()
+	tmpDir := t.TempDir()
+	agentapiPath := filepath.Join(binDir, "agentapi")
+	script := `#!/bin/sh
+if [ "$1" = "new-conversation" ]; then
+	printf "agentapi response"
+else
+	exit 1
+fi
+`
+	require.NoError(t, os.WriteFile(agentapiPath, []byte(script), 0700))
+	t.Setenv("PATH", binDir)
+	t.Setenv("TMPDIR", tmpDir)
+
+	response, err := Run("test agentapi prompt")
+	require.NoError(t, err)
+	assert.Equal(t, "agentapi response", response)
 }

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -893,7 +893,7 @@ func archivedSpecNameForFormat(sourceBasename string) string {
 func specChecksum(path string) (string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) || os.IsNotExist(err) {
 			return "", nil
 		}
 		return "", fmt.Errorf("reading spec for checksum: %w", err)

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -551,7 +551,7 @@ func TestSpecChecksum(t *testing.T) {
 }
 
 func TestSpecChecksumNonexistentFile(t *testing.T) {
-	checksum, err := specChecksum("/nonexistent/file.json")
+	checksum, err := specChecksum(filepath.Join(t.TempDir(), "nonexistent.json"))
 	require.NoError(t, err)
 	assert.Empty(t, checksum)
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ umask 022
 # Options:
 #   --cli-only          Install or update only the Go generator binary.
 #   --skills-only       Install or refresh only the Printing Press skills.
-#   -a, --agent NAME    Install skills for an agent supported by `skills`.
+#   -a, --agent NAME    Install skills for an agent (claude-code, antigravity, codex, cursor).
 #                       May be repeated. Defaults to claude-code.
 #   --dry-run           Print commands without executing them.
 #   --quiet             Suppress non-error output.
@@ -61,7 +61,7 @@ Usage:
 Options:
   --cli-only          Install or update only the Go generator binary.
   --skills-only       Install or refresh only the Printing Press skills.
-  -a, --agent NAME    Install skills for an agent supported by `skills`.
+  -a, --agent NAME    Install skills for an agent (claude-code, antigravity, codex, cursor).
                        May be repeated. Defaults to claude-code.
   --dry-run           Print commands without executing them.
   --quiet             Suppress non-error output.
@@ -392,12 +392,62 @@ install_cli() {
 }
 
 install_skills() {
-  local cmd=(npx -y "$SKILLS_PACKAGE" add "$SKILL_SOURCE" --skill "*" -g -y)
+  local standard_agents=()
+  local install_antigravity=0
+
   local agent
   for agent in "${AGENTS[@]}"; do
-    cmd+=(-a "$agent")
+    if [[ "$agent" == "antigravity" ]]; then
+      install_antigravity=1
+    else
+      standard_agents+=("$agent")
+    fi
   done
-  run_with_spinner "Installing Printing Press skills" "${cmd[@]}"
+
+  if ((${#standard_agents[@]} > 0)); then
+    local cmd=(npx -y "$SKILLS_PACKAGE" add "$SKILL_SOURCE" --skill "*" -g -y)
+    for agent in "${standard_agents[@]}"; do
+      cmd+=(-a "$agent")
+    done
+    run_with_spinner "Installing Printing Press skills for ${standard_agents[*]}" "${cmd[@]}"
+  fi
+
+  if [[ "$install_antigravity" -eq 1 ]]; then
+    local gemini_skills_dir="${GEMINI_CONFIG_DIR:-$HOME/.gemini/config}/skills"
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      info "Would install Printing Press skills to $gemini_skills_dir"
+    else
+      mkdir -p "$gemini_skills_dir"
+      local repo_root
+      repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+      if [[ -n "$repo_root" && -d "$repo_root/skills" ]]; then
+        for skill_dir in "$repo_root"/skills/*; do
+          if [[ -d "$skill_dir" ]]; then
+            local sname
+            sname="$(basename "$skill_dir")"
+            rm -rf "$gemini_skills_dir/$sname"
+            cp -r "$skill_dir" "$gemini_skills_dir/$sname"
+          fi
+        done
+      else
+        local tmp_skills="$TMP_DIR/skills_download"
+        mkdir -p "$tmp_skills"
+        (cd "$tmp_skills" && npx -y "$SKILLS_PACKAGE" add "$SKILL_SOURCE" --skill "*" -y >/dev/null 2>&1 || true)
+        find "$tmp_skills" -name "SKILL.md" | while read -r sfile; do
+          local sdir
+          sdir="$(dirname "$sfile")"
+          local sname
+          sname="$(basename "$sdir")"
+          if [[ "$sname" == printing-press* ]]; then
+            rm -rf "$gemini_skills_dir/$sname"
+            cp -r "$sdir" "$gemini_skills_dir/$sname"
+          fi
+        done
+      fi
+      ok "Installed Printing Press skills to Antigravity ($gemini_skills_dir)"
+    fi
+  fi
+
   if [[ "$DRY_RUN" -eq 1 ]]; then
     SKILLS_STATUS="planned"
   else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -420,20 +420,24 @@ install_skills() {
       mkdir -p "$gemini_skills_dir"
       local repo_root
       repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-      if [[ -n "$repo_root" && -d "$repo_root/skills" ]]; then
-        for skill_dir in "$repo_root"/skills/*; do
+      local installed_count=0
+      if [[ -n "$repo_root" && -f "$repo_root/skills/printing-press/SKILL.md" ]]; then
+        for skill_dir in "$repo_root"/skills/printing-press*; do
           if [[ -d "$skill_dir" ]]; then
             local sname
             sname="$(basename "$skill_dir")"
             rm -rf "$gemini_skills_dir/$sname"
             cp -r "$skill_dir" "$gemini_skills_dir/$sname"
+            installed_count=$((installed_count + 1))
           fi
         done
       else
         local tmp_skills="$TMP_DIR/skills_download"
         mkdir -p "$tmp_skills"
-        (cd "$tmp_skills" && npx -y "$SKILLS_PACKAGE" add "$SKILL_SOURCE" --skill "*" -y >/dev/null 2>&1 || true)
-        find "$tmp_skills" -name "SKILL.md" | while read -r sfile; do
+        if ! (cd "$tmp_skills" && npx -y "$SKILLS_PACKAGE" add "$SKILL_SOURCE" --skill "*" -y >/dev/null 2>&1); then
+          warn "Could not download skills via $SKILLS_PACKAGE"
+        fi
+        while IFS= read -r sfile; do
           local sdir
           sdir="$(dirname "$sfile")"
           local sname
@@ -441,10 +445,15 @@ install_skills() {
           if [[ "$sname" == printing-press* ]]; then
             rm -rf "$gemini_skills_dir/$sname"
             cp -r "$sdir" "$gemini_skills_dir/$sname"
+            installed_count=$((installed_count + 1))
           fi
-        done
+        done < <(find "$tmp_skills" -name "SKILL.md" 2>/dev/null || true)
       fi
-      ok "Installed Printing Press skills to Antigravity ($gemini_skills_dir)"
+      if [[ "$installed_count" -gt 0 ]]; then
+        ok "Installed $installed_count Printing Press skills to Antigravity ($gemini_skills_dir)"
+      else
+        warn "No Printing Press skills could be installed to Antigravity ($gemini_skills_dir)"
+      fi
     fi
   fi
 

--- a/skills/printing-press-amend/SKILL.md
+++ b/skills/printing-press-amend/SKILL.md
@@ -307,7 +307,7 @@ When `MODE=dogfood`, run only `### 1a`. When `MODE=direct`, run only `### 1b`. W
 
 Read `references/transcript-parsing.md` for the full procedure. Summary of what this sub-section does:
 
-1. **Resolve the active session transcript file** — derive `<project-dir-slug>` from the current working directory, list `~/.claude/projects/<slug>/*.jsonl` by mtime, pick the most-recently-modified. ALWAYS confirm the resolved path with the user via `AskUserQuestion` before reading — wrong-file selection ingests friction from the wrong session.
+1. **Resolve the active session transcript file** — per `references/transcript-parsing.md`, resolve the active Claude Code (`~/.claude/projects/`) or Antigravity (`<appDataDir>/brain/<id>/.system_generated/logs/transcript.jsonl`) transcript file. ALWAYS confirm the resolved path with the user via `AskUserQuestion` (Claude Code) or `ask_question` (Antigravity) before reading — wrong-file selection ingests friction from the wrong session.
 
 2. **Walk the transcript and extract friction signals** — non-zero exit codes, error messages, hand-rolled API payloads (e.g. direct `curl` POSTs that should be a CLI command), retry-after-failure patterns, agent commentary like "X doesn't exist" / "X returns 400", missing-flag references, silent-null returns, auth confusion. Each signal carries timestamp + category + verbatim evidence + the `<slug>-pp-cli` it references.
 

--- a/skills/printing-press-amend/references/transcript-parsing.md
+++ b/skills/printing-press-amend/references/transcript-parsing.md
@@ -2,36 +2,39 @@
 
 **Scope:** This reference applies when `MODE=dogfood` (Phase 0 detected a session-friction invocation) or when running the dogfood half of `MODE=both`. For direct-input mode (`MODE=direct`), see `direct-input-parsing.md` instead — that mode parses the user's prompt and never touches the transcript.
 
-This reference is loaded by Phase 1's `### 1a. Dogfood mode` sub-section of `printing-press-amend`. It defines how the agent reads a Claude Code session transcript and extracts friction signals tied to a specific printed CLI invocation.
+This reference is loaded by Phase 1's `### 1a. Dogfood mode` sub-section of `printing-press-amend`. It defines how the agent reads a Claude Code or Antigravity session transcript and extracts friction signals tied to a specific printed CLI invocation.
 
 ## Where the active session transcript lives
-
-Claude Code stores per-session transcripts as JSONL files under `~/.claude/projects/<project-dir-slug>/<session-uuid>.jsonl`. The slug is derived from the working directory path (slashes replaced with `-`).
 
 Resolution order (use the first that resolves to a readable file):
 
 1. **Skill argument or environment** — if the user passed an explicit transcript path, use it.
-2. **Active session via working dir** — derive `<project-dir-slug>` from `pwd -P` (replace `/` with `-`, strip leading `-`), then list `~/.claude/projects/<slug>/*.jsonl` and pick the most-recently-modified. This is the heuristic; it can be wrong when multiple Claude Code panes are running in the same dir, so confirm with the user.
-3. **Fallback** — list `~/.claude/projects/` directories sorted by mtime, list each one's `*.jsonl` files, pick the most-recently-modified across all. This catches the case where the user invokes `/printing-press-amend` from a different working directory than the session was started in.
+2. **Claude Code active session via working dir** — derive `<project-dir-slug>` from `pwd -P` (replace `/` with `-`, strip leading `-`), then list `~/.claude/projects/<slug>/*.jsonl` and pick the most-recently-modified.
+3. **Antigravity active session** — in Antigravity, transcripts live under `<appDataDir>/brain/<conversation-id>/.system_generated/logs/transcript.jsonl`. Pick the active conversation's log or most-recently-modified.
+4. **Fallback** — list `~/.claude/projects/` or `<appDataDir>/brain/` directories sorted by mtime, list each one's `*.jsonl` files, pick the most-recently-modified across all.
 
-After picking a candidate file, ALWAYS show the user the resolved path with `AskUserQuestion`:
+After picking a candidate file, ALWAYS show the user the resolved path with `AskUserQuestion` (Claude Code) or `ask_question` (Antigravity):
 
 > "Detected active session at `<path>` (modified <relative-time>). Mine this session for friction, or pick a different transcript?"
 
 Options:
 - Use this transcript (recommended)
-- Pick a different file (drops into a list of recent JSONL files under `~/.claude/projects/`)
+- Pick a different file (drops into a list of recent JSONL files)
 - Cancel
 
 The confirmation is non-optional — wrong-file selection ingests friction from the wrong session and ships PRs for bugs the user never hit.
 
 ## Signal extraction taxonomy
 
-The transcript is line-delimited JSON; each line is a turn in the conversation. Walk the file and extract these signal categories. Each signal carries: `timestamp` (from the turn), `category` (one of below), `evidence` (the verbatim quote that triggered it), and `target_cli` (when the signal references a specific `<slug>-pp-cli` invocation).
+The transcript is line-delimited JSON; each line is a turn or step in the conversation:
+- In **Claude Code**: lines are conversation turns with `type: "user"`, `type: "tool_use"`, `type: "tool_result"`.
+- In **Antigravity**: lines are steps with `type: "USER_INPUT"` or `"PLANNER_RESPONSE"`, carrying `content` and `tool_calls` (including tool name, arguments, and execution status).
+
+Walk the file and extract these signal categories. Each signal carries: `timestamp` (or `step_index`), `category` (one of below), `evidence` (the verbatim quote that triggered it), and `target_cli` (when the signal references a specific `<slug>-pp-cli` invocation).
 
 | Category | Signal | Bug or feature? |
 |---|---|---|
-| **Non-zero exit code** | A `tool_result` block whose stderr indicates a non-zero exit on a `<cli>-pp-cli` invocation | Bug |
+| **Non-zero exit code** | A tool execution block (`tool_result` or `tool_calls`) whose stderr/output indicates a non-zero exit on a `<cli>-pp-cli` invocation | Bug |
 | **Error message** | Lines like `Error: ...`, `failed:`, `panic:`, `HTTP 4xx`, `HTTP 5xx` returned from the CLI | Bug (usually) |
 | **Hand-rolled API payload** | Bash commands that POST/PUT directly to a URL (e.g. `curl -X POST https://api.example.com/...` or scripted JSON construction) instead of calling the CLI | Feature (the CLI doesn't expose what the user needed) |
 | **Retry-after-failure** | The same command run ≥ 2 times in a row with similar args, separated by manual edits or tool tweaks | Bug or feature (look at what changed) |

--- a/skills/printing-press-import/SKILL.md
+++ b/skills/printing-press-import/SKILL.md
@@ -43,6 +43,10 @@ re-publish — the publish step will re-apply the module path rewrites.
 If the user is asking to polish a CLI and mentions "in/from the public
 library" or "from the repo", suggest running this skill first.
 
+## Interaction Method
+
+When prompting the user with discrete choices, use Claude Code's `AskUserQuestion` tool or Antigravity's `ask_question` tool (`{questions: [{question, options, is_multi_select}]}`). In Codex or non-interactive environments, prompt via stdout/stdin. For open-ended questions in Antigravity, output regular markdown text and end your turn.
+
 ## Setup
 
 ```bash

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -43,6 +43,10 @@ After any `/printing-press` generation, especially when:
 
 Can also be run standalone on any CLI in `$PRESS_LIBRARY/`.
 
+## Interaction Method
+
+When prompting the user with discrete choices, use Claude Code's `AskUserQuestion` tool or Antigravity's `ask_question` tool (`{questions: [{question, options, is_multi_select}]}`). In Codex or non-interactive environments, prompt via stdout/stdin. For open-ended questions in Antigravity, output regular markdown text and end your turn.
+
 ## Setup
 
 ```bash
@@ -516,13 +520,23 @@ Classify these as environmental in `skipped_findings` with the specific reason; 
 
 ### Phase 4.85 — Agentic output review (Wave B)
 
-After the mechanical diagnostics above complete, invoke the `printing-press-output-review` sub-skill via the Skill tool. The sub-skill carries `context: fork` and owns the dispatch prompt, gate logic, and known blind spots — single source of truth shared with the main printing-press skill.
+After the mechanical diagnostics above complete, invoke the `printing-press-output-review` sub-skill via the Skill tool (Claude Code) or by reading with `view_file` / dispatching via `invoke_subagent` (Antigravity). The sub-skill carries `context: fork` and owns the dispatch prompt, gate logic, and known blind spots — single source of truth shared with the main printing-press skill.
 
-```
+```text
+# Claude Code:
 Skill(
   skill: "cli-printing-press:printing-press-output-review",
   args: "$CLI_DIR"
 )
+
+# Antigravity:
+invoke_subagent({
+  "Subagents": [{
+    "TypeName": "research",
+    "Role": "Output Reviewer",
+    "Prompt": "<Contents of printing-press-output-review/SKILL.md with $CLI_DIR substituted>"
+  }]
+})
 ```
 
 Parse the returned `---OUTPUT-REVIEW-RESULT---` block. `status: WARN` findings flow into the diagnostic categories above so Phase 2 fixes address both rule-based and plausibility issues. `status: SKIP` is informational — record but don't block.

--- a/skills/printing-press-polish/references/pii-polish.md
+++ b/skills/printing-press-polish/references/pii-polish.md
@@ -74,7 +74,7 @@ When a downstream consumer (parser, schema validator) needs a valid-shape value,
 
 **Generated test fixtures (`*_test.go`, `testdata/`).** Exempt from the audit by design — generated tests commonly carry standards-reserved or synthetic placeholder values, and rewriting them during polish creates churn without reducing customer-PII risk. Real PII in production code, config, README, and manuscript files remains in scope.
 
-**Tooling workspaces (`.omc/`, `.claude/`).** Exempt from the audit at the CLI root — these are agent orchestration or scratch directories, not shippable printed-CLI content.
+**Tooling workspaces (`.omc/`, `.claude/`, `.gemini/`, `.antigravity/`, `.agent/`).** Exempt from the audit at the CLI root — these are agent orchestration or scratch directories, not shippable printed-CLI content.
 
 **Vendor spec files at the CLI root (`spec.yaml`, `spec.yml`, `spec.json`).** Exempt from the audit by design — these are the OpenAPI/internal source the operator passed to `--spec`, and vendor `example:` blocks (Stripe `jenny@example.com`, GitHub user-schema example phones) are documentation, not customer PII.
 

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -35,6 +35,10 @@ docs-only, plan, proposal, or spec PR as a substitute for a CLI that is not
 ready to publish. If generation, validation, or live testing is blocked, report
 the exact blocker and stop.
 
+## Interaction Method
+
+When prompting the user with discrete choices, use Claude Code's `AskUserQuestion` tool or Antigravity's `ask_question` tool (`{questions: [{question, options, is_multi_select}]}`). In Codex or non-interactive environments, prompt via stdout/stdin. For open-ended questions in Antigravity, output regular markdown text and end your turn.
+
 ## Direct User Invocation Required
 
 Publishing can fork `mvanhorn/printing-press-library`, push a branch, and open or

--- a/skills/printing-press-reprint/SKILL.md
+++ b/skills/printing-press-reprint/SKILL.md
@@ -46,6 +46,10 @@ current machine — keep, reframe, or drop with reasons, never silent.
 For one-off code-quality fixes, prefer `/printing-press-polish` — it doesn't
 redo research or rebuild the manuscript.
 
+## Interaction Method
+
+When prompting the user with discrete choices, use Claude Code's `AskUserQuestion` tool or Antigravity's `ask_question` tool (`{questions: [{question, options, is_multi_select}]}`). In Codex or non-interactive environments, prompt via stdout/stdin. For open-ended questions in Antigravity, output regular markdown text and end your turn.
+
 ## Setup
 
 ```bash

--- a/skills/printing-press-retro/SKILL.md
+++ b/skills/printing-press-retro/SKILL.md
@@ -60,7 +60,7 @@ that survive triage and the adversarial check, plus artifacts, so maintainers
   user-facing output (issues, retros, prompts). It has four subsystems:
   - **Generator** — templates that emit Go code (`internal/generator/`)
   - **Scorer** — tools that grade the output: verify, dogfood, scorecard
-  - **Skills** — SKILL.md instructions that guide Claude during generation
+  - **Skills** — SKILL.md instructions that guide the agent during generation
   - **Binary** — the Go CLI itself: commands, flags, parsers (`cmd/cli-printing-press/`)
 - **Printed CLI**: A CLI produced by the Printing Press for a specific API (e.g.,
   `notion-pp-cli`). Printed-CLI fixes only help that one CLI.
@@ -68,6 +68,10 @@ that survive triage and the adversarial check, plus artifacts, so maintainers
 Use "the Printing Press" when talking about the system. Use the subsystem name when
 pointing a developer at what to fix — "fix the scorer" and "fix the generator" are
 different PRs.
+
+## Interaction Method
+
+When prompting the user with discrete choices, use Claude Code's `AskUserQuestion` tool or Antigravity's `ask_question` tool (`{questions: [{question, options, is_multi_select}]}`). In Codex or non-interactive environments, prompt via stdout/stdin. For open-ended questions in Antigravity, output regular markdown text and end your turn.
 
 ## Cardinal rules
 

--- a/skills/printing-press-score/SKILL.md
+++ b/skills/printing-press-score/SKILL.md
@@ -30,6 +30,10 @@ Score generated CLIs against the Steinberger bar. Supports rescoring, scoring by
 - Go 1.26.6 or newer installed
 - `cli-printing-press` binary on PATH (install with `go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest`)
 
+## Interaction Method
+
+When prompting the user with discrete choices, use Claude Code's `AskUserQuestion` tool or Antigravity's `ask_question` tool (`{questions: [{question, options, is_multi_select}]}`). In Codex or non-interactive environments, prompt via stdout/stdin. For open-ended questions in Antigravity, output regular markdown text and end your turn.
+
 ## Step 0: Setup
 
 Before any other commands, run the setup contract to verify the cli-printing-press binary is on PATH and initialize scope variables:

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -84,7 +84,8 @@ See the `printing-press-polish` skill for details. It runs diagnostics, fixes ve
 - **Do not ship a CLI that hasn't been behaviorally tested against real targets.** `go build` and `verify` pass-rate are structural signals, not correctness signals. Phase 5's mechanical test matrix runs every subcommand + `--json` + error paths; if that matrix was not executed, the CLI is not shippable. Quick Check is the floor; Full Dogfood is required when the user asks for thoroughness.
 - **Bugs found during dogfood are fix-before-ship, not "file for v0.2".** If a 1-3 file edit resolves it, do it now. `ship-with-gaps` is deprecated as a default verdict (see Phase 4). Context is freshest in-session; a v0.2 backlog that may never be revisited ships known-broken CLIs.
 - **Features approved in Phase 1.5 are shipping scope.** Do not downgrade a shipping-scope feature to a stub mid-build. If implementation becomes infeasible, return to Phase 1.5 with a revised manifest and get explicit re-approval.
-- **Do not quote human-time estimates for sub-tasks** ("~15-30 min", "~1 hour", "quick fix") in `AskUserQuestion` options, phase descriptions, or reference docs. The agent does the work, not the user; agent-fabricated estimates are notoriously bad and train users to distrust the prompt. Describe scope instead (lines of code, files touched, relative size). The carve-outs are wall-clock estimates for genuinely time-bound things: the whole-CLI run (set the user's expectation up front — most CLIs take 30+ minutes), tool installs (`go install` takes ~10 seconds), and printing-press subcommands that do network-bound work (crowd-sniff scans npm + GitHub, ~5-10 minutes). Anything bounded by agent reasoning time is not time-bound — describe scope.
+- **Harness-aware interaction method:** When prompting the user with discrete choices, use Claude Code's `AskUserQuestion` tool or Antigravity's `ask_question` tool (`{questions: [{question, options, is_multi_select}]}`). In Codex or non-interactive environments, prompt via stdout/stdin. For open-ended questions in Antigravity, output regular markdown text and end your turn.
+- **Do not quote human-time estimates for sub-tasks** ("~15-30 min", "~1 hour", "quick fix") in `AskUserQuestion`/`ask_question` options, phase descriptions, or reference docs. The agent does the work, not the user; agent-fabricated estimates are notoriously bad and train users to distrust the prompt. Describe scope instead (lines of code, files touched, relative size). The carve-outs are wall-clock estimates for genuinely time-bound things: the whole-CLI run (set the user's expectation up front — most CLIs take 30+ minutes), tool installs (`go install` takes ~10 seconds), and printing-press subcommands that do network-bound work (crowd-sniff scans npm + GitHub, ~5-10 minutes). Anything bounded by agent reasoning time is not time-bound — describe scope.
 - **Use raw captures for contract research.** When reading official docs, auth/error/rate-limit pages, endpoint references, OpenAPI/Postman links, or source pages whose exact identifiers affect the generated CLI, read [references/fetch-docs.md](references/fetch-docs.md) and use its `fetch-docs.sh` helper. Reserve `WebFetch` for quick TL;DR reads where losing field-level details is acceptable.
 - Optimize for time-to-ship, not time-to-document.
 - Reuse prior research whenever it is already good enough.
@@ -4149,13 +4150,24 @@ their current local fix path.
 
 **Runs after Phase 4.8, before Phase 4.95.** Phase 4.8 reviews SKILL.md prose against the shipped CLI. Phase 4.85 reviews the CLI's **actual command output** for plausibility bugs that rule-based checks can't encode (substring-match relevance failures, format bugs, silent source drops, ranking failures). The dispatch prompt, gate logic, and known blind spots live in the `printing-press-output-review` sub-skill — single source of truth shared with the polish skill (which runs the same review during its diagnostic loop).
 
-Invoke the sub-skill via the Skill tool:
+Invoke the sub-skill via the Skill tool (Claude Code) or by reading with `view_file` / dispatching via `invoke_subagent` (Antigravity):
 
-```
+```text
+# Claude Code:
 Skill(
   skill: "cli-printing-press:printing-press-output-review",
   args: "$CLI_WORK_DIR"
 )
+
+# Antigravity:
+# Read skills/printing-press-output-review/SKILL.md or dispatch:
+invoke_subagent({
+  "Subagents": [{
+    "TypeName": "research",
+    "Role": "Output Reviewer",
+    "Prompt": "<Contents of printing-press-output-review/SKILL.md with $CLI_WORK_DIR substituted>"
+  }]
+})
 ```
 
 The sub-skill carries `context: fork` so the reviewer agent's diagnostic chatter stays isolated from this generation flow. It returns a `---OUTPUT-REVIEW-RESULT---` block with `status: PASS|WARN|SKIP` and a list of findings.
@@ -4182,9 +4194,9 @@ aligned. Non-description code findings keep the normal Phase 4.95 autofix path.
 
 **Tool selection — pick what's installed, do not name-match.** This phase needs *a* code review, not a specific named command. Survey the review-shaped capabilities the current harness has and pick the best fit. Plausible candidates (names drift across harnesses and plugin sets; treat this as an example list, not a closed set):
 
-- A standalone, working-dir-shaped code review skill that runs against `git diff` and a file list without needing an open PR (e.g., `compound-engineering:ce-code-review`, or similar).
+- A standalone, working-dir-shaped code review skill that runs against `git diff` and a file list without needing an open PR (e.g., an installed review skill or custom plugin, if available).
 - Codex's built-in code-review mode (`/codex:review`), which reviews the current diff or target directly.
-- **Direct reviewer-subagent dispatch via the Agent tool.** Spawn `correctness`, `security`, and `maintainability` reviewers (always-on) plus any conditional reviewers warranted by the diff (`api-contract`, `data-migrations`, `reliability`, `performance`) against the in-scope paths. This is the universal fallback: any harness that runs the press skill has the Agent tool, so this path is always available. When dispatching multiple reviewers, a "round" (per the autofix loop below) means re-running *all* spawned reviewers in parallel and merging their findings into a single set before autofix; convergence is the merged set being empty, not any individual reviewer clearing. Do not re-run only the reviewer whose prior findings were touched — every round must include every reviewer so cascading or newly-introduced issues surface.
+- **Direct reviewer-subagent dispatch via the Agent/invoke_subagent tool.** Spawn `correctness`, `security`, and `maintainability` reviewers (always-on) plus any conditional reviewers warranted by the diff (`api-contract`, `data-migrations`, `reliability`, `performance`) against the in-scope paths. This is the universal fallback: any harness that runs the press skill has access to subagents, so this path is always available. When dispatching multiple reviewers, a "round" (per the autofix loop below) means re-running *all* spawned reviewers in parallel and merging their findings into a single set before autofix; convergence is the merged set being empty, not any individual reviewer clearing. Do not re-run only the reviewer whose prior findings were touched — every round must include every reviewer so cascading or newly-introduced issues surface.
 
 **Do not invoke Claude Code's `/review` for this phase.** `/review` is PR-shaped — it fetches an open GitHub PR and comments back via `gh`. There is no PR yet at Phase 4.95; the CLI is in a working dir that has not been promoted or published. Reaching for `/review`, bouncing off its shape, and claiming "harness has no code review" is the failure mode this section is written to prevent.
 
@@ -4219,7 +4231,7 @@ The retro skill scans the template-shape and out-of-scope sections for candidate
 
 **Template-shape escape hatch.** Even if a finding lives in an in-scope path, if it appears to come from a generator template (recurs across files in identical shape, sits in a path matched by `internal/generator/templates/`'s emit set, or duplicates a known prior template bug), file as retro-candidate and surface to the user rather than autofixing. Patching the printed CLI hides the machine bug from the next CLI.
 
-**Post-fix simplification (Claude Code only).** After the review + autofix loop converges, the printed CLI has fresh edits from the autofix passes — typically defensive guards, sanitization helpers, and near-duplicate fixes across sibling files. Run `/simplify` scoped to the same in-scope paths to consolidate duplication, remove dead code, and tighten the autofix output before dogfood. `/simplify` is Claude Code-only; skip on Codex and other harnesses (they have no built-in equivalent, and the press skill explicitly avoids custom simplification logic — same rule as the review path above).
+**Post-fix simplification.** After the review + autofix loop converges, the printed CLI has fresh edits from the autofix passes — typically defensive guards, sanitization helpers, and near-duplicate fixes across sibling files. In Claude Code, run `/simplify` scoped to the same in-scope paths to consolidate duplication, remove dead code, and tighten the autofix output before dogfood. In Antigravity or other harnesses without a built-in simplification command, execute a targeted simplification pass (or invoke an installed simplification skill if available). On Codex and other harnesses without a built-in simplification tool, skip this step.
 
 **Harness exemption — narrow.** Skipping this phase is legitimate only when the current harness has *neither* a working-dir-shaped review skill *nor* the Agent/subagent capability needed for the direct-dispatch fallback. In practice this is almost never true — any harness that runs the press skill has access to subagents. The following rationales are **not** acceptable for skipping:
 
@@ -4524,7 +4536,7 @@ prior_sub60_reprint: <true|false>
 partial_transcendence_override: <none or build-log note path>
 ```
 
-Invoke via the Skill tool (**foreground** — must complete before promoting).
+Invoke via the Skill tool (Claude Code) or by loading `skills/printing-press-polish/SKILL.md` / dispatching via `invoke_subagent` (Antigravity, **foreground** — must complete before promoting).
 Pass `$CLI_WORK_DIR` as the first line of `args`, followed by the Phase 3 bundle:
 
 ```
@@ -4959,7 +4971,7 @@ Invoke `/printing-press-retro`. The retro skill analyzes the session for generat
 
 #### If "Polish to retry"
 
-**Invoke polish via the Skill tool with `$CLI_WORK_DIR` as the arg:**
+**Invoke polish via the Skill tool (Claude Code) or via `skills/printing-press-polish/SKILL.md` / `invoke_subagent` (Antigravity) with `$CLI_WORK_DIR` as the arg:**
 
 ```
 Skill(

--- a/skills/printing-press/references/novel-features-subagent.md
+++ b/skills/printing-press/references/novel-features-subagent.md
@@ -68,16 +68,29 @@ inside the brief. The subagent detects their presence by checking for the
 
 ## Subagent invocation
 
-One Task tool call. Do not split passes across multiple invocations — the cut
+One subagent invocation. Do not split passes across multiple invocations — the cut
 pass must see the candidates it generated.
 
-```
+**Under Claude Code:**
+```text
 Agent({
   description: "Novel-features brainstorm + adversarial cut",
   subagent_type: "general-purpose",
   prompt: <Subagent prompt template below, with ${...} placeholders substituted>
 })
 ```
+
+**Under Antigravity:**
+```json
+invoke_subagent({
+  "Subagents": [{
+    "TypeName": "research",
+    "Role": "Novel Features Brainstormer",
+    "Prompt": "<Subagent prompt template below, with ${...} placeholders substituted>"
+  }]
+})
+```
+*Note on Antigravity:* Antigravity operates on a Reactive Wakeup model. After calling `invoke_subagent`, stop calling tools and end your turn. The system will automatically wake you and deliver the subagent's response.
 
 ## Subagent prompt template
 

--- a/skills/printing-press/references/setup-checks.md
+++ b/skills/printing-press/references/setup-checks.md
@@ -49,9 +49,9 @@ If the setup contract output contains a line starting with `[repo-upgrade-availa
 - `PRESS_REPO_HEAD=<current HEAD sha>`
 - `PRESS_REPO_MAIN=<origin/main sha>`
 
-Then ask the user via `AskUserQuestion` before continuing setup:
+Then ask the user via `AskUserQuestion` (Claude Code) or `ask_question` (Antigravity) before continuing setup:
 
-- **question:** `"origin/main has newer Printing Press changes. Pull the latest main now? After this, reload the skill with /reload-plugin."`
+- **question:** `"origin/main has newer Printing Press changes. Pull the latest main now? After this, reload the skill (/reload-plugin in Claude Code, or start a new conversation in Antigravity)."`
 - **header:** `"Update repo"`
 - **multiSelect:** `false`
 - **options:**
@@ -66,7 +66,7 @@ git -C "$PRESS_REPO_DIR" pull --ff-only origin main
 
 After it completes, tell the user:
 
-> "Updated the Printing Press checkout. Run `/reload-plugin`, then re-run `/printing-press` so the refreshed skill and rebuilt local binary are used."
+> "Updated the Printing Press checkout. Run `/reload-plugin` (Claude Code) or start a new conversation (Antigravity), then re-run `/printing-press` so the refreshed skill and rebuilt local binary are used."
 
 Then stop the skill immediately. Do not continue the current run, because the skill text that is executing may now be stale.
 
@@ -113,7 +113,7 @@ Interpret the output as follows:
 
   Do not proceed to research, generation, scoring, publishing, or any other workflow after a skill update.
 - If it reports `All global skills are up to date` or otherwise completes without an updated-skill summary, continue.
-- If it reports `No installed skills found matching: ...`, continue without blocking. The current skill is already running, so absence from the global open-agent-skills registry usually means this session was loaded from another install surface, such as the Claude Code plugin/marketplace channel, a project-scoped skill install, or a local plugin directory. Do not tell the user to reinstall through `npx skills` as a prerequisite. If they explicitly ask how to move to the global open-agent-skills install path, give them the skills-only installer command so they do not have to name individual skills:
+- If it reports `No installed skills found matching: ...`, continue without blocking. The current skill is already running, so absence from the global open-agent-skills registry usually means this session was loaded from another install surface, such as the Claude Code plugin/marketplace channel, Antigravity global skills (`~/.gemini/config/skills/`), a project-scoped skill install, or a local plugin directory. Do not tell the user to reinstall through `npx skills` as a prerequisite. If they explicitly ask how to move to the global install path, give them the skills-only installer command so they do not have to name individual skills:
 
   ```bash
   curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --skills-only
@@ -146,7 +146,7 @@ If the setup contract output contains a line starting with `[upgrade-required]`,
 - `PRESS_REQUIRED_INSTALLED=<installed version>`
 - `PRESS_REQUIRED_REASON=<one-line reason>`
 
-This is a hard gate. Do not proceed to research, generation, scoring, publishing, or any other workflow on a binary below the floor. Offer a one-click upgrade via `AskUserQuestion` before continuing:
+This is a hard gate. Do not proceed to research, generation, scoring, publishing, or any other workflow on a binary below the floor. Offer a one-click upgrade via `AskUserQuestion` (Claude Code) or `ask_question` (Antigravity) before continuing:
 
 - **question:** `"printing-press v<installed> is below the minimum supported v<minimum>. <reason> Upgrade now? Takes about 10 seconds."`
 - **header:** `"Update required"`
@@ -176,7 +176,7 @@ If the setup contract output contains a line starting with `[upgrade-available]`
 - `PRESS_UPGRADE_AVAILABLE=<latest>`
 - `PRESS_UPGRADE_INSTALLED=<installed>`
 
-Then ask the user via `AskUserQuestion` before continuing setup:
+Then ask the user via `AskUserQuestion` (Claude Code) or `ask_question` (Antigravity) before continuing setup:
 
 - **question:** `"printing-press v<latest> is available (you have v<installed>). Upgrade now? Takes about 10 seconds."`
 - **header:** `"Update available"`
@@ -220,7 +220,7 @@ If the setup contract output contains a line starting with `[browser-tools-missi
 - `PRESS_BROWSER_USE_MISSING=<true|false>`
 - `PRESS_AGENT_BROWSER_MISSING=<true|false>`
 
-Then ask the user via `AskUserQuestion` before continuing setup. The prompt fires every run when either tool is missing — there is no decline cache. Re-prompting is intentional: browser-use and agent-browser are the preferred Phase 1.7 backends, and mid-flight install gates during generation are more disruptive than one short preflight prompt.
+Then ask the user via `AskUserQuestion` (Claude Code) or `ask_question` (Antigravity) before continuing setup. The prompt fires every run when either tool is missing — there is no decline cache. Re-prompting is intentional: browser-use and agent-browser are the preferred Phase 1.7 backends, and mid-flight install gates during generation are more disruptive than one short preflight prompt.
 
 - **question** (compose based on which are missing — pick the matching row):
   - Both missing: `"browser-use and agent-browser are not installed. These are the preferred Phase 1.7 browser-sniff backends — broadly useful for future runs and avoids mid-flight install prompts. (chrome-MCP is a narrow-case fallback, not a substitute.) Install now?"`

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/README.md
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/README.md
@@ -6,7 +6,7 @@ Created by [@printing-press-golden](https://github.com/printing-press-golden) (p
 
 ## Install
 
-The recommended path installs both the `printing-press-oauth2-pp-cli` binary and the `pp-printing-press-oauth2` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
+The recommended path installs both the `printing-press-oauth2-pp-cli` binary and the `pp-printing-press-oauth2` agent skill (Claude Code, Antigravity, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
 npx -y @mvanhorn/printing-press-library install printing-press-oauth2

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/SKILL.md
@@ -379,8 +379,18 @@ Install the MCP binary from this CLI's published public-library entry or pre-bui
 ```bash
 claude mcp add printing-press-oauth2-pp-mcp -- printing-press-oauth2-pp-mcp
 ```
+Or add to Antigravity `mcp_config.json`:
+```json
+{
+  "mcpServers": {
+    "printing-press-oauth2-pp-mcp": {
+      "command": "printing-press-oauth2-pp-mcp"
+    }
+  }
+}
+```
 
-Verify: `claude mcp list`
+Verify: `claude mcp list` or inspect Antigravity MCP tool catalog
 
 ## Direct Use
 

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/README.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/README.md
@@ -6,7 +6,7 @@ Created by [@printing-press-golden](https://github.com/printing-press-golden) (p
 
 ## Install
 
-The recommended path installs both the `printing-press-rich-pp-cli` binary and the `pp-printing-press-rich` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
+The recommended path installs both the `printing-press-rich-pp-cli` binary and the `pp-printing-press-rich` agent skill (Claude Code, Antigravity, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
 npx -y @mvanhorn/printing-press-library install printing-press-rich

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/SKILL.md
@@ -376,8 +376,18 @@ Install the MCP binary from this CLI's published public-library entry or pre-bui
 ```bash
 claude mcp add printing-press-rich-pp-mcp -- printing-press-rich-pp-mcp
 ```
+Or add to Antigravity `mcp_config.json`:
+```json
+{
+  "mcpServers": {
+    "printing-press-rich-pp-mcp": {
+      "command": "printing-press-rich-pp-mcp"
+    }
+  }
+}
+```
 
-Verify: `claude mcp list`
+Verify: `claude mcp list` or inspect Antigravity MCP tool catalog
 
 ## Direct Use
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
@@ -6,7 +6,7 @@ Created by [@printing-press-golden](https://github.com/printing-press-golden) (p
 
 ## Install
 
-The recommended path installs both the `printing-press-golden-pp-cli` binary and the `pp-printing-press-golden` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
+The recommended path installs both the `printing-press-golden-pp-cli` binary and the `pp-printing-press-golden` agent skill (Claude Code, Antigravity, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
 npx -y @mvanhorn/printing-press-library install printing-press-golden

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
@@ -403,8 +403,18 @@ Install the MCP binary from this CLI's published public-library entry or pre-bui
 ```bash
 claude mcp add printing-press-golden-pp-mcp -- printing-press-golden-pp-mcp
 ```
+Or add to Antigravity `mcp_config.json`:
+```json
+{
+  "mcpServers": {
+    "printing-press-golden-pp-mcp": {
+      "command": "printing-press-golden-pp-mcp"
+    }
+  }
+}
+```
 
-Verify: `claude mcp list`
+Verify: `claude mcp list` or inspect Antigravity MCP tool catalog
 
 ## Direct Use
 

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/README.md
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/README.md
@@ -14,7 +14,7 @@ Created by [@printing-press-golden](https://github.com/printing-press-golden) (p
 
 ## Install
 
-The recommended path installs both the `learn-disabled-example-pp-cli` binary and the `pp-learn-disabled-example` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
+The recommended path installs both the `learn-disabled-example-pp-cli` binary and the `pp-learn-disabled-example` agent skill (Claude Code, Antigravity, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
 npx -y @mvanhorn/printing-press-library install learn-disabled-example

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/SKILL.md
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/SKILL.md
@@ -194,8 +194,18 @@ Install the MCP binary from this CLI's published public-library entry or pre-bui
 ```bash
 claude mcp add learn-disabled-example-pp-mcp -- learn-disabled-example-pp-mcp
 ```
+Or add to Antigravity `mcp_config.json`:
+```json
+{
+  "mcpServers": {
+    "learn-disabled-example-pp-mcp": {
+      "command": "learn-disabled-example-pp-mcp"
+    }
+  }
+}
+```
 
-Verify: `claude mcp list`
+Verify: `claude mcp list` or inspect Antigravity MCP tool catalog
 
 ## Direct Use
 

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/README.md
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/README.md
@@ -17,7 +17,7 @@ Created by [@printing-press-golden](https://github.com/printing-press-golden) (p
 
 ## Install
 
-The recommended path installs both the `learn-loop-example-pp-cli` binary and the `pp-learn-loop-example` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
+The recommended path installs both the `learn-loop-example-pp-cli` binary and the `pp-learn-loop-example` agent skill (Claude Code, Antigravity, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
 npx -y @mvanhorn/printing-press-library install learn-loop-example

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/SKILL.md
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/SKILL.md
@@ -393,8 +393,18 @@ Install the MCP binary from this CLI's published public-library entry or pre-bui
 ```bash
 claude mcp add learn-loop-example-pp-mcp -- learn-loop-example-pp-mcp
 ```
+Or add to Antigravity `mcp_config.json`:
+```json
+{
+  "mcpServers": {
+    "learn-loop-example-pp-mcp": {
+      "command": "learn-loop-example-pp-mcp"
+    }
+  }
+}
+```
 
-Verify: `claude mcp list`
+Verify: `claude mcp list` or inspect Antigravity MCP tool catalog
 
 ## Direct Use
 

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/README.md
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/README.md
@@ -6,7 +6,7 @@ Created by [@printing-press-golden](https://github.com/printing-press-golden) (p
 
 ## Install
 
-The recommended path installs both the `public-param-golden-pp-cli` binary and the `pp-public-param-golden` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
+The recommended path installs both the `public-param-golden-pp-cli` binary and the `pp-public-param-golden` agent skill (Claude Code, Antigravity, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
 npx -y @mvanhorn/printing-press-library install public-param-golden

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/SKILL.md
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/SKILL.md
@@ -369,8 +369,18 @@ Install the MCP binary from this CLI's published public-library entry or pre-bui
 ```bash
 claude mcp add public-param-golden-pp-mcp -- public-param-golden-pp-mcp
 ```
+Or add to Antigravity `mcp_config.json`:
+```json
+{
+  "mcpServers": {
+    "public-param-golden-pp-mcp": {
+      "command": "public-param-golden-pp-mcp"
+    }
+  }
+}
+```
 
-Verify: `claude mcp list`
+Verify: `claude mcp list` or inspect Antigravity MCP tool catalog
 
 ## Direct Use
 


### PR DESCRIPTION
## Intent

Add first-class native support for running Printing Press skills and generated MCP servers inside Google DeepMind's Antigravity environment.

Issue: N/A

## Approach

1. **Shared Skills (`skills/`):**
   - Added harness-aware interactions to use Antigravity's native `ask_question` tool for discrete choices and markdown text for open questions.
   - Handled Antigravity's **Reactive Wakeup** execution model for subagents (`invoke_subagent`).
   - Added Antigravity transcript discovery (`<appDataDir>/brain/<conversation-id>/.system_generated/logs/transcript.jsonl`) for friction mining in `/printing-press-amend`.

2. **Installer (`scripts/install.sh`):**
   - Added `--agent antigravity` support to automatically install the 9 Printing Press skills into `~/.gemini/config/skills/`.

3. **Templates & Goldens (`internal/generator/templates/`):**
   - Added Antigravity `mcp_config.json` configuration blocks to generated `SKILL.md` template and updated all 32 golden fixtures.

4. **Internal Packages & Documentation:**
   - Added `.antigravity` directory exemptions to PII scanner (`internal/artifacts/pii.go`).
   - Added [docs/ANTIGRAVITY.md](docs/ANTIGRAVITY.md) onboarding and tool-mapping guide.

## Scope

Primary area: `skills`, `generator`, `scripts`, `docs`

Why this belongs in this repo:
This expands the generator and skill harness support to Antigravity as a supported agent environment alongside Claude Code and Codex.

## Risk

Low. Changes to generated outputs are additive (adding Antigravity MCP server configuration snippets to generated README/SKILL docs) and all existing golden test suites pass without regression.

## Output Contract

- Updated `internal/generator/templates/skill.md.tmpl` and `readme.md.tmpl` to include Antigravity configuration examples.
- Updated all 32 golden fixture files in `testdata/golden/expected/`.
- Verified with `scripts/golden.sh verify` and `scripts/verify-generator-output.sh`.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output (`scripts/verify-generator-output.sh`)
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures (`scripts/golden.sh verify`)
- [x] Generator/template change: checked emitted definitions and call sites for matching gates
- `go test ./...` passed across all packages.
- `go vet ./...` passed.
- `scripts/verify-learn-purity.sh` passed for all 52 learn templates.

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
