### PR TITLE
fix(cli): treat HTTP 200 ok:false envelopes as sync failures

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -5614,6 +5614,29 @@ func TestExtractPageItemsJSendNullDataEnvelope(t *testing.T) {
 	if isEmptyPageResponse(statusSuccess) {
 		t.Fatalf("status=success null data envelope should not be treated as an empty page")
 	}
+
+	okFalse := json.RawMessage(` + "`" + `{"ok": false, "error": "not_authed"}` + "`" + `)
+	if isEmptyPageResponse(okFalse) {
+		t.Fatalf("ok:false envelope should not be treated as an empty page")
+	}
+	if !responseDeclaresFailure(okFalse) {
+		t.Fatalf("ok:false envelope should be detected as a declared failure")
+	}
+
+	okTrue := json.RawMessage(` + "`" + `{"ok": true, "data": [{"id": "ch1"}]}` + "`" + `)
+	if responseDeclaresFailure(okTrue) {
+		t.Fatalf("ok:true envelope should not be detected as a declared failure")
+	}
+
+	pascalOkFalse := json.RawMessage(` + "`" + `{"Ok": false, "error": "not_authed"}` + "`" + `)
+	if !responseDeclaresFailure(pascalOkFalse) {
+		t.Fatalf("PascalCase Ok:false envelope should be detected as a declared failure")
+	}
+
+	noEnvelope := json.RawMessage(` + "`" + `{"id": "plain-1", "name": "widget"}` + "`" + `)
+	if responseDeclaresFailure(noEnvelope) {
+		t.Fatalf("body without success/ok/status should not be a declared failure")
+	}
 }
 
 func TestLookupFieldValuePascalCase(t *testing.T) {

--- a/internal/generator/sync_store_template_fixes_test.go
+++ b/internal/generator/sync_store_template_fixes_test.go
@@ -474,9 +474,181 @@ func TestSyncDependentResourceDeclaredFailureWithItemsIsIntegrityFailure(t *test
 		t.Fatalf("events did not contain dependent declared-failure sync error: %s", events.String())
 	}
 }
+
+func TestSyncResourceOkFalseEnvelopeIsIntegrityFailure(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	var events bytes.Buffer
+	res := syncResource(context.Background(), fixedBodyClient{body: json.RawMessage(` + "`" + `{"ok":false,"error":"not_authed"}` + "`" + `)}, db, "things", "", false, 1, false, false, nil, &events)
+	if res.Err == nil {
+		t.Fatalf("syncResource returned clean success for ok:false body; events: %s", events.String())
+	}
+	if !res.IntegrityFailure {
+		t.Fatalf("IntegrityFailure = false, want true")
+	}
+	if res.Count != 0 {
+		t.Fatalf("Count = %d, want 0", res.Count)
+	}
+	if !strings.Contains(events.String(), "response declared failure") {
+		t.Fatalf("events did not contain ok:false sync error: %s", events.String())
+	}
+	rows, err := db.List("things", 10)
+	if err != nil {
+		t.Fatalf("list things: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("stored rows = %d, want 0 (ok:false body must not upsert)", len(rows))
+	}
+}
+
+func TestSyncResourceOkFalseEnvelopeWithItemsIsIntegrityFailure(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	var events bytes.Buffer
+	res := syncResource(context.Background(), fixedBodyClient{body: json.RawMessage(` + "`" + `{"ok":false,"error":"not_authed","data":[{"id":"bad"}],"next_cursor":"still-more"}` + "`" + `)}, db, "things", "", false, 1, false, false, nil, &events)
+	if res.Err == nil {
+		t.Fatalf("syncResource returned clean success for ok:false body with items; events: %s", events.String())
+	}
+	if !res.IntegrityFailure {
+		t.Fatalf("IntegrityFailure = false, want true")
+	}
+	if res.Count != 0 {
+		t.Fatalf("Count = %d, want 0", res.Count)
+	}
+	rows, err := db.List("things", 10)
+	if err != nil {
+		t.Fatalf("list things: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("stored rows = %d, want 0 (ok:false body must not upsert)", len(rows))
+	}
+}
+
+func TestSyncResourcePascalOkFalseIsIntegrityFailure(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	var events bytes.Buffer
+	res := syncResource(context.Background(), fixedBodyClient{body: json.RawMessage(` + "`" + `{"Ok":false,"error":"not_authed"}` + "`" + `)}, db, "things", "", false, 1, false, false, nil, &events)
+	if res.Err == nil {
+		t.Fatalf("syncResource returned clean success for Ok:false body; events: %s", events.String())
+	}
+	if !res.IntegrityFailure {
+		t.Fatalf("IntegrityFailure = false, want true")
+	}
+	rows, err := db.List("things", 10)
+	if err != nil {
+		t.Fatalf("list things: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("stored rows = %d, want 0 (Ok:false body must not upsert)", len(rows))
+	}
+}
+
+func TestSyncResourceOkTrueEnvelopeStoresItems(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	var events bytes.Buffer
+	res := syncResource(context.Background(), fixedBodyClient{body: json.RawMessage(` + "`" + `{"ok":true,"data":[{"id":"good-1"},{"id":"good-2"}]}` + "`" + `)}, db, "things", "", false, 1, false, false, nil, &events)
+	if res.Err != nil {
+		t.Fatalf("syncResource error for ok:true body: %v; events: %s", res.Err, events.String())
+	}
+	if res.IntegrityFailure {
+		t.Fatalf("IntegrityFailure = true, want false")
+	}
+	if res.Count != 2 {
+		t.Fatalf("Count = %d, want 2", res.Count)
+	}
+	rows, err := db.List("things", 10)
+	if err != nil {
+		t.Fatalf("list things: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("stored rows = %d, want 2", len(rows))
+	}
+}
+
+func TestSyncResourceWithoutOkFieldStillStores(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	var events bytes.Buffer
+	res := syncResource(context.Background(), fixedBodyClient{body: json.RawMessage(` + "`" + `[{"id":"plain-1"},{"id":"plain-2"}]` + "`" + `)}, db, "things", "", false, 1, false, false, nil, &events)
+	if res.Err != nil {
+		t.Fatalf("syncResource error for body without ok: %v; events: %s", res.Err, events.String())
+	}
+	if res.IntegrityFailure {
+		t.Fatalf("IntegrityFailure = true, want false")
+	}
+	if res.Count != 2 {
+		t.Fatalf("Count = %d, want 2", res.Count)
+	}
+	rows, err := db.List("things", 10)
+	if err != nil {
+		t.Fatalf("list things: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("stored rows = %d, want 2", len(rows))
+	}
+}
+
+func TestSyncDependentResourceOkFalseEnvelopeIsIntegrityFailure(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Upsert("parents", "p1", []byte(` + "`" + `{"id":"p1"}` + "`" + `)); err != nil {
+		t.Fatalf("insert parent: %v", err)
+	}
+
+	var events bytes.Buffer
+	res := syncDependentResource(
+		context.Background(),
+		fixedBodyClient{body: json.RawMessage(` + "`" + `{"ok":false,"error":"not_authed","data":[{"id":"c1"}]}` + "`" + `)},
+		db,
+		dependentResourceDef{Name: "children", ParentTable: "parents", ParentIDParam: "parentId", PathTemplate: "/parents/{parentId}/children"},
+		"", false, 1, false, false, nil, &events, 1,
+	)
+	if res.Err == nil {
+		t.Fatalf("syncDependentResource returned clean success for ok:false body; events: %s", events.String())
+	}
+	if !res.IntegrityFailure {
+		t.Fatalf("IntegrityFailure = false, want true")
+	}
+	if res.Count != 0 {
+		t.Fatalf("Count = %d, want 0", res.Count)
+	}
+	rows, err := db.List("children", 10)
+	if err != nil {
+		t.Fatalf("list children: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("stored rows = %d, want 0 (ok:false body must not upsert)", len(rows))
+	}
+}
 `
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "batch4_sync_test.go"), []byte(cliTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "test", "./internal/store", "-run", "TestCurrencyCodeSuffixExtractsResourceID", "-count=1")
-	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "Test(SyncExtractIDSuffixFallbackIsGuarded|ExtractPageItemsDRFTopLevelNextURL|ExtractPageItemsDRFTopLevelRelativeNextURL|ExtractPageItemsBareTokenCursorUnaffected|SyncResourceNonJSONBodyEmitsAnomaly|SyncResourceValidEmptyJSONDoesNotEmitNonJSONAnomaly|SyncResourceZeroStoredIsIntegrityFailure|SyncResourceDeclaredFailure|SyncDependentResourceNonJSONBodyEmitsAnomaly|SyncDependentResourceDeclaredFailure)", "-count=1")
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "Test(SyncExtractIDSuffixFallbackIsGuarded|ExtractPageItemsDRFTopLevelNextURL|ExtractPageItemsDRFTopLevelRelativeNextURL|ExtractPageItemsBareTokenCursorUnaffected|SyncResourceNonJSONBodyEmitsAnomaly|SyncResourceValidEmptyJSONDoesNotEmitNonJSONAnomaly|SyncResourceZeroStoredIsIntegrityFailure|SyncResourceDeclaredFailure|SyncDependentResourceNonJSONBodyEmitsAnomaly|SyncDependentResourceDeclaredFailure|SyncResourceOkFalseEnvelope|SyncResourcePascalOkFalse|SyncResourceOkTrueEnvelopeStoresItems|SyncResourceWithoutOkFieldStillStores|SyncDependentResourceOkFalseEnvelope)", "-count=1")
 }

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -2193,7 +2193,9 @@ func responseDeclaresFailure(data json.RawMessage) bool {
 }
 
 func envelopeReportsFailure(envelope map[string]json.RawMessage) bool {
-	for _, key := range []string{"success", "Success"} {
+	// JSend uses success; Slack-style RPC uses ok. Both declare failure
+	// in-band on HTTP 200, so a false value must not reach upsert.
+	for _, key := range []string{"success", "Success", "ok", "Ok"} {
 		if raw, ok := envelope[key]; ok {
 			var success bool
 			if json.Unmarshal(raw, &success) == nil {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -1411,7 +1411,9 @@ func responseDeclaresFailure(data json.RawMessage) bool {
 }
 
 func envelopeReportsFailure(envelope map[string]json.RawMessage) bool {
-	for _, key := range []string{"success", "Success"} {
+	// JSend uses success; Slack-style RPC uses ok. Both declare failure
+	// in-band on HTTP 200, so a false value must not reach upsert.
+	for _, key := range []string{"success", "Success", "ok", "Ok"} {
 		if raw, ok := envelope[key]; ok {
 			var success bool
 			if json.Unmarshal(raw, &success) == nil {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -1414,7 +1414,9 @@ func responseDeclaresFailure(data json.RawMessage) bool {
 }
 
 func envelopeReportsFailure(envelope map[string]json.RawMessage) bool {
-	for _, key := range []string{"success", "Success"} {
+	// JSend uses success; Slack-style RPC uses ok. Both declare failure
+	// in-band on HTTP 200, so a false value must not reach upsert.
+	for _, key := range []string{"success", "Success", "ok", "Ok"} {
 		if raw, ok := envelope[key]; ok {
 			var success bool
 			if json.Unmarshal(raw, &success) == nil {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -1391,7 +1391,9 @@ func responseDeclaresFailure(data json.RawMessage) bool {
 }
 
 func envelopeReportsFailure(envelope map[string]json.RawMessage) bool {
-	for _, key := range []string{"success", "Success"} {
+	// JSend uses success; Slack-style RPC uses ok. Both declare failure
+	// in-band on HTTP 200, so a false value must not reach upsert.
+	for _, key := range []string{"success", "Success", "ok", "Ok"} {
 		if raw, ok := envelope[key]; ok {
 			var success bool
 			if json.Unmarshal(raw, &success) == nil {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -1362,7 +1362,9 @@ func responseDeclaresFailure(data json.RawMessage) bool {
 }
 
 func envelopeReportsFailure(envelope map[string]json.RawMessage) bool {
-	for _, key := range []string{"success", "Success"} {
+	// JSend uses success; Slack-style RPC uses ok. Both declare failure
+	// in-band on HTTP 200, so a false value must not reach upsert.
+	for _, key := range []string{"success", "Success", "ok", "Ok"} {
 		if raw, ok := envelope[key]; ok {
 			var success bool
 			if json.Unmarshal(raw, &success) == nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Closes #3956.

Slack-style RPC APIs return `{"ok":false,"error":"not_authed"}` with HTTP 200. Generated sync already treated JSend `success:false` and `status:error|fail|failed` as integrity failures before upsert, but it ignored boolean `ok`/`Ok`. Those 200-with-error bodies were stored as data and sync reported success against a corrupt local mirror.

## Approach

Extend the existing `envelopeReportsFailure` helper to treat top-level boolean `ok`/`Ok` the same way as `success`/`Success`. The check already sits on both the top-level resource path and the dependent walker path, before `upsertSingleObject` and before batch upsert, so `ok:false` never reaches the store.

No new spec-level `error_envelope` surface. No GraphQL `errors[]` or JSON-RPC `error` object auto-detection.

## Scope

Primary area: generated sync envelope failure detection (`internal/generator/templates/sync.go.tmpl`).

Why this belongs in this repo: this is a machine change so every future printed CLI rejects Slack-style HTTP 200 error envelopes instead of corrupting the SQLite mirror.

## Risk

Generated `sync.go` goldens change in the four cases that snapshot `envelopeReportsFailure`. Specs without a top-level `ok` field behave as today. A legitimate top-level boolean `ok:false` on a single-object resource is now treated as a declared failure, matching the existing `success:false` contract.

## Output Contract

- Template change in `envelopeReportsFailure`.
- Golden fixtures updated for `generate-golden-api`, `generate-query-endpoint-api`, `generate-sync-walker-api`, and `generate-tier-routing-api`.
- Generated-CLI tests in `TestGeneratedSyncStoreBatch4TemplateFixes` prove a 200 `{"ok":false,...}` body is not upserted and is counted as an integrity failure, and that `{"ok":true,...}` with real items still stores.

## Verification

- [x] `go test ./internal/generator -run 'TestGeneratedSyncStoreBatch4TemplateFixes|TestGeneratedSyncHandlesPascalCaseDotNetShape' -count=1`
- [x] `go test ./...` (non-generator packages passed; generator package re-run with `-timeout 30m` passed)
- [x] `GOLDEN_ALLOW_DIRTY=1 scripts/golden.sh update` (intended generate-* sync.go fixtures updated; `verify-runtime-matrix` could not normalize in this environment because fixture modules request a Go 1.24 toolchain that is not available here)
- [x] `scripts/verify-generator-output.sh generate-golden-api generate-query-endpoint-api generate-sync-walker-api generate-tier-routing-api`

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96e42f1a-39e1-45dc-89d9-cfa16a6862bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96e42f1a-39e1-45dc-89d9-cfa16a6862bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

