### PR TITLE
fix(cli): honor an explicit --module-path in publish package's module check

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -473,11 +473,12 @@ func newPublishPackageCmd() *cobra.Command {
 					return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("rewriting module path: %w", err)}
 				}
 			}
-			// Verify the staged tree's module path is library-canonical. Runs
-			// after the rewrite in both branches: without --module-path the
-			// bare module name fails here; with a wrong --module-path value
-			// the mismatch is caught before it reaches the library CI.
-			modulePathCheck := checkModulePath(outCLIDir)
+			// Verify the staged tree's module path. Runs after the rewrite in
+			// both branches: without --module-path the bare module name fails
+			// the canonical-prefix requirement here; with --module-path the
+			// staged go.mod must declare exactly the requested path, so a
+			// failed or partial rewrite is caught before it reaches CI.
+			modulePathCheck := checkModulePath(outCLIDir, modulePath)
 			if !modulePathCheck.Passed {
 				if asJSON {
 					enc := json.NewEncoder(os.Stdout)
@@ -856,8 +857,9 @@ func runValidation(dir string) ValidateResult {
 	// legitimately declares the bare CLI module path; the check is
 	// authoritative in the package flow, which validates the staged tree after
 	// --module-path rewrite. Surface it as a warning so a library-shaped tree
-	// with a wrong module path is still flagged before packaging.
-	modulePathCheck := checkModulePath(dir)
+	// with a wrong module path is still flagged before packaging. Standalone
+	// validate has no --module-path context, so the canonical prefix applies.
+	modulePathCheck := checkModulePath(dir, "")
 	if !modulePathCheck.Passed {
 		modulePathCheck.Warning = modulePathCheck.Error
 		modulePathCheck.Error = ""
@@ -1517,9 +1519,20 @@ func checkGoModTidy(dir string) CheckResult {
 	return CheckResult{Name: "go mod tidy", Passed: true}
 }
 
+// canonicalLibraryModulePrefix is the module path prefix the upstream library
+// CI requires when no module path was requested explicitly.
+const canonicalLibraryModulePrefix = "github.com/mvanhorn/printing-press-library/library/"
+
 // checkModulePath catches the bare CLI-name module declaration the library CI
 // rejects, before the PR opens.
-func checkModulePath(dir string) CheckResult {
+//
+// requested is the explicit `publish package --module-path` value, or "" when
+// none was given. With an explicit request the check is internal consistency:
+// go.mod must declare exactly the path that was asked for, which honors the
+// documented $PUBLISH_CONFIG module_path_base override while still rejecting a
+// bare CLI name. With no request the canonical library prefix is required,
+// exactly as before.
+func checkModulePath(dir, requested string) CheckResult {
 	modPath := filepath.Join(dir, "go.mod")
 	modBytes, err := os.ReadFile(modPath)
 	if err != nil {
@@ -1536,11 +1549,31 @@ func checkModulePath(dir string) CheckResult {
 	if declared == "" {
 		return CheckResult{Name: "module path", Passed: false, Error: "go.mod declares no module line"}
 	}
-	if strings.HasPrefix(declared, "github.com/mvanhorn/printing-press-library/library/") {
+	if requested != "" {
+		if declared != requested {
+			return CheckResult{Name: "module path", Passed: false,
+				Error: fmt.Sprintf("go.mod module path %q does not match the requested --module-path %q", declared, requested)}
+		}
+		if isBareModuleName(declared) {
+			return CheckResult{Name: "module path", Passed: false,
+				Error: fmt.Sprintf("go.mod module path %q is a bare CLI name; use a domain-qualified module path like github.com/<org>/<repo>/library/<category>/<slug>", declared)}
+		}
+		return CheckResult{Name: "module path", Passed: true}
+	}
+	if strings.HasPrefix(declared, canonicalLibraryModulePrefix) {
 		return CheckResult{Name: "module path", Passed: true}
 	}
 	return CheckResult{Name: "module path", Passed: false,
 		Error: fmt.Sprintf("go.mod module path %q does not start with the canonical library prefix github.com/mvanhorn/printing-press-library/library/<category>/<slug>", declared)}
+}
+
+// isBareModuleName reports whether a declared module path is a bare name like
+// "exa-pp-cli" rather than a fetchable, domain-qualified path. Go treats the
+// first path element as the host, so a first element with no dot is never
+// resolvable by the library CI.
+func isBareModuleName(declared string) bool {
+	host, _, _ := strings.Cut(declared, "/")
+	return !strings.Contains(host, ".")
 }
 
 func buildValidationBinary(dir, cliName string) (path string, cleanup func(), err error) {

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -2416,21 +2416,55 @@ func TestCheckModulePath(t *testing.T) {
 	t.Run("canonical prefix passes", func(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
 			[]byte("module github.com/mvanhorn/printing-press-library/library/ai/exa\n\ngo 1.26.6\n"), 0o644))
-		res := checkModulePath(dir)
+		res := checkModulePath(dir, "")
 		assert.True(t, res.Passed, res.Error)
 		assert.Equal(t, "module path", res.Name)
+	})
+
+	t.Run("canonical prefix passes when requested explicitly", func(t *testing.T) {
+		const canonical = "github.com/mvanhorn/printing-press-library/library/ai/exa"
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+			[]byte("module "+canonical+"\n\ngo 1.26.6\n"), 0o644))
+		res := checkModulePath(dir, canonical)
+		assert.True(t, res.Passed, res.Error)
+	})
+
+	t.Run("custom requested path passes when go.mod matches", func(t *testing.T) {
+		// The documented $PUBLISH_CONFIG module_path_base override: a
+		// non-mvanhorn base is honored as long as the rewrite landed.
+		const custom = "github.com/acme/my-library/library/ai/exa"
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+			[]byte("module "+custom+"\n\ngo 1.26.6\n"), 0o644))
+		res := checkModulePath(dir, custom)
+		assert.True(t, res.Passed, res.Error)
+	})
+
+	t.Run("declared path that differs from the requested path fails", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+			[]byte("module github.com/acme/my-library/library/ai/exa\n\ngo 1.26.6\n"), 0o644))
+		res := checkModulePath(dir, "github.com/acme/my-library/library/ai/other")
+		assert.False(t, res.Passed)
+		assert.Contains(t, res.Error, "does not match the requested --module-path")
 	})
 
 	t.Run("bare CLI name fails", func(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
 			[]byte("module exa-pp-cli\n\ngo 1.26.6\n"), 0o644))
-		res := checkModulePath(dir)
+		res := checkModulePath(dir, "")
 		assert.False(t, res.Passed)
 		assert.Contains(t, res.Error, "does not start with the canonical library prefix")
 	})
 
+	t.Run("bare CLI name fails even when requested explicitly", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+			[]byte("module exa-pp-cli\n\ngo 1.26.6\n"), 0o644))
+		res := checkModulePath(dir, "exa-pp-cli")
+		assert.False(t, res.Passed)
+		assert.Contains(t, res.Error, "is a bare CLI name")
+	})
+
 	t.Run("missing go.mod fails", func(t *testing.T) {
-		res := checkModulePath(filepath.Join(t.TempDir(), "nope"))
+		res := checkModulePath(filepath.Join(t.TempDir(), "nope"), "")
 		assert.False(t, res.Passed)
 		assert.Contains(t, res.Error, "go.mod not found")
 	})
@@ -2438,7 +2472,7 @@ func TestCheckModulePath(t *testing.T) {
 	t.Run("no module line fails", func(t *testing.T) {
 		emptyDir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(emptyDir, "go.mod"), []byte("go 1.26.6\n"), 0o644))
-		res := checkModulePath(emptyDir)
+		res := checkModulePath(emptyDir, "")
 		assert.False(t, res.Passed)
 		assert.Contains(t, res.Error, "declares no module line")
 	})
@@ -2477,4 +2511,49 @@ func TestPublishValidateModulePathCheckWired(t *testing.T) {
 	// authoritative failure lives in the package flow's staged-tree check.
 	assert.NotEmpty(t, modulePathCheck.Warning)
 	assert.Contains(t, modulePathCheck.Warning, "canonical library prefix")
+}
+
+// TestPublishPackageHonorsCustomModulePath covers the documented
+// $PUBLISH_CONFIG module_path_base override: an explicitly requested
+// --module-path outside the mvanhorn library must package, not be rejected by
+// the module-path check that runs right after the rewrite.
+func TestPublishPackageHonorsCustomModulePath(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	cliDir := filepath.Join(home, "library", "test-pp-cli")
+	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
+
+	const custom = "github.com/acme/my-library/library/other/test"
+	target := filepath.Join(t.TempDir(), "staging")
+	cmd := newPublishCmd()
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", custom, "--json"})
+
+	output, err := runWithCapturedStdout(t, cmd.Execute)
+	require.NoError(t, err, "a custom --module-path must not be rejected by the module-path check")
+
+	var result PackageResult
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	assert.Equal(t, custom, result.ModulePath)
+
+	staged, err := os.ReadFile(filepath.Join(result.StagedDir, "go.mod"))
+	require.NoError(t, err)
+	assert.Contains(t, string(staged), "module "+custom)
+}
+
+// TestPublishPackageRejectsBareModulePathRequest keeps the check's original
+// purpose intact: a bare CLI-name module the library CI rejects still fails,
+// even when it is what --module-path asked for.
+func TestPublishPackageRejectsBareModulePathRequest(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	cliDir := filepath.Join(home, "library", "test-pp-cli")
+	writePublishableTestCLI(t, cliDir)
+	stubPublishPackageValidation(t)
+
+	target := filepath.Join(t.TempDir(), "staging")
+	cmd := newPublishCmd()
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--module-path", "test-pp-cli", "--json"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is a bare CLI name")
 }


### PR DESCRIPTION
## Intent

`skills/printing-press-publish/SKILL.md` documents `$PUBLISH_CONFIG`'s `module_path_base` as a user-editable knob:

> `$PUBLISH_CONFIG` stores persistent publish settings as JSON. On first publish, create it with defaults. **The user can edit it to change the library repo or module path base.** (`SKILL.md:349`)

> The `module_path_base` field sets the Go module path prefix for published CLIs. During packaging, the full module path is constructed as `<module_path_base>/<category>/<api-slug>`. **If the user wants CLIs published to a different repo or path, they edit this field.** (`SKILL.md:363`)

`checkModulePath()` (`internal/cli/publish.go`) hardcoded the `github.com/mvanhorn/printing-press-library/library/` prefix and hard-failed `publish package` on anything else — *after* `--module-path` had already rewritten `go.mod` to the requested value. The flag rewrote go.mod and the very next check rejected its own output, so the documented override was unusable:

```
validation failed, cannot package: go.mod module path "github.com/acme/my-library/library/other/my-cli"
does not start with the canonical library prefix github.com/mvanhorn/printing-press-library/library/<category>/<slug>
```

Issue: Fixes #4367

## Approach

`checkModulePath` now takes the requested `--module-path` value alongside the directory, and branches on whether one was given:

- **Explicit `--module-path`**: the check becomes internal consistency — the staged `go.mod` must declare exactly the path that was requested. That still catches a failed or partial rewrite before it reaches CI, and a bare-name guard (`isBareModuleName`: first path element has no dot, so Go can never resolve it as a host) keeps the bare CLI-name declaration the check's comment says it exists for failing even when it is what was asked for.
- **No `--module-path`**: unchanged. The canonical library prefix is still required, byte-identical error message included.

The hardcoded prefix moved into a named `canonicalLibraryModulePrefix` const at the same time.

## Scope

Primary area: `cli` — `internal/cli/publish.go` (`publish package` / `publish validate` check wiring).

Why this belongs in this repo: the contradiction is between this repo's skill docs and this repo's publish command; the printed CLIs are only the payload being packaged.

## Risk

Confined to the `publish package` / `publish validate` module-path check.

**What does NOT change:**

- With no explicit `--module-path`, behavior is identical — canonical prefix required, same error string (covered by the pre-existing `TestCheckModulePath` cases, which still assert the original message).
- The canonical mvanhorn path passes exactly as before, whether requested explicitly or not.
- Standalone `publish validate` has no flag context, so it passes `""` and keeps today's canonical-prefix warning (`TestPublishValidateModulePathCheckWired` unchanged).
- A bare CLI-name module still fails both ways.

The deliberate loosening: with an explicit `--module-path`, a domain-qualified non-mvanhorn path now packages instead of erroring. That is the documented behavior being restored, and the upstream library CI remains the authority for what it will accept in a PR to *its* repo.

## Output Contract

N/A — no templates, generated files, manifests, command output, MCP schemas, scorecard output, or pipeline artifacts changed. The only user-visible string change is a new error message on a path that previously could not succeed at all.

## Verification

- `go build ./...` — clean
- `go vet ./internal/cli/...` — clean
- `go test ./internal/cli/...` — `ok ... 167.030s`

Tests added/extended in `internal/cli/publish_test.go`:

- `TestCheckModulePath`: existing cases updated for the new signature; added canonical-path-requested-explicitly passes, custom `--module-path` passes when go.mod matches, declared-vs-requested mismatch fails, bare CLI name fails **both** with and without an explicit request.
- `TestPublishPackageHonorsCustomModulePath` (new, end-to-end): `publish package --module-path github.com/acme/my-library/library/other/test` succeeds and the staged `go.mod` declares that path.
- `TestPublishPackageRejectsBareModulePathRequest` (new, end-to-end): `--module-path test-pp-cli` still hard-fails packaging.

- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates

(Not a generator/template change — no golden coverage applicable; `scripts/golden.sh verify` not run for that reason.)

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
