### PR TITLE
fix(profiler): stop using page-size defaults as sync pageSize

### DIFF
--- a/internal/generator/sync_pagination_limit_only_test.go
+++ b/internal/generator/sync_pagination_limit_only_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Anthropic, PBC. Licensed under Apache-2.0.
+
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// limitOnlyPaginationSpec is the cursorless shape that used to copy a
+// declared page-size default into sync, capping the local mirror at that
+// many rows with no way to advance.
+func limitOnlyPaginationSpec(name string, defaultLimit int, maximum *float64) *spec.APISpec {
+	apiSpec := minimalSpec(name)
+	param := spec.Param{Name: "limit", Type: "integer", Default: defaultLimit}
+	if maximum != nil {
+		param.Maximum = maximum
+	}
+	apiSpec.Resources = map[string]spec.Resource{
+		"computers": {
+			Description: "Computers",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:   "GET",
+					Path:     "/api/v1/computers",
+					Params:   []spec.Param{param},
+					Response: spec.ResponseDef{Type: "array"},
+				},
+			},
+		},
+	}
+	return apiSpec
+}
+
+// TestGeneratedSyncLimitOnlyIgnoresPageSizeDefault proves the emitted
+// determinePaginationDefaults does not copy a spec-declared limit default
+// onto a cursorless resource. The assertion runs the generated helper so it
+// is compile-level, not a comment or template-source check.
+func TestGeneratedSyncLimitOnlyIgnoresPageSizeDefault(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := limitOnlyPaginationSpec("limonly", 25, nil)
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	runtimeTest := `package cli
+
+import "testing"
+
+func TestDeterminePaginationDefaultsLimitOnlyIgnoresDefault(t *testing.T) {
+	if !resourceSupportsPagination("computers") {
+		t.Fatal("resourceSupportsPagination(\"computers\") = false, want true so sync still attempts a paged fetch")
+	}
+	got := determinePaginationDefaults("computers")
+	if got.limitParam != "limit" {
+		t.Fatalf("limitParam = %q, want \"limit\"", got.limitParam)
+	}
+	if got.cursorParam != "" {
+		t.Fatalf("cursorParam = %q, want empty for a limit-only resource", got.cursorParam)
+	}
+	if got.limit != 100 {
+		t.Fatalf("limit = %d, want 100 (generator default), not the spec-declared page-size default of 25", got.limit)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "cli", "sync_limit_only_page_size_test.go"),
+		[]byte(runtimeTest), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestDeterminePaginationDefaultsLimitOnlyIgnoresDefault")
+}
+
+func TestGeneratedSyncLimitOnlyPrefersDeclaredMaximum(t *testing.T) {
+	t.Parallel()
+
+	max500 := 500.0
+	apiSpec := limitOnlyPaginationSpec("limax", 25, &max500)
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	runtimeTest := `package cli
+
+import "testing"
+
+func TestDeterminePaginationDefaultsLimitOnlyPrefersMaximum(t *testing.T) {
+	got := determinePaginationDefaults("computers")
+	if got.limit != 500 {
+		t.Fatalf("limit = %d, want 500 (declared maximum on a cursorless resource), not the spec default of 25 or the generator default of 100", got.limit)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "cli", "sync_limit_only_max_page_size_test.go"),
+		[]byte(runtimeTest), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestDeterminePaginationDefaultsLimitOnlyPrefersMaximum")
+}

--- a/internal/generator/sync_pagination_limit_only_test.go
+++ b/internal/generator/sync_pagination_limit_only_test.go
@@ -12,9 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// limitOnlyPaginationSpec is the cursorless shape that used to copy a
-// declared page-size default into sync, capping the local mirror at that
-// many rows with no way to advance.
+// Cursorless list whose spec default used to become the sync page size.
 func limitOnlyPaginationSpec(name string, defaultLimit int, maximum *float64) *spec.APISpec {
 	apiSpec := minimalSpec(name)
 	param := spec.Param{Name: "limit", Type: "integer", Default: defaultLimit}
@@ -37,10 +35,8 @@ func limitOnlyPaginationSpec(name string, defaultLimit int, maximum *float64) *s
 	return apiSpec
 }
 
-// TestGeneratedSyncLimitOnlyIgnoresPageSizeDefault proves the emitted
-// determinePaginationDefaults does not copy a spec-declared limit default
-// onto a cursorless resource. The assertion runs the generated helper so it
-// is compile-level, not a comment or template-source check.
+// Proves the emitted helper does not copy a spec-declared limit default
+// onto a cursorless resource. Compile-level: runs the generated helper.
 func TestGeneratedSyncLimitOnlyIgnoresPageSizeDefault(t *testing.T) {
 	t.Parallel()
 

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -10,18 +10,24 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/vision"
 )
 
-// warnWriter receives profiler diagnostics. Tests redirect it so they do not
-// swap process-wide os.Stderr, which races with other packages' t.Parallel
-// generate tests under `go test ./...`.
-var warnWriter io.Writer = os.Stderr
+// Tests redirect diagnostics here instead of swapping process-wide stderr,
+// which races with other packages under `go test ./...`.
+var (
+	warnMu     sync.Mutex
+	warnWriter io.Writer = os.Stderr
+)
 
 func writeProfilerWarning(format string, args ...any) {
-	fmt.Fprintf(warnWriter, format, args...)
+	warnMu.Lock()
+	w := warnWriter
+	warnMu.Unlock()
+	fmt.Fprintf(w, format, args...)
 }
 
 type DomainArchetype string
@@ -2992,8 +2998,7 @@ func syncPaginationDefaultsFromEndpoint(endpoint spec.Endpoint) (string, string,
 	return cursorParam, cursorType, limitParam, syncPageSizeFromEndpoint(endpoint, cursorParam, limitParam)
 }
 
-// syncPageSizeFromEndpoint chooses the page size sync will send. A spec-declared
-// default on a page-size parameter is the server's no-param fallback, not a
+// A spec-declared page-size default is the server's no-param fallback, not a
 // client request size. Copying it onto a cursorless resource caps the first
 // (and only) page at that conservative number.
 func syncPageSizeFromEndpoint(endpoint spec.Endpoint, cursorParam, limitParam string) int {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -2,6 +2,7 @@ package profiler
 
 import (
 	"fmt"
+	"io"
 	"maps"
 	"math"
 	"os"
@@ -13,6 +14,15 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/vision"
 )
+
+// warnWriter receives profiler diagnostics. Tests redirect it so they do not
+// swap process-wide os.Stderr, which races with other packages' t.Parallel
+// generate tests under `go test ./...`.
+var warnWriter io.Writer = os.Stderr
+
+func writeProfilerWarning(format string, args ...any) {
+	fmt.Fprintf(warnWriter, format, args...)
+}
 
 type DomainArchetype string
 
@@ -32,6 +42,11 @@ const (
 	ReconcileModeFlat       = "flat"
 	ReconcileModeFlatGlobal = "flat_global"
 	ReconcileModePerParent  = "per_parent"
+)
+
+const (
+	generatorSyncPageSize           = 100
+	warningPaginationUndeterminable = "pagination_undeterminable"
 )
 
 type DomainSignals struct {
@@ -708,6 +723,7 @@ func Profile(s *spec.APISpec) *APIProfile {
 	sortDependentResources(p.DependentSyncResources, nil)
 	addUnresolvedPathTemplateCollections(syncable, parameterized, p.DependentSyncResources)
 	p.SyncableResources = sortedSyncableResources(syncable)
+	warnUndeterminablePagination(p.SyncableResources, p.DependentSyncResources)
 	classifyFlatReconcileModes(p.SyncableResources, specHasTenantScopeColumn(s))
 	// Populate reconcile metadata for each dependent resource.
 	// per_parent is safe only for a single-path-param dependent with a PK.
@@ -737,7 +753,7 @@ func Profile(s *spec.APISpec) *APIProfile {
 		SortValue:       sortValue,
 		DateRangeParam:  mostCommon(dateRangeParams, ""),
 		ItemsKey:        mostCommon(responsePaths, ""),
-		DefaultPageSize: 100,
+		DefaultPageSize: generatorSyncPageSize,
 	}
 
 	return p
@@ -2079,7 +2095,7 @@ func applySpecWalkers(s *spec.APISpec, deps []DependentResource, syncable map[st
 			}
 			parent := strings.ToLower(strings.TrimSpace(e.Walker.Parent))
 			if _, ok := syncable[parent]; !ok {
-				fmt.Fprintf(os.Stderr,
+				writeProfilerWarning(
 					"warning: walker on %s.%s: parent %q is not a syncable resource; ignoring\n",
 					resourceName, endpointName, e.Walker.Parent)
 				continue
@@ -2093,12 +2109,12 @@ func applySpecWalkers(s *spec.APISpec, deps []DependentResource, syncable map[st
 						keyParam = p
 					}
 				case 0:
-					fmt.Fprintf(os.Stderr,
+					writeProfilerWarning(
 						"warning: walker on %s.%s: path %q has no {placeholder}; declare key_param explicitly\n",
 						resourceName, endpointName, e.Path)
 					continue
 				default:
-					fmt.Fprintf(os.Stderr,
+					writeProfilerWarning(
 						"warning: walker on %s.%s: path %q has %d placeholders; declare key_param explicitly\n",
 						resourceName, endpointName, e.Path, placeholders)
 					continue
@@ -2859,7 +2875,7 @@ func detectIDWalkParams(endpoint spec.Endpoint) (string, string, int) {
 	if !hasLimit || filterParam == "" {
 		return "", "", 0
 	}
-	pageSize := 100
+	pageSize := generatorSyncPageSize
 	if defaultSize, ok := paginationLimitDefault(endpoint, resolvedLimitParam); ok {
 		pageSize = defaultSize
 	}
@@ -2973,18 +2989,65 @@ func syncPaginationDefaultsFromEndpoint(endpoint spec.Endpoint) (string, string,
 		(cursorType == "page" || cursorType == "offset") {
 		cursorType = inferredType
 	}
-	pageSize := 100
-	if defaultSize, ok := paginationLimitDefault(endpoint, limitParam); ok {
+	return cursorParam, cursorType, limitParam, syncPageSizeFromEndpoint(endpoint, cursorParam, limitParam)
+}
+
+// syncPageSizeFromEndpoint chooses the page size sync will send. A spec-declared
+// default on a page-size parameter is the server's no-param fallback, not a
+// client request size. Copying it onto a cursorless resource caps the first
+// (and only) page at that conservative number.
+func syncPageSizeFromEndpoint(endpoint spec.Endpoint, cursorParam, limitParam string) int {
+	maxSize, hasMax := paginationLimitMaximum(endpoint, limitParam)
+	defaultSize, hasDefault := paginationLimitDefault(endpoint, limitParam)
+
+	if strings.TrimSpace(cursorParam) == "" {
+		if hasMax {
+			return maxSize
+		}
+		if hasDefault && defaultSize > generatorSyncPageSize {
+			return defaultSize
+		}
+		return generatorSyncPageSize
+	}
+
+	pageSize := generatorSyncPageSize
+	if hasDefault {
 		pageSize = defaultSize
 	}
 	// Clamp to the limit param's declared maximum so sync never requests a
 	// page size the API rejects with a validation error. An API-declared cap
 	// always wins over the default (e.g. Granola's public API caps page_size
 	// at 30, and a spec may declare a maximum without any default).
-	if maxSize, ok := paginationLimitMaximum(endpoint, limitParam); ok && pageSize > maxSize {
+	if hasMax && pageSize > maxSize {
 		pageSize = maxSize
 	}
-	return cursorParam, cursorType, limitParam, pageSize
+	return pageSize
+}
+
+func isLimitWithoutCursor(cursorParam, limitParam string) bool {
+	return strings.TrimSpace(limitParam) != "" && strings.TrimSpace(cursorParam) == ""
+}
+
+func warnUndeterminablePagination(resources []SyncableResource, deps []DependentResource) {
+	for _, resource := range resources {
+		warnLimitWithoutCursor(resource.Name, resource.PaginationCursorParam, resource.PaginationLimitParam)
+	}
+	for _, dep := range deps {
+		name := dep.Name
+		if dep.ParentResource != "" {
+			name = dep.ParentResource + "/" + dep.Name
+		}
+		warnLimitWithoutCursor(name, dep.PaginationCursorParam, dep.PaginationLimitParam)
+	}
+}
+
+func warnLimitWithoutCursor(resourceName, cursorParam, limitParam string) {
+	if !isLimitWithoutCursor(cursorParam, limitParam) {
+		return
+	}
+	writeProfilerWarning(
+		"warning: %s: resource %q declares page-size parameter %q without a cursor, page, or offset parameter; sync cannot page beyond the first request\n",
+		warningPaginationUndeterminable, resourceName, limitParam)
 }
 
 func inferPaginationParamsFromEndpoint(endpoint spec.Endpoint) (string, string) {

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -2,7 +2,6 @@ package profiler
 
 import (
 	"bytes"
-	"os"
 	"slices"
 	"testing"
 
@@ -11,21 +10,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// captureStderr swaps os.Stderr for a pipe, runs fn, and returns whatever
-// fn wrote to stderr. The swap is single-threaded — safe for go test's
-// per-package sequential execution; do not use across parallel subtests
-// that both touch stderr.
+// captureStderr redirects profiler diagnostics into a buffer. It does not
+// swap process-wide os.Stderr, which races with other packages under
+// `go test ./...`.
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
-	orig := os.Stderr
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	os.Stderr = w
-	t.Cleanup(func() { os.Stderr = orig })
-	fn()
-	require.NoError(t, w.Close())
 	var buf bytes.Buffer
-	_, _ = buf.ReadFrom(r)
+	orig := warnWriter
+	warnWriter = &buf
+	t.Cleanup(func() { warnWriter = orig })
+	fn()
 	return buf.String()
 }
 
@@ -3480,6 +3474,158 @@ func TestProfilePagination_ClampsToParamMaximum(t *testing.T) {
 		"an exclusive maximum must clamp to the largest value strictly below it")
 	assert.Equal(t, 30, byName["webhooks"].PaginationPageSize,
 		"the most restrictive of a co-declared inclusive and exclusive bound must win")
+}
+
+func TestSyncPageSizeFromEndpoint_LimitOnlyIgnoresDeclaredDefault(t *testing.T) {
+	max30 := 30.0
+	max500 := 500.0
+	for _, tc := range []struct {
+		name       string
+		endpoint   spec.Endpoint
+		wantCursor string
+		wantType   string
+		wantLimit  string
+		wantSize   int
+	}{
+		{
+			name: "limit-only default is not a client page size",
+			endpoint: spec.Endpoint{
+				Params: []spec.Param{{Name: "limit", Type: "integer", Default: 25}},
+			},
+			wantLimit: "limit",
+			wantSize:  100,
+		},
+		{
+			name: "limit-only default above generator size is a floor",
+			endpoint: spec.Endpoint{
+				Params: []spec.Param{{Name: "limit", Type: "integer", Default: 200}},
+			},
+			wantLimit: "limit",
+			wantSize:  200,
+		},
+		{
+			name: "limit-only prefers declared maximum",
+			endpoint: spec.Endpoint{
+				Params: []spec.Param{{Name: "limit", Type: "integer", Default: 25, Maximum: &max500}},
+			},
+			wantLimit: "limit",
+			wantSize:  500,
+		},
+		{
+			name: "limit-only clamps generator size to a smaller maximum",
+			endpoint: spec.Endpoint{
+				Params: []spec.Param{{Name: "limit", Type: "integer", Default: 25, Maximum: &max30}},
+			},
+			wantLimit: "limit",
+			wantSize:  30,
+		},
+		{
+			name: "cursor resources still honor a declared default",
+			endpoint: spec.Endpoint{
+				Params: []spec.Param{
+					{Name: "cursor", Type: "string"},
+					{Name: "limit", Type: "integer", Default: 25},
+				},
+			},
+			wantCursor: "cursor",
+			wantType:   "cursor",
+			wantLimit:  "limit",
+			wantSize:   25,
+		},
+		{
+			name: "offset resources still honor a declared default",
+			endpoint: spec.Endpoint{
+				Params: []spec.Param{
+					{Name: "offset", Type: "int"},
+					{Name: "count", Type: "int", Default: 25},
+				},
+			},
+			wantCursor: "offset",
+			wantType:   "offset",
+			wantLimit:  "count",
+			wantSize:   25,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cursor, cursorType, limit, pageSize := syncPaginationDefaultsFromEndpoint(tc.endpoint)
+			assert.Equal(t, tc.wantCursor, cursor)
+			assert.Equal(t, tc.wantType, cursorType)
+			assert.Equal(t, tc.wantLimit, limit)
+			assert.Equal(t, tc.wantSize, pageSize)
+		})
+	}
+}
+
+func TestProfilePagination_LimitOnlyDoesNotCopyDeclaredDefault(t *testing.T) {
+	max500 := 500.0
+	s := &spec.APISpec{
+		Name: "limit-only-pagination",
+		Resources: map[string]spec.Resource{
+			"computers": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/api/v1/computers",
+						Params:   []spec.Param{{Name: "limit", Type: "integer", Default: 25}},
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+			"devices": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method: "GET",
+						Path:   "/api/v1/devices",
+						Params: []spec.Param{
+							{Name: "limit", Type: "integer", Default: 25, Maximum: &max500},
+						},
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+			"agents": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/api/v1/agents",
+						Params:   []spec.Param{{Name: "offset", Type: "int"}, {Name: "limit", Type: "integer", Default: 25}},
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+		},
+	}
+
+	var profile *APIProfile
+	stderr := captureStderr(t, func() {
+		profile = Profile(s)
+	})
+	byName := map[string]SyncableResource{}
+	for _, resource := range profile.SyncableResources {
+		byName[resource.Name] = resource
+	}
+
+	require.Contains(t, byName, "computers")
+	assert.True(t, byName["computers"].SupportsPagination,
+		"limit-only resources stay pagination-capable; sync still reports cursor_unavailable")
+	assert.Equal(t, "limit", byName["computers"].PaginationLimitParam)
+	assert.Empty(t, byName["computers"].PaginationCursorParam)
+	assert.Equal(t, 100, byName["computers"].PaginationPageSize,
+		"a declared limit default must not cap a cursorless first page")
+	assert.Contains(t, stderr, warningPaginationUndeterminable)
+	assert.Contains(t, stderr, `resource "computers"`)
+	assert.Contains(t, stderr, `page-size parameter "limit"`)
+
+	require.Contains(t, byName, "devices")
+	assert.Equal(t, 500, byName["devices"].PaginationPageSize,
+		"limit-only sync should request the declared maximum on the only page")
+	assert.Contains(t, stderr, `resource "devices"`)
+
+	require.Contains(t, byName, "agents")
+	assert.Equal(t, "offset", byName["agents"].PaginationCursorParam)
+	assert.Equal(t, 25, byName["agents"].PaginationPageSize,
+		"resources that can advance must keep using a declared default")
+	assert.NotContains(t, stderr, `resource "agents"`)
 }
 
 // The ID-walk sync path (pagination.type: id_walk over a POST search endpoint)

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -10,15 +10,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// captureStderr redirects profiler diagnostics into a buffer. It does not
-// swap process-wide os.Stderr, which races with other packages under
-// `go test ./...`.
+// Redirects profiler diagnostics into a buffer. Not safe with t.Parallel in
+// this package: the writer is process-wide, so concurrent captures would
+// interleave. A mutex only makes the pointer swap race-free.
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
 	var buf bytes.Buffer
+	warnMu.Lock()
 	orig := warnWriter
 	warnWriter = &buf
-	t.Cleanup(func() { warnWriter = orig })
+	warnMu.Unlock()
+	t.Cleanup(func() {
+		warnMu.Lock()
+		warnWriter = orig
+		warnMu.Unlock()
+	})
 	fn()
 	return buf.String()
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Closes #4371.

The profiler treated a spec-declared page-size **default** as the sync request size. On cursorless / limit-only resources that becomes a hard first-page ceiling: the endpoint will serve more when asked, but sync requests `default` rows and cannot advance. On current main that usually ends `cursor_unavailable` rather than a silent green, but the truncated first page is still real.

## Approach

Stop copying `paginationLimitDefault` into sync `pageSize` when there is no cursor, page, or offset parameter.

- Limit-only: prefer a declared **maximum**, otherwise the generator default (100), using a declared default only as a floor above 100.
- Cursor / page / offset resources keep today's default-then-clamp behavior.
- Generate time emits `pagination_undeterminable` naming the resource so the missing paginator is visible.
- `endpointSupportsPagination` stays true for limit-only; sync still reports `cursor_unavailable`. This PR does not implement sticky-cursor / #4239.

## Scope

Primary area: profiler sync pagination defaults.

Machine change: every future printed CLI. The symptom showed up in printed CLIs (e.g. a `limit` default of 25 with no cursor), but the generator was choosing the request size.

## Risk

- Limit-only resources may request a larger first page (100 or the spec maximum instead of a small default). APIs that reject that without declaring a maximum would 400; those already needed a declared maximum (#3440).
- Cursor-based page sizes are unchanged, so existing goldens stay byte-stable.
- No sticky-cursor / #4239 product work.

## Output Contract

Generated `determinePaginationDefaults` for a limit-only resource no longer emits the spec-declared page-size default as `limit`.

Proof (generated-output, not comment-only):

- `TestGeneratedSyncLimitOnlyIgnoresPageSizeDefault` generates a CLI with `limit` default 25 and no cursor, then runs the emitted helper (`limit == 100`, pagination still declared).
- `TestGeneratedSyncLimitOnlyPrefersDeclaredMaximum` asserts a cursorless `maximum: 500` wins over the default of 25.
- Profiler unit tests cover default-as-floor, max clamp, and that offset/cursor resources still honor defaults.
- `scripts/golden.sh verify` (34/34) — existing fixtures have advance params, so generated output is unchanged.

## Verification

- [x] `GOTOOLCHAIN=go1.26.6 go test ./... -timeout 25m`
- [x] `GOTOOLCHAIN=go1.26.6 bash scripts/golden.sh verify` (34/34, no fixture updates)
- [x] Generator/template change: verified generated output via compile-level helper tests
- [x] Covered limit-only default, limit-only maximum, and cursor/offset unchanged fallbacks
- [x] `syncPageSizeFromEndpoint` call site gated on empty cursor param; maximum clamp on the advancing path unchanged

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6772b0d-fddb-4468-89e6-83bb6e0b006a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6772b0d-fddb-4468-89e6-83bb6e0b006a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

