### PR TITLE
fix(cli): send spec-declared query param defaults from sync

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -460,6 +460,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"endpointClientSideFilters": endpointClientSideFilters,
 		"globalScopeParams":         globalScopeParams,
 		"responsePathCases":         responsePathCases,
+		"syncParamDefaultCases":     syncParamDefaultCases,
 		"envName":                   naming.EnvPrefix,
 		// endpointTemplateEnvName resolves the env-var name for a
 		// {placeholder} in EndpointTemplateVars. Returns the spec-declared
@@ -6397,6 +6398,39 @@ func sortedResourcePathEntries(entries map[string]resourcePathEntry) []resourceP
 	out := make([]resourcePathEntry, 0, len(names))
 	for _, name := range names {
 		out = append(out, entries[name])
+	}
+	return out
+}
+
+// syncParamDefaultCase is one deduplicated entry for the sync template's
+// syncResourceParamDefaults switch. Flat and dependent resource sets can carry
+// the same resource name, and a repeated case in a Go switch does not compile.
+type syncParamDefaultCase struct {
+	Resource string
+	Defaults []profiler.SyncQueryParamDefault
+}
+
+// syncParamDefaultCases returns the resources whose list endpoint declares a
+// query-param default, flat set first so a name present in both wins the same
+// way it does everywhere else sync resolves a resource.
+func syncParamDefaultCases(syncable []profiler.SyncableResource, dependents []profiler.DependentResource) []syncParamDefaultCase {
+	seen := map[string]struct{}{}
+	var out []syncParamDefaultCase
+	add := func(name string, defaults []profiler.SyncQueryParamDefault) {
+		if len(defaults) == 0 {
+			return
+		}
+		if _, dup := seen[name]; dup {
+			return
+		}
+		seen[name] = struct{}{}
+		out = append(out, syncParamDefaultCase{Resource: name, Defaults: defaults})
+	}
+	for _, resource := range syncable {
+		add(resource.Name, resource.QueryParamDefaults)
+	}
+	for _, dependent := range dependents {
+		add(dependent.Name, dependent.QueryParamDefaults)
 	}
 	return out
 }

--- a/internal/generator/sync_owned_params_test.go
+++ b/internal/generator/sync_owned_params_test.go
@@ -1,0 +1,87 @@
+package generator
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// syncOwnedParamDefaultsSpec declares one list endpoint whose spec puts a
+// `default:` on both kinds of param at once: keys the syncer assigns itself
+// (the since filter, its companion ascending sort, the date range, and paging)
+// and a genuinely load-bearing tenant scope. Only the scope may be seeded. Sync
+// sends the others conditionally, so a seeded default would survive exactly the
+// branch where sync chose to withhold it and quietly turn a full sync into a
+// filtered, re-ordered one.
+func syncOwnedParamDefaultsSpec(name string) *spec.APISpec {
+	apiSpec := minimalSpec(name)
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"tickets": {
+			Description: "Tickets",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:   "GET",
+					Path:     "/tickets",
+					Response: spec.ResponseDef{Type: "array"},
+					Params: []spec.Param{
+						{Name: "workspace-id", In: "query", Type: "string", Default: "ws-42"},
+						{Name: "updated_since", In: "query", Type: "string", Default: "2020-01-01"},
+						{Name: "sort", In: "query", Type: "string", Default: "updated_at:asc"},
+						{Name: "dates", In: "query", Type: "string", Default: "last_30_days"},
+						{Name: "limit", In: "query", Type: "integer", Default: 25},
+					},
+				},
+			},
+		},
+	}
+	return apiSpec
+}
+
+// TestGeneratedSyncSeedsScopeDefaultsButNotSyncOwnedParams pins the boundary the
+// seeding must respect. A tenant scope default is the reported symptom: the
+// endpoint command puts it on the wire, so sync must too. The since, sort,
+// date-range, and paging keys are the inverse case -- sync owns them and
+// decides per run whether to send them at all, so seeding them would override a
+// deliberate decision rather than fill a gap.
+func TestGeneratedSyncSeedsScopeDefaultsButNotSyncOwnedParams(t *testing.T) {
+	outputDir := t.TempDir()
+	apiSpec := syncOwnedParamDefaultsSpec("sync-owned-defaults")
+
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	defaults := extractSyncParamDefaultsBlock(t, syncSrc, "tickets")
+
+	assert.Contains(t, defaults, `"workspace-id": "ws-42"`,
+		"tenant scope default must be seeded so sync and list address the same slice of the API")
+
+	for _, owned := range []string{"updated_since", "sort", "dates", "limit"} {
+		assert.NotContains(t, defaults, `"`+owned+`"`,
+			"%q is assigned by the syncer itself and must not be seeded from a spec default", owned)
+	}
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
+// extractSyncParamDefaultsBlock returns the body of the syncResourceParamDefaults
+// case for one resource, so a NotContains assertion cannot be satisfied or
+// defeated by a key that appears elsewhere in the generated file.
+func extractSyncParamDefaultsBlock(t *testing.T, src, resource string) string {
+	t.Helper()
+
+	fnIdx := strings.Index(src, "func syncResourceParamDefaults(")
+	require.GreaterOrEqual(t, fnIdx, 0, "generated sync.go must declare syncResourceParamDefaults")
+
+	caseIdx := strings.Index(src[fnIdx:], "case "+strconv.Quote(resource)+":")
+	require.GreaterOrEqual(t, caseIdx, 0, "syncResourceParamDefaults must have a case for %q", resource)
+	start := fnIdx + caseIdx
+
+	end := strings.Index(src[start:], "\n\t\t}")
+	require.GreaterOrEqual(t, end, 0, "unterminated case body for %q", resource)
+	return src[start : start+end]
+}

--- a/internal/generator/sync_param_defaults_test.go
+++ b/internal/generator/sync_param_defaults_test.go
@@ -1,0 +1,310 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/openapi"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// syncParamDefaultsSpec declares a flat list endpoint with a spec `default:`,
+// a dependent (walker-driven) list endpoint with its own default, and a third
+// resource with no defaults at all — the fallback shape that must keep
+// emitting an empty params map.
+func syncParamDefaultsSpec(name string) *spec.APISpec {
+	apiSpec := minimalSpec(name)
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"posts": {
+			Description: "Posts",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:   "GET",
+					Path:     "/posts",
+					Response: spec.ResponseDef{Type: "array"},
+					Params: []spec.Param{
+						{Name: "sort", In: "query", Type: "string", Default: "new"},
+						{Name: "include_drafts", In: "query", Type: "boolean", Default: true},
+					},
+				},
+			},
+		},
+		"authors": {
+			Description: "Authors",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:   "GET",
+					Path:     "/authors",
+					Response: spec.ResponseDef{Type: "array"},
+				},
+			},
+		},
+		"comments": {
+			Description: "Comments scoped to a post",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:   "GET",
+					Path:     "/comments",
+					Response: spec.ResponseDef{Type: "array"},
+					Params: []spec.Param{
+						{Name: "postId", In: "query", Type: "string", Required: true},
+						{Name: "depth", In: "query", Type: "integer", Default: 3},
+					},
+					Walker: &spec.WalkerConfig{
+						Parent:   "posts",
+						KeyField: "id",
+						KeyParam: "postId",
+					},
+				},
+			},
+		},
+	}
+	return apiSpec
+}
+
+// TestGeneratedSyncSendsSpecParamDefaults is the generated-output proof that a
+// spec-declared query `default:` reaches sync requests. Endpoint commands bind
+// the same default to their cobra flag, so before this the two surfaces
+// addressed different slices of the API: a list command sent the scope or the
+// stable ordering and sync silently omitted it.
+func TestGeneratedSyncSendsSpecParamDefaults(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := syncParamDefaultsSpec("syncdefaults")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+
+	// Flat and dependent resources both land in the same lookup, and a
+	// resource without defaults gets no case at all.
+	assert.Contains(t, syncSrc, "func syncResourceParamDefaults(resource string) map[string]string {")
+	assert.Contains(t, syncSrc, `"sort":           "new"`)
+	assert.Contains(t, syncSrc, `"include_drafts": "true"`)
+	assert.Contains(t, syncSrc, `"depth": "3"`)
+	defaultsIdx := strings.Index(syncSrc, "func syncResourceParamDefaults(resource string) map[string]string {")
+	require.NotEqual(t, -1, defaultsIdx)
+	defaultsFn := syncSrc[defaultsIdx : defaultsIdx+strings.Index(syncSrc[defaultsIdx:], "\n}\n")]
+	assert.NotContains(t, defaultsFn, `case "authors":`,
+		"a resource whose spec declares no param default must not get a lookup case")
+
+	// The seeding happens before everything sync computes, so paging, the
+	// since filter, and --param overrides all still win on key conflict.
+	seedIdx := strings.Index(syncSrc, "for defaultKey, defaultValue := range syncResourceParamDefaults(resource)")
+	limitIdx := strings.Index(syncSrc, "params[pageSize.limitParam] = strconv.Itoa(pageSize.limit)")
+	applyIdx := strings.Index(syncSrc, "userParams.applyTo(resource, params, false)")
+	require.NotEqual(t, -1, seedIdx, "flat sync loop must seed spec param defaults")
+	require.NotEqual(t, -1, limitIdx)
+	require.NotEqual(t, -1, applyIdx)
+	assert.Less(t, seedIdx, limitIdx, "spec defaults must not overwrite sync-owned paging params")
+	assert.Less(t, seedIdx, applyIdx, "--param must still override a spec default")
+
+	depSeedIdx := strings.Index(syncSrc, "for defaultKey, defaultValue := range syncResourceParamDefaults(dep.Name)")
+	depApplyIdx := strings.Index(syncSrc, "userParams.applyTo(dep.Name, params, true)")
+	require.NotEqual(t, -1, depSeedIdx, "dependent sync loop must seed spec param defaults too")
+	require.NotEqual(t, -1, depApplyIdx)
+	assert.Less(t, depSeedIdx, depApplyIdx)
+
+	requireGeneratedCompiles(t, outputDir)
+
+	inlineTest := `package cli
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"` + naming.CLI(apiSpec.Name) + `/internal/store"
+)
+
+type paramDefaultsClient struct {
+	got []map[string]string
+}
+
+func (c *paramDefaultsClient) Get(_ context.Context, _ string, params map[string]string) (json.RawMessage, error) {
+	copied := map[string]string{}
+	for k, v := range params {
+		copied[k] = v
+	}
+	c.got = append(c.got, copied)
+	return json.RawMessage(` + "`" + `[{"id":"one"}]` + "`" + `), nil
+}
+
+func (*paramDefaultsClient) RateLimit() float64 { return 0 }
+
+func openParamDefaultsStore(t *testing.T) *store.Store {
+	t.Helper()
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestSyncFlatResourceSendsSpecParamDefaults(t *testing.T) {
+	db := openParamDefaultsStore(t)
+	client := &paramDefaultsClient{}
+
+	res := syncResource(context.Background(), client, db, "posts", "", false, 1, false, false, nil, nil)
+	if res.Err != nil {
+		t.Fatalf("syncResource error: %v", res.Err)
+	}
+	if len(client.got) == 0 {
+		t.Fatal("no request issued")
+	}
+	if got := client.got[0]["sort"]; got != "new" {
+		t.Fatalf("sort = %q, want %q (spec default must reach the sync request)", got, "new")
+	}
+	if got := client.got[0]["include_drafts"]; got != "true" {
+		t.Fatalf("include_drafts = %q, want %q", got, "true")
+	}
+}
+
+func TestSyncFlatResourceUserParamOverridesSpecDefault(t *testing.T) {
+	db := openParamDefaultsStore(t)
+	client := &paramDefaultsClient{}
+
+	userParams, err := parseSyncUserParams([]string{"sort=top"}, nil, nil)
+	if err != nil {
+		t.Fatalf("parseSyncUserParams: %v", err)
+	}
+	res := syncResource(context.Background(), client, db, "posts", "", false, 1, false, false, userParams, nil)
+	if res.Err != nil {
+		t.Fatalf("syncResource error: %v", res.Err)
+	}
+	if got := client.got[0]["sort"]; got != "top" {
+		t.Fatalf("sort = %q, want %q (--param must win over a spec default)", got, "top")
+	}
+}
+
+func TestSyncResourceWithoutDefaultsSendsNone(t *testing.T) {
+	db := openParamDefaultsStore(t)
+	client := &paramDefaultsClient{}
+
+	res := syncResource(context.Background(), client, db, "authors", "", false, 1, false, false, nil, nil)
+	if res.Err != nil {
+		t.Fatalf("syncResource error: %v", res.Err)
+	}
+	if _, ok := client.got[0]["sort"]; ok {
+		t.Fatalf("params = %#v, want no sort key for a resource with no declared default", client.got[0])
+	}
+}
+
+func TestSyncDependentResourceSendsSpecParamDefaults(t *testing.T) {
+	db := openParamDefaultsStore(t)
+	if err := db.Upsert("posts", "post-a", []byte(` + "`" + `{"id":"post-a"}` + "`" + `)); err != nil {
+		t.Fatalf("seed parent: %v", err)
+	}
+	client := &paramDefaultsClient{}
+
+	res := syncDependentResource(
+		context.Background(),
+		client,
+		db,
+		dependentResourceDef{
+			Name:          "comments",
+			ParentTable:   "posts",
+			ParentIDParam: "postId",
+			PathTemplate:  "/comments",
+			KeyField:      "id",
+			PathParams:    []dependentPathParamDef{{Param: "postId", Field: "id"}},
+		},
+		"", false, 1, false, false, nil, nil, 1,
+	)
+	if res.Err != nil {
+		t.Fatalf("syncDependentResource error: %v", res.Err)
+	}
+	if len(client.got) == 0 {
+		t.Fatal("no dependent request issued")
+	}
+	if got := client.got[0]["depth"]; got != "3" {
+		t.Fatalf("depth = %q, want %q (spec default must reach dependent sync requests)", got, "3")
+	}
+	if got := client.got[0]["postId"]; got != "post-a" {
+		t.Fatalf("postId = %q, want post-a (parent key must still be injected)", got)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "sync_param_defaults_test.go"), []byte(inlineTest), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "TestSync(FlatResourceSendsSpecParamDefaults|FlatResourceUserParamOverridesSpecDefault|ResourceWithoutDefaultsSendsNone|DependentResourceSendsSpecParamDefaults)")
+}
+
+// TestGeneratedSyncOmitsParamDefaultsHelperWhenSpecDeclaresNone locks the
+// fallback: CLIs whose specs carry no query defaults keep their previous
+// emitted shape rather than gaining a dead lookup.
+func TestGeneratedSyncOmitsParamDefaultsHelperWhenSpecDeclaresNone(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("nodefaults")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	assert.NotContains(t, syncSrc, "syncResourceParamDefaults",
+		"the defaults lookup and its call sites must be gated on the same condition")
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
+// TestGeneratedSyncSendsOpenAPIParamDefaults covers the other spec front-end:
+// the same contract has to hold for OpenAPI-parsed specs, not only the
+// internal YAML format.
+func TestGeneratedSyncSendsOpenAPIParamDefaults(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := openapi.Parse([]byte(`
+openapi: 3.0.3
+info:
+  title: Sync Defaults
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /posts:
+    get:
+      operationId: listPosts
+      parameters:
+        - name: sort
+          in: query
+          schema:
+            type: string
+            default: new
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 25
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+`))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	assert.Contains(t, syncSrc, `"sort": "new"`,
+		"an OpenAPI schema default must reach the sync request the same way an internal-spec default does")
+	assert.NotContains(t, syncSrc, `"limit": "25"`,
+		"the endpoint's own page-size param is sync-owned; a default there would fight the paging loop")
+
+	requireGeneratedCompiles(t, outputDir)
+}

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -9,6 +9,7 @@
 {{- $hasHTMLSync := false -}}
 {{- range .SyncableResources}}{{if .UsesHTMLResponse}}{{- $hasHTMLSync = true -}}{{end}}{{end -}}
 {{- range .DependentSyncResources}}{{if .UsesHTMLResponse}}{{- $hasHTMLSync = true -}}{{end}}{{end }}
+{{- $syncParamDefaultCases := syncParamDefaultCases .SyncableResources .DependentSyncResources -}}
 {{- $hasHTMLPageModeSync := false -}}
 {{- range .HTMLPageModeResources}}{{- $hasHTMLPageModeSync = true -}}{{end }}
 {{- $hasDomainTable := false -}}
@@ -747,6 +748,13 @@ func syncResource(ctx context.Context, c interface {
 
 	for {
 	params := map[string]string{}
+{{- if $syncParamDefaultCases}}
+	// Seed spec-declared param defaults before anything sync computes, so
+	// paging, the since filter, and user --param overrides all still win.
+	for defaultKey, defaultValue := range syncResourceParamDefaults(resource) {
+		params[defaultKey] = defaultValue
+	}
+{{- end}}
 
 {{ if $hasIDWalk}}
 	if usesIDWalk {
@@ -1759,6 +1767,29 @@ func syncResourceSinceParam(resource string) string {
 	}
 	return ""
 }
+
+{{- if $syncParamDefaultCases}}
+
+// syncResourceParamDefaults returns the query params this resource's list
+// endpoint declares a spec `default:` for. Endpoint commands bind the same
+// defaults to their cobra flags, so a list command already sends them; sync
+// seeds them at the top of each page request so both surfaces address the same
+// slice of the API. Everything sync assigns afterwards (paging, the since
+// filter, --param overrides) still wins on key conflict.
+func syncResourceParamDefaults(resource string) map[string]string {
+	switch resource {
+{{- range $syncParamDefaultCases}}
+	case {{printf "%q" .Resource}}:
+		return map[string]string{
+{{- range .Defaults}}
+			{{printf "%q" .Name}}: {{printf "%q" .Value}},
+{{- end}}
+		}
+{{- end}}
+	}
+	return nil
+}
+{{- end}}
 
 // syncResourceSortParam and syncResourceSortValue describe a spec-declared
 // ascending last-modified ordering. Sync adds them only when it sends a since
@@ -3399,6 +3430,13 @@ func syncOneParent(
 
 	for {
 		params := map[string]string{}
+{{- if $syncParamDefaultCases}}
+		// Same seeding as the flat loop: spec defaults first, everything
+		// sync or the operator sets afterwards overrides them.
+		for defaultKey, defaultValue := range syncResourceParamDefaults(dep.Name) {
+			params[defaultKey] = defaultValue
+		}
+{{- end}}
 {{- if $hasIDWalk}}
 		if usesIDWalk {
 			params[idWalk.limitParam] = strconv.Itoa(idWalk.limit)

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -1,6 +1,7 @@
 package profiler
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"maps"
@@ -9,6 +10,7 @@ import (
 	"regexp"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -106,6 +108,16 @@ func (f SyncBodyField) BodyWireName() string {
 	return f.Name
 }
 
+// SyncQueryParamDefault pairs a spec-declared query-parameter default with the
+// wire key sync must send it under. Endpoint commands bind the same `default:`
+// to their cobra flag, so a printed CLI's list command puts it on the wire;
+// carrying the pair onto the sync path keeps both surfaces addressing the same
+// slice of the API instead of letting the server pick an implicit default.
+type SyncQueryParamDefault struct {
+	Name  string
+	Value string
+}
+
 // FieldSelector describes a query param that asks sparse-response APIs to
 // include a richer set of response fields during sync.
 type FieldSelector struct {
@@ -190,6 +202,13 @@ type SyncableResource struct {
 	// this to send pagination and user-supplied params in the body for
 	// RPC-style list calls.
 	BodyFields []SyncBodyField
+
+	// QueryParamDefaults carries the list endpoint's spec-declared query-param
+	// defaults so sync seeds the same values the endpoint command's flags
+	// bind. Without it a sync page request omits a default the API treats as
+	// load-bearing (a workspace scope, a stable ordering) and silently
+	// mirrors a different slice of the corpus than the list command reads.
+	QueryParamDefaults []SyncQueryParamDefault
 
 	// IDWalkFilterParam names the array body field that accepts filter
 	// predicates for id-walk POST query pagination.
@@ -285,6 +304,10 @@ type DependentResource struct {
 
 	// BodyFields mirrors SyncableResource.BodyFields for child sync paths.
 	BodyFields []SyncBodyField
+
+	// QueryParamDefaults mirrors SyncableResource.QueryParamDefaults for child
+	// sync paths.
+	QueryParamDefaults []SyncQueryParamDefault
 
 	// IDWalkFilterParam mirrors SyncableResource.IDWalkFilterParam.
 	IDWalkFilterParam string
@@ -1929,6 +1952,7 @@ func dependentResourceFromEntry(entry parameterizedEntry, knownParents map[strin
 		UsesHTMLResponse:         entry.meta.UsesHTMLResponse,
 		HTMLExtract:              entry.meta.HTMLExtract,
 		BodyFields:               entry.meta.BodyFields,
+		QueryParamDefaults:       entry.meta.QueryParamDefaults,
 		IDWalkFilterParam:        entry.meta.IDWalkFilterParam,
 		IDWalkLimitParam:         entry.meta.IDWalkLimitParam,
 		IDWalkPageSize:           entry.meta.IDWalkPageSize,
@@ -2165,6 +2189,7 @@ func applySpecWalkers(s *spec.APISpec, deps []DependentResource, syncable map[st
 				UsesHTMLResponse:         meta.UsesHTMLResponse,
 				HTMLExtract:              meta.HTMLExtract,
 				BodyFields:               meta.BodyFields,
+				QueryParamDefaults:       meta.QueryParamDefaults,
 				IDWalkFilterParam:        meta.IDWalkFilterParam,
 				IDWalkLimitParam:         meta.IDWalkLimitParam,
 				IDWalkPageSize:           meta.IDWalkPageSize,
@@ -2488,6 +2513,7 @@ type syncableMeta struct {
 	UsesHTMLResponse         bool
 	HTMLExtract              *spec.HTMLExtract
 	BodyFields               []SyncBodyField
+	QueryParamDefaults       []SyncQueryParamDefault
 	IDWalkFilterParam        string
 	IDWalkLimitParam         string
 	IDWalkPageSize           int
@@ -2552,17 +2578,25 @@ func metaFromEndpoint(s *spec.APISpec, resourceName string, resource spec.Resour
 		UsesHTMLResponse:         e.UsesHTMLResponse(),
 		HTMLExtract:              e.HTMLExtract,
 		BodyFields:               syncBodyFieldsFromEndpoint(e),
-		IDWalkFilterParam:        idWalkFilterParam,
-		IDWalkLimitParam:         idWalkLimitParam,
-		IDWalkPageSize:           idWalkPageSize,
-		FieldSelector:            detectEndpointFieldSelector(e),
-		Discriminator:            discriminatorDispatchForEndpoint(e, types, resourceNameIndex),
-		ResponseItem:             e.Response.Item,
-		QueryEntity:              queryEntityForEndpoint(s, e),
-		TenantScopeColumn:        e.TenantScopeColumn,
-		HydratePath:              hydratePath,
-		HydrateIDParam:           hydrateIDParam,
-		MembershipField:          e.MembershipField,
+		QueryParamDefaults: syncQueryParamDefaultsFromEndpoint(e, syncOwnedParams{
+			cursor:    paginationCursorParam,
+			limit:     paginationLimitParam,
+			idWalk:    idWalkLimitParam,
+			since:     sinceParam,
+			sort:      paginationSortParam,
+			dateRange: syncDateRangeParamNames,
+		}),
+		IDWalkFilterParam: idWalkFilterParam,
+		IDWalkLimitParam:  idWalkLimitParam,
+		IDWalkPageSize:    idWalkPageSize,
+		FieldSelector:     detectEndpointFieldSelector(e),
+		Discriminator:     discriminatorDispatchForEndpoint(e, types, resourceNameIndex),
+		ResponseItem:      e.Response.Item,
+		QueryEntity:       queryEntityForEndpoint(s, e),
+		TenantScopeColumn: e.TenantScopeColumn,
+		HydratePath:       hydratePath,
+		HydrateIDParam:    hydrateIDParam,
+		MembershipField:   e.MembershipField,
 	}
 }
 
@@ -2844,6 +2878,126 @@ func syncBodyFieldsFromEndpoint(endpoint spec.Endpoint) []SyncBodyField {
 		fields = append(fields, field)
 	}
 	return fields
+}
+
+// syncOwnedParams names the query keys the generated syncer assigns itself.
+// Sync decides per run whether to send each one, and several are assigned only
+// inside a conditional: the since filter and its companion sort go on the wire
+// only when an incremental watermark applies, the date range only when the
+// operator passed one, and the paging keys only when the resource paginates.
+// A spec `default:` seeded into one of these keys would survive precisely when
+// sync deliberately chose not to send it, turning "full sync" into a filtered
+// or re-ordered walk. Seeding must therefore skip them and let sync stay the
+// sole author of its own request state.
+type syncOwnedParams struct {
+	cursor    string
+	limit     string
+	idWalk    string
+	since     string
+	sort      string
+	dateRange []string
+}
+
+// keys flattens the reserved names to the lowercased form the seeding filter
+// compares against.
+func (o syncOwnedParams) keys() map[string]struct{} {
+	names := []string{o.cursor, o.limit, o.idWalk, o.since, o.sort}
+	names = append(names, o.dateRange...)
+	out := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if key := strings.ToLower(strings.TrimSpace(name)); key != "" {
+			out[key] = struct{}{}
+		}
+	}
+	return out
+}
+
+// syncDateRangeParamNames lists the spellings the profiler recognizes as the
+// date-range filter, kept beside the detection that populates DateRangeParam so
+// the two cannot drift.
+var syncDateRangeParamNames = []string{"dates", "date_range", "daterange"}
+
+// syncQueryParamDefaultsFromEndpoint collects the query params this list
+// endpoint declares a `default:` for, rendered as the strings sync must put on
+// the wire. Header, path, and positional params are excluded because they are
+// not query keys, and every key in syncOwned is excluded because sync assigns
+// it itself: seeding one would fight the page loop, or worse, survive the
+// branch where sync deliberately withheld it. What remains is the scoping and
+// filtering the endpoint command already sends, which is the whole point --
+// list and sync should address the same slice of the API.
+func syncQueryParamDefaultsFromEndpoint(endpoint spec.Endpoint, syncOwned syncOwnedParams) []SyncQueryParamDefault {
+	if len(endpoint.Params) == 0 {
+		return nil
+	}
+	reserved := syncOwned.keys()
+	var out []SyncQueryParamDefault
+	seen := map[string]struct{}{}
+	for _, param := range endpoint.Params {
+		if param.Positional || param.PathParam {
+			continue
+		}
+		if location := strings.TrimSpace(param.In); location != "" && !strings.EqualFold(location, "query") {
+			continue
+		}
+		wireName := param.WireName()
+		if wireName == "" {
+			continue
+		}
+		key := strings.ToLower(wireName)
+		if _, owned := reserved[key]; owned {
+			continue
+		}
+		if _, owned := reserved[strings.ToLower(param.Name)]; owned {
+			continue
+		}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		value, ok := syncQueryParamDefaultValue(param)
+		if !ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, SyncQueryParamDefault{Name: wireName, Value: value})
+	}
+	return out
+}
+
+// syncQueryParamDefaultValue renders a param default as the query-string value
+// a request should carry. Formatting mirrors the generated formatCLIParamValue
+// so the sync path and the endpoint command put identical bytes on the wire.
+func syncQueryParamDefaultValue(param spec.Param) (string, bool) {
+	switch value := param.Default.(type) {
+	case nil:
+		return "", false
+	case string:
+		if value == "" {
+			return "", false
+		}
+		return value, true
+	case bool:
+		return strconv.FormatBool(value), true
+	case float64:
+		return strconv.FormatFloat(value, 'f', -1, 64), true
+	case float32:
+		return strconv.FormatFloat(float64(value), 'f', -1, 64), true
+	case int:
+		return strconv.Itoa(value), true
+	case int64:
+		return strconv.FormatInt(value, 10), true
+	case map[string]any, []any:
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return "", false
+		}
+		return string(encoded), true
+	default:
+		rendered := fmt.Sprintf("%v", value)
+		if rendered == "" {
+			return "", false
+		}
+		return rendered, true
+	}
 }
 
 func syncBodyDefault(param spec.Param) (any, bool) {
@@ -3644,6 +3798,7 @@ func sortedSyncableResources(m map[string]syncableMeta) []SyncableResource {
 			UsesHTMLResponse:         meta.UsesHTMLResponse,
 			HTMLExtract:              meta.HTMLExtract,
 			BodyFields:               meta.BodyFields,
+			QueryParamDefaults:       meta.QueryParamDefaults,
 			IDWalkFilterParam:        meta.IDWalkFilterParam,
 			IDWalkLimitParam:         meta.IDWalkLimitParam,
 			IDWalkPageSize:           meta.IDWalkPageSize,

--- a/internal/profiler/sync_owned_params_test.go
+++ b/internal/profiler/sync_owned_params_test.go
@@ -1,0 +1,74 @@
+package profiler
+
+import (
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSyncQueryParamDefaultsExcludeSyncOwnedKeys pins which spec defaults reach
+// the syncer. The syncer assigns the paging, since, sort, and date-range keys
+// itself, and does so inside conditionals -- a seeded default would survive the
+// branch where it deliberately withheld the key. Everything else is scoping the
+// endpoint command already sends, and must be seeded so both surfaces address
+// the same slice of the API.
+func TestSyncQueryParamDefaultsExcludeSyncOwnedKeys(t *testing.T) {
+	t.Parallel()
+
+	endpoint := spec.Endpoint{
+		Method:   "GET",
+		Path:     "/tickets",
+		Response: spec.ResponseDef{Type: "array"},
+		Params: []spec.Param{
+			{Name: "workspace-id", In: "query", Type: "string", Default: "ws-42"},
+			{Name: "updated_since", In: "query", Type: "string", Default: "2020-01-01"},
+			{Name: "sort", In: "query", Type: "string", Default: "updated_at:asc"},
+			{Name: "dates", In: "query", Type: "string", Default: "last_30_days"},
+			{Name: "cursor", In: "query", Type: "string", Default: "abc"},
+			{Name: "limit", In: "query", Type: "integer", Default: 25},
+			{Name: "include_closed", In: "query", Type: "boolean", Default: true},
+		},
+	}
+
+	got := syncQueryParamDefaultsFromEndpoint(endpoint, syncOwnedParams{
+		cursor:    "cursor",
+		limit:     "limit",
+		since:     "updated_since",
+		sort:      "sort",
+		dateRange: syncDateRangeParamNames,
+	})
+
+	assert.ElementsMatch(t, []SyncQueryParamDefault{
+		{Name: "workspace-id", Value: "ws-42"},
+		{Name: "include_closed", Value: "true"},
+	}, got)
+}
+
+// TestSyncQueryParamDefaultsFromEndpointHonorsDetectedSort proves the sort
+// exclusion is wired to the same detection the generated syncResourceSortParam
+// is emitted from, rather than to a hardcoded name, so the two cannot drift.
+func TestSyncQueryParamDefaultsFromEndpointHonorsDetectedSort(t *testing.T) {
+	t.Parallel()
+
+	endpoint := spec.Endpoint{
+		Method:   "GET",
+		Path:     "/tickets",
+		Response: spec.ResponseDef{Type: "array"},
+		Params: []spec.Param{
+			{Name: "updated_since", In: "query", Type: "string"},
+			{Name: "order_by", In: "query", Type: "string", Default: "updated_at:asc"},
+		},
+	}
+
+	sortParam, sortValue := detectEndpointSyncSort(endpoint)
+	assert.Equal(t, "order_by", sortParam, "an ascending last-modified sort must be detected")
+	assert.Equal(t, "updated_at:asc", sortValue)
+
+	got := syncQueryParamDefaultsFromEndpoint(endpoint, syncOwnedParams{
+		since:     "updated_since",
+		sort:      sortParam,
+		dateRange: syncDateRangeParamNames,
+	})
+	assert.Empty(t, got, "the detected sort param must not be seeded under any spelling")
+}

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -514,6 +514,11 @@ func syncResource(ctx context.Context, c interface {
 
 	for {
 		params := map[string]string{}
+		// Seed spec-declared param defaults before anything sync computes, so
+		// paging, the since filter, and user --param overrides all still win.
+		for defaultKey, defaultValue := range syncResourceParamDefaults(resource) {
+			params[defaultKey] = defaultValue
+		}
 
 		if resourceSupportsPagination(resource) {
 			params[pageSize.limitParam] = strconv.Itoa(pageSize.limit)
@@ -1128,6 +1133,28 @@ func syncResourceSinceParam(resource string) string {
 	switch resource {
 	}
 	return ""
+}
+
+// syncResourceParamDefaults returns the query params this resource's list
+// endpoint declares a spec `default:` for. Endpoint commands bind the same
+// defaults to their cobra flags, so a list command already sends them; sync
+// seeds them at the top of each page request so both surfaces address the same
+// slice of the API. Everything sync assigns afterwards (paging, the since
+// filter, --param overrides) still wins on key conflict.
+func syncResourceParamDefaults(resource string) map[string]string {
+	switch resource {
+	case "gadgets":
+		return map[string]string{
+			"query":        "select * from Gadget maxresults 100",
+			"minorversion": "75",
+		}
+	case "widgets":
+		return map[string]string{
+			"query":        "select * from Widget maxresults 100",
+			"minorversion": "75",
+		}
+	}
+	return nil
 }
 
 // syncResourceSortParam and syncResourceSortValue describe a spec-declared


### PR DESCRIPTION
## Intent

A spec-declared query param `default:` never reached a sync request. The generated syncer built its params from pagination, the since filter, and user `--param` / `--resource-param` / `--global-param` overrides only, while the endpoint-command builder bound the same `default:` to its cobra flag. The two surfaces therefore addressed different slices of the API: a printed CLI's `<resource> list` sent the declared scope or ordering and `sync --resources <resource>` silently omitted it, which shows up as a working list command next to a 404-ing sync.

The one existing default-injection path in sync, `applySyncGlobalScopeEnvDefaults`, was also structurally unreachable for non-OpenAPI specs: it is gated on `Param.GlobalScope`, which was assigned only inside the OpenAPI parser's `classifyGlobalParams`. The internal / HAR / browser-sniff loader in `internal/spec` never called it, so every sniffed CLI was excluded from the tenant-scope path.

Issue: Fixes #4316

## Approach

Two parts, both in the machine.

**Part 1 — carry spec defaults onto the sync path.** `internal/profiler` now derives `QueryParamDefaults` per syncable and dependent resource from the endpoint's own declared params, formatting values the same way the generated `formatCLIParamValue` does. The generator dedupes them into `syncParamDefaultCases` (mirroring the existing `responsePathCases` idiom — a resource name can appear in both the flat and dependent sets, which would otherwise emit a duplicate switch case), and `sync.go.tmpl` emits a `syncResourceParamDefaults(resource)` lookup that both the flat and the dependent page loop seed into `params` **first**.

Seeding first rather than last is what keeps the change inside the issue's scope boundaries: sync-owned paging, the since filter and its sort, and every user override still win on key conflict. No since-filter sort behavior changes, and nothing infers which defaults are "lossy" — the CLI simply sends what the spec declares, exactly as the endpoint command already does. Keys the syncer assigns itself are excluded entirely -- paging, the since filter, its companion sort, and the date range -- for the reason spelled out under Verification below.

**Part 2 — make global-scope promotion reachable from every front-end.** The naming rule and thresholds move to a new `internal/spec/global_scope.go` as `IsGlobalScopeParamName`, `IsGlobalScopeCandidate`, `MinEndpointsForGlobalScope`, `GlobalScopeRecurrenceRatio`, and `(*APISpec).PromoteGlobalScopeParams()`. `ParseBytes` calls the promotion after body promotion, so write-endpoint payload fields already moved out of `Params` cannot be miscounted as recurring query scope. The OpenAPI parser now consumes the shared rule; its behavior is byte-identical (the separate 0.8 high-frequency *filter* half stays local and unchanged), which the golden suite confirms with zero OpenAPI or sniff churn from this half.

Only the naming rule moved rather than all of `classifyGlobalParams`, because that function interleaves scope promotion with an unrelated high-frequency param filter and an endpoint-surface guard — moving the whole thing would have changed OpenAPI output.

## Scope

Primary area: generator + profiler + spec parsers (`internal/profiler`, `internal/generator`, `internal/spec`, `internal/openapi`).

Why this belongs in this repo: the divergence between the endpoint-command builder and the sync param builder is a generator defect, not an API quirk. Every printed CLI whose spec declares a query default is affected, and any per-CLI patch would have to be re-applied on each reprint.

## Risk

Generated output changes for any CLI whose spec declares a non-paging query default: `sync.go` gains a `syncResourceParamDefaults` lookup and two seeding loops. CLIs with no such defaults emit byte-identical `sync.go` (locked by a fallback test), so the blast radius is limited to specs that already declared the default the endpoint command was honoring anyway.

The dependent-resource seeding uses only the dependent endpoint's *own* declared params, so it does not reintroduce the scope-leak the flat/dependent `--param` split guards against — a dependent request now carries exactly what its own endpoint command would send.

Part 2 broadens which specs can promote a param to `GlobalScope` (and therefore to `Required` with an env-backed flag default). Internal / HAR / sniff specs newly reach it; the OpenAPI path is unchanged.

## Output Contract

One golden fixture changed: `testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go`. It gains the seeding loops plus a `syncResourceParamDefaults` returning that spec's declared `query` and `minorversion` defaults for `widgets` and `gadgets`. Runtime behavior for that case is unchanged, because the query-sync branch overwrites `query` / `minorversion` after user params. `generate-golden-api` shows zero churn: its only query defaults are `limit` params, which are deliberately excluded as sync-owned. Part 2 produced no golden churn at all.

**Known golden conflict with #4335** (map-keyed collections, issue #4330). Both branches regenerate fixtures, and `testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go` is touched by both. Whichever merges second resolves it by rebasing and re-running `scripts/golden.sh update`, never by hand-merging the fixture — a hand-merged golden is no longer a faithful record of what the generator emits.

Two further tests pin the exclusion boundary. `internal/profiler/sync_owned_params_test.go` asserts that all five sync-owned keys are dropped while `workspace-id` and `include_closed` survive, and that the sort exclusion follows detection rather than a hardcoded name (an `order_by` spelling is excluded too). `internal/generator/sync_owned_params_test.go` proves the same at the emitted-code level on a spec carrying defaults for `workspace-id`, `updated_since`, `sort`, `dates`, and `limit` at once: only the tenant scope is seeded, then the module compiles. Its assertions run against just that resource's `case` body, so a `NotContains` cannot be satisfied by an unrelated part of the file.

Generated-output evidence in `internal/generator/sync_param_defaults_test.go`: emitted-code assertions on the lookup and on seed-before-paging / seed-before-`applyTo` ordering, `requireGeneratedCompiles`, and — the real proof — an inline test written into the generated module and run with `go test ./internal/cli`, driving `syncResource` and `syncDependentResource` against a fake client that records params. It asserts the default lands on the wire, `--param sort=top` overrides it, a resource with no declared default sends nothing, and a dependent request carries both its own `depth=3` default and the injected parent key.

## Verification

Run with `GOTOOLCHAIN=go1.26.6` (matching `go.mod`; the local go1.27 toolchain fails building a transitive `enetx/http2` dependency, unrelated to this change).

| Command | Result |
| --- | --- |
| `go test <43 packages, all but internal/generator> -count=1` | **pass** — 37 `ok`, 0 `FAIL`. Includes `internal/profiler` 0.302s, `internal/spec` 0.414s, `internal/openapi` 84.4s, `internal/cli` 251.0s |
| `go test ./internal/generator/ -timeout 0 -count=1` | **pass** — `ok ... 3391.978s`, 0 `--- FAIL`, no panics or timeouts |
| `bash scripts/golden.sh verify` | **pass** — `Golden verify passed: 34 case(s).` |
| `bash scripts/verify-generator-output.sh` | **pass** — 11 default cases generated, tidied, and compiled |
| `bash scripts/verify-generator-output.sh generate-sync-walker-api generate-async-job-api` | **pass** — 2 extra cases; the defaults do not exercise the dependent/walker sync variant this change touches |
| `go test ./internal/profiler/ -run SyncQueryParamDefaults -count=1` | **pass** (0.482s) |
| `go test ./internal/generator/ -run TestGeneratedSync -count=1` | **pass** (215.2s) |
| `go fmt ./...` | **pass** — no files reformatted |

The suite was split because `internal/generator` compiles many generated modules and needs its own timeout budget; together the two legs are a full `go test ./...`.

### A regression this caught, and the fix

The first full `internal/generator` run failed `TestGeneratedSyncPreservesWatermarkAcrossPaginationCaps`: a full sync and a latest-only sync both sent `sort=updated_at:asc`. The first draft excluded only the paging keys from seeding, which crossed the issue's "no change to the since-filter sort behavior" boundary.

The real rule is narrower than "paging" and wider than "sort": the syncer assigns several keys **inside conditionals**, and a seeded default survives exactly the branch where sync deliberately withheld the key. Unconditional assignments (query-sync's `query` / `minorversion`, the dependent parent key) overwrite a seed harmlessly, which is why the one golden fixture was already correct. Four keys qualify:

- `sortParam` — the reported failure; a sort applied to a full sync can change API behavior
- `sinceParam` — the same class and worse: a `default:` here silently filters a *full* sync, dropping records rather than reordering them
- `determineDateRangeParam()` — leaks whenever the operator passed no `--dates`
- `idWalk.limitParam` — a paging key the first draft missed

`syncOwnedParams` in `internal/profiler` now carries all of them. The sort exclusion is keyed to `detectEndpointSyncSort`, the same source that feeds the emitted `syncResourceSortParam`, so the exclusion and the assignment cannot drift.

It deliberately does **not** exclude the whole sort-name class: `detectEndpointSyncSort` returns empty without a since param, so a `sort` default on a non-incremental resource is a genuine load-bearing default this PR exists to send.

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission

---

If CI shows `TestGeneratorSkipsReservedNovelFeatureRootCommands` red, that is a known pre-existing flake tracked in #4341 (`captureNovelFeatureStderr` swaps the process-global `os.Stderr` while the test runs under `t.Parallel()`), not a fault of this change. It passed in the full `internal/generator` run recorded above.
