### PR TITLE
fix(sync): honor per-endpoint base_url overrides

### DIFF
--- a/internal/generator/effective_request_path.go
+++ b/internal/generator/effective_request_path.go
@@ -1,0 +1,137 @@
+package generator
+
+import (
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+)
+
+type resolvedRequestEndpoint struct {
+	parent   spec.Resource
+	resource spec.Resource
+	endpoint spec.Endpoint
+	isSub    bool
+}
+
+// effectiveRequestPath returns the same host+path the generated list/get
+// command would call: endpoint BaseURL, then resource BaseURL, then the
+// original path when neither override is set.
+func effectiveRequestPath(api *spec.APISpec, resourceName, path, method string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return path
+	}
+	resolved, ok := resolveRequestEndpoint(api, resourceName, path, method)
+	if !ok {
+		return path
+	}
+	if resolved.isSub {
+		return effectiveSubEndpointPath(resolved.parent, resolved.resource, resolved.endpoint)
+	}
+	return effectiveEndpointPath(resolved.resource, resolved.endpoint)
+}
+
+func resolveRequestEndpoint(api *spec.APISpec, resourceName, path, method string) (resolvedRequestEndpoint, bool) {
+	if api == nil {
+		return resolvedRequestEndpoint{}, false
+	}
+	path = strings.TrimSpace(path)
+	method = strings.ToUpper(strings.TrimSpace(method))
+	resourceName = strings.TrimSpace(resourceName)
+	if path == "" {
+		return resolvedRequestEndpoint{}, false
+	}
+
+	var (
+		namePathMethod resolvedRequestEndpoint
+		pathMethod     resolvedRequestEndpoint
+		namePath       resolvedRequestEndpoint
+		haveNamePath   bool
+		havePathMethod bool
+		haveNameMethod bool
+	)
+
+	var walk func(parent spec.Resource, resources map[string]spec.Resource, isSub bool)
+	walk = func(parent spec.Resource, resources map[string]spec.Resource, isSub bool) {
+		names := make([]string, 0, len(resources))
+		for name := range resources {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			resource := resources[name]
+			endpointNames := make([]string, 0, len(resource.Endpoints))
+			for endpointName := range resource.Endpoints {
+				endpointNames = append(endpointNames, endpointName)
+			}
+			sort.Strings(endpointNames)
+			nameOK := resourceName == "" || name == resourceName || spec.ToSnakeCase(name) == resourceName
+			for _, endpointName := range endpointNames {
+				endpoint := resource.Endpoints[endpointName]
+				if strings.TrimSpace(endpoint.Path) != path {
+					continue
+				}
+				match := resolvedRequestEndpoint{
+					parent:   parent,
+					resource: resource,
+					endpoint: endpoint,
+					isSub:    isSub,
+				}
+				methodOK := method == "" || strings.EqualFold(strings.TrimSpace(endpoint.Method), method)
+				if nameOK && methodOK && !haveNameMethod {
+					namePathMethod = match
+					haveNameMethod = true
+				}
+				if methodOK && !havePathMethod {
+					pathMethod = match
+					havePathMethod = true
+				}
+				if nameOK && !haveNamePath {
+					namePath = match
+					haveNamePath = true
+				}
+			}
+			walk(resource, resource.SubResources, true)
+		}
+	}
+	walk(spec.Resource{}, api.Resources, false)
+
+	switch {
+	case haveNameMethod:
+		return namePathMethod, true
+	case havePathMethod:
+		return pathMethod, true
+	case haveNamePath:
+		return namePath, true
+	default:
+		return resolvedRequestEndpoint{}, false
+	}
+}
+
+func withEffectiveSyncableRequestPaths(api *spec.APISpec, resources []profiler.SyncableResource) []profiler.SyncableResource {
+	if len(resources) == 0 {
+		return resources
+	}
+	out := slices.Clone(resources)
+	for i, resource := range out {
+		out[i].Path = effectiveRequestPath(api, resource.Name, resource.Path, resource.Method)
+		if resource.HydratePath != "" {
+			out[i].HydratePath = effectiveRequestPath(api, resource.Name, resource.HydratePath, "GET")
+		}
+	}
+	return out
+}
+
+func withEffectiveDependentRequestPaths(api *spec.APISpec, resources []profiler.DependentResource) []profiler.DependentResource {
+	if len(resources) == 0 {
+		return resources
+	}
+	out := slices.Clone(resources)
+	for i, resource := range out {
+		out[i].Path = effectiveRequestPath(api, resource.Name, resource.Path, resource.Method)
+	}
+	return out
+}

--- a/internal/generator/effective_request_path.go
+++ b/internal/generator/effective_request_path.go
@@ -28,10 +28,58 @@ func effectiveRequestPath(api *spec.APISpec, resourceName, path, method string) 
 	if !ok {
 		return path
 	}
+	got := effectivePathOf(resolved)
+	if (strings.TrimSpace(resourceName) == "" || strings.TrimSpace(method) == "") &&
+		!requestOverrideIsUnambiguous(api, path, method, got) {
+		return path
+	}
+	return got
+}
+
+func effectivePathOf(resolved resolvedRequestEndpoint) string {
 	if resolved.isSub {
 		return effectiveSubEndpointPath(resolved.parent, resolved.resource, resolved.endpoint)
 	}
 	return effectiveEndpointPath(resolved.resource, resolved.endpoint)
+}
+
+func requestOverrideIsUnambiguous(api *spec.APISpec, path, method, candidate string) bool {
+	if api == nil {
+		return true
+	}
+	path = strings.TrimSpace(path)
+	method = strings.ToUpper(strings.TrimSpace(method))
+	unambiguous := true
+	var walk func(parent spec.Resource, resources map[string]spec.Resource, isSub bool)
+	walk = func(parent spec.Resource, resources map[string]spec.Resource, isSub bool) {
+		if !unambiguous {
+			return
+		}
+		names := make([]string, 0, len(resources))
+		for name := range resources {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			resource := resources[name]
+			for _, endpoint := range resource.Endpoints {
+				if strings.TrimSpace(endpoint.Path) != path {
+					continue
+				}
+				if method != "" && !strings.EqualFold(strings.TrimSpace(endpoint.Method), method) {
+					continue
+				}
+				match := resolvedRequestEndpoint{parent: parent, resource: resource, endpoint: endpoint, isSub: isSub}
+				if effectivePathOf(match) != candidate {
+					unambiguous = false
+					return
+				}
+			}
+			walk(resource, resource.SubResources, true)
+		}
+	}
+	walk(spec.Resource{}, api.Resources, false)
+	return unambiguous
 }
 
 func resolveRequestEndpoint(api *spec.APISpec, resourceName, path, method string) (resolvedRequestEndpoint, bool) {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -400,6 +400,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		},
 		"effectiveEndpointPath":        effectiveEndpointPath,
 		"effectiveSubEndpointPath":     effectiveSubEndpointPath,
+		"effectiveRequestPath":         effectiveRequestPath,
 		"enumLiteral":                  enumLiteral,
 		"enumDescriptionHint":          enumDescriptionHint,
 		"jsonStringParam":              isJSONStringParam,
@@ -4586,8 +4587,8 @@ func (g *Generator) visionRenderData(schema []TableDef) visionRenderData {
 		VisionSet:                    g.VisionSet,
 		CommandNames:                 maps.Clone(g.visionCommandNames),
 		HasSync:                      g.hasGeneratedSyncImplementation(),
-		SyncableResources:            g.profile.SyncableResources,
-		DependentSyncResources:       g.profile.DependentSyncResources,
+		SyncableResources:            withEffectiveSyncableRequestPaths(g.Spec, g.profile.SyncableResources),
+		DependentSyncResources:       withEffectiveDependentRequestPaths(g.Spec, g.profile.DependentSyncResources),
 		SyncResourcesExample:         syncResourcesExample(g.profile.SyncableResources, g.profile.DependentSyncResources),
 		TenantScopedParents:          g.profile.TenantScopedParents(),
 		MembershipScopedParents:      g.profile.MembershipScopedParents(),
@@ -4597,7 +4598,7 @@ func (g *Generator) visionRenderData(schema []TableDef) visionRenderData {
 		SearchableFields:             g.profile.SearchableFields,
 		Tables:                       schema,
 		Pagination:                   g.profile.Pagination,
-		SearchEndpointPath:           g.profile.SearchEndpointPath,
+		SearchEndpointPath:           effectiveRequestPath(g.Spec, "", g.profile.SearchEndpointPath, g.profile.SearchEndpointMethod),
 		SearchQueryParam:             g.profile.SearchQueryParam,
 		SearchEndpointMethod:         g.profile.SearchEndpointMethod,
 		SearchBodyFields:             g.profile.SearchBodyFields,
@@ -6137,6 +6138,7 @@ type resourcePathEntry struct {
 func resourceReadPathEntries(data visionRenderData) []resourcePathEntry {
 	entries := map[string]resourcePathEntry{}
 	pathCounts := map[string]int{}
+	rawPaths := map[string]string{}
 	for name, resource := range data.Resources {
 		endpoint, ok := resourceEndpointForMethod(resource, "GET")
 		if !ok {
@@ -6144,15 +6146,16 @@ func resourceReadPathEntries(data visionRenderData) []resourcePathEntry {
 		}
 		entries[name] = resourcePathEntry{
 			Name:         name,
-			Path:         endpoint.Path,
+			Path:         effectiveEndpointPath(resource, endpoint),
 			ResponsePath: endpoint.ResponsePath,
 			Pagination:   endpoint.Pagination,
 			PageSize:     resourcePathPageSize(data, endpoint),
 		}
+		rawPaths[name] = endpoint.Path
 		pathCounts[endpoint.Path]++
 	}
-	for name, entry := range entries {
-		if pathCounts[entry.Path] > 1 {
+	for name := range entries {
+		if pathCounts[rawPaths[name]] > 1 {
 			delete(entries, name)
 		}
 	}
@@ -6187,7 +6190,7 @@ func resourceWritePathEntries(data visionRenderData) []resourcePathEntry {
 		if !ok {
 			continue
 		}
-		entries[name] = resourcePathEntry{Name: name, Path: endpoint.Path}
+		entries[name] = resourcePathEntry{Name: name, Path: effectiveEndpointPath(resource, endpoint)}
 	}
 	return sortedResourcePathEntries(entries)
 }
@@ -6207,7 +6210,7 @@ func resourceDetailPathEntries(data visionRenderData) []resourcePathEntry {
 			if !strings.EqualFold(endpoint.Method, "GET") || endpoint.Response.Type == "array" || endpoint.Pagination != nil || strings.Count(endpoint.Path, "{") != 1 || strings.Count(endpoint.Path, "}") != 1 {
 				continue
 			}
-			entries[name] = resourcePathEntry{Name: name, Path: endpoint.Path}
+			entries[name] = resourcePathEntry{Name: name, Path: effectiveEndpointPath(resource, endpoint)}
 			break
 		}
 	}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -400,7 +400,6 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		},
 		"effectiveEndpointPath":        effectiveEndpointPath,
 		"effectiveSubEndpointPath":     effectiveSubEndpointPath,
-		"effectiveRequestPath":         effectiveRequestPath,
 		"enumLiteral":                  enumLiteral,
 		"enumDescriptionHint":          enumDescriptionHint,
 		"jsonStringParam":              isJSONStringParam,

--- a/internal/generator/query_endpoint_sync_test.go
+++ b/internal/generator/query_endpoint_sync_test.go
@@ -44,14 +44,16 @@ func TestGeneratedQueryEndpointSyncEmitsConstructs(t *testing.T) {
 	assert.Contains(t, syncContent, `queryPath     = "/query"`)
 
 	// Query injection: SELECT built from the hint template + injected version param.
-	assert.Contains(t, syncContent, `if entity, ok := queryEntity[resource]; ok && path == queryPath {`)
+	assert.Contains(t, syncContent, `if entity, ok := queryEntity[resource]; ok && isQuerySyncPath(resource, path) {`)
 	assert.Contains(t, syncContent, `strings.ReplaceAll("select * from {entity} startposition {start} maxresults {limit}", "{entity}", entity)`)
 	assert.Contains(t, syncContent, `params["minorversion"] = "75"`)
 
-	// Offset paging driven by page fill, and break-guard exemptions (the
-	// qbo-query-paging hand-fix asserts path != "/query" appears at least twice).
+	// Offset paging driven by page fill, and break-guard exemptions. Identity
+	// is per-resource so a shared /query path with distinct base_url overrides
+	// still injects and pages against the matching list/get host.
 	assert.Contains(t, syncContent, "nextCursor = strconv.Itoa(start + queryPageSize)")
-	assert.GreaterOrEqual(t, strings.Count(syncContent, "path != queryPath"), 2,
+	assert.Contains(t, syncContent, "func isQuerySyncPath(resource, path string) bool")
+	assert.GreaterOrEqual(t, strings.Count(syncContent, "!isQuerySyncPath(resource, path)"), 2,
 		"break guards must exempt the query path in both the pagination and short-page checks")
 
 	// Response-envelope unwrap: the entity-named envelope key is query-only,

--- a/internal/generator/sync_base_url_override_test.go
+++ b/internal/generator/sync_base_url_override_test.go
@@ -1,0 +1,286 @@
+package generator
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEffectiveRequestPathHonorsBaseURLOverrides(t *testing.T) {
+	t.Parallel()
+
+	api := &spec.APISpec{
+		BaseURL: "https://webapi.example.com",
+		Resources: map[string]spec.Resource{
+			"listings": {
+				BaseURL: "https://resource.example.com",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:  "GET",
+						Path:    "/api/v1/listings",
+						BaseURL: "https://www.example.com",
+					},
+					"get": {Method: "GET", Path: "/api/v1/listings/{id}"},
+				},
+			},
+			"users": {
+				BaseURL: "https://users.example.com",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/users"},
+				},
+			},
+			"root": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/root"},
+				},
+			},
+			"parent": {
+				SubResources: map[string]spec.Resource{
+					"children": {
+						BaseURL: "https://child.example.com",
+						Endpoints: map[string]spec.Endpoint{
+							"list": {Method: "GET", Path: "/parent/{id}/children"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		resource string
+		path     string
+		method   string
+		want     string
+	}{
+		{
+			name:     "endpoint override wins over resource",
+			resource: "listings",
+			path:     "/api/v1/listings",
+			method:   "GET",
+			want:     "https://www.example.com/api/v1/listings",
+		},
+		{
+			name:     "resource override",
+			resource: "users",
+			path:     "/users",
+			method:   "GET",
+			want:     "https://users.example.com/users",
+		},
+		{
+			name:     "single-host path stays relative",
+			resource: "root",
+			path:     "/root",
+			method:   "GET",
+			want:     "/root",
+		},
+		{
+			name:     "sub-resource override",
+			resource: "children",
+			path:     "/parent/{id}/children",
+			method:   "GET",
+			want:     "https://child.example.com/parent/{id}/children",
+		},
+		{
+			name:     "unknown path unchanged",
+			resource: "",
+			path:     "/missing",
+			method:   "GET",
+			want:     "/missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, effectiveRequestPath(api, tt.resource, tt.path, tt.method))
+		})
+	}
+}
+
+func TestWithEffectiveSyncableRequestPathsRewritesHydratePath(t *testing.T) {
+	t.Parallel()
+
+	api := &spec.APISpec{
+		BaseURL: "https://webapi.example.com",
+		Resources: map[string]spec.Resource{
+			"listings": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/listings", BaseURL: "https://www.example.com"},
+					"get":  {Method: "GET", Path: "/listings/{id}", BaseURL: "https://www.example.com"},
+				},
+			},
+		},
+	}
+	got := withEffectiveSyncableRequestPaths(api, []profiler.SyncableResource{{
+		Name:        "listings",
+		Path:        "/listings",
+		Method:      "GET",
+		HydratePath: "/listings/{id}",
+	}})
+	require.Len(t, got, 1)
+	assert.Equal(t, "https://www.example.com/listings", got[0].Path)
+	assert.Equal(t, "https://www.example.com/listings/{id}", got[0].HydratePath)
+}
+
+func TestGeneratedSyncHonorsEndpointBaseURLOverride(t *testing.T) {
+	t.Parallel()
+
+	var (
+		overrideMu    sync.Mutex
+		overridePaths []string
+	)
+	override := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		overrideMu.Lock()
+		overridePaths = append(overridePaths, r.URL.Path)
+		overrideMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"id":"1","name":"hat"}]`))
+	}))
+	t.Cleanup(override.Close)
+
+	var (
+		rootMu    sync.Mutex
+		rootPaths []string
+	)
+	root := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rootMu.Lock()
+		rootPaths = append(rootPaths, r.URL.Path)
+		rootMu.Unlock()
+		http.Error(w, "Forbidden - wrong host", http.StatusForbidden)
+	}))
+	t.Cleanup(root.Close)
+
+	apiSpec := multiHostListingsSpec("syncbaseurl", root.URL, override.URL)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	assert.Contains(t, syncSrc, `"listings": "`+override.URL+`/api/v1/listings"`,
+		"syncResourcePath must emit the list endpoint's base_url override")
+	assert.NotContains(t, syncSrc, `"listings": "/api/v1/listings"`,
+		"sync must not fall back to the root-relative list path")
+
+	listSrc := readGeneratedFile(t, outputDir, "internal", "cli", "listings_list.go")
+	assert.Contains(t, listSrc, `path := "`+override.URL+`/api/v1/listings"`,
+		"list command and sync must share the same override host")
+
+	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
+	assert.Contains(t, clientSrc, "func isAbsoluteURL(path string) bool",
+		"per-endpoint base_url must emit the absolute-URL client branch")
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	binaryPath := filepath.Join(outputDir, "syncbaseurl-pp-cli")
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/syncbaseurl-pp-cli")
+
+	listCmd := exec.Command(binaryPath, "listings", "list", "--json")
+	listCmd.Env = append(os.Environ(), "SYNCBASEURL_BASE_URL="+root.URL)
+	listOut, err := listCmd.CombinedOutput()
+	require.NoError(t, err, string(listOut))
+	var listResp any
+	require.NoError(t, json.Unmarshal(listOut, &listResp), string(listOut))
+
+	dbPath := filepath.Join(t.TempDir(), "sync.db")
+	syncCmd := exec.Command(binaryPath, "sync", "--resources", "listings", "--max-pages", "1", "--json", "--db", dbPath)
+	syncCmd.Env = append(os.Environ(), "SYNCBASEURL_BASE_URL="+root.URL)
+	syncOut, err := syncCmd.CombinedOutput()
+	require.NoError(t, err, string(syncOut))
+
+	overrideMu.Lock()
+	defer overrideMu.Unlock()
+	assert.Contains(t, overridePaths, "/api/v1/listings",
+		"list and sync should request the override host")
+	assert.GreaterOrEqual(t, countStrings(overridePaths, "/api/v1/listings"), 2,
+		"both list and sync should hit the override host")
+
+	rootMu.Lock()
+	defer rootMu.Unlock()
+	assert.NotContains(t, rootPaths, "/api/v1/listings",
+		"root base_url host must not receive the overridden list/sync request")
+}
+
+func TestGeneratedSyncKeepsRelativePathWithoutOverride(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := multiHostListingsSpec("syncsinglehost", "https://webapi.example.com", "")
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	assert.Contains(t, syncSrc, `"listings": "/api/v1/listings"`,
+		"single-host syncer should keep the root-relative path")
+	assert.NotContains(t, syncSrc, `"listings": "https://webapi.example.com/api/v1/listings"`,
+		"single-host syncer must not bake the root base_url into the path")
+}
+
+func multiHostListingsSpec(name, rootURL, overrideURL string) *spec.APISpec {
+	list := spec.Endpoint{
+		Method:      "GET",
+		Path:        "/api/v1/listings",
+		Description: "List listings",
+		Response:    spec.ResponseDef{Type: "array", Item: "Listing"},
+	}
+	if overrideURL != "" {
+		list.BaseURL = overrideURL
+	}
+	get := spec.Endpoint{
+		Method:      "GET",
+		Path:        "/api/v1/listings/{id}",
+		Description: "Get a listing",
+		Response:    spec.ResponseDef{Type: "object", Item: "Listing"},
+	}
+	if overrideURL != "" {
+		get.BaseURL = overrideURL
+	}
+	return &spec.APISpec{
+		Name:    name,
+		Version: "0.1.0",
+		BaseURL: rootURL,
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/" + name + "-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"listings": {
+				Description: "Listings",
+				Endpoints: map[string]spec.Endpoint{
+					"list": list,
+					"get":  get,
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Listing": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "string"},
+					{Name: "name", Type: "string"},
+				},
+			},
+		},
+	}
+}
+
+func countStrings(values []string, want string) int {
+	n := 0
+	for _, value := range values {
+		if value == want {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/generator/sync_base_url_override_test.go
+++ b/internal/generator/sync_base_url_override_test.go
@@ -110,6 +110,146 @@ func TestEffectiveRequestPathHonorsBaseURLOverrides(t *testing.T) {
 	}
 }
 
+func TestEffectiveRequestPathRefusesAmbiguousQueryIdentity(t *testing.T) {
+	t.Parallel()
+
+	api := &spec.APISpec{
+		BaseURL: "https://webapi.example.com",
+		Resources: map[string]spec.Resource{
+			"gadgets": {
+				BaseURL: "https://gadgets.example.com",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/query"},
+				},
+			},
+			"widgets": {
+				BaseURL: "https://widgets.example.com",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/query"},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, "/query", effectiveRequestPath(api, "", "/query", ""),
+		"empty resource+method must not pick the first sorted host")
+	assert.Equal(t, "https://widgets.example.com/query",
+		effectiveRequestPath(api, "widgets", "/query", "GET"))
+	assert.Equal(t, "https://gadgets.example.com/query",
+		effectiveRequestPath(api, "gadgets", "/query", "GET"))
+}
+
+func TestGeneratedQuerySyncHonorsPerResourceBaseURL(t *testing.T) {
+	t.Parallel()
+
+	var (
+		widgetMu    sync.Mutex
+		widgetHits  int
+		gadgetMu    sync.Mutex
+		gadgetHits  int
+		widgetQuery string
+		gadgetQuery string
+	)
+	widgets := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		widgetMu.Lock()
+		widgetHits++
+		widgetQuery = r.URL.Query().Get("query")
+		widgetMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"QueryResponse":{"Widget":[{"id":"w1","name":"w"}]}}`))
+	}))
+	t.Cleanup(widgets.Close)
+	gadgets := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gadgetMu.Lock()
+		gadgetHits++
+		gadgetQuery = r.URL.Query().Get("query")
+		gadgetMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"QueryResponse":{"Gadget":[{"id":"g1","name":"g"}]}}`))
+	}))
+	t.Cleanup(gadgets.Close)
+
+	apiSpec := &spec.APISpec{
+		Name:    "querymultihost",
+		Version: "0.1.0",
+		BaseURL: "https://webapi.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/querymultihost-pp-cli/config.toml",
+		},
+		QuerySync: &spec.QuerySyncConfig{
+			Path:          "/query",
+			QueryParam:    "query",
+			QueryTemplate: "select * from {entity} startposition {start} maxresults {limit}",
+			PageSize:      2,
+			EnvelopeKey:   "QueryResponse",
+		},
+		Resources: map[string]spec.Resource{
+			"widgets": {
+				BaseURL:     widgets.URL,
+				Description: "Widgets",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:       "GET",
+						Path:         "/query",
+						Description:  "Query widgets",
+						Response:     spec.ResponseDef{Type: "array", Item: "Widget"},
+						ResponsePath: "QueryResponse.Widget",
+					},
+				},
+			},
+			"gadgets": {
+				BaseURL:     gadgets.URL,
+				Description: "Gadgets",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:       "GET",
+						Path:         "/query",
+						Description:  "Query gadgets",
+						Response:     spec.ResponseDef{Type: "array", Item: "Gadget"},
+						ResponsePath: "QueryResponse.Gadget",
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Widget": {Fields: []spec.TypeField{{Name: "id", Type: "string"}, {Name: "name", Type: "string"}}},
+			"Gadget": {Fields: []spec.TypeField{{Name: "id", Type: "string"}, {Name: "name", Type: "string"}}},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	assert.Contains(t, syncSrc, `"widgets": "`+widgets.URL+`/query"`)
+	assert.Contains(t, syncSrc, `"gadgets": "`+gadgets.URL+`/query"`)
+	assert.Contains(t, syncSrc, `queryPath     = "/query"`)
+	assert.Contains(t, syncSrc, "func isQuerySyncPath(resource, path string) bool")
+	assert.NotContains(t, syncSrc, `effectiveRequestPath .APISpec ""`)
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	binaryPath := filepath.Join(outputDir, "querymultihost-pp-cli")
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/querymultihost-pp-cli")
+
+	for _, resource := range []string{"widgets", "gadgets"} {
+		dbPath := filepath.Join(t.TempDir(), resource+".db")
+		cmd := exec.Command(binaryPath, "sync", "--resources", resource, "--max-pages", "1", "--json", "--db", dbPath)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+
+	widgetMu.Lock()
+	defer widgetMu.Unlock()
+	gadgetMu.Lock()
+	defer gadgetMu.Unlock()
+	assert.GreaterOrEqual(t, widgetHits, 1, "widgets sync must hit the widgets host")
+	assert.GreaterOrEqual(t, gadgetHits, 1, "gadgets sync must hit the gadgets host")
+	assert.Contains(t, widgetQuery, "select * from Widget")
+	assert.Contains(t, gadgetQuery, "select * from Gadget")
+}
+
 func TestWithEffectiveSyncableRequestPathsRewritesHydratePath(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -801,7 +801,7 @@ func syncResource(ctx context.Context, c interface {
 	// the generator. The query + version params are set on top of any
 	// user-supplied --param overrides applied above (which are preserved);
 	// sync owns the query string itself so paging stays correct.
-	if entity, ok := queryEntity[resource]; ok && path == queryPath {
+	if entity, ok := queryEntity[resource]; ok && isQuerySyncPath(resource, path) {
 		start := 1
 		if cursor != "" {
 			if n, convErr := strconv.Atoi(cursor); convErr == nil && n > 0 {
@@ -917,7 +917,7 @@ func syncResource(ctx context.Context, c interface {
 	// surfaces no next page. A full page (== queryPageSize) means more rows
 	// may follow — advance the offset; a short page is the last. Without
 	// this the offline mirror silently truncates large books at one page.
-	if _, ok := queryEntity[resource]; ok && path == queryPath {
+	if _, ok := queryEntity[resource]; ok && isQuerySyncPath(resource, path) {
 		if len(items) >= queryPageSize {
 			start := 1
 			if cursor != "" {
@@ -1099,7 +1099,7 @@ func syncResource(ctx context.Context, c interface {
 		if maxPages > 0 && pagesFetched >= maxPages {
 {{- if .QuerySync}}
 			truncatedByCap := resourceSupportsPagination(resource) && hasMore
-			if _, ok := queryEntity[resource]; ok && path == queryPath {
+			if _, ok := queryEntity[resource]; ok && isQuerySyncPath(resource, path) {
 				// Query resources page via STARTPOSITION, so resourceSupportsPagination
 				// is false for them; a full page (== queryPageSize) means rows remain,
 				// so the cap truncated and the STARTPOSITION resume cursor must persist.
@@ -1141,7 +1141,7 @@ func syncResource(ctx context.Context, c interface {
 			}
 {{- end}}
 {{- if .QuerySync}}
-			if _, ok := queryEntity[resource]; ok && path == queryPath {
+			if _, ok := queryEntity[resource]; ok && isQuerySyncPath(resource, path) {
 				capPageLimit = queryPageSize
 			}
 {{- end}}
@@ -1169,7 +1169,7 @@ func syncResource(ctx context.Context, c interface {
 				outcome.reason = "cursor_unavailable"
 			} else if !hasMore ||
 {{- if .QuerySync}}
-				(path != queryPath && shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, capPageLimit)) {
+				(!isQuerySyncPath(resource, path) && shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, capPageLimit)) {
 {{- else}}
 				shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, capPageLimit) {
 {{- end}}
@@ -1206,7 +1206,7 @@ func syncResource(ctx context.Context, c interface {
 		// "resource declares no pagination" guard (resourceSupportsPagination is
 		// false for them) nor on the generic short-page check (their page size
 		// is the in-query page size, not pageSize.limit).
-		if !resourceSupportsPagination(resource) && path != queryPath {
+		if !resourceSupportsPagination(resource) && !isQuerySyncPath(resource, path) {
 			outcome.complete = true // resource declares no pagination: one page is the whole set
 			break
 		}
@@ -1223,9 +1223,9 @@ func syncResource(ctx context.Context, c interface {
 			break
 	}
 {{- if $hasIDWalk}}
-		if path != queryPath && shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, activePageLimit) {
+		if !isQuerySyncPath(resource, path) && shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, activePageLimit) {
 {{- else}}
-		if path != queryPath && shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit) {
+		if !isQuerySyncPath(resource, path) && shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit) {
 {{- end}}
 			outcome.complete = true
 			break
@@ -4159,9 +4159,27 @@ var queryEntity = map[string]string{
 // queryPath is the shared endpoint every query-sync resource reads through; its
 // page size ({limit}) and STARTPOSITION-style offset stride.
 const (
-	queryPath     = {{printf "%q" (effectiveRequestPath .APISpec "" .QuerySync.Path "")}}
+	queryPath     = {{printf "%q" .QuerySync.Path}}
 	queryPageSize = {{.QuerySync.EffectivePageSize}}
 )
+
+// querySyncRequestPath is the host+path this resource's list/get command
+// would call. Shared query endpoints can carry per-resource base_url
+// overrides, so identity cannot be a single resolved URL.
+func querySyncRequestPath(resource string) string {
+	if _, ok := queryEntity[resource]; !ok {
+		return queryPath
+	}
+	resolved, err := syncResourcePath(resource)
+	if err != nil || resolved == "" {
+		return queryPath
+	}
+	return resolved
+}
+
+func isQuerySyncPath(resource, path string) bool {
+	return path == querySyncRequestPath(resource)
+}
 {{- end}}
 
 // pageItemKeys is scanned in priority order; lowercase REST-convention keys

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -4159,7 +4159,7 @@ var queryEntity = map[string]string{
 // queryPath is the shared endpoint every query-sync resource reads through; its
 // page size ({limit}) and STARTPOSITION-style offset stride.
 const (
-	queryPath     = {{printf "%q" .QuerySync.Path}}
+	queryPath     = {{printf "%q" (effectiveRequestPath .APISpec "" .QuerySync.Path "")}}
 	queryPageSize = {{.QuerySync.EffectivePageSize}}
 )
 {{- end}}

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -546,7 +546,7 @@ func syncResource(ctx context.Context, c interface {
 		// the generator. The query + version params are set on top of any
 		// user-supplied --param overrides applied above (which are preserved);
 		// sync owns the query string itself so paging stays correct.
-		if entity, ok := queryEntity[resource]; ok && path == queryPath {
+		if entity, ok := queryEntity[resource]; ok && isQuerySyncPath(resource, path) {
 			start := 1
 			if cursor != "" {
 				if n, convErr := strconv.Atoi(cursor); convErr == nil && n > 0 {
@@ -640,7 +640,7 @@ func syncResource(ctx context.Context, c interface {
 		// surfaces no next page. A full page (== queryPageSize) means more rows
 		// may follow — advance the offset; a short page is the last. Without
 		// this the offline mirror silently truncates large books at one page.
-		if _, ok := queryEntity[resource]; ok && path == queryPath {
+		if _, ok := queryEntity[resource]; ok && isQuerySyncPath(resource, path) {
 			if len(items) >= queryPageSize {
 				start := 1
 				if cursor != "" {
@@ -809,7 +809,7 @@ func syncResource(ctx context.Context, c interface {
 		// sync_error output in the same stream.
 		if maxPages > 0 && pagesFetched >= maxPages {
 			truncatedByCap := resourceSupportsPagination(resource) && hasMore
-			if _, ok := queryEntity[resource]; ok && path == queryPath {
+			if _, ok := queryEntity[resource]; ok && isQuerySyncPath(resource, path) {
 				// Query resources page via STARTPOSITION, so resourceSupportsPagination
 				// is false for them; a full page (== queryPageSize) means rows remain,
 				// so the cap truncated and the STARTPOSITION resume cursor must persist.
@@ -831,7 +831,7 @@ func syncResource(ctx context.Context, c interface {
 			}
 			capResumed = truncatedByCap && capExitCursor != cursor
 			capPageLimit := pageSize.limit
-			if _, ok := queryEntity[resource]; ok && path == queryPath {
+			if _, ok := queryEntity[resource]; ok && isQuerySyncPath(resource, path) {
 				capPageLimit = queryPageSize
 			}
 			// A resume cursor alone does not prove that the page window was
@@ -857,7 +857,7 @@ func syncResource(ctx context.Context, c interface {
 			} else if paginationEndUnprovable(resourceSupportsPagination(resource), nextCursor, fetchedThisPage, capPageLimit, data, responsePathForResource(resource, path)...) {
 				outcome.reason = "cursor_unavailable"
 			} else if !hasMore ||
-				(path != queryPath && shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, capPageLimit)) {
+				(!isQuerySyncPath(resource, path) && shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, capPageLimit)) {
 				outcome.complete = true
 			} else {
 				outcome.reason = "max_pages_cap"
@@ -890,7 +890,7 @@ func syncResource(ctx context.Context, c interface {
 		// "resource declares no pagination" guard (resourceSupportsPagination is
 		// false for them) nor on the generic short-page check (their page size
 		// is the in-query page size, not pageSize.limit).
-		if !resourceSupportsPagination(resource) && path != queryPath {
+		if !resourceSupportsPagination(resource) && !isQuerySyncPath(resource, path) {
 			outcome.complete = true // resource declares no pagination: one page is the whole set
 			break
 		}
@@ -902,7 +902,7 @@ func syncResource(ctx context.Context, c interface {
 			outcome.complete = true
 			break
 		}
-		if path != queryPath && shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit) {
+		if !isQuerySyncPath(resource, path) && shortPageEndsPagination(pageSize.cursorType, fetchedThisPage, pageSize.limit) {
 			outcome.complete = true
 			break
 		}
@@ -2210,6 +2210,24 @@ const (
 	queryPath     = "/query"
 	queryPageSize = 2
 )
+
+// querySyncRequestPath is the host+path this resource's list/get command
+// would call. Shared query endpoints can carry per-resource base_url
+// overrides, so identity cannot be a single resolved URL.
+func querySyncRequestPath(resource string) string {
+	if _, ok := queryEntity[resource]; !ok {
+		return queryPath
+	}
+	resolved, err := syncResourcePath(resource)
+	if err != nil || resolved == "" {
+		return queryPath
+	}
+	return resolved
+}
+
+func isQuerySyncPath(resource, path string) bool {
+	return path == querySyncRequestPath(resource)
+}
 
 // pageItemKeys is scanned in priority order; lowercase REST-convention keys
 // come first, PascalCase .NET variants second. Without the PascalCase row,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Generated `sync` built request URLs from the root `base_url` and ignored per-endpoint / per-resource `base_url` overrides that list/get commands already honor. Multi-host CLIs then synced the wrong host and 403'd (Depop: list hits `www.depop.com`, sync hits `webapi.depop.com`).

Closes #2966

## Approach

List/get commands already bake overrides into `EffectivePath` (`endpoint > resource > root`) and the generated client skips `BaseURL` concatenation for absolute paths. Sync (and search / hydrate / resource-path maps) still emitted the raw spec path.

This change runs those generated request paths through the same helper before emission. Profiler matching still uses the raw spec path so dependent-path heuristics stay intact. Single-host specs keep root-relative paths.

Query-sync keeps the raw shared path as identity and compares each resource against `syncResourcePath(resource)` (the same host the matching list/get command uses). An empty resource+method lookup no longer picks the first sorted override host.

## Scope

Primary area: generator sync/client URL construction.

Why this belongs in this repo: every printed CLI inherits the miss. A printed-CLI patch would revert on regen.

## Risk

Generated request URLs change only when a spec declares a resource or endpoint `base_url`. Existing single-host goldens stay byte-identical except the query-endpoint generate fixture, which now emits `isQuerySyncPath`. Wrong override resolution would send sync to the wrong host; the live generate tests fail if the root or sibling host receives the request.

## Output Contract

- Emitted-code assertion: `syncResourcePath` contains the override host, not the raw path.
- Compiled generated CLI: `listings list` and `sync --resources listings` both hit the override httptest host; the root host sees nothing.
- Query-sync: widgets and gadgets sharing `/query` with different resource `base_url`s each hit their own host and still get SELECT injection.
- Negative: single-host spec still emits `"listings": "/api/v1/listings"`.
- Golden: `generate-query-endpoint-api` `internal/cli/sync.go` updated for `isQuerySyncPath`.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates
- [x] `go test ./... -timeout 20m`
- [x] `scripts/verify-generator-output.sh generate-query-endpoint-api generate-golden-api generate-sync-walker-api`
- [x] `scripts/golden.sh update` + verify: `generate-query-endpoint-api` sync.go updated. All other `generate-*` cases unchanged. `dogfood-verdict-matrix` / `verify-runtime-matrix` still fail here because fixture CLIs pin `go 1.24` and this environment cannot download that toolchain — not committed.

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef3f5858-56ed-44e5-bacb-ce62bcbe2f3d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef3f5858-56ed-44e5-bacb-ce62bcbe2f3d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

