### PR TITLE
fix(generator): count binary/text resources toward the sync-stub decision

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -4690,19 +4690,23 @@ func (g *Generator) resetHTMLSyncStubCache() {
 	g.htmlSyncStub = false
 }
 
+// countHTMLPageModeSyncResources counts profiled sync resources overall and
+// how many of them lack a JSON enumeration (HTML page-mode, binary, or text
+// responses). The name keeps its historical HTML framing; the ratio feeds
+// shouldEmitHTMLSyncStub.
 func (g *Generator) countHTMLPageModeSyncResources() (total int, html int) {
 	if g == nil || g.profile == nil {
 		return 0, 0
 	}
 	for _, resource := range g.profile.SyncableResources {
 		total++
-		if syncableResourceUsesHTMLPageMode(resource) {
+		if syncableResourceLacksJSONEnumeration(resource) {
 			html++
 		}
 	}
 	for _, resource := range g.profile.DependentSyncResources {
 		total++
-		if dependentResourceUsesHTMLPageMode(resource) {
+		if dependentResourceLacksJSONEnumeration(resource) {
 			html++
 		}
 	}
@@ -4717,6 +4721,29 @@ func dependentResourceUsesHTMLPageMode(resource profiler.DependentResource) bool
 	return resource.UsesHTMLResponse && resource.HTMLExtract.EffectiveMode() == spec.HTMLExtractModePage
 }
 
+// syncableResourceLacksJSONEnumeration reports whether spec-driven sync cannot
+// produce a trustworthy JSON enumeration from this resource: HTML page-mode
+// extraction stores prose pages rather than records, and binary/text responses
+// (sitemaps, downloads, plain text) have no records at all. A CLI whose
+// syncable resources are predominantly of these shapes builds its corpus with
+// a hand-authored command, and its generated sync would stamp sync_state and
+// report success over an empty store — so such resources count toward the
+// sync-stub decision.
+func syncableResourceLacksJSONEnumeration(resource profiler.SyncableResource) bool {
+	return syncableResourceUsesHTMLPageMode(resource) || responseFormatLacksJSONEnumeration(resource.ResponseFormat)
+}
+
+func dependentResourceLacksJSONEnumeration(resource profiler.DependentResource) bool {
+	return dependentResourceUsesHTMLPageMode(resource) || responseFormatLacksJSONEnumeration(resource.ResponseFormat)
+}
+
+func responseFormatLacksJSONEnumeration(format string) bool {
+	return format == spec.ResponseFormatBinary || format == spec.ResponseFormatText
+}
+
+// countHTMLPageModeEndpoints is the spec-level fallback for
+// countHTMLPageModeSyncResources when profiling found no sync resources; it
+// applies the same lacks-JSON-enumeration test per endpoint.
 func countHTMLPageModeEndpoints(api *spec.APISpec) (total int, html int) {
 	if api == nil {
 		return 0, 0
@@ -4732,7 +4759,8 @@ func countHTMLPageModeEndpoints(api *spec.APISpec) (total int, html int) {
 func countResourceHTMLPageModeEndpoints(resource spec.Resource) (total int, html int) {
 	for _, endpoint := range resource.Endpoints {
 		total++
-		if endpoint.UsesHTMLResponse() && endpoint.HTMLExtract.EffectiveMode() == spec.HTMLExtractModePage {
+		if (endpoint.UsesHTMLResponse() && endpoint.HTMLExtract.EffectiveMode() == spec.HTMLExtractModePage) ||
+			responseFormatLacksJSONEnumeration(endpoint.EffectiveResponseFormat()) {
 			html++
 		}
 	}

--- a/internal/generator/html_sync_stub_test.go
+++ b/internal/generator/html_sync_stub_test.go
@@ -136,7 +136,7 @@ func TestGenerateHTMLMajorityWithJSONSyncKeepsGenericSync(t *testing.T) {
 	skillSrc := readGeneratedFile(t, outputDir, "SKILL.md")
 
 	assert.Contains(t, syncSrc, "func syncResource(")
-	assert.NotContains(t, syncSrc, "generic spec-driven sync template does not fit predominantly HTML page-mode endpoints")
+	assert.NotContains(t, syncSrc, "generic spec-driven sync template does not fit predominantly non-JSON endpoints")
 	assert.Contains(t, workflowSrc, "newWorkflowArchiveCmd")
 	assert.Contains(t, workflowSrc, "workflow archive")
 	assert.Contains(t, readmeSrc, "## Freshness")
@@ -276,4 +276,120 @@ func htmlPageEndpoint(path, description, responseType string) spec.Endpoint {
 		HTMLExtract:    &spec.HTMLExtract{Mode: spec.HTMLExtractModePage},
 		Response:       spec.ResponseDef{Type: responseType},
 	}
+}
+
+// TestGenerateBinarySyncablesEmitSyncStub covers the #4342 shape: a CLI whose
+// syncable resources are binary/text (sitemap indexes, downloads) has no JSON
+// enumeration for spec-driven sync, so it must get the sync stub — not a
+// generated sync that stamps sync_state and reports success over an empty
+// store. Before the fix, binary resources counted as JSON-syncable and diluted
+// the HTML-page-mode ratio below the stub threshold.
+func TestGenerateBinarySyncablesEmitSyncStub(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("binary-syncables")
+	apiSpec.Resources = map[string]spec.Resource{
+		"page": {
+			Description: "Documentation sitemap",
+			Endpoints: map[string]spec.Endpoint{
+				"index": {
+					Method:         "GET",
+					Path:           "/sitemap.xml",
+					Description:    "Fetch the documentation sitemap",
+					ResponseFormat: spec.ResponseFormatBinary,
+					Response:       spec.ResponseDef{Type: "array"},
+				},
+			},
+		},
+		"product": {
+			Description: "Product sitemap",
+			Endpoints: map[string]spec.Endpoint{
+				"index": {
+					Method:         "GET",
+					Path:           "/product-sitemap.xml",
+					Description:    "Fetch the product sitemap",
+					ResponseFormat: spec.ResponseFormatBinary,
+					Response:       spec.ResponseDef{Type: "array"},
+				},
+			},
+		},
+		"support": {
+			Description: "Support article export",
+			Endpoints: map[string]spec.Endpoint{
+				"index": {
+					Method:         "GET",
+					Path:           "/support-index.txt",
+					Description:    "Fetch the support article index",
+					ResponseFormat: spec.ResponseFormatText,
+					Response:       spec.ResponseDef{Type: "array"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, MCP: true}
+	require.True(t, gen.shouldEmitHTMLSyncStub())
+	require.NoError(t, gen.Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	assert.Contains(t, syncSrc, "generic spec-driven sync template does not fit predominantly non-JSON endpoints")
+	assert.NotContains(t, syncSrc, "func syncResource(")
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "build", "./...")
+}
+
+// TestGenerateMinorityBinarySyncableKeepsGenericSync guards the other
+// direction: one binary resource among JSON list resources must not push the
+// CLI into the stub — the JSON resources still enumerate fine.
+func TestGenerateMinorityBinarySyncableKeepsGenericSync(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("binary-minority")
+	apiSpec.Resources = map[string]spec.Resource{
+		"sitemap": {
+			Description: "Sitemap",
+			Endpoints: map[string]spec.Endpoint{
+				"index": {
+					Method:         "GET",
+					Path:           "/sitemap.xml",
+					Description:    "Fetch the sitemap",
+					ResponseFormat: spec.ResponseFormatBinary,
+					Response:       spec.ResponseDef{Type: "array"},
+				},
+			},
+		},
+		"articles": {
+			Description: "Articles",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/articles", Description: "List articles", Response: spec.ResponseDef{Type: "array"}},
+			},
+		},
+		"authors": {
+			Description: "Authors",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/authors", Description: "List authors", Response: spec.ResponseDef{Type: "array"}},
+			},
+		},
+		"tags": {
+			Description: "Tags",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/tags", Description: "List tags", Response: spec.ResponseDef{Type: "array"}},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, MCP: true}
+	require.False(t, gen.shouldEmitHTMLSyncStub())
+	require.NoError(t, gen.Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	assert.Contains(t, syncSrc, "func syncResource(")
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "build", "./...")
 }

--- a/internal/generator/templates/sync_stub.go.tmpl
+++ b/internal/generator/templates/sync_stub.go.tmpl
@@ -17,7 +17,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 			"mcp:hidden": "true",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("sync is not implemented for this CLI; write internal/cli/sync_{{.Name}}.go because the generic spec-driven sync template does not fit predominantly HTML page-mode endpoints")
+			return fmt.Errorf("sync is not implemented for this CLI; write internal/cli/sync_{{.Name}}.go (or use this CLI's dedicated corpus-builder command — see its README) because the generic spec-driven sync template does not fit predominantly non-JSON endpoints (HTML page-mode, binary, or text responses)")
 		},
 	}
 }

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -165,6 +165,12 @@ type SyncableResource struct {
 	UsesHTMLResponse bool
 	HTMLExtract      *spec.HTMLExtract
 
+	// ResponseFormat is the chosen list endpoint's effective response_format
+	// ("json" when the spec omits it). The generator uses it to keep
+	// binary/text resources — which yield no JSON enumeration — from counting
+	// as spec-driven-syncable when deciding whether to emit the sync stub.
+	ResponseFormat string
+
 	// BodyFields names request-body fields on POST list endpoints. Sync uses
 	// this to send pagination and user-supplied params in the body for
 	// RPC-style list calls.
@@ -261,6 +267,10 @@ type DependentResource struct {
 	// paths.
 	UsesHTMLResponse bool
 	HTMLExtract      *spec.HTMLExtract
+
+	// ResponseFormat mirrors SyncableResource.ResponseFormat for child sync
+	// paths.
+	ResponseFormat string
 
 	// BodyFields mirrors SyncableResource.BodyFields for child sync paths.
 	BodyFields []SyncBodyField
@@ -1906,6 +1916,7 @@ func dependentResourceFromEntry(entry parameterizedEntry, knownParents map[strin
 		PaginationPageSize:       entry.meta.PaginationPageSize,
 		UsesHTMLResponse:         entry.meta.UsesHTMLResponse,
 		HTMLExtract:              entry.meta.HTMLExtract,
+		ResponseFormat:           entry.meta.ResponseFormat,
 		BodyFields:               entry.meta.BodyFields,
 		IDWalkFilterParam:        entry.meta.IDWalkFilterParam,
 		IDWalkLimitParam:         entry.meta.IDWalkLimitParam,
@@ -2142,6 +2153,7 @@ func applySpecWalkers(s *spec.APISpec, deps []DependentResource, syncable map[st
 				PaginationPageSize:       meta.PaginationPageSize,
 				UsesHTMLResponse:         meta.UsesHTMLResponse,
 				HTMLExtract:              meta.HTMLExtract,
+				ResponseFormat:           meta.ResponseFormat,
 				BodyFields:               meta.BodyFields,
 				IDWalkFilterParam:        meta.IDWalkFilterParam,
 				IDWalkLimitParam:         meta.IDWalkLimitParam,
@@ -2465,6 +2477,7 @@ type syncableMeta struct {
 	PaginationSortField      string
 	UsesHTMLResponse         bool
 	HTMLExtract              *spec.HTMLExtract
+	ResponseFormat           string
 	BodyFields               []SyncBodyField
 	IDWalkFilterParam        string
 	IDWalkLimitParam         string
@@ -2528,6 +2541,7 @@ func metaFromEndpoint(s *spec.APISpec, resourceName string, resource spec.Resour
 		PaginationSortValue:      paginationSortValue,
 		PaginationSortField:      paginationSortField,
 		UsesHTMLResponse:         e.UsesHTMLResponse(),
+		ResponseFormat:           e.EffectiveResponseFormat(),
 		HTMLExtract:              e.HTMLExtract,
 		BodyFields:               syncBodyFieldsFromEndpoint(e),
 		IDWalkFilterParam:        idWalkFilterParam,
@@ -3575,6 +3589,7 @@ func sortedSyncableResources(m map[string]syncableMeta) []SyncableResource {
 			PaginationSortField:      meta.PaginationSortField,
 			UsesHTMLResponse:         meta.UsesHTMLResponse,
 			HTMLExtract:              meta.HTMLExtract,
+			ResponseFormat:           meta.ResponseFormat,
 			BodyFields:               meta.BodyFields,
 			IDWalkFilterParam:        meta.IDWalkFilterParam,
 			IDWalkLimitParam:         meta.IDWalkLimitParam,


### PR DESCRIPTION
## Intent

Closes #4342.

A CLI whose syncable resources are `response_format: binary` or `text` (sitemap indexes, plain-text exports) has no JSON enumeration for spec-driven sync, yet the generator emitted a full `sync` command for it. That sync fetches the non-JSON body, stores nothing useful (a NULL resource row on the extron shape, a `non_json_200_body` anomaly on the averusa shape), stamps `sync_state`, and exits 0 — after which `doctor` reports "Cache: fresh" over an empty store and staleness hints steer users at the generated no-op instead of the CLI's real corpus-builder command. Measured blast radius on the public library's `main`: 10 CLIs carry a non-JSON resource in `defaultSyncResources()`, and 9 of them have *only* non-JSON resources there — every one builds its corpus with a hand-authored command (`harvest`, `catalog sync`).

## Approach

The generator already has the right mechanism: `shouldEmitHTMLSyncStub` swaps in the sync stub when ≥70% of syncable resources are HTML page-mode. The gap is the predicate — binary/text resources counted as JSON-syncable, so they *diluted* the ratio below threshold (e.g. one HTML page-mode + two binary sitemaps = 1/3 = 33% → full sync emitted, exactly the qsys shape).

- Plumb the chosen list endpoint's `EffectiveResponseFormat()` through the profiler (`syncableMeta` → `SyncableResource`/`DependentResource.ResponseFormat`).
- Broaden the stub-count predicate from "HTML page-mode" to "lacks a JSON enumeration": HTML page-mode ∪ binary ∪ text, in both the profiled-resource counter and the spec-level endpoint fallback.
- Generalize the stub's error message and point it at the CLI's dedicated corpus-builder command.

Deliberately unchanged: HTML links/table/list-mode resources still count as syncable (link extraction is a real enumeration), `csv`/`xml` still count as syncable (the client converts them to JSON), and the existing `syncableResourceUsesHTMLPageMode` consumers outside the stub decision are untouched.

## Scope

Primary area: generator sync-stub decision + profiler response-format plumbing.

Why this belongs in this repo: every printed CLI inherits the sync template selection, so the fix belongs in the generator rather than hand-stubbing `sync` in each affected library CLI.

## Risk

A spec whose syncable resources are predominantly binary/text now gets the sync stub instead of a generated sync that appeared to work. That is the intent — such CLIs (all 9 in the library) already build their corpus with a hand-authored command — but any spec author relying on generated sync to fetch-and-discard a binary resource will now see an explicit error instead of silent success. Mixed specs below the existing 70% threshold keep generic sync (covered by a new regression test).

## Output Contract

Binary/text-majority specs emit the sync stub (clear error, no `sync_state` stamp, no "Cache: fresh" over an empty store). `TestGenerateBinarySyncablesEmitSyncStub` pins the stub for the pure-non-JSON shape (fails before this change: 0/3 counted → full sync), and `TestGenerateMinorityBinarySyncableKeepsGenericSync` pins that one binary resource among JSON list resources does not flip the decision.

## Verification

- `GOTOOLCHAIN=go1.26.6 go test ./internal/generator -run 'TestGenerateBinarySyncablesEmitSyncStub|TestGenerateMinorityBinarySyncableKeepsGenericSync' -count=1` — new tests; the stub test fails without the fix (verified by stashing the non-test changes)
- `GOTOOLCHAIN=go1.26.6 go test ./internal/profiler -count=1` — pass
- `GOTOOLCHAIN=go1.26.6 scripts/golden.sh verify` — all 34 cases pass (no golden fixture uses `response_format`)
- `GOTOOLCHAIN=go1.26.6 go test ./internal/generator -count=1` — one unrelated flake in a broad parallel run (`TestGeneratorSkipsReservedNovelFeatureRootCommands`, stderr-capture cross-talk between parallel tests; passes in isolation both with and without this change, and on a re-run)
- `GOTOOLCHAIN=go1.26.6 go build ./...`
