### PR TITLE
fix(cli): derive manifest, MCPB, and SKILL auth env vars from the credentials the binary reads

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"sort"
 	"strconv"
@@ -307,6 +308,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"clientCredentialsTokenURLHasTenant":  clientCredentialsTokenURLHasTenant,
 		"hasNonCookieAuth":                    hasNonCookieAuth,
 		"authAgentEnvVars":                    authAgentEnvVars,
+		"skillAuthNarrative":                  skillAuthNarrative,
 		"hasAuthEnvVarKind":                   hasAuthEnvVarKind,
 		"isRequestAuthEnvVar":                 isRequestAuthEnvVar,
 		"requiredRequestAuthEnvVars":          requiredRequestAuthEnvVars,
@@ -1587,6 +1589,43 @@ func isTenantAuthEnvVar(name string) bool {
 func isClientIDAuthEnvVar(name string) bool {
 	placeholder := naming.EnvVarPlaceholder(name)
 	return placeholder == "client_id" || strings.HasSuffix(placeholder, "_client_id")
+}
+
+var skillAuthEnvVarToken = regexp.MustCompile(`\b[A-Z][A-Z0-9]*_[A-Z0-9_]+\b`)
+
+// skillAuthNarrative returns independently authored auth prose only when
+// every env-var-shaped token is in the resolved credential set the binary
+// reads. A narrative that names a variable the CLI ignores is dropped so
+// SKILL.md falls through to the type-aware Auth Setup branch.
+func skillAuthNarrative(auth spec.AuthConfig, narrative string) string {
+	narrative = strings.TrimSpace(narrative)
+	if narrative == "" {
+		return ""
+	}
+	resolved := resolvedSkillAuthEnvVarNames(auth)
+	for _, name := range skillAuthEnvVarToken.FindAllString(narrative, -1) {
+		if _, ok := resolved[name]; !ok {
+			return ""
+		}
+	}
+	return narrative
+}
+
+func resolvedSkillAuthEnvVarNames(auth spec.AuthConfig) map[string]struct{} {
+	names := make(map[string]struct{})
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		names[name] = struct{}{}
+	}
+	for _, envVar := range authAgentEnvVars(auth) {
+		add(envVar.Name)
+	}
+	for _, envVar := range requestAuthEnvVars(auth) {
+		add(envVar.Name)
+	}
+	return names
 }
 
 func authAgentEnvVars(auth spec.AuthConfig) []spec.AuthEnvVar {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1593,10 +1593,8 @@ func isClientIDAuthEnvVar(name string) bool {
 
 var skillAuthEnvVarToken = regexp.MustCompile(`\b[A-Z][A-Z0-9]*_[A-Z0-9_]+\b`)
 
-// skillAuthNarrative returns independently authored auth prose only when
-// every env-var-shaped token is in the resolved credential set the binary
-// reads. A narrative that names a variable the CLI ignores is dropped so
-// SKILL.md falls through to the type-aware Auth Setup branch.
+// Independently authored prose can name secrets the compiled binary
+// ignores; drop it so Auth Setup lists only credentials the CLI reads.
 func skillAuthNarrative(auth spec.AuthConfig, narrative string) string {
 	narrative = strings.TrimSpace(narrative)
 	if narrative == "" {

--- a/internal/generator/skill_test.go
+++ b/internal/generator/skill_test.go
@@ -449,7 +449,6 @@ func TestSkillAuthSetupNamesTheCredentialTheBinaryReads(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(skill), "export SKILLCRED_API_KEY=")
 	assert.NotContains(t, string(skill), "PRINTING_PRESS_CLIENT_PROFILE")
-	requireGeneratedCompiles(t, outputDir)
 }
 
 func TestSkillAuthSetupDropsNarrativeThatNamesUnreadEnvVar(t *testing.T) {

--- a/internal/generator/skill_test.go
+++ b/internal/generator/skill_test.go
@@ -523,7 +523,6 @@ func TestSkillAuthSetupUsesResolvedBasicPairOverForeignNarrative(t *testing.T) {
 	assert.Contains(t, string(configSrc), `os.Getenv("MAXIOPAIR_USERNAME")`)
 	assert.Contains(t, string(configSrc), `os.Getenv("MAXIOPAIR_PASSWORD")`)
 	assert.NotContains(t, string(configSrc), `os.Getenv("MAXIOPAIR_API_KEY")`)
-	requireGeneratedCompiles(t, outputDir)
 }
 
 // TestSkillRendersExtraCommands asserts that hand-written commands declared

--- a/internal/generator/skill_test.go
+++ b/internal/generator/skill_test.go
@@ -409,7 +409,50 @@ func TestSkillRendersAuthBranchPerType(t *testing.T) {
 	}
 }
 
-func TestSkillAuthSetupPrefersNarrativeEvenWhenSpecAuthIsNone(t *testing.T) {
+func TestSkillAuthNarrative(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		assert.Empty(t, skillAuthNarrative(spec.AuthConfig{Type: "api_key", EnvVars: []string{"FOO_API_KEY"}}, ""))
+	})
+	t.Run("no env tokens", func(t *testing.T) {
+		got := skillAuthNarrative(spec.AuthConfig{Type: "none"}, "Run auth login in a browser.")
+		assert.Equal(t, "Run auth login in a browser.", got)
+	})
+	t.Run("resolved name", func(t *testing.T) {
+		got := skillAuthNarrative(spec.AuthConfig{Type: "api_key", EnvVars: []string{"FOO_API_KEY"}}, "Export FOO_API_KEY.")
+		assert.Equal(t, "Export FOO_API_KEY.", got)
+	})
+	t.Run("foreign name", func(t *testing.T) {
+		got := skillAuthNarrative(spec.AuthConfig{Type: "api_key", EnvVars: []string{"FOO_USERNAME", "FOO_PASSWORD"}}, "Set FOO_API_KEY.")
+		assert.Empty(t, got)
+	})
+}
+
+func TestSkillAuthSetupNamesTheCredentialTheBinaryReads(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("skillcred")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:    "api_key",
+		Header:  "X-API-Key",
+		EnvVars: []string{"SKILLCRED_API_KEY"},
+	}
+	outputDir := filepath.Join(t.TempDir(), "skillcred-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	configSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(configSrc), `os.Getenv("SKILLCRED_API_KEY")`)
+
+	skill, err := os.ReadFile(filepath.Join(outputDir, "SKILL.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(skill), "export SKILLCRED_API_KEY=")
+	assert.NotContains(t, string(skill), "PRINTING_PRESS_CLIENT_PROFILE")
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestSkillAuthSetupDropsNarrativeThatNamesUnreadEnvVar(t *testing.T) {
 	t.Parallel()
 
 	apiSpec := minimalSpec("tierfree")
@@ -425,8 +468,63 @@ func TestSkillAuthSetupPrefersNarrativeEvenWhenSpecAuthIsNone(t *testing.T) {
 	require.NoError(t, err)
 	content := string(skill)
 
-	assert.Contains(t, content, "Most commands are public, but premium download routes require `AA_API_KEY`.")
+	assert.NotContains(t, content, "AA_API_KEY")
+	assert.Contains(t, content, "No authentication required.")
+}
+
+func TestSkillAuthSetupKeepsNarrativeThatNamesResolvedEnvVar(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("narratedauth")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:    "api_key",
+		EnvVars: []string{"NARRATEDAUTH_API_KEY"},
+	}
+	outputDir := filepath.Join(t.TempDir(), "narratedauth-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.Narrative = &ReadmeNarrative{
+		AuthNarrative: "Export `NARRATEDAUTH_API_KEY` before calling premium routes.",
+	}
+	require.NoError(t, gen.Generate())
+
+	skill, err := os.ReadFile(filepath.Join(outputDir, "SKILL.md"))
+	require.NoError(t, err)
+	content := string(skill)
+
+	assert.Contains(t, content, "Export `NARRATEDAUTH_API_KEY` before calling premium routes.")
 	assert.NotContains(t, content, "No authentication required.")
+}
+
+func TestSkillAuthSetupUsesResolvedBasicPairOverForeignNarrative(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("maxiopair")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:    "api_key",
+		Format:  "Basic {username}:{password}",
+		EnvVars: []string{"MAXIOPAIR_USERNAME", "MAXIOPAIR_PASSWORD"},
+	}
+	outputDir := filepath.Join(t.TempDir(), "maxiopair-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.Narrative = &ReadmeNarrative{
+		AuthNarrative: "Set one secret, MAXIOPAIR_API_KEY. The CLI supplies the constant 'x' password for you.",
+	}
+	require.NoError(t, gen.Generate())
+
+	skill, err := os.ReadFile(filepath.Join(outputDir, "SKILL.md"))
+	require.NoError(t, err)
+	content := string(skill)
+
+	assert.NotContains(t, content, "MAXIOPAIR_API_KEY")
+	assert.Contains(t, content, "export MAXIOPAIR_USERNAME=")
+	assert.Contains(t, content, "export MAXIOPAIR_PASSWORD=")
+
+	configSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(configSrc), `os.Getenv("MAXIOPAIR_USERNAME")`)
+	assert.Contains(t, string(configSrc), `os.Getenv("MAXIOPAIR_PASSWORD")`)
+	assert.NotContains(t, string(configSrc), `os.Getenv("MAXIOPAIR_API_KEY")`)
+	requireGeneratedCompiles(t, outputDir)
 }
 
 // TestSkillRendersExtraCommands asserts that hand-written commands declared

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -209,6 +209,7 @@ These commands are declared by the spec author and require separate hand-written
 {{- end}}
 
 ## Auth Setup
+{{- /* Published-library sweep: heading stays "## Auth Setup"; body must name only resolved credential env vars (same set as .printing-press.json auth_env_vars). Drop independently authored prose that names unread vars; prefer the type-aware export block, including the basic-auth pair. */}}
 {{- $canonicalEnvVar := .Auth.CanonicalEnvVar}}
 {{- $basicAuthEnvVars := basicAuthEnvVars .Auth}}
 {{- $authNarrative := ""}}

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -210,9 +210,27 @@ These commands are declared by the spec author and require separate hand-written
 
 ## Auth Setup
 {{- $canonicalEnvVar := .Auth.CanonicalEnvVar}}
+{{- $basicAuthEnvVars := basicAuthEnvVars .Auth}}
+{{- $authNarrative := ""}}
 {{- if and .Narrative .Narrative.AuthNarrative}}
+{{- $authNarrative = skillAuthNarrative .Auth .Narrative.AuthNarrative}}
+{{- end}}
+{{- if $authNarrative}}
 
-{{.Narrative.AuthNarrative}}
+{{$authNarrative}}
+{{- else if $basicAuthEnvVars}}
+
+Run `{{.Name}}-pp-cli auth setup` to print the URL and steps for getting credentials (add `--launch` to open the URL). Then set:
+
+```bash
+{{- range $basicAuthEnvVars}}
+export {{.Name}}="{{authEnvPlaceholder .}}"
+{{- end}}
+```
+
+{{- if $authPersistenceCommand}}
+To persist credentials, use `{{$authPersistenceCommand}}`. Stored secrets live in `credentials.toml` under the data dir, not in `config.toml`.
+{{- end}}
 {{- else if eq .Auth.Type "api_key"}}
 
 {{- with $canonicalEnvVar}}

--- a/internal/pipeline/client_env_scanner.go
+++ b/internal/pipeline/client_env_scanner.go
@@ -91,6 +91,9 @@ func scanPackageEnvReads(pkgDir string, seen map[string]struct{}) error {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
 			continue
 		}
+		if strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
 		path := filepath.Join(pkgDir, e.Name())
 		file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
 		if err != nil {
@@ -146,16 +149,9 @@ func isDeniedDiscoveredEnvVar(name string) bool {
 // Safe by construction:
 //   - APIs with neither scanned package produce no changes.
 //   - Env vars already declared in mcp_config.env are skipped.
-//   - Platform-profile CLIs keep PRINTING_PRESS_CLIENT_PROFILE as the
-//     credential surface. Suffix-classified per-instance reads (BASE_URL
-//     and similar) and endpoint-template placeholders ({shop}) are still
-//     promoted: the profile selector does not fill a store hostname.
-//     Credential Getenv calls in config.go are not re-added beside the
-//     profile selector.
 //   - Goldens for spec-driven APIs without hand-written client code are
 //     untouched for credential names because those os.Getenv calls all
-//     resolve to names already in mcp_config.env (or are skipped under
-//     the platform-profile rule).
+//     resolve to names already in mcp_config.env.
 func reconcileMCPBManifestFromClient(dir string, cli CLIManifest) error {
 	manifestPath := filepath.Join(dir, MCPBManifestFilename)
 	data, err := os.ReadFile(manifestPath)
@@ -186,13 +182,9 @@ func reconcileMCPBManifestFromClient(dir string, cli CLIManifest) error {
 	cli.generatedEnvReads = generated
 	cli = dropCollidingEndpointTemplateOverrides(cli, generated)
 
-	platformProfiles := usesPlatformClientProfiles(dir)
 	var missing []string
 	for _, name := range envReads {
 		if _, declared := manifest.Server.MCPConfig.Env[name]; declared {
-			continue
-		}
-		if platformProfiles && !isPlatformProfileSafeDiscoveredEnvVar(cli, name) {
 			continue
 		}
 		missing = append(missing, name)
@@ -277,19 +269,4 @@ func isNonCredentialDiscoveredEnvVar(name string) bool {
 		}
 	}
 	return false
-}
-
-// The profile selector covers credentials that are not also required
-// endpoint placeholders. Suffix-classified knobs and declared endpoint
-// vars (including a credential-shaped default such as {access_token})
-// stay collectible; a colliding auth override is not an endpoint var
-// and stays off the installer.
-func isPlatformProfileSafeDiscoveredEnvVar(cli CLIManifest, name string) bool {
-	if isEndpointTemplateEnvVar(cli, name) {
-		return true
-	}
-	if isAuthOrCredentialEnvVar(cli, name) {
-		return false
-	}
-	return isNonCredentialDiscoveredEnvVar(name)
 }

--- a/internal/pipeline/client_env_scanner_test.go
+++ b/internal/pipeline/client_env_scanner_test.go
@@ -145,6 +145,25 @@ func Load() {
 			"config-package BASE_URL must be declared; config-file path and harness flags must not")
 	})
 
+	t.Run("skips Getenv calls in _test.go files", func(t *testing.T) {
+		dir := t.TempDir()
+		writeConfigFile(t, dir, "config.go", `package config
+
+import "os"
+
+func Load() { _ = os.Getenv("HUDU_API_KEY") }
+`)
+		writeConfigFile(t, dir, "config_perms_test.go", `package config
+
+import "os"
+
+func helper() { _ = os.Getenv("USERNAME") }
+`)
+		got, err := scanClientEnvReads(dir)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"HUDU_API_KEY"}, got)
+	})
+
 	t.Run("unions client and config env reads", func(t *testing.T) {
 		dir := t.TempDir()
 		writeClientFile(t, dir, "client.go", `package client
@@ -414,7 +433,7 @@ func Load() {
 		assert.NotContains(t, entry.Description, "credential refresh")
 	})
 
-	t.Run("platform profile keeps credentials off user_config but still declares BASE_URL", func(t *testing.T) {
+	t.Run("platform profile still promotes credentials the binary reads", func(t *testing.T) {
 		dir := t.TempDir()
 		require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "platform"), 0o755))
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "internal", "platform", "profile.go"), []byte("package platform\n"), 0o644))
@@ -423,17 +442,12 @@ func Load() {
 			DisplayName: "Hudu",
 			MCPBinary:   "hudu-pp-mcp",
 			AuthType:    "api_key",
-			AuthEnvVars: []string{"PRINTING_PRESS_CLIENT_PROFILE"},
+			AuthEnvVars: []string{"HUDU_API_KEY"},
 		}
 		writeMCPBManifest(t, dir, MCPBManifest{
 			Name: "hudu-pp-mcp",
 			Server: MCPBServer{
-				MCPConfig: MCPBLaunchSpec{Env: map[string]string{
-					"PRINTING_PRESS_CLIENT_PROFILE": "${user_config.printing_press_client_profile}",
-				}},
-			},
-			UserConfig: map[string]MCPBVar{
-				"printing_press_client_profile": {Type: "string", Title: "Client profile", Required: true},
+				MCPConfig: MCPBLaunchSpec{Env: map[string]string{}},
 			},
 		})
 		writeConfigFile(t, dir, "config.go", `package config
@@ -449,10 +463,10 @@ func Load() {
 		require.NoError(t, reconcileMCPBManifestFromClient(dir, cli))
 
 		got := readMCPBManifest(t, dir)
-		assert.Equal(t, "${user_config.printing_press_client_profile}", got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"])
+		assert.Equal(t, "${user_config.hudu_api_key}", got.Server.MCPConfig.Env["HUDU_API_KEY"])
 		assert.Equal(t, "${user_config.hudu_base_url}", got.Server.MCPConfig.Env["HUDU_BASE_URL"])
-		_, hasAPIKey := got.Server.MCPConfig.Env["HUDU_API_KEY"]
-		assert.False(t, hasAPIKey, "platform-profile CLIs must not re-add credentials from config.go")
+		_, hasProfile := got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"]
+		assert.False(t, hasProfile)
 		_, ok := got.UserConfig["hudu_base_url"]
 		assert.True(t, ok)
 	})
@@ -466,18 +480,13 @@ func Load() {
 			DisplayName:          "Shopify",
 			MCPBinary:            "shopify-pp-mcp",
 			AuthType:             "api_key",
-			AuthEnvVars:          []string{"PRINTING_PRESS_CLIENT_PROFILE"},
+			AuthEnvVars:          []string{"SHOPIFY_ACCESS_TOKEN"},
 			EndpointTemplateVars: []string{"shop"},
 		}
 		writeMCPBManifest(t, dir, MCPBManifest{
 			Name: "shopify-pp-mcp",
 			Server: MCPBServer{
-				MCPConfig: MCPBLaunchSpec{Env: map[string]string{
-					"PRINTING_PRESS_CLIENT_PROFILE": "${user_config.printing_press_client_profile}",
-				}},
-			},
-			UserConfig: map[string]MCPBVar{
-				"printing_press_client_profile": {Type: "string", Title: "Client profile", Required: true},
+				MCPConfig: MCPBLaunchSpec{Env: map[string]string{}},
 			},
 		})
 		writeConfigFile(t, dir, "config.go", `package config
@@ -493,10 +502,10 @@ func Load() {
 		require.NoError(t, reconcileMCPBManifestFromClient(dir, cli))
 
 		got := readMCPBManifest(t, dir)
-		assert.Equal(t, "${user_config.printing_press_client_profile}", got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"])
+		assert.Equal(t, "${user_config.shopify_access_token}", got.Server.MCPConfig.Env["SHOPIFY_ACCESS_TOKEN"])
 		assert.Equal(t, "${user_config.shopify_shop}", got.Server.MCPConfig.Env["SHOPIFY_SHOP"])
-		_, hasToken := got.Server.MCPConfig.Env["SHOPIFY_ACCESS_TOKEN"]
-		assert.False(t, hasToken, "platform-profile CLIs must not re-add credentials from config.go")
+		_, hasProfile := got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"]
+		assert.False(t, hasProfile)
 		shop, ok := got.UserConfig["shopify_shop"]
 		require.True(t, ok, "required {shop} must be promoted when discovered next to the profile selector")
 		assert.Equal(t, "SHOPIFY_SHOP", shop.Title)
@@ -515,19 +524,14 @@ func Load() {
 			DisplayName:                  "Shopify",
 			MCPBinary:                    "shopify-pp-mcp",
 			AuthType:                     "api_key",
-			AuthEnvVars:                  []string{"PRINTING_PRESS_CLIENT_PROFILE"},
+			AuthEnvVars:                  []string{"SHOPIFY_ACCESS_TOKEN"},
 			EndpointTemplateVars:         []string{"shop"},
 			EndpointTemplateEnvOverrides: map[string]string{"shop": "SHOPIFY_ACCESS_TOKEN"},
 		}
 		writeMCPBManifest(t, dir, MCPBManifest{
 			Name: "shopify-pp-mcp",
 			Server: MCPBServer{
-				MCPConfig: MCPBLaunchSpec{Env: map[string]string{
-					"PRINTING_PRESS_CLIENT_PROFILE": "${user_config.printing_press_client_profile}",
-				}},
-			},
-			UserConfig: map[string]MCPBVar{
-				"printing_press_client_profile": {Type: "string", Title: "Client profile", Required: true},
+				MCPConfig: MCPBLaunchSpec{Env: map[string]string{}},
 			},
 		})
 		writeConfigFile(t, dir, "config.go", `package config
@@ -543,17 +547,17 @@ func Load() {
 		require.NoError(t, reconcileMCPBManifestFromClient(dir, cli))
 
 		got := readMCPBManifest(t, dir)
-		_, hasToken := got.Server.MCPConfig.Env["SHOPIFY_ACCESS_TOKEN"]
-		assert.False(t, hasToken, "auth-named endpoint override must not re-add the credential beside the profile selector")
-		_, hasTokenField := got.UserConfig["shopify_access_token"]
-		assert.False(t, hasTokenField)
+		assert.Equal(t, "${user_config.shopify_access_token}", got.Server.MCPConfig.Env["SHOPIFY_ACCESS_TOKEN"])
+		tokenField, hasTokenField := got.UserConfig["shopify_access_token"]
+		require.True(t, hasTokenField)
+		assert.True(t, tokenField.Sensitive)
 		assert.Equal(t, "${user_config.shopify_shop}", got.Server.MCPConfig.Env["SHOPIFY_SHOP"])
 		shop, ok := got.UserConfig["shopify_shop"]
 		require.True(t, ok)
 		assert.False(t, shop.Sensitive)
 	})
 
-	t.Run("platform profile does not promote undeclared shop-shaped names", func(t *testing.T) {
+	t.Run("platform profile promotes Getenv names the binary reads", func(t *testing.T) {
 		dir := t.TempDir()
 		require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "platform"), 0o755))
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "internal", "platform", "profile.go"), []byte("package platform\n"), 0o644))
@@ -562,17 +566,12 @@ func Load() {
 			DisplayName: "Shopify",
 			MCPBinary:   "shopify-pp-mcp",
 			AuthType:    "api_key",
-			AuthEnvVars: []string{"PRINTING_PRESS_CLIENT_PROFILE"},
+			AuthEnvVars: []string{"SHOPIFY_ACCESS_TOKEN"},
 		}
 		writeMCPBManifest(t, dir, MCPBManifest{
 			Name: "shopify-pp-mcp",
 			Server: MCPBServer{
-				MCPConfig: MCPBLaunchSpec{Env: map[string]string{
-					"PRINTING_PRESS_CLIENT_PROFILE": "${user_config.printing_press_client_profile}",
-				}},
-			},
-			UserConfig: map[string]MCPBVar{
-				"printing_press_client_profile": {Type: "string", Title: "Client profile", Required: true},
+				MCPConfig: MCPBLaunchSpec{Env: map[string]string{}},
 			},
 		})
 		writeConfigFile(t, dir, "config.go", `package config
@@ -588,10 +587,10 @@ func Load() {
 		require.NoError(t, reconcileMCPBManifestFromClient(dir, cli))
 
 		got := readMCPBManifest(t, dir)
-		_, hasShop := got.Server.MCPConfig.Env["SHOPIFY_SHOP"]
-		assert.False(t, hasShop, "SHOPIFY_SHOP is not a suffix-classified knob; without EndpointTemplateVars it must stay off the profile installer")
-		_, hasToken := got.Server.MCPConfig.Env["SHOPIFY_ACCESS_TOKEN"]
-		assert.False(t, hasToken)
+		assert.Equal(t, "${user_config.shopify_access_token}", got.Server.MCPConfig.Env["SHOPIFY_ACCESS_TOKEN"])
+		assert.Equal(t, "${user_config.shopify_shop}", got.Server.MCPConfig.Env["SHOPIFY_SHOP"])
+		_, hasProfile := got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"]
+		assert.False(t, hasProfile)
 	})
 
 	t.Run("manifest with nil env/userconfig maps gets populated", func(t *testing.T) {
@@ -685,10 +684,10 @@ func Load() {
 	require.NoError(t, WriteMCPBManifestFromStruct(dir, m))
 
 	got := readMCPBManifest(t, dir)
-	assert.Equal(t, "${user_config.printing_press_client_profile}", got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"])
+	assert.Equal(t, "${user_config.hudu_api_key}", got.Server.MCPConfig.Env["HUDU_API_KEY"])
 	assert.Equal(t, "${user_config.hudu_base_url}", got.Server.MCPConfig.Env["HUDU_BASE_URL"])
-	_, hasAPIKey := got.Server.MCPConfig.Env["HUDU_API_KEY"]
-	assert.False(t, hasAPIKey)
+	_, hasProfile := got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"]
+	assert.False(t, hasProfile)
 	_, hasConfig := got.Server.MCPConfig.Env["HUDU_CONFIG"]
 	assert.False(t, hasConfig)
 	entry, ok := got.UserConfig["hudu_base_url"]
@@ -892,13 +891,18 @@ func TestWriteManifestForGenerate_IncludesGeneratedConfigBaseURL(t *testing.T) {
 		Spec:      apiSpec,
 	}))
 
+	cli, err := ReadCLIManifest(dir)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"HUDU_API_KEY"}, cli.AuthEnvVars)
+	assert.NotContains(t, cli.AuthEnvVars, "PRINTING_PRESS_CLIENT_PROFILE")
+
 	got := readMCPBManifest(t, dir)
 	assert.Equal(t, "${user_config.hudu_base_url}", got.Server.MCPConfig.Env["HUDU_BASE_URL"])
-	assert.Equal(t, "${user_config.printing_press_client_profile}", got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"])
+	assert.Equal(t, "${user_config.hudu_api_key}", got.Server.MCPConfig.Env["HUDU_API_KEY"])
+	_, hasProfile := got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"]
+	assert.False(t, hasProfile, "tenant profile selector is not a credential the binary reads")
 	_, hasConfig := got.Server.MCPConfig.Env["HUDU_CONFIG"]
 	assert.False(t, hasConfig, "HUDU_CONFIG is a local file path, not an MCPB install prompt")
-	_, hasAPIKey := got.Server.MCPConfig.Env["HUDU_API_KEY"]
-	assert.False(t, hasAPIKey, "platform-profile generate must not re-add HUDU_API_KEY beside the profile selector")
 	_, hasVerify := got.Server.MCPConfig.Env["PRINTING_PRESS_VERIFY"]
 	assert.False(t, hasVerify)
 
@@ -912,8 +916,8 @@ func TestWriteManifestForGenerate_IncludesGeneratedConfigBaseURL(t *testing.T) {
 
 // A suffix allowlist cannot name {shop}: SHOPIFY_SHOP has no
 // _BASE_URL-style ending, but the printed CLI still reads it before
-// the first request. The installer prompt has to collect it without
-// also collecting the access token that rides the profile.
+// the first request. The installer prompt has to collect it alongside
+// the credential the binary reads.
 func TestWriteManifestForGenerate_IncludesRequiredEndpointTemplateVar(t *testing.T) {
 	apiSpec := &spec.APISpec{
 		Name:                 "shopify",
@@ -957,9 +961,9 @@ func TestWriteManifestForGenerate_IncludesRequiredEndpointTemplateVar(t *testing
 
 	got := readMCPBManifest(t, dir)
 	assert.Equal(t, "${user_config.shopify_shop}", got.Server.MCPConfig.Env["SHOPIFY_SHOP"])
-	assert.Equal(t, "${user_config.printing_press_client_profile}", got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"])
-	_, hasToken := got.Server.MCPConfig.Env["SHOPIFY_ACCESS_TOKEN"]
-	assert.False(t, hasToken, "platform-profile generate must not re-add SHOPIFY_ACCESS_TOKEN beside the profile selector")
+	assert.Equal(t, "${user_config.shopify_access_token}", got.Server.MCPConfig.Env["SHOPIFY_ACCESS_TOKEN"])
+	_, hasProfile := got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"]
+	assert.False(t, hasProfile, "tenant profile selector is not a credential the binary reads")
 
 	entry, ok := got.UserConfig["shopify_shop"]
 	require.True(t, ok, "generated MCPB manifest must prompt for SHOPIFY_SHOP")
@@ -1023,18 +1027,12 @@ func TestWriteManifestForGenerate_CollidingEndpointOverrideAgreesWithGetenv(t *t
 	require.Contains(t, got.Server.MCPConfig.Env, shopGetenv,
 		"MCPB env key must be the generated {shop} Getenv")
 	assert.Equal(t, "${user_config."+userConfigKey(shopGetenv)+"}", got.Server.MCPConfig.Env[shopGetenv])
-	_, hasToken := got.Server.MCPConfig.Env["SHOPIFY_ACCESS_TOKEN"]
-	assert.False(t, hasToken, "SHOPIFY_ACCESS_TOKEN must not be an installer field beside the profile selector")
+	assert.Equal(t, "${user_config.shopify_access_token}", got.Server.MCPConfig.Env["SHOPIFY_ACCESS_TOKEN"])
 	tokenField, hasTokenField := got.UserConfig["shopify_access_token"]
-	assert.False(t, hasTokenField, "installer must not prompt for the access token as an unmasked endpoint field")
-	if hasTokenField {
-		assert.True(t, tokenField.Sensitive)
-	}
-	assert.Equal(t, "${user_config.printing_press_client_profile}", got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"])
-	profile, ok := got.UserConfig["printing_press_client_profile"]
-	require.True(t, ok)
-	assert.True(t, profile.Required)
-	assert.False(t, profile.Sensitive)
+	require.True(t, hasTokenField, "installer must prompt for the credential the binary reads")
+	assert.True(t, tokenField.Sensitive)
+	_, hasProfile := got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"]
+	assert.False(t, hasProfile)
 	shop, ok := got.UserConfig[userConfigKey(shopGetenv)]
 	require.True(t, ok)
 	assert.False(t, shop.Sensitive)
@@ -1083,11 +1081,8 @@ func Load() {
 	_, hasShop := got.Server.MCPConfig.Env["SHOPIFY_SHOP"]
 	assert.False(t, hasShop, "must not silently rebind the installer to the default shop name")
 
-	assert.Equal(t, "${user_config.printing_press_client_profile}", got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"])
-	profile, ok := got.UserConfig["printing_press_client_profile"]
-	require.True(t, ok)
-	assert.True(t, profile.Required)
-	assert.False(t, profile.Sensitive)
+	_, hasProfile := got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"]
+	assert.False(t, hasProfile)
 
 	token, ok := got.UserConfig["shopify_access_token"]
 	require.True(t, ok, "legacy colliding Getenv must stay on the installer")
@@ -1205,8 +1200,8 @@ func TestRenameCLI_PlatformProfileEndpointEnvMatchesRewrittenGetenv(t *testing.T
 		"MCPB manifest must collect the rewritten Getenv, not the pre-rename override")
 	_, stale := got.Server.MCPConfig.Env["SHOPIFY_SHOP"]
 	assert.False(t, stale, "stale SHOPIFY_SHOP must not remain on the installer prompt")
-	_, hasToken := got.Server.MCPConfig.Env["SHOPIFY_ACCESS_TOKEN"]
-	assert.False(t, hasToken, "platform-profile rename must not re-add the access token beside the profile selector")
+	assert.Equal(t, "${user_config.shopify_access_token}", got.Server.MCPConfig.Env["SHOPIFY_ACCESS_TOKEN"],
+		"rename must keep the credential the binary reads")
 
 	cliData, err := os.ReadFile(filepath.Join(newDir, CLIManifestFilename))
 	require.NoError(t, err)

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -341,8 +341,6 @@ func WriteCLIManifest(dir string, m CLIManifest) error {
 	return nil
 }
 
-// AuthEnvVars stay the credentials the generated binary reads. The optional
-// tenant profile selector is a separate binding, not a substitute credential.
 func normalizeCLIManifestForWrite(dir string, m CLIManifest) CLIManifest {
 	return dropCollidingEndpointTemplateOverrides(m, scanGeneratedEnvSet(dir))
 }

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -341,15 +341,9 @@ func WriteCLIManifest(dir string, m CLIManifest) error {
 	return nil
 }
 
+// AuthEnvVars stay the credentials the generated binary reads. The optional
+// tenant profile selector is a separate binding, not a substitute credential.
 func normalizeCLIManifestForWrite(dir string, m CLIManifest) CLIManifest {
-	if usesPlatformClientProfiles(dir) {
-		m.AuthEnvVars = []string{"PRINTING_PRESS_CLIENT_PROFILE"}
-		m.AuthEnvVarSpecs = []spec.AuthEnvVar{{
-			Name: "PRINTING_PRESS_CLIENT_PROFILE", Kind: spec.AuthEnvVarKindPerCall,
-			Required: true, Sensitive: false,
-		}}
-		m.AuthAdditionalHeaders = nil
-	}
 	return dropCollidingEndpointTemplateOverrides(m, scanGeneratedEnvSet(dir))
 }
 

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -97,7 +97,7 @@ func TestReadCLIBinaryNameRejectsPathComponents(t *testing.T) {
 	}
 }
 
-func TestWriteCLIManifestUsesOnlyClientProfileForPlatformRuntime(t *testing.T) {
+func TestWriteCLIManifestPreservesResolvedAuthEnvVarsForPlatformRuntime(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "platform"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "internal", "platform", "profile.go"), []byte("package platform\n"), 0o644))
@@ -108,11 +108,12 @@ func TestWriteCLIManifestUsesOnlyClientProfileForPlatformRuntime(t *testing.T) {
 	}))
 	got, err := ReadCLIManifest(dir)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"PRINTING_PRESS_CLIENT_PROFILE"}, got.AuthEnvVars)
+	assert.Equal(t, []string{"SHOPIFY_ACCESS_TOKEN"}, got.AuthEnvVars)
 	require.Len(t, got.AuthEnvVarSpecs, 1)
-	assert.Equal(t, "PRINTING_PRESS_CLIENT_PROFILE", got.AuthEnvVarSpecs[0].Name)
+	assert.Equal(t, "SHOPIFY_ACCESS_TOKEN", got.AuthEnvVarSpecs[0].Name)
 	assert.True(t, got.AuthEnvVarSpecs[0].Required)
-	assert.False(t, got.AuthEnvVarSpecs[0].Sensitive)
+	assert.True(t, got.AuthEnvVarSpecs[0].Sensitive)
+	assert.NotContains(t, got.AuthEnvVars, "PRINTING_PRESS_CLIENT_PROFILE")
 }
 
 func TestWriteCLIManifestPreservesExistingReleaseLedger(t *testing.T) {
@@ -1477,7 +1478,7 @@ func TestWriteMCPBManifest(t *testing.T) {
 		assert.Contains(t, key.Description, "https://dashboard.stripe.com/apikeys")
 	})
 
-	t.Run("platform runtime emits profile selector plus required endpoint template vars", func(t *testing.T) {
+	t.Run("platform runtime emits resolved credentials plus required endpoint template vars", func(t *testing.T) {
 		dir := t.TempDir()
 		require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "platform"), 0o755))
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "internal", "platform", "profile.go"), []byte("package platform\n"), 0o644))
@@ -1489,18 +1490,18 @@ func TestWriteMCPBManifest(t *testing.T) {
 		require.NoError(t, WriteMCPBManifest(dir))
 		got := readMCPBManifest(t, dir)
 		assert.Equal(t, map[string]string{
-			"PRINTING_PRESS_CLIENT_PROFILE": "${user_config.printing_press_client_profile}",
-			"SHOPIFY_SHOP":                  "${user_config.shopify_shop}",
+			"SHOPIFY_ACCESS_TOKEN": "${user_config.shopify_access_token}",
+			"SHOPIFY_SHOP":         "${user_config.shopify_shop}",
 		}, got.Server.MCPConfig.Env)
-		_, hasToken := got.Server.MCPConfig.Env["SHOPIFY_ACCESS_TOKEN"]
-		assert.False(t, hasToken, "platform-profile manifests must not collect the access token beside the profile selector")
+		_, hasProfile := got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"]
+		assert.False(t, hasProfile, "tenant profile selector is not a credential the binary reads")
 		require.Len(t, got.UserConfig, 2)
-		profile := got.UserConfig["printing_press_client_profile"]
-		assert.Equal(t, "Client profile", profile.Title)
-		assert.True(t, profile.Required)
-		assert.False(t, profile.Sensitive)
+		token := got.UserConfig["shopify_access_token"]
+		assert.Equal(t, "SHOPIFY_ACCESS_TOKEN", token.Title)
+		assert.True(t, token.Required)
+		assert.True(t, token.Sensitive)
 		shop, ok := got.UserConfig["shopify_shop"]
-		require.True(t, ok, "required {shop} must still be collected when credentials ride the profile selector")
+		require.True(t, ok, "required {shop} must still be collected alongside the credential")
 		assert.Equal(t, "SHOPIFY_SHOP", shop.Title)
 		assert.True(t, shop.Required, "{shop} has no spec-level default; user must supply it")
 		assert.False(t, shop.Sensitive)
@@ -1531,19 +1532,13 @@ func TestWriteMCPBManifest(t *testing.T) {
 		require.NoError(t, WriteMCPBManifest(dir))
 		got := readMCPBManifest(t, dir)
 
-		_, hasToken := got.Server.MCPConfig.Env["SHOPIFY_ACCESS_TOKEN"]
-		assert.False(t, hasToken, "auth-named endpoint override must not collect the credential beside the profile selector")
+		assert.Equal(t, "${user_config.shopify_access_token}", got.Server.MCPConfig.Env["SHOPIFY_ACCESS_TOKEN"],
+			"resolved credential must still reach the installer after a colliding {shop} override is rejected")
 		tokenField, hasTokenField := got.UserConfig["shopify_access_token"]
-		assert.False(t, hasTokenField, "installer must not prompt for SHOPIFY_ACCESS_TOKEN as a non-sensitive endpoint field")
-		if hasTokenField {
-			assert.True(t, tokenField.Sensitive, "if the access token appears at all it must stay masked")
-		}
-
-		assert.Equal(t, "${user_config.printing_press_client_profile}", got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"])
-		profile, ok := got.UserConfig["printing_press_client_profile"]
-		require.True(t, ok)
-		assert.True(t, profile.Required)
-		assert.False(t, profile.Sensitive)
+		require.True(t, hasTokenField, "installer must prompt for the credential the binary reads")
+		assert.True(t, tokenField.Sensitive, "the access token must stay masked")
+		_, hasProfile := got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"]
+		assert.False(t, hasProfile)
 
 		assert.Equal(t, "${user_config.shopify_shop}", got.Server.MCPConfig.Env["SHOPIFY_SHOP"])
 		shop, ok := got.UserConfig["shopify_shop"]
@@ -1558,12 +1553,16 @@ func TestWriteMCPBManifest(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "platform"), 0o755))
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "internal", "platform", "profile.go"), []byte("package platform\n"), 0o644))
 		writeManifest(t, dir, CLIManifest{
-			APIName:              "shopify",
-			DisplayName:          "Shopify",
-			MCPBinary:            "shopify-pp-mcp",
-			MCPReady:             "full",
-			AuthType:             "api_key",
-			AuthEnvVars:          []string{"PRINTING_PRESS_CLIENT_PROFILE"},
+			APIName:     "shopify",
+			DisplayName: "Shopify",
+			MCPBinary:   "shopify-pp-mcp",
+			MCPReady:    "full",
+			AuthType:    "api_key",
+			AuthEnvVars: []string{"PRINTING_PRESS_CLIENT_PROFILE"},
+			AuthEnvVarSpecs: []spec.AuthEnvVar{{
+				Name: "PRINTING_PRESS_CLIENT_PROFILE", Kind: spec.AuthEnvVarKindPerCall,
+				Required: true, Sensitive: false,
+			}},
 			EndpointTemplateVars: []string{"access_token"},
 		})
 
@@ -1577,9 +1576,9 @@ func TestWriteMCPBManifest(t *testing.T) {
 		require.True(t, ok, "omitting the binding leaves the generated client unset")
 		assert.Equal(t, "SHOPIFY_ACCESS_TOKEN", token.Title)
 		assert.True(t, token.Required)
-		assert.True(t, token.Sensitive, "credential-shaped endpoint defaults stay masked; they must not bypass the profile as an unmasked field")
+		assert.True(t, token.Sensitive, "credential-shaped endpoint defaults stay masked")
 		profile, ok := got.UserConfig["printing_press_client_profile"]
-		require.True(t, ok)
+		require.True(t, ok, "a CLI that only declares the profile variable keeps that binding")
 		assert.False(t, profile.Sensitive)
 	})
 

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -1508,6 +1508,60 @@ func TestWriteMCPBManifest(t *testing.T) {
 		assert.Contains(t, shop.Description, "{shop}")
 	})
 
+	t.Run("registered platform source binds client profile alongside credentials", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "cli"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "internal", "cli", "adapter.go"), []byte(`package cli
+
+func init() {
+	registerPlatformSource(platformSourceRegistration{Source: "shopify"})
+}
+`), 0o644))
+		writeManifest(t, dir, CLIManifest{
+			APIName: "shopify", DisplayName: "Shopify", MCPBinary: "shopify-pp-mcp", MCPReady: "full",
+			AuthType: "api_key", AuthEnvVars: []string{"SHOPIFY_ACCESS_TOKEN"},
+		})
+
+		require.NoError(t, WriteMCPBManifest(dir))
+		got := readMCPBManifest(t, dir)
+
+		assert.Equal(t, "${user_config.shopify_access_token}", got.Server.MCPConfig.Env["SHOPIFY_ACCESS_TOKEN"],
+			"installer must still collect the credential the binary reads")
+		assert.Equal(t, "${user_config.printing_press_client_profile}", got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"],
+			"fresh MCPB installs have no default profile; startup requires the selector")
+		token, ok := got.UserConfig["shopify_access_token"]
+		require.True(t, ok)
+		assert.True(t, token.Required)
+		assert.True(t, token.Sensitive)
+		profile, ok := got.UserConfig["printing_press_client_profile"]
+		require.True(t, ok, "missing-client-profile at MCP startup when no default_client_profile is configured")
+		assert.Equal(t, "Client profile", profile.Title)
+		assert.True(t, profile.Required)
+		assert.False(t, profile.Sensitive)
+	})
+
+	t.Run("registered platform source binds client profile even without credentials", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "cli"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "internal", "cli", "adapter.go"), []byte(`package cli
+
+func init() {
+	registerPlatformSource(platformSourceRegistration{Source: "public-site"})
+}
+`), 0o644))
+		writeManifest(t, dir, CLIManifest{
+			APIName: "espn", MCPBinary: "espn-pp-mcp", MCPReady: "full", AuthType: "none",
+		})
+
+		require.NoError(t, WriteMCPBManifest(dir))
+		got := readMCPBManifest(t, dir)
+		assert.Equal(t, "${user_config.printing_press_client_profile}", got.Server.MCPConfig.Env["PRINTING_PRESS_CLIENT_PROFILE"])
+		profile, ok := got.UserConfig["printing_press_client_profile"]
+		require.True(t, ok)
+		assert.True(t, profile.Required)
+		assert.False(t, profile.Sensitive)
+	})
+
 	t.Run("platform runtime rejects auth-named endpoint override", func(t *testing.T) {
 		dir := t.TempDir()
 		require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "platform"), 0o755))
@@ -3028,4 +3082,42 @@ func TestWriteManifestForGenerateUsesSelectedArchiveName(t *testing.T) {
 			assert.Equal(t, tt.wantPath, got.SpecPath)
 		})
 	}
+}
+
+func TestSourceRegistersPlatformSource(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{name: "definition only", src: "func registerPlatformSource(registration platformSourceRegistration) {\n}\n", want: false},
+		{name: "call in init", src: "func init() {\n\tregisterPlatformSource(platformSourceRegistration{Source: \"shopify\"})\n}\n", want: true},
+		{name: "definition then call", src: "func registerPlatformSource(registration platformSourceRegistration) {}\nfunc init() { registerPlatformSource(platformSourceRegistration{}) }\n", want: true},
+		{name: "unrelated", src: "package cli\n", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sourceRegistersPlatformSource(tt.src))
+		})
+	}
+}
+
+func TestNeedsMCPBClientProfileBindingSkipsGeneratedDefinition(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "cli"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "internal", "cli", "platform_cli.go"), []byte(`package cli
+
+func registerPlatformSource(registration platformSourceRegistration) {
+}
+`), 0o644))
+	assert.False(t, needsMCPBClientProfileBinding(dir))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "internal", "cli", "adapter.go"), []byte(`package cli
+
+func init() {
+	registerPlatformSource(platformSourceRegistration{Source: "shopify"})
+}
+`), 0o644))
+	assert.True(t, needsMCPBClientProfileBinding(dir))
 }

--- a/internal/pipeline/mcpb_manifest.go
+++ b/internal/pipeline/mcpb_manifest.go
@@ -178,9 +178,7 @@ func WriteMCPBManifestFromStruct(dir string, m CLIManifest) error {
 	// build didn't surface (per-instance BASE_URL, credential-flow JWT
 	// refreshers, hand-written auth helpers). Runs from every writer
 	// call site so lock+promote and one-off bundle builds read the same
-	// reconciled file. Platform-profile CLIs still go through this pass
-	// so *_BASE_URL and required endpoint placeholders land; credential
-	// Getenv calls are not re-added beside the profile selector.
+	// reconciled file.
 	return reconcileMCPBManifestFromClient(dir, m)
 }
 
@@ -214,20 +212,6 @@ func buildMCPBManifest(dir string, m CLIManifest) MCPBManifest {
 	}
 	launchEnv := buildMCPBEnv(m)
 	userConfig := buildMCPBUserConfig(m)
-	if usesPlatformClientProfiles(dir) {
-		// The profile selector is the credential surface. Endpoint
-		// placeholders such as {shop} are not credentials — dropping them
-		// here means the installer never collects them and the first API
-		// call fails with "<API>_SHOP not set".
-		launchEnv = map[string]string{"PRINTING_PRESS_CLIENT_PROFILE": "${user_config.printing_press_client_profile}"}
-		userConfig = map[string]MCPBVar{
-			"printing_press_client_profile": {
-				Type: mcpbVarTypeString, Title: "Client profile", Required: true,
-				Description: "Binds the MCP server to an existing tenant-gated Printing Press client profile.",
-			},
-		}
-		bindEndpointTemplateVars(m, launchEnv, userConfig)
-	}
 
 	return MCPBManifest{
 		ManifestVersion: MCPBManifestVersion,
@@ -255,11 +239,6 @@ func buildMCPBManifest(dir string, m CLIManifest) MCPBManifest {
 			Platforms:     defaultMCPBPlatforms,
 		},
 	}
-}
-
-func usesPlatformClientProfiles(dir string) bool {
-	info, err := os.Stat(filepath.Join(dir, "internal", "platform", "profile.go"))
-	return err == nil && !info.IsDir()
 }
 
 // bundleVersion returns the best known printed CLI bundle version at generate
@@ -585,9 +564,9 @@ func alignPrefixedEnvName(name, apiName string) string {
 	return name
 }
 
-// Auth-named or credential-shaped env vars stay on the profile selector
-// (or the sensitive auth user_config slot). Emitting them as unmasked
-// endpoint fields would prompt the installer for the raw secret.
+// Auth-named or credential-shaped env vars stay on the sensitive auth
+// user_config slot. Emitting them as unmasked endpoint fields would
+// prompt the installer for the raw secret.
 func isAuthOrCredentialEnvVar(m CLIManifest, name string) bool {
 	return spec.IsAuthOrCredentialEnvName(name, manifestAuthEnvNames(m))
 }
@@ -632,11 +611,6 @@ func endpointTemplateVarForEnv(m CLIManifest, name string) (string, bool) {
 		}
 	}
 	return "", false
-}
-
-func isEndpointTemplateEnvVar(m CLIManifest, name string) bool {
-	_, ok := endpointTemplateVarForEnv(m, name)
-	return ok
 }
 
 // userConfigKey lowercases the env var so manifest user_config keys match

--- a/internal/pipeline/mcpb_manifest.go
+++ b/internal/pipeline/mcpb_manifest.go
@@ -26,6 +26,9 @@ const (
 	authTypeBearerToken   = "bearer_token"
 	authTypeOAuth2        = "oauth2"
 	authTypeOAuth2Refresh = "oauth2_refresh"
+
+	mcpbClientProfileEnvName = "PRINTING_PRESS_CLIENT_PROFILE"
+	mcpbClientProfileUserKey = "printing_press_client_profile"
 )
 
 // defaultMCPBPlatforms is the set of host platforms our generated bundles
@@ -212,6 +215,7 @@ func buildMCPBManifest(dir string, m CLIManifest) MCPBManifest {
 	}
 	launchEnv := buildMCPBEnv(m)
 	userConfig := buildMCPBUserConfig(m)
+	launchEnv, userConfig = ensureMCPBClientProfileBinding(dir, launchEnv, userConfig)
 
 	return MCPBManifest{
 		ManifestVersion: MCPBManifestVersion,
@@ -312,6 +316,75 @@ func loadExistingMCPBManifest(dir string) *existingMCPBManifest {
 		return nil
 	}
 	return &existing
+}
+
+// Fresh MCPB installs have no default_client_profile. A registered
+// platform source exits at startup unless the installer collects the
+// tenant selector. That selector is not a substitute for the credentials
+// the binary reads.
+func ensureMCPBClientProfileBinding(dir string, env map[string]string, vars map[string]MCPBVar) (map[string]string, map[string]MCPBVar) {
+	if !needsMCPBClientProfileBinding(dir) {
+		return env, vars
+	}
+	if env == nil {
+		env = make(map[string]string, 1)
+	}
+	if vars == nil {
+		vars = make(map[string]MCPBVar, 1)
+	}
+	env[mcpbClientProfileEnvName] = "${user_config." + mcpbClientProfileUserKey + "}"
+	vars[mcpbClientProfileUserKey] = MCPBVar{
+		Type:        mcpbVarTypeString,
+		Title:       "Client profile",
+		Required:    true,
+		Description: "Binds the MCP server to an existing tenant-gated Printing Press client profile.",
+	}
+	return env, vars
+}
+
+func needsMCPBClientProfileBinding(dir string) bool {
+	var needed bool
+	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || needed {
+			return nil
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "testdata", "vendor", ".git":
+				return filepath.SkipDir
+			default:
+				return nil
+			}
+		}
+		if !strings.HasSuffix(d.Name(), ".go") || strings.HasSuffix(d.Name(), "_test.go") {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		if sourceRegistersPlatformSource(string(data)) {
+			needed = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return needed
+}
+
+func sourceRegistersPlatformSource(src string) bool {
+	for {
+		i := strings.Index(src, "registerPlatformSource(")
+		if i < 0 {
+			return false
+		}
+		prefix := strings.TrimRight(src[:i], " \t")
+		if strings.HasSuffix(prefix, "func") {
+			src = src[i+len("registerPlatformSource("):]
+			continue
+		}
+		return true
+	}
 }
 
 // buildMCPBEnv maps each declared auth env var into the launch spec's env

--- a/internal/pipeline/mcpsync/sync_test.go
+++ b/internal/pipeline/mcpsync/sync_test.go
@@ -543,19 +543,14 @@ func TestSyncRefreshesProvenanceFromSpec(t *testing.T) {
 	assert.Equal(t, "https://example.com/get-a-token", prov.AuthKeyURL, "auth_key_url must refresh from spec.yaml on mcp-sync")
 	assert.True(t, prov.AuthOptional, "auth_optional must refresh from spec.yaml on mcp-sync")
 
-	// Step 6: verify the MCPB manifest keeps credentials behind the client
-	// profile boundary while still declaring per-instance non-secret config
-	// reads such as BASE_URL. The provenance manifest above still refreshes
-	// the source auth metadata; the platform runtime exposes the profile
-	// binding plus those non-secret operator inputs to MCP hosts.
+	// Step 6: verify the MCPB manifest names the credential the binary
+	// reads, plus per-instance non-secret config such as BASE_URL.
 	manifestData, err := os.ReadFile(filepath.Join(cliDir, pipeline.MCPBManifestFilename))
 	require.NoError(t, err)
 	manifestStr := string(manifestData)
-	assert.NotContains(t, manifestStr, "https://example.com/get-a-token", "platform MCP manifest must not surface credential acquisition metadata")
-	assert.NotContains(t, manifestStr, "PROVREFRESH_TOKEN", "platform MCP manifest must not expose raw credential configuration")
-	assert.Contains(t, manifestStr, `"PRINTING_PRESS_CLIENT_PROFILE": "${user_config.printing_press_client_profile}"`)
+	assert.Contains(t, manifestStr, `"PROVREFRESH_TOKEN": "${user_config.provrefresh_token}"`)
+	assert.NotContains(t, manifestStr, `"PRINTING_PRESS_CLIENT_PROFILE"`)
 	assert.Contains(t, manifestStr, `"PROVREFRESH_BASE_URL": "${user_config.provrefresh_base_url}"`)
-	assert.Contains(t, manifestStr, `"required": true`)
 }
 
 // TestValidateSpecNameMatchesDirAccepts ensures matching name and dir

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/.printing-press.json
@@ -1,17 +1,6 @@
 {
   "api_name": "fastapi-operationids-golden",
   "api_version": "1.0",
-  "auth_env_var_specs": [
-    {
-      "kind": "per_call",
-      "name": "PRINTING_PRESS_CLIENT_PROFILE",
-      "required": true,
-      "sensitive": false
-    }
-  ],
-  "auth_env_vars": [
-    "PRINTING_PRESS_CLIENT_PROFILE"
-  ],
   "auth_type": "none",
   "cli_name": "fastapi-operationids-golden-pp-cli",
   "creator": {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/manifest.json
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/manifest.json
@@ -22,8 +22,7 @@
       "command": "${__dirname}/bin/fastapi-operationids-golden-pp-mcp",
       "env": {
         "FASTAPI_OPERATIONIDS_GOLDEN_BASE_URL": "${user_config.fastapi_operationids_golden_base_url}",
-        "FASTAPI_OPERATIONIDS_GOLDEN_USER_AGENT": "${user_config.fastapi_operationids_golden_user_agent}",
-        "PRINTING_PRESS_CLIENT_PROFILE": "${user_config.printing_press_client_profile}"
+        "FASTAPI_OPERATIONIDS_GOLDEN_USER_AGENT": "${user_config.fastapi_operationids_golden_user_agent}"
       }
     },
     "type": "binary"
@@ -37,12 +36,6 @@
     "fastapi_operationids_golden_user_agent": {
       "description": "Optional. Sets FASTAPI_OPERATIONIDS_GOLDEN_USER_AGENT for the Fastapi Operationids Golden MCP server. Per-instance, non-secret setting; not a credential.",
       "title": "FASTAPI_OPERATIONIDS_GOLDEN_USER_AGENT",
-      "type": "string"
-    },
-    "printing_press_client_profile": {
-      "description": "Binds the MCP server to an existing tenant-gated Printing Press client profile.",
-      "required": true,
-      "title": "Client profile",
       "type": "string"
     }
   },

--- a/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/.printing-press.json
+++ b/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/.printing-press.json
@@ -1,16 +1,8 @@
 {
   "api_name": "cafe-bistro",
   "api_version": "1.0.0",
-  "auth_env_var_specs": [
-    {
-      "kind": "per_call",
-      "name": "PRINTING_PRESS_CLIENT_PROFILE",
-      "required": true,
-      "sensitive": false
-    }
-  ],
   "auth_env_vars": [
-    "PRINTING_PRESS_CLIENT_PROFILE"
+    "CAFE_BISTRO_API_KEY"
   ],
   "auth_preference": "ApiKeyAuth",
   "auth_type": "api_key",

--- a/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/manifest.json
+++ b/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/manifest.json
@@ -21,14 +21,21 @@
       "args": [],
       "command": "${__dirname}/bin/cafe-bistro-pp-mcp",
       "env": {
+        "CAFE_BISTRO_API_KEY": "${user_config.cafe_bistro_api_key}",
         "CAFE_BISTRO_BASE_URL": "${user_config.cafe_bistro_base_url}",
-        "CAFE_BISTRO_USER_AGENT": "${user_config.cafe_bistro_user_agent}",
-        "PRINTING_PRESS_CLIENT_PROFILE": "${user_config.printing_press_client_profile}"
+        "CAFE_BISTRO_USER_AGENT": "${user_config.cafe_bistro_user_agent}"
       }
     },
     "type": "binary"
   },
   "user_config": {
+    "cafe_bistro_api_key": {
+      "description": "Sets CAFE_BISTRO_API_KEY for the Café Bistro MCP server.",
+      "required": true,
+      "sensitive": true,
+      "title": "CAFE_BISTRO_API_KEY",
+      "type": "string"
+    },
     "cafe_bistro_base_url": {
       "description": "Optional. Sets CAFE_BISTRO_BASE_URL for the Café Bistro MCP server. Per-instance, non-secret setting; not a credential.",
       "title": "CAFE_BISTRO_BASE_URL",
@@ -37,12 +44,6 @@
     "cafe_bistro_user_agent": {
       "description": "Optional. Sets CAFE_BISTRO_USER_AGENT for the Café Bistro MCP server. Per-instance, non-secret setting; not a credential.",
       "title": "CAFE_BISTRO_USER_AGENT",
-      "type": "string"
-    },
-    "printing_press_client_profile": {
-      "description": "Binds the MCP server to an existing tenant-gated Printing Press client profile.",
-      "required": true,
-      "title": "Client profile",
       "type": "string"
     }
   },

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/.printing-press.json
@@ -1,16 +1,8 @@
 {
   "api_name": "printing-press-golden",
   "api_version": "2026.04",
-  "auth_env_var_specs": [
-    {
-      "kind": "per_call",
-      "name": "PRINTING_PRESS_CLIENT_PROFILE",
-      "required": true,
-      "sensitive": false
-    }
-  ],
   "auth_env_vars": [
-    "PRINTING_PRESS_CLIENT_PROFILE"
+    "PRINTING_PRESS_GOLDEN_API_KEY"
   ],
   "auth_preference": "ApiKeyAuth",
   "auth_type": "api_key",

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/manifest.json
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/manifest.json
@@ -21,7 +21,7 @@
       "args": [],
       "command": "${__dirname}/bin/printing-press-golden-pp-mcp",
       "env": {
-        "PRINTING_PRESS_CLIENT_PROFILE": "${user_config.printing_press_client_profile}",
+        "PRINTING_PRESS_GOLDEN_API_KEY": "${user_config.printing_press_golden_api_key}",
         "PRINTING_PRESS_GOLDEN_BASE_URL": "${user_config.printing_press_golden_base_url}",
         "PRINTING_PRESS_GOLDEN_USER_AGENT": "${user_config.printing_press_golden_user_agent}"
       }
@@ -29,10 +29,11 @@
     "type": "binary"
   },
   "user_config": {
-    "printing_press_client_profile": {
-      "description": "Binds the MCP server to an existing tenant-gated Printing Press client profile.",
+    "printing_press_golden_api_key": {
+      "description": "Sets PRINTING_PRESS_GOLDEN_API_KEY for the Printing Press Studio MCP server.",
       "required": true,
-      "title": "Client profile",
+      "sensitive": true,
+      "title": "PRINTING_PRESS_GOLDEN_API_KEY",
       "type": "string"
     },
     "printing_press_golden_base_url": {

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/.printing-press.json
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/.printing-press.json
@@ -1,16 +1,8 @@
 {
   "api_name": "learn-disabled-example",
   "api_version": "1.0.0",
-  "auth_env_var_specs": [
-    {
-      "kind": "per_call",
-      "name": "PRINTING_PRESS_CLIENT_PROFILE",
-      "required": true,
-      "sensitive": false
-    }
-  ],
   "auth_env_vars": [
-    "PRINTING_PRESS_CLIENT_PROFILE"
+    "LEARN_DISABLED_TOKEN"
   ],
   "auth_type": "bearer_token",
   "cli_name": "learn-disabled-example-pp-cli",

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/.printing-press.json
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/.printing-press.json
@@ -1,16 +1,8 @@
 {
   "api_name": "learn-loop-example",
   "api_version": "1.0.0",
-  "auth_env_var_specs": [
-    {
-      "kind": "per_call",
-      "name": "PRINTING_PRESS_CLIENT_PROFILE",
-      "required": true,
-      "sensitive": false
-    }
-  ],
   "auth_env_vars": [
-    "PRINTING_PRESS_CLIENT_PROFILE"
+    "LEARN_LOOP_TOKEN"
   ],
   "auth_type": "bearer_token",
   "cli_name": "learn-loop-example-pp-cli",

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/manifest.json
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/manifest.json
@@ -23,7 +23,7 @@
       "env": {
         "LEARN_LOOP_EXAMPLE_BASE_URL": "${user_config.learn_loop_example_base_url}",
         "LEARN_LOOP_EXAMPLE_USER_AGENT": "${user_config.learn_loop_example_user_agent}",
-        "PRINTING_PRESS_CLIENT_PROFILE": "${user_config.printing_press_client_profile}"
+        "LEARN_LOOP_TOKEN": "${user_config.learn_loop_token}"
       }
     },
     "type": "binary"
@@ -39,10 +39,11 @@
       "title": "LEARN_LOOP_EXAMPLE_USER_AGENT",
       "type": "string"
     },
-    "printing_press_client_profile": {
-      "description": "Binds the MCP server to an existing tenant-gated Printing Press client profile.",
+    "learn_loop_token": {
+      "description": "Sets LEARN_LOOP_TOKEN for the Learn Loop Example MCP server.",
       "required": true,
-      "title": "Client profile",
+      "sensitive": true,
+      "title": "LEARN_LOOP_TOKEN",
       "type": "string"
     }
   },

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/.printing-press.json
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/.printing-press.json
@@ -1,16 +1,8 @@
 {
   "api_name": "mcp-cloudflare",
   "api_version": "1.0.0",
-  "auth_env_var_specs": [
-    {
-      "kind": "per_call",
-      "name": "PRINTING_PRESS_CLIENT_PROFILE",
-      "required": true,
-      "sensitive": false
-    }
-  ],
   "auth_env_vars": [
-    "PRINTING_PRESS_CLIENT_PROFILE"
+    "MCP_CLOUDFLARE_API_KEY"
   ],
   "auth_preference": "ApiKeyAuth",
   "auth_type": "api_key",

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/.printing-press.json
@@ -1,16 +1,8 @@
 {
   "api_name": "query-endpoint-golden",
   "api_version": "1.0.0",
-  "auth_env_var_specs": [
-    {
-      "kind": "per_call",
-      "name": "PRINTING_PRESS_CLIENT_PROFILE",
-      "required": true,
-      "sensitive": false
-    }
-  ],
   "auth_env_vars": [
-    "PRINTING_PRESS_CLIENT_PROFILE"
+    "QUERY_ENDPOINT_GOLDEN_TOKEN"
   ],
   "auth_type": "bearer_token",
   "cli_name": "query-endpoint-golden-pp-cli",

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/.printing-press.json
@@ -1,16 +1,8 @@
 {
   "api_name": "sync-walker-golden",
   "api_version": "1.0.0",
-  "auth_env_var_specs": [
-    {
-      "kind": "per_call",
-      "name": "PRINTING_PRESS_CLIENT_PROFILE",
-      "required": true,
-      "sensitive": false
-    }
-  ],
   "auth_env_vars": [
-    "PRINTING_PRESS_CLIENT_PROFILE"
+    "WALKER_GOLDEN_TOKEN"
   ],
   "auth_type": "bearer_token",
   "cli_name": "sync-walker-golden-pp-cli",

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/.printing-press.json
@@ -1,16 +1,10 @@
 {
   "api_name": "tier-routing-golden",
   "api_version": "1.0.0",
-  "auth_env_var_specs": [
-    {
-      "kind": "per_call",
-      "name": "PRINTING_PRESS_CLIENT_PROFILE",
-      "required": true,
-      "sensitive": false
-    }
-  ],
   "auth_env_vars": [
-    "PRINTING_PRESS_CLIENT_PROFILE"
+    "TIER_GLOBAL_TOKEN",
+    "TIER_ENTERPRISE_TOKEN",
+    "TIER_PAID_KEY"
   ],
   "auth_type": "bearer_token",
   "cli_name": "tier-routing-golden-pp-cli",

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/manifest.json
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/manifest.json
@@ -21,7 +21,9 @@
       "args": [],
       "command": "${__dirname}/bin/tier-routing-golden-pp-mcp",
       "env": {
-        "PRINTING_PRESS_CLIENT_PROFILE": "${user_config.printing_press_client_profile}",
+        "TIER_ENTERPRISE_TOKEN": "${user_config.tier_enterprise_token}",
+        "TIER_GLOBAL_TOKEN": "${user_config.tier_global_token}",
+        "TIER_PAID_KEY": "${user_config.tier_paid_key}",
         "TIER_ROUTING_GOLDEN_BASE_URL": "${user_config.tier_routing_golden_base_url}",
         "TIER_ROUTING_GOLDEN_USER_AGENT": "${user_config.tier_routing_golden_user_agent}"
       }
@@ -29,10 +31,25 @@
     "type": "binary"
   },
   "user_config": {
-    "printing_press_client_profile": {
-      "description": "Binds the MCP server to an existing tenant-gated Printing Press client profile.",
+    "tier_enterprise_token": {
+      "description": "Sets TIER_ENTERPRISE_TOKEN for the Tier Routing Golden MCP server.",
       "required": true,
-      "title": "Client profile",
+      "sensitive": true,
+      "title": "TIER_ENTERPRISE_TOKEN",
+      "type": "string"
+    },
+    "tier_global_token": {
+      "description": "Sets TIER_GLOBAL_TOKEN for the Tier Routing Golden MCP server.",
+      "required": true,
+      "sensitive": true,
+      "title": "TIER_GLOBAL_TOKEN",
+      "type": "string"
+    },
+    "tier_paid_key": {
+      "description": "Sets TIER_PAID_KEY for the Tier Routing Golden MCP server.",
+      "required": true,
+      "sensitive": true,
+      "title": "TIER_PAID_KEY",
       "type": "string"
     },
     "tier_routing_golden_base_url": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Generated `.printing-press.json`, MCPB `manifest.json`, and `SKILL.md` could name env vars the printed binary does not read. Operators and agents then set `PRINTING_PRESS_CLIENT_PROFILE` (or an independently authored SKILL secret) while config still reads the real credential — and the publish live gate consumes the wrong key.

Closes #4022
Closes #3405

## Approach

One contract: the env vars the binary reads for those credentials are the names manifest, MCPB, and SKILL must use.

- `normalizeCLIManifestForWrite` no longer overwrites `AuthEnvVars` / `AuthEnvVarSpecs` when `internal/platform/profile.go` exists. Every printed CLI emits that file, so the old write-time swap replaced real credentials with the tenant profile selector.
- MCPB launch env and `user_config` come from the same resolved auth set (`buildMCPBEnv` / `buildMCPBUserConfig`). The profile selector is not a substitute credential.
- When a preserved adapter calls `registerPlatformSource`, MCPB also binds `PRINTING_PRESS_CLIENT_PROFILE` as a required install field. Fresh MCPB installs have no `default_client_profile`; without that binding, `BindMCPServerProfile` exits missing-client-profile. Presence of `internal/platform/profile.go` alone does not require the selector — that file is generated for every CLI.
- The client env scanner promotes Getenv names the generated client actually reads, including credentials, and skips `*_test.go` so Windows `USERNAME` helpers never become install prompts.
- SKILL Auth Setup keeps independently authored `AuthNarrative` only when every env-var-shaped token is in the resolved set. Otherwise it falls through to the type-aware branch, including a basic-auth pair export.

## Published-library sweep

This changes the generated `## Auth Setup` body (not the heading). Already-published CLIs can still ship prose that names a secret the binary ignores. Fresh prints pick up the resolved-env form; existing entries need a reprint or sweep.

Tracking issue (library-side sweep): https://github.com/mvanhorn/printing-press-library/issues/1869

Anchors for that sweep: `## Auth Setup` through the next `## ` heading; compare env-var-shaped tokens against `.printing-press.json` `auth_env_vars`. Idempotent second run must be zero diff.

## Scope

Primary area: generator + CLI manifest / MCPB emit.

This is a Printing Press machine fix. Fresh prints and reprints pick up the correct names; already-published CLIs need a reprint to refresh their manifests.

## Risk

- Generated `.printing-press.json` `auth_env_vars` and MCPB `server.mcp_config.env` change for every CLI that previously recorded only `PRINTING_PRESS_CLIENT_PROFILE`.
- Publish live gate (`auth_env_vars[0]`) now receives the real credential key.
- SKILL.md Auth Setup can drop a research narrative that named a variable the binary ignores.
- Tenant profile selection via `--client-profile` / `PRINTING_PRESS_CLIENT_PROFILE` is unchanged as a CLI flag; it is just no longer advertised as the credential. MCPB still collects it when a registered platform source makes startup require it.

## Output Contract

Manifest `auth_env_vars`, MCPB env/user_config, and SKILL Auth Setup name the same request credentials `internal/config` reads. MCPB additionally names `PRINTING_PRESS_CLIENT_PROFILE` only when a registered platform source makes MCP startup require that selector.

Evidence:
- `TestWriteCLIManifestPreservesResolvedAuthEnvVarsForPlatformRuntime`
- `TestWriteManifestForGenerate_IncludesGeneratedConfigBaseURL` (manifest + MCPB vs `HUDU_API_KEY`)
- `TestWriteMCPBManifest/registered_platform_source_binds_client_profile_alongside_credentials`
- `TestSkillAuthSetupNamesTheCredentialTheBinaryReads` (SKILL vs `os.Getenv`)
- `TestSkillAuthSetupUsesResolvedBasicPairOverForeignNarrative` (maxio-shaped pair vs config Getenv)
- Golden fixtures updated for the generate cases that previously recorded `PRINTING_PRESS_CLIENT_PROFILE`

## Verification

- [x] `go test ./internal/pipeline/ ./internal/pipeline/mcpsync/`
- [x] `go test -timeout 15m ./internal/generator/` (864s)
- [x] Other packages from `go test ./...`
- [x] `scripts/golden.sh update` + `verify`: all generate-* cases PASS. Left `dogfood-verdict-matrix` and `verify-runtime-matrix` untouched (environment could not build those fixture CLIs / emit `structural-fail.json`; unrelated to this contract)
- [x] `scripts/verify-generator-output.sh` (11 cases)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68d5636e-d46b-4fe2-8996-3aced8b9a205?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68d5636e-d46b-4fe2-8996-3aced8b9a205&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

