### PR TITLE
fix(verifier): probe sync capabilities before bounding pages

### DIFF
--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -655,11 +655,13 @@ func runDataPipelineTest(binary, cliDir, mode string, envFn func() []string, exp
 	dbPath := filepath.Join(tmpDir, "test.db")
 	env = append(env, "HOME="+tmpDir) // so sync uses temp location
 
-	// Test sync (if it exists)
-	// Discover whether live sync supports pagination before adding the
-	// bounding flag; some CLIs expose a complete, non-paginated sync.
+	// Test sync (if it exists). Discover whether live sync supports pagination
+	// once before trying fallback command shapes; probing --help for every
+	// attempt can be slow and can produce inconsistent answers on a transient
+	// CLI failure.
+	maxPagesSupported := mode == "live" && syncSupportsFlag(binary, env, "--max-pages")
 	syncArgs := func(args []string) []string {
-		return boundedSyncProbeArgs(binary, env, mode, args)
+		return boundedSyncProbeArgs(maxPagesSupported, mode, args)
 	}
 	var syncErrors []error
 	syncErr := runCLI(binary, syncArgs([]string{"sync", "--db", dbPath, "--resources", "repos", "--full"}), env, 30*time.Second)
@@ -759,8 +761,8 @@ func runDataPipelineTest(binary, cliDir, mode string, envFn func() []string, exp
 	return false, fmt.Sprintf("FAIL: %d domain tables created but 0 rows after sync (%s mode)", len(tables), mode)
 }
 
-func boundedSyncProbeArgs(binary string, env []string, mode string, args []string) []string {
-	if mode != "live" || !syncSupportsFlag(binary, env, "--max-pages") {
+func boundedSyncProbeArgs(maxPagesSupported bool, mode string, args []string) []string {
+	if mode != "live" || !maxPagesSupported {
 		return args
 	}
 	bounded := append([]string(nil), args...)

--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -656,27 +656,32 @@ func runDataPipelineTest(binary, cliDir, mode string, envFn func() []string, exp
 	env = append(env, "HOME="+tmpDir) // so sync uses temp location
 
 	// Test sync (if it exists)
+	// Discover whether live sync supports pagination before adding the
+	// bounding flag; some CLIs expose a complete, non-paginated sync.
+	syncArgs := func(args []string) []string {
+		return boundedSyncProbeArgs(binary, env, mode, args)
+	}
 	var syncErrors []error
-	syncErr := runCLI(binary, boundedSyncProbeArgs(mode, []string{"sync", "--db", dbPath, "--resources", "repos", "--full"}), env, 30*time.Second)
+	syncErr := runCLI(binary, syncArgs([]string{"sync", "--db", dbPath, "--resources", "repos", "--full"}), env, 30*time.Second)
 	if syncErr != nil {
 		syncErrors = append(syncErrors, syncErr)
-		syncErr = runCLI(binary, boundedSyncProbeArgs(mode, []string{"sync", "--db", dbPath, "--full"}), env, 30*time.Second)
+		syncErr = runCLI(binary, syncArgs([]string{"sync", "--db", dbPath, "--full"}), env, 30*time.Second)
 	}
 	if syncErr != nil {
 		syncErrors = append(syncErrors, syncErr)
 		// Sync might not accept --resources or --full; keep --db when
 		// possible so downstream sql probes read the same temporary store.
-		syncErr = runCLI(binary, boundedSyncProbeArgs(mode, []string{"sync", "--db", dbPath}), env, 30*time.Second)
+		syncErr = runCLI(binary, syncArgs([]string{"sync", "--db", dbPath}), env, 30*time.Second)
 	}
 	if syncErr != nil {
 		syncErrors = append(syncErrors, syncErr)
 		// Sync might not accept --db either; try the bare command before
 		// deciding the pipeline crashed.
-		syncErr = runCLI(binary, boundedSyncProbeArgs(mode, []string{"sync", "--full"}), env, 30*time.Second)
+		syncErr = runCLI(binary, syncArgs([]string{"sync", "--full"}), env, 30*time.Second)
 	}
 	if syncErr != nil {
 		syncErrors = append(syncErrors, syncErr)
-		syncErr = runCLI(binary, boundedSyncProbeArgs(mode, []string{"sync"}), env, 30*time.Second)
+		syncErr = runCLI(binary, syncArgs([]string{"sync"}), env, 30*time.Second)
 	}
 	if syncErr != nil {
 		syncErrors = append(syncErrors, syncErr)
@@ -754,12 +759,20 @@ func runDataPipelineTest(binary, cliDir, mode string, envFn func() []string, exp
 	return false, fmt.Sprintf("FAIL: %d domain tables created but 0 rows after sync (%s mode)", len(tables), mode)
 }
 
-func boundedSyncProbeArgs(mode string, args []string) []string {
-	if mode != "live" {
+func boundedSyncProbeArgs(binary string, env []string, mode string, args []string) []string {
+	if mode != "live" || !syncSupportsFlag(binary, env, "--max-pages") {
 		return args
 	}
 	bounded := append([]string(nil), args...)
 	return append(bounded, "--max-pages", "1")
+}
+
+func syncSupportsFlag(binary string, env []string, flag string) bool {
+	out, err := runCLIWithOutput(binary, []string{"sync", "--help"}, env, 10*time.Second)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(out), flag)
 }
 
 func allSyncAttemptsWereUnknownCommand(errs []error) bool {

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -341,6 +341,15 @@ func TestRunDataPipelineTestBoundsLiveSync(t *testing.T) {
 	assert.Contains(t, detail, "items has 1 rows")
 }
 
+func TestRunDataPipelineTestLeavesUnpaginatedLiveSyncUnmodified(t *testing.T) {
+	binary := buildLiveUnboundedSyncProbeBinary(t)
+
+	pass, detail := runDataPipelineTest(binary, "", "live", os.Environ, 1)
+
+	assert.True(t, pass)
+	assert.Contains(t, detail, "items has 1 rows")
+}
+
 func TestUnknownSyncFlagIgnoresEmptyFlagName(t *testing.T) {
 	flag, ok := unknownSyncFlag(errors.New("unknown flag: "))
 
@@ -897,6 +906,10 @@ func main() {
 	}
 	switch args[0] {
 	case "sync":
+		if len(args) > 1 && args[1] == "--help" {
+			fmt.Println("--max-pages int")
+			return
+		}
 		if !hasFlagValue(args[1:], "--max-pages", "1") {
 			fmt.Fprintln(os.Stderr, "live sync probe requires --max-pages 1")
 			os.Exit(1)
@@ -938,6 +951,83 @@ func hasFlagValue(args []string, flag, want string) bool {
 		}
 	}
 	return false
+}
+
+func dbArg(args []string) string {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--db" {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+`)
+	binaryPath := filepath.Join(dir, "test-cli")
+	buildCmd := exec.Command("go", "build", "-o", "./test-cli", mainFile)
+	buildCmd.Dir = dir
+	out, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, "building test binary: %s", string(out))
+	return binaryPath
+}
+
+func buildLiveUnboundedSyncProbeBinary(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	mainFile := filepath.Join(dir, "main.go")
+	writeTestFile(t, mainFile, `package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	args := os.Args[1:]
+	if len(args) == 0 {
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "sync":
+		if len(args) > 1 && args[1] == "--help" {
+			fmt.Println("--full")
+			return
+		}
+		for _, arg := range args[1:] {
+			if arg == "--max-pages" {
+				fmt.Fprintln(os.Stderr, "unknown flag: --max-pages")
+				os.Exit(1)
+			}
+		}
+		dbPath := dbArg(args[1:])
+		if dbPath == "" {
+			os.Exit(1)
+		}
+		if err := os.WriteFile(dbPath+".marker", []byte(dbPath), 0o644); err != nil {
+			os.Exit(1)
+		}
+		return
+	case "sql":
+		dbPath := dbArg(args[1:])
+		if dbPath == "" {
+			os.Exit(1)
+		}
+		usedDB, err := os.ReadFile(dbPath + ".marker")
+		if err != nil || string(usedDB) != dbPath {
+			os.Exit(1)
+		}
+		query := args[len(args)-1]
+		if strings.Contains(query, "sqlite_master") {
+			fmt.Println("items")
+			return
+		}
+		if strings.Contains(query, "count(*)") {
+			fmt.Println(1)
+			return
+		}
+	}
+	os.Exit(1)
 }
 
 func dbArg(args []string) string {

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	apispec "github.com/mvanhorn/cli-printing-press/v4/internal/spec"
@@ -348,6 +349,25 @@ func TestRunDataPipelineTestLeavesUnpaginatedLiveSyncUnmodified(t *testing.T) {
 
 	assert.True(t, pass)
 	assert.Contains(t, detail, "items has 1 rows")
+}
+
+func TestRunDataPipelineTestProbesLiveSyncCapabilitiesOnce(t *testing.T) {
+	binary := buildLiveBoundedSyncProbeBinary(t)
+	logPath := filepath.Join(t.TempDir(), "sync-help.log")
+	envFn := func() []string {
+		return append(os.Environ(),
+			"PP_SYNC_HELP_LOG="+logPath,
+			"PP_FORCE_SYNC_FALLBACK=1",
+		)
+	}
+
+	pass, detail := runDataPipelineTest(binary, "", "live", envFn, 1)
+
+	assert.True(t, pass)
+	assert.Contains(t, detail, "items has 1 rows")
+	contents, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(string(contents), "help\n"))
 }
 
 func TestUnknownSyncFlagIgnoresEmptyFlagName(t *testing.T) {
@@ -907,8 +927,19 @@ func main() {
 	switch args[0] {
 	case "sync":
 		if len(args) > 1 && args[1] == "--help" {
+			if logPath := os.Getenv("PP_SYNC_HELP_LOG"); logPath != "" {
+				f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+				if err == nil {
+					_, _ = f.WriteString("help\n")
+					_ = f.Close()
+				}
+			}
 			fmt.Println("--max-pages int")
 			return
+		}
+		if os.Getenv("PP_FORCE_SYNC_FALLBACK") == "1" && (hasFlag(args[1:], "--resources") || hasFlag(args[1:], "--full")) {
+			fmt.Fprintln(os.Stderr, "unsupported sync shape")
+			os.Exit(1)
 		}
 		if !hasFlagValue(args[1:], "--max-pages", "1") {
 			fmt.Fprintln(os.Stderr, "live sync probe requires --max-pages 1")
@@ -947,6 +978,15 @@ func main() {
 func hasFlagValue(args []string, flag, want string) bool {
 	for i := 0; i+1 < len(args); i++ {
 		if args[i] == flag && args[i+1] == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasFlag(args []string, flag string) bool {
+	for _, arg := range args {
+		if arg == flag {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

Make the live data-pipeline verifier probe a CLI's `sync --help` output before appending `--max-pages 1`.

## Problem

The verifier was adding `--max-pages 1` to every live sync attempt. That is safe for paginated CLIs, but it makes a complete, non-paginated sync fail with an unknown-flag error. The verifier was changing the command it was supposed to inspect.

## Fix

- Run `sync --help` once for the live probe.
- Add the page bound only when the help output advertises `--max-pages`.
- Leave mock mode and unpaginated live sync unchanged.
- Add a regression test using a harmless live-sync probe that rejects `--max-pages`.

## Verification

- Focused sync-capability tests — passed
- `GOFLAGS=-buildvcs=false go test ./internal/pipeline` — passed
- `GOFLAGS=-buildvcs=false go vet ./...` — passed
- `GOFLAGS=-buildvcs=false go build ./...` — passed
- `git diff --check` — passed

The unmodified upstream full suite also contains an existing generator expectation failure (`TestGeneratorSkipsReservedNovelFeatureRootCommands`); the verifier package and this patch's focused tests are green. The `GOFLAGS` setting only disables VCS stamping for generated temporary test binaries.
