### PR TITLE
fix(cli): normalize hyphenated parent FK for typed-table sync

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -6149,8 +6149,10 @@ func TestGenerateDependentSyncInjectsSubResourceParentFK(t *testing.T) {
 		"test fixture should exercise the dependent-resource sync path")
 	assert.Contains(t, syncContent, `obj["parent_id"] = parentIDJSON`,
 		"dependent sync should keep populating the generic parent_id context column")
-	assert.Contains(t, syncContent, `parentFKKey := dep.ParentTable + "_id"`,
+	assert.Contains(t, syncContent, `parentFKKey := parentFKColumnName(dep.ParentTable)`,
 		"dependent sync should derive the typed parent FK column from the parent table")
+	assert.Contains(t, syncContent, `return strings.ReplaceAll(parentTable, "-", "_") + "_id"`,
+		"typed parent FK derivation must share the schema builder hyphen-to-underscore helper")
 	assert.Contains(t, syncContent, `if _, ok := obj[parentFKKey]; !ok {`,
 		"dependent sync should not overwrite a response body value for the typed parent FK")
 	assert.Contains(t, syncContent, `obj[parentFKKey] = parentIDJSON`,

--- a/internal/generator/schema_builder.go
+++ b/internal/generator/schema_builder.go
@@ -471,7 +471,7 @@ func hasTypeField(fields []spec.TypeField, name string) bool {
 // parent_id column between id and data.
 func buildSubResourceTable(name string, r spec.Resource, parentTable string) TableDef {
 	tableName := toSnakeCase(name)
-	parentCol := parentTable + "_id"
+	parentCol := parentFKColumnName(parentTable)
 
 	columns := make([]ColumnDef, 0, len(baseTableColumns)+1)
 	columns = append(columns, baseTableColumns[0]) // id
@@ -511,4 +511,10 @@ func sqlStringLiteral(s string) string {
 // toSnakeCase aliases spec.ToSnakeCase; shared so profiler/schema agree.
 func toSnakeCase(s string) string {
 	return spec.ToSnakeCase(s)
+}
+
+// Hyphenated parent resource names must produce the same typed FK column
+// that dependent sync injects; both sides call this.
+func parentFKColumnName(parentTable string) string {
+	return strings.ReplaceAll(parentTable, "-", "_") + "_id"
 }

--- a/internal/generator/schema_builder_test.go
+++ b/internal/generator/schema_builder_test.go
@@ -646,6 +646,60 @@ func TestBuildSchema_SubResourceUniqueKeepsBareName(t *testing.T) {
 	messages := byName["messages"]
 	require.Greater(t, len(messages.Columns), 1)
 	assert.Equal(t, "channels_id", messages.Columns[1].Name, "FK column matches sole parent")
+	assert.Equal(t, parentFKColumnName("channels"), messages.Columns[1].Name,
+		"single-word parent FK must stay the helper's unchanged form")
+}
+
+func TestParentFKColumnName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		parent string
+		want   string
+	}{
+		{parent: "chats", want: "chats_id"},
+		{parent: "chat-attendees", want: "chat_attendees_id"},
+		{parent: "groups-2", want: "groups_2_id"},
+		{parent: "routing-forms", want: "routing_forms_id"},
+		{parent: "agent-runners", want: "agent_runners_id"},
+		{parent: "chat_attendees", want: "chat_attendees_id"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.parent, func(t *testing.T) {
+			assert.Equal(t, tt.want, parentFKColumnName(tt.parent))
+		})
+	}
+}
+
+func TestBuildSchema_HyphenatedParentFKColumn(t *testing.T) {
+	t.Parallel()
+
+	s := &spec.APISpec{
+		Resources: map[string]spec.Resource{
+			"chat-attendees": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/chat-attendees"},
+				},
+				SubResources: map[string]spec.Resource{
+					"chats": {
+						Endpoints: map[string]spec.Endpoint{
+							"list": {Method: "GET", Path: "/chat-attendees/{id}/chats"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tables := BuildSchema(s)
+	chats := findTable(tables, "chats")
+	require.NotNil(t, chats, "unique chats sub-resource should keep its bare table")
+	require.Greater(t, len(chats.Columns), 1)
+	assert.Equal(t, "chat_attendees_id", chats.Columns[1].Name)
+	assert.Equal(t, parentFKColumnName("chat-attendees"), chats.Columns[1].Name,
+		"typed-table FK column and helper must agree for hyphenated parents")
+	assert.Equal(t, parentFKColumnName(toSnakeCase("chat-attendees")), chats.Columns[1].Name,
+		"helper must be stable on already-normalized parent table names")
 }
 
 // findTable returns nil when no match exists so callers can render

--- a/internal/generator/sync_hyphenated_parent_fk_test.go
+++ b/internal/generator/sync_hyphenated_parent_fk_test.go
@@ -1,0 +1,183 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateDependentSyncHyphenatedParentFKPopulatesTypedTable(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "hyphenated-parent-fk",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/hyphenated-parent-fk-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"chat-attendees": {
+				Description: "Chat attendees",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/chat-attendees",
+						Description: "List chat attendees",
+						Response:    spec.ResponseDef{Type: "array"},
+					},
+				},
+				SubResources: map[string]spec.Resource{
+					"chats": {
+						Description: "Attendee chats",
+						Endpoints: map[string]spec.Endpoint{
+							"list": {
+								Method:      "GET",
+								Path:        "/chat-attendees/{id}/chats",
+								Description: "List chats for an attendee",
+								Response:    spec.ResponseDef{Type: "array"},
+								Params:      []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	gen.profile = &profiler.APIProfile{
+		SyncableResources: []profiler.SyncableResource{
+			{Name: "chat-attendees", Path: "/chat-attendees", Method: "GET"},
+		},
+		DependentSyncResources: []profiler.DependentResource{
+			{Name: "chats", ParentResource: "chat-attendees", ParentIDParam: "id", Path: "/chat-attendees/{id}/chats", Method: "GET"},
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	syncContent := string(syncGo)
+	assert.Contains(t, syncContent, `Name: "chats", ParentTable: "chat-attendees"`,
+		"fixture must keep the hyphenated parent resource name at runtime")
+	assert.Contains(t, syncContent, `parentFKKey := parentFKColumnName(dep.ParentTable)`,
+		"dependent sync must derive the typed parent FK through the shared helper")
+	assert.Contains(t, syncContent, `return strings.ReplaceAll(parentTable, "-", "_") + "_id"`,
+		"emitted helper must match the schema builder hyphen-to-underscore rule")
+	assert.NotContains(t, syncContent, `parentFKKey := dep.ParentTable + "_id"`,
+		"raw ParentTable concatenation reintroduces the hyphenated FK mismatch")
+	assert.Equal(t, parentFKColumnName("chats"), "chats_id",
+		"single-word parents must stay unchanged")
+
+	storeGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	storeContent := string(storeGo)
+	assert.Contains(t, storeContent, `lookupFieldValue(obj, "chat_attendees_id")`,
+		"typed upsert must read the normalized NOT NULL parent FK column")
+	assert.Contains(t, storeContent, `"chat_attendees_id" TEXT NOT NULL`,
+		"typed chats table must declare the normalized parent FK")
+
+	module := naming.CLI(apiSpec.Name)
+	inlineTest := `package cli
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"` + module + `/internal/store"
+)
+
+type hyphenatedParentFKClient struct{}
+
+func (hyphenatedParentFKClient) Get(ctx context.Context, path string, params map[string]string) (json.RawMessage, error) {
+	return json.RawMessage(` + "`" + `[
+		{"id":"chat-1","subject":"hello"},
+		{"id":"chat-2","subject":"follow-up"}
+	]` + "`" + `), nil
+}
+
+func (hyphenatedParentFKClient) RateLimit() float64 { return 0 }
+
+func TestSyncHyphenatedParentTypedCountMatchesResources(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Upsert("chat-attendees", "att-A", []byte(` + "`" + `{"id":"att-A"}` + "`" + `)); err != nil {
+		t.Fatalf("insert parent attendee: %v", err)
+	}
+
+	res := syncDependentResource(
+		context.Background(),
+		hyphenatedParentFKClient{},
+		db,
+		dependentResourceDef{Name: "chats", ParentTable: "chat-attendees", ParentIDParam: "id", PathTemplate: "/chat-attendees/{id}/chats"},
+		"", false, 1, false, false, nil, nil, 1,
+	)
+	if res.Err != nil {
+		t.Fatalf("syncDependentResource error: %v", res.Err)
+	}
+	if res.Count != 2 {
+		t.Fatalf("synced count = %d, want 2", res.Count)
+	}
+
+	var typed, generic int
+	if err := db.DB().QueryRow(` + "`" + `SELECT COUNT(*) FROM chats` + "`" + `).Scan(&typed); err != nil {
+		t.Fatalf("count typed chats: %v", err)
+	}
+	if err := db.DB().QueryRow(` + "`" + `SELECT COUNT(*) FROM resources WHERE resource_type = 'chats'` + "`" + `).Scan(&generic); err != nil {
+		t.Fatalf("count generic chats: %v", err)
+	}
+	if typed != generic {
+		t.Fatalf("typed chats = %d, generic resources = %d; typed projection was dropped", typed, generic)
+	}
+	if typed != 2 {
+		t.Fatalf("typed chats = %d, want 2", typed)
+	}
+
+	rows, err := db.DB().Query(` + "`" + `SELECT id, chat_attendees_id FROM chats ORDER BY id` + "`" + `)
+	if err != nil {
+		t.Fatalf("query chats: %v", err)
+	}
+	defer rows.Close()
+
+	got := 0
+	for rows.Next() {
+		var id, parentFK string
+		if err := rows.Scan(&id, &parentFK); err != nil {
+			t.Fatalf("scan chat: %v", err)
+		}
+		if parentFK != "att-A" {
+			t.Fatalf("chat %q chat_attendees_id = %q, want att-A", id, parentFK)
+		}
+		got++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate chats: %v", err)
+	}
+	if got != 2 {
+		t.Fatalf("scanned %d typed rows, want 2", got)
+	}
+}
+`
+	testPath := filepath.Join(outputDir, "internal", "cli", "hyphenated_parent_fk_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "mod", "tidy")
+	runGoCommandRequired(t, outputDir, "test", "-run", "TestSyncHyphenatedParentTypedCountMatchesResources", "./internal/cli")
+}

--- a/internal/generator/sync_hyphenated_parent_fk_test.go
+++ b/internal/generator/sync_hyphenated_parent_fk_test.go
@@ -15,37 +15,29 @@ import (
 func TestGenerateDependentSyncHyphenatedParentFKPopulatesTypedTable(t *testing.T) {
 	t.Parallel()
 
-	apiSpec := &spec.APISpec{
-		Name:    "hyphenated-parent-fk",
-		Version: "0.1.0",
-		BaseURL: "https://api.example.com",
-		Auth:    spec.AuthConfig{Type: "none"},
-		Config: spec.ConfigSpec{
-			Format: "toml",
-			Path:   "~/.config/hyphenated-parent-fk-pp-cli/config.toml",
-		},
-		Resources: map[string]spec.Resource{
-			"chat-attendees": {
-				Description: "Chat attendees",
-				Endpoints: map[string]spec.Endpoint{
-					"list": {
-						Method:      "GET",
-						Path:        "/chat-attendees",
-						Description: "List chat attendees",
-						Response:    spec.ResponseDef{Type: "array"},
-					},
+	apiSpec := minimalSpec("hyphenated-parent-fk")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"chat-attendees": {
+			Description: "Chat attendees",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/chat-attendees",
+					Description: "List chat attendees",
+					Response:    spec.ResponseDef{Type: "array"},
 				},
-				SubResources: map[string]spec.Resource{
-					"chats": {
-						Description: "Attendee chats",
-						Endpoints: map[string]spec.Endpoint{
-							"list": {
-								Method:      "GET",
-								Path:        "/chat-attendees/{id}/chats",
-								Description: "List chats for an attendee",
-								Response:    spec.ResponseDef{Type: "array"},
-								Params:      []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true}},
-							},
+			},
+			SubResources: map[string]spec.Resource{
+				"chats": {
+					Description: "Attendee chats",
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method:      "GET",
+							Path:        "/chat-attendees/{id}/chats",
+							Description: "List chats for an attendee",
+							Response:    spec.ResponseDef{Type: "array"},
+							Params:      []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true}},
 						},
 					},
 				},
@@ -55,7 +47,7 @@ func TestGenerateDependentSyncHyphenatedParentFKPopulatesTypedTable(t *testing.T
 
 	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
 	gen := New(apiSpec, outputDir)
-	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, MCP: true}
 	gen.profile = &profiler.APIProfile{
 		SyncableResources: []profiler.SyncableResource{
 			{Name: "chat-attendees", Path: "/chat-attendees", Method: "GET"},
@@ -65,6 +57,7 @@ func TestGenerateDependentSyncHyphenatedParentFKPopulatesTypedTable(t *testing.T
 		},
 	}
 	require.NoError(t, gen.Generate())
+	requireGeneratedCompiles(t, outputDir)
 
 	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
 	require.NoError(t, err)

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -3253,6 +3253,12 @@ func dependentParentKeyValue(parentResource, field, value string) string {
 	return bareValue
 }
 
+// parentFKColumnName is the typed parent foreign-key column. The schema
+// builder uses the same helper so hyphenated parents keep one name.
+func parentFKColumnName(parentTable string) string {
+	return strings.ReplaceAll(parentTable, "-", "_") + "_id"
+}
+
 func resourceURLIDPathParam(resource, field string) bool {
 	idField, ok := resourceIDFieldOverrides[resource]
 	return ok && idField == field && urlIDFieldName(field)
@@ -3486,7 +3492,7 @@ func syncOneParent(
 		parentID = parentRow[pathParams[0].Field]
 	}
 	parentIDJSON, _ := json.Marshal(parentID)
-	parentFKKey := dep.ParentTable + "_id"
+	parentFKKey := parentFKColumnName(dep.ParentTable)
 	path := dep.PathTemplate
 	queryParams := make([]dependentPathParamDef, 0)
 	for _, pathParam := range pathParams {

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -3253,8 +3253,8 @@ func dependentParentKeyValue(parentResource, field, value string) string {
 	return bareValue
 }
 
-// parentFKColumnName is the typed parent foreign-key column. The schema
-// builder uses the same helper so hyphenated parents keep one name.
+// Schema generation and dependent sync must share this hyphen-to-underscore
+// rule; a mismatched key leaves the typed NOT NULL parent column empty.
 func parentFKColumnName(parentTable string) string {
 	return strings.ReplaceAll(parentTable, "-", "_") + "_id"
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -2282,6 +2282,12 @@ func dependentParentKeyValue(parentResource, field, value string) string {
 	return bareValue
 }
 
+// parentFKColumnName is the typed parent foreign-key column. The schema
+// builder uses the same helper so hyphenated parents keep one name.
+func parentFKColumnName(parentTable string) string {
+	return strings.ReplaceAll(parentTable, "-", "_") + "_id"
+}
+
 func resourceURLIDPathParam(resource, field string) bool {
 	idField, ok := resourceIDFieldOverrides[resource]
 	return ok && idField == field && urlIDFieldName(field)
@@ -2401,7 +2407,7 @@ func syncOneParent(
 		parentID = parentRow[pathParams[0].Field]
 	}
 	parentIDJSON, _ := json.Marshal(parentID)
-	parentFKKey := dep.ParentTable + "_id"
+	parentFKKey := parentFKColumnName(dep.ParentTable)
 	path := dep.PathTemplate
 	queryParams := make([]dependentPathParamDef, 0)
 	for _, pathParam := range pathParams {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -2282,8 +2282,8 @@ func dependentParentKeyValue(parentResource, field, value string) string {
 	return bareValue
 }
 
-// parentFKColumnName is the typed parent foreign-key column. The schema
-// builder uses the same helper so hyphenated parents keep one name.
+// Schema generation and dependent sync must share this hyphen-to-underscore
+// rule; a mismatched key leaves the typed NOT NULL parent column empty.
 func parentFKColumnName(parentTable string) string {
 	return strings.ReplaceAll(parentTable, "-", "_") + "_id"
 }

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -2255,8 +2255,8 @@ func dependentParentKeyValue(parentResource, field, value string) string {
 	return bareValue
 }
 
-// parentFKColumnName is the typed parent foreign-key column. The schema
-// builder uses the same helper so hyphenated parents keep one name.
+// Schema generation and dependent sync must share this hyphen-to-underscore
+// rule; a mismatched key leaves the typed NOT NULL parent column empty.
 func parentFKColumnName(parentTable string) string {
 	return strings.ReplaceAll(parentTable, "-", "_") + "_id"
 }

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -2255,6 +2255,12 @@ func dependentParentKeyValue(parentResource, field, value string) string {
 	return bareValue
 }
 
+// parentFKColumnName is the typed parent foreign-key column. The schema
+// builder uses the same helper so hyphenated parents keep one name.
+func parentFKColumnName(parentTable string) string {
+	return strings.ReplaceAll(parentTable, "-", "_") + "_id"
+}
+
 func resourceURLIDPathParam(resource, field string) bool {
 	idField, ok := resourceIDFieldOverrides[resource]
 	return ok && idField == field && urlIDFieldName(field)
@@ -2377,7 +2383,7 @@ func syncOneParent(
 		parentID = parentRow[pathParams[0].Field]
 	}
 	parentIDJSON, _ := json.Marshal(parentID)
-	parentFKKey := dep.ParentTable + "_id"
+	parentFKKey := parentFKColumnName(dep.ParentTable)
 	path := dep.PathTemplate
 	queryParams := make([]dependentPathParamDef, 0)
 	for _, pathParam := range pathParams {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Dependent sync now injects the parent foreign key through `parentFKColumnName`, the same hyphen-to-underscore helper the typed-table column emitter uses.

Hyphenated parents such as `chat-attendees` write `chat_attendees_id` on both sides, so typed-table upserts succeed and typed row counts match generic `resources` rows. Single-word parents such as `chats` still produce `chats_id`. NOT NULL constraints, reconcile mode, and other dependent-sync behavior are unchanged.

Proof: a generator test prints a hyphenated parent plus dependent, runs the emitted sync path, and asserts typed-table count equals generic resources. Goldens for `generate-golden-api` and `generate-sync-walker-api` include the shared helper.

Closes #4398
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e6b1f5c-a64f-4e25-b8a8-4220118a5a4f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e6b1f5c-a64f-4e25-b8a8-4220118a5a4f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

