### PR TITLE
fix(cli): chmod rewritten cache files to 0600 and skip multipart file IO on --dry-run

### DIFF
--- a/internal/generator/client_cache_scope_test.go
+++ b/internal/generator/client_cache_scope_test.go
@@ -57,6 +57,8 @@ func TestGeneratedCacheWritesUsePrivatePermissions(t *testing.T) {
 	client := string(clientSrc)
 	require.Contains(t, client, "os.MkdirAll(resourceDir, 0o700)")
 	require.Contains(t, client, "os.WriteFile(cacheFile, []byte(data), 0o600)")
+	require.Contains(t, client, "os.Chmod(cacheFile, 0o600)",
+		"rewriting an existing cache file must chmod 0600; WriteFile ignores perm on an extant file")
 	require.NotContains(t, client, "os.MkdirAll(resourceDir, 0o755)")
 	require.NotContains(t, client, "os.WriteFile(cacheFile, []byte(data), 0o644)")
 
@@ -70,6 +72,62 @@ func TestGeneratedCacheWritesUsePrivatePermissions(t *testing.T) {
 	require.Contains(t, config, "cliutil.AtomicWritePrivateFile(c.Path, data, 0o600, 0o700)")
 	require.NotContains(t, config, "os.WriteFile(c.Path, data, 0o644)")
 	require.NotContains(t, config, "os.MkdirAll(dir, 0o755)")
+}
+
+func TestWriteCacheWithHeadersRechmodsExistingFile(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("cache-chmod")
+	outputDir := filepath.Join(t.TempDir(), "cache-chmod-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const runtimeTest = `package client
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"cache-chmod-pp-cli/internal/config"
+)
+
+func TestWriteCacheWithHeadersRechmodsExistingFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not preserved on Windows")
+	}
+
+	c := New(&config.Config{BaseURL: "https://api.example.invalid"}, time.Second, 0)
+	c.cacheDir = t.TempDir()
+
+	c.writeCacheWithHeaders("/items", nil, nil, json.RawMessage(` + "`" + `{"ok":true}` + "`" + `))
+	matches, err := filepath.Glob(filepath.Join(c.cacheDir, "resources", "*", "*.json"))
+	if err != nil {
+		t.Fatalf("glob cache files: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("wrote %d cache files, want 1: %v", len(matches), matches)
+	}
+	cacheFile := matches[0]
+	if err := os.Chmod(cacheFile, 0o644); err != nil {
+		t.Fatalf("chmod leftover 0644: %v", err)
+	}
+
+	c.writeCacheWithHeaders("/items", nil, nil, json.RawMessage(` + "`" + `{"ok":true}` + "`" + `))
+	info, err := os.Stat(cacheFile)
+	if err != nil {
+		t.Fatalf("stat rewritten cache file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("rewritten cache mode = %04o, want 0600", got)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "cache_chmod_runtime_test.go"), []byte(runtimeTest), 0o600))
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^TestWriteCacheWithHeadersRechmodsExistingFile$", "-count=1")
 }
 
 func TestGeneratedClientQueryParamContractsPass(t *testing.T) {

--- a/internal/generator/multipart_test.go
+++ b/internal/generator/multipart_test.go
@@ -1,7 +1,9 @@
 package generator
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
@@ -96,8 +98,136 @@ func TestGenerateMultipartRequestBodyUsesMultipartClient(t *testing.T) {
 	assert.Contains(t, mcpSrc, `multipartFields[binding.WireName] = mcpMultipartFieldValue(v)`)
 	assert.Regexp(t, `(?s)func mcpMultipartFieldValue\(v any\) string \{.*?json\.Marshal\(v\)`, mcpSrc)
 
+	assertMultipartDryRunSkipsFileIO(t, clientSrc)
+
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "build", "./...")
+}
+
+func TestMultipartDryRunDoesNotOpenFileFields(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("multipart-dryrun")
+	apiSpec.Resources = map[string]spec.Resource{
+		"assets": {
+			Description: "Manage assets",
+			Endpoints: map[string]spec.Endpoint{
+				"upload": {
+					Method:             "POST",
+					Path:               "/assets",
+					Description:        "Upload an asset",
+					RequestContentType: "multipart/form-data",
+					Body: []spec.Param{
+						{Name: "assetData", Type: "string", Format: "binary", Required: true, Description: "Asset file"},
+						{Name: "filename", Type: "string", Required: true, Description: "File name"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
+	assertMultipartDryRunSkipsFileIO(t, clientSrc)
+
+	const runtimeTest = `package client
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"multipart-dryrun-pp-cli/internal/config"
+)
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	original := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe() error = %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = original }()
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing stderr pipe: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading stderr pipe: %v", err)
+	}
+	return string(out)
+}
+
+func TestMultipartDryRunDoesNotOpenFileFields(t *testing.T) {
+	c := New(&config.Config{BaseURL: "https://api.example.invalid"}, time.Second, 0)
+	c.DryRun = true
+	c.NoCache = true
+
+	missing := filepath.Join(t.TempDir(), "does-not-exist.bin")
+	stderr := captureStderr(t, func() {
+		_, _, err := c.PostMultipartWithParams(context.Background(), "/assets", nil,
+			map[string]string{"filename": "clip.wav"},
+			map[string]string{"assetData": missing})
+		if err != nil {
+			t.Fatalf("dry-run opened or failed on missing file: %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "@"+missing) {
+		t.Fatalf("dry-run preview did not name the file field; stderr=%s", stderr)
+	}
+	if !strings.Contains(stderr, "assetData") {
+		t.Fatalf("dry-run preview omitted the file field name; stderr=%s", stderr)
+	}
+	if !strings.Contains(stderr, "clip.wav") {
+		t.Fatalf("dry-run preview did not name the text field; stderr=%s", stderr)
+	}
+}
+
+func TestMultipartLivePathStillOpensFileFields(t *testing.T) {
+	c := New(&config.Config{BaseURL: "https://api.example.invalid"}, time.Second, 0)
+	c.NoCache = true
+
+	missing := filepath.Join(t.TempDir(), "does-not-exist.bin")
+	_, _, err := c.PostMultipartWithParams(context.Background(), "/assets", nil,
+		map[string]string{"filename": "clip.wav"},
+		map[string]string{"assetData": missing})
+	if err == nil {
+		t.Fatal("live multipart path must still open FileFields")
+	}
+	if !strings.Contains(err.Error(), "opening multipart file field") {
+		t.Fatalf("live error = %v, want opening multipart file field", err)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "multipart_dryrun_runtime_test.go"), []byte(runtimeTest), 0o600))
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^TestMultipart(DryRunDoesNotOpenFileFields|LivePathStillOpensFileFields)$", "-count=1")
+}
+
+func assertMultipartDryRunSkipsFileIO(t *testing.T, clientSrc string) {
+	t.Helper()
+
+	implStart := strings.Index(clientSrc, "func (c *Client) doInternal(")
+	require.NotEqual(t, -1, implStart, "client.go must contain Client.doInternal")
+	implBody := clientSrc[implStart:]
+	if next := strings.Index(implBody[1:], "\nfunc "); next != -1 {
+		implBody = implBody[:next+1]
+	}
+	dryRunIdx := strings.Index(implBody, "if c.DryRun {")
+	encodeIdx := strings.Index(implBody, "b, ct, err := encodeMultipartBody(multipartBody)")
+	require.GreaterOrEqual(t, dryRunIdx, 0, "doInternal must short-circuit multipart encoding under DryRun")
+	require.GreaterOrEqual(t, encodeIdx, 0, "doInternal must still call encodeMultipartBody on the live path")
+	assert.Less(t, dryRunIdx, encodeIdx, "doInternal must skip encodeMultipartBody (and its os.Open) under DryRun")
+	assert.Contains(t, implBody, `preview[name] = "@" + filePath`)
+	assert.Contains(t, clientSrc, "file, err := os.Open(filePath)")
 }
 
 func TestGenerateOpenAPIMultipartRequestBodyUsesMultipartClient(t *testing.T) {

--- a/internal/generator/security_suppressions_test.go
+++ b/internal/generator/security_suppressions_test.go
@@ -48,6 +48,7 @@ func TestGeneratedInfraSecuritySuppressionsAreExplicit(t *testing.T) {
 	assert.Contains(t, clientGo, `os.ReadFile(filepath.Clean(cacheFile)) // #nosec G304 -- app-derived cache path from sha256 cache key.`)
 	assert.Contains(t, clientGo, `_ = os.MkdirAll(resourceDir, 0o700)`)
 	assert.Contains(t, clientGo, `_ = os.WriteFile(cacheFile, []byte(data), 0o600)`)
+	assert.Contains(t, clientGo, `_ = os.Chmod(cacheFile, 0o600)`)
 	assert.Contains(t, clientGo, `_ = resp.Body.Close()`)
 
 	cacheGo := readGenerated(t, outputDir, "internal", "cache", "cache.go")

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -1172,6 +1172,8 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	_ = os.Chmod(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
+	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
+	_ = os.Chmod(cacheFile, 0o600)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)
 	}
@@ -1841,12 +1843,29 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 {{- end}}
 {{- if .HasMultipartRequest}}
 		if multipartBody, ok := body.(multipartRequestBody); ok {
-			b, ct, err := encodeMultipartBody(multipartBody)
-			if err != nil {
-				return nil, 0, err
+			if c.DryRun {
+				// Do not open FileFields: --dry-run must preview without IO.
+				preview := make(map[string]string, len(multipartBody.Fields)+len(multipartBody.FileFields))
+				for name, value := range multipartBody.Fields {
+					preview[name] = value
+				}
+				for name, filePath := range multipartBody.FileFields {
+					preview[name] = "@" + filePath
+				}
+				b, err := json.Marshal(preview)
+				if err != nil {
+					return nil, 0, fmt.Errorf("marshaling multipart dry-run preview: %w", err)
+				}
+				bodyBytes = b
+				contentType = "multipart/form-data"
+			} else {
+				b, ct, err := encodeMultipartBody(multipartBody)
+				if err != nil {
+					return nil, 0, err
+				}
+				bodyBytes = b
+				contentType = ct
 			}
-			bodyBytes = b
-			contentType = ct
 		} else {{end}}{{- if .HasFormRequest}}if formBody, ok := body.(formRequestBody); ok {
 			b, ct, err := encodeFormBody(formBody)
 			if err != nil {

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -624,6 +624,8 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	_ = os.Chmod(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
+	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
+	_ = os.Chmod(cacheFile, 0o600)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)
 	}

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -608,6 +608,8 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	_ = os.Chmod(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
+	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
+	_ = os.Chmod(cacheFile, 0o600)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)
 	}

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -625,6 +625,8 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	_ = os.Chmod(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
+	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
+	_ = os.Chmod(cacheFile, 0o600)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)
 	}

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -608,6 +608,8 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	_ = os.Chmod(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
+	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
+	_ = os.Chmod(cacheFile, 0o600)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -609,6 +609,8 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	_ = os.Chmod(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
+	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
+	_ = os.Chmod(cacheFile, 0o600)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)
 	}
@@ -1027,12 +1029,29 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	var contentType string
 	if body != nil {
 		if multipartBody, ok := body.(multipartRequestBody); ok {
-			b, ct, err := encodeMultipartBody(multipartBody)
-			if err != nil {
-				return nil, 0, err
+			if c.DryRun {
+				// Do not open FileFields: --dry-run must preview without IO.
+				preview := make(map[string]string, len(multipartBody.Fields)+len(multipartBody.FileFields))
+				for name, value := range multipartBody.Fields {
+					preview[name] = value
+				}
+				for name, filePath := range multipartBody.FileFields {
+					preview[name] = "@" + filePath
+				}
+				b, err := json.Marshal(preview)
+				if err != nil {
+					return nil, 0, fmt.Errorf("marshaling multipart dry-run preview: %w", err)
+				}
+				bodyBytes = b
+				contentType = "multipart/form-data"
+			} else {
+				b, ct, err := encodeMultipartBody(multipartBody)
+				if err != nil {
+					return nil, 0, err
+				}
+				bodyBytes = b
+				contentType = ct
 			}
-			bodyBytes = b
-			contentType = ct
 		} else {
 			b, err := json.Marshal(body)
 			if err != nil {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -716,6 +716,8 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	_ = os.Chmod(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
+	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
+	_ = os.Chmod(cacheFile, 0o600)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Generated client cache and multipart request IO were unsafe in two sibling ways on `client.go.tmpl`.

- Cache rewrites used `os.WriteFile(..., 0o600)`, but that perm applies only on create. A leftover `0644` cache file stayed world-readable after upgrade.
- Multipart `--dry-run` encoded the body (and `os.Open`ed every `FileFields` path) before the DryRun branch, so a preview could fail on a missing file or read a file it promised not to touch.

Closes #4428
Closes #4424

## Approach

- After writing the cache file, `writeCacheWithHeaders` now `os.Chmod(cacheFile, 0o600)`, matching the existing directory chmod after `MkdirAll`.
- In `doInternal`, multipart DryRun skips `encodeMultipartBody` entirely. It marshals a JSON preview of text fields plus `@<path>` file-field placeholders so `--dry-run` still names every field without opening files. The live encoder and `multipartRequestBody` maps are unchanged.

The original #4424 also mentioned `map[string]string` being unable to repeat or order parts. That is a different encoder hole and would be a new multipart API, so it is out of scope here.

## Scope

Primary area: generator client template (`internal/generator/templates/client.go.tmpl`)

Why this belongs in this repo: both defects ship in every printed CLI that emits HTTP cache writes or multipart requests. Fixing them in the Printing Press generalizes; a printed-CLI-only patch would not compound.

## Risk

- Cache files that previously survived a rewrite at `0644` become `0600` on the next write. That is the intended hardening.
- Multipart `--dry-run` now prints a JSON field preview instead of a silent non-JSON body. Live multipart bytes are unchanged.
- No MCP, auth, publish, verifier, scorer, or release-surface changes.

## Output Contract

Templates and generated `internal/client/client.go` change. Goldens were updated for the fixtures that snapshot that file:

- chmod-only: cookie-auth, oauth2-authcode, oauth2-cc, oauth2-device-code, tier-routing
- chmod + multipart DryRun skip: `generate-golden-api` (the fixture with multipart endpoints)

Generated-output evidence:

- Emitted-code assertions for `os.Chmod(cacheFile, 0o600)` and the DryRun-before-`encodeMultipartBody` gate
- Compiled generated CLIs with injected runtime tests:
  - rewrite an existing `0644` cache file and assert the result is `0600`
  - `--dry-run` against a missing FileFields path exits success and previews `@<path>`
  - live multipart path still opens FileFields and fails on a missing path

`scripts/golden.sh update` also tried `dogfood-verdict-matrix` and `verify-runtime-matrix`; those cases failed in this environment because fixture CLIs could not download `go1.24`. Their expected fixtures were left unchanged. Main CI `full-golden` later passed on this head.

## Verification

- [x] `go test ./internal/generator -run 'Test(GeneratedCacheWritesUsePrivatePermissions|WriteCacheWithHeadersRechmodsExistingFile|GenerateMultipartRequestBodyUsesMultipartClient|MultipartDryRunDoesNotOpenFileFields|GeneratedInfraSecuritySuppressionsAreExplicit)' -count=1`
- [x] `GOLDEN_ALLOW_DIRTY=1 scripts/golden.sh update` (dogfood/verify-runtime-matrix toolchain flake reverted; remaining client.go fixture diffs are the intended contract)
- [x] `go test ./... -count=1 -timeout 25m`
- [x] `scripts/verify-generator-output.sh generate-golden-api`
- [x] Main CI `full-golden`, `generated-output-compile`, `build-and-test`, and `go-lint` passed on this head

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f63fe14a-d9dc-4a32-b9e5-ee1637d470a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f63fe14a-d9dc-4a32-b9e5-ee1637d470a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

