### PR TITLE
fix(generator): add missing Example to feedback command template

### DIFF
--- a/internal/generator/templates/feedback.go.tmpl
+++ b/internal/generator/templates/feedback.go.tmpl
@@ -108,6 +108,9 @@ POSTed as JSON after the local write.
 Write what surprised you or tripped you up, not a bug report. The
 loop is: agent notices friction -> one invocation -> captured -> the
 maintainer sees it.`,
+		Example: `  {{.Name}}-pp-cli feedback "the --since flag is inclusive but docs say exclusive"
+  {{.Name}}-pp-cli feedback --stdin < notes.txt
+  {{.Name}}-pp-cli feedback list --limit 10`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var text string
 			if useStdin {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/feedback.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/feedback.go
@@ -108,6 +108,9 @@ POSTed as JSON after the local write.
 Write what surprised you or tripped you up, not a bug report. The
 loop is: agent notices friction -> one invocation -> captured -> the
 maintainer sees it.`,
+		Example: `  printing-press-golden-pp-cli feedback "the --since flag is inclusive but docs say exclusive"
+  printing-press-golden-pp-cli feedback --stdin < notes.txt
+  printing-press-golden-pp-cli feedback list --limit 10`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var text string
 			if useStdin {


### PR DESCRIPTION
## Summary

Fixes #4242. The framework `feedback [text]` parent command template had no `Example:` field, failing `dogfood --live`'s help check on every printed CLI. The `feedback list` child command already had one — only the parent lacked it, unlike its sibling framework commands (`sync`, `doctor`, `search`), which all supply an Example.

## Change

One-line-of-context addition to `internal/generator/templates/feedback.go.tmpl`, mirroring the exact style already used by `doctor.go.tmpl` and `feedback.go.tmpl`'s own `list` child:

```go
Example: `  {{.Name}}-pp-cli feedback "the --since flag is inclusive but docs say exclusive"
  {{.Name}}-pp-cli feedback --stdin < notes.txt
  {{.Name}}-pp-cli feedback list --limit 10`,
```

## Verification

- Generated a fresh scratch test CLI with this fix applied.
- Confirmed `<cli> feedback --help` now renders a proper `Examples:` section with the `{{.Name}}` placeholder correctly substituted.
- Ran `dogfood --live` against the generated CLI: `[PASS] feedback help` (was `[FAIL] feedback help: missing Examples section` before the fix).
- `go test ./internal/generator/ -run TestFeedback` passes.

## Scope

Only the `feedback` command template's Example, per the issue's stated scope. Did not touch the dogfood help check itself (it's correct) or any other command template — including the two adjacent thin-`Short` findings noted in the issue thread (`platform_cli.go.tmpl`, `teach.go.tmpl`), which are a separate class of finding and out of scope for this fix.