### PR TITLE
fix(cli): rewrite go.mod and name tokens on publish rename

### DIFF
--- a/internal/pipeline/renamecli.go
+++ b/internal/pipeline/renamecli.go
@@ -11,17 +11,28 @@ import (
 )
 
 // renameExtensions lists file extensions walked during CLI rename.
-// Makefile is handled separately by base-name check in shouldRenameFile.
+// Makefile, go.mod, NOTICE, and research.json are handled by basename
+// in shouldRenameFile / rewriteResearchJSON.
 var renameExtensions = []string{".go", ".yaml", ".yml", ".md"}
+
+var renameBasenames = map[string]struct{}{
+	"Makefile":   {},
+	".gitignore": {},
+	"go.mod":     {},
+	"NOTICE":     {},
+}
 
 // RenameCLI renames all user-visible CLI name references in a staged CLI
 // directory. It handles:
 //   - Filesystem: outer directory rename to the slug-keyed directory derived
 //     from newCLIName, and cmd/oldCLIName/ → cmd/newCLIName/
 //   - File content: replaces occurrences of oldCLIName with newCLIName in
-//     .go, .yaml, .yml, .md files and Makefiles (skips .manuscripts/)
-//   - Metadata: updates .printing-press.json, manifest.json, and
-//     tools-manifest.json to the final public slug/binary names
+//     .go, .yaml, .yml, .md files, Makefiles, go.mod, and NOTICE
+//     (skips .manuscripts/ prose; research.json is updated separately)
+//   - Name tokens: leftover module-path slug, installer slug, and env prefix
+//   - Metadata: updates .printing-press.json, manifest.json,
+//     tools-manifest.json, and research.json api_name to the final public
+//     slug/binary names
 //
 // This function does NOT call RewriteModulePath — that handles import
 // paths and is run separately during packaging. RenameCLI handles exactly
@@ -88,6 +99,9 @@ func RenameCLI(dir, oldCLIName, newCLIName, _ string) (int, error) {
 		}
 
 		result := renameCLIContent(string(content), oldCLIName, newCLIName, oldMCPName, newMCPName, oldSlug, newSlug)
+		if filepath.Base(path) == "go.mod" {
+			result = renameGoModModuleSegment(result, oldSlug, newSlug)
+		}
 		if filepath.Base(path) == ".gitignore" {
 			result = anchorRenamedGitignorePatterns(result, newCLIName, newMCPName)
 		}
@@ -129,6 +143,11 @@ func RenameCLI(dir, oldCLIName, newCLIName, _ string) (int, error) {
 	} else if modified {
 		filesModified++
 	}
+	researchModified, err := rewriteResearchJSON(absDir, oldCLIName, newCLIName, oldMCPName, newMCPName, oldSlug, newSlug)
+	if err != nil {
+		return filesModified, err
+	}
+	filesModified += researchModified
 
 	// 3. Rename cmd/ subdirectory if it exists.
 	oldCmdDir := filepath.Join(absDir, "cmd", oldCLIName)
@@ -184,7 +203,126 @@ func renameCLIContent(content, oldCLIName, newCLIName, oldMCPName, newMCPName, o
 	result = strings.ReplaceAll(result, oldMCPName, newMCPName)
 	result = strings.ReplaceAll(result, "pp-"+oldSlug, "pp-"+newSlug)
 	result = strings.ReplaceAll(result, "/"+oldSlug+"/cmd/", "/"+newSlug+"/cmd/")
+	result = strings.ReplaceAll(result, "/"+oldSlug+"/internal/", "/"+newSlug+"/internal/")
+	result = renameInstallSlug(result, oldSlug, newSlug)
+	result = renameEnvPrefix(result, oldSlug, newSlug)
 	return result
+}
+
+func renameInstallSlug(content, oldSlug, newSlug string) string {
+	if oldSlug == "" || oldSlug == newSlug {
+		return content
+	}
+	needle := "install " + oldSlug
+	var b strings.Builder
+	rest := content
+	for {
+		idx := strings.Index(rest, needle)
+		if idx == -1 {
+			b.WriteString(rest)
+			return b.String()
+		}
+		end := idx + len(needle)
+		if end < len(rest) && isRenameSlugContinue(rest[end]) {
+			b.WriteString(rest[:end])
+			rest = rest[end:]
+			continue
+		}
+		b.WriteString(rest[:idx])
+		b.WriteString("install " + newSlug)
+		rest = rest[end:]
+	}
+}
+
+func isRenameSlugContinue(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_'
+}
+
+func renameEnvPrefix(content, oldSlug, newSlug string) string {
+	oldPrefix := naming.EnvPrefix(oldSlug)
+	newPrefix := naming.EnvPrefix(newSlug)
+	if oldPrefix == "" || oldPrefix == newPrefix {
+		return content
+	}
+	result := strings.ReplaceAll(content, oldPrefix+"_", newPrefix+"_")
+	for _, q := range []string{`"`, "`", `'`} {
+		result = strings.ReplaceAll(result, q+oldPrefix+q, q+newPrefix+q)
+	}
+	return result
+}
+
+func renameGoModModuleSegment(content, oldSlug, newSlug string) string {
+	if oldSlug == "" || oldSlug == newSlug {
+		return content
+	}
+	lines := strings.Split(content, "\n")
+	changed := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "module ") {
+			continue
+		}
+		path := strings.TrimSpace(strings.TrimPrefix(trimmed, "module "))
+		path = strings.TrimSuffix(path, "\r")
+		switch {
+		case path == oldSlug:
+			lines[i] = strings.Replace(line, oldSlug, newSlug, 1)
+			changed = true
+		case strings.HasSuffix(path, "/"+oldSlug):
+			lines[i] = strings.Replace(line, "/"+oldSlug, "/"+newSlug, 1)
+			changed = true
+		}
+	}
+	if !changed {
+		return content
+	}
+	return strings.Join(lines, "\n")
+}
+
+func rewriteResearchJSON(root, oldCLIName, newCLIName, oldMCPName, newMCPName, oldSlug, newSlug string) (int, error) {
+	modified := 0
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || d.Name() != "research.json" {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", path, err)
+		}
+		result := renameCLIContent(string(content), oldCLIName, newCLIName, oldMCPName, newMCPName, oldSlug, newSlug)
+		result = renameResearchAPIName(result, oldSlug, newSlug)
+		if result == string(content) {
+			return nil
+		}
+		if err := os.WriteFile(path, []byte(result), 0o644); err != nil {
+			return fmt.Errorf("writing %s: %w", path, err)
+		}
+		modified++
+		return nil
+	})
+	if err != nil {
+		return modified, fmt.Errorf("updating research.json: %w", err)
+	}
+	return modified, nil
+}
+
+func renameResearchAPIName(content, oldSlug, newSlug string) string {
+	if oldSlug == "" || oldSlug == newSlug {
+		return content
+	}
+	replacements := [][2]string{
+		{`"api_name": "` + oldSlug + `"`, `"api_name": "` + newSlug + `"`},
+		{`"api_name":"` + oldSlug + `"`, `"api_name":"` + newSlug + `"`},
+	}
+	for _, pair := range replacements {
+		if strings.Contains(content, pair[0]) {
+			return strings.Replace(content, pair[0], pair[1], 1)
+		}
+	}
+	return content
 }
 
 func anchorRenamedGitignorePatterns(content, cliName, mcpName string) string {
@@ -226,10 +364,12 @@ func updateToolsManifestAPIName(dir, apiName string) (bool, error) {
 }
 
 // shouldRenameFile returns true if a file should be processed during rename.
-// Checks extension (.go, .yaml, .yml, .md) and base name (Makefile).
+// Checks extension (.go, .yaml, .yml, .md) and identity basenames (Makefile,
+// go.mod, NOTICE). research.json is handled separately so .manuscripts
+// prose stays untouched.
 func shouldRenameFile(path string) bool {
 	base := filepath.Base(path)
-	if base == "Makefile" || base == ".gitignore" {
+	if _, ok := renameBasenames[base]; ok {
 		return true
 	}
 	for _, ext := range renameExtensions {

--- a/internal/pipeline/renamecli.go
+++ b/internal/pipeline/renamecli.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
@@ -264,19 +265,27 @@ func renameGoModModuleSegment(content, oldSlug, newSlug string) string {
 		}
 		path := strings.TrimSpace(strings.TrimPrefix(trimmed, "module "))
 		path = strings.TrimSuffix(path, "\r")
-		switch {
-		case path == oldSlug:
-			lines[i] = strings.Replace(line, oldSlug, newSlug, 1)
-			changed = true
-		case strings.HasSuffix(path, "/"+oldSlug):
-			lines[i] = strings.Replace(line, "/"+oldSlug, "/"+newSlug, 1)
-			changed = true
+		newPath, ok := replaceFinalModuleSegment(path, oldSlug, newSlug)
+		if !ok {
+			continue
 		}
+		lines[i] = strings.Replace(line, path, newPath, 1)
+		changed = true
 	}
 	if !changed {
 		return content
 	}
 	return strings.Join(lines, "\n")
+}
+
+func replaceFinalModuleSegment(path, oldSlug, newSlug string) (string, bool) {
+	if path == oldSlug {
+		return newSlug, true
+	}
+	if strings.HasSuffix(path, "/"+oldSlug) {
+		return strings.TrimSuffix(path, oldSlug) + newSlug, true
+	}
+	return path, false
 }
 
 func rewriteResearchJSON(root, oldCLIName, newCLIName, oldMCPName, newMCPName, oldSlug, newSlug string) (int, error) {
@@ -286,6 +295,9 @@ func rewriteResearchJSON(root, oldCLIName, newCLIName, oldMCPName, newMCPName, o
 			return walkErr
 		}
 		if d.IsDir() || d.Name() != "research.json" {
+			return nil
+		}
+		if d.Type()&os.ModeSymlink != 0 {
 			return nil
 		}
 		content, err := os.ReadFile(path)
@@ -313,14 +325,9 @@ func renameResearchAPIName(content, oldSlug, newSlug string) string {
 	if oldSlug == "" || oldSlug == newSlug {
 		return content
 	}
-	replacements := [][2]string{
-		{`"api_name": "` + oldSlug + `"`, `"api_name": "` + newSlug + `"`},
-		{`"api_name":"` + oldSlug + `"`, `"api_name":"` + newSlug + `"`},
-	}
-	for _, pair := range replacements {
-		if strings.Contains(content, pair[0]) {
-			return strings.Replace(content, pair[0], pair[1], 1)
-		}
+	re := regexp.MustCompile(`("api_name"\s*:\s*")` + regexp.QuoteMeta(oldSlug) + `(")`)
+	if re.MatchString(content) {
+		return re.ReplaceAllString(content, `${1}`+newSlug+`${2}`)
 	}
 	return content
 }
@@ -363,10 +370,9 @@ func updateToolsManifestAPIName(dir, apiName string) (bool, error) {
 	return true, nil
 }
 
-// shouldRenameFile returns true if a file should be processed during rename.
-// Checks extension (.go, .yaml, .yml, .md) and identity basenames (Makefile,
-// go.mod, NOTICE). research.json is handled separately so .manuscripts
-// prose stays untouched.
+// shouldRenameFile limits broad text replacement to generated text formats and
+// explicit identity files. research.json requires separate structured handling
+// so manuscript prose remains untouched.
 func shouldRenameFile(path string) bool {
 	base := filepath.Base(path)
 	if _, ok := renameBasenames[base]; ok {

--- a/internal/pipeline/renamecli_build_test.go
+++ b/internal/pipeline/renamecli_build_test.go
@@ -1,0 +1,127 @@
+package pipeline
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/generator"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenameCLIGeneratedTreeBuildsAndKeepsResearchName(t *testing.T) {
+	setPressTestEnv(t)
+
+	apiSpec := &spec.APISpec{
+		Name:      "subject",
+		Version:   "0.1.0",
+		BaseURL:   "https://api.example.com",
+		Owner:     "test-owner",
+		OwnerName: "Test Author",
+		Auth: spec.AuthConfig{
+			Type:    "api_key",
+			Header:  "Authorization",
+			Format:  "Bearer {token}",
+			EnvVars: []string{"SUBJECT_TOKEN"},
+		},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/subject-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Description: "Manage items",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/items", Description: "List items"},
+				},
+			},
+		},
+	}
+
+	root := t.TempDir()
+	cliDir := filepath.Join(root, "subject-pp-cli")
+	require.NoError(t, generator.New(apiSpec, cliDir).Generate())
+	require.NoError(t, writeResearchJSON(&ResearchResult{
+		APIName: "subject",
+		NovelFeatures: []NovelFeature{{
+			Name:        "List items",
+			Command:     "items list",
+			Description: "List items from the API.",
+		}},
+		Narrative: &ReadmeNarrative{
+			AuthNarrative: "Export the API token.",
+		},
+	}, cliDir))
+
+	_, err := RenameCLI(cliDir, "subject-pp-cli", "overpass-pp-cli", "subject")
+	require.NoError(t, err)
+
+	newDir := filepath.Join(root, naming.LibraryDirName("overpass-pp-cli"))
+	gomod, err := os.ReadFile(filepath.Join(newDir, "go.mod"))
+	require.NoError(t, err)
+	assert.Contains(t, string(gomod), "module overpass-pp-cli")
+	assert.NotContains(t, string(gomod), "subject-pp-cli")
+
+	runRenameGoCommand(t, newDir, "mod", "tidy")
+	runRenameGoCommand(t, newDir, "build", "./...")
+
+	leftovers := collectRenameLeftovers(t, newDir, []string{"subject-pp-cli", "module subject-pp-cli"})
+	assert.Empty(t, leftovers, "renamed tree still mentions the old module path")
+
+	_, err = RunDogfood(newDir, "", WithResearchDir(newDir))
+	require.NoError(t, err)
+
+	research, err := LoadResearch(newDir)
+	require.NoError(t, err)
+	assert.Equal(t, "overpass", research.APIName)
+
+	leftovers = collectRenameLeftovers(t, newDir, []string{"subject-pp-cli"})
+	assert.Empty(t, leftovers, "dogfood --research-dir resurrected the old CLI name")
+}
+
+func runRenameGoCommand(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("go", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOCACHE="+filepath.Join(dir, ".cache", "go-build"))
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+}
+
+func collectRenameLeftovers(t *testing.T, dir string, needles []string) []string {
+	t.Helper()
+	var leftovers []string
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if d.Name() == ".manuscripts" || d.Name() == ".cache" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		text := string(data)
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			rel = path
+		}
+		for _, needle := range needles {
+			if strings.Contains(text, needle) {
+				leftovers = append(leftovers, rel+": "+needle)
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return leftovers
+}

--- a/internal/pipeline/renamecli_test.go
+++ b/internal/pipeline/renamecli_test.go
@@ -112,6 +112,12 @@ CLI for the `+apiName+` API.
 claude mcp add `+apiName+` `+mcpName+`
 `+"```"+`
 
+Install via:
+
+`+"```"+`
+npx -y @mvanhorn/printing-press-library install `+apiName+` --cli-only
+`+"```"+`
+
 Install the skill from `+"`cli-skills/pp-"+apiName+"`"+` and install with:
 
 `+"```"+`
@@ -132,6 +138,7 @@ metadata:
 # `+apiName+`
 
 `+"```bash"+`
+npx -y @mvanhorn/printing-press-library install `+apiName+` --cli-only
 go install github.com/mvanhorn/printing-press-library/library/other/`+apiName+`/cmd/`+cliName+`@latest
 `+"```"+`
 `), 0o644))
@@ -142,11 +149,38 @@ go install github.com/mvanhorn/printing-press-library/library/other/`+apiName+`/
 go 1.24
 `), 0o644))
 
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "NOTICE"), []byte(cliName+`
+Copyright 2026 Example
+`), 0o644))
+
+	pathsDir := filepath.Join(dir, "internal", "cliutil")
+	require.NoError(t, os.MkdirAll(pathsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pathsDir, "paths.go"), []byte(`package cliutil
+
+const envPrefix = "`+naming.EnvPrefix(apiName)+`"
+
+func envName(suffix string) string {
+	return envPrefix + "_" + suffix
+}
+`), 0o644))
+
 	// .manuscripts/ — should NOT be modified
 	msDir := filepath.Join(dir, ".manuscripts", "20260329-100000", "research")
 	require.NoError(t, os.MkdirAll(msDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(msDir, "brief.md"),
 		[]byte("# Research Brief for "+cliName+"\n\nGenerated from "+cliName+" spec.\n"), 0o644))
+	require.NoError(t, writeResearchJSON(&ResearchResult{
+		APIName: apiName,
+		Narrative: &ReadmeNarrative{
+			AuthNarrative: "Export the API token for " + cliName + ".",
+		},
+	}, filepath.Join(dir, ".manuscripts", "20260329-100000")))
+	require.NoError(t, writeResearchJSON(&ResearchResult{
+		APIName: apiName,
+		Narrative: &ReadmeNarrative{
+			AuthNarrative: "Export the API token for " + cliName + ".",
+		},
+	}, dir))
 
 	// .printing-press.json manifest
 	m := CLIManifest{
@@ -306,6 +340,41 @@ func TestRenameCLI(t *testing.T) {
 		var tools ToolsManifest
 		require.NoError(t, json.Unmarshal(toolsData, &tools))
 		assert.Equal(t, naming.TrimCLISuffix(newName), tools.APIName)
+
+		// go.mod module path must move with the CLI name so the tree still builds.
+		gomod, err := os.ReadFile(filepath.Join(newDir, "go.mod"))
+		require.NoError(t, err)
+		assert.Contains(t, string(gomod), "module "+newName)
+		assert.NotContains(t, string(gomod), oldName)
+
+		notice, err := os.ReadFile(filepath.Join(newDir, "NOTICE"))
+		require.NoError(t, err)
+		assert.Contains(t, string(notice), newName)
+		assert.NotContains(t, string(notice), oldName)
+
+		pathsGo, err := os.ReadFile(filepath.Join(newDir, "internal", "cliutil", "paths.go"))
+		require.NoError(t, err)
+		assert.Contains(t, string(pathsGo), `const envPrefix = "`+naming.EnvPrefix(naming.TrimCLISuffix(newName))+`"`)
+		assert.NotContains(t, string(pathsGo), naming.EnvPrefix(apiName)+`"`)
+
+		assert.Contains(t, string(readme), "install "+naming.TrimCLISuffix(newName)+" --cli-only")
+		assert.NotContains(t, string(readme), "install "+apiName+" --cli-only")
+		assert.Contains(t, string(skill), "install "+naming.TrimCLISuffix(newName)+" --cli-only")
+		assert.NotContains(t, string(skill), "install "+apiName+" --cli-only")
+
+		rootResearch, err := os.ReadFile(filepath.Join(newDir, "research.json"))
+		require.NoError(t, err)
+		var rootResearchResult ResearchResult
+		require.NoError(t, json.Unmarshal(rootResearch, &rootResearchResult))
+		assert.Equal(t, naming.TrimCLISuffix(newName), rootResearchResult.APIName)
+		assert.Contains(t, rootResearchResult.Narrative.AuthNarrative, newName)
+		assert.NotContains(t, rootResearchResult.Narrative.AuthNarrative, oldName)
+
+		msResearch, err := os.ReadFile(filepath.Join(newDir, ".manuscripts", "20260329-100000", "research.json"))
+		require.NoError(t, err)
+		var msResearchResult ResearchResult
+		require.NoError(t, json.Unmarshal(msResearch, &msResearchResult))
+		assert.Equal(t, naming.TrimCLISuffix(newName), msResearchResult.APIName)
 
 		// Bare binary ignore patterns must be root-anchored so cmd/<binary> is tracked.
 		gitignore, err := os.ReadFile(filepath.Join(newDir, ".gitignore"))
@@ -540,4 +609,70 @@ func main() {}
 		require.NoError(t, err)
 		assert.Contains(t, string(configData), oldName, "non-target files should not be modified")
 	})
+
+	t.Run("rewrites packaged module path slug", func(t *testing.T) {
+		root := t.TempDir()
+		oldName := "subject-pp-cli"
+		newName := "overpass-pp-cli"
+		cliDir := filepath.Join(root, oldName)
+		require.NoError(t, os.MkdirAll(filepath.Join(cliDir, "internal", "cli"), 0o755))
+
+		oldMod := "github.com/mvanhorn/printing-press-library/library/other/subject"
+		require.NoError(t, os.WriteFile(filepath.Join(cliDir, "go.mod"), []byte("module "+oldMod+"\n\ngo 1.24\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(cliDir, "internal", "cli", "root.go"), []byte(`package cli
+
+import "`+oldMod+`/internal/client"
+`), 0o644))
+		m := CLIManifest{SchemaVersion: 1, APIName: "subject", CLIName: oldName}
+		data, err := json.MarshalIndent(m, "", "  ")
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(cliDir, CLIManifestFilename), data, 0o644))
+
+		_, err = RenameCLI(cliDir, oldName, newName, "subject")
+		require.NoError(t, err)
+
+		newDir := filepath.Join(root, naming.LibraryDirName(newName))
+		gomod, err := os.ReadFile(filepath.Join(newDir, "go.mod"))
+		require.NoError(t, err)
+		assert.Contains(t, string(gomod), "module github.com/mvanhorn/printing-press-library/library/other/overpass")
+		assert.NotContains(t, string(gomod), oldMod)
+		assert.NotContains(t, string(gomod), "subject")
+
+		rootGo, err := os.ReadFile(filepath.Join(newDir, "internal", "cli", "root.go"))
+		require.NoError(t, err)
+		assert.Contains(t, string(rootGo), "github.com/mvanhorn/printing-press-library/library/other/overpass/internal/client")
+		assert.NotContains(t, string(rootGo), oldMod)
+	})
+}
+
+func TestRenameCLIContentIdentityTokens(t *testing.T) {
+	t.Parallel()
+
+	got := renameCLIContent(
+		`npx -y @mvanhorn/printing-press-library install subject --cli-only
+const envPrefix = "SUBJECT"
+req := os.Getenv("SUBJECT_NO_LEARN")
+import "github.com/acme/library/other/subject/internal/cli"
+`,
+		"subject-pp-cli", "overpass-pp-cli",
+		"subject-pp-mcp", "overpass-pp-mcp",
+		"subject", "overpass",
+	)
+	assert.Contains(t, got, "install overpass --cli-only")
+	assert.NotContains(t, got, "install subject --cli-only")
+	assert.Contains(t, got, `const envPrefix = "OVERPASS"`)
+	assert.Contains(t, got, `os.Getenv("OVERPASS_NO_LEARN")`)
+	assert.NotContains(t, got, "SUBJECT")
+	assert.Contains(t, got, "/other/overpass/internal/cli")
+	assert.NotContains(t, got, "/other/subject/internal/cli")
+
+	// Installer slug must not clip a longer token that only shares a prefix.
+	got = renameInstallSlug("npx install subject-extra --cli-only", "subject", "overpass")
+	assert.Equal(t, "npx install subject-extra --cli-only", got)
+
+	got = renameGoModModuleSegment("module github.com/acme/library/other/subject\n", "subject", "overpass")
+	assert.Equal(t, "module github.com/acme/library/other/overpass\n", got)
+
+	got = renameResearchAPIName(`{"api_name": "subject", "novelty_score": 8}`, "subject", "overpass")
+	assert.Equal(t, `{"api_name": "overpass", "novelty_score": 8}`, got)
 }

--- a/internal/pipeline/renamecli_test.go
+++ b/internal/pipeline/renamecli_test.go
@@ -636,7 +636,7 @@ import "`+oldMod+`/internal/client"
 		require.NoError(t, err)
 		assert.Contains(t, string(gomod), "module github.com/mvanhorn/printing-press-library/library/other/overpass")
 		assert.NotContains(t, string(gomod), oldMod)
-		assert.NotContains(t, string(gomod), "subject")
+		assert.NotContains(t, string(gomod), "/subject")
 
 		rootGo, err := os.ReadFile(filepath.Join(newDir, "internal", "cli", "root.go"))
 		require.NoError(t, err)
@@ -673,6 +673,38 @@ import "github.com/acme/library/other/subject/internal/cli"
 	got = renameGoModModuleSegment("module github.com/acme/library/other/subject\n", "subject", "overpass")
 	assert.Equal(t, "module github.com/acme/library/other/overpass\n", got)
 
+	// Earlier path segments that happen to equal the slug must stay put.
+	got = renameGoModModuleSegment("module github.com/subject/library/other/subject\n", "subject", "overpass")
+	assert.Equal(t, "module github.com/subject/library/other/overpass\n", got)
+
 	got = renameResearchAPIName(`{"api_name": "subject", "novelty_score": 8}`, "subject", "overpass")
 	assert.Equal(t, `{"api_name": "overpass", "novelty_score": 8}`, got)
+	got = renameResearchAPIName("{\n  \"api_name\" :\t\"subject\"\n}", "subject", "overpass")
+	assert.Equal(t, "{\n  \"api_name\" :\t\"overpass\"\n}", got)
+}
+
+func TestRenameCLISkipsResearchJSONSymlink(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	oldName := "subject-pp-cli"
+	newName := "overpass-pp-cli"
+	cliDir := filepath.Join(root, oldName)
+	require.NoError(t, os.MkdirAll(cliDir, 0o755))
+
+	outside := filepath.Join(root, "outside-research.json")
+	require.NoError(t, os.WriteFile(outside, []byte(`{"api_name": "subject"}`+"\n"), 0o644))
+	require.NoError(t, os.Symlink(outside, filepath.Join(cliDir, "research.json")))
+
+	m := CLIManifest{SchemaVersion: 1, APIName: "subject", CLIName: oldName}
+	data, err := json.MarshalIndent(m, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, CLIManifestFilename), data, 0o644))
+
+	_, err = RenameCLI(cliDir, oldName, newName, "subject")
+	require.NoError(t, err)
+
+	outsideData, err := os.ReadFile(outside)
+	require.NoError(t, err)
+	assert.Equal(t, `{"api_name": "subject"}`+"\n", string(outsideData), "symlink target outside the CLI tree must stay untouched")
 }

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -1329,7 +1329,7 @@ If a suggestion collides, skip it or increment the numeric suffix.
 
 **4. Rename the CLI in the publish repo:**
 
-Since Step 6 copied the staged CLI into `$PUBLISH_REPO_DIR`, the rename operates on that directory. Note: `--old-name`/`--new-name` still use CLI-name format (e.g., `dub-pp-cli`) because `RenameCLI` does content replacement — bare slugs would cause collateral damage. The `--dir` path uses the slug-keyed directory.
+Since Step 6 copied the staged CLI into `$PUBLISH_REPO_DIR`, the rename operates on that directory. Note: `--old-name`/`--new-name` still use CLI-name format (e.g., `dub-pp-cli`) because `RenameCLI` does content replacement — bare slugs would cause collateral damage. The `--dir` path uses the slug-keyed directory. Rename also rewrites `go.mod`, leftover module-path slugs, installer slugs, env prefixes, and `research.json` `api_name` (including under `.manuscripts/`). Do not hand-fix those after a successful rename.
 
 ```bash
 cli-printing-press publish rename \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

`publish rename` rewrote only `.go` / `.yaml` / `.yml` / `.md` (and Makefile). After a rename the tree still contained the old `go.mod` module path, installer slug, env prefix, NOTICE line, and `research.json` `api_name`, then exited 0. Dogfood `--research-dir` could put the old binary name back into README/SKILL.

Closes #3813

## Approach

Drive rename from the existing name-token replacements plus the identity forms that actually keep a CLI buildable and consistently named:

- Walk `go.mod` and `NOTICE` in addition to the current extensions
- Rewrite leftover packaged module-path slugs (`/{old}/internal/` and the final `go.mod` segment only)
- Rewrite installer slugs (`install <slug>`) without clipping longer tokens
- Rewrite env prefixes (`SUBJECT_` / `"SUBJECT"`)
- Update `research.json` `api_name` with flexible JSON whitespace (including copies under `.manuscripts/`); skip `research.json` symlinks
- Leave manuscript prose (`brief.md`, `research/*.md`) untouched

## Scope

Primary area: `publish rename` / `pipeline.RenameCLI`.

This belongs in the Printing Press because every future publish-time rename inherits the walk set and token table.

## Risk

Bare API-name prose is still not globally replaced (existing `notion` → `notion-alt` fixture). Non-target `.json` files such as `config.json` stay unwalked. No generator template or golden contract change.

## Output Contract

N/A — rename is a publish-time rewrite, not generated output. All `generate-*` golden cases passed unchanged.

## Verification

- [x] `go test ./internal/pipeline -run 'TestRenameCLI$|TestRenameCLIContentIdentityTokens|TestRenameCLISkipsResearchJSONSymlink|TestRenameCLIGeneratedTreeBuildsAndKeepsResearchName'`
- [x] Generated `subject-pp-cli` renamed to `overpass-pp-cli`; `go build ./...` passes; no leftover `subject-pp-cli` module path
- [x] Dogfood with `--research-dir` does not resurrect `subject-pp-cli`
- [x] Full `go test ./... -count=1 -timeout 45m` on the first revision
- [x] `scripts/golden.sh verify` — all `generate-*` cases passed with no fixture update. Local `dogfood-verdict-matrix` / `verify-runtime-matrix` failures are the `go 1.24` fixture-build environment issue; CI `full-golden` passed.

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53bc7464-f2ef-4c71-abfa-74739e06c8ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53bc7464-f2ef-4c71-abfa-74739e06c8ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

