### PR TITLE
fix(cli): re-mint client_credentials on 401 and unwrap mutation-output envelopes

### DIFF
--- a/internal/generator/client_cc_remint_test.go
+++ b/internal/generator/client_cc_remint_test.go
@@ -110,7 +110,7 @@ func TestClientCredentials401RemintBehavior(t *testing.T) {
 	goModBytes, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
 	require.NoError(t, err)
 	modulePath := ""
-	for _, line := range strings.Split(string(goModBytes), "\n") {
+	for line := range strings.SplitSeq(string(goModBytes), "\n") {
 		if rest, ok := strings.CutPrefix(strings.TrimSpace(line), "module "); ok {
 			modulePath = strings.TrimSpace(rest)
 			break

--- a/internal/generator/client_cc_remint_test.go
+++ b/internal/generator/client_cc_remint_test.go
@@ -1,0 +1,238 @@
+package generator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Guards #4000 (defects 1+2): the client_credentials grant issues no refresh
+// token, so the generated 401-recovery branch must re-mint via the token
+// endpoint instead of gating on RefreshToken (which structurally never fires
+// for this grant), and a stored token with no recorded expiry must be
+// re-minted once per process instead of trusted forever.
+func ccRemintSpec() *spec.APISpec {
+	return &spec.APISpec{
+		Name:    "ccremint",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:        "bearer_token",
+			Header:      "Authorization",
+			Format:      "Bearer {token}",
+			OAuth2Grant: spec.OAuth2GrantClientCredentials,
+			TokenURL:    "https://api.example.com/oauth/token",
+			EnvVars:     []string{"CCREMINT_API_KEY", "CCREMINT_SECRET_KEY"},
+		},
+		Config: spec.ConfigSpec{Format: "toml", Path: "~/.config/ccremint-pp-cli/config.toml"},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/items"}},
+			},
+		},
+	}
+}
+
+func TestClientCredentials401RemintEmission(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := ccRemintSpec()
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	body := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
+
+	assert.Contains(t, body, "re-minting access token after 401",
+		"client_credentials 401 branch recovers via a fresh mint")
+	assert.NotContains(t, body, `c.Config.RefreshToken != ""`,
+		"client_credentials 401 branch must not gate on a refresh token the grant never issues")
+	assert.Contains(t, body, "func (c *Client) needsClientCredentialsMint()",
+		"mint-window helper is a method so it can see the per-process unknown-expiry cap")
+	assert.Contains(t, body, "ccMintedUnknownExpiry",
+		"unknown-expiry tokens re-mint once per process instead of being trusted forever")
+}
+
+func TestAuthorizationCode401RefreshUnchanged(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "acremint",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:             "bearer_token",
+			Header:           "Authorization",
+			Format:           "Bearer {token}",
+			AuthorizationURL: "https://api.example.com/oauth/authorize",
+			TokenURL:         "https://api.example.com/oauth/token",
+			EnvVars:          []string{"ACREMINT_TOKEN"},
+		},
+		Config: spec.ConfigSpec{Format: "toml", Path: "~/.config/acremint-pp-cli/config.toml"},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/items"}},
+			},
+		},
+	}
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	body := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
+
+	assert.Contains(t, body, "refreshing access token after 401",
+		"refresh-token grants keep the refresh-based 401 recovery")
+	assert.Contains(t, body, `c.Config.RefreshToken != ""`,
+		"refresh-token grants keep the RefreshToken gate")
+	assert.NotContains(t, body, "re-minting access token after 401",
+		"non-client_credentials specs must not emit the mint-based recovery")
+}
+
+// TestClientCredentials401RemintBehavior proves the emitted client actually
+// recovers: a request rejected with 401 mints a fresh token and succeeds on
+// the retry, and a stored token of unknown age costs exactly one mint per
+// process. The behavior test is injected into the generated module and run
+// with the module's own toolchain so the assertion is on compiled behavior,
+// not template text.
+func TestClientCredentials401RemintBehavior(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := ccRemintSpec()
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	goModBytes, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
+	require.NoError(t, err)
+	modulePath := ""
+	for _, line := range strings.Split(string(goModBytes), "\n") {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(line), "module "); ok {
+			modulePath = strings.TrimSpace(rest)
+			break
+		}
+	}
+	require.NotEmpty(t, modulePath, "generated go.mod must declare a module path")
+
+	behaviorTest := fmt.Sprintf(`package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"%s/internal/config"
+)
+
+func newCCRemintServer(mints, apiCalls *int32) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/oauth/token" {
+			atomic.AddInt32(mints, 1)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `+"`"+`{"access_token":"fresh-%%d"}`+"`"+`, atomic.LoadInt32(mints))
+			return
+		}
+		atomic.AddInt32(apiCalls, 1)
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer fresh-") {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprint(w, `+"`"+`{"error":"not_authenticated"}`+"`"+`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `+"`"+`{"ok":true}`+"`"+`)
+	}))
+}
+
+func ccRemintConfig(t *testing.T, srvURL string, expiry time.Time) *config.Config {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmp, "cache"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("LOCALAPPDATA", filepath.Join(tmp, "localapp"))
+	t.Setenv("APPDATA", filepath.Join(tmp, "appdata"))
+	return &config.Config{
+		BaseURL:      srvURL,
+		TokenURL:     srvURL + "/oauth/token",
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		AccessToken:  "stale-token",
+		TokenExpiry:  expiry,
+		Path:         filepath.Join(tmp, "config.toml"),
+	}
+}
+
+func TestDo401RemintsClientCredentials(t *testing.T) {
+	var mints, apiCalls int32
+	srv := newCCRemintServer(&mints, &apiCalls)
+	defer srv.Close()
+
+	// Expiry an hour out: the proactive window does not fire, so the stale
+	// token is sent, rejected with 401, and recovery must come from the
+	// 401 re-mint branch.
+	cfg := ccRemintConfig(t, srv.URL, time.Now().Add(time.Hour))
+	c := New(cfg, 10*time.Second, 0)
+	c.NoCache = true
+
+	body, err := c.Get(context.Background(), "/items", nil)
+	if err != nil {
+		t.Fatalf("Get after 401 should recover via re-mint, got error: %%v", err)
+	}
+	if !strings.Contains(string(body), `+"`"+`"ok":true`+"`"+`) {
+		t.Fatalf("unexpected body after re-mint retry: %%s", body)
+	}
+	if got := atomic.LoadInt32(&mints); got != 1 {
+		t.Fatalf("token mints = %%d, want exactly 1", got)
+	}
+	if got := atomic.LoadInt32(&apiCalls); got != 2 {
+		t.Fatalf("api calls = %%d, want 2 (401 then success)", got)
+	}
+}
+
+func TestUnknownExpiryTokenMintsOncePerProcess(t *testing.T) {
+	var mints, apiCalls int32
+	srv := newCCRemintServer(&mints, &apiCalls)
+	defer srv.Close()
+
+	// Zero expiry: unknown age. The token server omits expires_in, so the
+	// minted token's expiry stays unknown too — the second call must trust
+	// it instead of minting again.
+	cfg := ccRemintConfig(t, srv.URL, time.Time{})
+	c := New(cfg, 10*time.Second, 0)
+	c.NoCache = true
+
+	for i := 0; i < 2; i++ {
+		body, err := c.Get(context.Background(), "/items", nil)
+		if err != nil {
+			t.Fatalf("Get %%d: %%v", i, err)
+		}
+		if !strings.Contains(string(body), `+"`"+`"ok":true`+"`"+`) {
+			t.Fatalf("Get %%d unexpected body: %%s", i, body)
+		}
+	}
+	if got := atomic.LoadInt32(&mints); got != 1 {
+		t.Fatalf("token mints = %%d, want exactly 1 per process for unknown expiry", got)
+	}
+	if got := atomic.LoadInt32(&apiCalls); got != 2 {
+		t.Fatalf("api calls = %%d, want 2 successes", got)
+	}
+}
+`, modulePath)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "client", "cc_remint_behavior_test.go"),
+		[]byte(behaviorTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "test", "./internal/client/...")
+}

--- a/internal/generator/client_cc_remint_test.go
+++ b/internal/generator/client_cc_remint_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Guards #4000 (defects 1+2): the client_credentials grant issues no refresh
-// token, so the generated 401-recovery branch must re-mint via the token
-// endpoint instead of gating on RefreshToken (which structurally never fires
-// for this grant), and a stored token with no recorded expiry must be
-// re-minted once per process instead of trusted forever.
+// The client_credentials grant issues no refresh token, so the generated
+// 401-recovery branch must re-mint via the token endpoint instead of gating
+// on RefreshToken (which structurally never fires for this grant), and a
+// stored token with no recorded expiry must be re-minted once per process
+// instead of trusted forever.
 func ccRemintSpec() *spec.APISpec {
 	return &spec.APISpec{
 		Name:    "ccremint",

--- a/internal/generator/client_cc_remint_test.go
+++ b/internal/generator/client_cc_remint_test.go
@@ -55,8 +55,10 @@ func TestClientCredentials401RemintEmission(t *testing.T) {
 		"client_credentials 401 branch must not gate on a refresh token the grant never issues")
 	assert.Contains(t, body, "func (c *Client) needsClientCredentialsMint()",
 		"mint-window helper is a method so it can see the per-process unknown-expiry cap")
-	assert.Contains(t, body, "ccMintedUnknownExpiry",
-		"unknown-expiry tokens re-mint once per process instead of being trusted forever")
+	assert.Contains(t, body, "ccMintedUnknownExpiry *atomic.Bool",
+		"unknown-expiry cap is a pointer so WithTier copies share one process flag")
+	assert.Contains(t, body, "ccMintedUnknownExpiry: &atomic.Bool{}",
+		"New initializes the shared unknown-expiry cap")
 }
 
 func TestAuthorizationCode401RefreshUnchanged(t *testing.T) {
@@ -92,6 +94,38 @@ func TestAuthorizationCode401RefreshUnchanged(t *testing.T) {
 		"refresh-token grants keep the RefreshToken gate")
 	assert.NotContains(t, body, "re-minting access token after 401",
 		"non-client_credentials specs must not emit the mint-based recovery")
+}
+
+// WithTier value-copies Client. The unknown-expiry cap must be a pointer so
+// the copy shares one process flag and go vet copylocks stays clean.
+func TestClientCredentialsWithTierSharesMintCap(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := ccRemintSpec()
+	apiSpec.Name = "cctier"
+	apiSpec.Auth.EnvVars = []string{"CCTIER_API_KEY", "CCTIER_SECRET_KEY"}
+	apiSpec.Config.Path = "~/.config/cctier-pp-cli/config.toml"
+	apiSpec.TierRouting = spec.TierRoutingConfig{
+		DefaultTier: "free",
+		Tiers: map[string]spec.TierConfig{
+			"free": {Auth: spec.AuthConfig{Type: "none"}},
+			"paid": {
+				BaseURL: "https://paid.example.com",
+				Auth:    apiSpec.Auth,
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	body := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
+	assert.Contains(t, body, "func (c *Client) WithTier")
+	assert.Contains(t, body, "ccMintedUnknownExpiry *atomic.Bool")
+	assert.Contains(t, body, "ccMintedUnknownExpiry: &atomic.Bool{}")
+	assert.NotContains(t, body, "ccMintedUnknownExpiry atomic.Bool")
+
+	requireGeneratedCompiles(t, outputDir)
 }
 
 // TestClientCredentials401RemintBehavior proves the emitted client actually

--- a/internal/generator/endpoint_verify_noop_test.go
+++ b/internal/generator/endpoint_verify_noop_test.go
@@ -53,18 +53,18 @@ func TestEndpoint_VerifyNoopPropagation(t *testing.T) {
 		"endpoint handler should flip success=false on synthetic envelope detection")
 
 	// Ordering invariant: detection MUST run against RAW data (before the
-	// `filtered := data` assignment) so the sentinel field cannot be
-	// stripped by --compact / --select before detection sees it. The
-	// verify_noop assignment must appear BEFORE the `filtered := data`
-	// line, and the envelope marshal must follow.
+	// `filtered := unwrapSingleKeyArray(data)` assignment) so the sentinel
+	// field cannot be stripped by --compact / --select / envelope unwrap
+	// before detection sees it. The verify_noop assignment must appear
+	// BEFORE the filtered assignment, and the envelope marshal must follow.
 	verifyNoop := strings.Index(emitted, `envelope["verify_noop"] = true`)
-	filteredAssign := strings.Index(emitted, `filtered := data`)
+	filteredAssign := strings.Index(emitted, `filtered := unwrapSingleKeyArray(data)`)
 	marshal := strings.Index(emitted, `envelopeJSON, err := json.Marshal(envelope)`)
 	require.NotEqual(t, -1, verifyNoop, "envelope[\"verify_noop\"] = true must exist")
-	require.NotEqual(t, -1, filteredAssign, "filtered := data assignment must exist")
+	require.NotEqual(t, -1, filteredAssign, "filtered := unwrapSingleKeyArray(data) assignment must exist")
 	require.NotEqual(t, -1, marshal, "envelopeJSON marshal call must exist")
 	assert.True(t, verifyNoop < filteredAssign,
-		"verify_noop detection must precede filtered := data so --compact/--select cannot strip the sentinel before detection")
+		"verify_noop detection must precede the filtered assignment so --compact/--select cannot strip the sentinel before detection")
 	assert.True(t, filteredAssign < marshal,
 		"filtered assignment must precede envelope marshal so populated data field makes it into output")
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2084,7 +2084,7 @@ func TestGenerateOAuth2ClientCredentialsClientRefresh(t *testing.T) {
 	body := string(clientBytes)
 	mintBlock := generatedSourceBlock(t, body, "func (c *Client) mintClientCredentials", "func (c *Client) refreshAccessToken")
 
-	assert.Contains(t, body, "func needsClientCredentialsMint",
+	assert.Contains(t, body, "func (c *Client) needsClientCredentialsMint",
 		"client_credentials spec emits the safety-window helper")
 	assert.Contains(t, body, "func resolveClientCredentials",
 		"client_credentials spec emits the env-var-fallback resolver")

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -7537,8 +7537,9 @@ func TestGeneratedOutput_MutatingCommandsHaveEnvelope(t *testing.T) {
 	// --quiet is respected before envelope output
 	assert.Contains(t, content, "if flags.quiet {")
 
-	// --select and --compact are applied to inner data before wrapping in envelope
-	assert.Contains(t, content, "filtered := data")
+	// --select and --compact are applied to inner data before wrapping in
+	// envelope; collection envelopes are unwrapped first so rows nest once.
+	assert.Contains(t, content, "filtered := unwrapSingleKeyArray(data)")
 	assert.Contains(t, content, "compactFields(filtered,")
 	assert.Contains(t, content, "filterFields(filtered, flags.selectFields)")
 	assert.Contains(t, content, `json.Unmarshal(filtered, &parsed)`)

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2114,8 +2114,10 @@ func TestGenerateOAuth2ClientCredentialsClientRefresh(t *testing.T) {
 		"client-secret resolver falls back to second env var")
 	assert.Contains(t, body, "ccMu *sync.Mutex",
 		"client_credentials spec emits a shared mutex to serialize concurrent mints")
-	assert.Contains(t, body, "ccMu:       &sync.Mutex{}",
+	assert.Contains(t, body, "ccMu:                  &sync.Mutex{}",
 		"client_credentials spec initializes the shared mint mutex")
+	assert.Contains(t, body, "ccMintedUnknownExpiry: &atomic.Bool{}",
+		"client_credentials spec initializes the shared unknown-expiry cap")
 	assert.Contains(t, body, "c.ccMu.Lock()",
 		"authHeader takes the mint mutex before re-checking the window")
 }

--- a/internal/generator/novel_feature_stubs_test.go
+++ b/internal/generator/novel_feature_stubs_test.go
@@ -909,12 +909,14 @@ func newItemsAuditCmd(flags *rootFlags) *cobra.Command {
 func captureNovelFeatureStderr(t *testing.T, fn func() error) (string, error) {
 	t.Helper()
 
+	stderrSwapMu.Lock()
 	oldErr := os.Stderr
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 	os.Stderr = w
 	defer func() {
 		os.Stderr = oldErr
+		stderrSwapMu.Unlock()
 	}()
 	callErr := fn()
 	require.NoError(t, w.Close())

--- a/internal/generator/post_read_output_test.go
+++ b/internal/generator/post_read_output_test.go
@@ -161,3 +161,99 @@ func runPostReadCommand(t *testing.T, args ...string) string {
 	requireGeneratedCompiles(t, outputDir)
 	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPOSTReadCommandsPrintCollectionBody", "-count=1")
 }
+
+// Guards #4390: mutation-output commands must unwrap single-key collection
+// envelopes before wrapping, so a POST that answers {"data":[...]} nests the
+// rows once (envelope data = array), not twice (data.data). Plain
+// created-object responses must pass through untouched.
+func TestMutationOutputUnwrapsCollectionEnvelope(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := postReadOutputSpec()
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	createSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sets_create.go")
+	require.Contains(t, createSrc, "filtered := unwrapSingleKeyArray(data)",
+		"mutation output must normalize collection envelopes before wrapping")
+
+	behaviorTest := `package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestMutationEnvelopeNestsRowsOnce(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost && r.URL.Path == "/sets" {
+			reqBody, _ := io.ReadAll(r.Body)
+			if strings.Contains(string(reqBody), "Solo") {
+				fmt.Fprint(w, "{\"id\":\"set-9\",\"name\":\"Solo\"}")
+				return
+			}
+			fmt.Fprint(w, "{\"data\":[{\"id\":\"row-1\",\"name\":\"First\"}],\"hasMore\":false}")
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("POST_READ_OUTPUT_BASE_URL", server.URL)
+
+	out := runMutationEnvelopeCommand(t, "sets", "create", "--name", "First", "--json")
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+		t.Fatalf("create output is not JSON: %v\n%s", err, out)
+	}
+	rows, ok := envelope["data"].([]any)
+	if !ok {
+		t.Fatalf("envelope data should be the unwrapped row array, got %T: %s", envelope["data"], out)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d: %s", len(rows), out)
+	}
+	row, _ := rows[0].(map[string]any)
+	if row["id"] != "row-1" {
+		t.Fatalf("row id = %v, want row-1: %s", row["id"], out)
+	}
+
+	out = runMutationEnvelopeCommand(t, "sets", "create", "--name", "Solo", "--json")
+	if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+		t.Fatalf("object-shape output is not JSON: %v\n%s", err, out)
+	}
+	obj, ok := envelope["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("plain object response must pass through untouched, got %T: %s", envelope["data"], out)
+	}
+	if obj["id"] != "set-9" {
+		t.Fatalf("object id = %v, want set-9: %s", obj["id"], out)
+	}
+}
+
+func runMutationEnvelopeCommand(t *testing.T, args ...string) string {
+	t.Helper()
+	var stdout bytes.Buffer
+	var flags rootFlags
+	cmd := newRootCmd(&flags)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("%v failed: %v\n%s", args, err, stdout.String())
+	}
+	return stdout.String()
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "mutation_envelope_test.go"), []byte(behaviorTest), 0o644))
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestMutationEnvelopeNestsRowsOnce", "-count=1")
+}

--- a/internal/generator/post_read_output_test.go
+++ b/internal/generator/post_read_output_test.go
@@ -162,10 +162,10 @@ func runPostReadCommand(t *testing.T, args ...string) string {
 	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPOSTReadCommandsPrintCollectionBody", "-count=1")
 }
 
-// Guards #4390: mutation-output commands must unwrap single-key collection
-// envelopes before wrapping, so a POST that answers {"data":[...]} nests the
-// rows once (envelope data = array), not twice (data.data). Plain
-// created-object responses must pass through untouched.
+// Mutation-output commands must unwrap single-key collection envelopes
+// before wrapping, so a POST that answers {"data":[...]} nests the rows
+// once (envelope data = array), not twice (data.data). Plain created-object
+// responses must pass through untouched.
 func TestMutationOutputUnwrapsCollectionEnvelope(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/stderr_swap_lock_test.go
+++ b/internal/generator/stderr_swap_lock_test.go
@@ -1,0 +1,10 @@
+package generator
+
+import "sync"
+
+// stderrSwapMu serializes tests that temporarily replace the process-global
+// os.Stderr (and os.Stdout) with a pipe. Two such tests overlapping restore
+// each other's stream mid-capture, sending expected output to the wrong
+// sink; every swap site holds this lock for the full swap-write-restore
+// window.
+var stderrSwapMu sync.Mutex

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -2279,8 +2279,17 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 				if c.ccMu == nil {
 					c.ccMu = &sync.Mutex{}
 				}
+				// Read the refreshed header inside the same critical section
+				// as the mint so a concurrent mint cannot replace Config
+				// fields mid-read. The tier-routing variant re-derives auth
+				// via authForRequest instead, which takes ccMu internally.
 				c.ccMu.Lock()
 				mintErr := c.mintClientCredentials(ctx, clientID, clientSecret)
+{{- if not .HasTierRouting}}
+				if mintErr == nil {
+					authHeader = c.Config.AuthHeader()
+				}
+{{- end}}
 				c.ccMu.Unlock()
 				if mintErr != nil {
 					return nil, resp.StatusCode, fmt.Errorf("re-minting access token after 401: %w", mintErr)
@@ -2291,8 +2300,6 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 					return nil, resp.StatusCode, err
 				}
 				authHeader = authInfo.Value
-{{- else}}
-				authHeader = c.Config.AuthHeader()
 {{- end}}
 				refreshedAfterUnauthorized = true
 				lastErr = apiErr

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -93,6 +93,10 @@ type Client struct {
 	// API calls inside the 60s pre-expiry window don't all dial the token
 	// endpoint and race on Config field writes / file persistence.
 	ccMu *sync.Mutex
+	// ccMintedUnknownExpiry caps the unknown-expiry mint policy at one
+	// token-endpoint POST per process: a stored token with no recorded
+	// expiry is re-minted once instead of trusted forever.
+	ccMintedUnknownExpiry bool
 {{- end}}
 {{- if eq .Auth.Subtype "google_service_account"}}
 	// googleMu serializes service-account token loading and keeps one reusable
@@ -2257,6 +2261,41 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		}
 
 {{- if and .HasAuthCommand (ne .Auth.TokenURL "")}}
+{{- if eq .Auth.EffectiveOAuth2Grant "client_credentials"}}
+		// OAuth providers can expire or revoke tokens early. The
+		// client_credentials grant issues no refresh token, so recovery from
+		// an unauthorized response is a fresh mint: re-mint once and retry;
+		// a 401 that survives a fresh token surfaces as the real error.
+		if resp.StatusCode == http.StatusUnauthorized && !refreshedAfterUnauthorized && attempt < maxRetries && c.Config != nil && !(cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv()) {
+			clientID, clientSecret := resolveClientCredentials(c.Config)
+			if clientID != "" && clientSecret != "" {
+				if authHeaderLooksLikePlaceholderCredential(clientID) || authHeaderLooksLikePlaceholderCredential(clientSecret) {
+					return nil, resp.StatusCode, authPlaceholderCredentialError(c.Config)
+				}
+				if c.ccMu == nil {
+					c.ccMu = &sync.Mutex{}
+				}
+				c.ccMu.Lock()
+				mintErr := c.mintClientCredentials(ctx, clientID, clientSecret)
+				c.ccMu.Unlock()
+				if mintErr != nil {
+					return nil, resp.StatusCode, fmt.Errorf("re-minting access token after 401: %w", mintErr)
+				}
+{{- if .HasTierRouting}}
+				authInfo, err = c.authForRequest(ctx)
+				if err != nil {
+					return nil, resp.StatusCode, err
+				}
+				authHeader = authInfo.Value
+{{- else}}
+				authHeader = c.Config.AuthHeader()
+{{- end}}
+				refreshedAfterUnauthorized = true
+				lastErr = apiErr
+				continue
+			}
+		}
+{{- else}}
 		// OAuth providers can expire tokens early, omit expires_in, or disagree
 		// with the local clock. Retry one unauthorized response after refreshing.
 		if resp.StatusCode == http.StatusUnauthorized && !refreshedAfterUnauthorized && attempt < maxRetries && c.Config != nil && c.Config.RefreshToken != "" && !(cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv()) {
@@ -2282,6 +2321,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			lastErr = apiErr
 			continue
 		}
+{{- end}}
 {{- end}}
 
 		// Rate limited: classify before provider decoding. Unsafe-to-replay
@@ -2660,12 +2700,12 @@ func (c *Client) authHeader(ctx context.Context) (string, error) {
 	}
 	// 60s window avoids in-flight requests racing the expiry boundary.
 	// Double-checked lock so only one goroutine mints under contention.
-	if needsClientCredentialsMint(c.Config) {
+	if c.needsClientCredentialsMint() {
 		if c.ccMu == nil {
 			c.ccMu = &sync.Mutex{}
 		}
 		c.ccMu.Lock()
-		if needsClientCredentialsMint(c.Config) {
+		if c.needsClientCredentialsMint() {
 			clientID, clientSecret := resolveClientCredentials(c.Config)
 			if clientID != "" && clientSecret != "" {
 				if authHeaderLooksLikePlaceholderCredential(clientID) || authHeaderLooksLikePlaceholderCredential(clientSecret) {
@@ -2834,12 +2874,20 @@ func authPlaceholderCredentialErrorWithSetup(cfg *config.Config, setup string) e
 
 {{- if eq .Auth.EffectiveOAuth2Grant "client_credentials"}}
 
-func needsClientCredentialsMint(cfg *config.Config) bool {
+func (c *Client) needsClientCredentialsMint() bool {
+	cfg := c.Config
 	if cfg.AccessToken == "" {
 		return true
 	}
 	if cfg.TokenExpiry.IsZero() {
-		return false
+		// A stored token with no recorded expiry can be long-dead. Mint once
+		// per process instead of trusting it forever: one extra POST beats
+		// every call failing until a human intervenes. Verify harnesses must
+		// not dial a real token endpoint, so they keep the old trust.
+		if cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv() {
+			return false
+		}
+		return !c.ccMintedUnknownExpiry
 	}
 	return time.Until(cfg.TokenExpiry) < 60*time.Second
 }
@@ -2966,6 +3014,7 @@ func (c *Client) mintClientCredentials(ctx context.Context, clientID, clientSecr
 	if err := c.Config.SaveTokens(clientID, clientSecret, tokenResp.AccessToken, "", expiry); err != nil {
 		return fmt.Errorf("saving minted token: %w", err)
 	}
+	c.ccMintedUnknownExpiry = true
 	return nil
 }
 {{- end}}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -98,9 +98,10 @@ type Client struct {
 	ccMu *sync.Mutex
 	// ccMintedUnknownExpiry caps the unknown-expiry mint policy at one
 	// token-endpoint POST per process: a stored token with no recorded
-	// expiry is re-minted once instead of trusted forever. Atomic because
-	// the pre-lock fast-path check reads it outside ccMu.
-	ccMintedUnknownExpiry atomic.Bool
+	// expiry is re-minted once instead of trusted forever. Pointer so
+	// WithTier's value copy shares the cap (and so copylocks stays clean).
+	// Atomic because the pre-lock fast-path check reads it outside ccMu.
+	ccMintedUnknownExpiry *atomic.Bool
 {{- end}}
 {{- if eq .Auth.Subtype "google_service_account"}}
 	// googleMu serializes service-account token loading and keeps one reusable
@@ -666,7 +667,8 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 		limiters:   newTierLimiters(rateLimit),
 {{- end}}
 {{- if eq .Auth.EffectiveOAuth2Grant "client_credentials"}}
-		ccMu:       &sync.Mutex{},
+		ccMu:                  &sync.Mutex{},
+		ccMintedUnknownExpiry: &atomic.Bool{},
 {{- end}}
 {{- if eq .Auth.Subtype "google_service_account"}}
 		googleMu:   &sync.RWMutex{},
@@ -720,7 +722,8 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 		limiters:   newTierLimiters(rateLimit),
 {{- end}}
 {{- if eq .Auth.EffectiveOAuth2Grant "client_credentials"}}
-		ccMu:       &sync.Mutex{},
+		ccMu:                  &sync.Mutex{},
+		ccMintedUnknownExpiry: &atomic.Bool{},
 {{- end}}
 {{- if eq .Auth.Subtype "google_service_account"}}
 		googleMu:   &sync.RWMutex{},
@@ -2902,7 +2905,7 @@ func (c *Client) needsClientCredentialsMint() bool {
 		if cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv() {
 			return false
 		}
-		return !c.ccMintedUnknownExpiry.Load()
+		return c.ccMintedUnknownExpiry == nil || !c.ccMintedUnknownExpiry.Load()
 	}
 	return time.Until(cfg.TokenExpiry) < 60*time.Second
 }
@@ -3028,6 +3031,9 @@ func (c *Client) mintClientCredentials(ctx context.Context, clientID, clientSecr
 	c.Config.AuthHeaderVal = "" // force AuthHeader() to use the new AccessToken path
 	if err := c.Config.SaveTokens(clientID, clientSecret, tokenResp.AccessToken, "", expiry); err != nil {
 		return fmt.Errorf("saving minted token: %w", err)
+	}
+	if c.ccMintedUnknownExpiry == nil {
+		c.ccMintedUnknownExpiry = &atomic.Bool{}
 	}
 	c.ccMintedUnknownExpiry.Store(true)
 	return nil

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -30,6 +30,9 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+{{- if eq .Auth.EffectiveOAuth2Grant "client_credentials"}}
+	"sync/atomic"
+{{- end}}
 	"time"
 	"unicode"
 
@@ -95,8 +98,9 @@ type Client struct {
 	ccMu *sync.Mutex
 	// ccMintedUnknownExpiry caps the unknown-expiry mint policy at one
 	// token-endpoint POST per process: a stored token with no recorded
-	// expiry is re-minted once instead of trusted forever.
-	ccMintedUnknownExpiry bool
+	// expiry is re-minted once instead of trusted forever. Atomic because
+	// the pre-lock fast-path check reads it outside ccMu.
+	ccMintedUnknownExpiry atomic.Bool
 {{- end}}
 {{- if eq .Auth.Subtype "google_service_account"}}
 	// googleMu serializes service-account token loading and keeps one reusable
@@ -2887,7 +2891,7 @@ func (c *Client) needsClientCredentialsMint() bool {
 		if cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv() {
 			return false
 		}
-		return !c.ccMintedUnknownExpiry
+		return !c.ccMintedUnknownExpiry.Load()
 	}
 	return time.Until(cfg.TokenExpiry) < 60*time.Second
 }
@@ -3014,7 +3018,7 @@ func (c *Client) mintClientCredentials(ctx context.Context, clientID, clientSecr
 	if err := c.Config.SaveTokens(clientID, clientSecret, tokenResp.AccessToken, "", expiry); err != nil {
 		return fmt.Errorf("saving minted token: %w", err)
 	}
-	c.ccMintedUnknownExpiry = true
+	c.ccMintedUnknownExpiry.Store(true)
 	return nil
 }
 {{- end}}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -2271,19 +2271,22 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		// an unauthorized response is a fresh mint: re-mint once and retry;
 		// a 401 that survives a fresh token surfaces as the real error.
 		if resp.StatusCode == http.StatusUnauthorized && !refreshedAfterUnauthorized && attempt < maxRetries && c.Config != nil && !(cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv()) {
+			if c.ccMu == nil {
+				c.ccMu = &sync.Mutex{}
+			}
+			// Resolve the credential pair, validate it, mint, and (without
+			// tier routing) read the refreshed header inside one critical
+			// section, so a concurrent mint persisting Config fields cannot
+			// interleave a stale or mismatched pair mid-recovery. The
+			// tier-routing variant re-derives auth via authForRequest after
+			// unlock instead, which takes ccMu internally.
+			c.ccMu.Lock()
 			clientID, clientSecret := resolveClientCredentials(c.Config)
 			if clientID != "" && clientSecret != "" {
 				if authHeaderLooksLikePlaceholderCredential(clientID) || authHeaderLooksLikePlaceholderCredential(clientSecret) {
+					c.ccMu.Unlock()
 					return nil, resp.StatusCode, authPlaceholderCredentialError(c.Config)
 				}
-				if c.ccMu == nil {
-					c.ccMu = &sync.Mutex{}
-				}
-				// Read the refreshed header inside the same critical section
-				// as the mint so a concurrent mint cannot replace Config
-				// fields mid-read. The tier-routing variant re-derives auth
-				// via authForRequest instead, which takes ccMu internally.
-				c.ccMu.Lock()
 				mintErr := c.mintClientCredentials(ctx, clientID, clientSecret)
 {{- if not .HasTierRouting}}
 				if mintErr == nil {
@@ -2305,6 +2308,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 				lastErr = apiErr
 				continue
 			}
+			c.ccMu.Unlock()
 		}
 {{- else}}
 		// OAuth providers can expire tokens early, omit expires_in, or disagree

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -1054,11 +1054,16 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 						}
 					}
 				}
+				// Mutation-riding reads (POST search, RPC-over-POST lists) return
+				// the same single-key collection envelopes as GET reads. Unwrap
+				// before filtering so rows nest once under the result key and
+				// --select filters rows, not envelope keys; plain created-object
+				// responses pass through unwrapSingleKeyArray untouched.
 				// Apply --compact and --select to the API response before wrapping.
 				// --select wins when both are set: explicit field choice trumps the
 				// generic high-gravity allow-list. Otherwise --compact still applies
 				// when --agent is on but the user did not name fields.
-				filtered := data
+				filtered := unwrapSingleKeyArray(data)
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {

--- a/testdata/golden/expected/generate-collection-item-collision/collection-item-collision/internal/cli/users_item_email_update.go
+++ b/testdata/golden/expected/generate-collection-item-collision/collection-item-collision/internal/cli/users_item_email_update.go
@@ -158,11 +158,16 @@ func newUsersItemEmailUpdateCmd(flags *rootFlags) *cobra.Command {
 						}
 					}
 				}
+				// Mutation-riding reads (POST search, RPC-over-POST lists) return
+				// the same single-key collection envelopes as GET reads. Unwrap
+				// before filtering so rows nest once under the result key and
+				// --select filters rows, not envelope keys; plain created-object
+				// responses pass through unwrapSingleKeyArray untouched.
 				// Apply --compact and --select to the API response before wrapping.
 				// --select wins when both are set: explicit field choice trumps the
 				// generic high-gravity allow-list. Otherwise --compact still applies
 				// when --agent is on but the user did not name fields.
-				filtered := data
+				filtered := unwrapSingleKeyArray(data)
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_create.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_create.go
@@ -139,11 +139,16 @@ func newQuotesCreateCmd(flags *rootFlags) *cobra.Command {
 						}
 					}
 				}
+				// Mutation-riding reads (POST search, RPC-over-POST lists) return
+				// the same single-key collection envelopes as GET reads. Unwrap
+				// before filtering so rows nest once under the result key and
+				// --select filters rows, not envelope keys; plain created-object
+				// responses pass through unwrapSingleKeyArray untouched.
 				// Apply --compact and --select to the API response before wrapping.
 				// --select wins when both are set: explicit field choice trumps the
 				// generic high-gravity allow-list. Otherwise --compact still applies
 				// when --agent is on but the user did not name fields.
-				filtered := data
+				filtered := unwrapSingleKeyArray(data)
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_delete.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_delete.go
@@ -136,11 +136,16 @@ func newQuotesDeleteCmd(flags *rootFlags) *cobra.Command {
 						}
 					}
 				}
+				// Mutation-riding reads (POST search, RPC-over-POST lists) return
+				// the same single-key collection envelopes as GET reads. Unwrap
+				// before filtering so rows nest once under the result key and
+				// --select filters rows, not envelope keys; plain created-object
+				// responses pass through unwrapSingleKeyArray untouched.
 				// Apply --compact and --select to the API response before wrapping.
 				// --select wins when both are set: explicit field choice trumps the
 				// generic high-gravity allow-list. Otherwise --compact still applies
 				// when --agent is on but the user did not name fields.
-				filtered := data
+				filtered := unwrapSingleKeyArray(data)
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update-status.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update-status.go
@@ -158,11 +158,16 @@ func newQuotesUpdateStatusCmd(flags *rootFlags) *cobra.Command {
 						}
 					}
 				}
+				// Mutation-riding reads (POST search, RPC-over-POST lists) return
+				// the same single-key collection envelopes as GET reads. Unwrap
+				// before filtering so rows nest once under the result key and
+				// --select filters rows, not envelope keys; plain created-object
+				// responses pass through unwrapSingleKeyArray untouched.
 				// Apply --compact and --select to the API response before wrapping.
 				// --select wins when both are set: explicit field choice trumps the
 				// generic high-gravity allow-list. Otherwise --compact still applies
 				// when --agent is on but the user did not name fields.
-				filtered := data
+				filtered := unwrapSingleKeyArray(data)
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update.go
@@ -158,11 +158,16 @@ func newQuotesUpdateCmd(flags *rootFlags) *cobra.Command {
 						}
 					}
 				}
+				// Mutation-riding reads (POST search, RPC-over-POST lists) return
+				// the same single-key collection envelopes as GET reads. Unwrap
+				// before filtering so rows nest once under the result key and
+				// --select filters rows, not envelope keys; plain created-object
+				// responses pass through unwrapSingleKeyArray untouched.
 				// Apply --compact and --select to the API response before wrapping.
 				// --select wins when both are set: explicit field choice trumps the
 				// generic high-gravity allow-list. Otherwise --compact still applies
 				// when --agent is on but the user did not name fields.
-				filtered := data
+				filtered := unwrapSingleKeyArray(data)
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -1149,13 +1149,19 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 				if c.ccMu == nil {
 					c.ccMu = &sync.Mutex{}
 				}
+				// Read the refreshed header inside the same critical section
+				// as the mint so a concurrent mint cannot replace Config
+				// fields mid-read. The tier-routing variant re-derives auth
+				// via authForRequest instead, which takes ccMu internally.
 				c.ccMu.Lock()
 				mintErr := c.mintClientCredentials(ctx, clientID, clientSecret)
+				if mintErr == nil {
+					authHeader = c.Config.AuthHeader()
+				}
 				c.ccMu.Unlock()
 				if mintErr != nil {
 					return nil, resp.StatusCode, fmt.Errorf("re-minting access token after 401: %w", mintErr)
 				}
-				authHeader = c.Config.AuthHeader()
 				refreshedAfterUnauthorized = true
 				lastErr = apiErr
 				continue

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 )
@@ -58,8 +59,9 @@ type Client struct {
 	ccMu *sync.Mutex
 	// ccMintedUnknownExpiry caps the unknown-expiry mint policy at one
 	// token-endpoint POST per process: a stored token with no recorded
-	// expiry is re-minted once instead of trusted forever.
-	ccMintedUnknownExpiry bool
+	// expiry is re-minted once instead of trusted forever. Atomic because
+	// the pre-lock fast-path check reads it outside ccMu.
+	ccMintedUnknownExpiry atomic.Bool
 }
 
 func (c *Client) IsDryRun() bool {
@@ -1391,7 +1393,7 @@ func (c *Client) needsClientCredentialsMint() bool {
 		if cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv() {
 			return false
 		}
-		return !c.ccMintedUnknownExpiry
+		return !c.ccMintedUnknownExpiry.Load()
 	}
 	return time.Until(cfg.TokenExpiry) < 60*time.Second
 }
@@ -1479,7 +1481,7 @@ func (c *Client) mintClientCredentials(ctx context.Context, clientID, clientSecr
 	if err := c.Config.SaveTokens(clientID, clientSecret, tokenResp.AccessToken, "", expiry); err != nil {
 		return fmt.Errorf("saving minted token: %w", err)
 	}
-	c.ccMintedUnknownExpiry = true
+	c.ccMintedUnknownExpiry.Store(true)
 	return nil
 }
 

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -1141,19 +1141,22 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		// an unauthorized response is a fresh mint: re-mint once and retry;
 		// a 401 that survives a fresh token surfaces as the real error.
 		if resp.StatusCode == http.StatusUnauthorized && !refreshedAfterUnauthorized && attempt < maxRetries && c.Config != nil && !(cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv()) {
+			if c.ccMu == nil {
+				c.ccMu = &sync.Mutex{}
+			}
+			// Resolve the credential pair, validate it, mint, and (without
+			// tier routing) read the refreshed header inside one critical
+			// section, so a concurrent mint persisting Config fields cannot
+			// interleave a stale or mismatched pair mid-recovery. The
+			// tier-routing variant re-derives auth via authForRequest after
+			// unlock instead, which takes ccMu internally.
+			c.ccMu.Lock()
 			clientID, clientSecret := resolveClientCredentials(c.Config)
 			if clientID != "" && clientSecret != "" {
 				if authHeaderLooksLikePlaceholderCredential(clientID) || authHeaderLooksLikePlaceholderCredential(clientSecret) {
+					c.ccMu.Unlock()
 					return nil, resp.StatusCode, authPlaceholderCredentialError(c.Config)
 				}
-				if c.ccMu == nil {
-					c.ccMu = &sync.Mutex{}
-				}
-				// Read the refreshed header inside the same critical section
-				// as the mint so a concurrent mint cannot replace Config
-				// fields mid-read. The tier-routing variant re-derives auth
-				// via authForRequest instead, which takes ccMu internally.
-				c.ccMu.Lock()
 				mintErr := c.mintClientCredentials(ctx, clientID, clientSecret)
 				if mintErr == nil {
 					authHeader = c.Config.AuthHeader()
@@ -1166,6 +1169,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 				lastErr = apiErr
 				continue
 			}
+			c.ccMu.Unlock()
 		}
 
 		// Rate limited: classify before provider decoding. Unsafe-to-replay

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -59,9 +59,10 @@ type Client struct {
 	ccMu *sync.Mutex
 	// ccMintedUnknownExpiry caps the unknown-expiry mint policy at one
 	// token-endpoint POST per process: a stored token with no recorded
-	// expiry is re-minted once instead of trusted forever. Atomic because
-	// the pre-lock fast-path check reads it outside ccMu.
-	ccMintedUnknownExpiry atomic.Bool
+	// expiry is re-minted once instead of trusted forever. Pointer so
+	// WithTier's value copy shares the cap (and so copylocks stays clean).
+	// Atomic because the pre-lock fast-path check reads it outside ccMu.
+	ccMintedUnknownExpiry *atomic.Bool
 }
 
 func (c *Client) IsDryRun() bool {
@@ -319,12 +320,13 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	}
 	httpClient := newHTTPClient(timeout, nil)
 	c := &Client{
-		BaseURL:    strings.TrimRight(cfg.BaseURL, "/"),
-		Config:     cfg,
-		HTTPClient: httpClient,
-		cacheDir:   cacheDir,
-		limiter:    newRateLimiter(rateLimit),
-		ccMu:       &sync.Mutex{},
+		BaseURL:               strings.TrimRight(cfg.BaseURL, "/"),
+		Config:                cfg,
+		HTTPClient:            httpClient,
+		cacheDir:              cacheDir,
+		limiter:               newRateLimiter(rateLimit),
+		ccMu:                  &sync.Mutex{},
+		ccMintedUnknownExpiry: &atomic.Bool{},
 	}
 	// CheckRedirect re-derives auth on each hop. Go's default replays the
 	// original Authorization header verbatim, which breaks nonce-bound
@@ -1403,7 +1405,7 @@ func (c *Client) needsClientCredentialsMint() bool {
 		if cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv() {
 			return false
 		}
-		return !c.ccMintedUnknownExpiry.Load()
+		return c.ccMintedUnknownExpiry == nil || !c.ccMintedUnknownExpiry.Load()
 	}
 	return time.Until(cfg.TokenExpiry) < 60*time.Second
 }
@@ -1490,6 +1492,9 @@ func (c *Client) mintClientCredentials(ctx context.Context, clientID, clientSecr
 	c.Config.AuthHeaderVal = "" // force AuthHeader() to use the new AccessToken path
 	if err := c.Config.SaveTokens(clientID, clientSecret, tokenResp.AccessToken, "", expiry); err != nil {
 		return fmt.Errorf("saving minted token: %w", err)
+	}
+	if c.ccMintedUnknownExpiry == nil {
+		c.ccMintedUnknownExpiry = &atomic.Bool{}
 	}
 	c.ccMintedUnknownExpiry.Store(true)
 	return nil

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -56,6 +56,10 @@ type Client struct {
 	// API calls inside the 60s pre-expiry window don't all dial the token
 	// endpoint and race on Config field writes / file persistence.
 	ccMu *sync.Mutex
+	// ccMintedUnknownExpiry caps the unknown-expiry mint policy at one
+	// token-endpoint POST per process: a stored token with no recorded
+	// expiry is re-minted once instead of trusted forever.
+	ccMintedUnknownExpiry bool
 }
 
 func (c *Client) IsDryRun() bool {
@@ -1130,22 +1134,30 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			StatusCode: resp.StatusCode,
 			Body:       c.maskCredentialText(truncateBody(respBody), authHeader),
 		}
-		// OAuth providers can expire tokens early, omit expires_in, or disagree
-		// with the local clock. Retry one unauthorized response after refreshing.
-		if resp.StatusCode == http.StatusUnauthorized && !refreshedAfterUnauthorized && attempt < maxRetries && c.Config != nil && c.Config.RefreshToken != "" && !(cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv()) {
-			if authHeaderLooksLikePlaceholderCredential(c.Config.AccessToken) || authHeaderLooksLikePlaceholderCredential(c.Config.RefreshToken) || authHeaderLooksLikePlaceholderCredential(c.Config.ClientID) || authHeaderLooksLikePlaceholderCredential(c.Config.ClientSecret) {
-				return nil, resp.StatusCode, authPlaceholderCredentialError(c.Config)
+		// OAuth providers can expire or revoke tokens early. The
+		// client_credentials grant issues no refresh token, so recovery from
+		// an unauthorized response is a fresh mint: re-mint once and retry;
+		// a 401 that survives a fresh token surfaces as the real error.
+		if resp.StatusCode == http.StatusUnauthorized && !refreshedAfterUnauthorized && attempt < maxRetries && c.Config != nil && !(cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv()) {
+			clientID, clientSecret := resolveClientCredentials(c.Config)
+			if clientID != "" && clientSecret != "" {
+				if authHeaderLooksLikePlaceholderCredential(clientID) || authHeaderLooksLikePlaceholderCredential(clientSecret) {
+					return nil, resp.StatusCode, authPlaceholderCredentialError(c.Config)
+				}
+				if c.ccMu == nil {
+					c.ccMu = &sync.Mutex{}
+				}
+				c.ccMu.Lock()
+				mintErr := c.mintClientCredentials(ctx, clientID, clientSecret)
+				c.ccMu.Unlock()
+				if mintErr != nil {
+					return nil, resp.StatusCode, fmt.Errorf("re-minting access token after 401: %w", mintErr)
+				}
+				authHeader = c.Config.AuthHeader()
+				refreshedAfterUnauthorized = true
+				lastErr = apiErr
+				continue
 			}
-			if err := c.refreshAccessToken(ctx); err != nil {
-				return nil, resp.StatusCode, fmt.Errorf("refreshing access token after 401: %w", err)
-			}
-			authHeader = c.Config.AuthHeader()
-			if authHeaderLooksLikePlaceholderCredential(authHeader) {
-				return nil, resp.StatusCode, authPlaceholderCredentialError(c.Config)
-			}
-			refreshedAfterUnauthorized = true
-			lastErr = apiErr
-			continue
 		}
 
 		// Rate limited: classify before provider decoding. Unsafe-to-replay
@@ -1279,12 +1291,12 @@ func (c *Client) authHeader(ctx context.Context) (string, error) {
 	}
 	// 60s window avoids in-flight requests racing the expiry boundary.
 	// Double-checked lock so only one goroutine mints under contention.
-	if needsClientCredentialsMint(c.Config) {
+	if c.needsClientCredentialsMint() {
 		if c.ccMu == nil {
 			c.ccMu = &sync.Mutex{}
 		}
 		c.ccMu.Lock()
-		if needsClientCredentialsMint(c.Config) {
+		if c.needsClientCredentialsMint() {
 			clientID, clientSecret := resolveClientCredentials(c.Config)
 			if clientID != "" && clientSecret != "" {
 				if authHeaderLooksLikePlaceholderCredential(clientID) || authHeaderLooksLikePlaceholderCredential(clientSecret) {
@@ -1366,12 +1378,20 @@ func authPlaceholderCredentialErrorWithSetup(cfg *config.Config, setup string) e
 	return fmt.Errorf("%w configured in %s; set a real token with: %s", ErrPlaceholderCredential, location, setup)
 }
 
-func needsClientCredentialsMint(cfg *config.Config) bool {
+func (c *Client) needsClientCredentialsMint() bool {
+	cfg := c.Config
 	if cfg.AccessToken == "" {
 		return true
 	}
 	if cfg.TokenExpiry.IsZero() {
-		return false
+		// A stored token with no recorded expiry can be long-dead. Mint once
+		// per process instead of trusting it forever: one extra POST beats
+		// every call failing until a human intervenes. Verify harnesses must
+		// not dial a real token endpoint, so they keep the old trust.
+		if cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv() {
+			return false
+		}
+		return !c.ccMintedUnknownExpiry
 	}
 	return time.Until(cfg.TokenExpiry) < 60*time.Second
 }
@@ -1459,6 +1479,7 @@ func (c *Client) mintClientCredentials(ctx context.Context, clientID, clientSecr
 	if err := c.Config.SaveTokens(clientID, clientSecret, tokenResp.AccessToken, "", expiry); err != nil {
 		return fmt.Errorf("saving minted token: %w", err)
 	}
+	c.ccMintedUnknownExpiry = true
 	return nil
 }
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
@@ -163,11 +163,16 @@ func newProjectsAvatarUploadProjectCmd(flags *rootFlags) *cobra.Command {
 						}
 					}
 				}
+				// Mutation-riding reads (POST search, RPC-over-POST lists) return
+				// the same single-key collection envelopes as GET reads. Unwrap
+				// before filtering so rows nest once under the result key and
+				// --select filters rows, not envelope keys; plain created-object
+				// responses pass through unwrapSingleKeyArray untouched.
 				// Apply --compact and --select to the API response before wrapping.
 				// --select wins when both are set: explicit field choice trumps the
 				// generic high-gravity allow-list. Otherwise --compact still applies
 				// when --agent is on but the user did not name fields.
-				filtered := data
+				filtered := unwrapSingleKeyArray(data)
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
@@ -188,11 +188,16 @@ func newProjectsCreateCmd(flags *rootFlags) *cobra.Command {
 						}
 					}
 				}
+				// Mutation-riding reads (POST search, RPC-over-POST lists) return
+				// the same single-key collection envelopes as GET reads. Unwrap
+				// before filtering so rows nest once under the result key and
+				// --select filters rows, not envelope keys; plain created-object
+				// responses pass through unwrapSingleKeyArray untouched.
 				// Apply --compact and --select to the API response before wrapping.
 				// --select wins when both are set: explicit field choice trumps the
 				// generic high-gravity allow-list. Otherwise --compact still applies
 				// when --agent is on but the user did not name fields.
-				filtered := data
+				filtered := unwrapSingleKeyArray(data)
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
@@ -187,11 +187,16 @@ func newProjectsTasksUpdateProjectCmd(flags *rootFlags) *cobra.Command {
 						}
 					}
 				}
+				// Mutation-riding reads (POST search, RPC-over-POST lists) return
+				// the same single-key collection envelopes as GET reads. Unwrap
+				// before filtering so rows nest once under the result key and
+				// --select filters rows, not envelope keys; plain created-object
+				// responses pass through unwrapSingleKeyArray untouched.
 				// Apply --compact and --select to the API response before wrapping.
 				// --select wins when both are set: explicit field choice trumps the
 				// generic high-gravity allow-list. Otherwise --compact still applies
 				// when --agent is on but the user did not name fields.
-				filtered := data
+				filtered := unwrapSingleKeyArray(data)
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {

--- a/testdata/golden/expected/generate-post-read-search/post-read-golden/internal/cli/sets_create.go
+++ b/testdata/golden/expected/generate-post-read-search/post-read-golden/internal/cli/sets_create.go
@@ -143,11 +143,16 @@ func newSetsCreateCmd(flags *rootFlags) *cobra.Command {
 						}
 					}
 				}
+				// Mutation-riding reads (POST search, RPC-over-POST lists) return
+				// the same single-key collection envelopes as GET reads. Unwrap
+				// before filtering so rows nest once under the result key and
+				// --select filters rows, not envelope keys; plain created-object
+				// responses pass through unwrapSingleKeyArray untouched.
 				// Apply --compact and --select to the API response before wrapping.
 				// --select wins when both are set: explicit field choice trumps the
 				// generic high-gravity allow-list. Otherwise --compact still applies
 				// when --agent is on but the user did not name fields.
-				filtered := data
+				filtered := unwrapSingleKeyArray(data)
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
@@ -169,11 +169,16 @@ func newStoresCreateCmd(flags *rootFlags) *cobra.Command {
 						}
 					}
 				}
+				// Mutation-riding reads (POST search, RPC-over-POST lists) return
+				// the same single-key collection envelopes as GET reads. Unwrap
+				// before filtering so rows nest once under the result key and
+				// --select filters rows, not envelope keys; plain created-object
+				// responses pass through unwrapSingleKeyArray untouched.
 				// Apply --compact and --select to the API response before wrapping.
 				// --select wins when both are set: explicit field choice trumps the
 				// generic high-gravity allow-list. Otherwise --compact still applies
 				// when --agent is on but the user did not name fields.
-				filtered := data
+				filtered := unwrapSingleKeyArray(data)
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {


### PR DESCRIPTION
## Intent

A 17-day audit of scheduled agent routines running against printed CLIs (2026-08-27) traced two classes of silent failure to the generated client and command templates:

1. Printed CLIs on the `client_credentials` grant cannot recover from a 401: the retry branch gates on `RefreshToken`, which that grant never issues, so a revoked or clock-skewed bearer (IDX10223 class) hard-fails every call until a human intervenes. A stored token with no recorded expiry is also trusted forever.
2. Mutation-output commands (`POST`/`PUT`/`PATCH`) wrap the raw API body, so collection responses render as `data.data` / `results.data` while the GET read path normalizes the same envelope — consumers probing one nesting depth get silent wrong answers.

Issue: Fixes #4390. Addresses #4000 defects 1 and 2 (defect 3, `retrieved_at` provenance, is intentionally out of scope here).

## Approach

- `client.go.tmpl`: the 401 recovery branch is now grant-aware. For `client_credentials` it re-mints once via the token endpoint (serialized on `ccMu`) and retries; a 401 that survives a fresh token surfaces as the real error. Other grants keep the existing refresh-token branch unchanged. `needsClientCredentialsMint` becomes a method so an unknown-expiry token mints once per process (`ccMintedUnknownExpiry`) instead of being trusted forever; verify harnesses keep the old trust so they never dial a token endpoint.
- `command_endpoint.go.tmpl`: the mutation-output path runs `unwrapSingleKeyArray` on the response before `--select`/`--compact`, mirroring the read path. The helper only fires when the sole non-metadata key is a canonical collection key with an array value, so plain created-object responses pass through untouched.

## Scope

Primary area: generator templates (generated client auth transport + endpoint command output).

Why this belongs in this repo: both defects reproduce in every printed CLI of the affected shapes (`client_credentials` auth; any mutation-output endpoint whose API answers with a collection envelope). The symptom surfaced in printed CLIs, but the behavior is emitted by these templates.

## Risk

- Mutation-output JSON shape changes for APIs that return collection envelopes on mutating verbs: rows now nest once under `data`/`results` instead of twice. That is the documented intent of #4390; single-object mutation responses are unchanged (guarded by the new behavior test).
- The 401 re-mint adds one token-endpoint POST on unauthorized responses for client_credentials CLIs; capped at once per request via the existing `refreshedAfterUnauthorized` latch and skipped under verify env.
- Unknown-expiry tokens now cost one mint POST per process for client_credentials CLIs.

## Output Contract

- Emitted-code assertions: `TestClientCredentials401RemintEmission`, `TestAuthorizationCode401RefreshUnchanged` (non-CC grants keep the refresh branch, no mint branch), updated `TestGenerateOAuth2ClientCredentialsClientRefresh`.
- Compiled generated-CLI behavior tests injected into the generated module and run with its own toolchain: `TestClientCredentials401RemintBehavior` (401 → exactly 1 mint → success; unknown-expiry mints once per process across two calls) and `TestMutationOutputUnwrapsCollectionEnvelope` (envelope response nests rows once; plain object response passes through).
- Golden fixtures updated for the 11 files the change actually emits differently (oauth2-cc `client.go`; mutation-output command files across the endpoint-template cases).

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures (non-CC grant unchanged; object-shaped mutation response unchanged; tier-routing branch shared with existing refresh path)
- [x] Generator/template change: checked emitted definitions and call sites for matching gates (`needsClientCredentialsMint` call sites updated with the method form; `refreshAccessToken` emission gate untouched)

Commands run: `go test ./...` (full suite, green), `bash scripts/golden.sh verify` + `update` (11 content fixtures committed; pre-existing CRLF/toolchain-drift fixtures left untouched), `bash scripts/verify-generator-output.sh` (default set + `generate-golden-api-oauth2-cc` + `generate-post-read-search`), `go fmt ./...` via gofmt on touched files.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
