### PR TITLE
fix(auth): pass Chrome cookie path via argv, not python -c

### DIFF
--- a/internal/generator/auth_pycookiecheat_argv_test.go
+++ b/internal/generator/auth_pycookiecheat_argv_test.go
@@ -1,0 +1,205 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package generator
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func emittedExtractViaPycookiecheat(authGo string) (string, bool) {
+	_, rest, found := strings.Cut(authGo, "func extractViaPycookiecheat(")
+	if !found {
+		return "", false
+	}
+	if i := strings.Index(rest, "\nfunc "); i >= 0 {
+		rest = rest[:i]
+	}
+	return rest, true
+}
+
+func buildPycookiecheatArgvStub(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "stub.go")
+	bin := filepath.Join(dir, "py-stub")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	const content = `package main
+import (
+	"encoding/json"
+	"os"
+)
+func main() {
+	path := os.Getenv("PP_ARGV_LOG")
+	data, _ := json.Marshal(os.Args[1:])
+	_ = os.WriteFile(path, data, 0o600)
+	_, _ = os.Stdout.Write([]byte("{\"session_id\":\"ok\"}\n"))
+}
+`
+	require.NoError(t, os.WriteFile(src, []byte(content), 0o600))
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	return bin
+}
+
+// Generated cookie-auth CLIs must pass the Chrome cookie DB path to
+// pycookiecheat via argv, not by interpolating it into a python -c program.
+// A hostile Profile * directory name is otherwise code execution.
+func TestGeneratedPycookiecheatPassesCookiePathViaArgv(t *testing.T) {
+	t.Parallel()
+
+	outputDir := filepath.Join(t.TempDir(), "pycookieargv-pp-cli")
+	require.NoError(t, New(chromeChannelSpec("pycookieargv"), outputDir).Generate())
+
+	authGo := readGeneratedFile(t, outputDir, "internal", "cli", "auth.go")
+	fn, found := emittedExtractViaPycookiecheat(authGo)
+	require.True(t, found, "expected extractViaPycookiecheat in generated auth.go")
+
+	assert.Contains(t, fn, "sys.argv")
+	assert.NotContains(t, fn, `cookie_file="%s"`)
+	assert.NotContains(t, fn, `chrome_cookies("https://%s"`)
+	assert.NotContains(t, fn, "fmt.Sprintf")
+	assert.NotContains(t, fn, "safePath")
+	assert.NotContains(t, fn, "filepath.ToSlash")
+	assert.Contains(t, fn, `"-c", script`)
+	assert.Contains(t, fn, `"https://"+cleanDomain`)
+	assert.Contains(t, fn, "cookiePath")
+
+	requireGeneratedCompiles(t, outputDir)
+
+	stub := buildPycookiecheatArgvStub(t)
+	runtimeTest := fmt.Sprintf(`package cli
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const argvStub = %q
+
+func readArgvLog(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var args []string
+	if err := json.Unmarshal(data, &args); err != nil {
+		t.Fatalf("argv log: %%v\n%%s", err, data)
+	}
+	return args
+}
+
+func TestExtractViaPycookiecheatProfile1ExtractsViaArgv(t *testing.T) {
+	dir := t.TempDir()
+	argvLog := filepath.Join(dir, "argv.json")
+	t.Setenv("PP_ARGV_LOG", argvLog)
+
+	dataDir := filepath.Join(dir, "Chrome")
+	got, err := extractViaPycookiecheat(cookieTool{name: "pycookiecheat", pyBin: argvStub}, ".example.com", chromeProfile{Dir: "Profile 1", DataDir: dataDir})
+	if err != nil {
+		t.Fatalf("extract Profile 1: %%v", err)
+	}
+	if got != "session_id=ok" {
+		t.Fatalf("extract Profile 1 = %%q, want session_id=ok", got)
+	}
+
+	args := readArgvLog(t, argvLog)
+	if len(args) < 4 || args[0] != "-c" {
+		t.Fatalf("argv = %%#v, want [-c script url path]", args)
+	}
+	script, url, cookiePath := args[1], args[2], args[3]
+	wantPath := filepath.Join(dataDir, "Profile 1", "Cookies")
+	if cookiePath != wantPath {
+		t.Fatalf("cookie path argv = %%q, want %%q", cookiePath, wantPath)
+	}
+	if url != "https://example.com" {
+		t.Fatalf("url argv = %%q, want https://example.com", url)
+	}
+	if strings.Contains(script, wantPath) || strings.Contains(script, "Profile 1") {
+		t.Fatalf("python -c program embedded the cookie path:\n%%s", script)
+	}
+	if !strings.Contains(script, "sys.argv") {
+		t.Fatalf("python -c program does not read argv:\n%%s", script)
+	}
+}
+
+func TestExtractViaPycookiecheatHostileProfileHasNoSideEffect(t *testing.T) {
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "pwned")
+	// Working injection against the old fmt.Sprintf python -c program:
+	// the trailing # comments out "/Cookies"))) so the os.system runs.
+	hostile := "x\") ) ) or __import__(\"os\").system(\"touch " + sentinel + "\")#"
+
+	argvLog := filepath.Join(dir, "argv.json")
+	t.Setenv("PP_ARGV_LOG", argvLog)
+
+	dataDir := filepath.Join(dir, "Chrome")
+	if _, err := extractViaPycookiecheat(cookieTool{name: "pycookiecheat", pyBin: argvStub}, ".example.com", chromeProfile{Dir: hostile, DataDir: dataDir}); err != nil {
+		t.Fatalf("hostile extract (stub): %%v", err)
+	}
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Fatalf("hostile profile created sentinel via stub: %%v", err)
+	}
+	args := readArgvLog(t, argvLog)
+	if len(args) < 2 {
+		t.Fatalf("argv = %%#v", args)
+	}
+	if strings.Contains(args[1], hostile) || strings.Contains(args[1], sentinel) {
+		t.Fatalf("python -c program embedded hostile profile:\n%%s", args[1])
+	}
+	if len(args) < 4 || !strings.Contains(args[3], hostile) {
+		t.Fatalf("hostile path missing from argv: %%#v", args)
+	}
+
+	py, err := exec.LookPath("python3")
+	if err != nil {
+		if py, err = exec.LookPath("python"); err != nil {
+			return
+		}
+	}
+	if _, err := extractViaPycookiecheat(cookieTool{name: "pycookiecheat", pyBin: py}, ".example.com", chromeProfile{Dir: hostile, DataDir: dataDir}); err == nil {
+		t.Fatal("real python extract unexpectedly succeeded")
+	}
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Fatal("hostile profile executed code via real python")
+	}
+}
+
+func TestExtractViaPycookiecheatOmitsPathArgWhenNoProfile(t *testing.T) {
+	dir := t.TempDir()
+	argvLog := filepath.Join(dir, "argv.json")
+	t.Setenv("PP_ARGV_LOG", argvLog)
+
+	got, err := extractViaPycookiecheat(cookieTool{name: "pycookiecheat", pyBin: argvStub}, ".example.com", chromeProfile{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "session_id=ok" {
+		t.Fatalf("got %%q", got)
+	}
+	args := readArgvLog(t, argvLog)
+	if len(args) != 3 || args[0] != "-c" || args[2] != "https://example.com" {
+		t.Fatalf("argv = %%#v, want [-c script url]", args)
+	}
+}
+`, stub)
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "pycookiecheat_argv_test.go"), []byte(runtimeTest), 0o600))
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestExtractViaPycookiecheat")
+}

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -2013,23 +2013,16 @@ func extractViaPycookiecheat(tool cookieTool, domain string, profile chromeProfi
 		cookiePath = filepath.Join(profile.DataDir, profile.Dir, "Cookies")
 	}
 
-	var script string
+	// Static program: URL and optional cookie path arrive via argv so a
+	// hostile Chrome profile name cannot close a Python string literal.
+	script := `import json, sys; from pycookiecheat import chrome_cookies; url = sys.argv[1]; print(json.dumps(chrome_cookies(url, cookie_file=sys.argv[2]) if len(sys.argv) > 2 else chrome_cookies(url)))`
+	args := append(append([]string{}, tool.pyArgs...), "-c", script, "https://"+cleanDomain)
 	if cookiePath != "" {
-		// Use forward slashes so Python doesn't interpret backslashes as escapes on Windows
-		safePath := filepath.ToSlash(cookiePath)
-		script = fmt.Sprintf(
-			`import json; from pycookiecheat import chrome_cookies; print(json.dumps(chrome_cookies("https://%s", cookie_file="%s")))`,
-			cleanDomain, safePath,
-		)
-	} else {
-		script = fmt.Sprintf(
-			`import json; from pycookiecheat import chrome_cookies; print(json.dumps(chrome_cookies("https://%s")))`,
-			cleanDomain,
-		)
+		args = append(args, cookiePath)
 	}
 
 	var out bytes.Buffer
-	cmd := exec.Command(tool.pyBin, append(append([]string{}, tool.pyArgs...), "-c", script)...)
+	cmd := exec.Command(tool.pyBin, args...)
 	cmd.Stdout = &out
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
@@ -987,23 +987,16 @@ func extractViaPycookiecheat(tool cookieTool, domain string, profile chromeProfi
 		cookiePath = filepath.Join(profile.DataDir, profile.Dir, "Cookies")
 	}
 
-	var script string
+	// Static program: URL and optional cookie path arrive via argv so a
+	// hostile Chrome profile name cannot close a Python string literal.
+	script := `import json, sys; from pycookiecheat import chrome_cookies; url = sys.argv[1]; print(json.dumps(chrome_cookies(url, cookie_file=sys.argv[2]) if len(sys.argv) > 2 else chrome_cookies(url)))`
+	args := append(append([]string{}, tool.pyArgs...), "-c", script, "https://"+cleanDomain)
 	if cookiePath != "" {
-		// Use forward slashes so Python doesn't interpret backslashes as escapes on Windows
-		safePath := filepath.ToSlash(cookiePath)
-		script = fmt.Sprintf(
-			`import json; from pycookiecheat import chrome_cookies; print(json.dumps(chrome_cookies("https://%s", cookie_file="%s")))`,
-			cleanDomain, safePath,
-		)
-	} else {
-		script = fmt.Sprintf(
-			`import json; from pycookiecheat import chrome_cookies; print(json.dumps(chrome_cookies("https://%s")))`,
-			cleanDomain,
-		)
+		args = append(args, cookiePath)
 	}
 
 	var out bytes.Buffer
-	cmd := exec.Command(tool.pyBin, append(append([]string{}, tool.pyArgs...), "-c", script)...)
+	cmd := exec.Command(tool.pyBin, args...)
 	cmd.Stdout = &out
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

`extractViaPycookiecheat` interpolated the Chrome profile cookie path into a `python -c` program via `fmt.Sprintf`. Profile discovery accepts any `Profile *` directory, so a name containing `"`, `\`, or a newline could close the Python string literal and execute code during `auth login --chrome`. `filepath.ToSlash` only normalizes separators; it does not escape.

Closes #4281

## Approach

Pass the URL and optional cookie path as argv to a static Python program (`sys.argv`). argv has no quoting context, so the injection class disappears rather than being escaped around. The sibling `pycookiecheat-cli` and `cookie-scoop` call sites already pass argv and are unchanged.

A hostile profile name is just a path argument (no side effect). A normal `Profile 1` still extracts because pycookiecheat receives the same cookie DB path, now as argv instead of an interpolated literal.

This does not touch `auth set-token` or MCP HTTP (#4322).

## Scope

Primary area: generator cookie-auth template (`internal/generator/templates/auth_browser.go.tmpl`)

Why this belongs in this repo: the defect is in the Printing Press template that every cookie-auth CLI inherits. A printed-CLI-only patch would not compound.

## Risk

Generated `internal/cli/auth.go` for cookie-auth CLIs changes on next regen. The `pycookiecheat` Python import path still runs the same `chrome_cookies()` call; only how URL/path reach that call changes. No MCP surface, set-token, or verifier contract change.

## Output Contract

- Emitted-code assertions: generated `extractViaPycookiecheat` must contain `sys.argv` and must not contain `cookie_file="%s"`, `fmt.Sprintf`, or `filepath.ToSlash`.
- Compile-level proof: `requireGeneratedCompiles` plus a runtime test compiled into a generated cookie-auth CLI.
- That runtime test uses a stub interpreter to prove `Profile 1` still extracts (`session_id=ok`) with the path as its own argv entry, and a hostile `Profile *` name never appears in the `-c` program (plus a real-python check that a working injection payload does not create a sentinel).
- Golden fixture: `generate-golden-api-cookie-auth` `internal/cli/auth.go`.
- `scripts/verify-generator-output.sh generate-golden-api-cookie-auth` compiles the regenerated module.

## Verification

- [x] `go test ./internal/generator -run TestGeneratedPycookiecheatPassesCookiePathViaArgv`
- [x] `go test ./internal/generator -run 'TestGenerate_CookieAuth|TestCookieAuth|TestGeneratedPycookiecheat'`
- [x] `go test ./internal/generator -timeout 25m`
- [x] `go test ./... -timeout 25m` (first full run: unrelated flake in `TestGeneratorSkipsReservedNovelFeatureRootCommands` from parallel `os.Stderr` capture; package re-run passed)
- [x] `GOLDEN_ALLOW_DIRTY=1 scripts/golden.sh update` then `verify` — cookie-auth fixture updated; other case noise (missing go1.24 toolchain in this environment) reverted
- [x] `scripts/verify-generator-output.sh generate-golden-api-cookie-auth`

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10c4b841-c824-4aaa-952a-d80f930a3e45?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10c4b841-c824-4aaa-952a-d80f930a3e45&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

