### PR TITLE
fix(cli): normalize text spec checksums

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -2,8 +2,6 @@ package cli
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -2699,12 +2697,14 @@ func retidyAfterMerge(dir string) {
 }
 
 // forceRegenSpecHashMatches reports whether the snapshot's recorded spec
-// checksum matches a sha256 over the current spec bytes. Returns true when:
+// checksum matches the canonical or legacy raw checksum for the current spec
+// bytes. Returns true when:
 //   - the snapshot manifest is missing (defensive — old binary or partial
 //     state from a CLI generated before SpecChecksum was populated),
 //   - the snapshot manifest has an empty SpecChecksum (plan-generated, old
 //     format, or docs source without a stored hash),
-//   - or the snapshot checksum equals the current spec hash.
+//   - or the snapshot checksum equals the current canonical hash or either
+//     line-ending form accepted during the transition window.
 //
 // Returns false when:
 //   - the manifest exists but cannot be decoded (corrupt JSON — treat as
@@ -2714,9 +2714,9 @@ func retidyAfterMerge(dir string) {
 //     lineage differs by construction so NOVEL-only is the safe fallback),
 //   - or both sides have a checksum and they differ.
 //
-// The hash matches climanifest.go's storage convention (sha256 over the
-// raw input spec bytes, "sha256:" + hex), so a same-spec regen produces a
-// byte-identical hash and the full-merge path runs.
+// The hash matches pipeline.ComputeSpecChecksum's storage convention. Legacy
+// all-LF and all-CRLF raw hashes remain accepted for known text spec formats so
+// a same-spec cross-platform regen still takes the full-merge path.
 func forceRegenSpecHashMatches(snapshotDir string, currentSpecBytes []byte) bool {
 	manifestPath := filepath.Join(snapshotDir, pipeline.CLIManifestFilename)
 	if _, err := os.Stat(manifestPath); errors.Is(err, os.ErrNotExist) {
@@ -2733,12 +2733,7 @@ func forceRegenSpecHashMatches(snapshotDir string, currentSpecBytes []byte) bool
 	if len(currentSpecBytes) == 0 {
 		return false
 	}
-	return manifest.SpecChecksum == currentSpecChecksum(currentSpecBytes)
-}
-
-func currentSpecChecksum(specBytes []byte) string {
-	sum := sha256.Sum256(specBytes)
-	return "sha256:" + hex.EncodeToString(sum[:])
+	return pipeline.SpecChecksumMatches(manifest.SpecChecksum, currentSpecBytes, manifest.SpecFormat)
 }
 
 // snapshotForceRegen renames absOut to a sibling tempdir for use as a regen

--- a/internal/cli/spec_checksum_test.go
+++ b/internal/cli/spec_checksum_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateCmdEmitsPlatformIndependentSpecChecksum(t *testing.T) {
+	lf := []byte(`name: checksum-output
+description: Generated checksum output fixture
+version: 0.1.0
+base_url: https://api.example.com
+auth:
+  type: none
+config:
+  format: toml
+  path: ~/.config/checksum-output-pp-cli/config.toml
+resources:
+  items:
+    description: Manage items
+    endpoints:
+      list:
+        method: GET
+        path: /items
+        description: List items
+`)
+	inputs := map[string][]byte{
+		"lf":   lf,
+		"crlf": bytes.ReplaceAll(lf, []byte("\n"), []byte("\r\n")),
+	}
+
+	checksums := make(map[string]string, len(inputs))
+	for name, input := range inputs {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			specPath := filepath.Join(dir, "spec.yaml")
+			outputDir := filepath.Join(dir, "generated")
+			require.NoError(t, os.WriteFile(specPath, input, 0o644))
+
+			cmd := newGenerateCmd()
+			cmd.SetArgs([]string{
+				"--spec", specPath,
+				"--output", outputDir,
+				"--validate=false",
+			})
+			require.NoError(t, cmd.Execute())
+
+			manifest, err := pipeline.ReadCLIManifest(outputDir)
+			require.NoError(t, err)
+			checksums[name] = manifest.SpecChecksum
+		})
+	}
+
+	assert.Equal(t, checksums["lf"], checksums["crlf"])
+	assert.Equal(t, pipeline.ComputeSpecChecksum(lf, "internal"), checksums["lf"])
+}
+
+func TestForceRegenSpecHashMatchesLegacyTextLineEndings(t *testing.T) {
+	lf := []byte("name: checksum-force\ndescription: force transition\n")
+	crlf := bytes.ReplaceAll(lf, []byte("\n"), []byte("\r\n"))
+
+	tests := []struct {
+		name             string
+		manifestSpec     []byte
+		currentSpecBytes []byte
+	}{
+		{name: "CRLF manifest with LF checkout", manifestSpec: crlf, currentSpecBytes: lf},
+		{name: "LF manifest with CRLF checkout", manifestSpec: lf, currentSpecBytes: crlf},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snapshotDir := t.TempDir()
+			require.NoError(t, pipeline.WriteCLIManifest(snapshotDir, pipeline.CLIManifest{
+				APIName:      "checksum-force",
+				SpecFormat:   "internal",
+				SpecChecksum: rawSpecChecksumForTest(tt.manifestSpec),
+			}))
+
+			assert.True(t, forceRegenSpecHashMatches(snapshotDir, tt.currentSpecBytes))
+			assert.False(t, forceRegenSpecHashMatches(snapshotDir, []byte("name: different\n")))
+		})
+	}
+}
+
+func rawSpecChecksumForTest(specBytes []byte) string {
+	sum := sha256.Sum256(specBytes)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -2,8 +2,6 @@ package pipeline
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -887,10 +885,10 @@ func archivedSpecNameForFormat(sourceBasename string) string {
 	}
 }
 
-// specChecksum computes a SHA-256 checksum of the file at path.
+// specChecksum computes the canonical SHA-256 checksum of the file at path.
 // Returns "sha256:<hex>" on success, or an empty string if the file
 // does not exist.
-func specChecksum(path string) (string, error) {
+func specChecksum(path string, specFormats ...string) (string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -898,8 +896,11 @@ func specChecksum(path string) (string, error) {
 		}
 		return "", fmt.Errorf("reading spec for checksum: %w", err)
 	}
-	h := sha256.Sum256(data)
-	return "sha256:" + hex.EncodeToString(h[:]), nil
+	specFormat := detectSpecFormat(data)
+	if len(specFormats) > 0 {
+		specFormat = specFormats[0]
+	}
+	return ComputeSpecChecksum(data, specFormat), nil
 }
 
 // computeMCPReady determines the MCP readiness label for scorecard /
@@ -1186,6 +1187,7 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 		m.Creator = &creator
 	}
 	m.Contributors = p.Contributors
+	var lineageSpecBytes []byte
 
 	// Populate spec_url / spec_path from the first spec source.
 	if p.DocsURL != "" {
@@ -1200,8 +1202,8 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 			// Compute checksum and format from the actual input spec file.
 			if data, err := os.ReadFile(src); err == nil {
 				m.SpecFormat = detectSpecFormat(data)
-				h := sha256.Sum256(data)
-				m.SpecChecksum = "sha256:" + hex.EncodeToString(h[:])
+				m.SpecChecksum = ComputeSpecChecksum(data, m.SpecFormat)
+				lineageSpecBytes = data
 			}
 		}
 	}
@@ -1214,14 +1216,15 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 
 	// Fallback: detect format and checksum from any spec file cached in the output dir.
 	if m.SpecFormat == "" || m.SpecChecksum == "" {
-		if specFile, data, err := findArchivedSpec(p.OutputDir); err == nil && specFile != "" {
+		if _, data, err := findArchivedSpec(p.OutputDir); err == nil && data != nil {
 			if m.SpecFormat == "" {
 				m.SpecFormat = detectSpecFormat(data)
 			}
 			if m.SpecChecksum == "" {
-				if cs, err := specChecksum(specFile); err == nil {
-					m.SpecChecksum = cs
-				}
+				m.SpecChecksum = ComputeSpecChecksum(data, m.SpecFormat)
+			}
+			if lineageSpecBytes == nil {
+				lineageSpecBytes = data
 			}
 		}
 	}
@@ -1268,7 +1271,7 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 	if description := strings.TrimSpace(p.Description); description != "" {
 		m.Description = description
 	}
-	preserveExisting := hasExisting && sameGenerateManifestLineage(existing, m)
+	preserveExisting := hasExisting && sameGenerateManifestLineage(existing, m, lineageSpecBytes)
 	// A durable manifest description may be hand-edited after generation.
 	// Operators can delete or replace the field when they want changed spec
 	// prose to become canonical on a later generate run.
@@ -1409,12 +1412,13 @@ func writeCLIManifestForGenerate(dir string, m CLIManifest, existingRaw map[stri
 	return nil
 }
 
-func sameGenerateManifestLineage(existing, generated CLIManifest) bool {
+func sameGenerateManifestLineage(existing, generated CLIManifest, generatedSpecBytes []byte) bool {
 	if existing.APIName == "" || generated.APIName == "" || existing.APIName != generated.APIName {
 		return false
 	}
 	if existing.SpecChecksum != "" && generated.SpecChecksum != "" {
-		return existing.SpecChecksum == generated.SpecChecksum
+		return existing.SpecChecksum == generated.SpecChecksum ||
+			(len(generatedSpecBytes) > 0 && SpecChecksumMatches(existing.SpecChecksum, generatedSpecBytes, generated.SpecFormat))
 	}
 	if (existing.SpecURL != "" || existing.SpecPath != "") && (generated.SpecURL != "" || generated.SpecPath != "") {
 		if existing.SpecURL != "" || generated.SpecURL != "" {

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -287,7 +287,7 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 	// these fields stay empty.
 	if specFile, data, err := findArchivedSpec(state.EffectiveWorkingDir()); err == nil && specFile != "" {
 		m.SpecFormat = detectSpecFormat(data)
-		if checksum, err := specChecksum(specFile); err == nil {
+		if checksum, err := specChecksum(specFile, m.SpecFormat); err == nil {
 			m.SpecChecksum = checksum
 		}
 

--- a/internal/pipeline/spec_checksum.go
+++ b/internal/pipeline/spec_checksum.go
@@ -1,0 +1,76 @@
+package pipeline
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+)
+
+var (
+	specLF   = []byte("\n")
+	specCRLF = []byte("\r\n")
+)
+
+// ComputeSpecChecksum returns the canonical SHA-256 checksum for specBytes.
+// Known text spec formats normalize CRLF line endings to LF before hashing so
+// the checksum does not depend on the checkout platform. Other formats retain
+// their byte-for-byte checksum semantics.
+func ComputeSpecChecksum(specBytes []byte, specFormat string) string {
+	return specChecksumCandidates(specBytes, specFormat)[0]
+}
+
+// SpecChecksumMatches reports whether checksum is the canonical checksum or a
+// legacy raw-byte checksum for specBytes. During the line-ending transition,
+// text specs accept both all-LF and all-CRLF legacy hashes so a manifest written
+// on either platform keeps its lineage when regenerated on the other.
+func SpecChecksumMatches(checksum string, specBytes []byte, specFormat string) bool {
+	for _, candidate := range specChecksumCandidates(specBytes, specFormat) {
+		if checksum == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func specChecksumCandidates(specBytes []byte, specFormat string) []string {
+	raw := hashSpecBytes(specBytes)
+	if !normalizesSpecLineEndings(specFormat) {
+		return []string{raw}
+	}
+
+	lfBytes := bytes.ReplaceAll(specBytes, specCRLF, specLF)
+	candidates := []string{hashSpecBytes(lfBytes)}
+	candidates = appendUniqueSpecChecksum(candidates, raw)
+
+	// A legacy manifest may have been written from the other checkout style.
+	// Reconstruct the all-CRLF form from canonical LF bytes so both directions
+	// of a Windows/Linux regeneration recognize the same spec lineage.
+	crlfBytes := bytes.ReplaceAll(lfBytes, specLF, specCRLF)
+	return appendUniqueSpecChecksum(candidates, hashSpecBytes(crlfBytes))
+}
+
+func appendUniqueSpecChecksum(checksums []string, candidate string) []string {
+	for _, checksum := range checksums {
+		if checksum == candidate {
+			return checksums
+		}
+	}
+	return append(checksums, candidate)
+}
+
+func hashSpecBytes(specBytes []byte) string {
+	sum := sha256.Sum256(specBytes)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func normalizesSpecLineEndings(specFormat string) bool {
+	switch strings.ToLower(strings.TrimSpace(specFormat)) {
+	case "openapi3", "graphql", "internal", spec.SourceLocalSQLite:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/pipeline/spec_checksum.go
+++ b/internal/pipeline/spec_checksum.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"slices"
 	"strings"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
@@ -27,12 +28,7 @@ func ComputeSpecChecksum(specBytes []byte, specFormat string) string {
 // text specs accept both all-LF and all-CRLF legacy hashes so a manifest written
 // on either platform keeps its lineage when regenerated on the other.
 func SpecChecksumMatches(checksum string, specBytes []byte, specFormat string) bool {
-	for _, candidate := range specChecksumCandidates(specBytes, specFormat) {
-		if checksum == candidate {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(specChecksumCandidates(specBytes, specFormat), checksum)
 }
 
 func specChecksumCandidates(specBytes []byte, specFormat string) []string {
@@ -53,10 +49,8 @@ func specChecksumCandidates(specBytes []byte, specFormat string) []string {
 }
 
 func appendUniqueSpecChecksum(checksums []string, candidate string) []string {
-	for _, checksum := range checksums {
-		if checksum == candidate {
-			return checksums
-		}
+	if slices.Contains(checksums, candidate) {
+		return checksums
 	}
 	return append(checksums, candidate)
 }

--- a/internal/pipeline/spec_checksum_test.go
+++ b/internal/pipeline/spec_checksum_test.go
@@ -1,0 +1,86 @@
+package pipeline
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeSpecChecksumNormalizesOnlyTextSpecLineEndings(t *testing.T) {
+	lf := []byte("name: checksum-test\ndescription: platform independent\n")
+	crlf := bytes.ReplaceAll(lf, []byte("\n"), []byte("\r\n"))
+
+	assert.Equal(t, hashSpecBytes(lf), ComputeSpecChecksum(lf, "internal"))
+	assert.Equal(t, hashSpecBytes(lf), ComputeSpecChecksum(crlf, "internal"))
+
+	withLoneCR := []byte("name: before\rafter\r\ndescription: preserved\r\n")
+	normalizedLoneCR := []byte("name: before\rafter\ndescription: preserved\n")
+	assert.Equal(t, hashSpecBytes(normalizedLoneCR), ComputeSpecChecksum(withLoneCR, "internal"),
+		"normalization must preserve carriage returns that are not part of CRLF")
+
+	assert.Equal(t, hashSpecBytes(crlf), ComputeSpecChecksum(crlf, "binary"),
+		"unknown or non-text formats must retain byte-for-byte checksum semantics")
+}
+
+func TestSpecChecksumMatchesLegacyTextLineEndings(t *testing.T) {
+	lf := []byte("name: checksum-test\ndescription: platform independent\n")
+	crlf := bytes.ReplaceAll(lf, []byte("\n"), []byte("\r\n"))
+
+	assert.True(t, SpecChecksumMatches(hashSpecBytes(crlf), lf, "internal"),
+		"an LF checkout must accept a manifest written from CRLF bytes")
+	assert.True(t, SpecChecksumMatches(hashSpecBytes(lf), crlf, "internal"),
+		"a CRLF checkout must accept a manifest written from LF bytes")
+	assert.False(t, SpecChecksumMatches(hashSpecBytes(crlf), lf, "binary"),
+		"transition matching must remain gated to text spec formats")
+	assert.False(t, SpecChecksumMatches(hashSpecBytes([]byte("different\n")), lf, "internal"))
+}
+
+func TestWriteManifestForGenerateRewritesLegacyCRLFChecksumOnLineageMatch(t *testing.T) {
+	outputDir := t.TempDir()
+	specPath := filepath.Join(t.TempDir(), "spec.yaml")
+	lf := []byte(`name: checksum-transition
+description: Checksum transition fixture
+version: 0.1.0
+base_url: https://api.example.com
+auth:
+  type: none
+resources: {}
+`)
+	crlf := bytes.ReplaceAll(lf, []byte("\n"), []byte("\r\n"))
+	require.NoError(t, os.WriteFile(specPath, lf, 0o644))
+
+	existing := fmt.Sprintf(`{
+  "api_name": "checksum-transition",
+  "cli_name": "checksum-transition-pp-cli",
+  "spec_format": "internal",
+  "spec_checksum": %q,
+  "operator_note": "preserve me"
+}`, hashSpecBytes(crlf))
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, CLIManifestFilename), []byte(existing), 0o644))
+
+	require.NoError(t, WriteManifestForGenerate(GenerateManifestParams{
+		APIName:   "checksum-transition",
+		SpecSrcs:  []string{specPath},
+		OutputDir: outputDir,
+		RunID:     "20260819-000000",
+	}))
+
+	manifest, err := ReadCLIManifest(outputDir)
+	require.NoError(t, err)
+	assert.Equal(t, ComputeSpecChecksum(lf, "internal"), manifest.SpecChecksum)
+	assert.NotEqual(t, hashSpecBytes(crlf), manifest.SpecChecksum,
+		"a matching legacy manifest must be rewritten to the canonical checksum")
+
+	data, err := os.ReadFile(filepath.Join(outputDir, CLIManifestFilename))
+	require.NoError(t, err)
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.JSONEq(t, `"preserve me"`, string(raw["operator_note"]),
+		"same-lineage unknown fields must survive the checksum transition")
+}


### PR DESCRIPTION
## Intent

Fixes #3689.

`spec_checksum` previously hashed raw input bytes, so the same text spec produced different manifest lineage on LF and CRLF checkouts. The published Plane example demonstrated the mismatch: the Windows-generated manifest carried `sha256:ca2852c5ed00be736a0fe3700e3e098e3a0bc242c78de53252d939134ed60ba5`, while the LF git blob hashes to `sha256:615011624088df2d3abf5ab0656b2198748898447d1ca57c53778a2b6c1cd6ff`.

## Approach

- Add one shared checksum helper that canonicalizes CRLF to LF for known text spec formats.
- Preserve raw-byte hashing for unknown/non-text formats and preserve lone carriage returns.
- Accept canonical, legacy raw-LF, and legacy raw-CRLF values during lineage checks so existing manifests remain compatible across checkout platforms.
- Rewrite a matched legacy manifest to the canonical checksum during generation.
- Cover the emitted manifest with a real `generate` command test using LF and CRLF copies of the same spec.

## Scope

Primary area: CLI manifest generation and `generate --force` lineage checks.

Why this belongs in the Printing Press: the checksum contract is emitted and consumed centrally, so the fix must apply consistently to every printed CLI rather than patching one published entry.

## Risk

Normalization is limited to known text formats (`openapi3`, `graphql`, `internal`, and internal YAML specs marked `local-sqlite`). Unknown/non-text formats retain byte-for-byte hashing. Transition matching is deliberately broader only for the two checkout line-ending forms of those text formats.

## Output Contract

For text specs, `cli-manifest.json` now records the SHA-256 of LF-canonicalized bytes. Existing legacy LF/CRLF hashes continue to identify the same lineage and are replaced with the canonical value on the next successful generation.

## Verification

- [x] Focused pipeline and CLI checksum tests pass.
- [x] `go build -o ./cli-printing-press ./cmd/cli-printing-press` passes.
- [x] `go fmt ./...` completed; `git diff --cached --check` passes.
- [ ] `go test ./...` was run but is not green in this Windows environment: existing platform assumptions fail around Unix executable modes/paths, missing `bash`/`awk`, CRLF-sensitive generator fixtures, and a live LLM documentation test. The checksum-focused packages/tests pass.
- [ ] `bash scripts/golden.sh verify` was run and reports 19 existing Windows/baseline fixture diffs (line endings and unrelated generated-output drift); no checksum manifest fixture changed. Goldens were not updated.
- [x] `golangci-lint v2.11.4 run ./...` with `GOOS=linux` passes locally with `0 issues`; the GitHub `go-lint` job also passes on the current head.
- [x] GitHub Main CI passes all full-test shards, `build-and-test`, and `full-golden` on the current head.
- [ ] Generator/template emitted-Go verification: not applicable; this change does not touch `internal/generator/**`, templates, or emitted Go contracts.
- [ ] Decoy-home field proof: not applicable; this change does not touch generated path/credential helpers or emitted tests.

## AI / Automation Disclosure

- [ ] No AI or automation was used for the code changes.
- [ ] AI or automation assisted, and a human reviewed the resulting diff and behavior.
- [x] AI or automation assisted; the resulting diff and behavior were reviewed by the coding agent only.
- [ ] AI or automation produced the changes without review.
