### PR TITLE
fix(client): bind cookie credentials to https canonical host for every token source

### DIFF
--- a/internal/generator/client_cookie_jar_seed_test.go
+++ b/internal/generator/client_cookie_jar_seed_test.go
@@ -23,10 +23,11 @@ func TestCookieAuthClientSeedsJar(t *testing.T) {
 	apiSpec := minimalSpec("cookieseed")
 	apiSpec.BaseURL = "https://api.cookieseed.example"
 	apiSpec.Auth = spec.AuthConfig{
-		Type:    "cookie",
-		Header:  "Cookie",
-		Cookies: []string{"session_id", "csrf_token"},
-		EnvVars: []string{"COOKIESEED_SESSION"},
+		Type:         "cookie",
+		Header:       "Cookie",
+		CookieDomain: ".cookieseed.example",
+		Cookies:      []string{"session_id", "csrf_token"},
+		EnvVars:      []string{"COOKIESEED_SESSION"},
 	}
 
 	outputDir := filepath.Join(t.TempDir(), "cookieseed-pp-cli")
@@ -39,10 +40,12 @@ func TestCookieAuthClientSeedsJar(t *testing.T) {
 	// New() must load the persistent jar AND seed it from the cookie credential.
 	assert.Contains(t, clientSrc, "cookieJar := LoadCookieJar()",
 		"cookie-auth New() must build the persistent jar")
-	assert.Contains(t, clientSrc, "SeedCookieJar(cookieJar, cfg.BaseURL, cfg.CookieCredential())",
-		"cookie-auth New() must seed legacy credentials at the configured base URL")
-	assert.Contains(t, clientSrc, "SeedCookieJarForDomain(cookieJar, seedBaseURL, cfg.CookieCredential(), cfg.CredentialDomain)",
-		"cookie-auth New() must seed the jar from the stored cookie credential at its bound domain")
+	assert.NotContains(t, clientSrc, "SeedCookieJar(cookieJar, cfg.BaseURL, cfg.CookieCredential())",
+		"cookie-auth New() must not seed a session against an overridable BaseURL")
+	assert.Contains(t, clientSrc, "seedDomain = canonicalCredentialDomain",
+		"cookie-auth New() must fall back to the spec cookie domain for env and set-token")
+	assert.Contains(t, clientSrc, "SeedCookieJarForDomain(cookieJar, seedBaseURL, cfg.CookieCredential(), seedDomain)",
+		"cookie-auth New() must seed the jar from the stored cookie credential at the https canonical host")
 	assert.Contains(t, clientSrc, "httpClient := newHTTPClient(timeout, cookieJar)",
 		"cookie-auth client must use the seeded jar, not a nil jar")
 	assert.NotContains(t, clientSrc, "newHTTPClient(timeout, nil)",
@@ -74,6 +77,10 @@ func TestCookieAuthClientSeedsJar(t *testing.T) {
 	assert.Contains(t, jarSrc, "func SeedCookieJar(jar http.CookieJar, baseURL, cookieStr string)")
 	assert.Contains(t, jarSrc, "func parseCookieJar(s string) []*http.Cookie")
 	assert.Contains(t, jarSrc, "func looksLikeCookieJar(s string) bool")
+	assert.Contains(t, jarSrc, "cookie.Secure = true",
+		"seeded session cookies must be https-only")
+	assert.Contains(t, jarSrc, "not sending your session cookie to it",
+		"rejected seed URLs must warn instead of attaching the credential")
 
 	// Runtime proof: a seeded jar attaches the stored cookies to a request for
 	// the base URL, and parseCookieJar handles the "k=v; k=v" wire format.
@@ -113,6 +120,27 @@ func TestSeedCookieJarForDomainAttachesSubdomainCookies(t *testing.T) {
 	u, _ = url.Parse("https://api.other.example/items")
 	if cs := jar.Cookies(u); len(cs) != 0 {
 		t.Fatalf("domain-scoped seed leaked outside its binding: %v", cs)
+	}
+}
+
+func TestSeedCookieJarRejectsHTTPAndWrongHost(t *testing.T) {
+	jar, _ := cookiejar.New(nil)
+	SeedCookieJar(jar, "http://api.cookieseed.example", "session_id=abc")
+	httpsURL, _ := url.Parse("https://api.cookieseed.example/items")
+	httpURL, _ := url.Parse("http://api.cookieseed.example/items")
+	if cs := jar.Cookies(httpsURL); len(cs) != 0 {
+		t.Fatalf("http seed must not attach cookies: %v", cs)
+	}
+	if cs := jar.Cookies(httpURL); len(cs) != 0 {
+		t.Fatalf("http seed must not attach cookies for http://: %v", cs)
+	}
+	SeedCookieJar(jar, "https://evil.example.net", "session_id=abc")
+	evil, _ := url.Parse("https://evil.example.net/items")
+	if cs := jar.Cookies(evil); len(cs) != 0 {
+		t.Fatalf("wrong-host seed must not attach cookies: %v", cs)
+	}
+	if cs := jar.Cookies(httpsURL); len(cs) != 0 {
+		t.Fatalf("wrong-host seed must not attach cookies to the canonical host: %v", cs)
 	}
 }
 

--- a/internal/generator/client_credential_domain_test.go
+++ b/internal/generator/client_credential_domain_test.go
@@ -46,21 +46,29 @@ func TestGeneratedBrowserCredentialBindsToCapturedDomain(t *testing.T) {
 	assert.Contains(t, configSrc, "CredentialDomain: c.CredentialDomain",
 		"persisted config must carry the captured credential domain")
 	assert.Contains(t, configSrc, "CredentialDomain = \"\"",
-		"environment auth overrides must clear a stale browser binding")
+		"environment auth overrides must clear a stale browser binding so they do not load the persisted jar")
 	assert.Contains(t, configSrc, "UsePersistedCookieJar",
 		"cookie clients must be able to suppress stale persisted browser cookies")
 	assert.Contains(t, credentialsSrc, "credential_domain",
 		"external credentials must carry the browser binding with the credential")
 	assert.Contains(t, authSrc, `cfg.CredentialDomain = ".auth.example.com"`,
 		"browser login and refresh must bind the stored credential to the capture domain")
-	assert.Contains(t, clientSrc, `seedBaseURL := "https://" + strings.TrimPrefix(cfg.CredentialDomain, ".")`,
-		"cookie seeding must use the captured domain instead of the merged BaseURL")
-	assert.Contains(t, clientSrc, "SeedCookieJarForDomain(cookieJar, seedBaseURL, cfg.CookieCredential(), cfg.CredentialDomain)",
-		"cookie seeding must preserve the captured domain across its subdomains")
+	assert.Contains(t, clientSrc, "const canonicalCredentialDomain = \".auth.example.com\"",
+		"every token source must bind to the spec cookie_domain")
+	assert.Contains(t, clientSrc, "seedDomain = canonicalCredentialDomain",
+		"empty CredentialDomain must fall back to the spec cookie_domain")
+	assert.Contains(t, clientSrc, `seedBaseURL := "https://" + strings.TrimPrefix(seedDomain, ".")`,
+		"cookie seeding must use the https canonical host instead of the merged BaseURL")
+	assert.Contains(t, clientSrc, "SeedCookieJarForDomain(cookieJar, seedBaseURL, cfg.CookieCredential(), seedDomain)",
+		"cookie seeding must preserve the canonical domain across its subdomains")
+	assert.NotContains(t, clientSrc, "SeedCookieJar(cookieJar, cfg.BaseURL, cfg.CookieCredential())",
+		"cookie seeding must never attach a session to an operator-overridable BaseURL")
 	assert.Contains(t, clientSrc, "credentialAllowed := c.credentialAppliesToURL(targetURL)",
 		"requests must check the captured credential domain before injection")
 	assert.Contains(t, clientSrc, "if authHeader != \"\" && credentialAllowed {",
 		"the primary auth header must be withheld from unrelated hosts")
+	assert.Contains(t, clientSrc, "if !credentialAllowed && isCredentialHeader(k)",
+		"config Headers must not restore Authorization or Cookie after a deny")
 	assert.Contains(t, clientSrc, "req.URL.Host == via[0].URL.Host && c.credentialAppliesToURL(req.URL.String())",
 		"same-host redirect re-stamping must retain the credential-domain gate")
 	assert.Contains(t, clientSrc, "publicsuffix.EffectiveTLDPlusOne",
@@ -92,6 +100,9 @@ func TestGeneratedBrowserCredentialBindsToCapturedDomain(t *testing.T) {
 	runtimeTest := `package client
 
 import (
+	"context"
+	"crypto/tls"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -103,28 +114,38 @@ import (
 )
 
 func TestCredentialAppliesToURL(t *testing.T) {
-	c := &Client{Config: &config.Config{CredentialDomain: ".auth.example.com"}}
+	bound := &Client{Config: &config.Config{CredentialDomain: ".auth.example.com"}}
+	unbound := &Client{Config: &config.Config{}}
+	envTok := &Client{Config: &config.Config{AuthSource: "env:CREDENTIALDOMAIN_SESSION"}}
 	for _, tc := range []struct {
-		name string
-		url  string
-		want bool
+		name   string
+		client *Client
+		url    string
+		want   bool
 	}{
-		{name: "captured host", url: "https://login.auth.example.com/session", want: true},
-		{name: "same registrable domain", url: "https://api.auth.example.com/items", want: true},
-		{name: "credential-free host", url: "https://api.credential-free.example/items", want: false},
+		{name: "captured host", client: bound, url: "https://login.auth.example.com/session", want: true},
+		{name: "same registrable domain", client: bound, url: "https://api.auth.example.com/items", want: true},
+		{name: "http canonical host", client: bound, url: "http://login.auth.example.com/session", want: false},
+		{name: "credential-free host", client: bound, url: "https://api.credential-free.example/items", want: false},
+		{name: "empty domain uses spec https host", client: unbound, url: "https://login.auth.example.com/session", want: true},
+		{name: "empty domain denies http", client: unbound, url: "http://login.auth.example.com/session", want: false},
+		{name: "empty domain denies wrong host", client: unbound, url: "https://api.credential-free.example/items", want: false},
+		{name: "env token uses spec https host", client: envTok, url: "https://api.auth.example.com/items", want: true},
+		{name: "env token denies http", client: envTok, url: "http://api.auth.example.com/items", want: false},
+		{name: "env token denies wrong host", client: envTok, url: "https://api.credential-free.example/items", want: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := c.credentialAppliesToURL(tc.url); got != tc.want {
+			if got := tc.client.credentialAppliesToURL(tc.url); got != tc.want {
 				t.Fatalf("credentialAppliesToURL(%q) = %v, want %v", tc.url, got, tc.want)
 			}
 		})
 	}
 	t.Setenv("PRINTING_PRESS_VERIFY", "1")
 	t.Setenv("PRINTING_PRESS_VERIFY_LIVE_HTTP", "1")
-	if !c.credentialAppliesToURL("http://127.0.0.1:12345/items") {
+	if !bound.credentialAppliesToURL("http://127.0.0.1:12345/items") {
 		t.Fatal("verified live HTTP must preserve mock-host credential behavior")
 	}
-	if c.credentialAppliesToURL("https://api.credential-free.example/items") {
+	if bound.credentialAppliesToURL("https://api.credential-free.example/items") {
 		t.Fatal("verify-live HTTP must not bypass matching for real targets")
 	}
 }
@@ -176,9 +197,12 @@ func TestCookieOverrideDoesNotInheritPersistedBrowserJar(t *testing.T) {
 	if len(cookies) != 1 || cookies[0].Value != "env" {
 		t.Fatalf("env cookie override inherited a persisted browser jar: %v", cookies)
 	}
-	cfg.AuthSource = "env:CREDENTIALDOMAIN_SESSION"
-	if !client.credentialAppliesToURL("https://api.credential-free.example/items") {
-		t.Fatal("environment override inherited a stale browser domain binding")
+	if client.credentialAppliesToURL("https://api.credential-free.example/items") {
+		t.Fatal("environment override must stay bound to the https canonical host")
+	}
+	httpTarget, _ := url.Parse("http://api.auth.example.com/items")
+	if cs := client.HTTPClient.Jar.Cookies(httpTarget); len(cs) != 0 {
+		t.Fatalf("env cookie override leaked to http://: %v", cs)
 	}
 }
 
@@ -194,7 +218,7 @@ func TestCookieOverrideRotatesInMemoryWithoutPersisting(t *testing.T) {
 	}
 
 	requests := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
 		want := "session_id=env"
 		if requests == 2 {
@@ -204,20 +228,26 @@ func TestCookieOverrideRotatesInMemoryWithoutPersisting(t *testing.T) {
 			t.Errorf("request %d Cookie = %q, want %q", requests, got, want)
 		}
 		if requests == 1 {
-			http.SetCookie(w, &http.Cookie{Name: "session_id", Value: "rotated", Path: "/"})
+			http.SetCookie(w, &http.Cookie{Name: "session_id", Value: "rotated", Path: "/", Secure: true, Domain: "auth.example.com"})
 		}
 	}))
 	defer server.Close()
 
 	cfg := &config.Config{
-		BaseURL:          server.URL,
+		BaseURL:          "https://api.auth.example.com",
 		AccessToken:      "session_id=env",
 		AuthSource:       "env:CREDENTIALDOMAIN_SESSION",
 		CredentialSource: "env:CREDENTIALDOMAIN_SESSION",
 	}
 	client := New(cfg, time.Second, 0)
+	client.HTTPClient.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, network, server.Listener.Addr().String())
+		},
+	}
 	for i := 0; i < 2; i++ {
-		resp, err := client.HTTPClient.Get(server.URL + "/rotate")
+		resp, err := client.HTTPClient.Get("https://api.auth.example.com/rotate")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -234,8 +264,100 @@ func TestCookieOverrideRotatesInMemoryWithoutPersisting(t *testing.T) {
 		t.Fatalf("override response cookie changed persisted browser jar: before=%s after=%s", before, after)
 	}
 }
+
+func TestEnvCookieBindsToCanonicalHTTPSHost(t *testing.T) {
+	cfg := &config.Config{
+		BaseURL:          "http://evil.example.net",
+		AccessToken:      "session_id=env",
+		AuthSource:       "env:CREDENTIALDOMAIN_SESSION",
+		CredentialSource: "env:CREDENTIALDOMAIN_SESSION",
+	}
+	client := New(cfg, time.Second, 0)
+	good, _ := url.Parse("https://api.auth.example.com/items")
+	if cs := client.HTTPClient.Jar.Cookies(good); len(cs) != 1 || cs[0].Value != "env" {
+		t.Fatalf("env cookie was not bound to the https canonical host: %v", cs)
+	}
+	httpCanon, _ := url.Parse("http://api.auth.example.com/items")
+	if cs := client.HTTPClient.Jar.Cookies(httpCanon); len(cs) != 0 {
+		t.Fatalf("env cookie leaked to http://: %v", cs)
+	}
+	evil, _ := url.Parse("https://evil.example.net/items")
+	if cs := client.HTTPClient.Jar.Cookies(evil); len(cs) != 0 {
+		t.Fatalf("env cookie leaked to a wrong host: %v", cs)
+	}
+	if !client.credentialAppliesToURL(good.String()) {
+		t.Fatal("env token must apply to the https canonical host")
+	}
+	if client.credentialAppliesToURL(httpCanon.String()) || client.credentialAppliesToURL(evil.String()) {
+		t.Fatal("env token must not apply to http:// or a wrong host")
+	}
+}
+
+func TestSetTokenCredentialBindsToCanonicalHTTPSHost(t *testing.T) {
+	const jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzZXR0b2tlbiIsIm5hbWUiOiJwcC10ZXN0IiwiaWF0IjoxNTE2MjM5MDIyfQ.extra-padding-to-satisfy-the-one-hundred-fifty-character-jwt-shape-gate"
+	cfg := &config.Config{
+		BaseURL:          "https://api.auth.example.com",
+		AuthHeaderVal:    "",
+		AccessToken:      jwt,
+		CredentialDomain: "",
+	}
+	client := New(cfg, time.Second, 0)
+	if !client.credentialAppliesToURL("https://login.auth.example.com/session") {
+		t.Fatal("set-token must bind to the https canonical host")
+	}
+	if client.credentialAppliesToURL("http://login.auth.example.com/session") {
+		t.Fatal("set-token must not send Authorization over http://")
+	}
+	if client.credentialAppliesToURL("https://api.credential-free.example/items") {
+		t.Fatal("set-token must not send Authorization to a wrong host")
+	}
+}
+
+func TestConfigHeadersCannotPunchThroughDeniedHost(t *testing.T) {
+	var gotAuth, gotCookie, gotExtra, gotKeep string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotCookie = r.Header.Get("Cookie")
+		gotExtra = r.Header.Get("X-Extra")
+		gotKeep = r.Header.Get("X-API-Version")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(` + "`" + `{"ok":true}` + "`" + `))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		BaseURL:          server.URL,
+		AuthHeaderVal:    "Bearer primary",
+		AccessToken:      "session_id=env",
+		AuthSource:       "env:CREDENTIALDOMAIN_SESSION",
+		CredentialSource: "env:CREDENTIALDOMAIN_SESSION",
+		Headers: map[string]string{
+			"Authorization": "Bearer punched",
+			"Cookie":        "session_id=punched",
+			"X-Extra":       "additional",
+			"X-API-Version": "keep-me",
+		},
+	}
+	client := New(cfg, time.Second, 0)
+	client.NoCache = true
+	if _, err := client.Get(context.Background(), "/items", nil); err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if gotAuth != "" {
+		t.Fatalf("Authorization reached a denied host: %q", gotAuth)
+	}
+	if gotCookie != "" {
+		t.Fatalf("Cookie reached a denied host: %q", gotCookie)
+	}
+	if gotExtra != "" {
+		t.Fatalf("additional auth header reached a denied host: %q", gotExtra)
+	}
+	if gotKeep != "keep-me" {
+		t.Fatalf("non-credential header = %q, want keep-me", gotKeep)
+	}
+}
 `
 	runtimePath := filepath.Join(outputDir, "internal", "client", "credential_domain_runtime_test.go")
 	require.NoError(t, os.WriteFile(runtimePath, []byte(runtimeTest), 0o600))
-	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^Test(CredentialAppliesToURL|CookieOverrideDoesNotInheritPersistedBrowserJar|CookieOverrideRotatesInMemoryWithoutPersisting)$", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^Test(CredentialAppliesToURL|CookieOverrideDoesNotInheritPersistedBrowserJar|CookieOverrideRotatesInMemoryWithoutPersisting|EnvCookieBindsToCanonicalHTTPSHost|SetTokenCredentialBindsToCanonicalHTTPSHost|ConfigHeadersCannotPunchThroughDeniedHost)$", "-count=1")
 }

--- a/internal/generator/client_credential_domain_test.go
+++ b/internal/generator/client_credential_domain_test.go
@@ -71,10 +71,12 @@ func TestGeneratedBrowserCredentialBindsToCapturedDomain(t *testing.T) {
 		"config Headers must not restore Authorization or Cookie after a deny")
 	assert.Contains(t, clientSrc, "req.URL.Host == via[0].URL.Host && c.credentialAppliesToURL(req.URL.String())",
 		"same-host redirect re-stamping must retain the credential-domain gate")
-	assert.Contains(t, clientSrc, "publicsuffix.EffectiveTLDPlusOne",
-		"credential matching must use registrable domains")
-	assert.Contains(t, goMod, "golang.org/x/net v0.55.0",
-		"browser-session clients must declare the publicsuffix dependency")
+	assert.NotContains(t, clientSrc, "publicsuffix.EffectiveTLDPlusOne",
+		"credential matching must not authorize eTLD+1 siblings of the canonical host")
+	assert.NotContains(t, clientSrc, "golang.org/x/net/publicsuffix",
+		"credential binding must not import publicsuffix")
+	assert.NotContains(t, goMod, "golang.org/x/net v0.55.0",
+		"cookie binding must not pull x/net just for host matching")
 
 	// The negative path must remain unchanged for ordinary token auth: it has
 	// no capture-time domain to bind and should not gain browser-only baggage.
@@ -115,6 +117,7 @@ import (
 
 func TestCredentialAppliesToURL(t *testing.T) {
 	bound := &Client{Config: &config.Config{CredentialDomain: ".auth.example.com"}}
+	hostSpecific := &Client{Config: &config.Config{CredentialDomain: ".app.example.com"}}
 	unbound := &Client{Config: &config.Config{}}
 	envTok := &Client{Config: &config.Config{AuthSource: "env:CREDENTIALDOMAIN_SESSION"}}
 	for _, tc := range []struct {
@@ -124,15 +127,22 @@ func TestCredentialAppliesToURL(t *testing.T) {
 		want   bool
 	}{
 		{name: "captured host", client: bound, url: "https://login.auth.example.com/session", want: true},
-		{name: "same registrable domain", client: bound, url: "https://api.auth.example.com/items", want: true},
+		{name: "canonical subdomain", client: bound, url: "https://api.auth.example.com/items", want: true},
+		{name: "sibling eTLD+1 host", client: bound, url: "https://api.example.com/items", want: false},
+		{name: "sibling other.example.com", client: bound, url: "https://other.example.com/items", want: false},
+		{name: "host-specific exact", client: hostSpecific, url: "https://app.example.com/session", want: true},
+		{name: "host-specific subdomain", client: hostSpecific, url: "https://login.app.example.com/session", want: true},
+		{name: "host-specific sibling", client: hostSpecific, url: "https://api.example.com/items", want: false},
 		{name: "http canonical host", client: bound, url: "http://login.auth.example.com/session", want: false},
 		{name: "credential-free host", client: bound, url: "https://api.credential-free.example/items", want: false},
 		{name: "empty domain uses spec https host", client: unbound, url: "https://login.auth.example.com/session", want: true},
 		{name: "empty domain denies http", client: unbound, url: "http://login.auth.example.com/session", want: false},
 		{name: "empty domain denies wrong host", client: unbound, url: "https://api.credential-free.example/items", want: false},
+		{name: "empty domain denies sibling eTLD+1", client: unbound, url: "https://api.example.com/items", want: false},
 		{name: "env token uses spec https host", client: envTok, url: "https://api.auth.example.com/items", want: true},
 		{name: "env token denies http", client: envTok, url: "http://api.auth.example.com/items", want: false},
 		{name: "env token denies wrong host", client: envTok, url: "https://api.credential-free.example/items", want: false},
+		{name: "env token denies sibling eTLD+1", client: envTok, url: "https://api.example.com/items", want: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := tc.client.credentialAppliesToURL(tc.url); got != tc.want {
@@ -310,6 +320,9 @@ func TestSetTokenCredentialBindsToCanonicalHTTPSHost(t *testing.T) {
 	}
 	if client.credentialAppliesToURL("https://api.credential-free.example/items") {
 		t.Fatal("set-token must not send Authorization to a wrong host")
+	}
+	if client.credentialAppliesToURL("https://api.example.com/items") {
+		t.Fatal("set-token must not send Authorization to an eTLD+1 sibling")
 	}
 }
 

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -659,15 +659,19 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	if cfg != nil && !cfg.UsePersistedCookieJar() {
 		cookieJar = NewCookieJar()
 	}
-	// Seed the jar from a session captured via the env var or stored in
-	// credentials but not yet in cookies.json, so the credential rides every
-	// request and net/http absorbs Set-Cookie rotation across the session.
+	// Seed the jar from a session captured via the env var, set-token, or
+	// credentials file so the credential rides https requests to the
+	// canonical host. Always seed against that host — never cfg.BaseURL —
+	// so an env override or http:// / wrong-host BaseURL cannot attach the
+	// session to an untrusted origin.
 	if cfg != nil {
-		if cfg.CredentialDomain != "" && cfg.UsePersistedCookieJar() {
-			seedBaseURL := "https://" + strings.TrimPrefix(cfg.CredentialDomain, ".")
-			SeedCookieJarForDomain(cookieJar, seedBaseURL, cfg.CookieCredential(), cfg.CredentialDomain)
-		} else {
-			SeedCookieJar(cookieJar, cfg.BaseURL, cfg.CookieCredential())
+		seedDomain := strings.TrimSpace(cfg.CredentialDomain)
+		if seedDomain == "" {
+			seedDomain = canonicalCredentialDomain
+		}
+		if seedDomain != "" {
+			seedBaseURL := "https://" + strings.TrimPrefix(seedDomain, ".")
+			SeedCookieJarForDomain(cookieJar, seedBaseURL, cfg.CookieCredential(), seedDomain)
 		}
 	}
 {{- end}}
@@ -2049,11 +2053,21 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 {{- end}}
 		if c.Config != nil {
 			for k, v := range c.Config.Headers {
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+				if !credentialAllowed && isCredentialHeader(k) {
+					continue
+				}
+{{- end}}
 				req.Header.Set(k, v)
 			}
 		}
 		// Per-endpoint header overrides (e.g., different API version per resource)
 		for k, v := range headerOverrides {
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+			if !credentialAllowed && isCredentialHeader(k) {
+				continue
+			}
+{{- end}}
 			req.Header.Set(k, v)
 		}
 		binaryResponse := strings.EqualFold(req.Header.Get(BinaryResponseHeader), "true")
@@ -3011,12 +3025,20 @@ func isAbsoluteURL(path string) bool {
 
 {{end -}}
 {{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
-// credentialAppliesToURL keeps a browser-captured credential on its own
-// registrable domain. An empty binding preserves legacy credentials and
-// explicit verify-live HTTP uses mock hosts that cannot match the real site.
+// canonicalCredentialDomain is the spec's cookie_domain (or the base_url
+// host derived at generate time). Env, set-token, and credentials-file
+// tokens all bind to this https host even when Config.CredentialDomain is
+// empty.
+const canonicalCredentialDomain = {{printf "%q" .Auth.CookieDomain}}
+
+// credentialAppliesToURL keeps a cookie or Authorization credential on the
+// https canonical host. Env and set-token clear Config.CredentialDomain so
+// they do not inherit a persisted browser jar; the spec domain still binds
+// those tokens. Verify-live HTTP is the only fail-open, and only for mock
+// loopback hosts.
 func (c *Client) credentialAppliesToURL(rawURL string) bool {
-	if c == nil || c.Config == nil || !c.Config.UsePersistedCookieJar() || strings.TrimSpace(c.Config.CredentialDomain) == "" {
-		return true
+	if c == nil || c.Config == nil {
+		return false
 	}
 	if cliutil.IsVerifyEnv() && cliutil.IsVerifyLiveHTTPEnv() && isVerifyMockURL(rawURL) {
 		return true
@@ -3025,14 +3047,52 @@ func (c *Client) credentialAppliesToURL(rawURL string) bool {
 	if err != nil || target.Hostname() == "" {
 		return false
 	}
+	if !strings.EqualFold(target.Scheme, "https") {
+		return false
+	}
+	boundHost := credentialBoundHost(c.Config.CredentialDomain)
+	if boundHost == "" {
+		return false
+	}
 	targetHost := strings.ToLower(strings.TrimSuffix(target.Hostname(), "."))
-	boundHost := strings.ToLower(strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(c.Config.CredentialDomain), "."), "."))
 	if targetHost == boundHost || strings.HasSuffix(targetHost, "."+boundHost) {
 		return true
 	}
 	targetRegistered, targetErr := publicsuffix.EffectiveTLDPlusOne(targetHost)
 	boundRegistered, boundErr := publicsuffix.EffectiveTLDPlusOne(boundHost)
 	return targetErr == nil && boundErr == nil && targetRegistered == boundRegistered
+}
+
+func credentialBoundHost(configDomain string) string {
+	d := strings.TrimSpace(configDomain)
+	if d == "" {
+		d = canonicalCredentialDomain
+	}
+	return strings.ToLower(strings.TrimSuffix(strings.TrimPrefix(d, "."), "."))
+}
+
+func isCredentialHeader(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	switch name {
+	case "authorization", "cookie", "proxy-authorization":
+		return true
+	}
+{{- if .Auth.Header}}
+{{- $authHeader := lower .Auth.Header}}
+{{- if and (ne $authHeader "authorization") (ne $authHeader "cookie") (ne $authHeader "proxy-authorization")}}
+	if name == {{printf "%q" $authHeader}} {
+		return true
+	}
+{{- end}}
+{{- end}}
+{{- range .Auth.AdditionalHeaders}}
+{{- if eq .In "header"}}
+	if name == {{printf "%q" (lower .Header)}} {
+		return true
+	}
+{{- end}}
+{{- end}}
+	return false
 }
 
 func isVerifyMockURL(rawURL string) bool {

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -36,9 +36,6 @@ import (
 {{- if eq .Auth.Subtype "google_service_account"}}
 	"golang.org/x/oauth2/google"
 {{- end}}
-{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
-	"golang.org/x/net/publicsuffix"
-{{- end}}
 {{- if .UsesBrowserHTTPTransport}}
 	enetxhttp "github.com/enetx/http"
 	"github.com/enetx/surf"
@@ -3055,12 +3052,7 @@ func (c *Client) credentialAppliesToURL(rawURL string) bool {
 		return false
 	}
 	targetHost := strings.ToLower(strings.TrimSuffix(target.Hostname(), "."))
-	if targetHost == boundHost || strings.HasSuffix(targetHost, "."+boundHost) {
-		return true
-	}
-	targetRegistered, targetErr := publicsuffix.EffectiveTLDPlusOne(targetHost)
-	boundRegistered, boundErr := publicsuffix.EffectiveTLDPlusOne(boundHost)
-	return targetErr == nil && boundErr == nil && targetRegistered == boundRegistered
+	return targetHost == boundHost || strings.HasSuffix(targetHost, "."+boundHost)
 }
 
 func credentialBoundHost(configDomain string) string {

--- a/internal/generator/templates/cookiejar.go.tmpl
+++ b/internal/generator/templates/cookiejar.go.tmpl
@@ -5,6 +5,7 @@ package client
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -149,15 +150,15 @@ func parseCookieJar(s string) []*http.Cookie {
 }
 
 // SeedCookieJar seeds jar with the cookies in a Cookie-header-style credential
-// string scoped to baseURL's host, so a session captured via the env var or
-// stored in credentials (not the on-disk cookies.json) still rides every
-// request. Seeding the jar (rather than setting a static Cookie header) lets
+// string scoped to the spec's canonical cookie domain, so a session captured
+// via the env var, set-token, or credentials file still rides requests to that
+// https host. Seeding the jar (rather than setting a static Cookie header) lets
 // net/http absorb Set-Cookie rotation — Cloudflare __cf_bm, AWS ALB AWSALB —
 // across a multi-request session that a static header would let go stale.
-// A no-op when the credential is empty, is not a cookie-jar string, or baseURL
-// does not parse.
+// A no-op when the credential is empty, is not a cookie-jar string, or
+// baseURL is not an https host on the canonical cookie domain.
 func SeedCookieJar(jar http.CookieJar, baseURL, cookieStr string) {
-	seedCookieJar(jar, baseURL, cookieStr, "")
+	seedCookieJar(jar, baseURL, cookieStr, {{printf "%q" .Auth.CookieDomain}})
 }
 
 // SeedCookieJarForDomain seeds a captured cookie session for the captured
@@ -171,18 +172,25 @@ func seedCookieJar(jar http.CookieJar, baseURL, cookieStr, cookieDomain string) 
 	if jar == nil || !looksLikeCookieJar(cookieStr) {
 		return
 	}
+	cookieDomain = strings.TrimPrefix(strings.TrimSpace(cookieDomain), ".")
+	if cookieDomain == "" {
+		return
+	}
 	u, err := url.Parse(baseURL)
-	if err != nil || u.Host == "" {
+	if err != nil || u.Hostname() == "" {
+		return
+	}
+	if !strings.EqualFold(u.Scheme, "https") || !seedHostMatchesDomain(u.Hostname(), cookieDomain) {
+		fmt.Fprintf(os.Stderr, "warning: base URL %q is not an https %s host — not sending your session cookie to it\n", baseURL, cookieDomain)
 		return
 	}
 	cookies := parseCookieJar(cookieStr)
 	if len(cookies) == 0 {
 		return
 	}
-	if cookieDomain != "" {
-		for _, cookie := range cookies {
-			cookie.Domain = cookieDomain
-		}
+	for _, cookie := range cookies {
+		cookie.Domain = cookieDomain
+		cookie.Secure = true
 	}
 	// Seed the in-memory jar only — never persist. The wrapper's SetCookies
 	// writes through to cookies.json (persistLocked -> mergeAndWriteCookieRows),
@@ -195,6 +203,15 @@ func seedCookieJar(jar http.CookieJar, baseURL, cookieStr, cookieDomain string) 
 		return
 	}
 	jar.SetCookies(u, cookies)
+}
+
+func seedHostMatchesDomain(host, domain string) bool {
+	host = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+	domain = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(domain), "."))
+	if host == "" || domain == "" {
+		return false
+	}
+	return host == domain || strings.HasSuffix(host, "."+domain)
 }
 
 // sanitizeCookieValue strips bytes that net/http's cookie jar rejects per

--- a/internal/generator/templates/go.mod.tmpl
+++ b/internal/generator/templates/go.mod.tmpl
@@ -21,7 +21,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/pelletier/go-toml/v2 v2.2.4
-{{- if or .HasHTMLExtraction (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+{{- if .HasHTMLExtraction}}
 	golang.org/x/net v0.55.0
 {{- end}}
 )

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/pelletier/go-toml/v2 v2.2.4
-	golang.org/x/net v0.55.0
 )
 require modernc.org/sqlite v1.37.0
 require github.com/mark3labs/mcp-go v0.57.0

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -289,15 +289,19 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	if cfg != nil && !cfg.UsePersistedCookieJar() {
 		cookieJar = NewCookieJar()
 	}
-	// Seed the jar from a session captured via the env var or stored in
-	// credentials but not yet in cookies.json, so the credential rides every
-	// request and net/http absorbs Set-Cookie rotation across the session.
+	// Seed the jar from a session captured via the env var, set-token, or
+	// credentials file so the credential rides https requests to the
+	// canonical host. Always seed against that host — never cfg.BaseURL —
+	// so an env override or http:// / wrong-host BaseURL cannot attach the
+	// session to an untrusted origin.
 	if cfg != nil {
-		if cfg.CredentialDomain != "" && cfg.UsePersistedCookieJar() {
-			seedBaseURL := "https://" + strings.TrimPrefix(cfg.CredentialDomain, ".")
-			SeedCookieJarForDomain(cookieJar, seedBaseURL, cfg.CookieCredential(), cfg.CredentialDomain)
-		} else {
-			SeedCookieJar(cookieJar, cfg.BaseURL, cfg.CookieCredential())
+		seedDomain := strings.TrimSpace(cfg.CredentialDomain)
+		if seedDomain == "" {
+			seedDomain = canonicalCredentialDomain
+		}
+		if seedDomain != "" {
+			seedBaseURL := "https://" + strings.TrimPrefix(seedDomain, ".")
+			SeedCookieJarForDomain(cookieJar, seedBaseURL, cfg.CookieCredential(), seedDomain)
 		}
 	}
 	httpClient := newHTTPClient(timeout, cookieJar)
@@ -1000,11 +1004,17 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		}
 		if c.Config != nil {
 			for k, v := range c.Config.Headers {
+				if !credentialAllowed && isCredentialHeader(k) {
+					continue
+				}
 				req.Header.Set(k, v)
 			}
 		}
 		// Per-endpoint header overrides (e.g., different API version per resource)
 		for k, v := range headerOverrides {
+			if !credentialAllowed && isCredentialHeader(k) {
+				continue
+			}
 			req.Header.Set(k, v)
 		}
 		binaryResponse := strings.EqualFold(req.Header.Get(BinaryResponseHeader), "true")
@@ -1313,12 +1323,20 @@ func authPlaceholderCredentialErrorWithSetup(cfg *config.Config, setup string) e
 	return fmt.Errorf("%w configured in %s; set a real token with: %s", ErrPlaceholderCredential, location, setup)
 }
 
-// credentialAppliesToURL keeps a browser-captured credential on its own
-// registrable domain. An empty binding preserves legacy credentials and
-// explicit verify-live HTTP uses mock hosts that cannot match the real site.
+// canonicalCredentialDomain is the spec's cookie_domain (or the base_url
+// host derived at generate time). Env, set-token, and credentials-file
+// tokens all bind to this https host even when Config.CredentialDomain is
+// empty.
+const canonicalCredentialDomain = ".cookie-auth.example"
+
+// credentialAppliesToURL keeps a cookie or Authorization credential on the
+// https canonical host. Env and set-token clear Config.CredentialDomain so
+// they do not inherit a persisted browser jar; the spec domain still binds
+// those tokens. Verify-live HTTP is the only fail-open, and only for mock
+// loopback hosts.
 func (c *Client) credentialAppliesToURL(rawURL string) bool {
-	if c == nil || c.Config == nil || !c.Config.UsePersistedCookieJar() || strings.TrimSpace(c.Config.CredentialDomain) == "" {
-		return true
+	if c == nil || c.Config == nil {
+		return false
 	}
 	if cliutil.IsVerifyEnv() && cliutil.IsVerifyLiveHTTPEnv() && isVerifyMockURL(rawURL) {
 		return true
@@ -1327,14 +1345,37 @@ func (c *Client) credentialAppliesToURL(rawURL string) bool {
 	if err != nil || target.Hostname() == "" {
 		return false
 	}
+	if !strings.EqualFold(target.Scheme, "https") {
+		return false
+	}
+	boundHost := credentialBoundHost(c.Config.CredentialDomain)
+	if boundHost == "" {
+		return false
+	}
 	targetHost := strings.ToLower(strings.TrimSuffix(target.Hostname(), "."))
-	boundHost := strings.ToLower(strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(c.Config.CredentialDomain), "."), "."))
 	if targetHost == boundHost || strings.HasSuffix(targetHost, "."+boundHost) {
 		return true
 	}
 	targetRegistered, targetErr := publicsuffix.EffectiveTLDPlusOne(targetHost)
 	boundRegistered, boundErr := publicsuffix.EffectiveTLDPlusOne(boundHost)
 	return targetErr == nil && boundErr == nil && targetRegistered == boundRegistered
+}
+
+func credentialBoundHost(configDomain string) string {
+	d := strings.TrimSpace(configDomain)
+	if d == "" {
+		d = canonicalCredentialDomain
+	}
+	return strings.ToLower(strings.TrimSuffix(strings.TrimPrefix(d, "."), "."))
+}
+
+func isCredentialHeader(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	switch name {
+	case "authorization", "cookie", "proxy-authorization":
+		return true
+	}
+	return false
 }
 
 func isVerifyMockURL(rawURL string) bool {

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"golang.org/x/net/publicsuffix"
 	"golden-api-cookie-auth-pp-cli/internal/cliutil"
 	"golden-api-cookie-auth-pp-cli/internal/config"
 	"golden-api-cookie-auth-pp-cli/internal/platform"
@@ -1353,12 +1352,7 @@ func (c *Client) credentialAppliesToURL(rawURL string) bool {
 		return false
 	}
 	targetHost := strings.ToLower(strings.TrimSuffix(target.Hostname(), "."))
-	if targetHost == boundHost || strings.HasSuffix(targetHost, "."+boundHost) {
-		return true
-	}
-	targetRegistered, targetErr := publicsuffix.EffectiveTLDPlusOne(targetHost)
-	boundRegistered, boundErr := publicsuffix.EffectiveTLDPlusOne(boundHost)
-	return targetErr == nil && boundErr == nil && targetRegistered == boundRegistered
+	return targetHost == boundHost || strings.HasSuffix(targetHost, "."+boundHost)
 }
 
 func credentialBoundHost(configDomain string) string {

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/cookiejar.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/cookiejar.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -149,15 +150,15 @@ func parseCookieJar(s string) []*http.Cookie {
 }
 
 // SeedCookieJar seeds jar with the cookies in a Cookie-header-style credential
-// string scoped to baseURL's host, so a session captured via the env var or
-// stored in credentials (not the on-disk cookies.json) still rides every
-// request. Seeding the jar (rather than setting a static Cookie header) lets
+// string scoped to the spec's canonical cookie domain, so a session captured
+// via the env var, set-token, or credentials file still rides requests to that
+// https host. Seeding the jar (rather than setting a static Cookie header) lets
 // net/http absorb Set-Cookie rotation — Cloudflare __cf_bm, AWS ALB AWSALB —
 // across a multi-request session that a static header would let go stale.
-// A no-op when the credential is empty, is not a cookie-jar string, or baseURL
-// does not parse.
+// A no-op when the credential is empty, is not a cookie-jar string, or
+// baseURL is not an https host on the canonical cookie domain.
 func SeedCookieJar(jar http.CookieJar, baseURL, cookieStr string) {
-	seedCookieJar(jar, baseURL, cookieStr, "")
+	seedCookieJar(jar, baseURL, cookieStr, ".cookie-auth.example")
 }
 
 // SeedCookieJarForDomain seeds a captured cookie session for the captured
@@ -171,18 +172,25 @@ func seedCookieJar(jar http.CookieJar, baseURL, cookieStr, cookieDomain string) 
 	if jar == nil || !looksLikeCookieJar(cookieStr) {
 		return
 	}
+	cookieDomain = strings.TrimPrefix(strings.TrimSpace(cookieDomain), ".")
+	if cookieDomain == "" {
+		return
+	}
 	u, err := url.Parse(baseURL)
-	if err != nil || u.Host == "" {
+	if err != nil || u.Hostname() == "" {
+		return
+	}
+	if !strings.EqualFold(u.Scheme, "https") || !seedHostMatchesDomain(u.Hostname(), cookieDomain) {
+		fmt.Fprintf(os.Stderr, "warning: base URL %q is not an https %s host — not sending your session cookie to it\n", baseURL, cookieDomain)
 		return
 	}
 	cookies := parseCookieJar(cookieStr)
 	if len(cookies) == 0 {
 		return
 	}
-	if cookieDomain != "" {
-		for _, cookie := range cookies {
-			cookie.Domain = cookieDomain
-		}
+	for _, cookie := range cookies {
+		cookie.Domain = cookieDomain
+		cookie.Secure = true
 	}
 	// Seed the in-memory jar only — never persist. The wrapper's SetCookies
 	// writes through to cookies.json (persistLocked -> mergeAndWriteCookieRows),
@@ -195,6 +203,15 @@ func seedCookieJar(jar http.CookieJar, baseURL, cookieStr, cookieDomain string) 
 		return
 	}
 	jar.SetCookies(u, cookies)
+}
+
+func seedHostMatchesDomain(host, domain string) bool {
+	host = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+	domain = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(domain), "."))
+	if host == "" || domain == "" {
+		return false
+	}
+	return host == domain || strings.HasSuffix(host, "."+domain)
 }
 
 // sanitizeCookieValue strips bytes that net/http's cookie jar rejects per


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cookie and Authorization credentials were only host-bound when they came from a credentials-file Chrome capture. Env tokens and `auth set-token` cleared `CredentialDomain`, `credentialAppliesToURL` fail-opened, `SeedCookieJar` accepted any host/scheme (including `http://`), and `cfg.Headers` could write `Authorization`/`Cookie` after a deny.

This binds every token source to the spec `cookie_domain` over HTTPS:

- `New()` always seeds the jar at `https://` plus the canonical host, never `cfg.BaseURL`
- `SeedCookieJar` refuses non-https and off-domain URLs, marks seeded cookies `Secure`, and warns instead of attaching
- `credentialAppliesToURL` uses the spec domain when `CredentialDomain` is empty, requires `https`, and no longer fail-opens for env/set-token
- Matching is host-or-subdomain only: sibling hosts on the same eTLD+1 do not receive credentials
- Denied requests drop credential-bearing keys from `cfg.Headers` and per-call header overrides

Bearer/api_key clients are unchanged. Does not include #4283 SaveTokens, #4281 python -c, or #4252 HTML envelope.

Generated-output proof: compiled cookie and composed clients assert env and set-token cookies stay on the https canonical host, `http://`, wrong-host, and eTLD+1 siblings get nothing, and `Authorization`/`Cookie` in `[headers]` cannot punch through a deny.

Closes #4284
Closes #4285

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65dc81e5-7a02-468f-b633-9ff8e9a9e4aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65dc81e5-7a02-468f-b633-9ff8e9a9e4aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

