### PR TITLE
fix(cli): skip JSON guard on binary response bodies

### DIFF
--- a/internal/generator/binary_json_guard_test.go
+++ b/internal/generator/binary_json_guard_test.go
@@ -141,6 +141,165 @@ func TestGeneratedBinaryAndTextReadsSkipLiveJSONGuard(t *testing.T) {
 	requireExitCode(t, err, 2)
 }
 
+func TestGeneratedPaginatedBinaryTextRejectsLiveAll(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/feeds/sitemap.xml":
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(sitemapXML))
+		case "/feeds/llms.txt":
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			_, _ = w.Write([]byte("# Docs\nUse the CLI.\n"))
+		case "/items":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"1"}]`))
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	apiSpec := minimalSpec("binary-paginated-all")
+	apiSpec.BaseURL = server.URL
+	apiSpec.Learn.Disabled = true
+	apiSpec.Resources = map[string]spec.Resource{
+		"feeds": {
+			Description: "Non-JSON feeds",
+			Endpoints: map[string]spec.Endpoint{
+				"sitemap": {
+					Method:         http.MethodGet,
+					Path:           "/feeds/sitemap.xml",
+					Description:    "Fetch the XML sitemap",
+					ResponseFormat: spec.ResponseFormatBinary,
+					Params: []spec.Param{
+						{Name: "limit", Type: "integer"},
+						{Name: "after", Type: "string"},
+					},
+					Pagination: &spec.Pagination{
+						Type:           "cursor",
+						LimitParam:     "limit",
+						CursorParam:    "after",
+						NextCursorPath: "next_cursor",
+					},
+				},
+				"robots": {
+					Method:         http.MethodGet,
+					Path:           "/feeds/robots.txt",
+					Description:    "Fetch robots.txt",
+					ResponseFormat: spec.ResponseFormatBinary,
+				},
+			},
+		},
+		"docs": {
+			Description: "Plain-text docs",
+			Endpoints: map[string]spec.Endpoint{
+				"llms": {
+					Method:         http.MethodGet,
+					Path:           "/feeds/llms.txt",
+					Description:    "Fetch llms.txt",
+					ResponseFormat: spec.ResponseFormatText,
+					Params: []spec.Param{
+						{Name: "limit", Type: "integer"},
+						{Name: "after", Type: "string"},
+					},
+					Pagination: &spec.Pagination{
+						Type:           "cursor",
+						LimitParam:     "limit",
+						CursorParam:    "after",
+						NextCursorPath: "next_cursor",
+					},
+				},
+			},
+		},
+		"items": {
+			Description: "JSON items",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      http.MethodGet,
+					Path:        "/items",
+					Description: "List items",
+					Params: []spec.Param{
+						{Name: "limit", Type: "integer"},
+						{Name: "after", Type: "string"},
+					},
+					Pagination: &spec.Pagination{
+						Type:           "cursor",
+						LimitParam:     "limit",
+						CursorParam:    "after",
+						NextCursorPath: "next_cursor",
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, Search: true, MCP: true}
+	require.NoError(t, gen.Generate())
+	requireGeneratedCompiles(t, outputDir)
+
+	feedsSrc := readGeneratedFile(t, outputDir, "internal", "cli", "feeds_sitemap.go")
+	require.Contains(t, feedsSrc, `false, liveAllRejectNonJSON, cmd.ErrOrStderr())`)
+	require.NotContains(t, feedsSrc, `liveAllRejectHTML`)
+
+	docsSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_docs.go")
+	require.Contains(t, docsSrc, `false, liveAllRejectNonJSON, cmd.ErrOrStderr())`)
+
+	itemsSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_items.go")
+	require.Contains(t, itemsSrc, `resolvePaginatedReadWithStrategy(`)
+	require.NotContains(t, itemsSrc, `liveAllRejectNonJSON`)
+
+	binaryPath := filepath.Join(outputDir, naming.CLI(apiSpec.Name))
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/"+naming.CLI(apiSpec.Name))
+
+	baseEnv := append(os.Environ(),
+		"HOME="+t.TempDir(),
+		"MYAPI_TOKEN=test-token",
+		strings.ToUpper(strings.ReplaceAll(apiSpec.Name, "-", "_"))+"_BASE_URL="+server.URL,
+	)
+
+	sitemapOut, err := runGeneratedCLI(t, binaryPath, baseEnv, "feeds", "sitemap")
+	require.NoError(t, err, sitemapOut)
+	require.Contains(t, sitemapOut, `<urlset`)
+	require.NotContains(t, sitemapOut, "[]")
+
+	allOut, err := runGeneratedCLI(t, binaryPath, baseEnv, "feeds", "sitemap", "--all")
+	require.Error(t, err, allOut)
+	require.Contains(t, allOut, "--all is not supported for live binary/text responses")
+	require.NotContains(t, allOut, "--all is not supported for live HTML responses")
+	require.NotContains(t, allOut, `"results":[]`)
+
+	docsAllOut, err := runGeneratedCLI(t, binaryPath, baseEnv, "docs", "--all")
+	require.Error(t, err, docsAllOut)
+	require.Contains(t, docsAllOut, "--all is not supported for live binary/text responses")
+	require.NotContains(t, docsAllOut, "--all is not supported for live HTML responses")
+
+	localAllOut, err := runGeneratedCLI(t, binaryPath, baseEnv, "feeds", "sitemap", "--all", "--data-source", "local")
+	require.Error(t, err, localAllOut)
+	require.NotContains(t, localAllOut, "--all is not supported for live binary/text responses")
+	require.Contains(t, localAllOut, "no local data")
+
+	itemsOut, err := runGeneratedCLI(t, binaryPath, baseEnv, "items", "--json", "--all")
+	require.NoError(t, err, itemsOut)
+	require.Contains(t, itemsOut, `"id": "1"`)
+
+	storelessSpec := *apiSpec
+	storelessSpec.Learn.Disabled = true
+	storelessDir := filepath.Join(t.TempDir(), naming.CLI(storelessSpec.Name))
+	storelessGen := New(&storelessSpec, storelessDir)
+	storelessGen.VisionSet = VisionTemplateSet{MCP: true}
+	require.NoError(t, storelessGen.Generate())
+	requireGeneratedCompiles(t, storelessDir)
+	storelessBinary := filepath.Join(storelessDir, naming.CLI(storelessSpec.Name))
+	runGoCommand(t, storelessDir, "build", "-o", storelessBinary, "./cmd/"+naming.CLI(storelessSpec.Name))
+
+	storelessAll, err := runGeneratedCLI(t, storelessBinary, baseEnv, "feeds", "sitemap", "--all")
+	require.Error(t, err, storelessAll)
+	require.Contains(t, storelessAll, "--all is not supported for live binary/text responses")
+	require.NotContains(t, storelessAll, "--all is not supported for live HTML responses")
+}
+
 func runGeneratedCLI(t *testing.T, binaryPath string, env []string, args ...string) (string, error) {
 	t.Helper()
 	cmd := exec.Command(binaryPath, args...)

--- a/internal/generator/binary_json_guard_test.go
+++ b/internal/generator/binary_json_guard_test.go
@@ -1,0 +1,157 @@
+package generator
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+const sitemapXML = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/</loc></url>
+</urlset>
+`
+
+func TestGeneratedBinaryAndTextReadsSkipLiveJSONGuard(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/sitemap.xml":
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(sitemapXML))
+		case "/llms.txt":
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			_, _ = w.Write([]byte("# Docs\nUse the CLI.\n"))
+		case "/items":
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = w.Write([]byte(`<html><body><form>login</form></body></html>`))
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	apiSpec := minimalSpec("binary-json-guard")
+	apiSpec.BaseURL = server.URL
+	apiSpec.Learn.Disabled = true
+	apiSpec.Resources = map[string]spec.Resource{
+		"page": {
+			Description: "Site pages",
+			Endpoints: map[string]spec.Endpoint{
+				"index": {
+					Method:         http.MethodGet,
+					Path:           "/sitemap.xml",
+					Description:    "Fetch the XML sitemap",
+					ResponseFormat: spec.ResponseFormatBinary,
+				},
+				"robots": {
+					Method:         http.MethodGet,
+					Path:           "/robots.txt",
+					Description:    "Fetch robots.txt",
+					ResponseFormat: spec.ResponseFormatBinary,
+				},
+			},
+		},
+		"docs": {
+			Description: "Plain-text docs",
+			Endpoints: map[string]spec.Endpoint{
+				"llms": {
+					Method:         http.MethodGet,
+					Path:           "/llms.txt",
+					Description:    "Fetch llms.txt",
+					ResponseFormat: spec.ResponseFormatText,
+				},
+			},
+		},
+		"items": {
+			Description: "JSON items",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      http.MethodGet,
+					Path:        "/items",
+					Description: "List items",
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, Search: true, MCP: true}
+	require.NoError(t, gen.Generate())
+	requireGeneratedCompiles(t, outputDir)
+
+	pageIndexSrc := readGeneratedFile(t, outputDir, "internal", "cli", "page_index.go")
+	require.Contains(t, pageIndexSrc, `resolveReadWithStrategyResponsePathAndJSONGuard(`,
+		"store-backed binary reads must use the JSON-guard variant")
+	require.Contains(t, pageIndexSrc, `false, cmd.ErrOrStderr())`,
+		"binary reads must pass guardLiveJSON=false")
+	require.NotContains(t, pageIndexSrc, `resolveReadWithStrategyAndResponsePath(`,
+		"binary reads must not use the wrapper that hardcodes guardLiveJSON=true")
+	require.Contains(t, pageIndexSrc, `"pp:typed-exit-codes": "0,1"`,
+		"binary commands that refuse --json must declare the designed exit")
+
+	docsSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_docs.go")
+	require.Contains(t, docsSrc, `resolveReadWithStrategyResponsePathAndJSONGuard(`,
+		"store-backed text reads must use the JSON-guard variant")
+	require.Contains(t, docsSrc, `false, cmd.ErrOrStderr())`,
+		"text reads must pass guardLiveJSON=false")
+
+	itemsSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_items.go")
+	require.Contains(t, itemsSrc, `resolveReadWithStrategyAndResponsePath(`,
+		"ordinary JSON reads must keep the default live JSON guard")
+	require.NotContains(t, itemsSrc, `resolveReadWithStrategyResponsePathAndJSONGuard(`,
+		"ordinary JSON reads must not skip the live JSON guard")
+
+	binaryPath := filepath.Join(outputDir, naming.CLI(apiSpec.Name))
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/"+naming.CLI(apiSpec.Name))
+
+	baseEnv := append(os.Environ(),
+		"HOME="+t.TempDir(),
+		"MYAPI_TOKEN=test-token",
+		strings.ToUpper(strings.ReplaceAll(apiSpec.Name, "-", "_"))+"_BASE_URL="+server.URL,
+	)
+
+	sitemapOut, err := runGeneratedCLI(t, binaryPath, baseEnv, "page", "index")
+	require.NoError(t, err, sitemapOut)
+	require.Contains(t, sitemapOut, `<urlset`)
+	require.NotContains(t, sitemapOut, "returned HTML instead of JSON")
+
+	docsOut, err := runGeneratedCLI(t, binaryPath, baseEnv, "docs")
+	require.NoError(t, err, docsOut)
+	require.Contains(t, docsOut, "# Docs")
+	require.NotContains(t, docsOut, "returned HTML instead of JSON")
+
+	itemsOut, err := runGeneratedCLI(t, binaryPath, baseEnv, "items", "--json")
+	require.Error(t, err, itemsOut)
+	require.Contains(t, itemsOut, "returned HTML instead of JSON")
+	requireExitCode(t, err, 4)
+
+	jsonOut, err := runGeneratedCLI(t, binaryPath, baseEnv, "page", "index", "--json")
+	require.Error(t, err, jsonOut)
+	require.Contains(t, jsonOut, "binary response cannot be rendered as structured output")
+	require.NotContains(t, jsonOut, "returned HTML instead of JSON")
+	requireExitCode(t, err, 1)
+}
+
+func runGeneratedCLI(t *testing.T, binaryPath string, env []string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(binaryPath, args...)
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func requireExitCode(t *testing.T, err error, want int) {
+	t.Helper()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, want, exitErr.ExitCode())
+}

--- a/internal/generator/binary_json_guard_test.go
+++ b/internal/generator/binary_json_guard_test.go
@@ -95,8 +95,8 @@ func TestGeneratedBinaryAndTextReadsSkipLiveJSONGuard(t *testing.T) {
 		"binary reads must pass guardLiveJSON=false")
 	require.NotContains(t, pageIndexSrc, `resolveReadWithStrategyAndResponsePath(`,
 		"binary reads must not use the wrapper that hardcodes guardLiveJSON=true")
-	require.Contains(t, pageIndexSrc, `"pp:typed-exit-codes": "0,1"`,
-		"binary commands that refuse --json must declare the designed exit")
+	require.NotContains(t, pageIndexSrc, `"pp:typed-exit-codes": "0,1"`,
+		"binary commands must not treat generic exit 1 as designed success")
 
 	docsSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_docs.go")
 	require.Contains(t, docsSrc, `resolveReadWithStrategyResponsePathAndJSONGuard(`,
@@ -138,7 +138,7 @@ func TestGeneratedBinaryAndTextReadsSkipLiveJSONGuard(t *testing.T) {
 	require.Error(t, err, jsonOut)
 	require.Contains(t, jsonOut, "binary response cannot be rendered as structured output")
 	require.NotContains(t, jsonOut, "returned HTML instead of JSON")
-	requireExitCode(t, err, 1)
+	requireExitCode(t, err, 2)
 }
 
 func runGeneratedCLI(t *testing.T, binaryPath string, env []string, args ...string) (string, error) {

--- a/internal/generator/binary_paginated_promoted_test.go
+++ b/internal/generator/binary_paginated_promoted_test.go
@@ -103,8 +103,8 @@ func TestGenerateBinaryStoreBackedPromotedThreadsHeader(t *testing.T) {
 		"store-backed binary GET must declare headerOverrides")
 	assert.Contains(t, endpointSrc, `"X-Printing-Press-Binary-Response": "true",`,
 		"store-backed binary GET must include the binary sentinel")
-	assert.Contains(t, endpointSrc, `resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "voices", false, path, params, headerOverrides, "", cmd.ErrOrStderr())`,
-		"store-backed binary GET must thread headerOverrides through the strategy-aware resolver")
+	assert.Contains(t, endpointSrc, `resolveReadWithStrategyResponsePathAndJSONGuard(cmd.Context(), c, flags, "auto", "voices", false, path, params, headerOverrides, "", false, cmd.ErrOrStderr())`,
+		"store-backed binary GET must skip the live JSON guard and thread headerOverrides")
 }
 
 func TestGenerateBinaryMCPToolsThreadHeaderOverrides(t *testing.T) {

--- a/internal/generator/binary_paginated_promoted_test.go
+++ b/internal/generator/binary_paginated_promoted_test.go
@@ -68,6 +68,10 @@ func TestGenerateBinaryPaginatedPromotedThreadsHeader(t *testing.T) {
 		"paginated binary endpoint must pass headerOverrides, not nil")
 	assert.Contains(t, endpointSrc, `}, headerOverrides, flagAll && !flags.dryRun,`,
 		"paginated binary endpoint must thread headerOverrides into paginatedGetWithResponsePath")
+	assert.Contains(t, endpointSrc, `--all is not supported for live binary/text responses`,
+		"storeless paginated binary --all must reject before JSON aggregation")
+	assert.NotContains(t, endpointSrc, `--all is not supported for live HTML responses`,
+		"storeless paginated binary --all must not reuse the HTML rejection")
 }
 
 // Regression: store-backed binary GET previously passed nil to resolveRead,
@@ -145,8 +149,10 @@ func TestGenerateBinaryStoreBackedPaginatedSkipsJSONGuard(t *testing.T) {
 	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_voices.go")
 	assert.Contains(t, endpointSrc, `resolvePaginatedReadWithStrategyAndJSONGuard(`,
 		"store-backed paginated binary reads must use the JSON-guard variant")
-	assert.Contains(t, endpointSrc, `false, false, cmd.ErrOrStderr())`,
-		"store-backed paginated binary reads must skip the JSON guard without the HTML --all rejection")
+	assert.Contains(t, endpointSrc, `false, liveAllRejectNonJSON, cmd.ErrOrStderr())`,
+		"store-backed paginated binary reads must skip the JSON guard and reject --all as binary/text")
+	assert.NotContains(t, endpointSrc, `liveAllRejectHTML`,
+		"store-backed paginated binary reads must not reuse the HTML --all rejection")
 	assert.NotContains(t, endpointSrc, `resolvePaginatedReadWithStrategy(`,
 		"store-backed paginated binary reads must not use the wrapper that hardcodes guardLiveJSON=true")
 }

--- a/internal/generator/binary_paginated_promoted_test.go
+++ b/internal/generator/binary_paginated_promoted_test.go
@@ -145,8 +145,8 @@ func TestGenerateBinaryStoreBackedPaginatedSkipsJSONGuard(t *testing.T) {
 	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_voices.go")
 	assert.Contains(t, endpointSrc, `resolvePaginatedReadWithStrategyAndJSONGuard(`,
 		"store-backed paginated binary reads must use the JSON-guard variant")
-	assert.Contains(t, endpointSrc, `false, cmd.ErrOrStderr())`,
-		"store-backed paginated binary reads must pass guardLiveJSON=false")
+	assert.Contains(t, endpointSrc, `false, false, cmd.ErrOrStderr())`,
+		"store-backed paginated binary reads must skip the JSON guard without the HTML --all rejection")
 	assert.NotContains(t, endpointSrc, `resolvePaginatedReadWithStrategy(`,
 		"store-backed paginated binary reads must not use the wrapper that hardcodes guardLiveJSON=true")
 }

--- a/internal/generator/binary_paginated_promoted_test.go
+++ b/internal/generator/binary_paginated_promoted_test.go
@@ -107,6 +107,50 @@ func TestGenerateBinaryStoreBackedPromotedThreadsHeader(t *testing.T) {
 		"store-backed binary GET must skip the live JSON guard and thread headerOverrides")
 }
 
+func TestGenerateBinaryStoreBackedPaginatedSkipsJSONGuard(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("audioapi")
+	apiSpec.Resources = map[string]spec.Resource{
+		"voices": {
+			Description: "Voices",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:         "GET",
+					Path:           "/voices",
+					Description:    "List voices",
+					ResponseFormat: spec.ResponseFormatBinary,
+					Pagination: &spec.Pagination{
+						Type:           "cursor",
+						LimitParam:     "limit",
+						CursorParam:    "after",
+						NextCursorPath: "next_cursor",
+						HasMoreField:   "has_more",
+					},
+					Params: []spec.Param{
+						{Name: "limit", Type: "integer", Description: "Page size"},
+						{Name: "after", Type: "string", Description: "Cursor"},
+					},
+				},
+			},
+		},
+	}
+	apiSpec.Learn.Disabled = true
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_voices.go")
+	assert.Contains(t, endpointSrc, `resolvePaginatedReadWithStrategyAndJSONGuard(`,
+		"store-backed paginated binary reads must use the JSON-guard variant")
+	assert.Contains(t, endpointSrc, `false, cmd.ErrOrStderr())`,
+		"store-backed paginated binary reads must pass guardLiveJSON=false")
+	assert.NotContains(t, endpointSrc, `resolvePaginatedReadWithStrategy(`,
+		"store-backed paginated binary reads must not use the wrapper that hardcodes guardLiveJSON=true")
+}
+
 func TestGenerateBinaryMCPToolsThreadHeaderOverrides(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -391,7 +391,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{printf "%q" .Endpoint.ResponsePath}}, {{if $skipLiveJSONGuard}}false, {{end}}cmd.ErrOrStderr())
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{printf "%q" .Endpoint.ResponsePath}}, {{if $skipLiveJSONGuard}}false, {{if .Endpoint.UsesHTMLResponse}}true{{else}}false{{end}}, {{end}}cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -81,7 +81,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 		// TODO: replace placeholder example values before relying on this for live dogfood.
 {{- end}}
 		Example: {{printf "%q" $example}},
-		Annotations: map[string]string{ {{- if not .APISpec.IsLocalSQLiteSource}}"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, {{end}}"pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if endpointSkipsErrorPathProbe .Endpoint}}, "pp:no-error-path-probe": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.HappyStdin}}, "pp:happy-stdin": {{printf "%q" .Endpoint.HappyStdin}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}},
+		Annotations: map[string]string{ {{- if not .APISpec.IsLocalSQLiteSource}}"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, {{end}}"pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if endpointSkipsErrorPathProbe .Endpoint}}, "pp:no-error-path-probe": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.HappyStdin}}, "pp:happy-stdin": {{printf "%q" .Endpoint.HappyStdin}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}{{if .Endpoint.UsesBinaryResponse}}, "pp:typed-exit-codes": "0,1"{{end}}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 {{- if endpointHasRequiredInput .Endpoint}}
 			// Bare invocation of a command with required input prints help
@@ -424,7 +424,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- if .HasStore}}
 {{- if .IsReadOnly}}
-{{- if eq .Endpoint.ResponseFormat "html"}}
+{{- if or .Endpoint.UsesHTMLResponse .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
 			data, prov, err := resolveReadWithStrategyResponsePathAndJSONGuard(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, false, cmd.ErrOrStderr())
 {{- else}}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, cmd.ErrOrStderr())

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -9,6 +9,7 @@
 {{- $isMutationOutput := and (not .IsReadOnly) (not (or (eq .Endpoint.Method "GET") (eq .Endpoint.Method "HEAD")))}}
 {{- $dataSourceStrategy := dataSourceStrategy .Resource .Endpoint}}
 {{- $documentedFields := compactFieldMapLiteral .Endpoint.Response.Item .Types}}
+{{- $skipLiveJSONGuard := or .Endpoint.UsesHTMLResponse .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
 
 package cli
 
@@ -81,7 +82,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 		// TODO: replace placeholder example values before relying on this for live dogfood.
 {{- end}}
 		Example: {{printf "%q" $example}},
-		Annotations: map[string]string{ {{- if not .APISpec.IsLocalSQLiteSource}}"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, {{end}}"pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if endpointSkipsErrorPathProbe .Endpoint}}, "pp:no-error-path-probe": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.HappyStdin}}, "pp:happy-stdin": {{printf "%q" .Endpoint.HappyStdin}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}{{if .Endpoint.UsesBinaryResponse}}, "pp:typed-exit-codes": "0,1"{{end}}},
+		Annotations: map[string]string{ {{- if not .APISpec.IsLocalSQLiteSource}}"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, {{end}}"pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if endpointSkipsErrorPathProbe .Endpoint}}, "pp:no-error-path-probe": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.HappyStdin}}, "pp:happy-stdin": {{printf "%q" .Endpoint.HappyStdin}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 {{- if endpointHasRequiredInput .Endpoint}}
 			// Bare invocation of a command with required input prints help
@@ -381,7 +382,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			}
 {{- end}}
 {{- if .HasStore}}
-			{{if eq .Endpoint.ResponseFormat "html"}}data, prov, err := resolvePaginatedReadWithStrategyAndJSONGuard{{else}}data, prov, err := resolvePaginatedReadWithStrategy{{end}}(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", path, map[string]string{
+			{{if $skipLiveJSONGuard}}data, prov, err := resolvePaginatedReadWithStrategyAndJSONGuard{{else}}data, prov, err := resolvePaginatedReadWithStrategy{{end}}(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", path, map[string]string{
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
@@ -390,7 +391,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{printf "%q" .Endpoint.ResponsePath}}, {{if eq .Endpoint.ResponseFormat "html"}}false, {{end}}cmd.ErrOrStderr())
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{printf "%q" .Endpoint.ResponsePath}}, {{if $skipLiveJSONGuard}}false, {{end}}cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")
@@ -424,7 +425,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- if .HasStore}}
 {{- if .IsReadOnly}}
-{{- if or .Endpoint.UsesHTMLResponse .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if $skipLiveJSONGuard}}
 			data, prov, err := resolveReadWithStrategyResponsePathAndJSONGuard(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, false, cmd.ErrOrStderr())
 {{- else}}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, cmd.ErrOrStderr())
@@ -866,7 +867,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				return nil
 			}
 			if flags.asJSON || flags.csv || flags.compact || flags.plain || flags.selectFields != "" {
-				return fmt.Errorf("binary response cannot be rendered as structured output; redirect stdout or use --deliver file:<path>")
+				return usageErr(fmt.Errorf("binary response cannot be rendered as structured output; redirect stdout or use --deliver file:<path>"))
 			}
 			_, err = cmd.OutOrStdout().Write(data)
 			return err

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -376,9 +376,13 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			}
 {{- end}}
 {{- else if $supportsAllPagination}}
-{{- if and (eq .Endpoint.ResponseFormat "html") (not .HasStore)}}
+{{- if and $skipLiveJSONGuard (not .HasStore)}}
 			if flagAll {
+{{- if .Endpoint.UsesHTMLResponse}}
 				return fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
+{{- else}}
+				return fmt.Errorf("--all is not supported for live binary/text responses; omit --all to fetch the current page")
+{{- end}}
 			}
 {{- end}}
 {{- if .HasStore}}
@@ -391,7 +395,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{printf "%q" .Endpoint.ResponsePath}}, {{if $skipLiveJSONGuard}}false, {{if .Endpoint.UsesHTMLResponse}}true{{else}}false{{end}}, {{end}}cmd.ErrOrStderr())
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{printf "%q" .Endpoint.ResponsePath}}, {{if $skipLiveJSONGuard}}false, {{if .Endpoint.UsesHTMLResponse}}liveAllRejectHTML{{else}}liveAllRejectNonJSON{{end}}, {{end}}cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -252,7 +252,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{printf "%q" .Endpoint.ResponsePath}}, {{if $skipLiveJSONGuard}}false, {{end}}cmd.ErrOrStderr())
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{printf "%q" .Endpoint.ResponsePath}}, {{if $skipLiveJSONGuard}}false, {{if .Endpoint.UsesHTMLResponse}}true{{else}}false{{end}}, {{end}}cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -237,9 +237,13 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 
 {{- if $supportsAllPagination}}
-{{- if and (eq .Endpoint.ResponseFormat "html") (not .HasStore)}}
+{{- if and $skipLiveJSONGuard (not .HasStore)}}
 			if flagAll {
+{{- if .Endpoint.UsesHTMLResponse}}
 				return fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
+{{- else}}
+				return fmt.Errorf("--all is not supported for live binary/text responses; omit --all to fetch the current page")
+{{- end}}
 			}
 {{- end}}
 {{- if .HasStore}}
@@ -252,7 +256,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{printf "%q" .Endpoint.ResponsePath}}, {{if $skipLiveJSONGuard}}false, {{if .Endpoint.UsesHTMLResponse}}true{{else}}false{{end}}, {{end}}cmd.ErrOrStderr())
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{printf "%q" .Endpoint.ResponsePath}}, {{if $skipLiveJSONGuard}}false, {{if .Endpoint.UsesHTMLResponse}}liveAllRejectHTML{{else}}liveAllRejectNonJSON{{end}}, {{end}}cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -67,7 +67,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 		// TODO: replace placeholder example values before relying on this for live dogfood.
 {{- end}}
 		Example: {{printf "%q" $example}},
-		Annotations: map[string]string{ {{- if not .APISpec.IsLocalSQLiteSource}}"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, {{end}}"pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if endpointSkipsErrorPathProbe .Endpoint}}, "pp:no-error-path-probe": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.HappyStdin}}, "pp:happy-stdin": {{printf "%q" .Endpoint.HappyStdin}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}},
+		Annotations: map[string]string{ {{- if not .APISpec.IsLocalSQLiteSource}}"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, {{end}}"pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if endpointSkipsErrorPathProbe .Endpoint}}, "pp:no-error-path-probe": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.HappyStdin}}, "pp:happy-stdin": {{printf "%q" .Endpoint.HappyStdin}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}{{if .Endpoint.UsesBinaryResponse}}, "pp:typed-exit-codes": "0,1"{{end}}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 {{- if endpointHasRequiredInput .Endpoint}}
 			// Bare invocation of a command with a required flag/body prints help
@@ -286,7 +286,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- end}}
 {{- if and .HasStore .IsReadOnly (eq (upper .Endpoint.Method) "GET")}}
-{{- if eq .Endpoint.ResponseFormat "html"}}
+{{- if or .Endpoint.UsesHTMLResponse .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
 			data, prov, err := resolveReadWithStrategyResponsePathAndJSONGuard(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, false, cmd.ErrOrStderr())
 {{- else}}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, cmd.ErrOrStderr())

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -13,6 +13,7 @@
 {{- $supportsAllPagination := and (ne .Endpoint.Pagination nil) (ne .Endpoint.Pagination.Type "id_walk") (eq $method "GET") .IsReadOnly}}
 {{- $dataSourceStrategy := dataSourceStrategy .Resource .Endpoint}}
 {{- $documentedFields := compactFieldMapLiteral .Endpoint.Response.Item .Types}}
+{{- $skipLiveJSONGuard := or .Endpoint.UsesHTMLResponse .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
 
 package cli
 
@@ -67,7 +68,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 		// TODO: replace placeholder example values before relying on this for live dogfood.
 {{- end}}
 		Example: {{printf "%q" $example}},
-		Annotations: map[string]string{ {{- if not .APISpec.IsLocalSQLiteSource}}"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, {{end}}"pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if endpointSkipsErrorPathProbe .Endpoint}}, "pp:no-error-path-probe": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.HappyStdin}}, "pp:happy-stdin": {{printf "%q" .Endpoint.HappyStdin}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}{{if .Endpoint.UsesBinaryResponse}}, "pp:typed-exit-codes": "0,1"{{end}}},
+		Annotations: map[string]string{ {{- if not .APISpec.IsLocalSQLiteSource}}"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, {{end}}"pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if endpointSkipsErrorPathProbe .Endpoint}}, "pp:no-error-path-probe": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}{{if .Endpoint.HappyStdin}}, "pp:happy-stdin": {{printf "%q" .Endpoint.HappyStdin}}{{end}}{{if .Endpoint.LiveDogfoodRequiresTier}}, "pp:requires-tier": {{printf "%q" .Endpoint.LiveDogfoodRequiresTier}}{{end}}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 {{- if endpointHasRequiredInput .Endpoint}}
 			// Bare invocation of a command with a required flag/body prints help
@@ -242,7 +243,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			}
 {{- end}}
 {{- if .HasStore}}
-			{{if eq .Endpoint.ResponseFormat "html"}}data, prov, err := resolvePaginatedReadWithStrategyAndJSONGuard{{else}}data, prov, err := resolvePaginatedReadWithStrategy{{end}}(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", path, map[string]string{
+			{{if $skipLiveJSONGuard}}data, prov, err := resolvePaginatedReadWithStrategyAndJSONGuard{{else}}data, prov, err := resolvePaginatedReadWithStrategy{{end}}(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", path, map[string]string{
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
@@ -251,7 +252,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{printf "%q" .Endpoint.ResponsePath}}, {{if eq .Endpoint.ResponseFormat "html"}}false, {{end}}cmd.ErrOrStderr())
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", {{.PageSize}}, "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", {{printf "%q" .Endpoint.ResponsePath}}, {{if $skipLiveJSONGuard}}false, {{end}}cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")
@@ -286,7 +287,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- end}}
 {{- if and .HasStore .IsReadOnly (eq (upper .Endpoint.Method) "GET")}}
-{{- if or .Endpoint.UsesHTMLResponse .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse}}
+{{- if $skipLiveJSONGuard}}
 			data, prov, err := resolveReadWithStrategyResponsePathAndJSONGuard(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, false, cmd.ErrOrStderr())
 {{- else}}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "{{if localReadSupported .Endpoint}}{{$dataSourceStrategy}}{{else}}live{{end}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse .Endpoint.UsesTextResponse (endpointHasHeaderParams .Endpoint)}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, cmd.ErrOrStderr())

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -23,6 +23,31 @@ import (
 
 const networkFallbackReason = "{{networkFallbackReason .APISpec}}"
 
+type liveAllRejectReason string
+
+const (
+	liveAllRejectNone    liveAllRejectReason = ""
+	liveAllRejectHTML    liveAllRejectReason = "html"
+	liveAllRejectNonJSON liveAllRejectReason = "non-json"
+)
+
+func liveAllUnsupportedError(reason liveAllRejectReason, allowLocalHint bool) error {
+	switch reason {
+	case liveAllRejectHTML:
+		if allowLocalHint {
+			return fmt.Errorf("--all is not supported for live HTML responses; omit --all or use --data-source local")
+		}
+		return fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
+	case liveAllRejectNonJSON:
+		if allowLocalHint {
+			return fmt.Errorf("--all is not supported for live binary/text responses; omit --all or use --data-source local")
+		}
+		return fmt.Errorf("--all is not supported for live binary/text responses; omit --all to fetch the current page")
+	default:
+		return nil
+	}
+}
+
 func unsupportedDataSourceError(strategy, requested string) error {
 	switch strategy {
 	case "local":
@@ -228,10 +253,10 @@ func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlag
 }
 
 func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
-	return resolvePaginatedReadWithStrategyAndJSONGuard(ctx, c, flags, strategy, resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath, true, false, hintWriter)
+	return resolvePaginatedReadWithStrategyAndJSONGuard(ctx, c, flags, strategy, resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath, true, liveAllRejectNone, hintWriter)
 }
 
-func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string, guardLiveJSON bool, rejectLiveAll bool, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string, guardLiveJSON bool, liveAllReject liveAllRejectReason, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
 	if err := validateDataSourceStrategy(flags, strategy); err != nil {
 		return nil, DataProvenance{}, err
 	}
@@ -243,8 +268,10 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		return data, attachFreshness(prov, flags), err
 	}
 	if strategy == "live" {
-		if rejectLiveAll && fetchAll {
-			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
+		if fetchAll {
+			if err := liveAllUnsupportedError(liveAllReject, false); err != nil {
+				return nil, DataProvenance{}, err
+			}
 		}
 		data, err := paginatedGetWithResponsePath(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath)
 		if err != nil {
@@ -266,8 +293,10 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		return data, attachFreshness(prov, flags), err
 
 	case "live":
-		if rejectLiveAll && fetchAll {
-			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
+		if fetchAll {
+			if err := liveAllUnsupportedError(liveAllReject, false); err != nil {
+				return nil, DataProvenance{}, err
+			}
 		}
 		data, err := paginatedGetWithResponsePath(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath)
 		if err != nil {
@@ -284,8 +313,10 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 
 	default: // "auto"
-		if rejectLiveAll && fetchAll {
-			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all or use --data-source local")
+		if fetchAll {
+			if err := liveAllUnsupportedError(liveAllReject, true); err != nil {
+				return nil, DataProvenance{}, err
+			}
 		}
 		data, err := paginatedGetWithResponsePath(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath)
 		if err == nil {

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -228,10 +228,10 @@ func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlag
 }
 
 func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
-	return resolvePaginatedReadWithStrategyAndJSONGuard(ctx, c, flags, strategy, resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath, true, hintWriter)
+	return resolvePaginatedReadWithStrategyAndJSONGuard(ctx, c, flags, strategy, resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath, true, false, hintWriter)
 }
 
-func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string, guardLiveJSON bool, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string, guardLiveJSON bool, rejectLiveAll bool, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
 	if err := validateDataSourceStrategy(flags, strategy); err != nil {
 		return nil, DataProvenance{}, err
 	}
@@ -243,7 +243,7 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		return data, attachFreshness(prov, flags), err
 	}
 	if strategy == "live" {
-		if !guardLiveJSON && fetchAll {
+		if rejectLiveAll && fetchAll {
 			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
 		}
 		data, err := paginatedGetWithResponsePath(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath)
@@ -266,7 +266,7 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		return data, attachFreshness(prov, flags), err
 
 	case "live":
-		if !guardLiveJSON && fetchAll {
+		if rejectLiveAll && fetchAll {
 			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
 		}
 		data, err := paginatedGetWithResponsePath(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath)
@@ -284,7 +284,7 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 
 	default: // "auto"
-		if !guardLiveJSON && fetchAll {
+		if rejectLiveAll && fetchAll {
 			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all or use --data-source local")
 		}
 		data, err := paginatedGetWithResponsePath(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -228,10 +228,10 @@ func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlag
 }
 
 func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
-	return resolvePaginatedReadWithStrategyAndJSONGuard(ctx, c, flags, strategy, resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath, true, hintWriter)
+	return resolvePaginatedReadWithStrategyAndJSONGuard(ctx, c, flags, strategy, resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath, true, false, hintWriter)
 }
 
-func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string, guardLiveJSON bool, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string, guardLiveJSON bool, rejectLiveAll bool, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
 	if err := validateDataSourceStrategy(flags, strategy); err != nil {
 		return nil, DataProvenance{}, err
 	}
@@ -243,7 +243,7 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		return data, attachFreshness(prov, flags), err
 	}
 	if strategy == "live" {
-		if !guardLiveJSON && fetchAll {
+		if rejectLiveAll && fetchAll {
 			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
 		}
 		data, err := paginatedGetWithResponsePath(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath)
@@ -266,7 +266,7 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		return data, attachFreshness(prov, flags), err
 
 	case "live":
-		if !guardLiveJSON && fetchAll {
+		if rejectLiveAll && fetchAll {
 			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
 		}
 		data, err := paginatedGetWithResponsePath(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath)
@@ -284,7 +284,7 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 
 	default: // "auto"
-		if !guardLiveJSON && fetchAll {
+		if rejectLiveAll && fetchAll {
 			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all or use --data-source local")
 		}
 		data, err := paginatedGetWithResponsePath(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -23,6 +23,31 @@ import (
 
 const networkFallbackReason = "api_unreachable"
 
+type liveAllRejectReason string
+
+const (
+	liveAllRejectNone    liveAllRejectReason = ""
+	liveAllRejectHTML    liveAllRejectReason = "html"
+	liveAllRejectNonJSON liveAllRejectReason = "non-json"
+)
+
+func liveAllUnsupportedError(reason liveAllRejectReason, allowLocalHint bool) error {
+	switch reason {
+	case liveAllRejectHTML:
+		if allowLocalHint {
+			return fmt.Errorf("--all is not supported for live HTML responses; omit --all or use --data-source local")
+		}
+		return fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
+	case liveAllRejectNonJSON:
+		if allowLocalHint {
+			return fmt.Errorf("--all is not supported for live binary/text responses; omit --all or use --data-source local")
+		}
+		return fmt.Errorf("--all is not supported for live binary/text responses; omit --all to fetch the current page")
+	default:
+		return nil
+	}
+}
+
 func unsupportedDataSourceError(strategy, requested string) error {
 	switch strategy {
 	case "local":
@@ -228,10 +253,10 @@ func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlag
 }
 
 func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
-	return resolvePaginatedReadWithStrategyAndJSONGuard(ctx, c, flags, strategy, resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath, true, false, hintWriter)
+	return resolvePaginatedReadWithStrategyAndJSONGuard(ctx, c, flags, strategy, resourceType, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath, true, liveAllRejectNone, hintWriter)
 }
 
-func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string, guardLiveJSON bool, rejectLiveAll bool, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, paginationType, limitParam string, defaultPageSize int, nextCursorPath, hasMoreField, responsePath string, guardLiveJSON bool, liveAllReject liveAllRejectReason, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
 	if err := validateDataSourceStrategy(flags, strategy); err != nil {
 		return nil, DataProvenance{}, err
 	}
@@ -243,8 +268,10 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		return data, attachFreshness(prov, flags), err
 	}
 	if strategy == "live" {
-		if rejectLiveAll && fetchAll {
-			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
+		if fetchAll {
+			if err := liveAllUnsupportedError(liveAllReject, false); err != nil {
+				return nil, DataProvenance{}, err
+			}
 		}
 		data, err := paginatedGetWithResponsePath(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath)
 		if err != nil {
@@ -266,8 +293,10 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		return data, attachFreshness(prov, flags), err
 
 	case "live":
-		if rejectLiveAll && fetchAll {
-			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all to extract the current page")
+		if fetchAll {
+			if err := liveAllUnsupportedError(liveAllReject, false); err != nil {
+				return nil, DataProvenance{}, err
+			}
 		}
 		data, err := paginatedGetWithResponsePath(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath)
 		if err != nil {
@@ -284,8 +313,10 @@ func resolvePaginatedReadWithStrategyAndJSONGuard(ctx context.Context, c *client
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 
 	default: // "auto"
-		if rejectLiveAll && fetchAll {
-			return nil, DataProvenance{}, fmt.Errorf("--all is not supported for live HTML responses; omit --all or use --data-source local")
+		if fetchAll {
+			if err := liveAllUnsupportedError(liveAllReject, true); err != nil {
+				return nil, DataProvenance{}, err
+			}
 		}
 		data, err := paginatedGetWithResponsePath(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, defaultPageSize, nextCursorPath, hasMoreField, responsePath)
 		if err == nil {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
@@ -21,7 +21,7 @@ func newReportsExportReportYearCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Download the annual report as a binary file",
 		// TODO: replace placeholder example values before relying on this for live dogfood.
 		Example:     "  printing-press-golden-pp-cli reports export report-year --x-api-version example-value --year 42",
-		Annotations: map[string]string{"pp:endpoint": "export.report-year", "pp:method": "GET", "pp:path": "/reports/{year}/export", "mcp:read-only": "true", "pp:typed-exit-codes": "0,1"},
+		Annotations: map[string]string{"pp:endpoint": "export.report-year", "pp:method": "GET", "pp:path": "/reports/{year}/export", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Bare invocation of a command with required input prints help
 			// instead of pflag's terse "required flag not set" error. Optional-
@@ -71,7 +71,7 @@ func newReportsExportReportYearCmd(flags *rootFlags) *cobra.Command {
 				return nil
 			}
 			if flags.asJSON || flags.csv || flags.compact || flags.plain || flags.selectFields != "" {
-				return fmt.Errorf("binary response cannot be rendered as structured output; redirect stdout or use --deliver file:<path>")
+				return usageErr(fmt.Errorf("binary response cannot be rendered as structured output; redirect stdout or use --deliver file:<path>"))
 			}
 			_, err = cmd.OutOrStdout().Write(data)
 			return err

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
@@ -21,7 +21,7 @@ func newReportsExportReportYearCmd(flags *rootFlags) *cobra.Command {
 		Short:   "Download the annual report as a binary file",
 		// TODO: replace placeholder example values before relying on this for live dogfood.
 		Example:     "  printing-press-golden-pp-cli reports export report-year --x-api-version example-value --year 42",
-		Annotations: map[string]string{"pp:endpoint": "export.report-year", "pp:method": "GET", "pp:path": "/reports/{year}/export", "mcp:read-only": "true"},
+		Annotations: map[string]string{"pp:endpoint": "export.report-year", "pp:method": "GET", "pp:path": "/reports/{year}/export", "mcp:read-only": "true", "pp:typed-exit-codes": "0,1"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Bare invocation of a command with required input prints help
 			// instead of pflag's terse "required flag not set" error. Optional-
@@ -60,7 +60,7 @@ func newReportsExportReportYearCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "live", "export", false, path, params, headerOverrides, "", cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyResponsePathAndJSONGuard(cmd.Context(), c, flags, "live", "export", false, path, params, headerOverrides, "", false, cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(cmd.OutOrStdout(), err, flags)
 			}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #4066

Store-backed `response_format: binary` and `text` reads were emitted through resolvers that hardcode `guardLiveJSON=true`. A valid XML sitemap, SVG, or CSS body was then classified as `not authenticated or session expired; API returned HTML instead of JSON` (exit 4).

Non-paginated and paginated store-backed reads now use the existing `JSONGuard=false` resolver variant already used for HTML. Ordinary JSON reads still go through `assertLiveJSONBody`.

Live `--all` is format-specific:
- HTML stays rejected with the HTML message.
- Binary/text reject `--all` with a binary/text-specific error so JSON page aggregation cannot silently return `[]`.
- Ordinary JSON `--all` still aggregates and still runs the JSON guard.

Nested binary commands that refuse `--json` return a usage error (exit 2). They do not declare `pp:typed-exit-codes: "0,1"`, so unrelated raw errors stay failures.

Generated-output proof: a store-backed XML/text fixture fetches without exit 4; a JSON endpoint given HTML still exits 4; paginated binary/text `--all` errors with the binary/text message and does not discard the body as `[]`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-645f67b7-9851-46c9-a46e-6bab63602089?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-645f67b7-9851-46c9-a46e-6bab63602089&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

