### PR TITLE
fix(cli): extract items from map-keyed collections

### DIFF
--- a/internal/generator/sync_map_keyed_collection_test.go
+++ b/internal/generator/sync_map_keyed_collection_test.go
@@ -136,6 +136,8 @@ func TestMapKeyedRejectsOrdinaryNestedObjects(t *testing.T) {
 		` + "`" + `{"id":"7788990011223344","title":"a detail record"}` + "`" + `,
 		` + "`" + `{"7788990011223344":{"id":"x"},"meta":{"total":3}}` + "`" + `,
 		` + "`" + `{"id":"detail-1","title":"Alice","tags":["a"],"7788990011223344":{"role":"admin"}}` + "`" + `,
+		` + "`" + `{"status":"pending","message":"ok","7788990011223344":{"role":"admin"}}` + "`" + `,
+		` + "`" + `{"total":5,"count":1,"7788990011223344":{"role":"admin"}}` + "`" + `,
 		` + "`" + `{"total":3,"next_cursor":"c2"}` + "`" + `,
 		` + "`" + `{"7788990011223344":"not an object"}` + "`" + `,
 		` + "`" + `{}` + "`" + `,
@@ -154,6 +156,27 @@ func TestMapKeyedRejectsNumericChildOnDetailObject(t *testing.T) {
 	payload := ` + "`" + `{"id":"detail-1","title":"Alice","tags":["a"],"7788990011223344":{"role":"admin"}}` + "`" + `
 	if _, ok := FlattenMapKeyedCollection(json.RawMessage(payload)); ok {
 		t.Fatalf("a detail object with one numeric-keyed child must not flatten: %s", payload)
+	}
+}
+
+// status/message/total/count are list-metadata names, but on a lone
+// record-shaped child they are ordinary detail fields. A one-record page
+// still needs a cursor or page signal.
+func TestMapKeyedRejectsAllowlistedDetailFieldsBesideOneChild(t *testing.T) {
+	rejected := []string{
+		` + "`" + `{"status":"pending","7788990011223344":{"role":"admin"}}` + "`" + `,
+		` + "`" + `{"message":"ok","7788990011223344":{"role":"admin"}}` + "`" + `,
+		` + "`" + `{"total":5,"count":1,"7788990011223344":{"role":"admin"}}` + "`" + `,
+		` + "`" + `{"success":true,"ok":true,"7788990011223344":{"role":"admin"}}` + "`" + `,
+	}
+	for _, payload := range rejected {
+		if _, ok := FlattenMapKeyedCollection(json.RawMessage(payload)); ok {
+			t.Fatalf("allowlisted detail fields beside one child must not flatten: %s", payload)
+		}
+	}
+	items, ok := FlattenMapKeyedCollection(json.RawMessage(` + "`" + `{"7788990011223344":{"id":"7788990011223344"},"1122334455667788":{"id":"1122334455667788"},"total":2}` + "`" + `))
+	if !ok || len(items) != 2 {
+		t.Fatalf("two records plus total must still flatten, ok=%v len=%d", ok, len(items))
 	}
 }
 
@@ -429,6 +452,10 @@ func TestMapKeyedExtractPageItemsRejectsNumericChildOnDetail(t *testing.T) {
 	items, _, _ := extractPageItems(json.RawMessage(` + "`" + `{"id":"detail-1","title":"Alice","tags":["a"],"7788990011223344":{"role":"admin"}}` + "`" + `), "cursor")
 	if len(items) != 0 {
 		t.Fatalf("a detail object with one numeric-keyed child must not flatten, got %d items", len(items))
+	}
+	items, _, _ = extractPageItems(json.RawMessage(` + "`" + `{"status":"pending","total":1,"7788990011223344":{"role":"admin"}}` + "`" + `), "cursor")
+	if len(items) != 0 {
+		t.Fatalf("status/total beside one numeric-keyed child must not flatten, got %d items", len(items))
 	}
 }
 

--- a/internal/generator/sync_map_keyed_collection_test.go
+++ b/internal/generator/sync_map_keyed_collection_test.go
@@ -87,6 +87,43 @@ func TestMapKeyedStampNeverOutranksARealID(t *testing.T) {
 	}
 }
 
+// A one-level date-keyed collection uses the date as the record id. That
+// string is a valid collection key, so the last-resort stamp must keep it.
+// CanonicalResourceID refuses ISO dates (a created_at-shaped field is not a
+// row id); running the stamp through that helper would drop the row.
+func TestMapKeyedOneLevelDateKeySurvivesUnusableIDGate(t *testing.T) {
+	if got := CanonicalResourceID("2026-08-19"); got != "" {
+		t.Fatalf("CanonicalResourceID must still refuse ISO dates, got %q", got)
+	}
+	items, ok := FlattenMapKeyedCollection(json.RawMessage(` + "`" + `{"2026-08-19":{"title":"day bucket"}}` + "`" + `))
+	if !ok || len(items) != 1 {
+		t.Fatalf("expected 1 date-keyed item, ok=%v len=%d", ok, len(items))
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(items[0], &obj); err != nil {
+		t.Fatalf("decode item: %v", err)
+	}
+	if obj[MapKeyIDField] != "2026-08-19" {
+		t.Fatalf("expected the date key stamped, got %#v", obj)
+	}
+	if got := ExtractResourceID("calls", obj); got != "2026-08-19" {
+		t.Fatalf("date-shaped map keys must resolve via ResourceIDString, got %q", got)
+	}
+	if got := extractObjectID(obj); got != "2026-08-19" {
+		t.Fatalf("extractObjectID must keep a date-shaped map key, got %q", got)
+	}
+
+	// A leaf that also copies the date into id is refused by the #4379
+	// canonical chain; the stamp is the arm that recovers it.
+	obj["id"] = "2026-08-19"
+	if got := ExtractResourceID("calls", obj); got != "2026-08-19" {
+		t.Fatalf("mapKeyIDFallback must recover after CanonicalResourceID refuses the date-shaped id field, got %q", got)
+	}
+	if got := extractObjectID(obj); got != "2026-08-19" {
+		t.Fatalf("extractObjectID must recover a date-shaped id via the stamped key, got %q", got)
+	}
+}
+
 // A detail object whose fields happen to hold sub-objects is the shape most at
 // risk of being misread as a collection. Field names are words, record keys are
 // not, and that is the whole discriminator.

--- a/internal/generator/sync_map_keyed_collection_test.go
+++ b/internal/generator/sync_map_keyed_collection_test.go
@@ -1,0 +1,300 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mapKeyedStoreTestSource exercises the flattener and the two id resolvers that
+// must agree with it. Anything the flattener lifts out of a map-keyed
+// collection has to resolve to an id, or the rows vanish from the local mirror
+// without an error.
+const mapKeyedStoreTestSource = `package store
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMapKeyedFlattenDepthOne(t *testing.T) {
+	items, ok := FlattenMapKeyedCollection(json.RawMessage(` + "`" + `{"7788990011223344":{"id":"7788990011223344","title":"weekly sync"}}` + "`" + `))
+	if !ok {
+		t.Fatalf("id-keyed object should be recognized as a map-keyed collection")
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(items[0], &obj); err != nil {
+		t.Fatalf("decode item: %v", err)
+	}
+	if obj["title"] != "weekly sync" {
+		t.Fatalf("expected the leaf record, got %#v", obj)
+	}
+	if got := ExtractResourceID("calls", obj); got != "7788990011223344" {
+		t.Fatalf("expected the record's own id, got %q", got)
+	}
+}
+
+func TestMapKeyedFlattenDepthTwo(t *testing.T) {
+	items, ok := FlattenMapKeyedCollection(json.RawMessage(` + "`" + `{"2026-08-19":{"7788990011223344":{"id":"7788990011223344","title":"a"}},"2026-08-20":{"1122334455667788":{"id":"1122334455667788","title":"b"}}}` + "`" + `))
+	if !ok {
+		t.Fatalf("bucketed id-keyed object should be recognized as a map-keyed collection")
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items across 2 buckets, got %d", len(items))
+	}
+	// Entries are key-sorted, so bucket order is stable across runs.
+	var first map[string]any
+	if err := json.Unmarshal(items[0], &first); err != nil {
+		t.Fatalf("decode item: %v", err)
+	}
+	if first["title"] != "a" {
+		t.Fatalf("expected deterministic key-sorted order, got %#v", first)
+	}
+}
+
+func TestMapKeyedFlattenStampsKeyOnIDLessRecord(t *testing.T) {
+	items, ok := FlattenMapKeyedCollection(json.RawMessage(` + "`" + `{"2026-08-19":{"7788990011223344":{"title":"no id field"}}}` + "`" + `))
+	if !ok || len(items) != 1 {
+		t.Fatalf("expected 1 flattened item, ok=%v len=%d", ok, len(items))
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(items[0], &obj); err != nil {
+		t.Fatalf("decode item: %v", err)
+	}
+	if obj[MapKeyIDField] != "7788990011223344" {
+		t.Fatalf("expected the leaf map key stamped on an id-less record, got %#v", obj)
+	}
+	if got := ExtractResourceID("calls", obj); got != "7788990011223344" {
+		t.Fatalf("ExtractResourceID must fall back to the stamped map key, got %q", got)
+	}
+	if got := extractObjectID(obj); got != "7788990011223344" {
+		t.Fatalf("extractObjectID must fall back to the stamped map key, got %q", got)
+	}
+}
+
+func TestMapKeyedStampNeverOutranksARealID(t *testing.T) {
+	obj := map[string]any{"id": "real-id", MapKeyIDField: "map-key"}
+	if got := ExtractResourceID("calls", obj); got != "real-id" {
+		t.Fatalf("a real id field must win over the stamped map key, got %q", got)
+	}
+	if got := extractObjectID(obj); got != "real-id" {
+		t.Fatalf("a real id field must win over the stamped map key, got %q", got)
+	}
+}
+
+// A detail object whose fields happen to hold sub-objects is the shape most at
+// risk of being misread as a collection. Field names are words, record keys are
+// not, and that is the whole discriminator.
+func TestMapKeyedRejectsOrdinaryNestedObjects(t *testing.T) {
+	rejected := []string{
+		` + "`" + `{"user":{"id":"u1"},"account":{"id":"a1"}}` + "`" + `,
+		` + "`" + `{"metadata":{"created":"now"}}` + "`" + `,
+		` + "`" + `{"line_items":{"sku":"a"},"shipping_address":{"zip":"1"}}` + "`" + `,
+		` + "`" + `{"oauth2":{"scope":"read"}}` + "`" + `,
+		` + "`" + `{"id":"7788990011223344","title":"a detail record"}` + "`" + `,
+		` + "`" + `{"2026-08-19":{"id":"x"},"total":3}` + "`" + `,
+		` + "`" + `{}` + "`" + `,
+		` + "`" + `[{"id":"1"}]` + "`" + `,
+	}
+	for _, payload := range rejected {
+		if _, ok := FlattenMapKeyedCollection(json.RawMessage(payload)); ok {
+			t.Fatalf("payload must not be treated as a map-keyed collection: %s", payload)
+		}
+	}
+}
+
+func TestMapKeyedAcceptsOpaqueAndUUIDKeys(t *testing.T) {
+	accepted := []string{
+		` + "`" + `{"d41d8cd98f00b204e9800998ecf8427e":{"n":1}}` + "`" + `,
+		` + "`" + `{"3f2504e0-4f89-11d3-9a0c-0305e82c3301":{"n":1}}` + "`" + `,
+		` + "`" + `{"-MxYz1234abcdEFGHijk":{"n":1}}` + "`" + `,
+	}
+	for _, payload := range accepted {
+		items, ok := FlattenMapKeyedCollection(json.RawMessage(payload))
+		if !ok || len(items) != 1 {
+			t.Fatalf("payload should flatten to one item: %s (ok=%v len=%d)", payload, ok, len(items))
+		}
+	}
+}
+
+// A bucket holding no records is an empty page, not a row keyed by the bucket.
+func TestMapKeyedEmptyBucketYieldsNoRows(t *testing.T) {
+	items, ok := FlattenMapKeyedCollection(json.RawMessage(` + "`" + `{"2026-08-19":{}}` + "`" + `))
+	if !ok {
+		t.Fatalf("an empty bucket is still a recognized collection")
+	}
+	if len(items) != 0 {
+		t.Fatalf("an empty bucket must yield no rows, got %d", len(items))
+	}
+}
+
+func TestMapKeyedUpsertBatchPersistsRows(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(dir + "/map-keyed.db")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	items, ok := FlattenMapKeyedCollection(json.RawMessage(` + "`" + `{"2026-08-19":{"7788990011223344":{"title":"no id field"}}}` + "`" + `))
+	if !ok {
+		t.Fatalf("expected a recognized map-keyed collection")
+	}
+	if _, _, err := db.UpsertBatch("calls", items); err != nil {
+		t.Fatalf("upsert batch: %v", err)
+	}
+	ids, err := db.ListIDs("calls")
+	if err != nil {
+		t.Fatalf("list ids: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "7788990011223344" {
+		t.Fatalf("expected the map key to become the row id, got %#v", ids)
+	}
+}
+`
+
+// mapKeyedCLITestSource asserts the sync extractor and the live write-through
+// path pull the same records out of the same map-keyed payloads.
+const mapKeyedCLITestSource = `package cli
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+func TestMapKeyedExtractPageItems(t *testing.T) {
+	cases := []struct {
+		name      string
+		payload   string
+		paths     []string
+		wantCount int
+	}{
+		{
+			name:      "wrapper key holds a bucketed collection",
+			payload:   ` + "`" + `{"results":{"2026-08-19":{"7788990011223344":{"id":"7788990011223344"},"1122334455667788":{"id":"1122334455667788"}}}}` + "`" + `,
+			wantCount: 2,
+		},
+		{
+			name:      "wrapper key holds a flat id-keyed collection",
+			payload:   ` + "`" + `{"data":{"7788990011223344":{"id":"7788990011223344"}}}` + "`" + `,
+			wantCount: 1,
+		},
+		{
+			name:      "payload is the collection itself",
+			payload:   ` + "`" + `{"7788990011223344":{"id":"7788990011223344"}}` + "`" + `,
+			wantCount: 1,
+		},
+		{
+			name:      "payload is a bucketed collection",
+			payload:   ` + "`" + `{"2026-08-19":{"7788990011223344":{"id":"7788990011223344"}}}` + "`" + `,
+			wantCount: 1,
+		},
+		{
+			name:      "declared response path resolves to a collection",
+			payload:   ` + "`" + `{"payload":{"7788990011223344":{"id":"7788990011223344"}}}` + "`" + `,
+			paths:     []string{"payload"},
+			wantCount: 1,
+		},
+		{
+			name:      "collection under a resource-named key beside scalar metadata",
+			payload:   ` + "`" + `{"calls_by_day":{"2026-08-19":{"7788990011223344":{"id":"7788990011223344"}}},"total":1}` + "`" + `,
+			wantCount: 1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			items, _, _ := extractPageItems(json.RawMessage(tc.payload), "cursor", tc.paths...)
+			if len(items) != tc.wantCount {
+				t.Fatalf("expected %d items, got %d", tc.wantCount, len(items))
+			}
+		})
+	}
+}
+
+// An array-shaped payload must keep taking the array path even when a
+// map-keyed strategy could also match something in the envelope.
+func TestMapKeyedDoesNotPreemptArrayExtraction(t *testing.T) {
+	items, _, _ := extractPageItems(json.RawMessage(` + "`" + `{"results":[{"id":"a"},{"id":"b"}],"index":{"7788990011223344":{"id":"a"}}}` + "`" + `), "cursor")
+	if len(items) != 2 {
+		t.Fatalf("array wrapper must win, got %d items", len(items))
+	}
+}
+
+func TestMapKeyedExtractPageItemsRejectsDetailObject(t *testing.T) {
+	items, _, _ := extractPageItems(json.RawMessage(` + "`" + `{"user":{"id":"u1"},"account":{"id":"a1"}}` + "`" + `), "cursor")
+	if len(items) != 0 {
+		t.Fatalf("a detail object with nested sub-objects must not be flattened, got %d items", len(items))
+	}
+}
+
+// The live path and sync must agree: both cache the records, not the envelope.
+func TestMapKeyedWriteThroughCachesRecords(t *testing.T) {
+	// Redirect every path root the store resolver consults, not just HOME, so
+	// the test cannot reach a real profile on a machine that sets XDG vars.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+
+	ctx := context.Background()
+	writeThroughCache(ctx, "calls", json.RawMessage(` + "`" + `{"results":{"2026-08-19":{"7788990011223344":{"id":"7788990011223344","title":"a"},"1122334455667788":{"id":"1122334455667788","title":"b"}}}}` + "`" + `))
+	writeThroughCache(ctx, "notes", json.RawMessage(` + "`" + `{"7788990011223344":{"title":"no id field"}}` + "`" + `))
+
+	db, err := openStoreForRead(ctx, "map-keyed-pp-cli")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if db == nil {
+		t.Fatalf("expected a store after write-through cache")
+	}
+	defer db.Close()
+
+	calls, err := db.List("calls", 10)
+	if err != nil {
+		t.Fatalf("list calls: %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 cached call rows, got %d", len(calls))
+	}
+
+	noteIDs, err := db.ListIDs("notes")
+	if err != nil {
+		t.Fatalf("list note ids: %v", err)
+	}
+	if len(noteIDs) != 1 || noteIDs[0] != "7788990011223344" {
+		t.Fatalf("expected the map key to key the id-less record, got %#v", noteIDs)
+	}
+}
+`
+
+// TestMapKeyedCollectionExtraction covers a collection that files each record
+// under its identifier instead of listing records in an array, at both nesting
+// depths, across the three surfaces that have to agree on it: the sync
+// extractor, the live write-through path, and the store's id resolvers.
+func TestMapKeyedCollectionExtraction(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("map-keyed")
+	outputDir := filepath.Join(t.TempDir(), "map-keyed-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "store", "map_keyed_collection_test.go"),
+		[]byte(mapKeyedStoreTestSource), 0o644))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "cli", "map_keyed_collection_test.go"),
+		[]byte(mapKeyedCLITestSource), 0o644))
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/store", "./internal/cli", "-run", "TestMapKeyed", "-count=1")
+}

--- a/internal/generator/sync_map_keyed_collection_test.go
+++ b/internal/generator/sync_map_keyed_collection_test.go
@@ -129,6 +129,35 @@ func TestMapKeyedCollectionKeepsRecordsBesideScalarMetadata(t *testing.T) {
 	}
 }
 
+// The pager needs the members the flattener skipped, so they come back beside
+// the records instead of being dropped.
+func TestMapKeyedFlattenReturnsSkippedMetadata(t *testing.T) {
+	items, metadata, ok := FlattenMapKeyedCollectionWithMetadata(json.RawMessage(` + "`" + `{"7788990011223344":{"id":"7788990011223344"},"next_cursor":"c2","total":1}` + "`" + `))
+	if !ok || len(items) != 1 {
+		t.Fatalf("expected 1 item, ok=%v len=%d", ok, len(items))
+	}
+	if string(metadata["next_cursor"]) != ` + "`" + `"c2"` + "`" + ` {
+		t.Fatalf("expected the sibling cursor in the metadata return, got %#v", metadata)
+	}
+	if _, ok := metadata["total"]; !ok {
+		t.Fatalf("every skipped member must come back, got %#v", metadata)
+	}
+}
+
+// A bucket's own metadata fills gaps the outer level left, and never overrides it.
+func TestMapKeyedBucketMetadataFillsGapsOnly(t *testing.T) {
+	_, metadata, ok := FlattenMapKeyedCollectionWithMetadata(json.RawMessage(` + "`" + `{"2026-08-19":{"7788990011223344":{"id":"a"},"next_cursor":"inner","page":2},"next_cursor":"outer"}` + "`" + `))
+	if !ok {
+		t.Fatalf("bucketed collection with metadata at both levels should be recognized")
+	}
+	if string(metadata["next_cursor"]) != ` + "`" + `"outer"` + "`" + ` {
+		t.Fatalf("the level closest to the caller must win, got %#v", metadata)
+	}
+	if string(metadata["page"]) != "2" {
+		t.Fatalf("bucket metadata must fill what the outer level lacks, got %#v", metadata)
+	}
+}
+
 // The enclosing key is the record's identity. A payload carrying the same field
 // name would otherwise file the row under a value the API never keyed it by.
 func TestMapKeyedStampOverwritesPayloadKeyField(t *testing.T) {
@@ -273,6 +302,63 @@ func TestMapKeyedMixedMetadataKeepsCursor(t *testing.T) {
 	}
 	if cursor != "c2" || !hasMore {
 		t.Fatalf("expected the sibling cursor to survive extraction, got %q hasMore=%v", cursor, hasMore)
+	}
+}
+
+// One case per site that lifts a map-keyed collection out of a sub-payload. A
+// cursor filed beside the records belongs to the page those records came from,
+// so it must outrank the envelope above them, and the envelope must still be
+// the answer when the collection carries none.
+func TestMapKeyedNestedCursorSurvives(t *testing.T) {
+	cases := []struct {
+		name       string
+		payload    string
+		paths      []string
+		wantItems  int
+		wantCursor string
+	}{
+		{
+			name:       "declared response path holds the collection and its cursor",
+			payload:    ` + "`" + `{"payload":{"7788990011223344":{"id":"7788990011223344"},"next_cursor":"p1"}}` + "`" + `,
+			paths:      []string{"payload"},
+			wantItems:  1,
+			wantCursor: "p1",
+		},
+		{
+			name:       "wrapper key holds the collection and its cursor",
+			payload:    ` + "`" + `{"data":{"7788990011223344":{"id":"7788990011223344"},"next_cursor":"w1"}}` + "`" + `,
+			wantItems:  1,
+			wantCursor: "w1",
+		},
+		{
+			name:       "resource-named sibling holds the collection and its cursor",
+			payload:    ` + "`" + `{"calls_by_day":{"7788990011223344":{"id":"7788990011223344"},"next_cursor":"s1"}}` + "`" + `,
+			wantItems:  1,
+			wantCursor: "s1",
+		},
+		{
+			name:       "bucketed collection carries the cursor at bucket level",
+			payload:    ` + "`" + `{"data":{"2026-08-19":{"7788990011223344":{"id":"7788990011223344"},"next_cursor":"b1"}}}` + "`" + `,
+			wantItems:  1,
+			wantCursor: "b1",
+		},
+		{
+			name:       "envelope cursor still wins when the collection carries none",
+			payload:    ` + "`" + `{"data":{"7788990011223344":{"id":"7788990011223344"}},"next_cursor":"o1"}` + "`" + `,
+			wantItems:  1,
+			wantCursor: "o1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			items, cursor, hasMore := extractPageItems(json.RawMessage(tc.payload), "cursor", tc.paths...)
+			if len(items) != tc.wantItems {
+				t.Fatalf("expected %d items, got %d", tc.wantItems, len(items))
+			}
+			if cursor != tc.wantCursor || !hasMore {
+				t.Fatalf("expected cursor %q with hasMore, got %q hasMore=%v", tc.wantCursor, cursor, hasMore)
+			}
+		})
 	}
 }
 

--- a/internal/generator/sync_map_keyed_collection_test.go
+++ b/internal/generator/sync_map_keyed_collection_test.go
@@ -135,6 +135,7 @@ func TestMapKeyedRejectsOrdinaryNestedObjects(t *testing.T) {
 		` + "`" + `{"oauth2":{"scope":"read"}}` + "`" + `,
 		` + "`" + `{"id":"7788990011223344","title":"a detail record"}` + "`" + `,
 		` + "`" + `{"7788990011223344":{"id":"x"},"meta":{"total":3}}` + "`" + `,
+		` + "`" + `{"id":"detail-1","title":"Alice","tags":["a"],"7788990011223344":{"role":"admin"}}` + "`" + `,
 		` + "`" + `{"total":3,"next_cursor":"c2"}` + "`" + `,
 		` + "`" + `{"7788990011223344":"not an object"}` + "`" + `,
 		` + "`" + `{}` + "`" + `,
@@ -144,6 +145,15 @@ func TestMapKeyedRejectsOrdinaryNestedObjects(t *testing.T) {
 		if _, ok := FlattenMapKeyedCollection(json.RawMessage(payload)); ok {
 			t.Fatalf("payload must not be treated as a map-keyed collection: %s", payload)
 		}
+	}
+}
+
+// A detail object may carry one numeric-keyed child beside ordinary fields.
+// Those siblings are not list metadata, so the child must not become the row.
+func TestMapKeyedRejectsNumericChildOnDetailObject(t *testing.T) {
+	payload := ` + "`" + `{"id":"detail-1","title":"Alice","tags":["a"],"7788990011223344":{"role":"admin"}}` + "`" + `
+	if _, ok := FlattenMapKeyedCollection(json.RawMessage(payload)); ok {
+		t.Fatalf("a detail object with one numeric-keyed child must not flatten: %s", payload)
 	}
 }
 
@@ -415,6 +425,13 @@ func TestMapKeyedExtractPageItemsRejectsDetailObject(t *testing.T) {
 	}
 }
 
+func TestMapKeyedExtractPageItemsRejectsNumericChildOnDetail(t *testing.T) {
+	items, _, _ := extractPageItems(json.RawMessage(` + "`" + `{"id":"detail-1","title":"Alice","tags":["a"],"7788990011223344":{"role":"admin"}}` + "`" + `), "cursor")
+	if len(items) != 0 {
+		t.Fatalf("a detail object with one numeric-keyed child must not flatten, got %d items", len(items))
+	}
+}
+
 // The live path and sync must agree: both cache the records, not the envelope.
 func TestMapKeyedWriteThroughCachesRecords(t *testing.T) {
 	// Redirect every path root the store resolver consults, not just HOME, so
@@ -454,6 +471,56 @@ func TestMapKeyedWriteThroughCachesRecords(t *testing.T) {
 	}
 	if len(noteIDs) != 1 || noteIDs[0] != "7788990011223344" {
 		t.Fatalf("expected the map key to key the id-less record, got %#v", noteIDs)
+	}
+}
+
+// A live detail response with one numeric-keyed child must cache the
+// envelope, not the child. Flattening would drop title and key the row
+// by the child's map key.
+func TestMapKeyedWriteThroughLeavesDetailNumericChildIntact(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+
+	ctx := context.Background()
+	writeThroughCache(ctx, "orders", json.RawMessage(` + "`" + `{"id":"detail-1","title":"Alice","tags":["a"],"7788990011223344":{"role":"admin"}}` + "`" + `))
+
+	db, err := openStoreForRead(ctx, "map-keyed-pp-cli")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if db == nil {
+		t.Fatalf("expected a store after write-through cache")
+	}
+	defer db.Close()
+
+	ids, err := db.ListIDs("orders")
+	if err != nil {
+		t.Fatalf("list order ids: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "detail-1" {
+		t.Fatalf("expected the detail object to stay the row, got %#v", ids)
+	}
+	rows, err := db.List("orders", 10)
+	if err != nil {
+		t.Fatalf("list orders: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 cached detail row, got %d", len(rows))
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(rows[0], &obj); err != nil {
+		t.Fatalf("decode cached row: %v", err)
+	}
+	if obj["title"] != "Alice" {
+		t.Fatalf("detail fields must survive write-through, got %#v", obj)
+	}
+	if _, ok := obj["7788990011223344"]; !ok {
+		t.Fatalf("the numeric-keyed child must remain on the detail row, got %#v", obj)
 	}
 }
 `

--- a/internal/generator/sync_map_keyed_collection_test.go
+++ b/internal/generator/sync_map_keyed_collection_test.go
@@ -113,7 +113,7 @@ func TestMapKeyedOneLevelDateKeySurvivesUnusableIDGate(t *testing.T) {
 		t.Fatalf("extractObjectID must keep a date-shaped map key, got %q", got)
 	}
 
-	// A leaf that also copies the date into id is refused by the #4379
+	// A leaf that also copies the date into id is refused by the
 	// canonical chain; the stamp is the arm that recovers it.
 	obj["id"] = "2026-08-19"
 	if got := ExtractResourceID("calls", obj); got != "2026-08-19" {

--- a/internal/generator/sync_map_keyed_collection_test.go
+++ b/internal/generator/sync_map_keyed_collection_test.go
@@ -97,7 +97,9 @@ func TestMapKeyedRejectsOrdinaryNestedObjects(t *testing.T) {
 		` + "`" + `{"line_items":{"sku":"a"},"shipping_address":{"zip":"1"}}` + "`" + `,
 		` + "`" + `{"oauth2":{"scope":"read"}}` + "`" + `,
 		` + "`" + `{"id":"7788990011223344","title":"a detail record"}` + "`" + `,
-		` + "`" + `{"2026-08-19":{"id":"x"},"total":3}` + "`" + `,
+		` + "`" + `{"7788990011223344":{"id":"x"},"meta":{"total":3}}` + "`" + `,
+		` + "`" + `{"total":3,"next_cursor":"c2"}` + "`" + `,
+		` + "`" + `{"7788990011223344":"not an object"}` + "`" + `,
 		` + "`" + `{}` + "`" + `,
 		` + "`" + `[{"id":"1"}]` + "`" + `,
 	}
@@ -105,6 +107,44 @@ func TestMapKeyedRejectsOrdinaryNestedObjects(t *testing.T) {
 		if _, ok := FlattenMapKeyedCollection(json.RawMessage(payload)); ok {
 			t.Fatalf("payload must not be treated as a map-keyed collection: %s", payload)
 		}
+	}
+}
+
+// Paging metadata filed beside the records must not cost the records: an API
+// is free to mix a cursor into the collection object itself.
+func TestMapKeyedCollectionKeepsRecordsBesideScalarMetadata(t *testing.T) {
+	items, ok := FlattenMapKeyedCollection(json.RawMessage(` + "`" + `{"7788990011223344":{"id":"7788990011223344","title":"a"},"next_cursor":"c2","total":1}` + "`" + `))
+	if !ok || len(items) != 1 {
+		t.Fatalf("expected 1 item beside scalar metadata, ok=%v len=%d", ok, len(items))
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(items[0], &obj); err != nil {
+		t.Fatalf("decode item: %v", err)
+	}
+	if obj["title"] != "a" {
+		t.Fatalf("expected the record, got %#v", obj)
+	}
+	if _, leaked := obj["next_cursor"]; leaked {
+		t.Fatalf("metadata must stay in the envelope, not ride along on the record: %#v", obj)
+	}
+}
+
+// The enclosing key is the record's identity. A payload carrying the same field
+// name would otherwise file the row under a value the API never keyed it by.
+func TestMapKeyedStampOverwritesPayloadKeyField(t *testing.T) {
+	items, ok := FlattenMapKeyedCollection(json.RawMessage(` + "`" + `{"7788990011223344":{"title":"no id field","_pp_map_key":"stale"}}` + "`" + `))
+	if !ok || len(items) != 1 {
+		t.Fatalf("expected 1 flattened item, ok=%v len=%d", ok, len(items))
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(items[0], &obj); err != nil {
+		t.Fatalf("decode item: %v", err)
+	}
+	if obj[MapKeyIDField] != "7788990011223344" {
+		t.Fatalf("the enclosing key must win over a payload field of the same name, got %#v", obj)
+	}
+	if got := ExtractResourceID("calls", obj); got != "7788990011223344" {
+		t.Fatalf("id resolution must follow the enclosing key, got %q", got)
 	}
 }
 
@@ -203,6 +243,11 @@ func TestMapKeyedExtractPageItems(t *testing.T) {
 			wantCount: 1,
 		},
 		{
+			name:      "records mixed with scalar metadata at the record level",
+			payload:   ` + "`" + `{"7788990011223344":{"id":"7788990011223344"},"1122334455667788":{"id":"1122334455667788"},"next_cursor":"c2"}` + "`" + `,
+			wantCount: 2,
+		},
+		{
 			name:      "collection under a resource-named key beside scalar metadata",
 			payload:   ` + "`" + `{"calls_by_day":{"2026-08-19":{"7788990011223344":{"id":"7788990011223344"}}},"total":1}` + "`" + `,
 			wantCount: 1,
@@ -215,6 +260,19 @@ func TestMapKeyedExtractPageItems(t *testing.T) {
 				t.Fatalf("expected %d items, got %d", tc.wantCount, len(items))
 			}
 		})
+	}
+}
+
+// Recognizing the payload as a collection must not cost the continuation
+// cursor sitting beside the records; dropping it would silently end the sync
+// after one page.
+func TestMapKeyedMixedMetadataKeepsCursor(t *testing.T) {
+	items, cursor, hasMore := extractPageItems(json.RawMessage(` + "`" + `{"7788990011223344":{"id":"7788990011223344"},"next_cursor":"c2"}` + "`" + `), "cursor")
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if cursor != "c2" || !hasMore {
+		t.Fatalf("expected the sibling cursor to survive extraction, got %q hasMore=%v", cursor, hasMore)
 	}
 }
 
@@ -248,7 +306,7 @@ func TestMapKeyedWriteThroughCachesRecords(t *testing.T) {
 
 	ctx := context.Background()
 	writeThroughCache(ctx, "calls", json.RawMessage(` + "`" + `{"results":{"2026-08-19":{"7788990011223344":{"id":"7788990011223344","title":"a"},"1122334455667788":{"id":"1122334455667788","title":"b"}}}}` + "`" + `))
-	writeThroughCache(ctx, "notes", json.RawMessage(` + "`" + `{"7788990011223344":{"title":"no id field"}}` + "`" + `))
+	writeThroughCache(ctx, "notes", json.RawMessage(` + "`" + `{"7788990011223344":{"title":"no id field"},"next_cursor":"c2"}` + "`" + `))
 
 	db, err := openStoreForRead(ctx, "map-keyed-pp-cli")
 	if err != nil {

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -486,7 +486,39 @@ func extractWriteThroughListItems(resourceType string, envelope map[string]json.
 		}
 	}
 
-	return extractWriteThroughSingleArraySibling(envelope, decodeWriteThroughNonEmptyArray)
+	if items, ok := extractWriteThroughSingleArraySibling(envelope, decodeWriteThroughNonEmptyArray); ok {
+		return items, true
+	}
+	return extractWriteThroughMapKeyedItems(envelope)
+}
+
+// extractWriteThroughMapKeyedItems mirrors the sync path's handling of a
+// collection that files each record under its id instead of listing records in
+// an array. Without it a live list and a sync of the same endpoint disagree:
+// sync caches the records, the live path caches the whole envelope or nothing.
+// The strategy order matches sync's — a wrapper key holding the collection,
+// then the envelope as the collection itself, then a lone non-metadata sibling
+// — so both paths pick the same records out of the same payload.
+func extractWriteThroughMapKeyedItems(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	for _, key := range writeThroughListWrapperKeys {
+		raw, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		if items, ok := store.FlattenMapKeyedCollection(raw); ok {
+			return items, true
+		}
+	}
+
+	if envelopeJSON, err := json.Marshal(envelope); err == nil {
+		if items, ok := store.FlattenMapKeyedCollection(envelopeJSON); ok {
+			return items, true
+		}
+	}
+
+	return store.FlattenSoleMapKeyedSibling(envelope, func(key string) bool {
+		return listEnvelopeMetadataKeys[key]
+	})
 }
 
 func extractWriteThroughResourceItems(resourceType string, envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -516,9 +516,12 @@ func extractWriteThroughMapKeyedItems(envelope map[string]json.RawMessage) ([]js
 		}
 	}
 
-	return store.FlattenSoleMapKeyedSibling(envelope, func(key string) bool {
+	// The live path serves one response, so a collection's own paging metadata
+	// has nothing to page and is dropped here.
+	items, _, ok := store.FlattenSoleMapKeyedSibling(envelope, func(key string) bool {
 		return listEnvelopeMetadataKeys[key]
 	})
+	return items, ok
 }
 
 func extractWriteThroughResourceItems(resourceType string, envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1325,6 +1325,11 @@ func FTSMatchQuery(query string) string {
 // object key here and the id resolvers below fall back to it once every real id
 // field has missed. Flattener and resolvers stay in one file because a shape
 // one recognizes and the other cannot key loses rows with no error.
+//
+// The _pp_ prefix is reserved for fields this CLI synthesizes, so the stamp
+// always wins over a same-named member of the payload: the enclosing key is
+// the record's identity, and a payload copy of it is either stale or a name
+// collision inside a namespace no API owns.
 const MapKeyIDField = "_pp_map_key"
 
 // One level covers {"<id>": {...}}, two covers a bucketed
@@ -1381,35 +1386,36 @@ type mapKeyedEntry struct {
 // dropping those members keeps the records reachable while the caller still
 // reads the cursor off the same envelope. Sorting makes repeated syncs of one
 // payload produce one row order.
-func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
+func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawMessage, bool) {
 	if !isJSONObjectPayload(raw) {
-		return nil, false
+		return nil, nil, false
 	}
 	var obj map[string]json.RawMessage
 	if json.Unmarshal(raw, &obj) != nil || len(obj) == 0 {
-		return nil, false
+		return nil, nil, false
 	}
 	keys := make([]string, 0, len(obj))
+	metadata := map[string]json.RawMessage{}
 	for key, value := range obj {
 		recordKeyed, objectValued := looksLikeRecordKey(key), isJSONObjectPayload(value)
 		switch {
 		case recordKeyed && objectValued:
 			keys = append(keys, key)
 		case !recordKeyed && !objectValued:
-			continue
+			metadata[key] = value
 		default:
-			return nil, false
+			return nil, nil, false
 		}
 	}
 	if len(keys) == 0 {
-		return nil, false
+		return nil, nil, false
 	}
 	sort.Strings(keys)
 	entries := make([]mapKeyedEntry, 0, len(keys))
 	for _, key := range keys {
 		entries = append(entries, mapKeyedEntry{key: key, value: obj[key]})
 	}
-	return entries, true
+	return entries, metadata, true
 }
 
 func isJSONObjectPayload(raw json.RawMessage) bool {
@@ -1427,19 +1433,35 @@ func isEmptyJSONObject(raw json.RawMessage) bool {
 // members are all empty reads as an empty page rather than as a shape this
 // could not extract.
 func FlattenMapKeyedCollection(raw json.RawMessage) ([]json.RawMessage, bool) {
+	items, _, ok := FlattenMapKeyedCollectionWithMetadata(raw)
+	return items, ok
+}
+
+// The members skipped as metadata come back with the records because a
+// collection nested under a wrapper key or a declared response path can carry
+// its own continuation cursor. Dropping them left the pager reading only the
+// envelope above, which ends a paginated sync after its first page.
+func FlattenMapKeyedCollectionWithMetadata(raw json.RawMessage) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	return flattenMapKeyedCollection(raw, mapKeyedMaxDepth)
 }
 
-func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessage, bool) {
-	entries, ok := mapKeyedEntries(raw)
+func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessage, map[string]json.RawMessage, bool) {
+	entries, metadata, ok := mapKeyedEntries(raw)
 	if !ok {
-		return nil, false
+		return nil, nil, false
 	}
 	items := make([]json.RawMessage, 0, len(entries))
 	for _, entry := range entries {
 		if depth > 1 {
-			if nested, ok := flattenMapKeyedCollection(entry.value, depth-1); ok {
+			if nested, nestedMetadata, ok := flattenMapKeyedCollection(entry.value, depth-1); ok {
 				items = append(items, nested...)
+				// A bucket's own metadata fills gaps only: the level closest to
+				// the caller describes the page it asked for.
+				for key, value := range nestedMetadata {
+					if _, taken := metadata[key]; !taken {
+						metadata[key] = value
+					}
+				}
 				continue
 			}
 		}
@@ -1448,7 +1470,7 @@ func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessag
 		}
 		items = append(items, stampMapKeyID(entry.value, entry.key))
 	}
-	return items, true
+	return items, metadata, true
 }
 
 // The enclosing key is the record's identity, so a same-named field already in
@@ -1476,22 +1498,23 @@ func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
 // their own isMetadataKey because the sync and live paths carry different
 // metadata vocabularies; recognition of the collection itself must not differ
 // between them.
-func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, bool) {
+func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	var collection []json.RawMessage
+	var collectionMetadata map[string]json.RawMessage
 	matches := 0
 	for key, raw := range envelope {
 		if isMetadataKey(key) {
 			continue
 		}
-		if items, ok := FlattenMapKeyedCollection(raw); ok {
-			collection = items
+		if items, metadata, ok := FlattenMapKeyedCollectionWithMetadata(raw); ok {
+			collection, collectionMetadata = items, metadata
 			matches++
 		}
 	}
 	if matches == 1 {
-		return collection, true
+		return collection, collectionMetadata, true
 	}
-	return nil, false
+	return nil, nil, false
 }
 
 // Callers must try every real id field first: the stamped key is only the right

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1378,14 +1378,40 @@ type mapKeyedEntry struct {
 	value json.RawMessage
 }
 
+// Field-name scalar/array siblings are list metadata only. Treating every
+// non-object field-name member as skippable metadata made a detail object
+// with one numeric-keyed child look like a one-record page, so sync and
+// write-through cached the child and dropped the remaining fields.
+var mapKeyedListMetadataKeys = map[string]bool{
+	"next_cursor": true, "nextCursor": true, "NextCursor": true,
+	"next_token": true, "nextToken": true, "NextToken": true,
+	"next_page_token": true, "nextPageToken": true, "NextPageToken": true,
+	"page_token": true, "pageToken": true, "PageToken": true,
+	"end_cursor": true, "endCursor": true, "EndCursor": true,
+	"start_cursor": true, "startCursor": true, "StartCursor": true,
+	"cursor": true, "Cursor": true, "after": true, "After": true, "before": true, "Before": true,
+	"has_more": true, "hasMore": true, "HasMore": true,
+	"has_next": true, "hasNext": true, "HasNext": true,
+	"next_page": true, "nextPage": true, "NextPage": true,
+	"previous_page": true, "previousPage": true, "PreviousPage": true,
+	"page": true, "Page": true, "page_size": true, "pageSize": true, "PageSize": true,
+	"per_page": true, "perPage": true, "PerPage": true,
+	"total": true, "Total": true, "count": true, "Count": true, "size": true, "Size": true,
+	"total_count": true, "totalCount": true, "TotalCount": true,
+	"success": true, "status": true, "message": true, "error": true, "errors": true,
+	"warnings": true, "Warnings": true, "ok": true, "Ok": true,
+	"next": true, "prev": true, "previous": true, "first": true, "last": true,
+}
+
 // A record identifier keying a JSON object is the only member shape a
 // collection may contain; anything else keyed like a record, or any object
 // keyed like a field, means the payload is something other than a collection
 // and is rejected whole. Scalar and array members under field-name keys are
-// the exception: an API is free to file paging metadata beside the records, so
-// dropping those members keeps the records reachable while the caller still
-// reads the cursor off the same envelope. Sorting makes repeated syncs of one
-// payload produce one row order.
+// kept only when the key is list metadata, so a real collection can still
+// file a cursor or total beside its records. A detail field (id, title, tags)
+// beside a single record-shaped child is not metadata: that payload stays a
+// detail object. Sorting makes repeated syncs of one payload produce one
+// row order.
 func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawMessage, bool) {
 	if !isJSONObjectPayload(raw) {
 		return nil, nil, false
@@ -1401,7 +1427,7 @@ func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawM
 		switch {
 		case recordKeyed && objectValued:
 			keys = append(keys, key)
-		case !recordKeyed && !objectValued:
+		case !recordKeyed && !objectValued && mapKeyedListMetadataKeys[key]:
 			metadata[key] = value
 		default:
 			return nil, nil, false

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1403,6 +1403,25 @@ var mapKeyedListMetadataKeys = map[string]bool{
 	"next": true, "prev": true, "previous": true, "first": true, "last": true,
 }
 
+// A lone record-shaped child plus only count/JSend fields is still a
+// detail object (status, message, total, count). A one-record page is
+// recognized only when a cursor, has-more flag, or page key is present.
+var mapKeyedPagingSignalKeys = map[string]bool{
+	"next_cursor": true, "nextCursor": true, "NextCursor": true,
+	"next_token": true, "nextToken": true, "NextToken": true,
+	"next_page_token": true, "nextPageToken": true, "NextPageToken": true,
+	"page_token": true, "pageToken": true, "PageToken": true,
+	"end_cursor": true, "endCursor": true, "EndCursor": true,
+	"start_cursor": true, "startCursor": true, "StartCursor": true,
+	"cursor": true, "Cursor": true, "after": true, "After": true, "before": true, "Before": true,
+	"has_more": true, "hasMore": true, "HasMore": true,
+	"has_next": true, "hasNext": true, "HasNext": true,
+	"next_page": true, "nextPage": true, "NextPage": true,
+	"previous_page": true, "previousPage": true, "PreviousPage": true,
+	"page": true, "Page": true, "page_size": true, "pageSize": true, "PageSize": true,
+	"per_page": true, "perPage": true, "PerPage": true,
+}
+
 // A record identifier keying a JSON object is the only member shape a
 // collection may contain; anything else keyed like a record, or any object
 // keyed like a field, means the payload is something other than a collection
@@ -1410,8 +1429,9 @@ var mapKeyedListMetadataKeys = map[string]bool{
 // kept only when the key is list metadata, so a real collection can still
 // file a cursor or total beside its records. A detail field (id, title, tags)
 // beside a single record-shaped child is not metadata: that payload stays a
-// detail object. Sorting makes repeated syncs of one payload produce one
-// row order.
+// detail object. One record plus only count/JSend siblings is also a detail
+// object; a one-record page needs a cursor, has-more flag, or page key.
+// Sorting makes repeated syncs of one payload produce one row order.
 func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawMessage, bool) {
 	if !isJSONObjectPayload(raw) {
 		return nil, nil, false
@@ -1436,12 +1456,24 @@ func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawM
 	if len(keys) == 0 {
 		return nil, nil, false
 	}
+	if len(keys) == 1 && len(metadata) > 0 && !hasMapKeyedPagingSignal(metadata) {
+		return nil, nil, false
+	}
 	sort.Strings(keys)
 	entries := make([]mapKeyedEntry, 0, len(keys))
 	for _, key := range keys {
 		entries = append(entries, mapKeyedEntry{key: key, value: obj[key]})
 	}
 	return entries, metadata, true
+}
+
+func hasMapKeyedPagingSignal(metadata map[string]json.RawMessage) bool {
+	for key := range metadata {
+		if mapKeyedPagingSignalKeys[key] {
+			return true
+		}
+	}
+	return false
 }
 
 func isJSONObjectPayload(raw json.RawMessage) bool {

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1320,19 +1320,14 @@ func FTSMatchQuery(query string) string {
 	return strings.Join(quoted, " ")
 }
 
-// MapKeyIDField is the synthetic field FlattenMapKeyedCollection stamps onto
-// every item it lifts out of a map-keyed collection, carrying the JSON object
-// key that identified the record. The id resolvers below consult it as a last
-// resort, so a leaf object that carries no id field of its own still resolves
-// to the key the API filed it under instead of being dropped.
-//
-// The flattener and the id resolvers live in this file together on purpose:
-// if one recognizes a shape the other cannot key, the rows disappear from the
-// local mirror without an error.
+// A record filed under its own identifier often carries no id field inside the
+// object, and would be dropped for want of one. The flattener stamps the JSON
+// object key here and the id resolvers below fall back to it once every real id
+// field has missed. Flattener and resolvers stay in one file because a shape
+// one recognizes and the other cannot key loses rows with no error.
 const MapKeyIDField = "_pp_map_key"
 
-// mapKeyedMaxDepth bounds how far FlattenMapKeyedCollection descends. One
-// level covers {"<id>": {...}}; two covers a bucketed
+// One level covers {"<id>": {...}}, two covers a bucketed
 // {"<bucket>": {"<id>": {...}}}. Descending further would start treating an
 // item's own nested sub-objects as sibling records.
 const mapKeyedMaxDepth = 2
@@ -1352,10 +1347,9 @@ var (
 	mapKeyHasDigitRE = regexp.MustCompile(`[0-9]`)
 )
 
-// looksLikeRecordKey reports whether a JSON object key reads as a record
-// identifier rather than a field name. A separator-free token must be long and
-// carry a digit before it qualifies, because a short alphabetic token is
-// indistinguishable from a field name.
+// A separator-free token must be long and carry a digit before it qualifies as
+// an identifier, because a short alphabetic token is indistinguishable from a
+// field name.
 func looksLikeRecordKey(key string) bool {
 	switch {
 	case key == "":
@@ -1379,11 +1373,14 @@ type mapKeyedEntry struct {
 	value json.RawMessage
 }
 
-// mapKeyedEntries decodes raw as a map-keyed collection. Every key must read
-// as a record identifier and every value must be a JSON object; a single
-// disqualifying member rejects the whole payload, so a mixed envelope is never
-// mistaken for a collection. Entries come back key-sorted so repeated syncs of
-// the same payload always produce the same row order.
+// A record identifier keying a JSON object is the only member shape a
+// collection may contain; anything else keyed like a record, or any object
+// keyed like a field, means the payload is something other than a collection
+// and is rejected whole. Scalar and array members under field-name keys are
+// the exception: an API is free to file paging metadata beside the records, so
+// dropping those members keeps the records reachable while the caller still
+// reads the cursor off the same envelope. Sorting makes repeated syncs of one
+// payload produce one row order.
 func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
 	if !isJSONObjectPayload(raw) {
 		return nil, false
@@ -1394,10 +1391,18 @@ func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
 	}
 	keys := make([]string, 0, len(obj))
 	for key, value := range obj {
-		if !looksLikeRecordKey(key) || !isJSONObjectPayload(value) {
+		recordKeyed, objectValued := looksLikeRecordKey(key), isJSONObjectPayload(value)
+		switch {
+		case recordKeyed && objectValued:
+			keys = append(keys, key)
+		case !recordKeyed && !objectValued:
+			continue
+		default:
 			return nil, false
 		}
-		keys = append(keys, key)
+	}
+	if len(keys) == 0 {
+		return nil, false
 	}
 	sort.Strings(keys)
 	entries := make([]mapKeyedEntry, 0, len(keys))
@@ -1417,12 +1422,10 @@ func isEmptyJSONObject(raw json.RawMessage) bool {
 	return json.Unmarshal(raw, &obj) == nil && len(obj) == 0
 }
 
-// FlattenMapKeyedCollection lifts the records out of a collection that files
-// each record under its own identifier — {"<id>": {...}} — including one level
-// of bucketing above the records — {"<bucket>": {"<id>": {...}}}. The second
-// return value reports whether raw was recognized as such a collection at all;
-// a recognized collection whose members are all empty yields no items, which
-// is an empty page rather than a failure to extract.
+// Recognition and extraction are separate answers: the second return reports
+// only whether raw was a collection at all, so a recognized collection whose
+// members are all empty reads as an empty page rather than as a shape this
+// could not extract.
 func FlattenMapKeyedCollection(raw json.RawMessage) ([]json.RawMessage, bool) {
 	return flattenMapKeyedCollection(raw, mapKeyedMaxDepth)
 }
@@ -1448,14 +1451,12 @@ func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessag
 	return items, true
 }
 
-// stampMapKeyID records the collection key on the item it identified. A key
-// the payload already carries is left alone so re-flattening is idempotent.
+// The enclosing key is the record's identity, so a same-named field already in
+// the payload is overwritten rather than trusted: keeping it would file the row
+// under a value the API never used as its key.
 func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
 	var obj map[string]json.RawMessage
 	if json.Unmarshal(value, &obj) != nil {
-		return value
-	}
-	if _, exists := obj[MapKeyIDField]; exists {
 		return value
 	}
 	encodedKey, err := json.Marshal(key)
@@ -1470,11 +1471,10 @@ func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
 	return stamped
 }
 
-// FlattenSoleMapKeyedSibling flattens the single member of an envelope that
-// holds a map-keyed collection alongside scalar metadata. Two flattenable
-// members leave the envelope ambiguous, so nothing is extracted. Callers pass
-// their own isMetadataKey because the sync and live paths each carry their own
-// metadata vocabulary; the collection recognition itself must not differ
+// Two flattenable members leave the envelope ambiguous, so nothing is
+// extracted rather than guessing which one holds the records. Callers pass
+// their own isMetadataKey because the sync and live paths carry different
+// metadata vocabularies; recognition of the collection itself must not differ
 // between them.
 func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, bool) {
 	var collection []json.RawMessage
@@ -1494,9 +1494,8 @@ func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataK
 	return nil, false
 }
 
-// mapKeyIDFallback resolves the identifier FlattenMapKeyedCollection stamped
-// onto an item. Callers must try every real id field first: the stamped key is
-// only the right answer when the record carries no identifier of its own.
+// Callers must try every real id field first: the stamped key is only the right
+// answer when the record carries no identifier of its own.
 func mapKeyIDFallback(obj map[string]any) string {
 	v, ok := obj[MapKeyIDField]
 	if !ok {

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1319,13 +1320,201 @@ func FTSMatchQuery(query string) string {
 	return strings.Join(quoted, " ")
 }
 
+// MapKeyIDField is the synthetic field FlattenMapKeyedCollection stamps onto
+// every item it lifts out of a map-keyed collection, carrying the JSON object
+// key that identified the record. The id resolvers below consult it as a last
+// resort, so a leaf object that carries no id field of its own still resolves
+// to the key the API filed it under instead of being dropped.
+//
+// The flattener and the id resolvers live in this file together on purpose:
+// if one recognizes a shape the other cannot key, the rows disappear from the
+// local mirror without an error.
+const MapKeyIDField = "_pp_map_key"
+
+// mapKeyedMaxDepth bounds how far FlattenMapKeyedCollection descends. One
+// level covers {"<id>": {...}}; two covers a bucketed
+// {"<bucket>": {"<id>": {...}}}. Descending further would start treating an
+// item's own nested sub-objects as sibling records.
+const mapKeyedMaxDepth = 2
+
+// A map-keyed collection files each record under its identifier instead of
+// listing records in an array, so the discriminator has to separate record
+// identifiers from ordinary field names. Field names are words; record
+// identifiers are not. These patterns admit only key shapes that no API uses
+// as a field name, which keeps an ordinary detail object carrying nested
+// sub-objects ({"user": {...}, "account": {...}}) out of the collection path.
+var (
+	mapKeyNumericRE  = regexp.MustCompile(`^[0-9]+$`)
+	mapKeyUUIDRE     = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	mapKeyDateRE     = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}([T ][0-9A-Za-z:.+-]*)?$`)
+	mapKeyOpaqueRE   = regexp.MustCompile(`^[A-Za-z0-9]{20,}$`)
+	mapKeyPrefixedRE = regexp.MustCompile(`^[-_][A-Za-z0-9_-]{15,}$`)
+	mapKeyHasDigitRE = regexp.MustCompile(`[0-9]`)
+)
+
+// looksLikeRecordKey reports whether a JSON object key reads as a record
+// identifier rather than a field name. A separator-free token must be long and
+// carry a digit before it qualifies, because a short alphabetic token is
+// indistinguishable from a field name.
+func looksLikeRecordKey(key string) bool {
+	switch {
+	case key == "":
+		return false
+	case mapKeyNumericRE.MatchString(key):
+		return true
+	case mapKeyUUIDRE.MatchString(key):
+		return true
+	case mapKeyDateRE.MatchString(key):
+		return true
+	case mapKeyOpaqueRE.MatchString(key) && mapKeyHasDigitRE.MatchString(key):
+		return true
+	case mapKeyPrefixedRE.MatchString(key) && mapKeyHasDigitRE.MatchString(key):
+		return true
+	}
+	return false
+}
+
+type mapKeyedEntry struct {
+	key   string
+	value json.RawMessage
+}
+
+// mapKeyedEntries decodes raw as a map-keyed collection. Every key must read
+// as a record identifier and every value must be a JSON object; a single
+// disqualifying member rejects the whole payload, so a mixed envelope is never
+// mistaken for a collection. Entries come back key-sorted so repeated syncs of
+// the same payload always produce the same row order.
+func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
+	if !isJSONObjectPayload(raw) {
+		return nil, false
+	}
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(raw, &obj) != nil || len(obj) == 0 {
+		return nil, false
+	}
+	keys := make([]string, 0, len(obj))
+	for key, value := range obj {
+		if !looksLikeRecordKey(key) || !isJSONObjectPayload(value) {
+			return nil, false
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	entries := make([]mapKeyedEntry, 0, len(keys))
+	for _, key := range keys {
+		entries = append(entries, mapKeyedEntry{key: key, value: obj[key]})
+	}
+	return entries, true
+}
+
+func isJSONObjectPayload(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) > 0 && trimmed[0] == '{'
+}
+
+func isEmptyJSONObject(raw json.RawMessage) bool {
+	var obj map[string]json.RawMessage
+	return json.Unmarshal(raw, &obj) == nil && len(obj) == 0
+}
+
+// FlattenMapKeyedCollection lifts the records out of a collection that files
+// each record under its own identifier — {"<id>": {...}} — including one level
+// of bucketing above the records — {"<bucket>": {"<id>": {...}}}. The second
+// return value reports whether raw was recognized as such a collection at all;
+// a recognized collection whose members are all empty yields no items, which
+// is an empty page rather than a failure to extract.
+func FlattenMapKeyedCollection(raw json.RawMessage) ([]json.RawMessage, bool) {
+	return flattenMapKeyedCollection(raw, mapKeyedMaxDepth)
+}
+
+func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessage, bool) {
+	entries, ok := mapKeyedEntries(raw)
+	if !ok {
+		return nil, false
+	}
+	items := make([]json.RawMessage, 0, len(entries))
+	for _, entry := range entries {
+		if depth > 1 {
+			if nested, ok := flattenMapKeyedCollection(entry.value, depth-1); ok {
+				items = append(items, nested...)
+				continue
+			}
+		}
+		if isEmptyJSONObject(entry.value) {
+			continue
+		}
+		items = append(items, stampMapKeyID(entry.value, entry.key))
+	}
+	return items, true
+}
+
+// stampMapKeyID records the collection key on the item it identified. A key
+// the payload already carries is left alone so re-flattening is idempotent.
+func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(value, &obj) != nil {
+		return value
+	}
+	if _, exists := obj[MapKeyIDField]; exists {
+		return value
+	}
+	encodedKey, err := json.Marshal(key)
+	if err != nil {
+		return value
+	}
+	obj[MapKeyIDField] = encodedKey
+	stamped, err := json.Marshal(obj)
+	if err != nil {
+		return value
+	}
+	return stamped
+}
+
+// FlattenSoleMapKeyedSibling flattens the single member of an envelope that
+// holds a map-keyed collection alongside scalar metadata. Two flattenable
+// members leave the envelope ambiguous, so nothing is extracted. Callers pass
+// their own isMetadataKey because the sync and live paths each carry their own
+// metadata vocabulary; the collection recognition itself must not differ
+// between them.
+func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, bool) {
+	var collection []json.RawMessage
+	matches := 0
+	for key, raw := range envelope {
+		if isMetadataKey(key) {
+			continue
+		}
+		if items, ok := FlattenMapKeyedCollection(raw); ok {
+			collection = items
+			matches++
+		}
+	}
+	if matches == 1 {
+		return collection, true
+	}
+	return nil, false
+}
+
+// mapKeyIDFallback resolves the identifier FlattenMapKeyedCollection stamped
+// onto an item. Callers must try every real id field first: the stamped key is
+// only the right answer when the record carries no identifier of its own.
+func mapKeyIDFallback(obj map[string]any) string {
+	v, ok := obj[MapKeyIDField]
+	if !ok {
+		return ""
+	}
+	if id := ResourceIDString(v); id != "" && id != "<nil>" {
+		return id
+	}
+	return ""
+}
+
 func extractObjectID(obj map[string]any) string {
 	for _, key := range []string{"id", "ID", "_id", "id_", "uuid", "slug", "name"} {
 		if s := canonicalIDFromKey(obj, key); s != "" {
 			return s
 		}
 	}
-	return ""
+	return mapKeyIDFallback(obj)
 }
 
 // ftsRowID derives a deterministic rowid from a string ID for use with FTS5.
@@ -1720,7 +1909,7 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 			return s
 		}
 	}
-	return ""
+	return mapKeyIDFallback(obj)
 }
 
 // suffixIDFieldFallback resolves an id-less resource that keys on its own

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1878,16 +1878,19 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 			continue
 		}
 		pathItems, found := extractJSONItemsArray(pathData)
+		var pathMetadata map[string]json.RawMessage
 		if !found {
 			// A declared response path can resolve to a map-keyed collection
 			// rather than an array. No wrapper key is a record key, so this
 			// can never shadow an array-shaped or enveloped payload.
-			pathItems, found = store.FlattenMapKeyedCollection(pathData)
+			pathItems, pathMetadata, found = store.FlattenMapKeyedCollectionWithMetadata(pathData)
 		}
 		if found {
-			nextCursor, hasMore := "", false
-			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
-				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
+			nextCursor, hasMore := mapKeyedPagination(pathMetadata, cursorParam)
+			if nextCursor == "" && !hasMore {
+				if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
+					nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
+				}
 			}
 			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 			if nextCursor == "" {
@@ -1910,9 +1913,13 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		}
 	}
 
-	if items, ok := extractItemsByKnownKeys(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
-		return items, nextCursor, hasMore
+	if items, metadata, ok := extractItemsByKnownKeysWithMetadata(envelope); ok {
+		nextCursor, hasMore := mapKeyedPagination(metadata, cursorParam)
+		outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		if nextCursor == "" {
+			nextCursor = outerCursor
+		}
+		return items, nextCursor, hasMore || outerHasMore
 	}
 
 	for _, key := range dataEnvelopeKeys {
@@ -1958,12 +1965,27 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		return items, nextCursor, hasMore
 	}
 
-	if items, ok := extractSingleMapKeyedSibling(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
-		return items, nextCursor, hasMore
+	if items, metadata, ok := extractSingleMapKeyedSibling(envelope); ok {
+		nextCursor, hasMore := mapKeyedPagination(metadata, cursorParam)
+		outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		if nextCursor == "" {
+			nextCursor = outerCursor
+		}
+		return items, nextCursor, hasMore || outerHasMore
 	}
 
 	return nil, "", false
+}
+
+// Metadata filed beside the records describes the page those records came from,
+// so it is consulted before the envelope above them. nextCursorPath is declared
+// against the response root, which this level is not, so only a plain field
+// match applies here.
+func mapKeyedPagination(metadata map[string]json.RawMessage, cursorParam string) (string, bool) {
+	if len(metadata) == 0 {
+		return "", false
+	}
+	return extractPaginationFromEnvelope(metadata, cursorParam, "")
 }
 
 func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
@@ -1973,21 +1995,31 @@ func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMe
 	if items, ok := extractSingleObjectArraySibling(envelope); ok {
 		return items, true
 	}
-	return extractSingleMapKeyedSibling(envelope)
+	items, _, ok := extractSingleMapKeyedSibling(envelope)
+	return items, ok
 }
 
 // extractSingleMapKeyedSibling handles an envelope that carries a map-keyed
 // collection under a resource-named key alongside scalar metadata. Exactly one
 // non-metadata key may flatten: an envelope holding two candidate collections
 // is ambiguous and is left for the caller to reject.
-func extractSingleMapKeyedSibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+func extractSingleMapKeyedSibling(envelope map[string]json.RawMessage) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	return store.FlattenSoleMapKeyedSibling(envelope, func(key string) bool {
 		return pageEnvelopeMetadataKeys[key]
 	})
 }
 
 func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	items, _, ok := extractItemsByKnownKeysWithMetadata(envelope)
+	return items, ok
+}
+
+// A wrapper key holding a map-keyed collection can carry that collection's own
+// paging metadata inside the wrapper. Callers that paginate take the metadata
+// return; the rest use the wrapper above and drop it.
+func extractItemsByKnownKeysWithMetadata(envelope map[string]json.RawMessage) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	var emptyItems []json.RawMessage
+	var emptyMetadata map[string]json.RawMessage
 	foundEmpty := false
 	for _, key := range pageItemKeys {
 		if raw, ok := envelope[key]; ok {
@@ -1997,7 +2029,7 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 			}
 			if items, ok := extract(raw); ok {
 				if len(items) > 0 {
-					return items, true
+					return items, nil, true
 				}
 				emptyItems = items
 				foundEmpty = true
@@ -2012,20 +2044,20 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 		if !ok {
 			continue
 		}
-		items, ok := store.FlattenMapKeyedCollection(raw)
+		items, metadata, ok := store.FlattenMapKeyedCollectionWithMetadata(raw)
 		if !ok {
 			continue
 		}
 		if len(items) > 0 {
-			return items, true
+			return items, metadata, true
 		}
-		emptyItems = items
+		emptyItems, emptyMetadata = items, metadata
 		foundEmpty = true
 	}
 	if foundEmpty {
-		return emptyItems, true
+		return emptyItems, emptyMetadata, true
 	}
-	return nil, false
+	return nil, nil, false
 }
 
 func extractSingleObjectArraySibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1852,6 +1852,8 @@ func determineDateRangeParam() string {
 // 1. Direct JSON array
 // 2. Common wrapper keys: "data", "results", "items", "records", "nodes", "entries"
 // 3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
+// 4. Map-keyed collections that file each record under its id instead of
+//    listing records in an array: {"<id>":{...}} and {"<bucket>":{"<id>":{...}}}
 // It also extracts the next cursor from common response fields.
 func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ...string) ([]json.RawMessage, string, bool) {
 	return extractPageItemsWithPagination(data, cursorParam, "", responsePaths...)
@@ -1875,7 +1877,14 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		if !ok {
 			continue
 		}
-		if items, ok := extractJSONItemsArray(pathData); ok {
+		pathItems, found := extractJSONItemsArray(pathData)
+		if !found {
+			// A declared response path can resolve to a map-keyed collection
+			// rather than an array. No wrapper key is a record key, so this
+			// can never shadow an array-shaped or enveloped payload.
+			pathItems, found = store.FlattenMapKeyedCollection(pathData)
+		}
+		if found {
 			nextCursor, hasMore := "", false
 			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
 				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
@@ -1885,7 +1894,7 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 				nextCursor = outerCursor
 			}
 			hasMore = hasMore || outerHasMore
-			return items, nextCursor, hasMore
+			return pathItems, nextCursor, hasMore
 		}
 		var inner map[string]json.RawMessage
 		if json.Unmarshal(pathData, &inner) == nil {
@@ -1941,6 +1950,19 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		return items, nextCursor, hasMore
 	}
 
+	// The response can be the collection itself, filing each record under its
+	// id rather than listing records in an array. Both map-keyed strategies
+	// run last so no array-shaped strategy is preempted.
+	if items, ok := store.FlattenMapKeyedCollection(data); ok {
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		return items, nextCursor, hasMore
+	}
+
+	if items, ok := extractSingleMapKeyedSibling(envelope); ok {
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		return items, nextCursor, hasMore
+	}
+
 	return nil, "", false
 }
 
@@ -1948,7 +1970,20 @@ func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMe
 	if items, ok := extractItemsByKnownKeys(envelope); ok {
 		return items, true
 	}
-	return extractSingleObjectArraySibling(envelope)
+	if items, ok := extractSingleObjectArraySibling(envelope); ok {
+		return items, true
+	}
+	return extractSingleMapKeyedSibling(envelope)
+}
+
+// extractSingleMapKeyedSibling handles an envelope that carries a map-keyed
+// collection under a resource-named key alongside scalar metadata. Exactly one
+// non-metadata key may flatten: an envelope holding two candidate collections
+// is ambiguous and is left for the caller to reject.
+func extractSingleMapKeyedSibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	return store.FlattenSoleMapKeyedSibling(envelope, func(key string) bool {
+		return pageEnvelopeMetadataKeys[key]
+	})
 }
 
 func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
@@ -1968,6 +2003,24 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 				foundEmpty = true
 			}
 		}
+	}
+	// A wrapper key can hold a map-keyed collection instead of an array. This
+	// runs only after every wrapper key has failed the array decode, so an
+	// array-shaped wrapper always wins.
+	for _, key := range pageItemKeys {
+		raw, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		items, ok := store.FlattenMapKeyedCollection(raw)
+		if !ok {
+			continue
+		}
+		if len(items) > 0 {
+			return items, true
+		}
+		emptyItems = items
+		foundEmpty = true
 	}
 	if foundEmpty {
 		return emptyItems, true

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -486,7 +486,39 @@ func extractWriteThroughListItems(resourceType string, envelope map[string]json.
 		}
 	}
 
-	return extractWriteThroughSingleArraySibling(envelope, decodeWriteThroughNonEmptyArray)
+	if items, ok := extractWriteThroughSingleArraySibling(envelope, decodeWriteThroughNonEmptyArray); ok {
+		return items, true
+	}
+	return extractWriteThroughMapKeyedItems(envelope)
+}
+
+// extractWriteThroughMapKeyedItems mirrors the sync path's handling of a
+// collection that files each record under its id instead of listing records in
+// an array. Without it a live list and a sync of the same endpoint disagree:
+// sync caches the records, the live path caches the whole envelope or nothing.
+// The strategy order matches sync's — a wrapper key holding the collection,
+// then the envelope as the collection itself, then a lone non-metadata sibling
+// — so both paths pick the same records out of the same payload.
+func extractWriteThroughMapKeyedItems(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	for _, key := range writeThroughListWrapperKeys {
+		raw, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		if items, ok := store.FlattenMapKeyedCollection(raw); ok {
+			return items, true
+		}
+	}
+
+	if envelopeJSON, err := json.Marshal(envelope); err == nil {
+		if items, ok := store.FlattenMapKeyedCollection(envelopeJSON); ok {
+			return items, true
+		}
+	}
+
+	return store.FlattenSoleMapKeyedSibling(envelope, func(key string) bool {
+		return listEnvelopeMetadataKeys[key]
+	})
 }
 
 func extractWriteThroughResourceItems(resourceType string, envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -516,9 +516,12 @@ func extractWriteThroughMapKeyedItems(envelope map[string]json.RawMessage) ([]js
 		}
 	}
 
-	return store.FlattenSoleMapKeyedSibling(envelope, func(key string) bool {
+	// The live path serves one response, so a collection's own paging metadata
+	// has nothing to page and is dropped here.
+	items, _, ok := store.FlattenSoleMapKeyedSibling(envelope, func(key string) bool {
 		return listEnvelopeMetadataKeys[key]
 	})
+	return items, ok
 }
 
 func extractWriteThroughResourceItems(resourceType string, envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -1209,16 +1209,19 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 			continue
 		}
 		pathItems, found := extractJSONItemsArray(pathData)
+		var pathMetadata map[string]json.RawMessage
 		if !found {
 			// A declared response path can resolve to a map-keyed collection
 			// rather than an array. No wrapper key is a record key, so this
 			// can never shadow an array-shaped or enveloped payload.
-			pathItems, found = store.FlattenMapKeyedCollection(pathData)
+			pathItems, pathMetadata, found = store.FlattenMapKeyedCollectionWithMetadata(pathData)
 		}
 		if found {
-			nextCursor, hasMore := "", false
-			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
-				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
+			nextCursor, hasMore := mapKeyedPagination(pathMetadata, cursorParam)
+			if nextCursor == "" && !hasMore {
+				if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
+					nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
+				}
 			}
 			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 			if nextCursor == "" {
@@ -1241,9 +1244,13 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		}
 	}
 
-	if items, ok := extractItemsByKnownKeys(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
-		return items, nextCursor, hasMore
+	if items, metadata, ok := extractItemsByKnownKeysWithMetadata(envelope); ok {
+		nextCursor, hasMore := mapKeyedPagination(metadata, cursorParam)
+		outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		if nextCursor == "" {
+			nextCursor = outerCursor
+		}
+		return items, nextCursor, hasMore || outerHasMore
 	}
 
 	for _, key := range dataEnvelopeKeys {
@@ -1289,12 +1296,27 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		return items, nextCursor, hasMore
 	}
 
-	if items, ok := extractSingleMapKeyedSibling(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
-		return items, nextCursor, hasMore
+	if items, metadata, ok := extractSingleMapKeyedSibling(envelope); ok {
+		nextCursor, hasMore := mapKeyedPagination(metadata, cursorParam)
+		outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		if nextCursor == "" {
+			nextCursor = outerCursor
+		}
+		return items, nextCursor, hasMore || outerHasMore
 	}
 
 	return nil, "", false
+}
+
+// Metadata filed beside the records describes the page those records came from,
+// so it is consulted before the envelope above them. nextCursorPath is declared
+// against the response root, which this level is not, so only a plain field
+// match applies here.
+func mapKeyedPagination(metadata map[string]json.RawMessage, cursorParam string) (string, bool) {
+	if len(metadata) == 0 {
+		return "", false
+	}
+	return extractPaginationFromEnvelope(metadata, cursorParam, "")
 }
 
 func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
@@ -1304,21 +1326,31 @@ func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMe
 	if items, ok := extractSingleObjectArraySibling(envelope); ok {
 		return items, true
 	}
-	return extractSingleMapKeyedSibling(envelope)
+	items, _, ok := extractSingleMapKeyedSibling(envelope)
+	return items, ok
 }
 
 // extractSingleMapKeyedSibling handles an envelope that carries a map-keyed
 // collection under a resource-named key alongside scalar metadata. Exactly one
 // non-metadata key may flatten: an envelope holding two candidate collections
 // is ambiguous and is left for the caller to reject.
-func extractSingleMapKeyedSibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+func extractSingleMapKeyedSibling(envelope map[string]json.RawMessage) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	return store.FlattenSoleMapKeyedSibling(envelope, func(key string) bool {
 		return pageEnvelopeMetadataKeys[key]
 	})
 }
 
 func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	items, _, ok := extractItemsByKnownKeysWithMetadata(envelope)
+	return items, ok
+}
+
+// A wrapper key holding a map-keyed collection can carry that collection's own
+// paging metadata inside the wrapper. Callers that paginate take the metadata
+// return; the rest use the wrapper above and drop it.
+func extractItemsByKnownKeysWithMetadata(envelope map[string]json.RawMessage) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	var emptyItems []json.RawMessage
+	var emptyMetadata map[string]json.RawMessage
 	foundEmpty := false
 	for _, key := range pageItemKeys {
 		if raw, ok := envelope[key]; ok {
@@ -1328,7 +1360,7 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 			}
 			if items, ok := extract(raw); ok {
 				if len(items) > 0 {
-					return items, true
+					return items, nil, true
 				}
 				emptyItems = items
 				foundEmpty = true
@@ -1343,20 +1375,20 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 		if !ok {
 			continue
 		}
-		items, ok := store.FlattenMapKeyedCollection(raw)
+		items, metadata, ok := store.FlattenMapKeyedCollectionWithMetadata(raw)
 		if !ok {
 			continue
 		}
 		if len(items) > 0 {
-			return items, true
+			return items, metadata, true
 		}
-		emptyItems = items
+		emptyItems, emptyMetadata = items, metadata
 		foundEmpty = true
 	}
 	if foundEmpty {
-		return emptyItems, true
+		return emptyItems, emptyMetadata, true
 	}
-	return nil, false
+	return nil, nil, false
 }
 
 func extractSingleObjectArraySibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -1179,9 +1179,12 @@ func formatSyncSinceValue(value string, paramFormat string) string {
 
 // extractPageItems attempts to extract an array of items and pagination cursor from a response.
 // It tries multiple strategies:
-// 1. Direct JSON array
-// 2. Common wrapper keys: "data", "results", "items", "records", "nodes", "entries"
-// 3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
+//  1. Direct JSON array
+//  2. Common wrapper keys: "data", "results", "items", "records", "nodes", "entries"
+//  3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
+//  4. Map-keyed collections that file each record under its id instead of
+//     listing records in an array: {"<id>":{...}} and {"<bucket>":{"<id>":{...}}}
+//
 // It also extracts the next cursor from common response fields.
 func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ...string) ([]json.RawMessage, string, bool) {
 	return extractPageItemsWithPagination(data, cursorParam, "", responsePaths...)
@@ -1205,7 +1208,14 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		if !ok {
 			continue
 		}
-		if items, ok := extractJSONItemsArray(pathData); ok {
+		pathItems, found := extractJSONItemsArray(pathData)
+		if !found {
+			// A declared response path can resolve to a map-keyed collection
+			// rather than an array. No wrapper key is a record key, so this
+			// can never shadow an array-shaped or enveloped payload.
+			pathItems, found = store.FlattenMapKeyedCollection(pathData)
+		}
+		if found {
 			nextCursor, hasMore := "", false
 			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
 				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
@@ -1215,7 +1225,7 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 				nextCursor = outerCursor
 			}
 			hasMore = hasMore || outerHasMore
-			return items, nextCursor, hasMore
+			return pathItems, nextCursor, hasMore
 		}
 		var inner map[string]json.RawMessage
 		if json.Unmarshal(pathData, &inner) == nil {
@@ -1271,6 +1281,19 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		return items, nextCursor, hasMore
 	}
 
+	// The response can be the collection itself, filing each record under its
+	// id rather than listing records in an array. Both map-keyed strategies
+	// run last so no array-shaped strategy is preempted.
+	if items, ok := store.FlattenMapKeyedCollection(data); ok {
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		return items, nextCursor, hasMore
+	}
+
+	if items, ok := extractSingleMapKeyedSibling(envelope); ok {
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		return items, nextCursor, hasMore
+	}
+
 	return nil, "", false
 }
 
@@ -1278,7 +1301,20 @@ func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMe
 	if items, ok := extractItemsByKnownKeys(envelope); ok {
 		return items, true
 	}
-	return extractSingleObjectArraySibling(envelope)
+	if items, ok := extractSingleObjectArraySibling(envelope); ok {
+		return items, true
+	}
+	return extractSingleMapKeyedSibling(envelope)
+}
+
+// extractSingleMapKeyedSibling handles an envelope that carries a map-keyed
+// collection under a resource-named key alongside scalar metadata. Exactly one
+// non-metadata key may flatten: an envelope holding two candidate collections
+// is ambiguous and is left for the caller to reject.
+func extractSingleMapKeyedSibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	return store.FlattenSoleMapKeyedSibling(envelope, func(key string) bool {
+		return pageEnvelopeMetadataKeys[key]
+	})
 }
 
 func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
@@ -1298,6 +1334,24 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 				foundEmpty = true
 			}
 		}
+	}
+	// A wrapper key can hold a map-keyed collection instead of an array. This
+	// runs only after every wrapper key has failed the array decode, so an
+	// array-shaped wrapper always wins.
+	for _, key := range pageItemKeys {
+		raw, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		items, ok := store.FlattenMapKeyedCollection(raw)
+		if !ok {
+			continue
+		}
+		if len(items) > 0 {
+			return items, true
+		}
+		emptyItems = items
+		foundEmpty = true
 	}
 	if foundEmpty {
 		return emptyItems, true

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -1115,6 +1115,25 @@ var mapKeyedListMetadataKeys = map[string]bool{
 	"next": true, "prev": true, "previous": true, "first": true, "last": true,
 }
 
+// A lone record-shaped child plus only count/JSend fields is still a
+// detail object (status, message, total, count). A one-record page is
+// recognized only when a cursor, has-more flag, or page key is present.
+var mapKeyedPagingSignalKeys = map[string]bool{
+	"next_cursor": true, "nextCursor": true, "NextCursor": true,
+	"next_token": true, "nextToken": true, "NextToken": true,
+	"next_page_token": true, "nextPageToken": true, "NextPageToken": true,
+	"page_token": true, "pageToken": true, "PageToken": true,
+	"end_cursor": true, "endCursor": true, "EndCursor": true,
+	"start_cursor": true, "startCursor": true, "StartCursor": true,
+	"cursor": true, "Cursor": true, "after": true, "After": true, "before": true, "Before": true,
+	"has_more": true, "hasMore": true, "HasMore": true,
+	"has_next": true, "hasNext": true, "HasNext": true,
+	"next_page": true, "nextPage": true, "NextPage": true,
+	"previous_page": true, "previousPage": true, "PreviousPage": true,
+	"page": true, "Page": true, "page_size": true, "pageSize": true, "PageSize": true,
+	"per_page": true, "perPage": true, "PerPage": true,
+}
+
 // A record identifier keying a JSON object is the only member shape a
 // collection may contain; anything else keyed like a record, or any object
 // keyed like a field, means the payload is something other than a collection
@@ -1122,8 +1141,9 @@ var mapKeyedListMetadataKeys = map[string]bool{
 // kept only when the key is list metadata, so a real collection can still
 // file a cursor or total beside its records. A detail field (id, title, tags)
 // beside a single record-shaped child is not metadata: that payload stays a
-// detail object. Sorting makes repeated syncs of one payload produce one
-// row order.
+// detail object. One record plus only count/JSend siblings is also a detail
+// object; a one-record page needs a cursor, has-more flag, or page key.
+// Sorting makes repeated syncs of one payload produce one row order.
 func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawMessage, bool) {
 	if !isJSONObjectPayload(raw) {
 		return nil, nil, false
@@ -1148,12 +1168,24 @@ func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawM
 	if len(keys) == 0 {
 		return nil, nil, false
 	}
+	if len(keys) == 1 && len(metadata) > 0 && !hasMapKeyedPagingSignal(metadata) {
+		return nil, nil, false
+	}
 	sort.Strings(keys)
 	entries := make([]mapKeyedEntry, 0, len(keys))
 	for _, key := range keys {
 		entries = append(entries, mapKeyedEntry{key: key, value: obj[key]})
 	}
 	return entries, metadata, true
+}
+
+func hasMapKeyedPagingSignal(metadata map[string]json.RawMessage) bool {
+	for key := range metadata {
+		if mapKeyedPagingSignalKeys[key] {
+			return true
+		}
+	}
+	return false
 }
 
 func isJSONObjectPayload(raw json.RawMessage) bool {

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -1090,14 +1090,40 @@ type mapKeyedEntry struct {
 	value json.RawMessage
 }
 
+// Field-name scalar/array siblings are list metadata only. Treating every
+// non-object field-name member as skippable metadata made a detail object
+// with one numeric-keyed child look like a one-record page, so sync and
+// write-through cached the child and dropped the remaining fields.
+var mapKeyedListMetadataKeys = map[string]bool{
+	"next_cursor": true, "nextCursor": true, "NextCursor": true,
+	"next_token": true, "nextToken": true, "NextToken": true,
+	"next_page_token": true, "nextPageToken": true, "NextPageToken": true,
+	"page_token": true, "pageToken": true, "PageToken": true,
+	"end_cursor": true, "endCursor": true, "EndCursor": true,
+	"start_cursor": true, "startCursor": true, "StartCursor": true,
+	"cursor": true, "Cursor": true, "after": true, "After": true, "before": true, "Before": true,
+	"has_more": true, "hasMore": true, "HasMore": true,
+	"has_next": true, "hasNext": true, "HasNext": true,
+	"next_page": true, "nextPage": true, "NextPage": true,
+	"previous_page": true, "previousPage": true, "PreviousPage": true,
+	"page": true, "Page": true, "page_size": true, "pageSize": true, "PageSize": true,
+	"per_page": true, "perPage": true, "PerPage": true,
+	"total": true, "Total": true, "count": true, "Count": true, "size": true, "Size": true,
+	"total_count": true, "totalCount": true, "TotalCount": true,
+	"success": true, "status": true, "message": true, "error": true, "errors": true,
+	"warnings": true, "Warnings": true, "ok": true, "Ok": true,
+	"next": true, "prev": true, "previous": true, "first": true, "last": true,
+}
+
 // A record identifier keying a JSON object is the only member shape a
 // collection may contain; anything else keyed like a record, or any object
 // keyed like a field, means the payload is something other than a collection
 // and is rejected whole. Scalar and array members under field-name keys are
-// the exception: an API is free to file paging metadata beside the records, so
-// dropping those members keeps the records reachable while the caller still
-// reads the cursor off the same envelope. Sorting makes repeated syncs of one
-// payload produce one row order.
+// kept only when the key is list metadata, so a real collection can still
+// file a cursor or total beside its records. A detail field (id, title, tags)
+// beside a single record-shaped child is not metadata: that payload stays a
+// detail object. Sorting makes repeated syncs of one payload produce one
+// row order.
 func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawMessage, bool) {
 	if !isJSONObjectPayload(raw) {
 		return nil, nil, false
@@ -1113,7 +1139,7 @@ func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawM
 		switch {
 		case recordKeyed && objectValued:
 			keys = append(keys, key)
-		case !recordKeyed && !objectValued:
+		case !recordKeyed && !objectValued && mapKeyedListMetadataKeys[key]:
 			metadata[key] = value
 		default:
 			return nil, nil, false

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -1037,6 +1037,11 @@ func FTSMatchQuery(query string) string {
 // object key here and the id resolvers below fall back to it once every real id
 // field has missed. Flattener and resolvers stay in one file because a shape
 // one recognizes and the other cannot key loses rows with no error.
+//
+// The _pp_ prefix is reserved for fields this CLI synthesizes, so the stamp
+// always wins over a same-named member of the payload: the enclosing key is
+// the record's identity, and a payload copy of it is either stale or a name
+// collision inside a namespace no API owns.
 const MapKeyIDField = "_pp_map_key"
 
 // One level covers {"<id>": {...}}, two covers a bucketed
@@ -1093,35 +1098,36 @@ type mapKeyedEntry struct {
 // dropping those members keeps the records reachable while the caller still
 // reads the cursor off the same envelope. Sorting makes repeated syncs of one
 // payload produce one row order.
-func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
+func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawMessage, bool) {
 	if !isJSONObjectPayload(raw) {
-		return nil, false
+		return nil, nil, false
 	}
 	var obj map[string]json.RawMessage
 	if json.Unmarshal(raw, &obj) != nil || len(obj) == 0 {
-		return nil, false
+		return nil, nil, false
 	}
 	keys := make([]string, 0, len(obj))
+	metadata := map[string]json.RawMessage{}
 	for key, value := range obj {
 		recordKeyed, objectValued := looksLikeRecordKey(key), isJSONObjectPayload(value)
 		switch {
 		case recordKeyed && objectValued:
 			keys = append(keys, key)
 		case !recordKeyed && !objectValued:
-			continue
+			metadata[key] = value
 		default:
-			return nil, false
+			return nil, nil, false
 		}
 	}
 	if len(keys) == 0 {
-		return nil, false
+		return nil, nil, false
 	}
 	sort.Strings(keys)
 	entries := make([]mapKeyedEntry, 0, len(keys))
 	for _, key := range keys {
 		entries = append(entries, mapKeyedEntry{key: key, value: obj[key]})
 	}
-	return entries, true
+	return entries, metadata, true
 }
 
 func isJSONObjectPayload(raw json.RawMessage) bool {
@@ -1139,19 +1145,35 @@ func isEmptyJSONObject(raw json.RawMessage) bool {
 // members are all empty reads as an empty page rather than as a shape this
 // could not extract.
 func FlattenMapKeyedCollection(raw json.RawMessage) ([]json.RawMessage, bool) {
+	items, _, ok := FlattenMapKeyedCollectionWithMetadata(raw)
+	return items, ok
+}
+
+// The members skipped as metadata come back with the records because a
+// collection nested under a wrapper key or a declared response path can carry
+// its own continuation cursor. Dropping them left the pager reading only the
+// envelope above, which ends a paginated sync after its first page.
+func FlattenMapKeyedCollectionWithMetadata(raw json.RawMessage) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	return flattenMapKeyedCollection(raw, mapKeyedMaxDepth)
 }
 
-func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessage, bool) {
-	entries, ok := mapKeyedEntries(raw)
+func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessage, map[string]json.RawMessage, bool) {
+	entries, metadata, ok := mapKeyedEntries(raw)
 	if !ok {
-		return nil, false
+		return nil, nil, false
 	}
 	items := make([]json.RawMessage, 0, len(entries))
 	for _, entry := range entries {
 		if depth > 1 {
-			if nested, ok := flattenMapKeyedCollection(entry.value, depth-1); ok {
+			if nested, nestedMetadata, ok := flattenMapKeyedCollection(entry.value, depth-1); ok {
 				items = append(items, nested...)
+				// A bucket's own metadata fills gaps only: the level closest to
+				// the caller describes the page it asked for.
+				for key, value := range nestedMetadata {
+					if _, taken := metadata[key]; !taken {
+						metadata[key] = value
+					}
+				}
 				continue
 			}
 		}
@@ -1160,7 +1182,7 @@ func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessag
 		}
 		items = append(items, stampMapKeyID(entry.value, entry.key))
 	}
-	return items, true
+	return items, metadata, true
 }
 
 // The enclosing key is the record's identity, so a same-named field already in
@@ -1188,22 +1210,23 @@ func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
 // their own isMetadataKey because the sync and live paths carry different
 // metadata vocabularies; recognition of the collection itself must not differ
 // between them.
-func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, bool) {
+func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	var collection []json.RawMessage
+	var collectionMetadata map[string]json.RawMessage
 	matches := 0
 	for key, raw := range envelope {
 		if isMetadataKey(key) {
 			continue
 		}
-		if items, ok := FlattenMapKeyedCollection(raw); ok {
-			collection = items
+		if items, metadata, ok := FlattenMapKeyedCollectionWithMetadata(raw); ok {
+			collection, collectionMetadata = items, metadata
 			matches++
 		}
 	}
 	if matches == 1 {
-		return collection, true
+		return collection, collectionMetadata, true
 	}
-	return nil, false
+	return nil, nil, false
 }
 
 // Callers must try every real id field first: the stamped key is only the right

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1031,13 +1032,201 @@ func FTSMatchQuery(query string) string {
 	return strings.Join(quoted, " ")
 }
 
+// MapKeyIDField is the synthetic field FlattenMapKeyedCollection stamps onto
+// every item it lifts out of a map-keyed collection, carrying the JSON object
+// key that identified the record. The id resolvers below consult it as a last
+// resort, so a leaf object that carries no id field of its own still resolves
+// to the key the API filed it under instead of being dropped.
+//
+// The flattener and the id resolvers live in this file together on purpose:
+// if one recognizes a shape the other cannot key, the rows disappear from the
+// local mirror without an error.
+const MapKeyIDField = "_pp_map_key"
+
+// mapKeyedMaxDepth bounds how far FlattenMapKeyedCollection descends. One
+// level covers {"<id>": {...}}; two covers a bucketed
+// {"<bucket>": {"<id>": {...}}}. Descending further would start treating an
+// item's own nested sub-objects as sibling records.
+const mapKeyedMaxDepth = 2
+
+// A map-keyed collection files each record under its identifier instead of
+// listing records in an array, so the discriminator has to separate record
+// identifiers from ordinary field names. Field names are words; record
+// identifiers are not. These patterns admit only key shapes that no API uses
+// as a field name, which keeps an ordinary detail object carrying nested
+// sub-objects ({"user": {...}, "account": {...}}) out of the collection path.
+var (
+	mapKeyNumericRE  = regexp.MustCompile(`^[0-9]+$`)
+	mapKeyUUIDRE     = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	mapKeyDateRE     = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}([T ][0-9A-Za-z:.+-]*)?$`)
+	mapKeyOpaqueRE   = regexp.MustCompile(`^[A-Za-z0-9]{20,}$`)
+	mapKeyPrefixedRE = regexp.MustCompile(`^[-_][A-Za-z0-9_-]{15,}$`)
+	mapKeyHasDigitRE = regexp.MustCompile(`[0-9]`)
+)
+
+// looksLikeRecordKey reports whether a JSON object key reads as a record
+// identifier rather than a field name. A separator-free token must be long and
+// carry a digit before it qualifies, because a short alphabetic token is
+// indistinguishable from a field name.
+func looksLikeRecordKey(key string) bool {
+	switch {
+	case key == "":
+		return false
+	case mapKeyNumericRE.MatchString(key):
+		return true
+	case mapKeyUUIDRE.MatchString(key):
+		return true
+	case mapKeyDateRE.MatchString(key):
+		return true
+	case mapKeyOpaqueRE.MatchString(key) && mapKeyHasDigitRE.MatchString(key):
+		return true
+	case mapKeyPrefixedRE.MatchString(key) && mapKeyHasDigitRE.MatchString(key):
+		return true
+	}
+	return false
+}
+
+type mapKeyedEntry struct {
+	key   string
+	value json.RawMessage
+}
+
+// mapKeyedEntries decodes raw as a map-keyed collection. Every key must read
+// as a record identifier and every value must be a JSON object; a single
+// disqualifying member rejects the whole payload, so a mixed envelope is never
+// mistaken for a collection. Entries come back key-sorted so repeated syncs of
+// the same payload always produce the same row order.
+func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
+	if !isJSONObjectPayload(raw) {
+		return nil, false
+	}
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(raw, &obj) != nil || len(obj) == 0 {
+		return nil, false
+	}
+	keys := make([]string, 0, len(obj))
+	for key, value := range obj {
+		if !looksLikeRecordKey(key) || !isJSONObjectPayload(value) {
+			return nil, false
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	entries := make([]mapKeyedEntry, 0, len(keys))
+	for _, key := range keys {
+		entries = append(entries, mapKeyedEntry{key: key, value: obj[key]})
+	}
+	return entries, true
+}
+
+func isJSONObjectPayload(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) > 0 && trimmed[0] == '{'
+}
+
+func isEmptyJSONObject(raw json.RawMessage) bool {
+	var obj map[string]json.RawMessage
+	return json.Unmarshal(raw, &obj) == nil && len(obj) == 0
+}
+
+// FlattenMapKeyedCollection lifts the records out of a collection that files
+// each record under its own identifier — {"<id>": {...}} — including one level
+// of bucketing above the records — {"<bucket>": {"<id>": {...}}}. The second
+// return value reports whether raw was recognized as such a collection at all;
+// a recognized collection whose members are all empty yields no items, which
+// is an empty page rather than a failure to extract.
+func FlattenMapKeyedCollection(raw json.RawMessage) ([]json.RawMessage, bool) {
+	return flattenMapKeyedCollection(raw, mapKeyedMaxDepth)
+}
+
+func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessage, bool) {
+	entries, ok := mapKeyedEntries(raw)
+	if !ok {
+		return nil, false
+	}
+	items := make([]json.RawMessage, 0, len(entries))
+	for _, entry := range entries {
+		if depth > 1 {
+			if nested, ok := flattenMapKeyedCollection(entry.value, depth-1); ok {
+				items = append(items, nested...)
+				continue
+			}
+		}
+		if isEmptyJSONObject(entry.value) {
+			continue
+		}
+		items = append(items, stampMapKeyID(entry.value, entry.key))
+	}
+	return items, true
+}
+
+// stampMapKeyID records the collection key on the item it identified. A key
+// the payload already carries is left alone so re-flattening is idempotent.
+func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(value, &obj) != nil {
+		return value
+	}
+	if _, exists := obj[MapKeyIDField]; exists {
+		return value
+	}
+	encodedKey, err := json.Marshal(key)
+	if err != nil {
+		return value
+	}
+	obj[MapKeyIDField] = encodedKey
+	stamped, err := json.Marshal(obj)
+	if err != nil {
+		return value
+	}
+	return stamped
+}
+
+// FlattenSoleMapKeyedSibling flattens the single member of an envelope that
+// holds a map-keyed collection alongside scalar metadata. Two flattenable
+// members leave the envelope ambiguous, so nothing is extracted. Callers pass
+// their own isMetadataKey because the sync and live paths each carry their own
+// metadata vocabulary; the collection recognition itself must not differ
+// between them.
+func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, bool) {
+	var collection []json.RawMessage
+	matches := 0
+	for key, raw := range envelope {
+		if isMetadataKey(key) {
+			continue
+		}
+		if items, ok := FlattenMapKeyedCollection(raw); ok {
+			collection = items
+			matches++
+		}
+	}
+	if matches == 1 {
+		return collection, true
+	}
+	return nil, false
+}
+
+// mapKeyIDFallback resolves the identifier FlattenMapKeyedCollection stamped
+// onto an item. Callers must try every real id field first: the stamped key is
+// only the right answer when the record carries no identifier of its own.
+func mapKeyIDFallback(obj map[string]any) string {
+	v, ok := obj[MapKeyIDField]
+	if !ok {
+		return ""
+	}
+	if id := ResourceIDString(v); id != "" && id != "<nil>" {
+		return id
+	}
+	return ""
+}
+
 func extractObjectID(obj map[string]any) string {
 	for _, key := range []string{"id", "ID", "_id", "id_", "uuid", "slug", "name"} {
 		if s := canonicalIDFromKey(obj, key); s != "" {
 			return s
 		}
 	}
-	return ""
+	return mapKeyIDFallback(obj)
 }
 
 // ftsRowID derives a deterministic rowid from a string ID for use with FTS5.
@@ -1342,7 +1531,7 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 			return s
 		}
 	}
-	return ""
+	return mapKeyIDFallback(obj)
 }
 
 // suffixIDFieldFallback resolves an id-less resource that keys on its own

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -1032,19 +1032,14 @@ func FTSMatchQuery(query string) string {
 	return strings.Join(quoted, " ")
 }
 
-// MapKeyIDField is the synthetic field FlattenMapKeyedCollection stamps onto
-// every item it lifts out of a map-keyed collection, carrying the JSON object
-// key that identified the record. The id resolvers below consult it as a last
-// resort, so a leaf object that carries no id field of its own still resolves
-// to the key the API filed it under instead of being dropped.
-//
-// The flattener and the id resolvers live in this file together on purpose:
-// if one recognizes a shape the other cannot key, the rows disappear from the
-// local mirror without an error.
+// A record filed under its own identifier often carries no id field inside the
+// object, and would be dropped for want of one. The flattener stamps the JSON
+// object key here and the id resolvers below fall back to it once every real id
+// field has missed. Flattener and resolvers stay in one file because a shape
+// one recognizes and the other cannot key loses rows with no error.
 const MapKeyIDField = "_pp_map_key"
 
-// mapKeyedMaxDepth bounds how far FlattenMapKeyedCollection descends. One
-// level covers {"<id>": {...}}; two covers a bucketed
+// One level covers {"<id>": {...}}, two covers a bucketed
 // {"<bucket>": {"<id>": {...}}}. Descending further would start treating an
 // item's own nested sub-objects as sibling records.
 const mapKeyedMaxDepth = 2
@@ -1064,10 +1059,9 @@ var (
 	mapKeyHasDigitRE = regexp.MustCompile(`[0-9]`)
 )
 
-// looksLikeRecordKey reports whether a JSON object key reads as a record
-// identifier rather than a field name. A separator-free token must be long and
-// carry a digit before it qualifies, because a short alphabetic token is
-// indistinguishable from a field name.
+// A separator-free token must be long and carry a digit before it qualifies as
+// an identifier, because a short alphabetic token is indistinguishable from a
+// field name.
 func looksLikeRecordKey(key string) bool {
 	switch {
 	case key == "":
@@ -1091,11 +1085,14 @@ type mapKeyedEntry struct {
 	value json.RawMessage
 }
 
-// mapKeyedEntries decodes raw as a map-keyed collection. Every key must read
-// as a record identifier and every value must be a JSON object; a single
-// disqualifying member rejects the whole payload, so a mixed envelope is never
-// mistaken for a collection. Entries come back key-sorted so repeated syncs of
-// the same payload always produce the same row order.
+// A record identifier keying a JSON object is the only member shape a
+// collection may contain; anything else keyed like a record, or any object
+// keyed like a field, means the payload is something other than a collection
+// and is rejected whole. Scalar and array members under field-name keys are
+// the exception: an API is free to file paging metadata beside the records, so
+// dropping those members keeps the records reachable while the caller still
+// reads the cursor off the same envelope. Sorting makes repeated syncs of one
+// payload produce one row order.
 func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
 	if !isJSONObjectPayload(raw) {
 		return nil, false
@@ -1106,10 +1103,18 @@ func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
 	}
 	keys := make([]string, 0, len(obj))
 	for key, value := range obj {
-		if !looksLikeRecordKey(key) || !isJSONObjectPayload(value) {
+		recordKeyed, objectValued := looksLikeRecordKey(key), isJSONObjectPayload(value)
+		switch {
+		case recordKeyed && objectValued:
+			keys = append(keys, key)
+		case !recordKeyed && !objectValued:
+			continue
+		default:
 			return nil, false
 		}
-		keys = append(keys, key)
+	}
+	if len(keys) == 0 {
+		return nil, false
 	}
 	sort.Strings(keys)
 	entries := make([]mapKeyedEntry, 0, len(keys))
@@ -1129,12 +1134,10 @@ func isEmptyJSONObject(raw json.RawMessage) bool {
 	return json.Unmarshal(raw, &obj) == nil && len(obj) == 0
 }
 
-// FlattenMapKeyedCollection lifts the records out of a collection that files
-// each record under its own identifier — {"<id>": {...}} — including one level
-// of bucketing above the records — {"<bucket>": {"<id>": {...}}}. The second
-// return value reports whether raw was recognized as such a collection at all;
-// a recognized collection whose members are all empty yields no items, which
-// is an empty page rather than a failure to extract.
+// Recognition and extraction are separate answers: the second return reports
+// only whether raw was a collection at all, so a recognized collection whose
+// members are all empty reads as an empty page rather than as a shape this
+// could not extract.
 func FlattenMapKeyedCollection(raw json.RawMessage) ([]json.RawMessage, bool) {
 	return flattenMapKeyedCollection(raw, mapKeyedMaxDepth)
 }
@@ -1160,14 +1163,12 @@ func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessag
 	return items, true
 }
 
-// stampMapKeyID records the collection key on the item it identified. A key
-// the payload already carries is left alone so re-flattening is idempotent.
+// The enclosing key is the record's identity, so a same-named field already in
+// the payload is overwritten rather than trusted: keeping it would file the row
+// under a value the API never used as its key.
 func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
 	var obj map[string]json.RawMessage
 	if json.Unmarshal(value, &obj) != nil {
-		return value
-	}
-	if _, exists := obj[MapKeyIDField]; exists {
 		return value
 	}
 	encodedKey, err := json.Marshal(key)
@@ -1182,11 +1183,10 @@ func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
 	return stamped
 }
 
-// FlattenSoleMapKeyedSibling flattens the single member of an envelope that
-// holds a map-keyed collection alongside scalar metadata. Two flattenable
-// members leave the envelope ambiguous, so nothing is extracted. Callers pass
-// their own isMetadataKey because the sync and live paths each carry their own
-// metadata vocabulary; the collection recognition itself must not differ
+// Two flattenable members leave the envelope ambiguous, so nothing is
+// extracted rather than guessing which one holds the records. Callers pass
+// their own isMetadataKey because the sync and live paths carry different
+// metadata vocabularies; recognition of the collection itself must not differ
 // between them.
 func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, bool) {
 	var collection []json.RawMessage
@@ -1206,9 +1206,8 @@ func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataK
 	return nil, false
 }
 
-// mapKeyIDFallback resolves the identifier FlattenMapKeyedCollection stamped
-// onto an item. Callers must try every real id field first: the stamped key is
-// only the right answer when the record carries no identifier of its own.
+// Callers must try every real id field first: the stamped key is only the right
+// answer when the record carries no identifier of its own.
 func mapKeyIDFallback(obj map[string]any) string {
 	v, ok := obj[MapKeyIDField]
 	if !ok {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1277,6 +1277,25 @@ var mapKeyedListMetadataKeys = map[string]bool{
 	"next": true, "prev": true, "previous": true, "first": true, "last": true,
 }
 
+// A lone record-shaped child plus only count/JSend fields is still a
+// detail object (status, message, total, count). A one-record page is
+// recognized only when a cursor, has-more flag, or page key is present.
+var mapKeyedPagingSignalKeys = map[string]bool{
+	"next_cursor": true, "nextCursor": true, "NextCursor": true,
+	"next_token": true, "nextToken": true, "NextToken": true,
+	"next_page_token": true, "nextPageToken": true, "NextPageToken": true,
+	"page_token": true, "pageToken": true, "PageToken": true,
+	"end_cursor": true, "endCursor": true, "EndCursor": true,
+	"start_cursor": true, "startCursor": true, "StartCursor": true,
+	"cursor": true, "Cursor": true, "after": true, "After": true, "before": true, "Before": true,
+	"has_more": true, "hasMore": true, "HasMore": true,
+	"has_next": true, "hasNext": true, "HasNext": true,
+	"next_page": true, "nextPage": true, "NextPage": true,
+	"previous_page": true, "previousPage": true, "PreviousPage": true,
+	"page": true, "Page": true, "page_size": true, "pageSize": true, "PageSize": true,
+	"per_page": true, "perPage": true, "PerPage": true,
+}
+
 // A record identifier keying a JSON object is the only member shape a
 // collection may contain; anything else keyed like a record, or any object
 // keyed like a field, means the payload is something other than a collection
@@ -1284,8 +1303,9 @@ var mapKeyedListMetadataKeys = map[string]bool{
 // kept only when the key is list metadata, so a real collection can still
 // file a cursor or total beside its records. A detail field (id, title, tags)
 // beside a single record-shaped child is not metadata: that payload stays a
-// detail object. Sorting makes repeated syncs of one payload produce one
-// row order.
+// detail object. One record plus only count/JSend siblings is also a detail
+// object; a one-record page needs a cursor, has-more flag, or page key.
+// Sorting makes repeated syncs of one payload produce one row order.
 func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawMessage, bool) {
 	if !isJSONObjectPayload(raw) {
 		return nil, nil, false
@@ -1310,12 +1330,24 @@ func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawM
 	if len(keys) == 0 {
 		return nil, nil, false
 	}
+	if len(keys) == 1 && len(metadata) > 0 && !hasMapKeyedPagingSignal(metadata) {
+		return nil, nil, false
+	}
 	sort.Strings(keys)
 	entries := make([]mapKeyedEntry, 0, len(keys))
 	for _, key := range keys {
 		entries = append(entries, mapKeyedEntry{key: key, value: obj[key]})
 	}
 	return entries, metadata, true
+}
+
+func hasMapKeyedPagingSignal(metadata map[string]json.RawMessage) bool {
+	for key := range metadata {
+		if mapKeyedPagingSignalKeys[key] {
+			return true
+		}
+	}
+	return false
 }
 
 func isJSONObjectPayload(raw json.RawMessage) bool {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1193,13 +1194,201 @@ func FTSMatchQuery(query string) string {
 	return strings.Join(quoted, " ")
 }
 
+// MapKeyIDField is the synthetic field FlattenMapKeyedCollection stamps onto
+// every item it lifts out of a map-keyed collection, carrying the JSON object
+// key that identified the record. The id resolvers below consult it as a last
+// resort, so a leaf object that carries no id field of its own still resolves
+// to the key the API filed it under instead of being dropped.
+//
+// The flattener and the id resolvers live in this file together on purpose:
+// if one recognizes a shape the other cannot key, the rows disappear from the
+// local mirror without an error.
+const MapKeyIDField = "_pp_map_key"
+
+// mapKeyedMaxDepth bounds how far FlattenMapKeyedCollection descends. One
+// level covers {"<id>": {...}}; two covers a bucketed
+// {"<bucket>": {"<id>": {...}}}. Descending further would start treating an
+// item's own nested sub-objects as sibling records.
+const mapKeyedMaxDepth = 2
+
+// A map-keyed collection files each record under its identifier instead of
+// listing records in an array, so the discriminator has to separate record
+// identifiers from ordinary field names. Field names are words; record
+// identifiers are not. These patterns admit only key shapes that no API uses
+// as a field name, which keeps an ordinary detail object carrying nested
+// sub-objects ({"user": {...}, "account": {...}}) out of the collection path.
+var (
+	mapKeyNumericRE  = regexp.MustCompile(`^[0-9]+$`)
+	mapKeyUUIDRE     = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	mapKeyDateRE     = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}([T ][0-9A-Za-z:.+-]*)?$`)
+	mapKeyOpaqueRE   = regexp.MustCompile(`^[A-Za-z0-9]{20,}$`)
+	mapKeyPrefixedRE = regexp.MustCompile(`^[-_][A-Za-z0-9_-]{15,}$`)
+	mapKeyHasDigitRE = regexp.MustCompile(`[0-9]`)
+)
+
+// looksLikeRecordKey reports whether a JSON object key reads as a record
+// identifier rather than a field name. A separator-free token must be long and
+// carry a digit before it qualifies, because a short alphabetic token is
+// indistinguishable from a field name.
+func looksLikeRecordKey(key string) bool {
+	switch {
+	case key == "":
+		return false
+	case mapKeyNumericRE.MatchString(key):
+		return true
+	case mapKeyUUIDRE.MatchString(key):
+		return true
+	case mapKeyDateRE.MatchString(key):
+		return true
+	case mapKeyOpaqueRE.MatchString(key) && mapKeyHasDigitRE.MatchString(key):
+		return true
+	case mapKeyPrefixedRE.MatchString(key) && mapKeyHasDigitRE.MatchString(key):
+		return true
+	}
+	return false
+}
+
+type mapKeyedEntry struct {
+	key   string
+	value json.RawMessage
+}
+
+// mapKeyedEntries decodes raw as a map-keyed collection. Every key must read
+// as a record identifier and every value must be a JSON object; a single
+// disqualifying member rejects the whole payload, so a mixed envelope is never
+// mistaken for a collection. Entries come back key-sorted so repeated syncs of
+// the same payload always produce the same row order.
+func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
+	if !isJSONObjectPayload(raw) {
+		return nil, false
+	}
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(raw, &obj) != nil || len(obj) == 0 {
+		return nil, false
+	}
+	keys := make([]string, 0, len(obj))
+	for key, value := range obj {
+		if !looksLikeRecordKey(key) || !isJSONObjectPayload(value) {
+			return nil, false
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	entries := make([]mapKeyedEntry, 0, len(keys))
+	for _, key := range keys {
+		entries = append(entries, mapKeyedEntry{key: key, value: obj[key]})
+	}
+	return entries, true
+}
+
+func isJSONObjectPayload(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) > 0 && trimmed[0] == '{'
+}
+
+func isEmptyJSONObject(raw json.RawMessage) bool {
+	var obj map[string]json.RawMessage
+	return json.Unmarshal(raw, &obj) == nil && len(obj) == 0
+}
+
+// FlattenMapKeyedCollection lifts the records out of a collection that files
+// each record under its own identifier — {"<id>": {...}} — including one level
+// of bucketing above the records — {"<bucket>": {"<id>": {...}}}. The second
+// return value reports whether raw was recognized as such a collection at all;
+// a recognized collection whose members are all empty yields no items, which
+// is an empty page rather than a failure to extract.
+func FlattenMapKeyedCollection(raw json.RawMessage) ([]json.RawMessage, bool) {
+	return flattenMapKeyedCollection(raw, mapKeyedMaxDepth)
+}
+
+func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessage, bool) {
+	entries, ok := mapKeyedEntries(raw)
+	if !ok {
+		return nil, false
+	}
+	items := make([]json.RawMessage, 0, len(entries))
+	for _, entry := range entries {
+		if depth > 1 {
+			if nested, ok := flattenMapKeyedCollection(entry.value, depth-1); ok {
+				items = append(items, nested...)
+				continue
+			}
+		}
+		if isEmptyJSONObject(entry.value) {
+			continue
+		}
+		items = append(items, stampMapKeyID(entry.value, entry.key))
+	}
+	return items, true
+}
+
+// stampMapKeyID records the collection key on the item it identified. A key
+// the payload already carries is left alone so re-flattening is idempotent.
+func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(value, &obj) != nil {
+		return value
+	}
+	if _, exists := obj[MapKeyIDField]; exists {
+		return value
+	}
+	encodedKey, err := json.Marshal(key)
+	if err != nil {
+		return value
+	}
+	obj[MapKeyIDField] = encodedKey
+	stamped, err := json.Marshal(obj)
+	if err != nil {
+		return value
+	}
+	return stamped
+}
+
+// FlattenSoleMapKeyedSibling flattens the single member of an envelope that
+// holds a map-keyed collection alongside scalar metadata. Two flattenable
+// members leave the envelope ambiguous, so nothing is extracted. Callers pass
+// their own isMetadataKey because the sync and live paths each carry their own
+// metadata vocabulary; the collection recognition itself must not differ
+// between them.
+func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, bool) {
+	var collection []json.RawMessage
+	matches := 0
+	for key, raw := range envelope {
+		if isMetadataKey(key) {
+			continue
+		}
+		if items, ok := FlattenMapKeyedCollection(raw); ok {
+			collection = items
+			matches++
+		}
+	}
+	if matches == 1 {
+		return collection, true
+	}
+	return nil, false
+}
+
+// mapKeyIDFallback resolves the identifier FlattenMapKeyedCollection stamped
+// onto an item. Callers must try every real id field first: the stamped key is
+// only the right answer when the record carries no identifier of its own.
+func mapKeyIDFallback(obj map[string]any) string {
+	v, ok := obj[MapKeyIDField]
+	if !ok {
+		return ""
+	}
+	if id := ResourceIDString(v); id != "" && id != "<nil>" {
+		return id
+	}
+	return ""
+}
+
 func extractObjectID(obj map[string]any) string {
 	for _, key := range []string{"id", "ID", "_id", "id_", "uuid", "slug", "name"} {
 		if s := canonicalIDFromKey(obj, key); s != "" {
 			return s
 		}
 	}
-	return ""
+	return mapKeyIDFallback(obj)
 }
 
 // ftsRowID derives a deterministic rowid from a string ID for use with FTS5.
@@ -1560,7 +1749,7 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 			return s
 		}
 	}
-	return ""
+	return mapKeyIDFallback(obj)
 }
 
 // suffixIDFieldFallback resolves an id-less resource that keys on its own

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1252,14 +1252,40 @@ type mapKeyedEntry struct {
 	value json.RawMessage
 }
 
+// Field-name scalar/array siblings are list metadata only. Treating every
+// non-object field-name member as skippable metadata made a detail object
+// with one numeric-keyed child look like a one-record page, so sync and
+// write-through cached the child and dropped the remaining fields.
+var mapKeyedListMetadataKeys = map[string]bool{
+	"next_cursor": true, "nextCursor": true, "NextCursor": true,
+	"next_token": true, "nextToken": true, "NextToken": true,
+	"next_page_token": true, "nextPageToken": true, "NextPageToken": true,
+	"page_token": true, "pageToken": true, "PageToken": true,
+	"end_cursor": true, "endCursor": true, "EndCursor": true,
+	"start_cursor": true, "startCursor": true, "StartCursor": true,
+	"cursor": true, "Cursor": true, "after": true, "After": true, "before": true, "Before": true,
+	"has_more": true, "hasMore": true, "HasMore": true,
+	"has_next": true, "hasNext": true, "HasNext": true,
+	"next_page": true, "nextPage": true, "NextPage": true,
+	"previous_page": true, "previousPage": true, "PreviousPage": true,
+	"page": true, "Page": true, "page_size": true, "pageSize": true, "PageSize": true,
+	"per_page": true, "perPage": true, "PerPage": true,
+	"total": true, "Total": true, "count": true, "Count": true, "size": true, "Size": true,
+	"total_count": true, "totalCount": true, "TotalCount": true,
+	"success": true, "status": true, "message": true, "error": true, "errors": true,
+	"warnings": true, "Warnings": true, "ok": true, "Ok": true,
+	"next": true, "prev": true, "previous": true, "first": true, "last": true,
+}
+
 // A record identifier keying a JSON object is the only member shape a
 // collection may contain; anything else keyed like a record, or any object
 // keyed like a field, means the payload is something other than a collection
 // and is rejected whole. Scalar and array members under field-name keys are
-// the exception: an API is free to file paging metadata beside the records, so
-// dropping those members keeps the records reachable while the caller still
-// reads the cursor off the same envelope. Sorting makes repeated syncs of one
-// payload produce one row order.
+// kept only when the key is list metadata, so a real collection can still
+// file a cursor or total beside its records. A detail field (id, title, tags)
+// beside a single record-shaped child is not metadata: that payload stays a
+// detail object. Sorting makes repeated syncs of one payload produce one
+// row order.
 func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawMessage, bool) {
 	if !isJSONObjectPayload(raw) {
 		return nil, nil, false
@@ -1275,7 +1301,7 @@ func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawM
 		switch {
 		case recordKeyed && objectValued:
 			keys = append(keys, key)
-		case !recordKeyed && !objectValued:
+		case !recordKeyed && !objectValued && mapKeyedListMetadataKeys[key]:
 			metadata[key] = value
 		default:
 			return nil, nil, false

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1199,6 +1199,11 @@ func FTSMatchQuery(query string) string {
 // object key here and the id resolvers below fall back to it once every real id
 // field has missed. Flattener and resolvers stay in one file because a shape
 // one recognizes and the other cannot key loses rows with no error.
+//
+// The _pp_ prefix is reserved for fields this CLI synthesizes, so the stamp
+// always wins over a same-named member of the payload: the enclosing key is
+// the record's identity, and a payload copy of it is either stale or a name
+// collision inside a namespace no API owns.
 const MapKeyIDField = "_pp_map_key"
 
 // One level covers {"<id>": {...}}, two covers a bucketed
@@ -1255,35 +1260,36 @@ type mapKeyedEntry struct {
 // dropping those members keeps the records reachable while the caller still
 // reads the cursor off the same envelope. Sorting makes repeated syncs of one
 // payload produce one row order.
-func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
+func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawMessage, bool) {
 	if !isJSONObjectPayload(raw) {
-		return nil, false
+		return nil, nil, false
 	}
 	var obj map[string]json.RawMessage
 	if json.Unmarshal(raw, &obj) != nil || len(obj) == 0 {
-		return nil, false
+		return nil, nil, false
 	}
 	keys := make([]string, 0, len(obj))
+	metadata := map[string]json.RawMessage{}
 	for key, value := range obj {
 		recordKeyed, objectValued := looksLikeRecordKey(key), isJSONObjectPayload(value)
 		switch {
 		case recordKeyed && objectValued:
 			keys = append(keys, key)
 		case !recordKeyed && !objectValued:
-			continue
+			metadata[key] = value
 		default:
-			return nil, false
+			return nil, nil, false
 		}
 	}
 	if len(keys) == 0 {
-		return nil, false
+		return nil, nil, false
 	}
 	sort.Strings(keys)
 	entries := make([]mapKeyedEntry, 0, len(keys))
 	for _, key := range keys {
 		entries = append(entries, mapKeyedEntry{key: key, value: obj[key]})
 	}
-	return entries, true
+	return entries, metadata, true
 }
 
 func isJSONObjectPayload(raw json.RawMessage) bool {
@@ -1301,19 +1307,35 @@ func isEmptyJSONObject(raw json.RawMessage) bool {
 // members are all empty reads as an empty page rather than as a shape this
 // could not extract.
 func FlattenMapKeyedCollection(raw json.RawMessage) ([]json.RawMessage, bool) {
+	items, _, ok := FlattenMapKeyedCollectionWithMetadata(raw)
+	return items, ok
+}
+
+// The members skipped as metadata come back with the records because a
+// collection nested under a wrapper key or a declared response path can carry
+// its own continuation cursor. Dropping them left the pager reading only the
+// envelope above, which ends a paginated sync after its first page.
+func FlattenMapKeyedCollectionWithMetadata(raw json.RawMessage) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	return flattenMapKeyedCollection(raw, mapKeyedMaxDepth)
 }
 
-func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessage, bool) {
-	entries, ok := mapKeyedEntries(raw)
+func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessage, map[string]json.RawMessage, bool) {
+	entries, metadata, ok := mapKeyedEntries(raw)
 	if !ok {
-		return nil, false
+		return nil, nil, false
 	}
 	items := make([]json.RawMessage, 0, len(entries))
 	for _, entry := range entries {
 		if depth > 1 {
-			if nested, ok := flattenMapKeyedCollection(entry.value, depth-1); ok {
+			if nested, nestedMetadata, ok := flattenMapKeyedCollection(entry.value, depth-1); ok {
 				items = append(items, nested...)
+				// A bucket's own metadata fills gaps only: the level closest to
+				// the caller describes the page it asked for.
+				for key, value := range nestedMetadata {
+					if _, taken := metadata[key]; !taken {
+						metadata[key] = value
+					}
+				}
 				continue
 			}
 		}
@@ -1322,7 +1344,7 @@ func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessag
 		}
 		items = append(items, stampMapKeyID(entry.value, entry.key))
 	}
-	return items, true
+	return items, metadata, true
 }
 
 // The enclosing key is the record's identity, so a same-named field already in
@@ -1350,22 +1372,23 @@ func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
 // their own isMetadataKey because the sync and live paths carry different
 // metadata vocabularies; recognition of the collection itself must not differ
 // between them.
-func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, bool) {
+func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	var collection []json.RawMessage
+	var collectionMetadata map[string]json.RawMessage
 	matches := 0
 	for key, raw := range envelope {
 		if isMetadataKey(key) {
 			continue
 		}
-		if items, ok := FlattenMapKeyedCollection(raw); ok {
-			collection = items
+		if items, metadata, ok := FlattenMapKeyedCollectionWithMetadata(raw); ok {
+			collection, collectionMetadata = items, metadata
 			matches++
 		}
 	}
 	if matches == 1 {
-		return collection, true
+		return collection, collectionMetadata, true
 	}
-	return nil, false
+	return nil, nil, false
 }
 
 // Callers must try every real id field first: the stamped key is only the right

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1194,19 +1194,14 @@ func FTSMatchQuery(query string) string {
 	return strings.Join(quoted, " ")
 }
 
-// MapKeyIDField is the synthetic field FlattenMapKeyedCollection stamps onto
-// every item it lifts out of a map-keyed collection, carrying the JSON object
-// key that identified the record. The id resolvers below consult it as a last
-// resort, so a leaf object that carries no id field of its own still resolves
-// to the key the API filed it under instead of being dropped.
-//
-// The flattener and the id resolvers live in this file together on purpose:
-// if one recognizes a shape the other cannot key, the rows disappear from the
-// local mirror without an error.
+// A record filed under its own identifier often carries no id field inside the
+// object, and would be dropped for want of one. The flattener stamps the JSON
+// object key here and the id resolvers below fall back to it once every real id
+// field has missed. Flattener and resolvers stay in one file because a shape
+// one recognizes and the other cannot key loses rows with no error.
 const MapKeyIDField = "_pp_map_key"
 
-// mapKeyedMaxDepth bounds how far FlattenMapKeyedCollection descends. One
-// level covers {"<id>": {...}}; two covers a bucketed
+// One level covers {"<id>": {...}}, two covers a bucketed
 // {"<bucket>": {"<id>": {...}}}. Descending further would start treating an
 // item's own nested sub-objects as sibling records.
 const mapKeyedMaxDepth = 2
@@ -1226,10 +1221,9 @@ var (
 	mapKeyHasDigitRE = regexp.MustCompile(`[0-9]`)
 )
 
-// looksLikeRecordKey reports whether a JSON object key reads as a record
-// identifier rather than a field name. A separator-free token must be long and
-// carry a digit before it qualifies, because a short alphabetic token is
-// indistinguishable from a field name.
+// A separator-free token must be long and carry a digit before it qualifies as
+// an identifier, because a short alphabetic token is indistinguishable from a
+// field name.
 func looksLikeRecordKey(key string) bool {
 	switch {
 	case key == "":
@@ -1253,11 +1247,14 @@ type mapKeyedEntry struct {
 	value json.RawMessage
 }
 
-// mapKeyedEntries decodes raw as a map-keyed collection. Every key must read
-// as a record identifier and every value must be a JSON object; a single
-// disqualifying member rejects the whole payload, so a mixed envelope is never
-// mistaken for a collection. Entries come back key-sorted so repeated syncs of
-// the same payload always produce the same row order.
+// A record identifier keying a JSON object is the only member shape a
+// collection may contain; anything else keyed like a record, or any object
+// keyed like a field, means the payload is something other than a collection
+// and is rejected whole. Scalar and array members under field-name keys are
+// the exception: an API is free to file paging metadata beside the records, so
+// dropping those members keeps the records reachable while the caller still
+// reads the cursor off the same envelope. Sorting makes repeated syncs of one
+// payload produce one row order.
 func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
 	if !isJSONObjectPayload(raw) {
 		return nil, false
@@ -1268,10 +1265,18 @@ func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
 	}
 	keys := make([]string, 0, len(obj))
 	for key, value := range obj {
-		if !looksLikeRecordKey(key) || !isJSONObjectPayload(value) {
+		recordKeyed, objectValued := looksLikeRecordKey(key), isJSONObjectPayload(value)
+		switch {
+		case recordKeyed && objectValued:
+			keys = append(keys, key)
+		case !recordKeyed && !objectValued:
+			continue
+		default:
 			return nil, false
 		}
-		keys = append(keys, key)
+	}
+	if len(keys) == 0 {
+		return nil, false
 	}
 	sort.Strings(keys)
 	entries := make([]mapKeyedEntry, 0, len(keys))
@@ -1291,12 +1296,10 @@ func isEmptyJSONObject(raw json.RawMessage) bool {
 	return json.Unmarshal(raw, &obj) == nil && len(obj) == 0
 }
 
-// FlattenMapKeyedCollection lifts the records out of a collection that files
-// each record under its own identifier — {"<id>": {...}} — including one level
-// of bucketing above the records — {"<bucket>": {"<id>": {...}}}. The second
-// return value reports whether raw was recognized as such a collection at all;
-// a recognized collection whose members are all empty yields no items, which
-// is an empty page rather than a failure to extract.
+// Recognition and extraction are separate answers: the second return reports
+// only whether raw was a collection at all, so a recognized collection whose
+// members are all empty reads as an empty page rather than as a shape this
+// could not extract.
 func FlattenMapKeyedCollection(raw json.RawMessage) ([]json.RawMessage, bool) {
 	return flattenMapKeyedCollection(raw, mapKeyedMaxDepth)
 }
@@ -1322,14 +1325,12 @@ func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessag
 	return items, true
 }
 
-// stampMapKeyID records the collection key on the item it identified. A key
-// the payload already carries is left alone so re-flattening is idempotent.
+// The enclosing key is the record's identity, so a same-named field already in
+// the payload is overwritten rather than trusted: keeping it would file the row
+// under a value the API never used as its key.
 func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
 	var obj map[string]json.RawMessage
 	if json.Unmarshal(value, &obj) != nil {
-		return value
-	}
-	if _, exists := obj[MapKeyIDField]; exists {
 		return value
 	}
 	encodedKey, err := json.Marshal(key)
@@ -1344,11 +1345,10 @@ func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
 	return stamped
 }
 
-// FlattenSoleMapKeyedSibling flattens the single member of an envelope that
-// holds a map-keyed collection alongside scalar metadata. Two flattenable
-// members leave the envelope ambiguous, so nothing is extracted. Callers pass
-// their own isMetadataKey because the sync and live paths each carry their own
-// metadata vocabulary; the collection recognition itself must not differ
+// Two flattenable members leave the envelope ambiguous, so nothing is
+// extracted rather than guessing which one holds the records. Callers pass
+// their own isMetadataKey because the sync and live paths carry different
+// metadata vocabularies; recognition of the collection itself must not differ
 // between them.
 func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, bool) {
 	var collection []json.RawMessage
@@ -1368,9 +1368,8 @@ func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataK
 	return nil, false
 }
 
-// mapKeyIDFallback resolves the identifier FlattenMapKeyedCollection stamped
-// onto an item. Callers must try every real id field first: the stamped key is
-// only the right answer when the record carries no identifier of its own.
+// Callers must try every real id field first: the stamped key is only the right
+// answer when the record carries no identifier of its own.
 func mapKeyIDFallback(obj map[string]any) string {
 	v, ok := obj[MapKeyIDField]
 	if !ok {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -1182,9 +1182,12 @@ func formatSyncSinceValue(value string, paramFormat string) string {
 
 // extractPageItems attempts to extract an array of items and pagination cursor from a response.
 // It tries multiple strategies:
-// 1. Direct JSON array
-// 2. Common wrapper keys: "data", "results", "items", "records", "nodes", "entries"
-// 3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
+//  1. Direct JSON array
+//  2. Common wrapper keys: "data", "results", "items", "records", "nodes", "entries"
+//  3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
+//  4. Map-keyed collections that file each record under its id instead of
+//     listing records in an array: {"<id>":{...}} and {"<bucket>":{"<id>":{...}}}
+//
 // It also extracts the next cursor from common response fields.
 func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ...string) ([]json.RawMessage, string, bool) {
 	return extractPageItemsWithPagination(data, cursorParam, "", responsePaths...)
@@ -1208,7 +1211,14 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		if !ok {
 			continue
 		}
-		if items, ok := extractJSONItemsArray(pathData); ok {
+		pathItems, found := extractJSONItemsArray(pathData)
+		if !found {
+			// A declared response path can resolve to a map-keyed collection
+			// rather than an array. No wrapper key is a record key, so this
+			// can never shadow an array-shaped or enveloped payload.
+			pathItems, found = store.FlattenMapKeyedCollection(pathData)
+		}
+		if found {
 			nextCursor, hasMore := "", false
 			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
 				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
@@ -1218,7 +1228,7 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 				nextCursor = outerCursor
 			}
 			hasMore = hasMore || outerHasMore
-			return items, nextCursor, hasMore
+			return pathItems, nextCursor, hasMore
 		}
 		var inner map[string]json.RawMessage
 		if json.Unmarshal(pathData, &inner) == nil {
@@ -1274,6 +1284,19 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		return items, nextCursor, hasMore
 	}
 
+	// The response can be the collection itself, filing each record under its
+	// id rather than listing records in an array. Both map-keyed strategies
+	// run last so no array-shaped strategy is preempted.
+	if items, ok := store.FlattenMapKeyedCollection(data); ok {
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		return items, nextCursor, hasMore
+	}
+
+	if items, ok := extractSingleMapKeyedSibling(envelope); ok {
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		return items, nextCursor, hasMore
+	}
+
 	return nil, "", false
 }
 
@@ -1281,7 +1304,20 @@ func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMe
 	if items, ok := extractItemsByKnownKeys(envelope); ok {
 		return items, true
 	}
-	return extractSingleObjectArraySibling(envelope)
+	if items, ok := extractSingleObjectArraySibling(envelope); ok {
+		return items, true
+	}
+	return extractSingleMapKeyedSibling(envelope)
+}
+
+// extractSingleMapKeyedSibling handles an envelope that carries a map-keyed
+// collection under a resource-named key alongside scalar metadata. Exactly one
+// non-metadata key may flatten: an envelope holding two candidate collections
+// is ambiguous and is left for the caller to reject.
+func extractSingleMapKeyedSibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	return store.FlattenSoleMapKeyedSibling(envelope, func(key string) bool {
+		return pageEnvelopeMetadataKeys[key]
+	})
 }
 
 func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
@@ -1301,6 +1337,24 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 				foundEmpty = true
 			}
 		}
+	}
+	// A wrapper key can hold a map-keyed collection instead of an array. This
+	// runs only after every wrapper key has failed the array decode, so an
+	// array-shaped wrapper always wins.
+	for _, key := range pageItemKeys {
+		raw, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		items, ok := store.FlattenMapKeyedCollection(raw)
+		if !ok {
+			continue
+		}
+		if len(items) > 0 {
+			return items, true
+		}
+		emptyItems = items
+		foundEmpty = true
 	}
 	if foundEmpty {
 		return emptyItems, true

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -1212,16 +1212,19 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 			continue
 		}
 		pathItems, found := extractJSONItemsArray(pathData)
+		var pathMetadata map[string]json.RawMessage
 		if !found {
 			// A declared response path can resolve to a map-keyed collection
 			// rather than an array. No wrapper key is a record key, so this
 			// can never shadow an array-shaped or enveloped payload.
-			pathItems, found = store.FlattenMapKeyedCollection(pathData)
+			pathItems, pathMetadata, found = store.FlattenMapKeyedCollectionWithMetadata(pathData)
 		}
 		if found {
-			nextCursor, hasMore := "", false
-			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
-				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
+			nextCursor, hasMore := mapKeyedPagination(pathMetadata, cursorParam)
+			if nextCursor == "" && !hasMore {
+				if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
+					nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
+				}
 			}
 			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 			if nextCursor == "" {
@@ -1244,9 +1247,13 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		}
 	}
 
-	if items, ok := extractItemsByKnownKeys(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
-		return items, nextCursor, hasMore
+	if items, metadata, ok := extractItemsByKnownKeysWithMetadata(envelope); ok {
+		nextCursor, hasMore := mapKeyedPagination(metadata, cursorParam)
+		outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		if nextCursor == "" {
+			nextCursor = outerCursor
+		}
+		return items, nextCursor, hasMore || outerHasMore
 	}
 
 	for _, key := range dataEnvelopeKeys {
@@ -1292,12 +1299,27 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		return items, nextCursor, hasMore
 	}
 
-	if items, ok := extractSingleMapKeyedSibling(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
-		return items, nextCursor, hasMore
+	if items, metadata, ok := extractSingleMapKeyedSibling(envelope); ok {
+		nextCursor, hasMore := mapKeyedPagination(metadata, cursorParam)
+		outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		if nextCursor == "" {
+			nextCursor = outerCursor
+		}
+		return items, nextCursor, hasMore || outerHasMore
 	}
 
 	return nil, "", false
+}
+
+// Metadata filed beside the records describes the page those records came from,
+// so it is consulted before the envelope above them. nextCursorPath is declared
+// against the response root, which this level is not, so only a plain field
+// match applies here.
+func mapKeyedPagination(metadata map[string]json.RawMessage, cursorParam string) (string, bool) {
+	if len(metadata) == 0 {
+		return "", false
+	}
+	return extractPaginationFromEnvelope(metadata, cursorParam, "")
 }
 
 func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
@@ -1307,21 +1329,31 @@ func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMe
 	if items, ok := extractSingleObjectArraySibling(envelope); ok {
 		return items, true
 	}
-	return extractSingleMapKeyedSibling(envelope)
+	items, _, ok := extractSingleMapKeyedSibling(envelope)
+	return items, ok
 }
 
 // extractSingleMapKeyedSibling handles an envelope that carries a map-keyed
 // collection under a resource-named key alongside scalar metadata. Exactly one
 // non-metadata key may flatten: an envelope holding two candidate collections
 // is ambiguous and is left for the caller to reject.
-func extractSingleMapKeyedSibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+func extractSingleMapKeyedSibling(envelope map[string]json.RawMessage) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	return store.FlattenSoleMapKeyedSibling(envelope, func(key string) bool {
 		return pageEnvelopeMetadataKeys[key]
 	})
 }
 
 func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	items, _, ok := extractItemsByKnownKeysWithMetadata(envelope)
+	return items, ok
+}
+
+// A wrapper key holding a map-keyed collection can carry that collection's own
+// paging metadata inside the wrapper. Callers that paginate take the metadata
+// return; the rest use the wrapper above and drop it.
+func extractItemsByKnownKeysWithMetadata(envelope map[string]json.RawMessage) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	var emptyItems []json.RawMessage
+	var emptyMetadata map[string]json.RawMessage
 	foundEmpty := false
 	for _, key := range pageItemKeys {
 		if raw, ok := envelope[key]; ok {
@@ -1331,7 +1363,7 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 			}
 			if items, ok := extract(raw); ok {
 				if len(items) > 0 {
-					return items, true
+					return items, nil, true
 				}
 				emptyItems = items
 				foundEmpty = true
@@ -1346,20 +1378,20 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 		if !ok {
 			continue
 		}
-		items, ok := store.FlattenMapKeyedCollection(raw)
+		items, metadata, ok := store.FlattenMapKeyedCollectionWithMetadata(raw)
 		if !ok {
 			continue
 		}
 		if len(items) > 0 {
-			return items, true
+			return items, metadata, true
 		}
-		emptyItems = items
+		emptyItems, emptyMetadata = items, metadata
 		foundEmpty = true
 	}
 	if foundEmpty {
-		return emptyItems, true
+		return emptyItems, emptyMetadata, true
 	}
-	return nil, false
+	return nil, nil, false
 }
 
 func extractSingleObjectArraySibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1258,14 +1258,40 @@ type mapKeyedEntry struct {
 	value json.RawMessage
 }
 
+// Field-name scalar/array siblings are list metadata only. Treating every
+// non-object field-name member as skippable metadata made a detail object
+// with one numeric-keyed child look like a one-record page, so sync and
+// write-through cached the child and dropped the remaining fields.
+var mapKeyedListMetadataKeys = map[string]bool{
+	"next_cursor": true, "nextCursor": true, "NextCursor": true,
+	"next_token": true, "nextToken": true, "NextToken": true,
+	"next_page_token": true, "nextPageToken": true, "NextPageToken": true,
+	"page_token": true, "pageToken": true, "PageToken": true,
+	"end_cursor": true, "endCursor": true, "EndCursor": true,
+	"start_cursor": true, "startCursor": true, "StartCursor": true,
+	"cursor": true, "Cursor": true, "after": true, "After": true, "before": true, "Before": true,
+	"has_more": true, "hasMore": true, "HasMore": true,
+	"has_next": true, "hasNext": true, "HasNext": true,
+	"next_page": true, "nextPage": true, "NextPage": true,
+	"previous_page": true, "previousPage": true, "PreviousPage": true,
+	"page": true, "Page": true, "page_size": true, "pageSize": true, "PageSize": true,
+	"per_page": true, "perPage": true, "PerPage": true,
+	"total": true, "Total": true, "count": true, "Count": true, "size": true, "Size": true,
+	"total_count": true, "totalCount": true, "TotalCount": true,
+	"success": true, "status": true, "message": true, "error": true, "errors": true,
+	"warnings": true, "Warnings": true, "ok": true, "Ok": true,
+	"next": true, "prev": true, "previous": true, "first": true, "last": true,
+}
+
 // A record identifier keying a JSON object is the only member shape a
 // collection may contain; anything else keyed like a record, or any object
 // keyed like a field, means the payload is something other than a collection
 // and is rejected whole. Scalar and array members under field-name keys are
-// the exception: an API is free to file paging metadata beside the records, so
-// dropping those members keeps the records reachable while the caller still
-// reads the cursor off the same envelope. Sorting makes repeated syncs of one
-// payload produce one row order.
+// kept only when the key is list metadata, so a real collection can still
+// file a cursor or total beside its records. A detail field (id, title, tags)
+// beside a single record-shaped child is not metadata: that payload stays a
+// detail object. Sorting makes repeated syncs of one payload produce one
+// row order.
 func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawMessage, bool) {
 	if !isJSONObjectPayload(raw) {
 		return nil, nil, false
@@ -1281,7 +1307,7 @@ func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawM
 		switch {
 		case recordKeyed && objectValued:
 			keys = append(keys, key)
-		case !recordKeyed && !objectValued:
+		case !recordKeyed && !objectValued && mapKeyedListMetadataKeys[key]:
 			metadata[key] = value
 		default:
 			return nil, nil, false

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1199,13 +1200,201 @@ func FTSMatchQuery(query string) string {
 	return strings.Join(quoted, " ")
 }
 
+// MapKeyIDField is the synthetic field FlattenMapKeyedCollection stamps onto
+// every item it lifts out of a map-keyed collection, carrying the JSON object
+// key that identified the record. The id resolvers below consult it as a last
+// resort, so a leaf object that carries no id field of its own still resolves
+// to the key the API filed it under instead of being dropped.
+//
+// The flattener and the id resolvers live in this file together on purpose:
+// if one recognizes a shape the other cannot key, the rows disappear from the
+// local mirror without an error.
+const MapKeyIDField = "_pp_map_key"
+
+// mapKeyedMaxDepth bounds how far FlattenMapKeyedCollection descends. One
+// level covers {"<id>": {...}}; two covers a bucketed
+// {"<bucket>": {"<id>": {...}}}. Descending further would start treating an
+// item's own nested sub-objects as sibling records.
+const mapKeyedMaxDepth = 2
+
+// A map-keyed collection files each record under its identifier instead of
+// listing records in an array, so the discriminator has to separate record
+// identifiers from ordinary field names. Field names are words; record
+// identifiers are not. These patterns admit only key shapes that no API uses
+// as a field name, which keeps an ordinary detail object carrying nested
+// sub-objects ({"user": {...}, "account": {...}}) out of the collection path.
+var (
+	mapKeyNumericRE  = regexp.MustCompile(`^[0-9]+$`)
+	mapKeyUUIDRE     = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	mapKeyDateRE     = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}([T ][0-9A-Za-z:.+-]*)?$`)
+	mapKeyOpaqueRE   = regexp.MustCompile(`^[A-Za-z0-9]{20,}$`)
+	mapKeyPrefixedRE = regexp.MustCompile(`^[-_][A-Za-z0-9_-]{15,}$`)
+	mapKeyHasDigitRE = regexp.MustCompile(`[0-9]`)
+)
+
+// looksLikeRecordKey reports whether a JSON object key reads as a record
+// identifier rather than a field name. A separator-free token must be long and
+// carry a digit before it qualifies, because a short alphabetic token is
+// indistinguishable from a field name.
+func looksLikeRecordKey(key string) bool {
+	switch {
+	case key == "":
+		return false
+	case mapKeyNumericRE.MatchString(key):
+		return true
+	case mapKeyUUIDRE.MatchString(key):
+		return true
+	case mapKeyDateRE.MatchString(key):
+		return true
+	case mapKeyOpaqueRE.MatchString(key) && mapKeyHasDigitRE.MatchString(key):
+		return true
+	case mapKeyPrefixedRE.MatchString(key) && mapKeyHasDigitRE.MatchString(key):
+		return true
+	}
+	return false
+}
+
+type mapKeyedEntry struct {
+	key   string
+	value json.RawMessage
+}
+
+// mapKeyedEntries decodes raw as a map-keyed collection. Every key must read
+// as a record identifier and every value must be a JSON object; a single
+// disqualifying member rejects the whole payload, so a mixed envelope is never
+// mistaken for a collection. Entries come back key-sorted so repeated syncs of
+// the same payload always produce the same row order.
+func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
+	if !isJSONObjectPayload(raw) {
+		return nil, false
+	}
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(raw, &obj) != nil || len(obj) == 0 {
+		return nil, false
+	}
+	keys := make([]string, 0, len(obj))
+	for key, value := range obj {
+		if !looksLikeRecordKey(key) || !isJSONObjectPayload(value) {
+			return nil, false
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	entries := make([]mapKeyedEntry, 0, len(keys))
+	for _, key := range keys {
+		entries = append(entries, mapKeyedEntry{key: key, value: obj[key]})
+	}
+	return entries, true
+}
+
+func isJSONObjectPayload(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) > 0 && trimmed[0] == '{'
+}
+
+func isEmptyJSONObject(raw json.RawMessage) bool {
+	var obj map[string]json.RawMessage
+	return json.Unmarshal(raw, &obj) == nil && len(obj) == 0
+}
+
+// FlattenMapKeyedCollection lifts the records out of a collection that files
+// each record under its own identifier — {"<id>": {...}} — including one level
+// of bucketing above the records — {"<bucket>": {"<id>": {...}}}. The second
+// return value reports whether raw was recognized as such a collection at all;
+// a recognized collection whose members are all empty yields no items, which
+// is an empty page rather than a failure to extract.
+func FlattenMapKeyedCollection(raw json.RawMessage) ([]json.RawMessage, bool) {
+	return flattenMapKeyedCollection(raw, mapKeyedMaxDepth)
+}
+
+func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessage, bool) {
+	entries, ok := mapKeyedEntries(raw)
+	if !ok {
+		return nil, false
+	}
+	items := make([]json.RawMessage, 0, len(entries))
+	for _, entry := range entries {
+		if depth > 1 {
+			if nested, ok := flattenMapKeyedCollection(entry.value, depth-1); ok {
+				items = append(items, nested...)
+				continue
+			}
+		}
+		if isEmptyJSONObject(entry.value) {
+			continue
+		}
+		items = append(items, stampMapKeyID(entry.value, entry.key))
+	}
+	return items, true
+}
+
+// stampMapKeyID records the collection key on the item it identified. A key
+// the payload already carries is left alone so re-flattening is idempotent.
+func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(value, &obj) != nil {
+		return value
+	}
+	if _, exists := obj[MapKeyIDField]; exists {
+		return value
+	}
+	encodedKey, err := json.Marshal(key)
+	if err != nil {
+		return value
+	}
+	obj[MapKeyIDField] = encodedKey
+	stamped, err := json.Marshal(obj)
+	if err != nil {
+		return value
+	}
+	return stamped
+}
+
+// FlattenSoleMapKeyedSibling flattens the single member of an envelope that
+// holds a map-keyed collection alongside scalar metadata. Two flattenable
+// members leave the envelope ambiguous, so nothing is extracted. Callers pass
+// their own isMetadataKey because the sync and live paths each carry their own
+// metadata vocabulary; the collection recognition itself must not differ
+// between them.
+func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, bool) {
+	var collection []json.RawMessage
+	matches := 0
+	for key, raw := range envelope {
+		if isMetadataKey(key) {
+			continue
+		}
+		if items, ok := FlattenMapKeyedCollection(raw); ok {
+			collection = items
+			matches++
+		}
+	}
+	if matches == 1 {
+		return collection, true
+	}
+	return nil, false
+}
+
+// mapKeyIDFallback resolves the identifier FlattenMapKeyedCollection stamped
+// onto an item. Callers must try every real id field first: the stamped key is
+// only the right answer when the record carries no identifier of its own.
+func mapKeyIDFallback(obj map[string]any) string {
+	v, ok := obj[MapKeyIDField]
+	if !ok {
+		return ""
+	}
+	if id := ResourceIDString(v); id != "" && id != "<nil>" {
+		return id
+	}
+	return ""
+}
+
 func extractObjectID(obj map[string]any) string {
 	for _, key := range []string{"id", "ID", "_id", "id_", "uuid", "slug", "name"} {
 		if s := canonicalIDFromKey(obj, key); s != "" {
 			return s
 		}
 	}
-	return ""
+	return mapKeyIDFallback(obj)
 }
 
 // ftsRowID derives a deterministic rowid from a string ID for use with FTS5.
@@ -1612,7 +1801,7 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 			return s
 		}
 	}
-	return ""
+	return mapKeyIDFallback(obj)
 }
 
 // suffixIDFieldFallback resolves an id-less resource that keys on its own

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1283,6 +1283,25 @@ var mapKeyedListMetadataKeys = map[string]bool{
 	"next": true, "prev": true, "previous": true, "first": true, "last": true,
 }
 
+// A lone record-shaped child plus only count/JSend fields is still a
+// detail object (status, message, total, count). A one-record page is
+// recognized only when a cursor, has-more flag, or page key is present.
+var mapKeyedPagingSignalKeys = map[string]bool{
+	"next_cursor": true, "nextCursor": true, "NextCursor": true,
+	"next_token": true, "nextToken": true, "NextToken": true,
+	"next_page_token": true, "nextPageToken": true, "NextPageToken": true,
+	"page_token": true, "pageToken": true, "PageToken": true,
+	"end_cursor": true, "endCursor": true, "EndCursor": true,
+	"start_cursor": true, "startCursor": true, "StartCursor": true,
+	"cursor": true, "Cursor": true, "after": true, "After": true, "before": true, "Before": true,
+	"has_more": true, "hasMore": true, "HasMore": true,
+	"has_next": true, "hasNext": true, "HasNext": true,
+	"next_page": true, "nextPage": true, "NextPage": true,
+	"previous_page": true, "previousPage": true, "PreviousPage": true,
+	"page": true, "Page": true, "page_size": true, "pageSize": true, "PageSize": true,
+	"per_page": true, "perPage": true, "PerPage": true,
+}
+
 // A record identifier keying a JSON object is the only member shape a
 // collection may contain; anything else keyed like a record, or any object
 // keyed like a field, means the payload is something other than a collection
@@ -1290,8 +1309,9 @@ var mapKeyedListMetadataKeys = map[string]bool{
 // kept only when the key is list metadata, so a real collection can still
 // file a cursor or total beside its records. A detail field (id, title, tags)
 // beside a single record-shaped child is not metadata: that payload stays a
-// detail object. Sorting makes repeated syncs of one payload produce one
-// row order.
+// detail object. One record plus only count/JSend siblings is also a detail
+// object; a one-record page needs a cursor, has-more flag, or page key.
+// Sorting makes repeated syncs of one payload produce one row order.
 func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawMessage, bool) {
 	if !isJSONObjectPayload(raw) {
 		return nil, nil, false
@@ -1316,12 +1336,24 @@ func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawM
 	if len(keys) == 0 {
 		return nil, nil, false
 	}
+	if len(keys) == 1 && len(metadata) > 0 && !hasMapKeyedPagingSignal(metadata) {
+		return nil, nil, false
+	}
 	sort.Strings(keys)
 	entries := make([]mapKeyedEntry, 0, len(keys))
 	for _, key := range keys {
 		entries = append(entries, mapKeyedEntry{key: key, value: obj[key]})
 	}
 	return entries, metadata, true
+}
+
+func hasMapKeyedPagingSignal(metadata map[string]json.RawMessage) bool {
+	for key := range metadata {
+		if mapKeyedPagingSignalKeys[key] {
+			return true
+		}
+	}
+	return false
 }
 
 func isJSONObjectPayload(raw json.RawMessage) bool {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1200,19 +1200,14 @@ func FTSMatchQuery(query string) string {
 	return strings.Join(quoted, " ")
 }
 
-// MapKeyIDField is the synthetic field FlattenMapKeyedCollection stamps onto
-// every item it lifts out of a map-keyed collection, carrying the JSON object
-// key that identified the record. The id resolvers below consult it as a last
-// resort, so a leaf object that carries no id field of its own still resolves
-// to the key the API filed it under instead of being dropped.
-//
-// The flattener and the id resolvers live in this file together on purpose:
-// if one recognizes a shape the other cannot key, the rows disappear from the
-// local mirror without an error.
+// A record filed under its own identifier often carries no id field inside the
+// object, and would be dropped for want of one. The flattener stamps the JSON
+// object key here and the id resolvers below fall back to it once every real id
+// field has missed. Flattener and resolvers stay in one file because a shape
+// one recognizes and the other cannot key loses rows with no error.
 const MapKeyIDField = "_pp_map_key"
 
-// mapKeyedMaxDepth bounds how far FlattenMapKeyedCollection descends. One
-// level covers {"<id>": {...}}; two covers a bucketed
+// One level covers {"<id>": {...}}, two covers a bucketed
 // {"<bucket>": {"<id>": {...}}}. Descending further would start treating an
 // item's own nested sub-objects as sibling records.
 const mapKeyedMaxDepth = 2
@@ -1232,10 +1227,9 @@ var (
 	mapKeyHasDigitRE = regexp.MustCompile(`[0-9]`)
 )
 
-// looksLikeRecordKey reports whether a JSON object key reads as a record
-// identifier rather than a field name. A separator-free token must be long and
-// carry a digit before it qualifies, because a short alphabetic token is
-// indistinguishable from a field name.
+// A separator-free token must be long and carry a digit before it qualifies as
+// an identifier, because a short alphabetic token is indistinguishable from a
+// field name.
 func looksLikeRecordKey(key string) bool {
 	switch {
 	case key == "":
@@ -1259,11 +1253,14 @@ type mapKeyedEntry struct {
 	value json.RawMessage
 }
 
-// mapKeyedEntries decodes raw as a map-keyed collection. Every key must read
-// as a record identifier and every value must be a JSON object; a single
-// disqualifying member rejects the whole payload, so a mixed envelope is never
-// mistaken for a collection. Entries come back key-sorted so repeated syncs of
-// the same payload always produce the same row order.
+// A record identifier keying a JSON object is the only member shape a
+// collection may contain; anything else keyed like a record, or any object
+// keyed like a field, means the payload is something other than a collection
+// and is rejected whole. Scalar and array members under field-name keys are
+// the exception: an API is free to file paging metadata beside the records, so
+// dropping those members keeps the records reachable while the caller still
+// reads the cursor off the same envelope. Sorting makes repeated syncs of one
+// payload produce one row order.
 func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
 	if !isJSONObjectPayload(raw) {
 		return nil, false
@@ -1274,10 +1271,18 @@ func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
 	}
 	keys := make([]string, 0, len(obj))
 	for key, value := range obj {
-		if !looksLikeRecordKey(key) || !isJSONObjectPayload(value) {
+		recordKeyed, objectValued := looksLikeRecordKey(key), isJSONObjectPayload(value)
+		switch {
+		case recordKeyed && objectValued:
+			keys = append(keys, key)
+		case !recordKeyed && !objectValued:
+			continue
+		default:
 			return nil, false
 		}
-		keys = append(keys, key)
+	}
+	if len(keys) == 0 {
+		return nil, false
 	}
 	sort.Strings(keys)
 	entries := make([]mapKeyedEntry, 0, len(keys))
@@ -1297,12 +1302,10 @@ func isEmptyJSONObject(raw json.RawMessage) bool {
 	return json.Unmarshal(raw, &obj) == nil && len(obj) == 0
 }
 
-// FlattenMapKeyedCollection lifts the records out of a collection that files
-// each record under its own identifier — {"<id>": {...}} — including one level
-// of bucketing above the records — {"<bucket>": {"<id>": {...}}}. The second
-// return value reports whether raw was recognized as such a collection at all;
-// a recognized collection whose members are all empty yields no items, which
-// is an empty page rather than a failure to extract.
+// Recognition and extraction are separate answers: the second return reports
+// only whether raw was a collection at all, so a recognized collection whose
+// members are all empty reads as an empty page rather than as a shape this
+// could not extract.
 func FlattenMapKeyedCollection(raw json.RawMessage) ([]json.RawMessage, bool) {
 	return flattenMapKeyedCollection(raw, mapKeyedMaxDepth)
 }
@@ -1328,14 +1331,12 @@ func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessag
 	return items, true
 }
 
-// stampMapKeyID records the collection key on the item it identified. A key
-// the payload already carries is left alone so re-flattening is idempotent.
+// The enclosing key is the record's identity, so a same-named field already in
+// the payload is overwritten rather than trusted: keeping it would file the row
+// under a value the API never used as its key.
 func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
 	var obj map[string]json.RawMessage
 	if json.Unmarshal(value, &obj) != nil {
-		return value
-	}
-	if _, exists := obj[MapKeyIDField]; exists {
 		return value
 	}
 	encodedKey, err := json.Marshal(key)
@@ -1350,11 +1351,10 @@ func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
 	return stamped
 }
 
-// FlattenSoleMapKeyedSibling flattens the single member of an envelope that
-// holds a map-keyed collection alongside scalar metadata. Two flattenable
-// members leave the envelope ambiguous, so nothing is extracted. Callers pass
-// their own isMetadataKey because the sync and live paths each carry their own
-// metadata vocabulary; the collection recognition itself must not differ
+// Two flattenable members leave the envelope ambiguous, so nothing is
+// extracted rather than guessing which one holds the records. Callers pass
+// their own isMetadataKey because the sync and live paths carry different
+// metadata vocabularies; recognition of the collection itself must not differ
 // between them.
 func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, bool) {
 	var collection []json.RawMessage
@@ -1374,9 +1374,8 @@ func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataK
 	return nil, false
 }
 
-// mapKeyIDFallback resolves the identifier FlattenMapKeyedCollection stamped
-// onto an item. Callers must try every real id field first: the stamped key is
-// only the right answer when the record carries no identifier of its own.
+// Callers must try every real id field first: the stamped key is only the right
+// answer when the record carries no identifier of its own.
 func mapKeyIDFallback(obj map[string]any) string {
 	v, ok := obj[MapKeyIDField]
 	if !ok {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1205,6 +1205,11 @@ func FTSMatchQuery(query string) string {
 // object key here and the id resolvers below fall back to it once every real id
 // field has missed. Flattener and resolvers stay in one file because a shape
 // one recognizes and the other cannot key loses rows with no error.
+//
+// The _pp_ prefix is reserved for fields this CLI synthesizes, so the stamp
+// always wins over a same-named member of the payload: the enclosing key is
+// the record's identity, and a payload copy of it is either stale or a name
+// collision inside a namespace no API owns.
 const MapKeyIDField = "_pp_map_key"
 
 // One level covers {"<id>": {...}}, two covers a bucketed
@@ -1261,35 +1266,36 @@ type mapKeyedEntry struct {
 // dropping those members keeps the records reachable while the caller still
 // reads the cursor off the same envelope. Sorting makes repeated syncs of one
 // payload produce one row order.
-func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
+func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawMessage, bool) {
 	if !isJSONObjectPayload(raw) {
-		return nil, false
+		return nil, nil, false
 	}
 	var obj map[string]json.RawMessage
 	if json.Unmarshal(raw, &obj) != nil || len(obj) == 0 {
-		return nil, false
+		return nil, nil, false
 	}
 	keys := make([]string, 0, len(obj))
+	metadata := map[string]json.RawMessage{}
 	for key, value := range obj {
 		recordKeyed, objectValued := looksLikeRecordKey(key), isJSONObjectPayload(value)
 		switch {
 		case recordKeyed && objectValued:
 			keys = append(keys, key)
 		case !recordKeyed && !objectValued:
-			continue
+			metadata[key] = value
 		default:
-			return nil, false
+			return nil, nil, false
 		}
 	}
 	if len(keys) == 0 {
-		return nil, false
+		return nil, nil, false
 	}
 	sort.Strings(keys)
 	entries := make([]mapKeyedEntry, 0, len(keys))
 	for _, key := range keys {
 		entries = append(entries, mapKeyedEntry{key: key, value: obj[key]})
 	}
-	return entries, true
+	return entries, metadata, true
 }
 
 func isJSONObjectPayload(raw json.RawMessage) bool {
@@ -1307,19 +1313,35 @@ func isEmptyJSONObject(raw json.RawMessage) bool {
 // members are all empty reads as an empty page rather than as a shape this
 // could not extract.
 func FlattenMapKeyedCollection(raw json.RawMessage) ([]json.RawMessage, bool) {
+	items, _, ok := FlattenMapKeyedCollectionWithMetadata(raw)
+	return items, ok
+}
+
+// The members skipped as metadata come back with the records because a
+// collection nested under a wrapper key or a declared response path can carry
+// its own continuation cursor. Dropping them left the pager reading only the
+// envelope above, which ends a paginated sync after its first page.
+func FlattenMapKeyedCollectionWithMetadata(raw json.RawMessage) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	return flattenMapKeyedCollection(raw, mapKeyedMaxDepth)
 }
 
-func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessage, bool) {
-	entries, ok := mapKeyedEntries(raw)
+func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessage, map[string]json.RawMessage, bool) {
+	entries, metadata, ok := mapKeyedEntries(raw)
 	if !ok {
-		return nil, false
+		return nil, nil, false
 	}
 	items := make([]json.RawMessage, 0, len(entries))
 	for _, entry := range entries {
 		if depth > 1 {
-			if nested, ok := flattenMapKeyedCollection(entry.value, depth-1); ok {
+			if nested, nestedMetadata, ok := flattenMapKeyedCollection(entry.value, depth-1); ok {
 				items = append(items, nested...)
+				// A bucket's own metadata fills gaps only: the level closest to
+				// the caller describes the page it asked for.
+				for key, value := range nestedMetadata {
+					if _, taken := metadata[key]; !taken {
+						metadata[key] = value
+					}
+				}
 				continue
 			}
 		}
@@ -1328,7 +1350,7 @@ func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessag
 		}
 		items = append(items, stampMapKeyID(entry.value, entry.key))
 	}
-	return items, true
+	return items, metadata, true
 }
 
 // The enclosing key is the record's identity, so a same-named field already in
@@ -1356,22 +1378,23 @@ func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
 // their own isMetadataKey because the sync and live paths carry different
 // metadata vocabularies; recognition of the collection itself must not differ
 // between them.
-func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, bool) {
+func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	var collection []json.RawMessage
+	var collectionMetadata map[string]json.RawMessage
 	matches := 0
 	for key, raw := range envelope {
 		if isMetadataKey(key) {
 			continue
 		}
-		if items, ok := FlattenMapKeyedCollection(raw); ok {
-			collection = items
+		if items, metadata, ok := FlattenMapKeyedCollectionWithMetadata(raw); ok {
+			collection, collectionMetadata = items, metadata
 			matches++
 		}
 	}
 	if matches == 1 {
-		return collection, true
+		return collection, collectionMetadata, true
 	}
-	return nil, false
+	return nil, nil, false
 }
 
 // Callers must try every real id field first: the stamped key is only the right

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -1159,9 +1159,12 @@ func formatSyncSinceValue(value string, paramFormat string) string {
 
 // extractPageItems attempts to extract an array of items and pagination cursor from a response.
 // It tries multiple strategies:
-// 1. Direct JSON array
-// 2. Common wrapper keys: "data", "results", "items", "records", "nodes", "entries"
-// 3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
+//  1. Direct JSON array
+//  2. Common wrapper keys: "data", "results", "items", "records", "nodes", "entries"
+//  3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
+//  4. Map-keyed collections that file each record under its id instead of
+//     listing records in an array: {"<id>":{...}} and {"<bucket>":{"<id>":{...}}}
+//
 // It also extracts the next cursor from common response fields.
 func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ...string) ([]json.RawMessage, string, bool) {
 	return extractPageItemsWithPagination(data, cursorParam, "", responsePaths...)
@@ -1185,7 +1188,14 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		if !ok {
 			continue
 		}
-		if items, ok := extractJSONItemsArray(pathData); ok {
+		pathItems, found := extractJSONItemsArray(pathData)
+		if !found {
+			// A declared response path can resolve to a map-keyed collection
+			// rather than an array. No wrapper key is a record key, so this
+			// can never shadow an array-shaped or enveloped payload.
+			pathItems, found = store.FlattenMapKeyedCollection(pathData)
+		}
+		if found {
 			nextCursor, hasMore := "", false
 			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
 				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
@@ -1195,7 +1205,7 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 				nextCursor = outerCursor
 			}
 			hasMore = hasMore || outerHasMore
-			return items, nextCursor, hasMore
+			return pathItems, nextCursor, hasMore
 		}
 		var inner map[string]json.RawMessage
 		if json.Unmarshal(pathData, &inner) == nil {
@@ -1251,6 +1261,19 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		return items, nextCursor, hasMore
 	}
 
+	// The response can be the collection itself, filing each record under its
+	// id rather than listing records in an array. Both map-keyed strategies
+	// run last so no array-shaped strategy is preempted.
+	if items, ok := store.FlattenMapKeyedCollection(data); ok {
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		return items, nextCursor, hasMore
+	}
+
+	if items, ok := extractSingleMapKeyedSibling(envelope); ok {
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		return items, nextCursor, hasMore
+	}
+
 	return nil, "", false
 }
 
@@ -1258,7 +1281,20 @@ func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMe
 	if items, ok := extractItemsByKnownKeys(envelope); ok {
 		return items, true
 	}
-	return extractSingleObjectArraySibling(envelope)
+	if items, ok := extractSingleObjectArraySibling(envelope); ok {
+		return items, true
+	}
+	return extractSingleMapKeyedSibling(envelope)
+}
+
+// extractSingleMapKeyedSibling handles an envelope that carries a map-keyed
+// collection under a resource-named key alongside scalar metadata. Exactly one
+// non-metadata key may flatten: an envelope holding two candidate collections
+// is ambiguous and is left for the caller to reject.
+func extractSingleMapKeyedSibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	return store.FlattenSoleMapKeyedSibling(envelope, func(key string) bool {
+		return pageEnvelopeMetadataKeys[key]
+	})
 }
 
 func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
@@ -1278,6 +1314,24 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 				foundEmpty = true
 			}
 		}
+	}
+	// A wrapper key can hold a map-keyed collection instead of an array. This
+	// runs only after every wrapper key has failed the array decode, so an
+	// array-shaped wrapper always wins.
+	for _, key := range pageItemKeys {
+		raw, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		items, ok := store.FlattenMapKeyedCollection(raw)
+		if !ok {
+			continue
+		}
+		if len(items) > 0 {
+			return items, true
+		}
+		emptyItems = items
+		foundEmpty = true
 	}
 	if foundEmpty {
 		return emptyItems, true

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -1189,16 +1189,19 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 			continue
 		}
 		pathItems, found := extractJSONItemsArray(pathData)
+		var pathMetadata map[string]json.RawMessage
 		if !found {
 			// A declared response path can resolve to a map-keyed collection
 			// rather than an array. No wrapper key is a record key, so this
 			// can never shadow an array-shaped or enveloped payload.
-			pathItems, found = store.FlattenMapKeyedCollection(pathData)
+			pathItems, pathMetadata, found = store.FlattenMapKeyedCollectionWithMetadata(pathData)
 		}
 		if found {
-			nextCursor, hasMore := "", false
-			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
-				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
+			nextCursor, hasMore := mapKeyedPagination(pathMetadata, cursorParam)
+			if nextCursor == "" && !hasMore {
+				if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
+					nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
+				}
 			}
 			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 			if nextCursor == "" {
@@ -1221,9 +1224,13 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		}
 	}
 
-	if items, ok := extractItemsByKnownKeys(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
-		return items, nextCursor, hasMore
+	if items, metadata, ok := extractItemsByKnownKeysWithMetadata(envelope); ok {
+		nextCursor, hasMore := mapKeyedPagination(metadata, cursorParam)
+		outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		if nextCursor == "" {
+			nextCursor = outerCursor
+		}
+		return items, nextCursor, hasMore || outerHasMore
 	}
 
 	for _, key := range dataEnvelopeKeys {
@@ -1269,12 +1276,27 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		return items, nextCursor, hasMore
 	}
 
-	if items, ok := extractSingleMapKeyedSibling(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
-		return items, nextCursor, hasMore
+	if items, metadata, ok := extractSingleMapKeyedSibling(envelope); ok {
+		nextCursor, hasMore := mapKeyedPagination(metadata, cursorParam)
+		outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		if nextCursor == "" {
+			nextCursor = outerCursor
+		}
+		return items, nextCursor, hasMore || outerHasMore
 	}
 
 	return nil, "", false
+}
+
+// Metadata filed beside the records describes the page those records came from,
+// so it is consulted before the envelope above them. nextCursorPath is declared
+// against the response root, which this level is not, so only a plain field
+// match applies here.
+func mapKeyedPagination(metadata map[string]json.RawMessage, cursorParam string) (string, bool) {
+	if len(metadata) == 0 {
+		return "", false
+	}
+	return extractPaginationFromEnvelope(metadata, cursorParam, "")
 }
 
 func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
@@ -1284,21 +1306,31 @@ func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMe
 	if items, ok := extractSingleObjectArraySibling(envelope); ok {
 		return items, true
 	}
-	return extractSingleMapKeyedSibling(envelope)
+	items, _, ok := extractSingleMapKeyedSibling(envelope)
+	return items, ok
 }
 
 // extractSingleMapKeyedSibling handles an envelope that carries a map-keyed
 // collection under a resource-named key alongside scalar metadata. Exactly one
 // non-metadata key may flatten: an envelope holding two candidate collections
 // is ambiguous and is left for the caller to reject.
-func extractSingleMapKeyedSibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+func extractSingleMapKeyedSibling(envelope map[string]json.RawMessage) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	return store.FlattenSoleMapKeyedSibling(envelope, func(key string) bool {
 		return pageEnvelopeMetadataKeys[key]
 	})
 }
 
 func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	items, _, ok := extractItemsByKnownKeysWithMetadata(envelope)
+	return items, ok
+}
+
+// A wrapper key holding a map-keyed collection can carry that collection's own
+// paging metadata inside the wrapper. Callers that paginate take the metadata
+// return; the rest use the wrapper above and drop it.
+func extractItemsByKnownKeysWithMetadata(envelope map[string]json.RawMessage) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	var emptyItems []json.RawMessage
+	var emptyMetadata map[string]json.RawMessage
 	foundEmpty := false
 	for _, key := range pageItemKeys {
 		if raw, ok := envelope[key]; ok {
@@ -1308,7 +1340,7 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 			}
 			if items, ok := extract(raw); ok {
 				if len(items) > 0 {
-					return items, true
+					return items, nil, true
 				}
 				emptyItems = items
 				foundEmpty = true
@@ -1323,20 +1355,20 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 		if !ok {
 			continue
 		}
-		items, ok := store.FlattenMapKeyedCollection(raw)
+		items, metadata, ok := store.FlattenMapKeyedCollectionWithMetadata(raw)
 		if !ok {
 			continue
 		}
 		if len(items) > 0 {
-			return items, true
+			return items, metadata, true
 		}
-		emptyItems = items
+		emptyItems, emptyMetadata = items, metadata
 		foundEmpty = true
 	}
 	if foundEmpty {
-		return emptyItems, true
+		return emptyItems, emptyMetadata, true
 	}
-	return nil, false
+	return nil, nil, false
 }
 
 func extractSingleObjectArraySibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1201,13 +1202,201 @@ func FTSMatchQuery(query string) string {
 	return strings.Join(quoted, " ")
 }
 
+// MapKeyIDField is the synthetic field FlattenMapKeyedCollection stamps onto
+// every item it lifts out of a map-keyed collection, carrying the JSON object
+// key that identified the record. The id resolvers below consult it as a last
+// resort, so a leaf object that carries no id field of its own still resolves
+// to the key the API filed it under instead of being dropped.
+//
+// The flattener and the id resolvers live in this file together on purpose:
+// if one recognizes a shape the other cannot key, the rows disappear from the
+// local mirror without an error.
+const MapKeyIDField = "_pp_map_key"
+
+// mapKeyedMaxDepth bounds how far FlattenMapKeyedCollection descends. One
+// level covers {"<id>": {...}}; two covers a bucketed
+// {"<bucket>": {"<id>": {...}}}. Descending further would start treating an
+// item's own nested sub-objects as sibling records.
+const mapKeyedMaxDepth = 2
+
+// A map-keyed collection files each record under its identifier instead of
+// listing records in an array, so the discriminator has to separate record
+// identifiers from ordinary field names. Field names are words; record
+// identifiers are not. These patterns admit only key shapes that no API uses
+// as a field name, which keeps an ordinary detail object carrying nested
+// sub-objects ({"user": {...}, "account": {...}}) out of the collection path.
+var (
+	mapKeyNumericRE  = regexp.MustCompile(`^[0-9]+$`)
+	mapKeyUUIDRE     = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	mapKeyDateRE     = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}([T ][0-9A-Za-z:.+-]*)?$`)
+	mapKeyOpaqueRE   = regexp.MustCompile(`^[A-Za-z0-9]{20,}$`)
+	mapKeyPrefixedRE = regexp.MustCompile(`^[-_][A-Za-z0-9_-]{15,}$`)
+	mapKeyHasDigitRE = regexp.MustCompile(`[0-9]`)
+)
+
+// looksLikeRecordKey reports whether a JSON object key reads as a record
+// identifier rather than a field name. A separator-free token must be long and
+// carry a digit before it qualifies, because a short alphabetic token is
+// indistinguishable from a field name.
+func looksLikeRecordKey(key string) bool {
+	switch {
+	case key == "":
+		return false
+	case mapKeyNumericRE.MatchString(key):
+		return true
+	case mapKeyUUIDRE.MatchString(key):
+		return true
+	case mapKeyDateRE.MatchString(key):
+		return true
+	case mapKeyOpaqueRE.MatchString(key) && mapKeyHasDigitRE.MatchString(key):
+		return true
+	case mapKeyPrefixedRE.MatchString(key) && mapKeyHasDigitRE.MatchString(key):
+		return true
+	}
+	return false
+}
+
+type mapKeyedEntry struct {
+	key   string
+	value json.RawMessage
+}
+
+// mapKeyedEntries decodes raw as a map-keyed collection. Every key must read
+// as a record identifier and every value must be a JSON object; a single
+// disqualifying member rejects the whole payload, so a mixed envelope is never
+// mistaken for a collection. Entries come back key-sorted so repeated syncs of
+// the same payload always produce the same row order.
+func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
+	if !isJSONObjectPayload(raw) {
+		return nil, false
+	}
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(raw, &obj) != nil || len(obj) == 0 {
+		return nil, false
+	}
+	keys := make([]string, 0, len(obj))
+	for key, value := range obj {
+		if !looksLikeRecordKey(key) || !isJSONObjectPayload(value) {
+			return nil, false
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	entries := make([]mapKeyedEntry, 0, len(keys))
+	for _, key := range keys {
+		entries = append(entries, mapKeyedEntry{key: key, value: obj[key]})
+	}
+	return entries, true
+}
+
+func isJSONObjectPayload(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) > 0 && trimmed[0] == '{'
+}
+
+func isEmptyJSONObject(raw json.RawMessage) bool {
+	var obj map[string]json.RawMessage
+	return json.Unmarshal(raw, &obj) == nil && len(obj) == 0
+}
+
+// FlattenMapKeyedCollection lifts the records out of a collection that files
+// each record under its own identifier — {"<id>": {...}} — including one level
+// of bucketing above the records — {"<bucket>": {"<id>": {...}}}. The second
+// return value reports whether raw was recognized as such a collection at all;
+// a recognized collection whose members are all empty yields no items, which
+// is an empty page rather than a failure to extract.
+func FlattenMapKeyedCollection(raw json.RawMessage) ([]json.RawMessage, bool) {
+	return flattenMapKeyedCollection(raw, mapKeyedMaxDepth)
+}
+
+func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessage, bool) {
+	entries, ok := mapKeyedEntries(raw)
+	if !ok {
+		return nil, false
+	}
+	items := make([]json.RawMessage, 0, len(entries))
+	for _, entry := range entries {
+		if depth > 1 {
+			if nested, ok := flattenMapKeyedCollection(entry.value, depth-1); ok {
+				items = append(items, nested...)
+				continue
+			}
+		}
+		if isEmptyJSONObject(entry.value) {
+			continue
+		}
+		items = append(items, stampMapKeyID(entry.value, entry.key))
+	}
+	return items, true
+}
+
+// stampMapKeyID records the collection key on the item it identified. A key
+// the payload already carries is left alone so re-flattening is idempotent.
+func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(value, &obj) != nil {
+		return value
+	}
+	if _, exists := obj[MapKeyIDField]; exists {
+		return value
+	}
+	encodedKey, err := json.Marshal(key)
+	if err != nil {
+		return value
+	}
+	obj[MapKeyIDField] = encodedKey
+	stamped, err := json.Marshal(obj)
+	if err != nil {
+		return value
+	}
+	return stamped
+}
+
+// FlattenSoleMapKeyedSibling flattens the single member of an envelope that
+// holds a map-keyed collection alongside scalar metadata. Two flattenable
+// members leave the envelope ambiguous, so nothing is extracted. Callers pass
+// their own isMetadataKey because the sync and live paths each carry their own
+// metadata vocabulary; the collection recognition itself must not differ
+// between them.
+func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, bool) {
+	var collection []json.RawMessage
+	matches := 0
+	for key, raw := range envelope {
+		if isMetadataKey(key) {
+			continue
+		}
+		if items, ok := FlattenMapKeyedCollection(raw); ok {
+			collection = items
+			matches++
+		}
+	}
+	if matches == 1 {
+		return collection, true
+	}
+	return nil, false
+}
+
+// mapKeyIDFallback resolves the identifier FlattenMapKeyedCollection stamped
+// onto an item. Callers must try every real id field first: the stamped key is
+// only the right answer when the record carries no identifier of its own.
+func mapKeyIDFallback(obj map[string]any) string {
+	v, ok := obj[MapKeyIDField]
+	if !ok {
+		return ""
+	}
+	if id := ResourceIDString(v); id != "" && id != "<nil>" {
+		return id
+	}
+	return ""
+}
+
 func extractObjectID(obj map[string]any) string {
 	for _, key := range []string{"id", "ID", "_id", "id_", "uuid", "slug", "name"} {
 		if s := canonicalIDFromKey(obj, key); s != "" {
 			return s
 		}
 	}
-	return ""
+	return mapKeyIDFallback(obj)
 }
 
 // ftsRowID derives a deterministic rowid from a string ID for use with FTS5.
@@ -1622,7 +1811,7 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 			return s
 		}
 	}
-	return ""
+	return mapKeyIDFallback(obj)
 }
 
 // suffixIDFieldFallback resolves an id-less resource that keys on its own

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1285,6 +1285,25 @@ var mapKeyedListMetadataKeys = map[string]bool{
 	"next": true, "prev": true, "previous": true, "first": true, "last": true,
 }
 
+// A lone record-shaped child plus only count/JSend fields is still a
+// detail object (status, message, total, count). A one-record page is
+// recognized only when a cursor, has-more flag, or page key is present.
+var mapKeyedPagingSignalKeys = map[string]bool{
+	"next_cursor": true, "nextCursor": true, "NextCursor": true,
+	"next_token": true, "nextToken": true, "NextToken": true,
+	"next_page_token": true, "nextPageToken": true, "NextPageToken": true,
+	"page_token": true, "pageToken": true, "PageToken": true,
+	"end_cursor": true, "endCursor": true, "EndCursor": true,
+	"start_cursor": true, "startCursor": true, "StartCursor": true,
+	"cursor": true, "Cursor": true, "after": true, "After": true, "before": true, "Before": true,
+	"has_more": true, "hasMore": true, "HasMore": true,
+	"has_next": true, "hasNext": true, "HasNext": true,
+	"next_page": true, "nextPage": true, "NextPage": true,
+	"previous_page": true, "previousPage": true, "PreviousPage": true,
+	"page": true, "Page": true, "page_size": true, "pageSize": true, "PageSize": true,
+	"per_page": true, "perPage": true, "PerPage": true,
+}
+
 // A record identifier keying a JSON object is the only member shape a
 // collection may contain; anything else keyed like a record, or any object
 // keyed like a field, means the payload is something other than a collection
@@ -1292,8 +1311,9 @@ var mapKeyedListMetadataKeys = map[string]bool{
 // kept only when the key is list metadata, so a real collection can still
 // file a cursor or total beside its records. A detail field (id, title, tags)
 // beside a single record-shaped child is not metadata: that payload stays a
-// detail object. Sorting makes repeated syncs of one payload produce one
-// row order.
+// detail object. One record plus only count/JSend siblings is also a detail
+// object; a one-record page needs a cursor, has-more flag, or page key.
+// Sorting makes repeated syncs of one payload produce one row order.
 func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawMessage, bool) {
 	if !isJSONObjectPayload(raw) {
 		return nil, nil, false
@@ -1318,12 +1338,24 @@ func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawM
 	if len(keys) == 0 {
 		return nil, nil, false
 	}
+	if len(keys) == 1 && len(metadata) > 0 && !hasMapKeyedPagingSignal(metadata) {
+		return nil, nil, false
+	}
 	sort.Strings(keys)
 	entries := make([]mapKeyedEntry, 0, len(keys))
 	for _, key := range keys {
 		entries = append(entries, mapKeyedEntry{key: key, value: obj[key]})
 	}
 	return entries, metadata, true
+}
+
+func hasMapKeyedPagingSignal(metadata map[string]json.RawMessage) bool {
+	for key := range metadata {
+		if mapKeyedPagingSignalKeys[key] {
+			return true
+		}
+	}
+	return false
 }
 
 func isJSONObjectPayload(raw json.RawMessage) bool {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1260,14 +1260,40 @@ type mapKeyedEntry struct {
 	value json.RawMessage
 }
 
+// Field-name scalar/array siblings are list metadata only. Treating every
+// non-object field-name member as skippable metadata made a detail object
+// with one numeric-keyed child look like a one-record page, so sync and
+// write-through cached the child and dropped the remaining fields.
+var mapKeyedListMetadataKeys = map[string]bool{
+	"next_cursor": true, "nextCursor": true, "NextCursor": true,
+	"next_token": true, "nextToken": true, "NextToken": true,
+	"next_page_token": true, "nextPageToken": true, "NextPageToken": true,
+	"page_token": true, "pageToken": true, "PageToken": true,
+	"end_cursor": true, "endCursor": true, "EndCursor": true,
+	"start_cursor": true, "startCursor": true, "StartCursor": true,
+	"cursor": true, "Cursor": true, "after": true, "After": true, "before": true, "Before": true,
+	"has_more": true, "hasMore": true, "HasMore": true,
+	"has_next": true, "hasNext": true, "HasNext": true,
+	"next_page": true, "nextPage": true, "NextPage": true,
+	"previous_page": true, "previousPage": true, "PreviousPage": true,
+	"page": true, "Page": true, "page_size": true, "pageSize": true, "PageSize": true,
+	"per_page": true, "perPage": true, "PerPage": true,
+	"total": true, "Total": true, "count": true, "Count": true, "size": true, "Size": true,
+	"total_count": true, "totalCount": true, "TotalCount": true,
+	"success": true, "status": true, "message": true, "error": true, "errors": true,
+	"warnings": true, "Warnings": true, "ok": true, "Ok": true,
+	"next": true, "prev": true, "previous": true, "first": true, "last": true,
+}
+
 // A record identifier keying a JSON object is the only member shape a
 // collection may contain; anything else keyed like a record, or any object
 // keyed like a field, means the payload is something other than a collection
 // and is rejected whole. Scalar and array members under field-name keys are
-// the exception: an API is free to file paging metadata beside the records, so
-// dropping those members keeps the records reachable while the caller still
-// reads the cursor off the same envelope. Sorting makes repeated syncs of one
-// payload produce one row order.
+// kept only when the key is list metadata, so a real collection can still
+// file a cursor or total beside its records. A detail field (id, title, tags)
+// beside a single record-shaped child is not metadata: that payload stays a
+// detail object. Sorting makes repeated syncs of one payload produce one
+// row order.
 func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawMessage, bool) {
 	if !isJSONObjectPayload(raw) {
 		return nil, nil, false
@@ -1283,7 +1309,7 @@ func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawM
 		switch {
 		case recordKeyed && objectValued:
 			keys = append(keys, key)
-		case !recordKeyed && !objectValued:
+		case !recordKeyed && !objectValued && mapKeyedListMetadataKeys[key]:
 			metadata[key] = value
 		default:
 			return nil, nil, false

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1207,6 +1207,11 @@ func FTSMatchQuery(query string) string {
 // object key here and the id resolvers below fall back to it once every real id
 // field has missed. Flattener and resolvers stay in one file because a shape
 // one recognizes and the other cannot key loses rows with no error.
+//
+// The _pp_ prefix is reserved for fields this CLI synthesizes, so the stamp
+// always wins over a same-named member of the payload: the enclosing key is
+// the record's identity, and a payload copy of it is either stale or a name
+// collision inside a namespace no API owns.
 const MapKeyIDField = "_pp_map_key"
 
 // One level covers {"<id>": {...}}, two covers a bucketed
@@ -1263,35 +1268,36 @@ type mapKeyedEntry struct {
 // dropping those members keeps the records reachable while the caller still
 // reads the cursor off the same envelope. Sorting makes repeated syncs of one
 // payload produce one row order.
-func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
+func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, map[string]json.RawMessage, bool) {
 	if !isJSONObjectPayload(raw) {
-		return nil, false
+		return nil, nil, false
 	}
 	var obj map[string]json.RawMessage
 	if json.Unmarshal(raw, &obj) != nil || len(obj) == 0 {
-		return nil, false
+		return nil, nil, false
 	}
 	keys := make([]string, 0, len(obj))
+	metadata := map[string]json.RawMessage{}
 	for key, value := range obj {
 		recordKeyed, objectValued := looksLikeRecordKey(key), isJSONObjectPayload(value)
 		switch {
 		case recordKeyed && objectValued:
 			keys = append(keys, key)
 		case !recordKeyed && !objectValued:
-			continue
+			metadata[key] = value
 		default:
-			return nil, false
+			return nil, nil, false
 		}
 	}
 	if len(keys) == 0 {
-		return nil, false
+		return nil, nil, false
 	}
 	sort.Strings(keys)
 	entries := make([]mapKeyedEntry, 0, len(keys))
 	for _, key := range keys {
 		entries = append(entries, mapKeyedEntry{key: key, value: obj[key]})
 	}
-	return entries, true
+	return entries, metadata, true
 }
 
 func isJSONObjectPayload(raw json.RawMessage) bool {
@@ -1309,19 +1315,35 @@ func isEmptyJSONObject(raw json.RawMessage) bool {
 // members are all empty reads as an empty page rather than as a shape this
 // could not extract.
 func FlattenMapKeyedCollection(raw json.RawMessage) ([]json.RawMessage, bool) {
+	items, _, ok := FlattenMapKeyedCollectionWithMetadata(raw)
+	return items, ok
+}
+
+// The members skipped as metadata come back with the records because a
+// collection nested under a wrapper key or a declared response path can carry
+// its own continuation cursor. Dropping them left the pager reading only the
+// envelope above, which ends a paginated sync after its first page.
+func FlattenMapKeyedCollectionWithMetadata(raw json.RawMessage) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	return flattenMapKeyedCollection(raw, mapKeyedMaxDepth)
 }
 
-func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessage, bool) {
-	entries, ok := mapKeyedEntries(raw)
+func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessage, map[string]json.RawMessage, bool) {
+	entries, metadata, ok := mapKeyedEntries(raw)
 	if !ok {
-		return nil, false
+		return nil, nil, false
 	}
 	items := make([]json.RawMessage, 0, len(entries))
 	for _, entry := range entries {
 		if depth > 1 {
-			if nested, ok := flattenMapKeyedCollection(entry.value, depth-1); ok {
+			if nested, nestedMetadata, ok := flattenMapKeyedCollection(entry.value, depth-1); ok {
 				items = append(items, nested...)
+				// A bucket's own metadata fills gaps only: the level closest to
+				// the caller describes the page it asked for.
+				for key, value := range nestedMetadata {
+					if _, taken := metadata[key]; !taken {
+						metadata[key] = value
+					}
+				}
 				continue
 			}
 		}
@@ -1330,7 +1352,7 @@ func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessag
 		}
 		items = append(items, stampMapKeyID(entry.value, entry.key))
 	}
-	return items, true
+	return items, metadata, true
 }
 
 // The enclosing key is the record's identity, so a same-named field already in
@@ -1358,22 +1380,23 @@ func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
 // their own isMetadataKey because the sync and live paths carry different
 // metadata vocabularies; recognition of the collection itself must not differ
 // between them.
-func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, bool) {
+func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	var collection []json.RawMessage
+	var collectionMetadata map[string]json.RawMessage
 	matches := 0
 	for key, raw := range envelope {
 		if isMetadataKey(key) {
 			continue
 		}
-		if items, ok := FlattenMapKeyedCollection(raw); ok {
-			collection = items
+		if items, metadata, ok := FlattenMapKeyedCollectionWithMetadata(raw); ok {
+			collection, collectionMetadata = items, metadata
 			matches++
 		}
 	}
 	if matches == 1 {
-		return collection, true
+		return collection, collectionMetadata, true
 	}
-	return nil, false
+	return nil, nil, false
 }
 
 // Callers must try every real id field first: the stamped key is only the right

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1202,19 +1202,14 @@ func FTSMatchQuery(query string) string {
 	return strings.Join(quoted, " ")
 }
 
-// MapKeyIDField is the synthetic field FlattenMapKeyedCollection stamps onto
-// every item it lifts out of a map-keyed collection, carrying the JSON object
-// key that identified the record. The id resolvers below consult it as a last
-// resort, so a leaf object that carries no id field of its own still resolves
-// to the key the API filed it under instead of being dropped.
-//
-// The flattener and the id resolvers live in this file together on purpose:
-// if one recognizes a shape the other cannot key, the rows disappear from the
-// local mirror without an error.
+// A record filed under its own identifier often carries no id field inside the
+// object, and would be dropped for want of one. The flattener stamps the JSON
+// object key here and the id resolvers below fall back to it once every real id
+// field has missed. Flattener and resolvers stay in one file because a shape
+// one recognizes and the other cannot key loses rows with no error.
 const MapKeyIDField = "_pp_map_key"
 
-// mapKeyedMaxDepth bounds how far FlattenMapKeyedCollection descends. One
-// level covers {"<id>": {...}}; two covers a bucketed
+// One level covers {"<id>": {...}}, two covers a bucketed
 // {"<bucket>": {"<id>": {...}}}. Descending further would start treating an
 // item's own nested sub-objects as sibling records.
 const mapKeyedMaxDepth = 2
@@ -1234,10 +1229,9 @@ var (
 	mapKeyHasDigitRE = regexp.MustCompile(`[0-9]`)
 )
 
-// looksLikeRecordKey reports whether a JSON object key reads as a record
-// identifier rather than a field name. A separator-free token must be long and
-// carry a digit before it qualifies, because a short alphabetic token is
-// indistinguishable from a field name.
+// A separator-free token must be long and carry a digit before it qualifies as
+// an identifier, because a short alphabetic token is indistinguishable from a
+// field name.
 func looksLikeRecordKey(key string) bool {
 	switch {
 	case key == "":
@@ -1261,11 +1255,14 @@ type mapKeyedEntry struct {
 	value json.RawMessage
 }
 
-// mapKeyedEntries decodes raw as a map-keyed collection. Every key must read
-// as a record identifier and every value must be a JSON object; a single
-// disqualifying member rejects the whole payload, so a mixed envelope is never
-// mistaken for a collection. Entries come back key-sorted so repeated syncs of
-// the same payload always produce the same row order.
+// A record identifier keying a JSON object is the only member shape a
+// collection may contain; anything else keyed like a record, or any object
+// keyed like a field, means the payload is something other than a collection
+// and is rejected whole. Scalar and array members under field-name keys are
+// the exception: an API is free to file paging metadata beside the records, so
+// dropping those members keeps the records reachable while the caller still
+// reads the cursor off the same envelope. Sorting makes repeated syncs of one
+// payload produce one row order.
 func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
 	if !isJSONObjectPayload(raw) {
 		return nil, false
@@ -1276,10 +1273,18 @@ func mapKeyedEntries(raw json.RawMessage) ([]mapKeyedEntry, bool) {
 	}
 	keys := make([]string, 0, len(obj))
 	for key, value := range obj {
-		if !looksLikeRecordKey(key) || !isJSONObjectPayload(value) {
+		recordKeyed, objectValued := looksLikeRecordKey(key), isJSONObjectPayload(value)
+		switch {
+		case recordKeyed && objectValued:
+			keys = append(keys, key)
+		case !recordKeyed && !objectValued:
+			continue
+		default:
 			return nil, false
 		}
-		keys = append(keys, key)
+	}
+	if len(keys) == 0 {
+		return nil, false
 	}
 	sort.Strings(keys)
 	entries := make([]mapKeyedEntry, 0, len(keys))
@@ -1299,12 +1304,10 @@ func isEmptyJSONObject(raw json.RawMessage) bool {
 	return json.Unmarshal(raw, &obj) == nil && len(obj) == 0
 }
 
-// FlattenMapKeyedCollection lifts the records out of a collection that files
-// each record under its own identifier — {"<id>": {...}} — including one level
-// of bucketing above the records — {"<bucket>": {"<id>": {...}}}. The second
-// return value reports whether raw was recognized as such a collection at all;
-// a recognized collection whose members are all empty yields no items, which
-// is an empty page rather than a failure to extract.
+// Recognition and extraction are separate answers: the second return reports
+// only whether raw was a collection at all, so a recognized collection whose
+// members are all empty reads as an empty page rather than as a shape this
+// could not extract.
 func FlattenMapKeyedCollection(raw json.RawMessage) ([]json.RawMessage, bool) {
 	return flattenMapKeyedCollection(raw, mapKeyedMaxDepth)
 }
@@ -1330,14 +1333,12 @@ func flattenMapKeyedCollection(raw json.RawMessage, depth int) ([]json.RawMessag
 	return items, true
 }
 
-// stampMapKeyID records the collection key on the item it identified. A key
-// the payload already carries is left alone so re-flattening is idempotent.
+// The enclosing key is the record's identity, so a same-named field already in
+// the payload is overwritten rather than trusted: keeping it would file the row
+// under a value the API never used as its key.
 func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
 	var obj map[string]json.RawMessage
 	if json.Unmarshal(value, &obj) != nil {
-		return value
-	}
-	if _, exists := obj[MapKeyIDField]; exists {
 		return value
 	}
 	encodedKey, err := json.Marshal(key)
@@ -1352,11 +1353,10 @@ func stampMapKeyID(value json.RawMessage, key string) json.RawMessage {
 	return stamped
 }
 
-// FlattenSoleMapKeyedSibling flattens the single member of an envelope that
-// holds a map-keyed collection alongside scalar metadata. Two flattenable
-// members leave the envelope ambiguous, so nothing is extracted. Callers pass
-// their own isMetadataKey because the sync and live paths each carry their own
-// metadata vocabulary; the collection recognition itself must not differ
+// Two flattenable members leave the envelope ambiguous, so nothing is
+// extracted rather than guessing which one holds the records. Callers pass
+// their own isMetadataKey because the sync and live paths carry different
+// metadata vocabularies; recognition of the collection itself must not differ
 // between them.
 func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataKey func(string) bool) ([]json.RawMessage, bool) {
 	var collection []json.RawMessage
@@ -1376,9 +1376,8 @@ func FlattenSoleMapKeyedSibling(envelope map[string]json.RawMessage, isMetadataK
 	return nil, false
 }
 
-// mapKeyIDFallback resolves the identifier FlattenMapKeyedCollection stamped
-// onto an item. Callers must try every real id field first: the stamped key is
-// only the right answer when the record carries no identifier of its own.
+// Callers must try every real id field first: the stamped key is only the right
+// answer when the record carries no identifier of its own.
 func mapKeyIDFallback(obj map[string]any) string {
 	v, ok := obj[MapKeyIDField]
 	if !ok {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -1160,16 +1160,19 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 			continue
 		}
 		pathItems, found := extractJSONItemsArray(pathData)
+		var pathMetadata map[string]json.RawMessage
 		if !found {
 			// A declared response path can resolve to a map-keyed collection
 			// rather than an array. No wrapper key is a record key, so this
 			// can never shadow an array-shaped or enveloped payload.
-			pathItems, found = store.FlattenMapKeyedCollection(pathData)
+			pathItems, pathMetadata, found = store.FlattenMapKeyedCollectionWithMetadata(pathData)
 		}
 		if found {
-			nextCursor, hasMore := "", false
-			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
-				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
+			nextCursor, hasMore := mapKeyedPagination(pathMetadata, cursorParam)
+			if nextCursor == "" && !hasMore {
+				if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
+					nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
+				}
 			}
 			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
 			if nextCursor == "" {
@@ -1192,9 +1195,13 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		}
 	}
 
-	if items, ok := extractItemsByKnownKeys(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
-		return items, nextCursor, hasMore
+	if items, metadata, ok := extractItemsByKnownKeysWithMetadata(envelope); ok {
+		nextCursor, hasMore := mapKeyedPagination(metadata, cursorParam)
+		outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		if nextCursor == "" {
+			nextCursor = outerCursor
+		}
+		return items, nextCursor, hasMore || outerHasMore
 	}
 
 	for _, key := range dataEnvelopeKeys {
@@ -1240,12 +1247,27 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		return items, nextCursor, hasMore
 	}
 
-	if items, ok := extractSingleMapKeyedSibling(envelope); ok {
-		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
-		return items, nextCursor, hasMore
+	if items, metadata, ok := extractSingleMapKeyedSibling(envelope); ok {
+		nextCursor, hasMore := mapKeyedPagination(metadata, cursorParam)
+		outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		if nextCursor == "" {
+			nextCursor = outerCursor
+		}
+		return items, nextCursor, hasMore || outerHasMore
 	}
 
 	return nil, "", false
+}
+
+// Metadata filed beside the records describes the page those records came from,
+// so it is consulted before the envelope above them. nextCursorPath is declared
+// against the response root, which this level is not, so only a plain field
+// match applies here.
+func mapKeyedPagination(metadata map[string]json.RawMessage, cursorParam string) (string, bool) {
+	if len(metadata) == 0 {
+		return "", false
+	}
+	return extractPaginationFromEnvelope(metadata, cursorParam, "")
 }
 
 func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
@@ -1255,21 +1277,31 @@ func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMe
 	if items, ok := extractSingleObjectArraySibling(envelope); ok {
 		return items, true
 	}
-	return extractSingleMapKeyedSibling(envelope)
+	items, _, ok := extractSingleMapKeyedSibling(envelope)
+	return items, ok
 }
 
 // extractSingleMapKeyedSibling handles an envelope that carries a map-keyed
 // collection under a resource-named key alongside scalar metadata. Exactly one
 // non-metadata key may flatten: an envelope holding two candidate collections
 // is ambiguous and is left for the caller to reject.
-func extractSingleMapKeyedSibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+func extractSingleMapKeyedSibling(envelope map[string]json.RawMessage) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	return store.FlattenSoleMapKeyedSibling(envelope, func(key string) bool {
 		return pageEnvelopeMetadataKeys[key]
 	})
 }
 
 func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	items, _, ok := extractItemsByKnownKeysWithMetadata(envelope)
+	return items, ok
+}
+
+// A wrapper key holding a map-keyed collection can carry that collection's own
+// paging metadata inside the wrapper. Callers that paginate take the metadata
+// return; the rest use the wrapper above and drop it.
+func extractItemsByKnownKeysWithMetadata(envelope map[string]json.RawMessage) ([]json.RawMessage, map[string]json.RawMessage, bool) {
 	var emptyItems []json.RawMessage
+	var emptyMetadata map[string]json.RawMessage
 	foundEmpty := false
 	for _, key := range pageItemKeys {
 		if raw, ok := envelope[key]; ok {
@@ -1279,7 +1311,7 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 			}
 			if items, ok := extract(raw); ok {
 				if len(items) > 0 {
-					return items, true
+					return items, nil, true
 				}
 				emptyItems = items
 				foundEmpty = true
@@ -1294,20 +1326,20 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 		if !ok {
 			continue
 		}
-		items, ok := store.FlattenMapKeyedCollection(raw)
+		items, metadata, ok := store.FlattenMapKeyedCollectionWithMetadata(raw)
 		if !ok {
 			continue
 		}
 		if len(items) > 0 {
-			return items, true
+			return items, metadata, true
 		}
-		emptyItems = items
+		emptyItems, emptyMetadata = items, metadata
 		foundEmpty = true
 	}
 	if foundEmpty {
-		return emptyItems, true
+		return emptyItems, emptyMetadata, true
 	}
-	return nil, false
+	return nil, nil, false
 }
 
 func extractSingleObjectArraySibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -1130,9 +1130,12 @@ func formatSyncSinceValue(value string, paramFormat string) string {
 
 // extractPageItems attempts to extract an array of items and pagination cursor from a response.
 // It tries multiple strategies:
-// 1. Direct JSON array
-// 2. Common wrapper keys: "data", "results", "items", "records", "nodes", "entries"
-// 3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
+//  1. Direct JSON array
+//  2. Common wrapper keys: "data", "results", "items", "records", "nodes", "entries"
+//  3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
+//  4. Map-keyed collections that file each record under its id instead of
+//     listing records in an array: {"<id>":{...}} and {"<bucket>":{"<id>":{...}}}
+//
 // It also extracts the next cursor from common response fields.
 func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ...string) ([]json.RawMessage, string, bool) {
 	return extractPageItemsWithPagination(data, cursorParam, "", responsePaths...)
@@ -1156,7 +1159,14 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		if !ok {
 			continue
 		}
-		if items, ok := extractJSONItemsArray(pathData); ok {
+		pathItems, found := extractJSONItemsArray(pathData)
+		if !found {
+			// A declared response path can resolve to a map-keyed collection
+			// rather than an array. No wrapper key is a record key, so this
+			// can never shadow an array-shaped or enveloped payload.
+			pathItems, found = store.FlattenMapKeyedCollection(pathData)
+		}
+		if found {
 			nextCursor, hasMore := "", false
 			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
 				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam, nextCursorPath)
@@ -1166,7 +1176,7 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 				nextCursor = outerCursor
 			}
 			hasMore = hasMore || outerHasMore
-			return items, nextCursor, hasMore
+			return pathItems, nextCursor, hasMore
 		}
 		var inner map[string]json.RawMessage
 		if json.Unmarshal(pathData, &inner) == nil {
@@ -1222,6 +1232,19 @@ func extractPageItemsWithPagination(data json.RawMessage, cursorParam, nextCurso
 		return items, nextCursor, hasMore
 	}
 
+	// The response can be the collection itself, filing each record under its
+	// id rather than listing records in an array. Both map-keyed strategies
+	// run last so no array-shaped strategy is preempted.
+	if items, ok := store.FlattenMapKeyedCollection(data); ok {
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		return items, nextCursor, hasMore
+	}
+
+	if items, ok := extractSingleMapKeyedSibling(envelope); ok {
+		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam, nextCursorPath)
+		return items, nextCursor, hasMore
+	}
+
 	return nil, "", false
 }
 
@@ -1229,7 +1252,20 @@ func extractItemsFromEnvelope(envelope map[string]json.RawMessage) ([]json.RawMe
 	if items, ok := extractItemsByKnownKeys(envelope); ok {
 		return items, true
 	}
-	return extractSingleObjectArraySibling(envelope)
+	if items, ok := extractSingleObjectArraySibling(envelope); ok {
+		return items, true
+	}
+	return extractSingleMapKeyedSibling(envelope)
+}
+
+// extractSingleMapKeyedSibling handles an envelope that carries a map-keyed
+// collection under a resource-named key alongside scalar metadata. Exactly one
+// non-metadata key may flatten: an envelope holding two candidate collections
+// is ambiguous and is left for the caller to reject.
+func extractSingleMapKeyedSibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	return store.FlattenSoleMapKeyedSibling(envelope, func(key string) bool {
+		return pageEnvelopeMetadataKeys[key]
+	})
 }
 
 func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
@@ -1249,6 +1285,24 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 				foundEmpty = true
 			}
 		}
+	}
+	// A wrapper key can hold a map-keyed collection instead of an array. This
+	// runs only after every wrapper key has failed the array decode, so an
+	// array-shaped wrapper always wins.
+	for _, key := range pageItemKeys {
+		raw, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		items, ok := store.FlattenMapKeyedCollection(raw)
+		if !ok {
+			continue
+		}
+		if len(items) > 0 {
+			return items, true
+		}
+		emptyItems = items
+		foundEmpty = true
 	}
 	if foundEmpty {
 		return emptyItems, true


### PR DESCRIPTION
## Intent

A printed CLI whose list endpoint returns a **map-keyed collection** — the record id is the JSON object *key*, not a field in an array element — extracted zero items. `sync` failed with `missing id for <resource>` and cached nothing; the live write-through path warned `no extractable ID field` and cached nothing, so the CLI looked like it worked interactively while its local mirror stayed empty.

The concept "the object key IS the id" did not exist anywhere in the generator: every extraction branch bottomed out in an array-only terminal extractor, and `extractObjectID` / `ExtractResourceID` were flat field scans with no key awareness.

Issue: Fixes #4330

## Approach

One recognizer, one id fallback, both in `internal/store` so they cannot drift.

`store.FlattenMapKeyedCollection` recognizes a collection that files each record under its identifier and lifts the records out, descending at most two levels (`{"<id>": {...}}` and `{"<bucket>": {"<id>": {...}}}`). It stamps the leaf key onto each item under a reserved `_pp_map_key` field; `extractObjectID` and `ExtractResourceID` consult that field as their **last** resort, after every real id strategy. Putting the flattener in the same file as the two id resolvers is deliberate — the generated `sync.go` already warns that a divergence between extractor and id resolver drops rows silently, so they now share a file and a contract, and the flattener always stamps so the resolver can never be handed an unkeyable item.

**The discrimination heuristic, and why it is safe.** The shape most at risk of a false positive is an ordinary detail object whose fields happen to hold sub-objects (`{"user": {...}, "account": {...}}`) — structurally identical to a two-record map-keyed collection. The discriminator is the *key shape*: field names are words, record identifiers are not. A payload qualifies only when **every** key matches one of a closed set — all-digits, UUID, `YYYY-MM-DD[...]`, a separator-free alphanumeric token of 20+ chars containing a digit, or a token starting with `-`/`_` of 16+ chars containing a digit — **and every value is a JSON object**, with at least one member. A single disqualifying member rejects the whole payload, so a mixed envelope is never mistaken for a collection. The last two rules are the loosest; both require a digit and a length no realistic field name reaches, and no field name begins with a separator. Short opaque ids (`abc123XY`) are deliberately *not* recognized — that is the conservative side of the trade, and it is why this is a closed set rather than a "looks id-ish" score.

Both map-keyed strategies run **after** every existing array-shaped strategy at every call site, so no working extraction path is preempted. A recognized-but-empty collection (a bucket with no records) yields zero items and reports as an empty page rather than a spurious row keyed by the bucket.

`data_source.go`'s write-through path calls the same recognizer in the same strategy order, so a live list and a sync of one endpoint now cache the same rows.

## Scope

Primary area: generator templates — `internal/generator/templates/{store,sync,data_source}.go.tmpl`.

Why this belongs in this repo: map-keyed collections are a general API shape (Firebase-style stores, undocumented ajax endpoints that key records by id for client-side lookup), not one API's quirk. Grepping the templates for any map-key handling returned zero hits before this change — the whole concept was missing from the machine, so every printed CLI wrapping such an endpoint stores zero rows.

## Risk

The real risk is over-eager recognition corrupting an existing CLI's store by reading an ordinary nested object as a collection. Mitigations, in order of strength:

1. Recognition requires *every* key to match the closed record-key set and *every* value to be an object — one field-name key rejects the payload.
2. Every map-keyed strategy runs last at its call site; an array-shaped payload keeps its existing path unchanged. A regression test asserts an array wrapper still wins when a map-keyed sibling is also present.
3. `_pp_map_key` is only ever a last-resort id: a record carrying any real id field keys on that id exactly as before.

Residual: items lifted from a map-keyed collection carry an extra `_pp_map_key` field in their cached JSON blob, visible via `sql` / `search` on raw payloads. It is namespaced to the existing `_pp_` convention and only appears on rows that came from this path. Re-marshalling also key-sorts those items' JSON.

## Output Contract

Emitted `internal/store/store.go`, `internal/cli/sync.go`, and `internal/cli/data_source.go` change in every print. Evidence:

- New generated-output test `TestMapKeyedCollectionExtraction` (`internal/generator/sync_map_keyed_collection_test.go`) generates a CLI, calls `requireGeneratedCompiles`, writes tests into both the generated `internal/store` and `internal/cli` packages, and runs them. It asserts emitted behavior — flatten at both nesting depths, key-sorted determinism, the id fallback in `ExtractResourceID` *and* `extractObjectID`, that a real id outranks the stamped key, `UpsertBatch` persisting an id-less record under its map key, `extractPageItems` across six payload shapes, and `writeThroughCache` caching records rather than the envelope.
- Negative-control run with the three templates reverted: the same tests fail with `expected 2 items, got 0` and the generated CLI emits the issue's exact warning, `1/1 calls items returned but not cached locally (no extractable ID field...)`.
- Regression guards in the same test assert an array wrapper still wins over a map-keyed sibling, and that a detail object with nested sub-objects is *not* flattened.
- Golden fixtures updated for the 9 affected emitted files. Every removed line in the golden diff is one this change replaced; no unrelated churn.
- No new golden case added: the emitted-artifact shape is already captured byte-for-byte by the existing fixtures, and the new behavior is runtime extraction, which the generated-output test exercises directly.

Heads-up for whoever merges second: #4316 also regenerates golden fixtures. The two branches overlap on exactly one file, `testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go` — #4316 adds `syncResourceParamDefaults` and its seeding loops, this PR adds the map-keyed branches. Resolve it with `scripts/golden.sh update` on the rebase, not a hand-merge of the fixture.

## Verification

Run with `GOTOOLCHAIN=go1.26.6` (matching `go.mod`; the local go1.27 toolchain fails to build a transitive `enetx/http2` dependency, unrelated to this change).

- `go test ./...` — every non-generator package `ok`. `internal/generator` does not fit the default 10 min per-package budget on this machine (CI splits the same package into 4 partitions at 15 min each), so it was re-run on its own: `go test ./internal/generator/ -timeout 0 -count=1` -> `ok github.com/mvanhorn/cli-printing-press/v4/internal/generator 3437.059s`, zero `--- FAIL` lines.
- `go test ./internal/generator/ -run TestMapKeyedCollectionExtraction -count=1` — pass; the same test fails with the templates reverted (negative control)
- `bash scripts/golden.sh verify` — 6 cases changed, all in emitted `sync.go` / `store.go` / `data_source.go`. `GOLDEN_ALLOW_DIRTY=1 bash scripts/golden.sh update`, then re-verified: 34/34 pass
- `bash scripts/verify-generator-output.sh` with the 11 default cases plus `generate-sync-walker-api generate-tier-routing-api generate-learn-disabled-api generate-embedded-paged-api` — 15/15 generated modules tidy and build
- `go fmt ./...`, `go vet ./internal/generator/`, `golangci-lint run ./internal/generator/...` — clean apart from 3 pre-existing `modernize` findings in files this PR does not touch

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
