### PR TITLE
fix(cli): key response-path unwrap on resource+endpoint identity

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -6107,8 +6107,10 @@ func globalScopeEnvName(apiName string, p spec.Param) string {
 }
 
 // responsePathCase is one deduplicated entry for the sync template's
-// responsePathForResource switch: the switch key (resource + NUL + path) and
-// the response envelope path to return for it.
+// responsePathForResource switch: the switch key is the resource name (the
+// syncable endpoint wins when several share a resource) and the response
+// envelope path to return for it. The live request path is not part of the
+// key, so absolute or rewritten URLs still unwrap.
 type responsePathCase struct {
 	Key          string
 	ResponsePath string
@@ -6225,8 +6227,10 @@ func sortedResourcePathEntries(entries map[string]resourcePathEntry) []resourceP
 }
 
 // responsePathCases returns deterministic switch cases deduplicated by resource
-// and path. Syncable endpoints take precedence because the generated lookup is
-// used by sync; endpoint name breaks ties to keep output stable.
+// identity. Syncable endpoints take precedence because the generated lookup is
+// used by sync; endpoint name breaks ties to keep output stable. The request
+// path is not part of the key so unwrap still fires when the live URL differs
+// from the spec path.
 func responsePathCases(resources map[string]spec.Resource) []responsePathCase {
 	resourceNames := make([]string, 0, len(resources))
 	for name := range resources {
@@ -6255,12 +6259,11 @@ func responsePathCases(resources map[string]spec.Resource) []responsePathCase {
 			if endpoint.ResponsePath == "" {
 				continue
 			}
-			key := resourceName + "\x00" + endpoint.Path
-			if _, ok := seen[key]; ok {
+			if _, ok := seen[resourceName]; ok {
 				continue
 			}
-			seen[key] = struct{}{}
-			out = append(out, responsePathCase{Key: key, ResponsePath: endpoint.ResponsePath})
+			seen[resourceName] = struct{}{}
+			out = append(out, responsePathCase{Key: resourceName, ResponsePath: endpoint.ResponsePath})
 		}
 	}
 	return out

--- a/internal/generator/read_search_extraction_test.go
+++ b/internal/generator/read_search_extraction_test.go
@@ -93,6 +93,10 @@ func TestGeneratedSyncExtractionHonorsResponsePath(t *testing.T) {
 	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
 	require.Contains(t, syncSrc, `responsePathForResource(resource, path)`)
 	require.Contains(t, syncSrc, `extractPageItemsWithPagination(data, pageSize.cursorParam, pageSize.nextCursorPath, responsePathForResource(resource, path)...)`)
+	require.Contains(t, syncSrc, `switch resource {`)
+	require.Contains(t, syncSrc, `case "widgets":`)
+	require.NotContains(t, syncSrc, `resource + "\x00" + path`)
+	require.NotContains(t, syncSrc, `case "widgets\x00/widgets":`)
 
 	testPath := filepath.Join(outputDir, "internal", "cli", "sync_response_path_test.go")
 	require.NoError(t, os.WriteFile(testPath, []byte(`package cli

--- a/internal/generator/sync_response_path_dedup_test.go
+++ b/internal/generator/sync_response_path_dedup_test.go
@@ -82,10 +82,14 @@ func testGenerateSyncResponsePathDedup(t *testing.T, syncableName, nonSyncableNa
 	require.NoError(t, err)
 	syncContent := string(syncGo)
 
-	caseLabel := `case "roles\x00/customer/{customer}/roles":`
+	caseLabel := `case "roles":`
 	got := strings.Count(syncContent, caseLabel)
 	assert.Equal(t, 1, got,
-		"responsePathForResource must emit the shared resource+path key exactly once; got %d", got)
+		"responsePathForResource must emit the shared resource identity key exactly once; got %d", got)
+	assert.NotContains(t, syncContent, `resource + "\x00" + path`,
+		"unwrap must not key on the live request path")
+	assert.NotContains(t, syncContent, `case "roles\x00/customer/{customer}/roles":`,
+		"unwrap cases must not bake the spec request path")
 
 	assert.Contains(t, syncContent, `return []string{"items"}`,
 		"syncable endpoint should own the deduped case")

--- a/internal/generator/sync_response_path_identity_test.go
+++ b/internal/generator/sync_response_path_identity_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Anthropic, PBC. Licensed under Apache-2.0.
+
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResponsePathCasesKeyOnResourceIdentity(t *testing.T) {
+	t.Parallel()
+
+	cases := responsePathCases(map[string]spec.Resource{
+		"zenodo": {
+			Description: "Records",
+			Endpoints: map[string]spec.Endpoint{
+				"search": {
+					Method:       "GET",
+					Path:         "/api/records",
+					Syncable:     true,
+					ResponsePath: "hits.hits",
+					Response:     spec.ResponseDef{Type: "array"},
+				},
+				"get": {
+					Method:       "GET",
+					Path:         "/api/records/{id}",
+					ResponsePath: "metadata",
+					Response:     spec.ResponseDef{Type: "object"},
+				},
+			},
+		},
+	})
+
+	require.Equal(t, []responsePathCase{{
+		Key:          "zenodo",
+		ResponsePath: "hits.hits",
+	}}, cases)
+}
+
+func TestGeneratedSyncUnwrapsWhenRequestPathDiffersFromSpec(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("path-identity")
+	apiSpec.Resources = map[string]spec.Resource{
+		"records": {
+			Description: "Records",
+			Endpoints: map[string]spec.Endpoint{
+				"search": {
+					Method:       "GET",
+					Path:         "/api/records",
+					Description:  "Search records",
+					Syncable:     true,
+					Response:     spec.ResponseDef{Type: "array", Item: "Record"},
+					ResponsePath: "hits.hits",
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Record": {Fields: []spec.TypeField{
+			{Name: "id", Type: "string"},
+			{Name: "title", Type: "string"},
+		}},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	require.Contains(t, syncSrc, `switch resource {`)
+	require.Contains(t, syncSrc, `case "records":`)
+	require.Contains(t, syncSrc, `return []string{"hits.hits"}`)
+	require.NotContains(t, syncSrc, `resource + "\x00" + path`)
+	require.NotContains(t, syncSrc, `case "records\x00/api/records":`)
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "sync_response_path_identity_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"`+naming.CLI(apiSpec.Name)+`/internal/store"
+)
+
+type fakeIdentityClient struct {
+	responses map[string]json.RawMessage
+	calls     []string
+}
+
+func (f *fakeIdentityClient) Get(_ context.Context, path string, _ map[string]string) (json.RawMessage, error) {
+	f.calls = append(f.calls, path)
+	if response, ok := f.responses[path]; ok {
+		return response, nil
+	}
+	return json.RawMessage(`+"`"+`null`+"`"+`), nil
+}
+
+func (f *fakeIdentityClient) RateLimit() float64 { return 0 }
+
+func openIdentityTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("close store: %v", err)
+		}
+	})
+	return db
+}
+
+func TestResponsePathForResourceIgnoresLiveRequestPath(t *testing.T) {
+	for _, path := range []string{
+		"https://records.example.test/api/records",
+		"/api/records/",
+		"/proxy/v2/api/records",
+		"/parents/p1/records",
+		"",
+	} {
+		got := responsePathForResource("records", path)
+		if len(got) != 1 || got[0] != "hits.hits" {
+			t.Fatalf("responsePathForResource(%q) = %#v, want [hits.hits]", path, got)
+		}
+	}
+}
+
+func TestExtractUnwrapsWhenRequestPathIsNotSpecPath(t *testing.T) {
+	body := json.RawMessage(`+"`"+`{"hits":{"hits":[{"id":"r1","title":"one"},{"id":"r2","title":"two"}]}}`+"`"+`)
+	path := "https://records.example.test/api/records"
+	items, _, _ := extractPageItemsWithPagination(body, "", "", responsePathForResource("records", path)...)
+	if len(items) != 2 {
+		t.Fatalf("absolute-path unwrap got %d items, want 2", len(items))
+	}
+}
+
+func TestSyncResourceStoresNestedEnvelope(t *testing.T) {
+	db := openIdentityTestStore(t)
+	body := json.RawMessage(`+"`"+`{"hits":{"hits":[{"id":"r1","title":"one"},{"id":"r2","title":"two"}]}}`+"`"+`)
+	client := &fakeIdentityClient{responses: map[string]json.RawMessage{
+		"/api/records": body,
+	}}
+	var events bytes.Buffer
+
+	res := syncResource(context.Background(), client, db, "records", "", true, 0, false, false, nil, &events)
+	if res.Err != nil {
+		t.Fatalf("syncResource error: %v\nevents: %s", res.Err, events.String())
+	}
+	if res.Count != 2 {
+		t.Fatalf("syncResource count = %d, want 2; events: %s", res.Count, events.String())
+	}
+	stored, err := db.Count("records")
+	if err != nil {
+		t.Fatalf("count store: %v", err)
+	}
+	if stored != 2 {
+		t.Fatalf("store count = %d, want 2", stored)
+	}
+}
+`), 0o644))
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "Test(ResponsePathForResourceIgnoresLiveRequestPath|ExtractUnwrapsWhenRequestPathIsNotSpecPath|SyncResourceStoresNestedEnvelope)", "-count=1")
+}
+
+func TestResponsePathCasesPrefersSyncableAcrossDifferentPaths(t *testing.T) {
+	t.Parallel()
+
+	cases := responsePathCases(map[string]spec.Resource{
+		"photos": {
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:       "GET",
+					Path:         "/photos",
+					Syncable:     true,
+					ResponsePath: "catalog.items",
+				},
+				"search": {
+					Method:       "GET",
+					Path:         "/photos/search",
+					ResponsePath: "photos",
+				},
+			},
+		},
+	})
+
+	assert.Equal(t, []responsePathCase{{
+		Key:          "photos",
+		ResponsePath: "catalog.items",
+	}}, cases)
+}

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -4176,14 +4176,17 @@ var pageItemKeys = []string{
 var dataEnvelopeKeys = []string{"data", "Data", "result", "Result"}
 
 func responsePathForResource(resource, path string) []string {
-	switch resource + "\x00" + path {
+	// path is the live request URL and is not the unwrap key. Envelope
+	// lookup is keyed on resource identity so absolute, proxied, or
+	// otherwise rewritten paths still unwrap.
+	switch resource {
 {{- range responsePathCases .Resources}}
 	case {{printf "%q" .Key}}:
 		return []string{ {{printf "%q" .ResponsePath}} }
 {{- end}}
 	}
 {{- if and .QuerySync .QuerySync.EnvelopeKey}}
-	if _, ok := queryEntity[resource]; ok && path == queryPath {
+	if _, ok := queryEntity[resource]; ok {
 		return []string{ {{printf "%q" .QuerySync.EnvelopeKey}} }
 	}
 {{- end}}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -2975,7 +2975,10 @@ var pageItemKeys = []string{
 var dataEnvelopeKeys = []string{"data", "Data", "result", "Result"}
 
 func responsePathForResource(resource, path string) []string {
-	switch resource + "\x00" + path {
+	// path is the live request URL and is not the unwrap key. Envelope
+	// lookup is keyed on resource identity so absolute, proxied, or
+	// otherwise rewritten paths still unwrap.
+	switch resource {
 	}
 	return nil
 }

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -2223,13 +2223,16 @@ var pageItemKeys = []string{
 var dataEnvelopeKeys = []string{"data", "Data", "result", "Result"}
 
 func responsePathForResource(resource, path string) []string {
-	switch resource + "\x00" + path {
-	case "gadgets\x00/query":
+	// path is the live request URL and is not the unwrap key. Envelope
+	// lookup is keyed on resource identity so absolute, proxied, or
+	// otherwise rewritten paths still unwrap.
+	switch resource {
+	case "gadgets":
 		return []string{"QueryResponse.Gadget"}
-	case "widgets\x00/query":
+	case "widgets":
 		return []string{"QueryResponse.Widget"}
 	}
-	if _, ok := queryEntity[resource]; ok && path == queryPath {
+	if _, ok := queryEntity[resource]; ok {
 		return []string{"QueryResponse"}
 	}
 	return nil

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -2947,7 +2947,10 @@ var pageItemKeys = []string{
 var dataEnvelopeKeys = []string{"data", "Data", "result", "Result"}
 
 func responsePathForResource(resource, path string) []string {
-	switch resource + "\x00" + path {
+	// path is the live request URL and is not the unwrap key. Envelope
+	// lookup is keyed on resource identity so absolute, proxied, or
+	// otherwise rewritten paths still unwrap.
+	switch resource {
 	}
 	return nil
 }

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -2155,7 +2155,10 @@ var pageItemKeys = []string{
 var dataEnvelopeKeys = []string{"data", "Data", "result", "Result"}
 
 func responsePathForResource(resource, path string) []string {
-	switch resource + "\x00" + path {
+	// path is the live request URL and is not the unwrap key. Envelope
+	// lookup is keyed on resource identity so absolute, proxied, or
+	// otherwise rewritten paths still unwrap.
+	switch resource {
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Closes #3537.

Generated sync keyed envelope unwrap on `resource + NUL + spec path`. When the live request path differed from that baked string (absolute per-host URLs, proxy/env prefix, trailing slash, dependent path fill), the switch missed. Nested envelopes like `hits.hits` never unwrapped, sync reported missing ids, stored nothing, and exited 0.

## Approach

Key unwrap on resource identity instead of the live request path. Sync already binds one endpoint per resource (syncable wins, same identity space as `pp:endpoint`); the request URL is no longer part of the lookup. Query-sync envelope fallback follows the same rule and no longer compares `path == queryPath`.

Does not implement #2966. This only stops unwrap from depending on the request path string matching the spec path.

## Scope

Primary area: generator / generated sync.

Why this belongs in this repo: every printed CLI inherits `responsePathForResource` from the sync template. A printed-CLI patch would not generalize.

## Risk

Generated `responsePathForResource` switch keys change from `resource\\x00<path>` to the resource name. Call-site signatures stay `(resource, path)` so existing extract plumbing is unchanged. Two endpoints on one resource still collapse to the syncable ResponsePath (same as before when they shared a path).

## Output Contract

- Emitted switch is `switch resource` with resource-name cases.
- Query-endpoint golden cases: `gadgets` / `widgets` (was `gadgets\\x00/query` / `widgets\\x00/query`).
- Empty-switch goldens only change the switch expression.
- Generated-output proof: `TestGeneratedSyncUnwrapsWhenRequestPathDiffersFromSpec` compiles a CLI whose spec path is `/api/records` and still unwraps `hits.hits` when the live path is an absolute URL (and stores both records through `syncResource`).

## Verification

- [x] `go test ./... -timeout 30m`
- [x] `GOLDEN_ALLOW_DIRTY=1 bash scripts/golden.sh update` then verify: all `generate-*` cases that snapshot `sync.go` PASS. `dogfood-verdict-matrix` and `verify-runtime-matrix` fail in this environment because fixture modules require a `go 1.24` toolchain that is not downloadable here (`toolchain not available`); those fixtures are hand-written stubs, not this template, and were not updated.
- [x] `bash scripts/verify-generator-output.sh` (default cases, including `generate-query-endpoint-api`)
- [x] Generator/template change: verified generated output, including emitted-code assertions and compiled generated CLI tests
- [x] Generator/template change: covered path-mismatch and query-sync fallback, not only empty-switch goldens
- [x] Generator/template change: call sites still pass `path`; lookup no longer reads it

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c527a54-5a66-41d5-af0b-2240310a6051?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c527a54-5a66-41d5-af0b-2240310a6051&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

