### PR TITLE
fix(cli): treat zero sync times as never synced

### DIFF
--- a/internal/generator/doctor_paths_test.go
+++ b/internal/generator/doctor_paths_test.go
@@ -154,6 +154,152 @@ func TestCollectCacheReportEmptyStore(t *testing.T) {
 	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestCollectCacheReportEmptyStore", "-count=1")
 }
 
+func TestGeneratedDoctorClassifiesSyncStateTimes(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := readOnlyCollectionSpec("doctor-sync-state-times")
+	apiSpec.Cache.Enabled = true
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	testSrc := strings.ReplaceAll(`package cli
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+type syncStateRow struct {
+	resourceType string
+	lastSyncedAt any
+}
+
+func TestCollectCacheReportSyncStateTimes(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+
+	dbPath := defaultDBPath("__CLI_NAME__")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("mkdir db dir: %v", err)
+	}
+	if err := os.WriteFile(dbPath, nil, 0o600); err != nil {
+		t.Fatalf("seed empty DB file: %v", err)
+	}
+	collectCacheReport(context.Background(), "")
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open DB: %v", err)
+	}
+	defer db.Close()
+
+	zero := time.Time{}.UTC().Format(time.RFC3339)
+	old := time.Now().UTC().Add(-12 * time.Hour).Format(time.RFC3339)
+	tests := []struct {
+		name       string
+		rows       []syncStateRow
+		wantStatus string
+		wantOldest bool
+	}{
+		{
+			name:       "null",
+			rows:       []syncStateRow{{resourceType: "null-resource", lastSyncedAt: nil}},
+			wantStatus: "empty",
+		},
+		{
+			name:       "zero",
+			rows:       []syncStateRow{{resourceType: "zero-resource", lastSyncedAt: zero}},
+			wantStatus: "empty",
+		},
+		{
+			name:       "real old",
+			rows:       []syncStateRow{{resourceType: "old-resource", lastSyncedAt: old}},
+			wantStatus: "stale",
+			wantOldest: true,
+		},
+		{
+			name: "mixed zero and real",
+			rows: []syncStateRow{
+				{resourceType: "zero-resource", lastSyncedAt: zero},
+				{resourceType: "old-resource", lastSyncedAt: old},
+			},
+			wantStatus: "stale",
+			wantOldest: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := db.Exec("DELETE FROM sync_state"); err != nil {
+				t.Fatalf("clear sync_state: %v", err)
+			}
+			for _, row := range tt.rows {
+				if _, err := db.Exec(
+					"INSERT INTO sync_state(resource_type, last_synced_at, total_count) VALUES (?, ?, 0)",
+					row.resourceType,
+					row.lastSyncedAt,
+				); err != nil {
+					t.Fatalf("insert sync_state: %v", err)
+				}
+			}
+
+			report := collectCacheReport(context.Background(), "6h")
+			if got := report["status"]; got != tt.wantStatus {
+				t.Fatalf("status = %v, want %q; report=%v", got, tt.wantStatus, report)
+			}
+
+			resources, ok := report["resources"].([]map[string]any)
+			if !ok {
+				t.Fatalf("resources has type %T, want []map[string]any", report["resources"])
+			}
+			for _, resource := range resources {
+				if resource["type"] == "zero-resource" || resource["type"] == "null-resource" {
+					if got := resource["staleness"]; got != "never" {
+						t.Fatalf("%v staleness = %v, want never", resource["type"], got)
+					}
+					if _, ok := resource["last_synced_at"]; ok {
+						t.Fatalf("%v must not render last_synced_at: %v", resource["type"], resource)
+					}
+				}
+			}
+
+			oldest, hasOldest := report["oldest_age"]
+			if !tt.wantOldest {
+				if hasOldest {
+					t.Fatalf("oldest_age = %v, want omitted; report=%v", oldest, report)
+				}
+				return
+			}
+			if !hasOldest {
+				t.Fatalf("oldest_age omitted; report=%v", report)
+			}
+			age, err := time.ParseDuration(oldest.(string))
+			if err != nil {
+				t.Fatalf("parse oldest_age %q: %v", oldest, err)
+			}
+			if age < 11*time.Hour || age > 13*time.Hour {
+				t.Fatalf("oldest_age = %v, want age of the real timestamp only", age)
+			}
+		})
+	}
+}
+`, "__CLI_NAME__", naming.CLI(apiSpec.Name))
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "cache_sync_state_test.go"), []byte(testSrc), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestCollectCacheReportSyncStateTimes", "-count=1")
+}
+
 func TestGeneratedDoctorAgentcookieSuppressesMultiLocationWarn(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -1323,7 +1323,7 @@ func collectCacheReport(ctx context.Context, staleAfterSpec string) map[string]a
 			continue
 		}
 		r := map[string]any{"type": rtype, "rows": count}
-		if lastSynced.Valid {
+		if lastSynced.Valid && !lastSynced.Time.IsZero() {
 			haveAny = true
 			r["last_synced_at"] = lastSynced.Time.UTC().Format(time.RFC3339)
 			age := time.Since(lastSynced.Time)
@@ -1344,7 +1344,7 @@ func collectCacheReport(ctx context.Context, staleAfterSpec string) map[string]a
 	report["stale_after"] = staleAfter.String()
 
 	switch {
-	case !haveAny && len(resources) == 0:
+	case !haveAny:
 		report["status"] = "empty"
 		// Only sync-tracked resources are counted here. A store seeded by
 		// other paths (built-in reference data, local writes) can hold rows

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/doctor.go
@@ -740,7 +740,7 @@ func collectCacheReport(ctx context.Context, staleAfterSpec string) map[string]a
 			continue
 		}
 		r := map[string]any{"type": rtype, "rows": count}
-		if lastSynced.Valid {
+		if lastSynced.Valid && !lastSynced.Time.IsZero() {
 			haveAny = true
 			r["last_synced_at"] = lastSynced.Time.UTC().Format(time.RFC3339)
 			age := time.Since(lastSynced.Time)
@@ -761,7 +761,7 @@ func collectCacheReport(ctx context.Context, staleAfterSpec string) map[string]a
 	report["stale_after"] = staleAfter.String()
 
 	switch {
-	case !haveAny && len(resources) == 0:
+	case !haveAny:
 		report["status"] = "empty"
 		// Only sync-tracked resources are counted here. A store seeded by
 		// other paths (built-in reference data, local writes) can hold rows

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/doctor.go
@@ -688,7 +688,7 @@ func collectCacheReport(ctx context.Context, staleAfterSpec string) map[string]a
 			continue
 		}
 		r := map[string]any{"type": rtype, "rows": count}
-		if lastSynced.Valid {
+		if lastSynced.Valid && !lastSynced.Time.IsZero() {
 			haveAny = true
 			r["last_synced_at"] = lastSynced.Time.UTC().Format(time.RFC3339)
 			age := time.Since(lastSynced.Time)
@@ -709,7 +709,7 @@ func collectCacheReport(ctx context.Context, staleAfterSpec string) map[string]a
 	report["stale_after"] = staleAfter.String()
 
 	switch {
-	case !haveAny && len(resources) == 0:
+	case !haveAny:
 		report["status"] = "empty"
 		// Only sync-tracked resources are counted here. A store seeded by
 		// other paths (built-in reference data, local writes) can hold rows

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/doctor.go
@@ -710,7 +710,7 @@ func collectCacheReport(ctx context.Context, staleAfterSpec string) map[string]a
 			continue
 		}
 		r := map[string]any{"type": rtype, "rows": count}
-		if lastSynced.Valid {
+		if lastSynced.Valid && !lastSynced.Time.IsZero() {
 			haveAny = true
 			r["last_synced_at"] = lastSynced.Time.UTC().Format(time.RFC3339)
 			age := time.Since(lastSynced.Time)
@@ -731,7 +731,7 @@ func collectCacheReport(ctx context.Context, staleAfterSpec string) map[string]a
 	report["stale_after"] = staleAfter.String()
 
 	switch {
-	case !haveAny && len(resources) == 0:
+	case !haveAny:
 		report["status"] = "empty"
 		// Only sync-tracked resources are counted here. A store seeded by
 		// other paths (built-in reference data, local writes) can hold rows


### PR DESCRIPTION
<!--
Maintainer-owned PRs may use a shorter body. Community PRs must keep these sections.
Write for reviewers: explain why this change is right, not every line that changed.
-->

## Intent

Fixes #4347.

Generated `doctor` commands treat a stored zero `last_synced_at` as a real year-0001 timestamp, producing an approximately 2.5-million-hour stale age instead of reporting that the resource has never synced.

## Approach

Count only valid, non-zero sync times as real timestamps. NULL and zero-time rows continue through the existing `never` path, reports with no real sync time use the existing `empty` status, and mixed reports derive `oldest_age` only from real timestamps.

## Scope

Primary area: generated CLI doctor cache reporting.

Why this belongs in this repo: `collectCacheReport` is emitted from the shared generator template, so the incorrect behavior affects every printed CLI with cache reporting.

## Risk

Risk is limited to doctor cache-state classification and its generated output. Real timestamps retain their existing fresh/stale behavior; unsynced rows no longer emit `last_synced_at` or inflate `oldest_age`. Three affected golden fixtures are updated.

## Output Contract

The generated `internal/cli/doctor.go` output changes in the golden API, rich-auth, and tier-routing fixtures. A compiled generated-CLI regression covers NULL-only, zero-only, genuinely old, and mixed zero/real states.

## Verification

- `go test ./internal/generator -run '^TestGeneratedDoctor(DistinguishesEmptyCacheFromFresh|ClassifiesSyncStateTimes)$' -count=1`
- `go build ./...`
- `go vet ./...`
- `scripts/verify-generator-output.sh generate-device-ble generate-device-ble-session generate-device-ble-opaque`
- Full `scripts/verify-generator-output.sh`: all relevant/default generated cases passed; the independent GraphQL shared-endpoint baseline still fails on an existing unused `internal/client` import in generated `things_list.go`.
- Full `scripts/golden.sh verify`: affected doctor outputs match the three updated fixtures exactly; the Windows run remains nonzero because of CRLF `exit.txt` drift and unrelated existing generated/docs differences.
- Full `go test ./...`: affected doctor tests pass; the Windows run remains nonzero on unrelated POSIX permission/path, generated `.exe`, CRLF, and subprocess-tooling baselines.
- `golangci-lint run ./...`: no changed-file findings; the repository run reports five unrelated existing findings in `internal/pipeline`, `internal/cli`, and `internal/openapi`.

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change
