### PR TITLE
fix(cli): fail workflow archive when every resource errors

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10374,6 +10374,10 @@ func TestGeneratedOutput_WorkflowArchiveDelegatesToSyncResource(t *testing.T) {
 			"archive --json must route syncResource event NDJSON away from stdout")
 		assert.Contains(t, src, `nil, syncEventWriter)`,
 			"archive must pass the wrapper-selected event writer into syncResource")
+		assert.Contains(t, src, `if resourcesSynced == 0 && len(resources) > 0`,
+			"archive must fail closed when every attempted resource failed")
+		assert.Contains(t, src, `workflow archive failed: 0 of %d resource(s) archived`,
+			"archive all-failed error must name the attempted resource count")
 		assert.Contains(t, syncSrc, "syncEvents io.Writer",
 			"syncResource should expose an event writer parameter for wrapper callers")
 		assert.Contains(t, syncSrc, "syncEventWriter := cmd.OutOrStdout()",
@@ -10669,6 +10673,10 @@ func TestGeneratedOutput_WorkflowBoundaries(t *testing.T) {
 		"workflow archive must cap the resource list under dogfood")
 	assert.Contains(t, src, `archiveMaxPages, false`,
 		"workflow archive must pass the dogfood-aware page limit to syncResource")
+	assert.Contains(t, src, `if resourcesSynced == 0 && len(resources) > 0`,
+		"workflow archive must fail closed when every attempted resource failed")
+	assert.Contains(t, src, `workflow archive failed: 0 of %d resource(s) archived`,
+		"workflow archive all-failed error must name the attempted resource count")
 
 	substackSpec := minimalSpec("substack")
 	substackDir := filepath.Join(t.TempDir(), naming.CLI(substackSpec.Name))
@@ -10928,6 +10936,65 @@ func TestWorkflowArchiveRejectsNegativeBounds(t *testing.T) {
 				t.Fatalf("negative %s created db path: stat err=%v", tc.flag, statErr)
 			}
 		})
+	}
+}
+
+func TestWorkflowArchiveFailsWhenEveryResourceErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("{\"error\":\"unauthorized\"}"))
+	}))
+	defer server.Close()
+	t.Setenv("WORKFLOWBOUNDARY_BASE_URL", server.URL)
+
+	stdout, stderr, err := runWorkflowBoundaryCommand("workflow", "archive", "--json", "--db", filepath.Join(t.TempDir(), "all-fail.db"))
+	if err == nil {
+		t.Fatalf("all-failed archive unexpectedly succeeded; stdout=%s stderr=%s", stdout, stderr)
+	}
+	if !strings.Contains(err.Error(), "workflow archive failed: 0 of 4 resource(s) archived") {
+		t.Fatalf("all-failed archive error = %v; stderr=%s", err, stderr)
+	}
+	if !strings.Contains(stdout, "\"resources_synced\": 0") {
+		t.Fatalf("all-failed archive stdout = %q, want resources_synced 0", stdout)
+	}
+	if strings.Contains(stdout, "Archived 0 items") {
+		t.Fatalf("all-failed archive stdout = %q, want no success-shaped human summary", stdout)
+	}
+
+	stdout, stderr, err = runWorkflowBoundaryCommand("workflow", "archive", "--db", filepath.Join(t.TempDir(), "all-fail-human.db"))
+	if err == nil {
+		t.Fatalf("all-failed human archive unexpectedly succeeded; stdout=%s stderr=%s", stdout, stderr)
+	}
+	if !strings.Contains(err.Error(), "workflow archive failed: 0 of 4 resource(s) archived") {
+		t.Fatalf("all-failed human archive error = %v; stderr=%s", err, stderr)
+	}
+	if strings.Contains(stdout, "Archived 0 items") {
+		t.Fatalf("all-failed human archive stdout = %q, want no success-shaped summary", stdout)
+	}
+}
+
+func TestWorkflowArchivePartialSuccessExitsZero(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/alpha") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{\"items\":[{\"id\":\"a1\"}],\"has_more\":false,\"next_cursor\":\"\"}"))
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("{\"error\":\"unauthorized\"}"))
+	}))
+	defer server.Close()
+	t.Setenv("WORKFLOWBOUNDARY_BASE_URL", server.URL)
+
+	stdout, stderr, err := runWorkflowBoundaryCommand("workflow", "archive", "--json", "--db", filepath.Join(t.TempDir(), "partial.db"))
+	if err != nil {
+		t.Fatalf("partial archive: %v; stdout=%s stderr=%s", err, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "\"resources_synced\": 1") {
+		t.Fatalf("partial archive stdout = %q, want resources_synced 1", stdout)
+	}
+	if !strings.Contains(stderr, "error:") {
+		t.Fatalf("partial archive stderr = %q, want per-resource errors", stderr)
 	}
 }
 `

--- a/internal/generator/templates/channel_workflow.go.tmpl
+++ b/internal/generator/templates/channel_workflow.go.tmpl
@@ -376,15 +376,22 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 			if flags.asJSON {
 				enc := json.NewEncoder(cmd.OutOrStdout())
 				enc.SetIndent("", "  ")
-				return enc.Encode(map[string]any{
+				if err := enc.Encode(map[string]any{
 					"resources_synced": resourcesSynced,
 					"total_items":      totalSynced,
 					"store_path":       dbPath,
 					"timestamp":        time.Now().UTC().Format(time.RFC3339),
-				})
+				}); err != nil {
+					return err
+				}
+			} else if resourcesSynced > 0 || len(resources) == 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "Archived %d items across %d resources to %s\n", totalSynced, resourcesSynced, dbPath)
 			}
-
-			fmt.Fprintf(cmd.OutOrStdout(), "Archived %d items across %d resources to %s\n", totalSynced, resourcesSynced, dbPath)
+			// Fail closed when every attempted resource errored or warned.
+			// Partial success stays exit 0, matching sync's default (non-strict) policy.
+			if resourcesSynced == 0 && len(resources) > 0 {
+				return fmt.Errorf("workflow archive failed: 0 of %d resource(s) archived", len(resources))
+			}
 			return nil
 		},
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Addresses #4314 (defect 1 only).

`workflow archive` still exited 0 with a success-shaped summary after every resource failed. Credentials expire, every request 401s, and agents treat the archive as complete. `resources_synced` already counts successes, but the command never failed closed.

This PR does not fix defect 2 on #4314 (generated installers verify nothing they download). That is a different surface and stays open on the issue. Do not close #4314 from this PR.

## Approach

After the resource loop, fail when `resourcesSynced == 0` and at least one resource was attempted. That matches `sync`'s `successCount == 0` guard.

Partial success stays exit 0. Per-resource errors still print, and the summary reports only the resources that succeeded. This matches sync's default (non-strict) policy: any successful archive plus no critical abort is success.

`--json` still emits the factual summary (`resources_synced`, `total_items`) before the error, so agents can see the zero count and the non-zero exit. Human mode skips the "Archived 0 items..." line when nothing succeeded.

Empty resource lists stay exit 0 (nothing was attempted).

## Scope

Primary area: `internal/generator/templates/channel_workflow.go.tmpl`.

Why this belongs in this repo: the silent-success exit is generated for every printed CLI with sync enabled.

## Risk

Archive runs that previously exited 0 with zero successful resources now exit non-zero. Scripts that treated "archive finished" as success will start failing when auth or the API is down, which is the intended contract. Partial-success runs are unchanged.

## Output Contract

Generated `workflow archive` now returns an error when every attempted resource errors or warns. Existing golden fixtures do not snapshot `channel_workflow.go`; coverage is emitted-code assertions plus compiled generated-CLI runtime tests in `TestGeneratedOutput_WorkflowBoundaries`.

## Verification

- [x] Generator/template change: emitted-code assertions plus compiled generated CLI runtime tests
- [x] Generator/template change: covered all-failed (JSON and human) and partial-success fallback shapes
- [x] Generator/template change: archive is the only call site for this exit policy

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0363939b-2d34-471c-aaf1-d3be28687807?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0363939b-2d34-471c-aaf1-d3be28687807&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

