### PR TITLE
fix(cli): recognize camelCase stemUid as resource primary key

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -1368,8 +1368,10 @@ Rules:
   snake-case normalization, so camelCase and PascalCase spellings such as
   `widgetId` are preserved when emitted); then vendor identifier keys `gid`,
   `sid`, `uid`, `uuid`, and `guid`; then a sole remaining `<stem>_uid` /
-  camelCase `stemUid` field when the resource name does not yield that stem
-  (two or more such fields stay ambiguous and fall through); then URL-shaped
+  camelCase `stemUid` field whose stem is the resource's own collection noun
+  (so `alertUid` matches `account-alerts-open`, while a foreign `accountUid`
+  on `/sites` falls through; two own-stem spellings stay ambiguous); then
+  URL-shaped
   identifier keys `uri`, `self`, `selfLink`, `href`, and `url`; then `name`;
   then the first plausible required scalar field. URL-shaped keys qualify only
   when the field schema is a plausible ID and either the field is required or

--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -1364,15 +1364,17 @@ Rules:
   fallback.
 - An empty or missing value falls through to the parser's automatic
   `resolveIDFieldFromResponseSchema` chain: bare `id`; then a resource-derived
-  singular key ending in `_id`, `_uuid`, or `_guid` (matched through
+  singular key ending in `_id`, `_uuid`, `_guid`, or `_uid` (matched through
   snake-case normalization, so camelCase and PascalCase spellings such as
   `widgetId` are preserved when emitted); then vendor identifier keys `gid`,
-  `sid`, `uid`, `uuid`, and `guid`; then URL-shaped identifier keys `uri`,
-  `self`, `selfLink`, `href`, and `url`; then `name`; then the first plausible
-  required scalar field. URL-shaped keys qualify only when the field schema is a
-  plausible ID and either the field is required or its name, title, description,
-  or format carries an identifier hint; an optional generic `url` therefore
-  falls through to `name`.
+  `sid`, `uid`, `uuid`, and `guid`; then a sole remaining `<stem>_uid` /
+  camelCase `stemUid` field when the resource name does not yield that stem
+  (two or more such fields stay ambiguous and fall through); then URL-shaped
+  identifier keys `uri`, `self`, `selfLink`, `href`, and `url`; then `name`;
+  then the first plausible required scalar field. URL-shaped keys qualify only
+  when the field schema is a plausible ID and either the field is required or
+  its name, title, description, or format carries an identifier hint; an
+  optional generic `url` therefore falls through to `name`.
 - URL-shaped keys intentionally trail id-shaped keys, so APIs that expose both
   `id` and `self` keep the compact primary key.
 - Qualified URL-shaped keys intentionally win over display `name` when no

--- a/internal/generator/store_resource_id_resolution_test.go
+++ b/internal/generator/store_resource_id_resolution_test.go
@@ -3,9 +3,12 @@ package generator
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/openapi"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -82,4 +85,76 @@ func TestGeneratedStoreResolvesNestedAndUnusableRecordIDs(t *testing.T) {
 	runGoCommandRequired(t, outputDir, "test", "./internal/store",
 		"-run", "Test(LookupFieldValue_DottedPathAndTrailingUnderscore|ExtractResourceID_NestedOverrideAndIDUnderscore|ExtractResourceID_RefusesUnusableValues|UpsertBatch_NestedOverrideStoresRows|UpsertBatch_RefusesUnusableIDsInsteadOfWritingThem|UpsertBatch_GenericFallbackList|UpsertBatch_TemplatedIDFieldOverrideWins)",
 		"-count=1")
+}
+
+func TestGeneratedStoreResolvesSoleCamelCaseStemUID(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := openapi.Parse([]byte(`openapi: "3.0.3"
+info:
+  title: Stem UID Alerts
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /account-alerts-open:
+    get:
+      operationId: listAccountAlertsOpen
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    alertUid: {type: string}
+                    alertContext: {type: string}
+                    severity: {type: string}
+  /account-alerts-resolved:
+    get:
+      operationId: listAccountAlertsResolved
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    alert_uid: {type: string}
+                    alert_context: {type: string}
+                    severity: {type: string}
+`))
+	require.NoError(t, err)
+	profile := profiler.Profile(apiSpec)
+	byName := make(map[string]string, len(profile.SyncableResources))
+	for _, resource := range profile.SyncableResources {
+		byName[resource.Name] = resource.IDField
+	}
+	require.Equal(t, "alertUid", byName["account-alerts-open"])
+	require.Equal(t, "alert_uid", byName["account-alerts-resolved"])
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	storeGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	storeContent := string(storeGo)
+	syncContent := string(syncGo)
+	openOverride := regexp.MustCompile(`"account-alerts-open":\s+"alertUid"`)
+	resolvedOverride := regexp.MustCompile(`"account-alerts-resolved":\s+"alert_uid"`)
+	assert.Regexp(t, openOverride, storeContent)
+	assert.Regexp(t, resolvedOverride, storeContent)
+	assert.Regexp(t, openOverride, syncContent)
+	assert.Regexp(t, resolvedOverride, syncContent)
+
+	requireGeneratedCompiles(t, outputDir)
 }

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -6172,10 +6172,12 @@ func responseItemSchema(op *openapi3.Operation) *openapi3.Schema {
 
 // resolveIDFieldFromResponseSchema implements tiers 2-6 of the IDField fallback
 // chain: prefer "id", then a resource-prefixed key (`<singular>_id` /
-// `_uuid` / `_guid`), then a vendor identifier (`gid` / `sid` / `uid` /
-// `uuid` / `guid`), then a URL-shaped identifier (`uri` / `self` /
-// `selfLink` / `href` / `url`), then "name", then the first scalar field listed
-// in the response schema's `required:` array (walking properties in their schema order).
+// `_uuid` / `_guid` / `_uid`), then a vendor identifier (`gid` / `sid` /
+// `uid` / `uuid` / `guid`), then a sole remaining `<stem>_uid` field when the
+// resource name does not yield that stem, then a URL-shaped identifier
+// (`uri` / `self` / `selfLink` / `href` / `url`), then "name", then the first
+// scalar field listed in the response schema's `required:` array (walking
+// properties in their schema order).
 // Returns "" when no field qualifies; templates fall through to runtime list
 // scanning. Tier 1 (`x-resource-id` extension) is handled separately by the
 // caller — it overrides every tier here.
@@ -6218,6 +6220,15 @@ func resolveIDFieldFromResponseSchema(op *openapi3.Operation, resourceName strin
 		if _, ok := itemSchema.Properties[key]; ok {
 			return key
 		}
+	}
+
+	// Tier 3.6: sole remaining `<stem>_uid` / camelCase `stemUid`. Resource
+	// names like `account-alerts-open` do not yield the mid-name stem
+	// `alert`, so tier 3 misses `alertUid`. Exactly one such field keeps
+	// this from promoting a foreign key when `deviceUid` and `siteUid` both
+	// appear. Exact `uid` stays in tier 3.5.
+	if id := soleStemUIDField(itemSchema); id != "" {
+		return id
 	}
 
 	// Tier 4: URL-shaped identifiers. These trail id-shaped keys so APIs that
@@ -6307,10 +6318,10 @@ func collectIDSchemaFieldsInto(schemaRef *openapi3.SchemaRef, fields *idSchemaFi
 }
 
 // resourcePrefixedIDField returns the first property whose snake-cased name
-// matches a resource-derived base plus `_id`, then `_uuid`, then `_guid`.
-// Composed resource names also probe their leaf segment so child collections
-// like `projects_tasks` can key on `taskId`. Property names are returned
-// verbatim so callers preserve the spec's original casing.
+// matches a resource-derived base plus `_id`, then `_uuid`, then `_guid`,
+// then `_uid`. Composed resource names also probe their leaf segment so
+// child collections like `projects_tasks` can key on `taskId`. Property
+// names are returned verbatim so callers preserve the spec's original casing.
 func resourcePrefixedIDField(schema *openapi3.Schema, resourceName string) string {
 	bases := resourceIDBaseCandidates(resourceName)
 	if len(bases) == 0 {
@@ -6324,7 +6335,7 @@ func resourcePrefixedIDField(schema *openapi3.Schema, resourceName string) strin
 		propNames = append(propNames, name)
 	}
 	sort.Strings(propNames)
-	for _, suffix := range []string{"_id", "_uuid", "_guid"} {
+	for _, suffix := range []string{"_id", "_uuid", "_guid", "_uid"} {
 		for _, base := range bases {
 			target := base + suffix
 			for _, propName := range propNames {
@@ -6335,6 +6346,35 @@ func resourcePrefixedIDField(schema *openapi3.Schema, resourceName string) strin
 		}
 	}
 	return ""
+}
+
+// soleStemUIDField returns the sole property whose snake-cased name is
+// `<stem>_uid` with a non-empty stem and a plausible scalar schema. Bare
+// `uid` is left to the vendor-identifier tier. Two or more such fields are
+// ambiguous and return "".
+func soleStemUIDField(schema *openapi3.Schema) string {
+	if schema == nil {
+		return ""
+	}
+	var match string
+	for name, propRef := range schema.Properties {
+		if !isStemUIDFieldName(name) {
+			continue
+		}
+		if !isPlausibleIDFieldSchema(schemaRefValue(propRef)) {
+			continue
+		}
+		if match != "" {
+			return ""
+		}
+		match = name
+	}
+	return match
+}
+
+func isStemUIDFieldName(propName string) bool {
+	snake := toSnakeCase(propName)
+	return strings.HasSuffix(snake, "_uid") && len(snake) > len("_uid")
 }
 
 func resourceIDBaseCandidates(resourceName string) []string {

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -6173,8 +6173,8 @@ func responseItemSchema(op *openapi3.Operation) *openapi3.Schema {
 // resolveIDFieldFromResponseSchema implements tiers 2-6 of the IDField fallback
 // chain: prefer "id", then a resource-prefixed key (`<singular>_id` /
 // `_uuid` / `_guid` / `_uid`), then a vendor identifier (`gid` / `sid` /
-// `uid` / `uuid` / `guid`), then a sole remaining `<stem>_uid` field when the
-// resource name does not yield that stem, then a URL-shaped identifier
+// `uid` / `uuid` / `guid`), then a sole remaining `<own>_uid` field whose
+// stem is the resource's collection noun, then a URL-shaped identifier
 // (`uri` / `self` / `selfLink` / `href` / `url`), then "name", then the first
 // scalar field listed in the response schema's `required:` array (walking
 // properties in their schema order).
@@ -6222,12 +6222,13 @@ func resolveIDFieldFromResponseSchema(op *openapi3.Operation, resourceName strin
 		}
 	}
 
-	// Tier 3.6: sole remaining `<stem>_uid` / camelCase `stemUid`. Resource
-	// names like `account-alerts-open` do not yield the mid-name stem
-	// `alert`, so tier 3 misses `alertUid`. Exactly one such field keeps
-	// this from promoting a foreign key when `deviceUid` and `siteUid` both
-	// appear. Exact `uid` stays in tier 3.5.
-	if id := soleStemUIDField(itemSchema); id != "" {
+	// Tier 3.6: sole remaining `<stem>_uid` / camelCase `stemUid` whose
+	// stem is the resource's own collection noun. Resource names like
+	// `account-alerts-open` do not yield the mid-name stem `alert` in
+	// tier 3, so `alertUid` would otherwise be missed. A foreign
+	// reference such as `accountUid` on `/sites` must not win over
+	// `name` or a qualified URL. Exact `uid` stays in tier 3.5.
+	if id := soleStemUIDField(itemSchema, resourceName); id != "" {
 		return id
 	}
 
@@ -6349,16 +6350,22 @@ func resourcePrefixedIDField(schema *openapi3.Schema, resourceName string) strin
 }
 
 // soleStemUIDField returns the sole property whose snake-cased name is
-// `<stem>_uid` with a non-empty stem and a plausible scalar schema. Bare
-// `uid` is left to the vendor-identifier tier. Two or more such fields are
-// ambiguous and return "".
-func soleStemUIDField(schema *openapi3.Schema) string {
+// `<own>_uid` for this resource's collection noun, with a plausible scalar
+// schema. Bare `uid` is left to the vendor-identifier tier. A foreign
+// `accountUid` on a non-account collection is ignored so later tiers can
+// keep `name` or a qualified URL. Two own-stem spellings are ambiguous
+// and return "".
+func soleStemUIDField(schema *openapi3.Schema, resourceName string) string {
 	if schema == nil {
+		return ""
+	}
+	own := resourceOwnIdentityStem(resourceName)
+	if own == "" {
 		return ""
 	}
 	var match string
 	for name, propRef := range schema.Properties {
-		if !isStemUIDFieldName(name) {
+		if stemUIDFieldStem(name) != own {
 			continue
 		}
 		if !isPlausibleIDFieldSchema(schemaRefValue(propRef)) {
@@ -6372,9 +6379,39 @@ func soleStemUIDField(schema *openapi3.Schema) string {
 	return match
 }
 
-func isStemUIDFieldName(propName string) bool {
+func stemUIDFieldStem(propName string) string {
 	snake := toSnakeCase(propName)
-	return strings.HasSuffix(snake, "_uid") && len(snake) > len("_uid")
+	if !strings.HasSuffix(snake, "_uid") || len(snake) <= len("_uid") {
+		return ""
+	}
+	return strings.TrimSuffix(snake, "_uid")
+}
+
+// resourceOwnIdentityStem is the collection noun a resource's own
+// `<stem>_uid` would use. Multi-segment names keep the last token that
+// actually singularizes (`account-alerts-open` → `alert`) so a parent
+// or status segment is not treated as the item identity.
+func resourceOwnIdentityStem(resourceName string) string {
+	snake := strings.Trim(toSnakeCase(resourceName), "_")
+	if snake == "" {
+		return ""
+	}
+	tokens := strings.Split(snake, "_")
+	own := ""
+	for _, tok := range tokens {
+		tok = strings.Trim(tok, "_")
+		if tok == "" {
+			continue
+		}
+		singular := singularizeIdentifier(tok)
+		if singular != tok {
+			own = singular
+		}
+	}
+	if own != "" {
+		return own
+	}
+	return singularizeIdentifier(tokens[len(tokens)-1])
 }
 
 func resourceIDBaseCandidates(resourceName string) []string {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -9069,10 +9069,10 @@ paths:
 }
 
 // TestParseIDFieldResourcePrefixedHeuristic covers list responses whose item
-// schemas key off `<singular_resource>_id` (or `_uuid`/`_guid`) instead of a
-// bare `id`. Without this heuristic, APIs like podscan whose Category items
-// only carry `category_id` would fall through every fallback tier and leave
-// IDField empty, causing sync to silently drop every row.
+// schemas key off `<singular_resource>_id` (or `_uuid`/`_guid`/`_uid`) instead
+// of a bare `id`. Without this heuristic, APIs like podscan whose Category
+// items only carry `category_id` would fall through every fallback tier and
+// leave IDField empty, causing sync to silently drop every row.
 func TestParseIDFieldResourcePrefixedHeuristic(t *testing.T) {
 	t.Parallel()
 
@@ -9142,6 +9142,79 @@ func TestParseIDFieldResourcePrefixedHeuristic(t *testing.T) {
                     last_seen: {type: string}
 `,
 			wantID: "device_guid",
+		},
+		{
+			name: "_uid suffix is recognized when _id/_uuid/_guid are absent",
+			path: "/alerts",
+			schemaYAML: `                  type: object
+                  properties:
+                    alert_uid: {type: string}
+                    severity: {type: string}
+`,
+			wantID: "alert_uid",
+		},
+		{
+			name: "camelCase stemUid when resource name does not yield that stem",
+			path: "/account-alerts-open",
+			schemaYAML: `                  type: object
+                  properties:
+                    alertUid: {type: string}
+                    alertContext: {type: string}
+                    severity: {type: string}
+`,
+			wantID: "alertUid",
+		},
+		{
+			name: "snake stem_uid when resource name does not yield that stem",
+			path: "/account-alerts-open",
+			schemaYAML: `                  type: object
+                  properties:
+                    alert_uid: {type: string}
+                    alert_context: {type: string}
+                    severity: {type: string}
+`,
+			wantID: "alert_uid",
+		},
+		{
+			name: "id still wins over a sole stemUid",
+			path: "/account-alerts-open",
+			schemaYAML: `                  type: object
+                  properties:
+                    id: {type: string}
+                    alertUid: {type: string}
+`,
+			wantID: "id",
+		},
+		{
+			name: "exact uid still wins over a prefixed stemUid",
+			path: "/account-alerts-open",
+			schemaYAML: `                  type: object
+                  properties:
+                    uid: {type: string}
+                    alertUid: {type: string}
+`,
+			wantID: "uid",
+		},
+		{
+			name: "two stemUid fields stay ambiguous and fall through to name",
+			path: "/account-alerts-open",
+			schemaYAML: `                  type: object
+                  properties:
+                    alertUid: {type: string}
+                    deviceUid: {type: string}
+                    name: {type: string}
+`,
+			wantID: "name",
+		},
+		{
+			name: "_id still preferred over _uid for the same resource stem",
+			path: "/alerts",
+			schemaYAML: `                  type: object
+                  properties:
+                    alert_id: {type: string}
+                    alert_uid: {type: string}
+`,
+			wantID: "alert_id",
 		},
 		{
 			name: "camelCase property name normalizes to snake match",

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -9196,7 +9196,7 @@ func TestParseIDFieldResourcePrefixedHeuristic(t *testing.T) {
 			wantID: "uid",
 		},
 		{
-			name: "two stemUid fields stay ambiguous and fall through to name",
+			name: "own stemUid wins over a foreign stemUid",
 			path: "/account-alerts-open",
 			schemaYAML: `                  type: object
                   properties:
@@ -9204,7 +9204,28 @@ func TestParseIDFieldResourcePrefixedHeuristic(t *testing.T) {
                     deviceUid: {type: string}
                     name: {type: string}
 `,
+			wantID: "alertUid",
+		},
+		{
+			name: "foreign accountUid does not beat per-item name",
+			path: "/sites",
+			schemaYAML: `                  type: object
+                  properties:
+                    accountUid: {type: string}
+                    name: {type: string}
+`,
 			wantID: "name",
+		},
+		{
+			name: "foreign accountUid does not beat a required per-item URL",
+			path: "/sites",
+			schemaYAML: `                  type: object
+                  required: [uri]
+                  properties:
+                    accountUid: {type: string}
+                    uri: {type: string}
+`,
+			wantID: "uri",
 		},
 		{
 			name: "_id still preferred over _uid for the same resource stem",
@@ -9318,6 +9339,28 @@ paths:
 
 			ep := findEndpoint(t, parsed, tt.path)
 			assert.Equal(t, tt.wantID, ep.IDField)
+		})
+	}
+}
+
+func TestResourceOwnIdentityStem(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		resource string
+		want     string
+	}{
+		{resource: "account-alerts-open", want: "alert"},
+		{resource: "account-alerts-resolved", want: "alert"},
+		{resource: "sites", want: "site"},
+		{resource: "alerts", want: "alert"},
+		{resource: "auth-tokens", want: "token"},
+		{resource: "user", want: "user"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.resource, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, resourceOwnIdentityStem(tt.resource))
 		})
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Sync stores 0 of N for resources whose only identifier is a camelCase `<stem>Uid` field (for example `alertUid` on `account-alerts-open`) when `x-resource-id` is absent. The parser's resource-prefixed IDField chain never probed `_uid`, and resource-name stems like `account-alerts-open` do not produce the mid-name stem `alert`. Runtime generic fallbacks also miss `alertUid`.

Closes #4266

## Approach

Keep the existing id / uuid / guid / name precedence. Extend resource-prefixed suffixes with `_uid`, then add a follow-on that accepts a sole `<stem>Uid` only when that stem is the resource's own collection noun (the last token that singularizes). A foreign `accountUid` on `/sites` falls through to `name` or a qualified URL.

## Scope

Primary area: OpenAPI parser IDField fallback (`internal/openapi/parser.go`).

Why this belongs in this repo: this is a generator/parser identity heuristic that should be correct for every future printed CLI, not a one-CLI hand-fix.

## Risk

Low. The new sole-`Uid` tier only fires when no stronger identifier exists and the stem matches the resource's own collection noun. Existing tests keep `id`, exact `uid`, `<stem>_id`, and `name` ahead of this fallback.

## Output Contract

Parser now emits `IDField` for sole `alertUid` / `alert_uid` on resources whose names do not singularize to that stem. Generated `resourceIDFieldOverrides` then carry that field. A sole foreign `accountUid` next to `name` or a required URL is not selected.

Evidence:
- `TestParseIDFieldResourcePrefixedHeuristic` cases for camelCase `alertUid`, snake `alert_uid`, precedence, own-vs-foreign Uid, and foreign `accountUid` plus name/URL
- `TestResourceOwnIdentityStem` pins `account-alerts-open` to `alert`
- `TestGeneratedStoreResolvesSoleCamelCaseStemUID` generates a CLI and asserts the override map, then compiles it

Existing golden fixtures do not include this shape.

## Verification

- [x] Scoped parser IDField tests passed
- [x] Full `./internal/openapi` package tests passed
- [x] Generated-output compile test passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc9700a6-5af3-4805-9026-e7489321801d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc9700a6-5af3-4805-9026-e7489321801d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

