### PR TITLE
fix(store): stop concurrent-reader SIGBUS on WAL-index mmap

### DIFF
--- a/docs/solutions/runtime-errors/modernc-sqlite-dsn-pragma-syntax-silently-ignored.md
+++ b/docs/solutions/runtime-errors/modernc-sqlite-dsn-pragma-syntax-silently-ignored.md
@@ -51,7 +51,7 @@ Switch both opens to the `_pragma=` form (verify with the pinned driver version,
 
 ```go
 // read-only
-sql.Open("sqlite", "file:"+dbPath+"?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)")
+sql.Open("sqlite", "file:"+dbPath+"?mode=ro&immutable=1&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)")
 
 // read-write (adds synchronous)
 sql.Open("sqlite", dbPath+"?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)")
@@ -65,7 +65,7 @@ Empirical proof with the pinned driver — the mattn-style DSN is byte-for-byte 
 | no params | `delete` | `0` | `0` |
 | `?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&…` | `wal` | `5000` | `1` |
 
-A `mode=ro` open of a WAL file is fine; `journal_mode(WAL)` on a read-only handle is a harmless no-op. The read-write open performs the one-time `delete`→`wal` conversion, and published CLIs convert automatically on their next read-write open.
+A `mode=ro` open of a WAL file is fine; `journal_mode(WAL)` on a read-only handle is a write and is omitted. `immutable=1` is required on that read-only URI so the connection skips the `-shm` WAL-index mmap, which `mmap_size(0)` does not govern. The read-write open performs the one-time `delete`→`wal` conversion, and published CLIs convert automatically on their next read-write open.
 
 ### Second bug, exposed by the first fix
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -4361,10 +4361,45 @@ func TestGenerateStoreDSNUsesImmediateTransactionsAndProfileJournalMode(t *testi
 				"read-write DSN must acquire immediate transactions and select the profile journal mode")
 			assert.NotContains(t, codeOnly, "_pragma=journal_mode("+tc.otherMode+")&_pragma=synchronous",
 				"read-write DSN must not emit the other profile journal mode")
+			assert.Contains(t, codeOnly, `?mode=ro&immutable=1&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)`,
+				"read-only DSN must skip the WAL-index mmap while keeping mmap_size(0)")
 			requireGeneratedCompiles(t, outputDir)
-			runGoCommandRequired(t, outputDir, "test", "./internal/store", "-run", "^Test(OpenHardensSQLiteFilePermissions|HardenSQLiteFilesSkipsSymlinkSidecars|OpenAppliesPragmas)$", "-count=1")
+			runGoCommandRequired(t, outputDir, "test", "./internal/store", "-run", "^Test(OpenHardensSQLiteFilePermissions|HardenSQLiteFilesSkipsSymlinkSidecars|OpenAppliesPragmas|OpenReadOnly_SkipsWALIndexSidecars|OpenReadOnly_ConcurrentProcesses)$", "-count=1")
 		})
 	}
+}
+
+// TestGenerateStoreReadOnlyDSNSkipsWALIndex pins the read-only DSN control
+// that stops concurrent OpenReadOnly processes from mapping the WAL-index.
+// mmap_size(0) is kept; it does not govern -shm. The generated module must
+// compile and the emitted store tests must prove two reader processes can
+// share one database without recreating -shm.
+func TestGenerateStoreReadOnlyDSNSkipsWALIndex(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("wal-index-ro")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, MCP: true}
+	require.NoError(t, gen.Generate())
+
+	storeSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	codeOnly := stripGoComments(string(storeSrc))
+
+	assert.Contains(t, codeOnly, `?mode=ro&immutable=1&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)`,
+		"read-only DSN must set immutable=1 so SQLite skips the WAL-index mmap")
+	assert.Contains(t, codeOnly, `?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)`,
+		"read-write DSN must keep WAL, immediate transactions, and mmap_size(0)")
+	assert.Contains(t, codeOnly, `?mode=ro&immutable=1&_pragma=busy_timeout(1000)&_pragma=mmap_size(0)`,
+		"schema preflight probe must skip the WAL-index mmap")
+	assert.NotContains(t, codeOnly, "nolock=1",
+		"read-only DSN must not use nolock; WAL databases refuse that URI flag")
+	assert.NotContains(t, codeOnly, "vfs=unix-none",
+		"read-only DSN must not use unix-none; WAL databases refuse that VFS")
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommandRequired(t, outputDir, "test", "./internal/store", "-run", "^Test(OpenAppliesPragmas|OpenReadOnly_SkipsWALIndexSidecars|OpenReadOnly_ConcurrentProcesses|OpenReadOnly_DeleteModeDBDoesNotWrite)$", "-count=1")
 }
 
 // Callers gating on existence rely on errors.Is(err, sql.ErrNoRows); the
@@ -4438,8 +4473,10 @@ func TestGenerateMCPSQLToolUsesReadOnlyStore(t *testing.T) {
 	// read-only handle.
 	assert.Contains(t, storeCode, `dsn := "file:" + dbPath`,
 		"OpenReadOnly DSN must use the file: URI prefix with mode=ro")
-	assert.Contains(t, storeCode, `?mode=ro`,
-		"OpenReadOnly DSN must request SQLite read-only mode")
+	assert.Contains(t, storeCode, `?mode=ro&immutable=1`,
+		"OpenReadOnly DSN must request SQLite read-only mode and skip the WAL-index mmap")
+	assert.Contains(t, storeCode, `_pragma=mmap_size(0)`,
+		"OpenReadOnly DSN must keep mmap_size(0) so the main database file stays pread-based")
 
 	mcpSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "mcp", "tools.go"))
 	require.NoError(t, err)

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -108,6 +108,17 @@ func Open(dbPath string) (*Store, error) {
 // delete mode (e.g. a pre-WAL database opened by an old binary before its
 // first read-write open) errors with "attempt to write a readonly database".
 //
+// immutable=1 is the WAL-index control. mmap_size(0) only bounds mmap of the
+// main database file; SQLite still memory-maps the -shm WAL-index for
+// multi-process WAL coordination, and concurrent read-only processes fault
+// inside that mapping. The URI flag tells SQLite this connection will not
+// observe writers, so it skips shared-memory and reads the main file with
+// pread. A WAL writer's last close already checkpoints, so a later
+// immutable reader sees the committed snapshot. Uncheckpointed frames from
+// a still-open writer are invisible; that is the trade for not mapping -shm.
+// nolock=1 and vfs=unix-none cannot open a WAL database; exclusive locking
+// mode serializes clients and fails a mode=ro open.
+//
 // OpenReadOnly uses context.Background(); callers holding a context should use
 // OpenReadOnlyContext so a cancelled command (SIGINT, deadline) interrupts the
 // SQLITE_BUSY retry during driver init instead of waiting out the full timeout.
@@ -118,7 +129,7 @@ func OpenReadOnly(dbPath string) (*Store, error) {
 // OpenReadOnlyContext is OpenReadOnly with a caller-supplied context honored by
 // the driver-init SQLITE_BUSY retry.
 func OpenReadOnlyContext(ctx context.Context, dbPath string) (*Store, error) {
-	dsn := "file:" + dbPath + "?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
+	dsn := "file:" + dbPath + "?mode=ro&immutable=1&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}
@@ -194,7 +205,7 @@ func rejectNewerSchemaBeforeJournalMode(ctx context.Context, dbPath string) erro
 	if err != nil {
 		return fmt.Errorf("stating database for schema preflight: %w", err)
 	}
-	probe, err := sql.Open("sqlite", "file:"+filepath.ToSlash(dbPath)+"?mode=ro&_pragma=busy_timeout(1000)")
+	probe, err := sql.Open("sqlite", "file:"+filepath.ToSlash(dbPath)+"?mode=ro&immutable=1&_pragma=busy_timeout(1000)&_pragma=mmap_size(0)")
 	if err != nil {
 		return nil
 	}

--- a/internal/generator/templates/store_schema_version_test.go.tmpl
+++ b/internal/generator/templates/store_schema_version_test.go.tmpl
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -162,9 +163,11 @@ func TestSchemaVersion_StampedOnFreshDB(t *testing.T) {
 
 // TestOpenAppliesPragmas pins the connection-string contract: the store
 // must use the profile-selected journal mode with a non-zero busy_timeout and
-// disabled mmap so concurrent cross-process access stays pread-based. It fails
-// the instant the DSN regresses to the mattn-style pragma form, which
-// modernc.org/sqlite silently drops.
+// disabled mmap so the main database file stays pread-based. The read-only
+// handle reports delete journal mode because immutable=1 skips the WAL-index
+// mmap that mmap_size does not govern. It fails the instant the DSN
+// regresses to the mattn-style pragma form, which modernc.org/sqlite
+// silently drops.
 func TestOpenAppliesPragmas(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "data.db")
 	s, err := Open(dbPath)
@@ -181,23 +184,18 @@ func TestOpenAppliesPragmas(t *testing.T) {
 	requirePragma(t, s.DB(), "busy_timeout", "5000")
 	requirePragma(t, s.DB(), "mmap_size", "0")
 
-	// The read-only handle (MCP sql/search, analytics) must retain its
-	// profile-compatible journal mode, carry the busy_timeout so it waits on a
-	// concurrent writer rather than erroring, and keep mmap disabled.
+	// The read-only handle (MCP sql/search, analytics) must carry the
+	// busy_timeout so it waits on a concurrent writer rather than erroring,
+	// keep mmap disabled, and skip the WAL-index. immutable=1 makes even a
+	// WAL file report delete journal mode because the connection does not
+	// attach the -shm mapping.
 	ro, err := OpenReadOnly(dbPath)
 	if err != nil {
 		t.Fatalf("open read-only: %v", err)
 	}
 	defer ro.Close()
 
-	{{- if .Cache.Enabled}}
-	// TRUNCATE is a per-connection setting. A read-only handle that does not
-	// set journal_mode reports SQLite's default delete mode, which is safe
-	// because the handle never creates a journal.
 	requirePragma(t, ro.DB(), "journal_mode", "delete")
-	{{- else}}
-	requirePragma(t, ro.DB(), "journal_mode", "wal")
-	{{- end}}
 	requirePragma(t, ro.DB(), "busy_timeout", "5000")
 	requirePragma(t, ro.DB(), "mmap_size", "0")
 }
@@ -213,6 +211,115 @@ func requirePragma(t *testing.T, db *sql.DB, name, want string) {
 	}
 	if got != want {
 		t.Fatalf("PRAGMA %s = %q, want %q", name, got, want)
+	}
+}
+
+// assertNoWALIndexSidecars fails if a read-only open recreated the WAL-index
+// mapping SQLite would otherwise place in -shm. mmap_size(0) does not govern
+// that mapping; the read-only DSN must skip it.
+func assertNoWALIndexSidecars(t *testing.T, dbPath string) {
+	t.Helper()
+	for _, sidecar := range []string{dbPath + "-shm", dbPath + "-wal"} {
+		if _, err := os.Stat(sidecar); err == nil {
+			t.Fatalf("read-only open created WAL sidecar %s", sidecar)
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat %s: %v", sidecar, err)
+		}
+	}
+}
+
+// TestOpenReadOnly_SkipsWALIndexSidecars proves a settled WAL store can be
+// opened read-only without recreating -shm. The current-ro DSN (mmap_size 0
+// without immutable=1) remaps the WAL-index on the next open; that mapping
+// is the concurrent-reader fault surface.
+func TestOpenReadOnly_SkipsWALIndexSidecars(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	ro, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open read-only: %v", err)
+	}
+	defer ro.Close()
+
+	var n int
+	if err := ro.DB().QueryRow(`SELECT count(*) FROM sqlite_master`).Scan(&n); err != nil {
+		t.Fatalf("read-only query: %v", err)
+	}
+	if n < 1 {
+		t.Fatalf("read-only query returned empty catalog")
+	}
+	assertNoWALIndexSidecars(t, dbPath)
+}
+
+// TestOpenReadOnly_ConcurrentProcesses runs two sibling read-only processes
+// against one store. Serial access never hits the WAL-index fault; two
+// concurrent OpenReadOnly processes is the smallest reproduction.
+func TestOpenReadOnly_ConcurrentProcesses(t *testing.T) {
+	if os.Getenv("PP_STORE_RO_HELPER") == "1" {
+		runOpenReadOnlyHelper()
+		return
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open seed: %v", err)
+	}
+	if _, err := s.DB().Exec(`INSERT INTO resources (id, resource_type, data) VALUES (?, ?, ?)`, "ro-1", "concurrent", `{"id":"ro-1"}`); err != nil {
+		t.Fatalf("seed row: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close seed: %v", err)
+	}
+
+	const helpers = 2
+	cmds := make([]*exec.Cmd, helpers)
+	for i := 0; i < helpers; i++ {
+		cmd := exec.Command(os.Args[0], "-test.run=^TestOpenReadOnly_ConcurrentProcesses$", "-test.count=1")
+		cmd.Env = append(os.Environ(),
+			"PP_STORE_RO_HELPER=1",
+			"PP_STORE_RO_DB="+dbPath,
+		)
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start helper %d: %v", i, err)
+		}
+		cmds[i] = cmd
+	}
+	for i, cmd := range cmds {
+		if err := cmd.Wait(); err != nil {
+			t.Fatalf("helper %d: %v", i, err)
+		}
+	}
+	assertNoWALIndexSidecars(t, dbPath)
+}
+
+func runOpenReadOnlyHelper() {
+	dbPath := os.Getenv("PP_STORE_RO_DB")
+	if dbPath == "" {
+		fmt.Fprintln(os.Stderr, "PP_STORE_RO_DB is required")
+		os.Exit(2)
+	}
+	ro, err := OpenReadOnly(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "open read-only: %v\n", err)
+		os.Exit(3)
+	}
+	defer ro.Close()
+	var n int
+	if err := ro.DB().QueryRow(`SELECT count(*) FROM resources`).Scan(&n); err != nil {
+		fmt.Fprintf(os.Stderr, "read-only query: %v\n", err)
+		os.Exit(4)
+	}
+	if n < 1 {
+		fmt.Fprintf(os.Stderr, "read-only count=%d\n", n)
+		os.Exit(5)
 	}
 }
 

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -103,6 +103,17 @@ func Open(dbPath string) (*Store, error) {
 // delete mode (e.g. a pre-WAL database opened by an old binary before its
 // first read-write open) errors with "attempt to write a readonly database".
 //
+// immutable=1 is the WAL-index control. mmap_size(0) only bounds mmap of the
+// main database file; SQLite still memory-maps the -shm WAL-index for
+// multi-process WAL coordination, and concurrent read-only processes fault
+// inside that mapping. The URI flag tells SQLite this connection will not
+// observe writers, so it skips shared-memory and reads the main file with
+// pread. A WAL writer's last close already checkpoints, so a later
+// immutable reader sees the committed snapshot. Uncheckpointed frames from
+// a still-open writer are invisible; that is the trade for not mapping -shm.
+// nolock=1 and vfs=unix-none cannot open a WAL database; exclusive locking
+// mode serializes clients and fails a mode=ro open.
+//
 // OpenReadOnly uses context.Background(); callers holding a context should use
 // OpenReadOnlyContext so a cancelled command (SIGINT, deadline) interrupts the
 // SQLITE_BUSY retry during driver init instead of waiting out the full timeout.
@@ -113,7 +124,7 @@ func OpenReadOnly(dbPath string) (*Store, error) {
 // OpenReadOnlyContext is OpenReadOnly with a caller-supplied context honored by
 // the driver-init SQLITE_BUSY retry.
 func OpenReadOnlyContext(ctx context.Context, dbPath string) (*Store, error) {
-	dsn := "file:" + dbPath + "?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
+	dsn := "file:" + dbPath + "?mode=ro&immutable=1&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}
@@ -182,7 +193,7 @@ func rejectNewerSchemaBeforeJournalMode(ctx context.Context, dbPath string) erro
 	if err != nil {
 		return fmt.Errorf("stating database for schema preflight: %w", err)
 	}
-	probe, err := sql.Open("sqlite", "file:"+filepath.ToSlash(dbPath)+"?mode=ro&_pragma=busy_timeout(1000)")
+	probe, err := sql.Open("sqlite", "file:"+filepath.ToSlash(dbPath)+"?mode=ro&immutable=1&_pragma=busy_timeout(1000)&_pragma=mmap_size(0)")
 	if err != nil {
 		return nil
 	}

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -107,6 +107,17 @@ func Open(dbPath string) (*Store, error) {
 // delete mode (e.g. a pre-WAL database opened by an old binary before its
 // first read-write open) errors with "attempt to write a readonly database".
 //
+// immutable=1 is the WAL-index control. mmap_size(0) only bounds mmap of the
+// main database file; SQLite still memory-maps the -shm WAL-index for
+// multi-process WAL coordination, and concurrent read-only processes fault
+// inside that mapping. The URI flag tells SQLite this connection will not
+// observe writers, so it skips shared-memory and reads the main file with
+// pread. A WAL writer's last close already checkpoints, so a later
+// immutable reader sees the committed snapshot. Uncheckpointed frames from
+// a still-open writer are invisible; that is the trade for not mapping -shm.
+// nolock=1 and vfs=unix-none cannot open a WAL database; exclusive locking
+// mode serializes clients and fails a mode=ro open.
+//
 // OpenReadOnly uses context.Background(); callers holding a context should use
 // OpenReadOnlyContext so a cancelled command (SIGINT, deadline) interrupts the
 // SQLITE_BUSY retry during driver init instead of waiting out the full timeout.
@@ -117,7 +128,7 @@ func OpenReadOnly(dbPath string) (*Store, error) {
 // OpenReadOnlyContext is OpenReadOnly with a caller-supplied context honored by
 // the driver-init SQLITE_BUSY retry.
 func OpenReadOnlyContext(ctx context.Context, dbPath string) (*Store, error) {
-	dsn := "file:" + dbPath + "?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
+	dsn := "file:" + dbPath + "?mode=ro&immutable=1&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}
@@ -186,7 +197,7 @@ func rejectNewerSchemaBeforeJournalMode(ctx context.Context, dbPath string) erro
 	if err != nil {
 		return fmt.Errorf("stating database for schema preflight: %w", err)
 	}
-	probe, err := sql.Open("sqlite", "file:"+filepath.ToSlash(dbPath)+"?mode=ro&_pragma=busy_timeout(1000)")
+	probe, err := sql.Open("sqlite", "file:"+filepath.ToSlash(dbPath)+"?mode=ro&immutable=1&_pragma=busy_timeout(1000)&_pragma=mmap_size(0)")
 	if err != nil {
 		return nil
 	}

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -107,6 +107,17 @@ func Open(dbPath string) (*Store, error) {
 // delete mode (e.g. a pre-WAL database opened by an old binary before its
 // first read-write open) errors with "attempt to write a readonly database".
 //
+// immutable=1 is the WAL-index control. mmap_size(0) only bounds mmap of the
+// main database file; SQLite still memory-maps the -shm WAL-index for
+// multi-process WAL coordination, and concurrent read-only processes fault
+// inside that mapping. The URI flag tells SQLite this connection will not
+// observe writers, so it skips shared-memory and reads the main file with
+// pread. A WAL writer's last close already checkpoints, so a later
+// immutable reader sees the committed snapshot. Uncheckpointed frames from
+// a still-open writer are invisible; that is the trade for not mapping -shm.
+// nolock=1 and vfs=unix-none cannot open a WAL database; exclusive locking
+// mode serializes clients and fails a mode=ro open.
+//
 // OpenReadOnly uses context.Background(); callers holding a context should use
 // OpenReadOnlyContext so a cancelled command (SIGINT, deadline) interrupts the
 // SQLITE_BUSY retry during driver init instead of waiting out the full timeout.
@@ -117,7 +128,7 @@ func OpenReadOnly(dbPath string) (*Store, error) {
 // OpenReadOnlyContext is OpenReadOnly with a caller-supplied context honored by
 // the driver-init SQLITE_BUSY retry.
 func OpenReadOnlyContext(ctx context.Context, dbPath string) (*Store, error) {
-	dsn := "file:" + dbPath + "?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
+	dsn := "file:" + dbPath + "?mode=ro&immutable=1&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}
@@ -186,7 +197,7 @@ func rejectNewerSchemaBeforeJournalMode(ctx context.Context, dbPath string) erro
 	if err != nil {
 		return fmt.Errorf("stating database for schema preflight: %w", err)
 	}
-	probe, err := sql.Open("sqlite", "file:"+filepath.ToSlash(dbPath)+"?mode=ro&_pragma=busy_timeout(1000)")
+	probe, err := sql.Open("sqlite", "file:"+filepath.ToSlash(dbPath)+"?mode=ro&immutable=1&_pragma=busy_timeout(1000)&_pragma=mmap_size(0)")
 	if err != nil {
 		return nil
 	}

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -107,6 +107,17 @@ func Open(dbPath string) (*Store, error) {
 // delete mode (e.g. a pre-WAL database opened by an old binary before its
 // first read-write open) errors with "attempt to write a readonly database".
 //
+// immutable=1 is the WAL-index control. mmap_size(0) only bounds mmap of the
+// main database file; SQLite still memory-maps the -shm WAL-index for
+// multi-process WAL coordination, and concurrent read-only processes fault
+// inside that mapping. The URI flag tells SQLite this connection will not
+// observe writers, so it skips shared-memory and reads the main file with
+// pread. A WAL writer's last close already checkpoints, so a later
+// immutable reader sees the committed snapshot. Uncheckpointed frames from
+// a still-open writer are invisible; that is the trade for not mapping -shm.
+// nolock=1 and vfs=unix-none cannot open a WAL database; exclusive locking
+// mode serializes clients and fails a mode=ro open.
+//
 // OpenReadOnly uses context.Background(); callers holding a context should use
 // OpenReadOnlyContext so a cancelled command (SIGINT, deadline) interrupts the
 // SQLITE_BUSY retry during driver init instead of waiting out the full timeout.
@@ -117,7 +128,7 @@ func OpenReadOnly(dbPath string) (*Store, error) {
 // OpenReadOnlyContext is OpenReadOnly with a caller-supplied context honored by
 // the driver-init SQLITE_BUSY retry.
 func OpenReadOnlyContext(ctx context.Context, dbPath string) (*Store, error) {
-	dsn := "file:" + dbPath + "?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
+	dsn := "file:" + dbPath + "?mode=ro&immutable=1&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(0)"
 	if err := ensureSQLiteDriverInitialized(ctx, dsn); err != nil {
 		return nil, err
 	}
@@ -186,7 +197,7 @@ func rejectNewerSchemaBeforeJournalMode(ctx context.Context, dbPath string) erro
 	if err != nil {
 		return fmt.Errorf("stating database for schema preflight: %w", err)
 	}
-	probe, err := sql.Open("sqlite", "file:"+filepath.ToSlash(dbPath)+"?mode=ro&_pragma=busy_timeout(1000)")
+	probe, err := sql.Open("sqlite", "file:"+filepath.ToSlash(dbPath)+"?mode=ro&immutable=1&_pragma=busy_timeout(1000)&_pragma=mmap_size(0)")
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Closes #4349.

Concurrent `OpenReadOnly` processes still SIGBUS in `_walFindFrame` after #4191 and #4138. `mmap_size(0)` only bounds mmap of the main database file. The WAL-index (`-shm`) mapping is a separate, ungoverned mmap.

## Approach

Investigated the SQLite controls that can stop that mapping without undoing WAL, `_txlock=immediate`, or `mmap_size(0)`:

- `nolock=1` and `vfs=unix-none` cannot open a WAL database (`SQLITE_CANTOPEN`).
- `locking_mode=EXCLUSIVE` puts the WAL-index in heap memory, but a `mode=ro` open fails or serializes clients (`SQLITE_BUSY` / I/O error). That blocks the ≥2 concurrent reader shape.
- `immutable=1` on the read-only URI is the control that works: SQLite skips shared-memory, does not recreate `-shm`, and still allows concurrent read-only processes. A WAL writer's last close already checkpoints, so a later immutable reader sees the committed snapshot.

The read-write DSN is unchanged: profile journal mode (WAL or TRUNCATE), `_txlock=immediate`, `busy_timeout` before journal mode, and `mmap_size(0)`.

## Scope

Primary area: generated store DSN in `internal/generator/templates/store.go.tmpl`.

Why this belongs in this repo: every printed CLI inherits `internal/store/store.go` from the Printing Press generator, including MCP concurrent readers.

## Risk

Read-only connections no longer observe uncheckpointed WAL frames from a still-open writer. That is the trade for not mapping `-shm`. Last-close checkpoint already flushes a finished writer. `mode=ro` write rejection, WAL conversion, and cache-profile TRUNCATE behavior are unchanged.

## Output Contract

Read-only DSNs now include `immutable=1` and still include `mmap_size(0)`. Schema preflight probes use the same WAL-index skip. Golden store fixtures for the generate cases that snapshot `store.go` are updated.

Generated-output proof:

- Emitted-code assertions on the read-only DSN, read-write WAL DSN, and preflight probe
- `requireGeneratedCompiles` plus emitted store tests, including two sibling `OpenReadOnly` processes against one database
- `scripts/verify-generator-output.sh` (11 default cases)
- Full `scripts/golden.sh update` (reverted unrelated dogfood-verdict-matrix toolchain noise)

## Verification

- `go test ./internal/generator -run '^TestGenerateStore(DSNOrdersBusyTimeoutBeforeJournalMode|DSNUsesImmediateTransactionsAndProfileJournalMode|ReadOnlyDSNSkipsWALIndex)$|^TestGenerateMCPSQLToolUsesReadOnlyStore$' -count=1`
- `scripts/verify-generator-output.sh`
- `GOLDEN_ALLOW_DIRTY=1 scripts/golden.sh update` (full set; `verify-runtime-matrix` could not rebuild fixture CLIs on the missing `go1.24` toolchain and was left unchanged)
- `go test ./... -timeout 45m`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4017bb73-4ead-42b4-9eab-cc641cea8e55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4017bb73-4ead-42b4-9eab-cc641cea8e55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

