### PR TITLE
fix(store): nested/id_/unusable record-ID resolution

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -1355,7 +1355,9 @@ Parsed field: `Endpoint.IDField`
 
 Rules:
 - Optional.
-- Must be a string.
+- Must be a string. A dotted path (`entityInfo.entityId`) is stored verbatim
+  and walked at runtime by `LookupFieldValue`; it is not limited to a
+  single top-level key.
 - Leading and trailing whitespace is trimmed.
 - Non-string values emit a warning and are ignored.
 - A non-empty `x-resource-id` wins over every automatic response-schema
@@ -1387,6 +1389,23 @@ paths:
     x-resource-id: widget_uid
     get:
       operationId: listWidgets
+      responses:
+        "200":
+          description: OK
+```
+
+Nested identifiers use the same extension with a dotted path. Generated
+`LookupFieldValue` walks each segment with snake/camel/Pascal spellings and
+a trailing-underscore variant, so `entityInfo.entityId` reaches a payload
+shaped like `{"entityInfo":{"entityId":"..."}}` without a hand-written
+override:
+
+```yaml
+paths:
+  /entities:
+    x-resource-id: entityInfo.entityId
+    get:
+      operationId: listEntities
       responses:
         "200":
           description: OK

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -16215,7 +16215,7 @@ func TestGeneratedSyncIDFieldOverridesAndProbes(t *testing.T) {
 	// Vendor identifiers (gid, sid, uid, uuid, guid) and resource-specific
 	// suffixes precede descriptive fields so APIs do not key rows by names.
 	assert.Contains(t, storeContent,
-		`var genericIDFieldFallbacks = []string{"id", "ID", "_id", "gid", "sid", "uid", "uuid", "guid", "api_id"}`,
+		`var genericIDFieldFallbacks = []string{"id", "ID", "_id", "id_", "gid", "sid", "uid", "uuid", "guid", "api_id"}`,
 		"store.go genericIDFieldFallbacks must include stable vendor identifiers")
 	assert.Contains(t, storeContent,
 		`var genericDescriptiveIDFieldFallbacks = []string{"name", "slug", "key", "code"}`,

--- a/internal/generator/store_resource_id_resolution_test.go
+++ b/internal/generator/store_resource_id_resolution_test.go
@@ -1,0 +1,85 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedStoreResolvesNestedAndUnusableRecordIDs(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "nestedidstore",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/nestedidstore-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"entities": {
+				Description: "Entities keyed on a nested identifier",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/entities",
+						Description: "List entities",
+						Response:    spec.ResponseDef{Type: "array"},
+						IDField:     "entityInfo.entityId",
+					},
+				},
+			},
+			"devices": {
+				Description: "Devices using generic ID fallbacks",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/devices",
+						Description: "List devices",
+						Response:    spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	storeGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	storeContent := string(storeGo)
+
+	assert.Contains(t, storeContent, `"entities": "entityInfo.entityId"`,
+		"dotted x-resource-id / id_field must land in resourceIDFieldOverrides")
+	assert.Contains(t, storeContent, "func lookupRawDottedFieldValue(",
+		"generated store must walk dotted identifier paths")
+	assert.Contains(t, storeContent, "func CanonicalResourceID(",
+		"generated store must expose CanonicalResourceID")
+	assert.Contains(t, storeContent, "func unusableResourceID(",
+		"generated store must refuse unusable identifier values")
+	assert.Contains(t, storeContent,
+		`var genericIDFieldFallbacks = []string{"id", "ID", "_id", "id_", "gid", "sid", "uid", "uuid", "guid", "api_id"}`,
+		"generated store must probe id_ as a generic identifier spelling")
+	assert.Contains(t, storeContent, "func fieldKeySpellings(",
+		"LookupFieldValue must widen identifier keys including trailing-underscore spellings")
+
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(syncGo), `"entities": "entityInfo.entityId"`,
+		"sync override map must carry the dotted identifier path")
+
+	requireGeneratedCompiles(t, outputDir)
+
+	runGoCommandRequired(t, outputDir, "test", "./internal/store",
+		"-run", "Test(LookupFieldValue_DottedPathAndTrailingUnderscore|ExtractResourceID_NestedOverrideAndIDUnderscore|ExtractResourceID_RefusesUnusableValues|UpsertBatch_NestedOverrideStoresRows|UpsertBatch_RefusesUnusableIDsInsteadOfWritingThem|UpsertBatch_GenericFallbackList|UpsertBatch_TemplatedIDFieldOverrideWins)",
+		"-count=1")
+}

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1320,11 +1320,9 @@ func FTSMatchQuery(query string) string {
 }
 
 func extractObjectID(obj map[string]any) string {
-	for _, key := range []string{"id", "Id", "ID", "_id", "uuid", "slug", "name"} {
-		if v, ok := obj[key]; ok {
-			if id := ResourceIDString(v); id != "" && id != "<nil>" {
-				return id
-			}
+	for _, key := range []string{"id", "ID", "_id", "id_", "uuid", "slug", "name"} {
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
 	return ""
@@ -1343,16 +1341,85 @@ func ftsRowID(scope, id string) int64 {
 	return int64(h.Sum64() & 0x7FFFFFFFFFFFFFFF) // ensure positive
 }
 
-// LookupFieldValue resolves a field value from a JSON object map, trying the
-// snake_case key first, then the camelCase rendering, then the PascalCase
-// rendering. Exported so the sync command's extractID and the upsert path
-// resolve fields the same way — a divergence here produces silent drops on
-// heterogeneous payloads. The PascalCase pass handles .NET-shaped responses
-// (`Id`, `Name`, `OrderId`) without forcing each spec to declare casing.
+// LookupFieldValue resolves a field value from a JSON object map. A dotted
+// key is walked as a path (`entityInfo.entityId`); each segment tries snake,
+// camel, and Pascal spellings, then the Python-style trailing-underscore
+// sibling (`id` → `id_`). Exported so the sync command's extractID and the
+// upsert path resolve fields the same way — a divergence here produces
+// silent drops on heterogeneous payloads. The PascalCase pass handles
+// .NET-shaped responses (`Id`, `Name`, `OrderId`) without forcing each spec
+// to declare casing.
 func LookupFieldValue(obj map[string]any, snakeKey string) any {
-	if v, ok := obj[snakeKey]; ok {
-		return sqliteFieldValue(v)
+	v, ok := lookupRawFieldValue(obj, snakeKey)
+	if !ok {
+		return nil
 	}
+	return sqliteFieldValue(v)
+}
+
+func lookupRawFieldValue(obj map[string]any, key string) (any, bool) {
+	if obj == nil || key == "" {
+		return nil, false
+	}
+	if strings.Contains(key, ".") {
+		return lookupRawDottedFieldValue(obj, key)
+	}
+	return lookupRawFlatFieldValue(obj, key)
+}
+
+func lookupRawDottedFieldValue(obj map[string]any, path string) (any, bool) {
+	if v, ok := lookupRawFlatFieldValue(obj, path); ok {
+		return v, true
+	}
+	segments := strings.Split(path, ".")
+	if len(segments) < 2 {
+		return nil, false
+	}
+	current := obj
+	for i, segment := range segments {
+		if segment == "" {
+			return nil, false
+		}
+		v, ok := lookupRawFlatFieldValue(current, segment)
+		if !ok {
+			return nil, false
+		}
+		if i == len(segments)-1 {
+			return v, true
+		}
+		next, ok := v.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current = next
+	}
+	return nil, false
+}
+
+func lookupRawFlatFieldValue(obj map[string]any, snakeKey string) (any, bool) {
+	for _, key := range fieldKeySpellings(snakeKey) {
+		if v, ok := obj[key]; ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func fieldKeySpellings(snakeKey string) []string {
+	seen := make(map[string]struct{}, 8)
+	out := make([]string, 0, 8)
+	add := func(s string) {
+		if s == "" {
+			return
+		}
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+
+	add(snakeKey)
 	parts := strings.Split(snakeKey, "_")
 	for i := 1; i < len(parts); i++ {
 		if parts[i] == "" {
@@ -1360,17 +1427,17 @@ func LookupFieldValue(obj map[string]any, snakeKey string) any {
 		}
 		parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
 	}
-	camel := strings.Join(parts, "")
-	if v, ok := obj[camel]; ok {
-		return sqliteFieldValue(v)
-	}
+	add(strings.Join(parts, ""))
 	if parts[0] != "" {
-		pascal := strings.ToUpper(parts[0][:1]) + parts[0][1:] + strings.Join(parts[1:], "")
-		if v, ok := obj[pascal]; ok {
-			return sqliteFieldValue(v)
+		add(strings.ToUpper(parts[0][:1]) + parts[0][1:] + strings.Join(parts[1:], ""))
+	}
+	n := len(out)
+	for i := 0; i < n; i++ {
+		if !strings.HasSuffix(out[i], "_") {
+			add(out[i] + "_")
 		}
 	}
-	return nil
+	return out
 }
 
 func sqliteFieldValue(v any) any {
@@ -1406,6 +1473,51 @@ func DecodeJSONObject(data json.RawMessage) (map[string]any, error) {
 		return nil, err
 	}
 	return obj, nil
+}
+
+// CanonicalResourceID returns the stable text form used for resources.id, or
+// empty when the value cannot be a primary key (nil, boolean, zero, or a
+// timestamp). Callers that would otherwise store ResourceIDString output
+// must use this so unusable values are refused instead of written.
+func CanonicalResourceID(v any) string {
+	switch v.(type) {
+	case nil, bool:
+		return ""
+	}
+	s := strings.TrimSpace(ResourceIDString(v))
+	if unusableResourceID(s) {
+		return ""
+	}
+	return s
+}
+
+func unusableResourceID(s string) bool {
+	if s == "" || s == "<nil>" {
+		return true
+	}
+	if isoDatePattern.MatchString(s) {
+		return true
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil && f == 0 {
+		return true
+	}
+	return false
+}
+
+func canonicalIDFromKey(obj map[string]any, key string) string {
+	if v, ok := lookupRawFieldValue(obj, key); ok {
+		if s := CanonicalResourceID(v); s != "" {
+			return s
+		}
+	}
+	if obj == nil || strings.HasSuffix(key, "_") {
+		return ""
+	}
+	v, ok := obj[key+"_"]
+	if !ok {
+		return ""
+	}
+	return CanonicalResourceID(v)
 }
 
 // ResourceIDString returns the stable text form used for resources.id.
@@ -1514,7 +1626,7 @@ func (s *Store) Upsert{{pascal .Name}}(data json.RawMessage) error {
 		return fmt.Errorf("unmarshaling {{.Name}}: %w", err)
 	}
 
-	id := extractObjectID(obj)
+	id := ExtractResourceID("{{.Resource}}", obj)
 	if id == "" {
 		return fmt.Errorf("missing id for {{.Name}}")
 	}
@@ -1560,7 +1672,9 @@ var resourceIDFieldOverrides = map[string]string{
 // Stable vendor identifiers win first; then fields derived from the resource
 // name (accountId, workspaceId); descriptive fallbacks are last. Keeping name
 // ahead of the resource-specific probe silently keys rows by display labels.
-var genericIDFieldFallbacks = []string{"id", "ID", "_id", "gid", "sid", "uid", "uuid", "guid", "api_id"}
+// `id_` is the Python-style trailing-underscore sibling of `id`; LookupFieldValue
+// also probes that spelling for every other key in this list.
+var genericIDFieldFallbacks = []string{"id", "ID", "_id", "id_", "gid", "sid", "uid", "uuid", "guid", "api_id"}
 var genericDescriptiveIDFieldFallbacks = []string{"name", "slug", "key", "code"}
 
 // resourceIDBaseOverrides preserves the complete final collection name for
@@ -1589,30 +1703,21 @@ var resourceParentKeyColumns = map[string][]string{
 // non-entity envelopes into the batch path.
 func ExtractResourceID(resourceType string, obj map[string]any) string {
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
-		if v := lookupFieldValue(obj, override); v != nil {
-			s := ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
+		if s := canonicalIDFromKey(obj, override); s != "" {
+			return s
 		}
 	}
 	for _, key := range genericIDFieldFallbacks {
-		if v := lookupFieldValue(obj, key); v != nil {
-			s := ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
 	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
 		return s
 	}
 	for _, key := range genericDescriptiveIDFieldFallbacks {
-		if v := lookupFieldValue(obj, key); v != nil {
-			s := ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
 	return ""
@@ -1622,27 +1727,31 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 // "<name>_code" / "<name>_id" / "<name>_key" / "<name>_slug" field (e.g. the
 // "currencies" resource keying on "currency_code" — see #2327). It is scoped to
 // the resource's OWN name so a foreign key like account_id/parent_id is never
-// promoted to the primary key, and it uses direct map lookups in a fixed suffix
-// order so the chosen id is deterministic.
+// promoted to the primary key, and it walks the same key spellings as
+// LookupFieldValue in a fixed suffix order so the chosen id is deterministic.
 func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 	for _, base := range resourceIDBaseNames(resourceType) {
 		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
-			if v, ok := obj[base+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
+			if s := canonicalScalarIDFromKey(obj, base+suffix); s != "" {
+				return s
 			}
 		}
 		camelBase := lowerCamelResourceIDBase(base)
 		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
-			if v, ok := obj[camelBase+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
+			if s := canonicalScalarIDFromKey(obj, camelBase+suffix); s != "" {
+				return s
 			}
 		}
 	}
 	return ""
+}
+
+func canonicalScalarIDFromKey(obj map[string]any, key string) string {
+	v, ok := lookupRawFieldValue(obj, key)
+	if !ok || scalarIDString(v) == "" {
+		return ""
+	}
+	return CanonicalResourceID(v)
 }
 
 // resourceIDBaseNames returns lowercase candidate singular/plural stems of a
@@ -2094,7 +2203,7 @@ func streamObjectID(data json.RawMessage, keys ...string) string {
 				continue
 			}
 			if v := LookupFieldValue(obj, key); v != nil {
-				if s := ResourceIDString(v); s != "" && s != "<nil>" {
+				if s := CanonicalResourceID(v); s != "" {
 					return s
 				}
 			}

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1475,10 +1475,10 @@ func DecodeJSONObject(data json.RawMessage) (map[string]any, error) {
 	return obj, nil
 }
 
-// CanonicalResourceID returns the stable text form used for resources.id, or
-// empty when the value cannot be a primary key (nil, boolean, zero, or a
-// timestamp). Callers that would otherwise store ResourceIDString output
-// must use this so unusable values are refused instead of written.
+// CanonicalResourceID is the identity invariant for generated stores: a value
+// becomes resources.id only when it can stably distinguish a row. ResourceIDString
+// will stringify zeros, timestamps, and booleans, and writing those keys
+// silently collapses or duplicates records on the next sync.
 func CanonicalResourceID(v any) string {
 	switch v.(type) {
 	case nil, bool:

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -185,7 +185,7 @@ func TestUpsertBatch_GenericFallbackList(t *testing.T) {
 	}
 	defer s.Close()
 
-	for _, key := range []string{"id", "ID", "_id", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"} {
+	for _, key := range []string{"id", "ID", "_id", "id_", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"} {
 		t.Run(key, func(t *testing.T) {
 			rt := "fallback_" + key
 			items := []json.RawMessage{
@@ -417,6 +417,142 @@ func TestUpsertBatch_ExtractFailuresReturnedForPerItemMisses(t *testing.T) {
 	}
 	if extractFailures != 2 {
 		t.Fatalf("extractFailures = %d, want 2 (two items have no extractable PK)", extractFailures)
+	}
+}
+
+func TestLookupFieldValue_DottedPathAndTrailingUnderscore(t *testing.T) {
+	nested := map[string]any{
+		"entityInfo": map[string]any{"entityId": "ent-1"},
+	}
+	if v := LookupFieldValue(nested, "entityInfo.entityId"); v != "ent-1" {
+		t.Fatalf("dotted camel path: want ent-1, got %v", v)
+	}
+	snakeNested := map[string]any{
+		"entity_info": map[string]any{"entity_id": "ent-2"},
+	}
+	if v := LookupFieldValue(snakeNested, "entity_info.entity_id"); v != "ent-2" {
+		t.Fatalf("dotted snake path: want ent-2, got %v", v)
+	}
+	if v := LookupFieldValue(map[string]any{"id_": "py-1"}, "id"); v != "py-1" {
+		t.Fatalf("trailing-underscore id_: want py-1, got %v", v)
+	}
+	if v := LookupFieldValue(map[string]any{"Id": "net-1"}, "id"); v != "net-1" {
+		t.Fatalf("PascalCase Id: want net-1, got %v", v)
+	}
+}
+
+func TestExtractResourceID_NestedOverrideAndIDUnderscore(t *testing.T) {
+	prev, hadPrev := resourceIDFieldOverrides["nestedEntities"]
+	resourceIDFieldOverrides["nestedEntities"] = "entityInfo.entityId"
+	defer func() {
+		if hadPrev {
+			resourceIDFieldOverrides["nestedEntities"] = prev
+		} else {
+			delete(resourceIDFieldOverrides, "nestedEntities")
+		}
+	}()
+
+	obj := map[string]any{
+		"name": "display",
+		"entityInfo": map[string]any{
+			"entityId": "ent-nested",
+		},
+	}
+	if got := ExtractResourceID("nestedEntities", obj); got != "ent-nested" {
+		t.Fatalf("dotted override = %q, want ent-nested", got)
+	}
+	if got := ExtractResourceID("devices", map[string]any{"id_": "dev-1", "name": "ignored"}); got != "dev-1" {
+		t.Fatalf("id_ fallback = %q, want dev-1", got)
+	}
+}
+
+func TestExtractResourceID_RefusesUnusableValues(t *testing.T) {
+	if got := ExtractResourceID("devices", map[string]any{"id": 0, "name": "keep-me"}); got != "keep-me" {
+		t.Fatalf("zero id must fall through, got %q", got)
+	}
+	if got := ExtractResourceID("devices", map[string]any{"id": "0", "uuid": "real-uuid"}); got != "real-uuid" {
+		t.Fatalf("string zero id must fall through, got %q", got)
+	}
+	if got := ExtractResourceID("devices", map[string]any{"id": "2026-08-22T15:04:05Z", "slug": "stable"}); got != "stable" {
+		t.Fatalf("timestamp id must fall through, got %q", got)
+	}
+	if got := ExtractResourceID("devices", map[string]any{"id": true}); got != "" {
+		t.Fatalf("boolean id must be refused, got %q", got)
+	}
+	if got := CanonicalResourceID("0"); got != "" {
+		t.Fatalf("CanonicalResourceID(0) = %q, want empty", got)
+	}
+	if got := CanonicalResourceID("2026-08-22"); got != "" {
+		t.Fatalf("CanonicalResourceID(date) = %q, want empty", got)
+	}
+}
+
+func TestUpsertBatch_NestedOverrideStoresRows(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	prev, hadPrev := resourceIDFieldOverrides["nestedEntities"]
+	resourceIDFieldOverrides["nestedEntities"] = "entityInfo.entityId"
+	defer func() {
+		if hadPrev {
+			resourceIDFieldOverrides["nestedEntities"] = prev
+		} else {
+			delete(resourceIDFieldOverrides, "nestedEntities")
+		}
+	}()
+
+	items := []json.RawMessage{
+		json.RawMessage(`{"name":"alpha","entityInfo":{"entityId":"ent-a"}}`),
+		json.RawMessage(`{"name":"beta","entityInfo":{"entityId":"ent-b"}}`),
+	}
+	stored, extractFailures, err := s.UpsertBatch("nestedEntities", items)
+	if err != nil {
+		t.Fatalf("UpsertBatch: %v", err)
+	}
+	if stored != 2 || extractFailures != 0 {
+		t.Fatalf("nested override stored=%d extractFailures=%d, want 2/0", stored, extractFailures)
+	}
+	row, err := s.Get("nestedEntities", "ent-a")
+	if err != nil {
+		t.Fatalf("Get ent-a: %v", err)
+	}
+	if !strings.Contains(string(row), `"ent-a"`) {
+		t.Fatalf("stored row missing nested id, got %s", row)
+	}
+}
+
+func TestUpsertBatch_RefusesUnusableIDsInsteadOfWritingThem(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	stored, extractFailures, err := s.UpsertBatch("restore_points", []json.RawMessage{
+		json.RawMessage(`{"id":"2026-08-22T15:04:05Z","label":"snapshot"}`),
+		json.RawMessage(`{"id":0,"label":"zero"}`),
+		json.RawMessage(`{"id_":"rp-1","label":"ok"}`),
+	})
+	if err != nil {
+		t.Fatalf("UpsertBatch: %v", err)
+	}
+	if stored != 1 || extractFailures != 2 {
+		t.Fatalf("unusable ids stored=%d extractFailures=%d, want 1/2", stored, extractFailures)
+	}
+	if _, err := s.Get("restore_points", "rp-1"); err != nil {
+		t.Fatalf("usable id_ row missing: %v", err)
+	}
+	var writtenZeros int
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM resources WHERE resource_type = ? AND id IN ('0', '2026-08-22T15:04:05Z')`, "restore_points").Scan(&writtenZeros); err != nil {
+		t.Fatalf("count unusable ids: %v", err)
+	}
+	if writtenZeros != 0 {
+		t.Fatalf("unusable ids were written: count=%d", writtenZeros)
 	}
 }
 

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -4284,8 +4284,7 @@ func extractID(resource string, obj map[string]any) string {
 func resourceIDFieldOverrideID(resource string, obj map[string]any) (string, bool) {
 	if override, ok := resourceIDFieldOverrides[resource]; ok && override != "" {
 		if v := store.LookupFieldValue(obj, override); v != nil {
-			s := store.ResourceIDString(v)
-			if s != "" && s != "<nil>" {
+			if s := store.CanonicalResourceID(v); s != "" {
 				return s, true
 			}
 		}
@@ -4300,8 +4299,7 @@ func synthesizeHTMLPageModeID(resource string, obj map[string]any) string {
 	}
 	for _, key := range []string{"canonical_url", "url", "image_url"} {
 		if v := store.LookupFieldValue(obj, key); v != nil {
-			s := store.ResourceIDString(v)
-			if s != "" && s != "<nil>" {
+			if s := store.CanonicalResourceID(v); s != "" {
 				return s
 			}
 		}

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -7971,9 +7971,10 @@ func TestParseReadsXResourceIDCriticalAndSyncable(t *testing.T) {
 			wantSyncable: true,
 		},
 		{
-			name:        "no extensions: response-schema fallback picks id",
-			extraExt:    ``,
-			wantIDField: "id",
+			name: "x-resource-id dotted path is preserved as a field path",
+			extraExt: `    x-resource-id: entityInfo.entityId
+`,
+			wantIDField: "entityInfo.entityId",
 		},
 	}
 

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -2353,9 +2353,10 @@ type Endpoint struct {
 	// IDField is the resolved primary-key field name for items returned by this
 	// endpoint, populated either by a path-item-level `x-resource-id` extension,
 	// a resource member path parameter that also appears in the response item,
-	// or, for OpenAPI specs, by walking the response schema. Empty when no key
-	// could be resolved; templates fall back to runtime list scanning. Internal
-	// YAML specs may set this directly.
+	// or, for OpenAPI specs, by walking the response schema. May be a dotted
+	// path (`entityInfo.entityId`); generated LookupFieldValue walks it.
+	// Empty when no key could be resolved; templates fall back to runtime list
+	// scanning. Internal YAML specs may set this directly.
 	IDField string `yaml:"id_field,omitempty" json:"id_field,omitempty"`
 	// TenantScopeColumn is the tenant discriminator column declared by the
 	// path-item-level `x-pp-tenant-scope-column` extension (e.g. "workspace").

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -1032,11 +1032,9 @@ func FTSMatchQuery(query string) string {
 }
 
 func extractObjectID(obj map[string]any) string {
-	for _, key := range []string{"id", "Id", "ID", "_id", "uuid", "slug", "name"} {
-		if v, ok := obj[key]; ok {
-			if id := ResourceIDString(v); id != "" && id != "<nil>" {
-				return id
-			}
+	for _, key := range []string{"id", "ID", "_id", "id_", "uuid", "slug", "name"} {
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
 	return ""
@@ -1055,16 +1053,85 @@ func ftsRowID(scope, id string) int64 {
 	return int64(h.Sum64() & 0x7FFFFFFFFFFFFFFF) // ensure positive
 }
 
-// LookupFieldValue resolves a field value from a JSON object map, trying the
-// snake_case key first, then the camelCase rendering, then the PascalCase
-// rendering. Exported so the sync command's extractID and the upsert path
-// resolve fields the same way — a divergence here produces silent drops on
-// heterogeneous payloads. The PascalCase pass handles .NET-shaped responses
-// (`Id`, `Name`, `OrderId`) without forcing each spec to declare casing.
+// LookupFieldValue resolves a field value from a JSON object map. A dotted
+// key is walked as a path (`entityInfo.entityId`); each segment tries snake,
+// camel, and Pascal spellings, then the Python-style trailing-underscore
+// sibling (`id` → `id_`). Exported so the sync command's extractID and the
+// upsert path resolve fields the same way — a divergence here produces
+// silent drops on heterogeneous payloads. The PascalCase pass handles
+// .NET-shaped responses (`Id`, `Name`, `OrderId`) without forcing each spec
+// to declare casing.
 func LookupFieldValue(obj map[string]any, snakeKey string) any {
-	if v, ok := obj[snakeKey]; ok {
-		return sqliteFieldValue(v)
+	v, ok := lookupRawFieldValue(obj, snakeKey)
+	if !ok {
+		return nil
 	}
+	return sqliteFieldValue(v)
+}
+
+func lookupRawFieldValue(obj map[string]any, key string) (any, bool) {
+	if obj == nil || key == "" {
+		return nil, false
+	}
+	if strings.Contains(key, ".") {
+		return lookupRawDottedFieldValue(obj, key)
+	}
+	return lookupRawFlatFieldValue(obj, key)
+}
+
+func lookupRawDottedFieldValue(obj map[string]any, path string) (any, bool) {
+	if v, ok := lookupRawFlatFieldValue(obj, path); ok {
+		return v, true
+	}
+	segments := strings.Split(path, ".")
+	if len(segments) < 2 {
+		return nil, false
+	}
+	current := obj
+	for i, segment := range segments {
+		if segment == "" {
+			return nil, false
+		}
+		v, ok := lookupRawFlatFieldValue(current, segment)
+		if !ok {
+			return nil, false
+		}
+		if i == len(segments)-1 {
+			return v, true
+		}
+		next, ok := v.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current = next
+	}
+	return nil, false
+}
+
+func lookupRawFlatFieldValue(obj map[string]any, snakeKey string) (any, bool) {
+	for _, key := range fieldKeySpellings(snakeKey) {
+		if v, ok := obj[key]; ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func fieldKeySpellings(snakeKey string) []string {
+	seen := make(map[string]struct{}, 8)
+	out := make([]string, 0, 8)
+	add := func(s string) {
+		if s == "" {
+			return
+		}
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+
+	add(snakeKey)
 	parts := strings.Split(snakeKey, "_")
 	for i := 1; i < len(parts); i++ {
 		if parts[i] == "" {
@@ -1072,17 +1139,17 @@ func LookupFieldValue(obj map[string]any, snakeKey string) any {
 		}
 		parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
 	}
-	camel := strings.Join(parts, "")
-	if v, ok := obj[camel]; ok {
-		return sqliteFieldValue(v)
-	}
+	add(strings.Join(parts, ""))
 	if parts[0] != "" {
-		pascal := strings.ToUpper(parts[0][:1]) + parts[0][1:] + strings.Join(parts[1:], "")
-		if v, ok := obj[pascal]; ok {
-			return sqliteFieldValue(v)
+		add(strings.ToUpper(parts[0][:1]) + parts[0][1:] + strings.Join(parts[1:], ""))
+	}
+	n := len(out)
+	for i := 0; i < n; i++ {
+		if !strings.HasSuffix(out[i], "_") {
+			add(out[i] + "_")
 		}
 	}
-	return nil
+	return out
 }
 
 func sqliteFieldValue(v any) any {
@@ -1118,6 +1185,51 @@ func DecodeJSONObject(data json.RawMessage) (map[string]any, error) {
 		return nil, err
 	}
 	return obj, nil
+}
+
+// CanonicalResourceID returns the stable text form used for resources.id, or
+// empty when the value cannot be a primary key (nil, boolean, zero, or a
+// timestamp). Callers that would otherwise store ResourceIDString output
+// must use this so unusable values are refused instead of written.
+func CanonicalResourceID(v any) string {
+	switch v.(type) {
+	case nil, bool:
+		return ""
+	}
+	s := strings.TrimSpace(ResourceIDString(v))
+	if unusableResourceID(s) {
+		return ""
+	}
+	return s
+}
+
+func unusableResourceID(s string) bool {
+	if s == "" || s == "<nil>" {
+		return true
+	}
+	if isoDatePattern.MatchString(s) {
+		return true
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil && f == 0 {
+		return true
+	}
+	return false
+}
+
+func canonicalIDFromKey(obj map[string]any, key string) string {
+	if v, ok := lookupRawFieldValue(obj, key); ok {
+		if s := CanonicalResourceID(v); s != "" {
+			return s
+		}
+	}
+	if obj == nil || strings.HasSuffix(key, "_") {
+		return ""
+	}
+	v, ok := obj[key+"_"]
+	if !ok {
+		return ""
+	}
+	return CanonicalResourceID(v)
 }
 
 // ResourceIDString returns the stable text form used for resources.id.
@@ -1190,7 +1302,9 @@ var resourceIDFieldOverrides = map[string]string{
 // Stable vendor identifiers win first; then fields derived from the resource
 // name (accountId, workspaceId); descriptive fallbacks are last. Keeping name
 // ahead of the resource-specific probe silently keys rows by display labels.
-var genericIDFieldFallbacks = []string{"id", "ID", "_id", "gid", "sid", "uid", "uuid", "guid", "api_id"}
+// `id_` is the Python-style trailing-underscore sibling of `id`; LookupFieldValue
+// also probes that spelling for every other key in this list.
+var genericIDFieldFallbacks = []string{"id", "ID", "_id", "id_", "gid", "sid", "uid", "uuid", "guid", "api_id"}
 var genericDescriptiveIDFieldFallbacks = []string{"name", "slug", "key", "code"}
 
 // resourceIDBaseOverrides preserves the complete final collection name for
@@ -1211,30 +1325,21 @@ var resourceParentKeyColumns = map[string][]string{}
 // non-entity envelopes into the batch path.
 func ExtractResourceID(resourceType string, obj map[string]any) string {
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
-		if v := lookupFieldValue(obj, override); v != nil {
-			s := ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
+		if s := canonicalIDFromKey(obj, override); s != "" {
+			return s
 		}
 	}
 	for _, key := range genericIDFieldFallbacks {
-		if v := lookupFieldValue(obj, key); v != nil {
-			s := ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
 	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
 		return s
 	}
 	for _, key := range genericDescriptiveIDFieldFallbacks {
-		if v := lookupFieldValue(obj, key); v != nil {
-			s := ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
 	return ""
@@ -1244,27 +1349,31 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 // "<name>_code" / "<name>_id" / "<name>_key" / "<name>_slug" field (e.g. the
 // "currencies" resource keying on "currency_code" — see #2327). It is scoped to
 // the resource's OWN name so a foreign key like account_id/parent_id is never
-// promoted to the primary key, and it uses direct map lookups in a fixed suffix
-// order so the chosen id is deterministic.
+// promoted to the primary key, and it walks the same key spellings as
+// LookupFieldValue in a fixed suffix order so the chosen id is deterministic.
 func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 	for _, base := range resourceIDBaseNames(resourceType) {
 		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
-			if v, ok := obj[base+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
+			if s := canonicalScalarIDFromKey(obj, base+suffix); s != "" {
+				return s
 			}
 		}
 		camelBase := lowerCamelResourceIDBase(base)
 		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
-			if v, ok := obj[camelBase+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
+			if s := canonicalScalarIDFromKey(obj, camelBase+suffix); s != "" {
+				return s
 			}
 		}
 	}
 	return ""
+}
+
+func canonicalScalarIDFromKey(obj map[string]any, key string) string {
+	v, ok := lookupRawFieldValue(obj, key)
+	if !ok || scalarIDString(v) == "" {
+		return ""
+	}
+	return CanonicalResourceID(v)
 }
 
 // resourceIDBaseNames returns lowercase candidate singular/plural stems of a

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -1187,10 +1187,10 @@ func DecodeJSONObject(data json.RawMessage) (map[string]any, error) {
 	return obj, nil
 }
 
-// CanonicalResourceID returns the stable text form used for resources.id, or
-// empty when the value cannot be a primary key (nil, boolean, zero, or a
-// timestamp). Callers that would otherwise store ResourceIDString output
-// must use this so unusable values are refused instead of written.
+// CanonicalResourceID is the identity invariant for generated stores: a value
+// becomes resources.id only when it can stably distinguish a row. ResourceIDString
+// will stringify zeros, timestamps, and booleans, and writing those keys
+// silently collapses or duplicates records on the next sync.
 func CanonicalResourceID(v any) string {
 	switch v.(type) {
 	case nil, bool:

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1349,10 +1349,10 @@ func DecodeJSONObject(data json.RawMessage) (map[string]any, error) {
 	return obj, nil
 }
 
-// CanonicalResourceID returns the stable text form used for resources.id, or
-// empty when the value cannot be a primary key (nil, boolean, zero, or a
-// timestamp). Callers that would otherwise store ResourceIDString output
-// must use this so unusable values are refused instead of written.
+// CanonicalResourceID is the identity invariant for generated stores: a value
+// becomes resources.id only when it can stably distinguish a row. ResourceIDString
+// will stringify zeros, timestamps, and booleans, and writing those keys
+// silently collapses or duplicates records on the next sync.
 func CanonicalResourceID(v any) string {
 	switch v.(type) {
 	case nil, bool:

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1194,11 +1194,9 @@ func FTSMatchQuery(query string) string {
 }
 
 func extractObjectID(obj map[string]any) string {
-	for _, key := range []string{"id", "Id", "ID", "_id", "uuid", "slug", "name"} {
-		if v, ok := obj[key]; ok {
-			if id := ResourceIDString(v); id != "" && id != "<nil>" {
-				return id
-			}
+	for _, key := range []string{"id", "ID", "_id", "id_", "uuid", "slug", "name"} {
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
 	return ""
@@ -1217,16 +1215,85 @@ func ftsRowID(scope, id string) int64 {
 	return int64(h.Sum64() & 0x7FFFFFFFFFFFFFFF) // ensure positive
 }
 
-// LookupFieldValue resolves a field value from a JSON object map, trying the
-// snake_case key first, then the camelCase rendering, then the PascalCase
-// rendering. Exported so the sync command's extractID and the upsert path
-// resolve fields the same way — a divergence here produces silent drops on
-// heterogeneous payloads. The PascalCase pass handles .NET-shaped responses
-// (`Id`, `Name`, `OrderId`) without forcing each spec to declare casing.
+// LookupFieldValue resolves a field value from a JSON object map. A dotted
+// key is walked as a path (`entityInfo.entityId`); each segment tries snake,
+// camel, and Pascal spellings, then the Python-style trailing-underscore
+// sibling (`id` → `id_`). Exported so the sync command's extractID and the
+// upsert path resolve fields the same way — a divergence here produces
+// silent drops on heterogeneous payloads. The PascalCase pass handles
+// .NET-shaped responses (`Id`, `Name`, `OrderId`) without forcing each spec
+// to declare casing.
 func LookupFieldValue(obj map[string]any, snakeKey string) any {
-	if v, ok := obj[snakeKey]; ok {
-		return sqliteFieldValue(v)
+	v, ok := lookupRawFieldValue(obj, snakeKey)
+	if !ok {
+		return nil
 	}
+	return sqliteFieldValue(v)
+}
+
+func lookupRawFieldValue(obj map[string]any, key string) (any, bool) {
+	if obj == nil || key == "" {
+		return nil, false
+	}
+	if strings.Contains(key, ".") {
+		return lookupRawDottedFieldValue(obj, key)
+	}
+	return lookupRawFlatFieldValue(obj, key)
+}
+
+func lookupRawDottedFieldValue(obj map[string]any, path string) (any, bool) {
+	if v, ok := lookupRawFlatFieldValue(obj, path); ok {
+		return v, true
+	}
+	segments := strings.Split(path, ".")
+	if len(segments) < 2 {
+		return nil, false
+	}
+	current := obj
+	for i, segment := range segments {
+		if segment == "" {
+			return nil, false
+		}
+		v, ok := lookupRawFlatFieldValue(current, segment)
+		if !ok {
+			return nil, false
+		}
+		if i == len(segments)-1 {
+			return v, true
+		}
+		next, ok := v.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current = next
+	}
+	return nil, false
+}
+
+func lookupRawFlatFieldValue(obj map[string]any, snakeKey string) (any, bool) {
+	for _, key := range fieldKeySpellings(snakeKey) {
+		if v, ok := obj[key]; ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func fieldKeySpellings(snakeKey string) []string {
+	seen := make(map[string]struct{}, 8)
+	out := make([]string, 0, 8)
+	add := func(s string) {
+		if s == "" {
+			return
+		}
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+
+	add(snakeKey)
 	parts := strings.Split(snakeKey, "_")
 	for i := 1; i < len(parts); i++ {
 		if parts[i] == "" {
@@ -1234,17 +1301,17 @@ func LookupFieldValue(obj map[string]any, snakeKey string) any {
 		}
 		parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
 	}
-	camel := strings.Join(parts, "")
-	if v, ok := obj[camel]; ok {
-		return sqliteFieldValue(v)
-	}
+	add(strings.Join(parts, ""))
 	if parts[0] != "" {
-		pascal := strings.ToUpper(parts[0][:1]) + parts[0][1:] + strings.Join(parts[1:], "")
-		if v, ok := obj[pascal]; ok {
-			return sqliteFieldValue(v)
+		add(strings.ToUpper(parts[0][:1]) + parts[0][1:] + strings.Join(parts[1:], ""))
+	}
+	n := len(out)
+	for i := 0; i < n; i++ {
+		if !strings.HasSuffix(out[i], "_") {
+			add(out[i] + "_")
 		}
 	}
-	return nil
+	return out
 }
 
 func sqliteFieldValue(v any) any {
@@ -1280,6 +1347,51 @@ func DecodeJSONObject(data json.RawMessage) (map[string]any, error) {
 		return nil, err
 	}
 	return obj, nil
+}
+
+// CanonicalResourceID returns the stable text form used for resources.id, or
+// empty when the value cannot be a primary key (nil, boolean, zero, or a
+// timestamp). Callers that would otherwise store ResourceIDString output
+// must use this so unusable values are refused instead of written.
+func CanonicalResourceID(v any) string {
+	switch v.(type) {
+	case nil, bool:
+		return ""
+	}
+	s := strings.TrimSpace(ResourceIDString(v))
+	if unusableResourceID(s) {
+		return ""
+	}
+	return s
+}
+
+func unusableResourceID(s string) bool {
+	if s == "" || s == "<nil>" {
+		return true
+	}
+	if isoDatePattern.MatchString(s) {
+		return true
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil && f == 0 {
+		return true
+	}
+	return false
+}
+
+func canonicalIDFromKey(obj map[string]any, key string) string {
+	if v, ok := lookupRawFieldValue(obj, key); ok {
+		if s := CanonicalResourceID(v); s != "" {
+			return s
+		}
+	}
+	if obj == nil || strings.HasSuffix(key, "_") {
+		return ""
+	}
+	v, ok := obj[key+"_"]
+	if !ok {
+		return ""
+	}
+	return CanonicalResourceID(v)
 }
 
 // ResourceIDString returns the stable text form used for resources.id.
@@ -1363,7 +1475,7 @@ func (s *Store) UpsertLeagues(data json.RawMessage) error {
 		return fmt.Errorf("unmarshaling leagues: %w", err)
 	}
 
-	id := extractObjectID(obj)
+	id := ExtractResourceID("leagues", obj)
 	if id == "" {
 		return fmt.Errorf("missing id for leagues")
 	}
@@ -1404,7 +1516,9 @@ var resourceIDFieldOverrides = map[string]string{
 // Stable vendor identifiers win first; then fields derived from the resource
 // name (accountId, workspaceId); descriptive fallbacks are last. Keeping name
 // ahead of the resource-specific probe silently keys rows by display labels.
-var genericIDFieldFallbacks = []string{"id", "ID", "_id", "gid", "sid", "uid", "uuid", "guid", "api_id"}
+// `id_` is the Python-style trailing-underscore sibling of `id`; LookupFieldValue
+// also probes that spelling for every other key in this list.
+var genericIDFieldFallbacks = []string{"id", "ID", "_id", "id_", "gid", "sid", "uid", "uuid", "guid", "api_id"}
 var genericDescriptiveIDFieldFallbacks = []string{"name", "slug", "key", "code"}
 
 // resourceIDBaseOverrides preserves the complete final collection name for
@@ -1429,30 +1543,21 @@ var resourceParentKeyColumns = map[string][]string{
 // non-entity envelopes into the batch path.
 func ExtractResourceID(resourceType string, obj map[string]any) string {
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
-		if v := lookupFieldValue(obj, override); v != nil {
-			s := ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
+		if s := canonicalIDFromKey(obj, override); s != "" {
+			return s
 		}
 	}
 	for _, key := range genericIDFieldFallbacks {
-		if v := lookupFieldValue(obj, key); v != nil {
-			s := ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
 	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
 		return s
 	}
 	for _, key := range genericDescriptiveIDFieldFallbacks {
-		if v := lookupFieldValue(obj, key); v != nil {
-			s := ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
 	return ""
@@ -1462,27 +1567,31 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 // "<name>_code" / "<name>_id" / "<name>_key" / "<name>_slug" field (e.g. the
 // "currencies" resource keying on "currency_code" — see #2327). It is scoped to
 // the resource's OWN name so a foreign key like account_id/parent_id is never
-// promoted to the primary key, and it uses direct map lookups in a fixed suffix
-// order so the chosen id is deterministic.
+// promoted to the primary key, and it walks the same key spellings as
+// LookupFieldValue in a fixed suffix order so the chosen id is deterministic.
 func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 	for _, base := range resourceIDBaseNames(resourceType) {
 		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
-			if v, ok := obj[base+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
+			if s := canonicalScalarIDFromKey(obj, base+suffix); s != "" {
+				return s
 			}
 		}
 		camelBase := lowerCamelResourceIDBase(base)
 		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
-			if v, ok := obj[camelBase+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
+			if s := canonicalScalarIDFromKey(obj, camelBase+suffix); s != "" {
+				return s
 			}
 		}
 	}
 	return ""
+}
+
+func canonicalScalarIDFromKey(obj map[string]any, key string) string {
+	v, ok := lookupRawFieldValue(obj, key)
+	if !ok || scalarIDString(v) == "" {
+		return ""
+	}
+	return CanonicalResourceID(v)
 }
 
 // resourceIDBaseNames returns lowercase candidate singular/plural stems of a

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1200,11 +1200,9 @@ func FTSMatchQuery(query string) string {
 }
 
 func extractObjectID(obj map[string]any) string {
-	for _, key := range []string{"id", "Id", "ID", "_id", "uuid", "slug", "name"} {
-		if v, ok := obj[key]; ok {
-			if id := ResourceIDString(v); id != "" && id != "<nil>" {
-				return id
-			}
+	for _, key := range []string{"id", "ID", "_id", "id_", "uuid", "slug", "name"} {
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
 	return ""
@@ -1223,16 +1221,85 @@ func ftsRowID(scope, id string) int64 {
 	return int64(h.Sum64() & 0x7FFFFFFFFFFFFFFF) // ensure positive
 }
 
-// LookupFieldValue resolves a field value from a JSON object map, trying the
-// snake_case key first, then the camelCase rendering, then the PascalCase
-// rendering. Exported so the sync command's extractID and the upsert path
-// resolve fields the same way — a divergence here produces silent drops on
-// heterogeneous payloads. The PascalCase pass handles .NET-shaped responses
-// (`Id`, `Name`, `OrderId`) without forcing each spec to declare casing.
+// LookupFieldValue resolves a field value from a JSON object map. A dotted
+// key is walked as a path (`entityInfo.entityId`); each segment tries snake,
+// camel, and Pascal spellings, then the Python-style trailing-underscore
+// sibling (`id` → `id_`). Exported so the sync command's extractID and the
+// upsert path resolve fields the same way — a divergence here produces
+// silent drops on heterogeneous payloads. The PascalCase pass handles
+// .NET-shaped responses (`Id`, `Name`, `OrderId`) without forcing each spec
+// to declare casing.
 func LookupFieldValue(obj map[string]any, snakeKey string) any {
-	if v, ok := obj[snakeKey]; ok {
-		return sqliteFieldValue(v)
+	v, ok := lookupRawFieldValue(obj, snakeKey)
+	if !ok {
+		return nil
 	}
+	return sqliteFieldValue(v)
+}
+
+func lookupRawFieldValue(obj map[string]any, key string) (any, bool) {
+	if obj == nil || key == "" {
+		return nil, false
+	}
+	if strings.Contains(key, ".") {
+		return lookupRawDottedFieldValue(obj, key)
+	}
+	return lookupRawFlatFieldValue(obj, key)
+}
+
+func lookupRawDottedFieldValue(obj map[string]any, path string) (any, bool) {
+	if v, ok := lookupRawFlatFieldValue(obj, path); ok {
+		return v, true
+	}
+	segments := strings.Split(path, ".")
+	if len(segments) < 2 {
+		return nil, false
+	}
+	current := obj
+	for i, segment := range segments {
+		if segment == "" {
+			return nil, false
+		}
+		v, ok := lookupRawFlatFieldValue(current, segment)
+		if !ok {
+			return nil, false
+		}
+		if i == len(segments)-1 {
+			return v, true
+		}
+		next, ok := v.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current = next
+	}
+	return nil, false
+}
+
+func lookupRawFlatFieldValue(obj map[string]any, snakeKey string) (any, bool) {
+	for _, key := range fieldKeySpellings(snakeKey) {
+		if v, ok := obj[key]; ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func fieldKeySpellings(snakeKey string) []string {
+	seen := make(map[string]struct{}, 8)
+	out := make([]string, 0, 8)
+	add := func(s string) {
+		if s == "" {
+			return
+		}
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+
+	add(snakeKey)
 	parts := strings.Split(snakeKey, "_")
 	for i := 1; i < len(parts); i++ {
 		if parts[i] == "" {
@@ -1240,17 +1307,17 @@ func LookupFieldValue(obj map[string]any, snakeKey string) any {
 		}
 		parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
 	}
-	camel := strings.Join(parts, "")
-	if v, ok := obj[camel]; ok {
-		return sqliteFieldValue(v)
-	}
+	add(strings.Join(parts, ""))
 	if parts[0] != "" {
-		pascal := strings.ToUpper(parts[0][:1]) + parts[0][1:] + strings.Join(parts[1:], "")
-		if v, ok := obj[pascal]; ok {
-			return sqliteFieldValue(v)
+		add(strings.ToUpper(parts[0][:1]) + parts[0][1:] + strings.Join(parts[1:], ""))
+	}
+	n := len(out)
+	for i := 0; i < n; i++ {
+		if !strings.HasSuffix(out[i], "_") {
+			add(out[i] + "_")
 		}
 	}
-	return nil
+	return out
 }
 
 func sqliteFieldValue(v any) any {
@@ -1286,6 +1353,51 @@ func DecodeJSONObject(data json.RawMessage) (map[string]any, error) {
 		return nil, err
 	}
 	return obj, nil
+}
+
+// CanonicalResourceID returns the stable text form used for resources.id, or
+// empty when the value cannot be a primary key (nil, boolean, zero, or a
+// timestamp). Callers that would otherwise store ResourceIDString output
+// must use this so unusable values are refused instead of written.
+func CanonicalResourceID(v any) string {
+	switch v.(type) {
+	case nil, bool:
+		return ""
+	}
+	s := strings.TrimSpace(ResourceIDString(v))
+	if unusableResourceID(s) {
+		return ""
+	}
+	return s
+}
+
+func unusableResourceID(s string) bool {
+	if s == "" || s == "<nil>" {
+		return true
+	}
+	if isoDatePattern.MatchString(s) {
+		return true
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil && f == 0 {
+		return true
+	}
+	return false
+}
+
+func canonicalIDFromKey(obj map[string]any, key string) string {
+	if v, ok := lookupRawFieldValue(obj, key); ok {
+		if s := CanonicalResourceID(v); s != "" {
+			return s
+		}
+	}
+	if obj == nil || strings.HasSuffix(key, "_") {
+		return ""
+	}
+	v, ok := obj[key+"_"]
+	if !ok {
+		return ""
+	}
+	return CanonicalResourceID(v)
 }
 
 // ResourceIDString returns the stable text form used for resources.id.
@@ -1369,7 +1481,7 @@ func (s *Store) UpsertGadgets(data json.RawMessage) error {
 		return fmt.Errorf("unmarshaling gadgets: %w", err)
 	}
 
-	id := extractObjectID(obj)
+	id := ExtractResourceID("gadgets", obj)
 	if id == "" {
 		return fmt.Errorf("missing id for gadgets")
 	}
@@ -1421,7 +1533,7 @@ func (s *Store) UpsertWidgets(data json.RawMessage) error {
 		return fmt.Errorf("unmarshaling widgets: %w", err)
 	}
 
-	id := extractObjectID(obj)
+	id := ExtractResourceID("widgets", obj)
 	if id == "" {
 		return fmt.Errorf("missing id for widgets")
 	}
@@ -1460,7 +1572,9 @@ var resourceIDFieldOverrides = map[string]string{}
 // Stable vendor identifiers win first; then fields derived from the resource
 // name (accountId, workspaceId); descriptive fallbacks are last. Keeping name
 // ahead of the resource-specific probe silently keys rows by display labels.
-var genericIDFieldFallbacks = []string{"id", "ID", "_id", "gid", "sid", "uid", "uuid", "guid", "api_id"}
+// `id_` is the Python-style trailing-underscore sibling of `id`; LookupFieldValue
+// also probes that spelling for every other key in this list.
+var genericIDFieldFallbacks = []string{"id", "ID", "_id", "id_", "gid", "sid", "uid", "uuid", "guid", "api_id"}
 var genericDescriptiveIDFieldFallbacks = []string{"name", "slug", "key", "code"}
 
 // resourceIDBaseOverrides preserves the complete final collection name for
@@ -1481,30 +1595,21 @@ var resourceParentKeyColumns = map[string][]string{}
 // non-entity envelopes into the batch path.
 func ExtractResourceID(resourceType string, obj map[string]any) string {
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
-		if v := lookupFieldValue(obj, override); v != nil {
-			s := ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
+		if s := canonicalIDFromKey(obj, override); s != "" {
+			return s
 		}
 	}
 	for _, key := range genericIDFieldFallbacks {
-		if v := lookupFieldValue(obj, key); v != nil {
-			s := ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
 	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
 		return s
 	}
 	for _, key := range genericDescriptiveIDFieldFallbacks {
-		if v := lookupFieldValue(obj, key); v != nil {
-			s := ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
 	return ""
@@ -1514,27 +1619,31 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 // "<name>_code" / "<name>_id" / "<name>_key" / "<name>_slug" field (e.g. the
 // "currencies" resource keying on "currency_code" — see #2327). It is scoped to
 // the resource's OWN name so a foreign key like account_id/parent_id is never
-// promoted to the primary key, and it uses direct map lookups in a fixed suffix
-// order so the chosen id is deterministic.
+// promoted to the primary key, and it walks the same key spellings as
+// LookupFieldValue in a fixed suffix order so the chosen id is deterministic.
 func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 	for _, base := range resourceIDBaseNames(resourceType) {
 		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
-			if v, ok := obj[base+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
+			if s := canonicalScalarIDFromKey(obj, base+suffix); s != "" {
+				return s
 			}
 		}
 		camelBase := lowerCamelResourceIDBase(base)
 		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
-			if v, ok := obj[camelBase+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
+			if s := canonicalScalarIDFromKey(obj, camelBase+suffix); s != "" {
+				return s
 			}
 		}
 	}
 	return ""
+}
+
+func canonicalScalarIDFromKey(obj map[string]any, key string) string {
+	v, ok := lookupRawFieldValue(obj, key)
+	if !ok || scalarIDString(v) == "" {
+		return ""
+	}
+	return CanonicalResourceID(v)
 }
 
 // resourceIDBaseNames returns lowercase candidate singular/plural stems of a

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1355,10 +1355,10 @@ func DecodeJSONObject(data json.RawMessage) (map[string]any, error) {
 	return obj, nil
 }
 
-// CanonicalResourceID returns the stable text form used for resources.id, or
-// empty when the value cannot be a primary key (nil, boolean, zero, or a
-// timestamp). Callers that would otherwise store ResourceIDString output
-// must use this so unusable values are refused instead of written.
+// CanonicalResourceID is the identity invariant for generated stores: a value
+// becomes resources.id only when it can stably distinguish a row. ResourceIDString
+// will stringify zeros, timestamps, and booleans, and writing those keys
+// silently collapses or duplicates records on the next sync.
 func CanonicalResourceID(v any) string {
 	switch v.(type) {
 	case nil, bool:

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1202,11 +1202,9 @@ func FTSMatchQuery(query string) string {
 }
 
 func extractObjectID(obj map[string]any) string {
-	for _, key := range []string{"id", "Id", "ID", "_id", "uuid", "slug", "name"} {
-		if v, ok := obj[key]; ok {
-			if id := ResourceIDString(v); id != "" && id != "<nil>" {
-				return id
-			}
+	for _, key := range []string{"id", "ID", "_id", "id_", "uuid", "slug", "name"} {
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
 	return ""
@@ -1225,16 +1223,85 @@ func ftsRowID(scope, id string) int64 {
 	return int64(h.Sum64() & 0x7FFFFFFFFFFFFFFF) // ensure positive
 }
 
-// LookupFieldValue resolves a field value from a JSON object map, trying the
-// snake_case key first, then the camelCase rendering, then the PascalCase
-// rendering. Exported so the sync command's extractID and the upsert path
-// resolve fields the same way — a divergence here produces silent drops on
-// heterogeneous payloads. The PascalCase pass handles .NET-shaped responses
-// (`Id`, `Name`, `OrderId`) without forcing each spec to declare casing.
+// LookupFieldValue resolves a field value from a JSON object map. A dotted
+// key is walked as a path (`entityInfo.entityId`); each segment tries snake,
+// camel, and Pascal spellings, then the Python-style trailing-underscore
+// sibling (`id` → `id_`). Exported so the sync command's extractID and the
+// upsert path resolve fields the same way — a divergence here produces
+// silent drops on heterogeneous payloads. The PascalCase pass handles
+// .NET-shaped responses (`Id`, `Name`, `OrderId`) without forcing each spec
+// to declare casing.
 func LookupFieldValue(obj map[string]any, snakeKey string) any {
-	if v, ok := obj[snakeKey]; ok {
-		return sqliteFieldValue(v)
+	v, ok := lookupRawFieldValue(obj, snakeKey)
+	if !ok {
+		return nil
 	}
+	return sqliteFieldValue(v)
+}
+
+func lookupRawFieldValue(obj map[string]any, key string) (any, bool) {
+	if obj == nil || key == "" {
+		return nil, false
+	}
+	if strings.Contains(key, ".") {
+		return lookupRawDottedFieldValue(obj, key)
+	}
+	return lookupRawFlatFieldValue(obj, key)
+}
+
+func lookupRawDottedFieldValue(obj map[string]any, path string) (any, bool) {
+	if v, ok := lookupRawFlatFieldValue(obj, path); ok {
+		return v, true
+	}
+	segments := strings.Split(path, ".")
+	if len(segments) < 2 {
+		return nil, false
+	}
+	current := obj
+	for i, segment := range segments {
+		if segment == "" {
+			return nil, false
+		}
+		v, ok := lookupRawFlatFieldValue(current, segment)
+		if !ok {
+			return nil, false
+		}
+		if i == len(segments)-1 {
+			return v, true
+		}
+		next, ok := v.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current = next
+	}
+	return nil, false
+}
+
+func lookupRawFlatFieldValue(obj map[string]any, snakeKey string) (any, bool) {
+	for _, key := range fieldKeySpellings(snakeKey) {
+		if v, ok := obj[key]; ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func fieldKeySpellings(snakeKey string) []string {
+	seen := make(map[string]struct{}, 8)
+	out := make([]string, 0, 8)
+	add := func(s string) {
+		if s == "" {
+			return
+		}
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+
+	add(snakeKey)
 	parts := strings.Split(snakeKey, "_")
 	for i := 1; i < len(parts); i++ {
 		if parts[i] == "" {
@@ -1242,17 +1309,17 @@ func LookupFieldValue(obj map[string]any, snakeKey string) any {
 		}
 		parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
 	}
-	camel := strings.Join(parts, "")
-	if v, ok := obj[camel]; ok {
-		return sqliteFieldValue(v)
-	}
+	add(strings.Join(parts, ""))
 	if parts[0] != "" {
-		pascal := strings.ToUpper(parts[0][:1]) + parts[0][1:] + strings.Join(parts[1:], "")
-		if v, ok := obj[pascal]; ok {
-			return sqliteFieldValue(v)
+		add(strings.ToUpper(parts[0][:1]) + parts[0][1:] + strings.Join(parts[1:], ""))
+	}
+	n := len(out)
+	for i := 0; i < n; i++ {
+		if !strings.HasSuffix(out[i], "_") {
+			add(out[i] + "_")
 		}
 	}
-	return nil
+	return out
 }
 
 func sqliteFieldValue(v any) any {
@@ -1288,6 +1355,51 @@ func DecodeJSONObject(data json.RawMessage) (map[string]any, error) {
 		return nil, err
 	}
 	return obj, nil
+}
+
+// CanonicalResourceID returns the stable text form used for resources.id, or
+// empty when the value cannot be a primary key (nil, boolean, zero, or a
+// timestamp). Callers that would otherwise store ResourceIDString output
+// must use this so unusable values are refused instead of written.
+func CanonicalResourceID(v any) string {
+	switch v.(type) {
+	case nil, bool:
+		return ""
+	}
+	s := strings.TrimSpace(ResourceIDString(v))
+	if unusableResourceID(s) {
+		return ""
+	}
+	return s
+}
+
+func unusableResourceID(s string) bool {
+	if s == "" || s == "<nil>" {
+		return true
+	}
+	if isoDatePattern.MatchString(s) {
+		return true
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil && f == 0 {
+		return true
+	}
+	return false
+}
+
+func canonicalIDFromKey(obj map[string]any, key string) string {
+	if v, ok := lookupRawFieldValue(obj, key); ok {
+		if s := CanonicalResourceID(v); s != "" {
+			return s
+		}
+	}
+	if obj == nil || strings.HasSuffix(key, "_") {
+		return ""
+	}
+	v, ok := obj[key+"_"]
+	if !ok {
+		return ""
+	}
+	return CanonicalResourceID(v)
 }
 
 // ResourceIDString returns the stable text form used for resources.id.
@@ -1371,7 +1483,7 @@ func (s *Store) UpsertLeagues(data json.RawMessage) error {
 		return fmt.Errorf("unmarshaling leagues: %w", err)
 	}
 
-	id := extractObjectID(obj)
+	id := ExtractResourceID("leagues", obj)
 	if id == "" {
 		return fmt.Errorf("missing id for leagues")
 	}
@@ -1423,7 +1535,7 @@ func (s *Store) UpsertStandings(data json.RawMessage) error {
 		return fmt.Errorf("unmarshaling standings: %w", err)
 	}
 
-	id := extractObjectID(obj)
+	id := ExtractResourceID("standings", obj)
 	if id == "" {
 		return fmt.Errorf("missing id for standings")
 	}
@@ -1464,7 +1576,9 @@ var resourceIDFieldOverrides = map[string]string{
 // Stable vendor identifiers win first; then fields derived from the resource
 // name (accountId, workspaceId); descriptive fallbacks are last. Keeping name
 // ahead of the resource-specific probe silently keys rows by display labels.
-var genericIDFieldFallbacks = []string{"id", "ID", "_id", "gid", "sid", "uid", "uuid", "guid", "api_id"}
+// `id_` is the Python-style trailing-underscore sibling of `id`; LookupFieldValue
+// also probes that spelling for every other key in this list.
+var genericIDFieldFallbacks = []string{"id", "ID", "_id", "id_", "gid", "sid", "uid", "uuid", "guid", "api_id"}
 var genericDescriptiveIDFieldFallbacks = []string{"name", "slug", "key", "code"}
 
 // resourceIDBaseOverrides preserves the complete final collection name for
@@ -1491,30 +1605,21 @@ var resourceParentKeyColumns = map[string][]string{
 // non-entity envelopes into the batch path.
 func ExtractResourceID(resourceType string, obj map[string]any) string {
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
-		if v := lookupFieldValue(obj, override); v != nil {
-			s := ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
+		if s := canonicalIDFromKey(obj, override); s != "" {
+			return s
 		}
 	}
 	for _, key := range genericIDFieldFallbacks {
-		if v := lookupFieldValue(obj, key); v != nil {
-			s := ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
 	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
 		return s
 	}
 	for _, key := range genericDescriptiveIDFieldFallbacks {
-		if v := lookupFieldValue(obj, key); v != nil {
-			s := ResourceIDString(v)
-			if s != "" && s != "<nil>" {
-				return s
-			}
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
 	return ""
@@ -1524,27 +1629,31 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 // "<name>_code" / "<name>_id" / "<name>_key" / "<name>_slug" field (e.g. the
 // "currencies" resource keying on "currency_code" — see #2327). It is scoped to
 // the resource's OWN name so a foreign key like account_id/parent_id is never
-// promoted to the primary key, and it uses direct map lookups in a fixed suffix
-// order so the chosen id is deterministic.
+// promoted to the primary key, and it walks the same key spellings as
+// LookupFieldValue in a fixed suffix order so the chosen id is deterministic.
 func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 	for _, base := range resourceIDBaseNames(resourceType) {
 		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
-			if v, ok := obj[base+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
+			if s := canonicalScalarIDFromKey(obj, base+suffix); s != "" {
+				return s
 			}
 		}
 		camelBase := lowerCamelResourceIDBase(base)
 		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
-			if v, ok := obj[camelBase+suffix]; ok {
-				if s := scalarIDString(v); s != "" && s != "<nil>" {
-					return s
-				}
+			if s := canonicalScalarIDFromKey(obj, camelBase+suffix); s != "" {
+				return s
 			}
 		}
 	}
 	return ""
+}
+
+func canonicalScalarIDFromKey(obj map[string]any, key string) string {
+	v, ok := lookupRawFieldValue(obj, key)
+	if !ok || scalarIDString(v) == "" {
+		return ""
+	}
+	return CanonicalResourceID(v)
 }
 
 // resourceIDBaseNames returns lowercase candidate singular/plural stems of a

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1357,10 +1357,10 @@ func DecodeJSONObject(data json.RawMessage) (map[string]any, error) {
 	return obj, nil
 }
 
-// CanonicalResourceID returns the stable text form used for resources.id, or
-// empty when the value cannot be a primary key (nil, boolean, zero, or a
-// timestamp). Callers that would otherwise store ResourceIDString output
-// must use this so unusable values are refused instead of written.
+// CanonicalResourceID is the identity invariant for generated stores: a value
+// becomes resources.id only when it can stably distinguish a row. ResourceIDString
+// will stringify zeros, timestamps, and booleans, and writing those keys
+// silently collapses or duplicates records on the next sync.
 func CanonicalResourceID(v any) string {
 	switch v.(type) {
 	case nil, bool:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Closes #4370.

Generated sync/store resolved record IDs with a flat, closed list of top-level key spellings. Nested identifiers (`entityInfo.entityId`), Python-style `id_` keys, and unusable values (zero, timestamp, boolean) either missed entirely or were written as primary keys, so reprints dropped or collapsed rows.

## Approach

Machine change in the generated store identity helpers:

- `LookupFieldValue` walks dotted paths and widens each segment with snake/camel/Pascal plus a trailing-underscore sibling, so `x-resource-id: entityInfo.entityId` and generic `id` → `id_` both resolve.
- `genericIDFieldFallbacks` includes `id_`.
- `CanonicalResourceID` refuses nil, boolean, numeric zero, and ISO date/date-time values; `ExtractResourceID` falls through to the next candidate instead of storing them.
- Typed single-row upserts use `ExtractResourceID` so they share the same contract as `UpsertBatch`.

Composite / parent-qualified keys remain #4145. This PR does not touch WAL/mmap/DSN.

## Scope

Primary area: generated store identity resolution (`store.go.tmpl`), with matching sync override lookups, OpenAPI `x-resource-id` docs, and internal `id_field` path semantics.

Why this belongs in this repo: the miss is in generator-owned store code that every printed CLI inherits. Downstream hand-fixes are discarded on reprint.

## Risk

Generated `internal/store/store.go` changes for every future print. Existing top-level `id` / camel / Pascal lookups stay first-match. Specs that keyed rows on a timestamp or `0` will now skip those items (extract failure) instead of silently upserting them.

## Output Contract

- Emitted helpers: `lookupRawDottedFieldValue`, `CanonicalResourceID`, `id_` in `genericIDFieldFallbacks`.
- Generated-output proof: `TestGeneratedStoreResolvesNestedAndUnusableRecordIDs` compiles a printed CLI and runs the emitted store tests (nested override, `id_`, unusable refusal, upsert).
- Goldens updated for `generate-sync-walker-api`, `generate-query-endpoint-api`, `generate-learn-loop-api`, and `generate-learn-disabled-api`.
- `scripts/verify-generator-output.sh` compiled those four store-emitting cases.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:

- `go test -timeout 45m ./...`
- `GOLDEN_ALLOW_DIRTY=1 bash scripts/golden.sh update` (store-emitting cases updated; `verify-runtime-matrix` could not normalize in this environment because fixture modules request a Go 1.24 toolchain that is not installed here)
- `bash scripts/verify-generator-output.sh generate-sync-walker-api generate-learn-disabled-api generate-query-endpoint-api generate-learn-loop-api`

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-786f186d-6a65-4180-9a91-f0bfef429557?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-786f186d-6a65-4180-9a91-f0bfef429557&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

