### PR TITLE
feat(pipeline): multi-platform .mcpb bundles that actually launch (#3547 finding 2)

### DIFF
--- a/internal/pipeline/mcpb_bundle.go
+++ b/internal/pipeline/mcpb_bundle.go
@@ -117,7 +117,13 @@ func BuildMCPBBundle(params BundleParams) error {
 	if err := zw.Close(); err != nil {
 		return fmt.Errorf("finalizing bundle archive: %w", err)
 	}
-	return nil
+	// Assert the finished archive actually contains every path its manifest
+	// declares. The single-platform path writes the binary to the declared
+	// entry_point, so this is normally a tautology - but it is the cheap guard
+	// that stops a future change to either half from shipping a bundle that
+	// installs, prompts for credentials, and fails at the first tool call
+	// (mvanhorn/cli-printing-press#3547 finding 2).
+	return ValidateMCPBBundle(params.OutputPath)
 }
 
 func rewriteMCPBManifestVersion(data []byte, version string) ([]byte, error) {

--- a/internal/pipeline/mcpb_manifest.go
+++ b/internal/pipeline/mcpb_manifest.go
@@ -105,6 +105,20 @@ type MCPBLaunchSpec struct {
 	Command string            `json:"command"`
 	Args    []string          `json:"args"`
 	Env     map[string]string `json:"env,omitempty"`
+	// PlatformOverrides selects a different command per OS. The MCPB spec keys
+	// this on OS only - "darwin", "linux", "win32" - with no CPU-architecture
+	// axis and no ${arch} template variable, so a bundle carrying one binary per
+	// (os, arch) cannot be addressed by Command alone. See BuildMCPBBundle for
+	// how a multi-platform bundle keeps every declared path resolvable.
+	PlatformOverrides map[string]MCPBLaunchOverride `json:"platform_overrides,omitempty"`
+}
+
+// MCPBLaunchOverride is the per-OS half of platform_overrides. Every field is
+// optional; the host merges what is present over the base MCPConfig.
+type MCPBLaunchOverride struct {
+	Command string            `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
 }
 
 // MCPBVar is one entry in user_config — a value the host collects from the

--- a/internal/pipeline/mcpb_multiplatform.go
+++ b/internal/pipeline/mcpb_multiplatform.go
@@ -1,0 +1,406 @@
+package pipeline
+
+import (
+	"archive/zip"
+	"debug/macho"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// A multi-platform .mcpb carries one MCP binary per target and selects between
+// them with manifest platform_overrides.
+//
+// Why this exists
+// ---------------
+// BuildMCPBBundle's single-platform path writes the binary to the exact path the
+// manifest declares, so command always resolves. A consumer that instead packs
+// every released binary into one bundle - which is what you want, because a
+// .mcpb is downloaded once and installed on whatever machine the operator has -
+// has to reconcile arch-suffixed filenames with a manifest that names one
+// command. Doing that by hand is how Servosity/msp-skills shipped 64 bundles
+// whose command pointed at bin/<slug>-mcp while the archive contained only
+// bin/<slug>-mcp-darwin-arm64 and friends: Claude Desktop installs the
+// extension, prompts for credentials, and fails at the first tool call.
+// Reported upstream as mvanhorn/cli-printing-press#3547 finding 2.
+//
+// The MCPB spec keys platform_overrides on OS only - darwin, linux, win32 -
+// and defines no ${arch} template variable, so per-OS overrides alone still
+// cannot separate Intel from Apple Silicon. #3547 called for a launcher shim or
+// a universal binary. This uses a universal binary for darwin, because a shim
+// depends on the host preserving the archive's executable bit and on a shell
+// being present, and neither is guaranteed. Linux and Windows have no fat-binary
+// format, so those overrides name a single architecture and the bundle records
+// which one.
+
+// BundleBinary is one target's pair of built binaries.
+type BundleBinary struct {
+	GOOS    string
+	GOARCH  string
+	MCPPath string // required: the MCP server binary for this target
+	CLIPath string // optional: the companion CLI the MCP server shells out to
+}
+
+// mcpbOSKey maps a Go GOOS to the MCPB platform_overrides key.
+func mcpbOSKey(goos string) string {
+	if goos == "windows" {
+		return "win32"
+	}
+	return goos
+}
+
+// archiveName is the in-bundle path for one target's binary.
+func archiveName(base, goos, goarch string) string {
+	name := fmt.Sprintf("bin/%s-%s-%s", base, goos, goarch)
+	if goos == "windows" {
+		name += ".exe"
+	}
+	return name
+}
+
+// preferredArch picks the architecture an OS override should name when the OS
+// has no fat-binary format. amd64 first: it is the broadest target, and Windows
+// on ARM runs x64 under emulation while the reverse is not true.
+var preferredArch = []string{"amd64", "arm64", "386", "arm"}
+
+func pickTarget(targets []BundleBinary, goos string) (BundleBinary, bool) {
+	for _, want := range preferredArch {
+		for _, t := range targets {
+			if t.GOOS == goos && t.GOARCH == want {
+				return t, true
+			}
+		}
+	}
+	for _, t := range targets {
+		if t.GOOS == goos {
+			return t, true
+		}
+	}
+	return BundleBinary{}, false
+}
+
+// applyPlatformOverrides rewrites the manifest so every OS present in targets
+// resolves to a real path inside the bundle, and returns the archive members to
+// write. universalDarwin, when non-empty, is the in-bundle path of a merged
+// darwin binary that covers both architectures.
+func applyPlatformOverrides(m *MCPBManifest, mcpBase, cliBase string, targets []BundleBinary, universalDarwin string) {
+	if m.Server.MCPConfig.PlatformOverrides == nil {
+		m.Server.MCPConfig.PlatformOverrides = map[string]MCPBLaunchOverride{}
+	}
+	oses := map[string]bool{}
+	for _, t := range targets {
+		oses[t.GOOS] = true
+	}
+	names := make([]string, 0, len(oses))
+	for goos := range oses {
+		names = append(names, goos)
+	}
+	sort.Strings(names)
+
+	var defaultCommand string
+	for _, goos := range names {
+		var member string
+		if goos == "darwin" && universalDarwin != "" {
+			member = universalDarwin
+		} else {
+			t, ok := pickTarget(targets, goos)
+			if !ok {
+				continue
+			}
+			member = archiveName(mcpBase, t.GOOS, t.GOARCH)
+		}
+		m.Server.MCPConfig.PlatformOverrides[mcpbOSKey(goos)] = MCPBLaunchOverride{
+			Command: "${__dirname}/" + member,
+		}
+		// Prefer darwin as the base command: Claude Desktop ships on macOS and
+		// Windows, and win32 always has its own override anyway.
+		if defaultCommand == "" || goos == "darwin" {
+			defaultCommand = "${__dirname}/" + member
+			m.Server.EntryPoint = member
+		}
+	}
+	if defaultCommand != "" {
+		m.Server.MCPConfig.Command = defaultCommand
+	}
+	_ = cliBase
+}
+
+// BuildMCPBMultiPlatformBundle writes a .mcpb carrying every target in params
+// and a manifest whose declared commands all resolve inside it. It validates the
+// finished archive before returning, so a bundle with an unresolvable command
+// cannot be produced.
+func BuildMCPBMultiPlatformBundle(params BundleParams, targets []BundleBinary) error {
+	if len(targets) == 0 {
+		return BuildMCPBBundle(params)
+	}
+	manifestPath := filepath.Join(params.CLIDir, MCPBManifestFilename)
+	manifestData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading manifest: %w", err)
+	}
+	var manifest MCPBManifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		return fmt.Errorf("parsing manifest: %w", err)
+	}
+	if manifest.Name == "" {
+		return fmt.Errorf("manifest name is empty; cannot derive in-bundle binary paths")
+	}
+	if params.Version != "" {
+		manifest.Version = params.Version
+	}
+
+	mcpBase := manifest.Name
+	cliBase := params.CLIBinaryName
+
+	// Merge the darwin slices into one universal binary when both are present;
+	// platform_overrides cannot express an architecture, so this is the only way
+	// a single darwin entry serves Intel and Apple Silicon.
+	tmp, err := os.MkdirTemp("", "mcpb-universal-")
+	if err != nil {
+		return fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
+
+	universalDarwin := ""
+	universalPath := ""
+	var darwinSlices []string
+	for _, want := range []string{"amd64", "arm64"} {
+		for _, t := range targets {
+			if t.GOOS == "darwin" && t.GOARCH == want {
+				darwinSlices = append(darwinSlices, t.MCPPath)
+			}
+		}
+	}
+	if len(darwinSlices) > 1 {
+		universalPath = filepath.Join(tmp, mcpBase+"-darwin")
+		if err := writeMachoUniversal(darwinSlices, universalPath); err != nil {
+			// A merge failure must not silently degrade to a bundle that breaks
+			// one darwin architecture; surface it.
+			return fmt.Errorf("building universal darwin binary: %w", err)
+		}
+		universalDarwin = "bin/" + mcpBase + "-darwin"
+	}
+
+	applyPlatformOverrides(&manifest, mcpBase, cliBase, targets, universalDarwin)
+
+	rendered, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("rendering manifest: %w", err)
+	}
+	rendered = append(rendered, '\n')
+
+	if err := os.MkdirAll(filepath.Dir(params.OutputPath), 0o755); err != nil {
+		return fmt.Errorf("creating bundle output dir: %w", err)
+	}
+	out, err := os.Create(params.OutputPath)
+	if err != nil {
+		return fmt.Errorf("creating bundle file: %w", err)
+	}
+	defer func() { _ = out.Close() }()
+
+	zw := zip.NewWriter(out)
+	if err := writeZipBytes(zw, MCPBManifestFilename, rendered, 0o644); err != nil {
+		_ = zw.Close()
+		return fmt.Errorf("writing manifest into bundle: %w", err)
+	}
+	if universalDarwin != "" {
+		if err := zipFile(zw, universalDarwin, universalPath); err != nil {
+			_ = zw.Close()
+			return fmt.Errorf("writing universal darwin binary: %w", err)
+		}
+	}
+	for _, t := range targets {
+		if err := zipFile(zw, archiveName(mcpBase, t.GOOS, t.GOARCH), t.MCPPath); err != nil {
+			_ = zw.Close()
+			return fmt.Errorf("writing %s/%s MCP binary: %w", t.GOOS, t.GOARCH, err)
+		}
+		if t.CLIPath != "" && cliBase != "" {
+			if err := zipFile(zw, archiveName(cliBase, t.GOOS, t.GOARCH), t.CLIPath); err != nil {
+				_ = zw.Close()
+				return fmt.Errorf("writing %s/%s CLI binary: %w", t.GOOS, t.GOARCH, err)
+			}
+		}
+	}
+	if err := zw.Close(); err != nil {
+		return fmt.Errorf("finalizing bundle archive: %w", err)
+	}
+	return ValidateMCPBBundle(params.OutputPath)
+}
+
+// ValidateMCPBBundle asserts every command path the bundle's manifest declares
+// names a file the bundle actually contains. This is the check that turns the
+// #3547 defect from "installs, prompts for credentials, then fails at the first
+// tool call" into a build-time error.
+func ValidateMCPBBundle(path string) error {
+	zr, err := zip.OpenReader(path)
+	if err != nil {
+		return fmt.Errorf("opening bundle: %w", err)
+	}
+	defer func() { _ = zr.Close() }()
+
+	members := map[string]bool{}
+	var manifestData []byte
+	for _, f := range zr.File {
+		members[f.Name] = true
+		if f.Name != MCPBManifestFilename {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return fmt.Errorf("opening manifest in bundle: %w", err)
+		}
+		manifestData, err = io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			return fmt.Errorf("reading manifest in bundle: %w", err)
+		}
+	}
+	if manifestData == nil {
+		return fmt.Errorf("bundle %s has no %s", path, MCPBManifestFilename)
+	}
+	var manifest MCPBManifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		return fmt.Errorf("parsing manifest in bundle: %w", err)
+	}
+
+	check := func(label, command string) error {
+		member := strings.TrimPrefix(command, "${__dirname}/")
+		if member == command {
+			// Not a bundle-relative path (e.g. "node"); the host resolves it.
+			return nil
+		}
+		if !members[member] {
+			return fmt.Errorf(
+				"%s: manifest %s is %q but the bundle contains no %q. The extension would install, "+
+					"prompt for credentials, and fail at the first tool call. Bundle members: %s",
+				filepath.Base(path), label, command, member, strings.Join(sortedMembers(members), ", "))
+		}
+		return nil
+	}
+	if err := check("server.mcp_config.command", manifest.Server.MCPConfig.Command); err != nil {
+		return err
+	}
+	keys := make([]string, 0, len(manifest.Server.MCPConfig.PlatformOverrides))
+	for k := range manifest.Server.MCPConfig.PlatformOverrides {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		ov := manifest.Server.MCPConfig.PlatformOverrides[k]
+		if ov.Command == "" {
+			continue
+		}
+		if err := check("server.mcp_config.platform_overrides."+k+".command", ov.Command); err != nil {
+			return err
+		}
+	}
+	if manifest.Server.EntryPoint != "" && !members[manifest.Server.EntryPoint] {
+		return fmt.Errorf("%s: manifest server.entry_point is %q but the bundle contains no such member",
+			filepath.Base(path), manifest.Server.EntryPoint)
+	}
+	return nil
+}
+
+func sortedMembers(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// writeMachoUniversal merges Mach-O files into one universal ("fat") binary.
+//
+// The format is a big-endian header followed by one 20-byte record per slice
+// and then the slices themselves, each aligned to 2^align. Building it here
+// rather than shelling out to lipo keeps the press free of an Xcode dependency
+// and lets a Linux CI runner produce a macOS-universal bundle.
+func writeMachoUniversal(paths []string, outPath string) error {
+	if len(paths) < 2 {
+		return fmt.Errorf("need at least two slices, got %d", len(paths))
+	}
+	type slice struct {
+		cpu    uint32
+		subCPU uint32
+		data   []byte
+	}
+	slices := make([]slice, 0, len(paths))
+	seen := map[uint32]bool{}
+	for _, p := range paths {
+		f, err := macho.Open(p)
+		if err != nil {
+			return fmt.Errorf("reading %s as Mach-O: %w", p, err)
+		}
+		cpu, sub := uint32(f.Cpu), f.SubCpu
+		_ = f.Close()
+		if seen[cpu] {
+			return fmt.Errorf("two slices share CPU type %d; a universal binary needs distinct architectures", cpu)
+		}
+		seen[cpu] = true
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", p, err)
+		}
+		slices = append(slices, slice{cpu: cpu, subCPU: sub, data: data})
+	}
+	// Apple orders slices by CPU type; keep it deterministic.
+	sort.Slice(slices, func(i, j int) bool { return slices[i].cpu < slices[j].cpu })
+
+	const (
+		fatMagic  = 0xCAFEBABE
+		headerLen = 8
+		archLen   = 20
+		// 2^14 = 16 KiB, the alignment arm64 requires and amd64 tolerates.
+		align = 14
+	)
+	offset := uint32(headerLen + archLen*len(slices))
+	aligned := func(v uint32) uint32 {
+		const a = 1 << align
+		if v%a == 0 {
+			return v
+		}
+		return v + (a - v%a)
+	}
+
+	var buf []byte
+	appendU32 := func(v uint32) { buf = binary.BigEndian.AppendUint32(buf, v) }
+	appendU32(fatMagic)
+	appendU32(uint32(len(slices)))
+	offsets := make([]uint32, len(slices))
+	for i, s := range slices {
+		offset = aligned(offset)
+		offsets[i] = offset
+		appendU32(s.cpu)
+		appendU32(s.subCPU)
+		appendU32(offset)
+		appendU32(uint32(len(s.data)))
+		appendU32(align)
+		offset += uint32(len(s.data))
+	}
+	out, err := os.OpenFile(outPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o755)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", outPath, err)
+	}
+	defer func() { _ = out.Close() }()
+	if _, err := out.Write(buf); err != nil {
+		return err
+	}
+	for i, s := range slices {
+		if _, err := out.Seek(int64(offsets[i]), io.SeekStart); err != nil {
+			return err
+		}
+		if _, err := out.Write(s.data); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/pipeline/mcpb_multiplatform_test.go
+++ b/internal/pipeline/mcpb_multiplatform_test.go
@@ -1,0 +1,289 @@
+package pipeline
+
+import (
+	"archive/zip"
+	"debug/macho"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildTinyMachO cross-compiles a trivial program for one darwin arch so the
+// universal-binary merge is exercised against real Mach-O files rather than a
+// hand-rolled fixture.
+func buildTinyMachO(t *testing.T, dir, goarch string) string {
+	t.Helper()
+	src := filepath.Join(dir, "main_"+goarch+".go")
+	require.NoError(t, os.WriteFile(src, []byte("package main\nfunc main() {}\n"), 0o644))
+	out := filepath.Join(dir, "tiny-"+goarch)
+	cmd := exec.Command("go", "build", "-o", out, src)
+	cmd.Env = append(os.Environ(), "GOOS=darwin", "GOARCH="+goarch, "CGO_ENABLED=0")
+	if b, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("cannot cross-compile darwin/%s here: %v\n%s", goarch, err, b)
+	}
+	return out
+}
+
+func writeMultiPlatformManifest(t *testing.T, dir, name string) {
+	t.Helper()
+	m := MCPBManifest{
+		ManifestVersion: MCPBManifestVersion,
+		Name:            name,
+		Version:         "1.0.0",
+		Description:     "demo",
+		Author:          MCPBAuthor{Name: "Test"},
+		Server: MCPBServer{
+			Type:       mcpbServerTypeBinary,
+			EntryPoint: "bin/" + name,
+			MCPConfig: MCPBLaunchSpec{
+				Command: "${__dirname}/bin/" + name,
+				Args:    []string{},
+			},
+		},
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, MCPBManifestFilename), data, 0o644))
+}
+
+func bundleMembers(t *testing.T, path string) (map[string]bool, MCPBManifest) {
+	t.Helper()
+	zr, err := zip.OpenReader(path)
+	require.NoError(t, err)
+	defer func() { _ = zr.Close() }()
+	members := map[string]bool{}
+	var manifest MCPBManifest
+	for _, f := range zr.File {
+		members[f.Name] = true
+		if f.Name == MCPBManifestFilename {
+			rc, err := f.Open()
+			require.NoError(t, err)
+			require.NoError(t, json.NewDecoder(rc).Decode(&manifest))
+			_ = rc.Close()
+		}
+	}
+	return members, manifest
+}
+
+// TestValidateMCPBBundleCatchesTheShippedDefect reproduces mvanhorn/cli-printing-press#3547
+// finding 2 exactly: a bundle whose manifest command names bin/<name> while the
+// archive carries only arch-suffixed binaries. Claude Desktop installs such an
+// extension, prompts for credentials, and only fails at the first tool call, so
+// nothing downstream catches it. The validator must.
+func TestValidateMCPBBundleCatchesTheShippedDefect(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "broken.mcpb")
+
+	manifest := MCPBManifest{
+		ManifestVersion: MCPBManifestVersion,
+		Name:            "demo-mcp",
+		Server: MCPBServer{
+			Type:       mcpbServerTypeBinary,
+			EntryPoint: "bin/demo-mcp-darwin-arm64",
+			MCPConfig:  MCPBLaunchSpec{Command: "${__dirname}/bin/demo-mcp"},
+		},
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	require.NoError(t, err)
+
+	f, err := os.Create(out)
+	require.NoError(t, err)
+	zw := zip.NewWriter(f)
+	require.NoError(t, writeZipBytes(zw, MCPBManifestFilename, data, 0o644))
+	// Exactly what the release ships: arch-suffixed names only.
+	for _, n := range []string{"bin/demo-mcp-darwin-arm64", "bin/demo-mcp-darwin-amd64", "bin/demo-mcp-windows-amd64.exe"} {
+		require.NoError(t, writeZipBytes(zw, n, []byte("binary"), 0o755))
+	}
+	require.NoError(t, zw.Close())
+	require.NoError(t, f.Close())
+
+	err = ValidateMCPBBundle(out)
+	require.Error(t, err, "a bundle whose command names a member it does not contain must not validate")
+	assert.Contains(t, err.Error(), "bin/demo-mcp")
+	assert.Contains(t, err.Error(), "fail at the first tool call")
+}
+
+func TestValidateMCPBBundleAcceptsAResolvableBundle(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "ok.mcpb")
+	manifest := MCPBManifest{
+		ManifestVersion: MCPBManifestVersion,
+		Name:            "demo-mcp",
+		Server: MCPBServer{
+			Type:       mcpbServerTypeBinary,
+			EntryPoint: "bin/demo-mcp-darwin-arm64",
+			MCPConfig: MCPBLaunchSpec{
+				Command: "${__dirname}/bin/demo-mcp-darwin-arm64",
+				PlatformOverrides: map[string]MCPBLaunchOverride{
+					"win32": {Command: "${__dirname}/bin/demo-mcp-windows-amd64.exe"},
+				},
+			},
+		},
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	require.NoError(t, err)
+	f, err := os.Create(out)
+	require.NoError(t, err)
+	zw := zip.NewWriter(f)
+	require.NoError(t, writeZipBytes(zw, MCPBManifestFilename, data, 0o644))
+	require.NoError(t, writeZipBytes(zw, "bin/demo-mcp-darwin-arm64", []byte("b"), 0o755))
+	require.NoError(t, writeZipBytes(zw, "bin/demo-mcp-windows-amd64.exe", []byte("b"), 0o755))
+	require.NoError(t, zw.Close())
+	require.NoError(t, f.Close())
+
+	require.NoError(t, ValidateMCPBBundle(out), "every declared command resolves; this must pass")
+}
+
+// TestValidateMCPBBundleCatchesABrokenOverride proves the check is not satisfied
+// by the base command alone - a per-OS override pointing at a missing member is
+// broken for exactly the users on that OS.
+func TestValidateMCPBBundleCatchesABrokenOverride(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "override.mcpb")
+	manifest := MCPBManifest{
+		ManifestVersion: MCPBManifestVersion,
+		Name:            "demo-mcp",
+		Server: MCPBServer{
+			Type:       mcpbServerTypeBinary,
+			EntryPoint: "bin/demo-mcp-darwin-arm64",
+			MCPConfig: MCPBLaunchSpec{
+				Command: "${__dirname}/bin/demo-mcp-darwin-arm64",
+				PlatformOverrides: map[string]MCPBLaunchOverride{
+					"win32": {Command: "${__dirname}/bin/demo-mcp-windows-amd64.exe"},
+				},
+			},
+		},
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	require.NoError(t, err)
+	f, err := os.Create(out)
+	require.NoError(t, err)
+	zw := zip.NewWriter(f)
+	require.NoError(t, writeZipBytes(zw, MCPBManifestFilename, data, 0o644))
+	require.NoError(t, writeZipBytes(zw, "bin/demo-mcp-darwin-arm64", []byte("b"), 0o755))
+	// the win32 binary is deliberately absent
+	require.NoError(t, zw.Close())
+	require.NoError(t, f.Close())
+
+	err = ValidateMCPBBundle(out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "platform_overrides.win32.command")
+}
+
+func TestBuildMCPBMultiPlatformBundle(t *testing.T) {
+	dir := t.TempDir()
+	writeMultiPlatformManifest(t, dir, "demo-mcp")
+
+	amd64 := buildTinyMachO(t, dir, "amd64")
+	arm64 := buildTinyMachO(t, dir, "arm64")
+	win := filepath.Join(dir, "win.exe")
+	require.NoError(t, os.WriteFile(win, []byte("MZ windows binary"), 0o755))
+
+	out := filepath.Join(dir, "build", "demo.mcpb")
+	require.NoError(t, BuildMCPBMultiPlatformBundle(BundleParams{
+		CLIDir:     dir,
+		OutputPath: out,
+		Version:    "2.3.4",
+	}, []BundleBinary{
+		{GOOS: "darwin", GOARCH: "amd64", MCPPath: amd64},
+		{GOOS: "darwin", GOARCH: "arm64", MCPPath: arm64},
+		{GOOS: "windows", GOARCH: "amd64", MCPPath: win},
+	}))
+
+	members, manifest := bundleMembers(t, out)
+
+	t.Run("every declared command resolves inside the bundle", func(t *testing.T) {
+		// BuildMCPBMultiPlatformBundle validates before returning, so reaching
+		// here already proves it; assert explicitly so the intent is recorded.
+		require.NoError(t, ValidateMCPBBundle(out))
+	})
+
+	t.Run("darwin is served by one universal binary, not a single arch", func(t *testing.T) {
+		assert.True(t, members["bin/demo-mcp-darwin"], "expected a merged darwin binary, members: %v", members)
+		assert.Equal(t, "${__dirname}/bin/demo-mcp-darwin",
+			manifest.Server.MCPConfig.PlatformOverrides["darwin"].Command)
+	})
+
+	t.Run("the universal binary really is a fat Mach-O carrying both slices", func(t *testing.T) {
+		extracted := filepath.Join(dir, "extracted-darwin")
+		zr, err := zip.OpenReader(out)
+		require.NoError(t, err)
+		defer func() { _ = zr.Close() }()
+		var wrote bool
+		for _, f := range zr.File {
+			if f.Name != "bin/demo-mcp-darwin" {
+				continue
+			}
+			rc, err := f.Open()
+			require.NoError(t, err)
+			data := make([]byte, f.UncompressedSize64)
+			_, err = readFull(rc, data)
+			_ = rc.Close()
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(extracted, data, 0o755))
+			wrote = true
+		}
+		require.True(t, wrote, "universal darwin binary missing from the bundle")
+
+		fat, err := macho.OpenFat(extracted)
+		require.NoError(t, err, "the merged file must be a valid universal Mach-O")
+		defer func() { _ = fat.Close() }()
+		require.Len(t, fat.Arches, 2)
+		cpus := map[macho.Cpu]bool{}
+		for _, a := range fat.Arches {
+			cpus[a.Cpu] = true
+		}
+		assert.True(t, cpus[macho.CpuAmd64], "missing the x86_64 slice")
+		assert.True(t, cpus[macho.CpuArm64], "missing the arm64 slice")
+	})
+
+	t.Run("win32 gets its own override", func(t *testing.T) {
+		assert.Equal(t, "${__dirname}/bin/demo-mcp-windows-amd64.exe",
+			manifest.Server.MCPConfig.PlatformOverrides["win32"].Command)
+		assert.True(t, members["bin/demo-mcp-windows-amd64.exe"])
+	})
+
+	t.Run("version is stamped", func(t *testing.T) {
+		assert.Equal(t, "2.3.4", manifest.Version)
+	})
+}
+
+// TestBuildMCPBMultiPlatformBundleSingleDarwinArch covers the case where only one
+// darwin slice exists: there is nothing to merge, so the override must name that
+// arch directly and still resolve.
+func TestBuildMCPBMultiPlatformBundleSingleDarwinArch(t *testing.T) {
+	dir := t.TempDir()
+	writeMultiPlatformManifest(t, dir, "demo-mcp")
+	only := filepath.Join(dir, "only")
+	require.NoError(t, os.WriteFile(only, []byte("binary"), 0o755))
+
+	out := filepath.Join(dir, "one.mcpb")
+	require.NoError(t, BuildMCPBMultiPlatformBundle(BundleParams{CLIDir: dir, OutputPath: out},
+		[]BundleBinary{{GOOS: "darwin", GOARCH: "arm64", MCPPath: only}}))
+
+	members, manifest := bundleMembers(t, out)
+	assert.False(t, members["bin/demo-mcp-darwin"], "nothing to merge, so no universal binary should be written")
+	assert.Equal(t, "${__dirname}/bin/demo-mcp-darwin-arm64",
+		manifest.Server.MCPConfig.PlatformOverrides["darwin"].Command)
+	require.NoError(t, ValidateMCPBBundle(out))
+}
+
+func readFull(r interface{ Read([]byte) (int, error) }, buf []byte) (int, error) {
+	total := 0
+	for total < len(buf) {
+		n, err := r.Read(buf[total:])
+		total += n
+		if err != nil {
+			if total == len(buf) {
+				return total, nil
+			}
+			return total, err
+		}
+	}
+	return total, nil
+}


### PR DESCRIPTION
## Intent

Issue: Refs #3547 (finding 2)

#3547 landed finding 1 (provenance moved out of the non-spec top-level keys). Finding 2 did not, and it is the one that makes an extension fail for a real user:

> The manifest sets `command: ${__dirname}/bin/<slug>-mcp`, but releases ship only **arch-suffixed** binaries. No file matches the generic name on any platform.

The press's own `BuildMCPBBundle` is single-platform and internally consistent - it writes the binary *to* the path the manifest declares, so `command` always resolves. The defect appears in a consumer that packs every released binary into one bundle, which is what you want, because a `.mcpb` is downloaded once and installed on whatever machine the operator has. The press had no way to express that: `MCPBLaunchSpec` had no `platform_overrides`, so there was no correct way to build a multi-platform bundle and consumers built an incorrect one.

Downstream receipt: Servosity/msp-skills currently publishes 64 such bundles. Verified by downloading two:

```
$ unzip -l hudu-mcp.mcpb | grep bin/
  bin/hudu-mcp-darwin-amd64   bin/hudu-mcp-darwin-arm64
  bin/hudu-mcp-linux-amd64    bin/hudu-mcp-linux-arm64
  bin/hudu-mcp-windows-amd64.exe
$ jq -r .server.mcp_config.command manifest.json
${__dirname}/bin/hudu-mcp          # in no bundle, on any platform
```

Claude Desktop validates the manifest but does not test-run the binary, so the extension installs, prompts for credentials, and only fails at the first tool call.

## Approach

Three pieces.

**`platform_overrides` in the manifest type.** `MCPBLaunchSpec` gains an omitempty `PlatformOverrides map[string]MCPBLaunchOverride`, so a multi-platform bundle is expressible at all.

**A universal binary for darwin.** MCPB keys `platform_overrides` on OS only - `darwin`, `linux`, `win32` - and defines no `${arch}` template variable, so per-OS overrides still cannot separate Intel from Apple Silicon. #3547 called for either a launcher shim or a universal binary and recommended the shim; this uses the universal binary instead, because a shim depends on the archive's executable bit surviving unpacking and on a shell being present, and neither is guaranteed. `writeMachoUniversal` builds the fat Mach-O directly through `debug/macho` - no `lipo`, no Xcode dependency, so a Linux runner can produce a macOS-universal bundle. Linux and Windows have no fat-binary format, so those overrides name one architecture (amd64 first: Windows on ARM runs x64 under emulation, the reverse is not true).

**A validator that makes the defect unshippable.** `ValidateMCPBBundle` opens the finished archive and asserts every command path the manifest declares - base `command`, each `platform_overrides.<os>.command`, and `entry_point` - names a member the archive actually contains. It runs at the end of **both** bundle paths, so the single-platform builder is covered too. That is what turns this from a first-tool-call mystery into a build error.

## Scope

Primary area: `internal/pipeline` (MCPB manifest + bundle)

Why this belongs in this repo: the manifest is generated here, and the missing `platform_overrides` capability is why no consumer could build a correct multi-platform bundle. Fixing it in one consumer would leave every other one to rediscover the same thing.

## Risk

Additive. `platform_overrides` is `omitempty`, so single-platform manifests are byte-identical to before. `BuildMCPBMultiPlatformBundle` is a new entry point; existing callers (`promote_artifacts.go`, `internal/cli/bundle.go`) are untouched.

The one behaviour change to an existing path: `BuildMCPBBundle` now returns `ValidateMCPBBundle`'s error instead of `nil`. For the single-platform path that is a tautology today - it writes the binary to the declared `entry_point` - so it should never fire; it is there so a future change to either half cannot silently reintroduce the defect. The full `internal/pipeline` suite passes unchanged, which is the evidence that it does not fire on current behaviour.

A universal-binary merge failure returns an error rather than degrading to a single-arch bundle, deliberately: a silent degrade breaks one darwin population and looks fine.

## Output Contract

Changes generated `manifest.json` only when a caller opts into the multi-platform builder. Covered by emitted-output assertions rather than by prose:

- `TestValidateMCPBBundleCatchesTheShippedDefect` constructs the exact archive shape shipped today (generic `command`, arch-suffixed members) and asserts it does not validate.
- `TestValidateMCPBBundleAcceptsAResolvableBundle` and `...CatchesABrokenOverride` prove the check discriminates, and that it is not satisfied by the base command alone.
- `TestBuildMCPBMultiPlatformBundle` cross-compiles real darwin/amd64 and darwin/arm64 binaries, builds the bundle, then reopens the merged file with `macho.OpenFat` and asserts both `CpuAmd64` and `CpuArm64` slices are present - so the universal binary is verified as a real fat Mach-O, not just as bytes on disk.
- `TestBuildMCPBMultiPlatformBundleSingleDarwinArch` covers the no-merge case.

## Verification

```
go build ./...                                    ok
go vet ./...                                      ok
go test ./internal/pipeline/                      ok  (81s, full suite, unchanged)
go test ./internal/pipeline/ -run 'MCPBMultiPlatform|ValidateMCPBBundle' -v
                                                  ok  (all cases above)
```

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission