### PR TITLE
fix(cli): apply --limit after HTML extraction, not on raw markup

### DIFF
--- a/internal/generator/limit_truncation_test.go
+++ b/internal/generator/limit_truncation_test.go
@@ -359,6 +359,123 @@ func TestHTMLResponseLimitFollowsStorelessResponsePath(t *testing.T) {
 		"storeless html-response commands must truncate after ResponsePath unwraps extracted items")
 }
 
+func TestHTMLResponseLimitFollowsStoreBackedResponsePath(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orders":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"results":[{"id":"1"},{"id":"2"},{"id":"3"},{"id":"4"},{"id":"5"}]}`))
+		default:
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = w.Write([]byte(`<html><body>
+				<a href="/items/1">One</a>
+				<a href="/items/2">Two</a>
+				<a href="/items/3">Three</a>
+				<a href="/items/4">Four</a>
+				<a href="/items/5">Five</a>
+			</body></html>`))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	limitParam := spec.Param{Name: "limit", Type: "integer", Default: 10}
+	htmlPage := spec.Endpoint{
+		Method:         http.MethodGet,
+		Path:           "/gallery",
+		Description:    "List gallery links from a page object",
+		Params:         []spec.Param{limitParam},
+		ResponseFormat: spec.ResponseFormatHTML,
+		ResponsePath:   "links",
+		HTMLExtract: &spec.HTMLExtract{
+			Mode:         spec.HTMLExtractModePage,
+			LinkPrefixes: []string{"/items"},
+		},
+		Response: spec.ResponseDef{Type: "array", Item: "html_link"},
+	}
+
+	apiSpec := minimalSpec("html-limit-store")
+	apiSpec.BaseURL = server.URL
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Learn.Disabled = true
+	apiSpec.Resources = map[string]spec.Resource{
+		"gallery": {
+			Description: "Promoted HTML gallery",
+			Endpoints:   map[string]spec.Endpoint{"list": htmlPage},
+		},
+		"album": {
+			Description: "Nested HTML album",
+			Endpoints: map[string]spec.Endpoint{
+				"list": htmlPage,
+				"page": {
+					Method:         http.MethodGet,
+					Path:           "/album/page",
+					Description:    "Read an album page",
+					ResponseFormat: spec.ResponseFormatHTML,
+					HTMLExtract:    &spec.HTMLExtract{Mode: spec.HTMLExtractModePage},
+				},
+			},
+		},
+		"orders": {
+			Description: "JSON orders",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:       http.MethodGet,
+					Path:         "/orders",
+					Description:  "List orders",
+					Params:       []spec.Param{limitParam},
+					ResponsePath: "results",
+					Response:     spec.ResponseDef{Type: "array", Item: "Order"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, MCP: true}
+	require.NoError(t, gen.Generate())
+
+	promotedHTML := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_gallery.go")
+	nestedHTML := readGeneratedFile(t, outputDir, "internal", "cli", "album_list.go")
+	jsonSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_orders.go")
+	assertHTMLLimitOrder(t, promotedHTML)
+	assertHTMLLimitOrder(t, nestedHTML)
+	require.Contains(t, promotedHTML, "applyResponsePath(",
+		"store-backed html-response commands must reapply ResponsePath after extract")
+	require.Contains(t, nestedHTML, "applyResponsePath(",
+		"store-backed nested html-response commands must reapply ResponsePath after extract")
+	require.NotContains(t, jsonSrc, "data = applyResponsePath(",
+		"store-backed JSON commands must not reapply ResponsePath after the resolver")
+	require.Contains(t, jsonSrc, "truncateJSONArray(cmd.Context(), data,")
+
+	binaryPath := filepath.Join(outputDir, naming.CLI(apiSpec.Name))
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/"+naming.CLI(apiSpec.Name))
+
+	home := t.TempDir()
+	baseEnv := isolatedCLIEnv(t, home,
+		strings.ToUpper(strings.ReplaceAll(apiSpec.Name, "-", "_"))+"_BASE_URL="+server.URL,
+	)
+	for _, tc := range []struct {
+		name string
+		args []string
+		want int
+	}{
+		{name: "promoted store html honors limit", args: []string{"gallery", "--limit", "2", "--json", "--data-source", "live"}, want: 2},
+		{name: "nested store html honors limit", args: []string{"album", "list", "--limit", "2", "--json", "--data-source", "live"}, want: 2},
+		{name: "store json still truncates selected array once", args: []string{"orders", "--limit", "2", "--json", "--data-source", "live"}, want: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command(binaryPath, tc.args...)
+			cmd.Env = baseEnv
+			out, err := cmd.CombinedOutput()
+			require.NoError(t, err, string(out))
+			require.Equal(t, tc.want, jsonResultCount(t, out), string(out))
+		})
+	}
+}
+
 func isolatedCLIEnv(t *testing.T, home string, extra ...string) []string {
 	t.Helper()
 	drop := map[string]struct{}{

--- a/internal/generator/limit_truncation_test.go
+++ b/internal/generator/limit_truncation_test.go
@@ -1,10 +1,16 @@
 package generator
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -180,4 +186,141 @@ func TestNumberTypedLimitParamCoercesToInt(t *testing.T) {
 		"number-typed limit param must not declare flagLimit as float64")
 
 	runGoCommand(t, outputDir, "build", "./internal/cli")
+}
+
+func TestHTMLResponseLimitAppliesAfterExtraction(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orders":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"1"},{"id":"2"},{"id":"3"},{"id":"4"},{"id":"5"}]`))
+		default:
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = w.Write([]byte(`<html><body>
+				<a href="/items/1">One</a>
+				<a href="/items/2">Two</a>
+				<a href="/items/3">Three</a>
+				<a href="/items/4">Four</a>
+				<a href="/items/5">Five</a>
+			</body></html>`))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	limitParam := spec.Param{Name: "limit", Type: "integer", Default: 10}
+	htmlList := spec.Endpoint{
+		Method:         http.MethodGet,
+		Path:           "/listings",
+		Description:    "List listings from HTML",
+		Params:         []spec.Param{limitParam},
+		ResponseFormat: spec.ResponseFormatHTML,
+		HTMLExtract: &spec.HTMLExtract{
+			Mode:         spec.HTMLExtractModeLinks,
+			LinkPrefixes: []string{"/items"},
+		},
+		Response: spec.ResponseDef{Type: "array", Item: "html_link"},
+	}
+
+	apiSpec := minimalSpec("html-limit")
+	apiSpec.BaseURL = server.URL
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Learn.Disabled = true
+	apiSpec.Resources = map[string]spec.Resource{
+		"listings": {
+			Description: "HTML listings",
+			Endpoints: map[string]spec.Endpoint{
+				"list": htmlList,
+			},
+		},
+		"catalog": {
+			Description: "Nested HTML catalog",
+			Endpoints: map[string]spec.Endpoint{
+				"list": htmlList,
+				"page": {
+					Method:         http.MethodGet,
+					Path:           "/catalog/page",
+					Description:    "Read a catalog page",
+					ResponseFormat: spec.ResponseFormatHTML,
+					HTMLExtract:    &spec.HTMLExtract{Mode: spec.HTMLExtractModePage},
+				},
+			},
+		},
+		"orders": {
+			Description: "JSON orders",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      http.MethodGet,
+					Path:        "/orders",
+					Description: "List orders",
+					Params:      []spec.Param{limitParam},
+					Response:    spec.ResponseDef{Type: "array", Item: "Order"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	promotedHTML := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_listings.go")
+	nestedHTML := readGeneratedFile(t, outputDir, "internal", "cli", "catalog_list.go")
+	jsonSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_orders.go")
+	assertTruncateAfterHTMLExtract(t, promotedHTML)
+	assertTruncateAfterHTMLExtract(t, nestedHTML)
+	require.Contains(t, jsonSrc, "truncateJSONArray(cmd.Context(), data,",
+		"JSON list endpoints must keep client-side --limit truncation")
+	require.NotContains(t, jsonSrc, "extractHTMLResponse(",
+		"JSON list endpoints must not route through HTML extraction")
+
+	binaryPath := filepath.Join(outputDir, naming.CLI(apiSpec.Name))
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/"+naming.CLI(apiSpec.Name))
+
+	baseEnv := append(os.Environ(),
+		"HOME="+t.TempDir(),
+		strings.ToUpper(strings.ReplaceAll(apiSpec.Name, "-", "_"))+"_BASE_URL="+server.URL,
+	)
+	for _, tc := range []struct {
+		name string
+		args []string
+		want int
+	}{
+		{name: "promoted html honors limit", args: []string{"listings", "--limit", "2", "--json"}, want: 2},
+		{name: "nested html honors limit", args: []string{"catalog", "list", "--limit", "2", "--json"}, want: 2},
+		{name: "json still truncates before parse", args: []string{"orders", "--limit", "2", "--json"}, want: 2},
+		{name: "promoted html keeps all extracted items without tighter limit", args: []string{"listings", "--json"}, want: 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command(binaryPath, tc.args...)
+			cmd.Env = baseEnv
+			out, err := cmd.CombinedOutput()
+			require.NoError(t, err, string(out))
+			require.Equal(t, tc.want, jsonResultCount(t, out), string(out))
+		})
+	}
+}
+
+func assertTruncateAfterHTMLExtract(t *testing.T, src string) {
+	t.Helper()
+	extractIdx := strings.Index(src, "extractHTMLResponse(")
+	truncateIdx := strings.Index(src, "truncateJSONArray(")
+	require.NotEqual(t, -1, extractIdx, "html-response command must call extractHTMLResponse")
+	require.NotEqual(t, -1, truncateIdx, "html-response command with --limit must call truncateJSONArray")
+	require.Less(t, extractIdx, truncateIdx,
+		"truncateJSONArray must run after extractHTMLResponse so --limit applies to extracted items")
+}
+
+func jsonResultCount(t *testing.T, out []byte) int {
+	t.Helper()
+	var envelope struct {
+		Results []json.RawMessage `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(out, &envelope), string(out))
+	if envelope.Results != nil {
+		return len(envelope.Results)
+	}
+	var arr []json.RawMessage
+	require.NoError(t, json.Unmarshal(out, &arr), string(out))
+	return len(arr)
 }

--- a/internal/generator/limit_truncation_test.go
+++ b/internal/generator/limit_truncation_test.go
@@ -267,8 +267,8 @@ func TestHTMLResponseLimitAppliesAfterExtraction(t *testing.T) {
 	promotedHTML := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_listings.go")
 	nestedHTML := readGeneratedFile(t, outputDir, "internal", "cli", "catalog_list.go")
 	jsonSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_orders.go")
-	assertTruncateAfterHTMLExtract(t, promotedHTML)
-	assertTruncateAfterHTMLExtract(t, nestedHTML)
+	assertHTMLLimitOrder(t, promotedHTML)
+	assertHTMLLimitOrder(t, nestedHTML)
 	require.Contains(t, jsonSrc, "truncateJSONArray(cmd.Context(), data,",
 		"JSON list endpoints must keep client-side --limit truncation")
 	require.NotContains(t, jsonSrc, "extractHTMLResponse(",
@@ -277,8 +277,8 @@ func TestHTMLResponseLimitAppliesAfterExtraction(t *testing.T) {
 	binaryPath := filepath.Join(outputDir, naming.CLI(apiSpec.Name))
 	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/"+naming.CLI(apiSpec.Name))
 
-	baseEnv := append(os.Environ(),
-		"HOME="+t.TempDir(),
+	home := t.TempDir()
+	baseEnv := isolatedCLIEnv(t, home,
 		strings.ToUpper(strings.ReplaceAll(apiSpec.Name, "-", "_"))+"_BASE_URL="+server.URL,
 	)
 	for _, tc := range []struct {
@@ -301,7 +301,7 @@ func TestHTMLResponseLimitAppliesAfterExtraction(t *testing.T) {
 	}
 }
 
-func assertTruncateAfterHTMLExtract(t *testing.T, src string) {
+func assertHTMLLimitOrder(t *testing.T, src string) {
 	t.Helper()
 	extractIdx := strings.Index(src, "extractHTMLResponse(")
 	truncateIdx := strings.Index(src, "truncateJSONArray(")
@@ -309,6 +309,83 @@ func assertTruncateAfterHTMLExtract(t *testing.T, src string) {
 	require.NotEqual(t, -1, truncateIdx, "html-response command with --limit must call truncateJSONArray")
 	require.Less(t, extractIdx, truncateIdx,
 		"truncateJSONArray must run after extractHTMLResponse so --limit applies to extracted items")
+	if pathIdx := strings.Index(src, "applyResponsePath("); pathIdx != -1 {
+		require.Less(t, pathIdx, truncateIdx,
+			"truncateJSONArray must run after applyResponsePath so --limit applies to the selected array")
+	}
+}
+
+func TestHTMLResponseLimitFollowsStorelessResponsePath(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("html-limit-path")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Learn.Disabled = true
+	apiSpec.Resources = map[string]spec.Resource{
+		"gallery": {
+			Description: "HTML gallery page",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:         http.MethodGet,
+					Path:           "/gallery",
+					Description:    "List gallery links from a page object",
+					Params:         []spec.Param{{Name: "limit", Type: "integer", Default: 10}},
+					ResponseFormat: spec.ResponseFormatHTML,
+					ResponsePath:   "links",
+					HTMLExtract: &spec.HTMLExtract{
+						Mode:         spec.HTMLExtractModePage,
+						LinkPrefixes: []string{"/items"},
+					},
+					Response: spec.ResponseDef{Type: "array", Item: "html_link"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{MCP: true}
+	require.NoError(t, gen.Generate())
+
+	src := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_gallery.go")
+	extractIdx := strings.Index(src, "extractHTMLResponse(")
+	pathIdx := strings.Index(src, "applyResponsePath(")
+	truncateIdx := strings.Index(src, "truncateJSONArray(")
+	require.NotEqual(t, -1, extractIdx)
+	require.NotEqual(t, -1, pathIdx)
+	require.NotEqual(t, -1, truncateIdx)
+	require.Less(t, extractIdx, pathIdx)
+	require.Less(t, pathIdx, truncateIdx,
+		"storeless html-response commands must truncate after ResponsePath unwraps extracted items")
+}
+
+func isolatedCLIEnv(t *testing.T, home string, extra ...string) []string {
+	t.Helper()
+	drop := map[string]struct{}{
+		"HOME": {}, "USERPROFILE": {},
+		"XDG_CONFIG_HOME": {}, "XDG_DATA_HOME": {},
+		"XDG_STATE_HOME": {}, "XDG_CACHE_HOME": {},
+	}
+	env := make([]string, 0, len(os.Environ())+len(extra)+6)
+	for _, kv := range os.Environ() {
+		key, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
+		if _, skip := drop[key]; skip {
+			continue
+		}
+		env = append(env, kv)
+	}
+	env = append(env,
+		"HOME="+home,
+		"USERPROFILE="+home,
+		"XDG_CONFIG_HOME="+filepath.Join(home, ".config"),
+		"XDG_DATA_HOME="+filepath.Join(home, ".local", "share"),
+		"XDG_STATE_HOME="+filepath.Join(home, ".local", "state"),
+		"XDG_CACHE_HOME="+filepath.Join(home, ".cache"),
+	)
+	return append(env, extra...)
 }
 
 func jsonResultCount(t *testing.T, out []byte) int {

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -906,7 +906,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				}
 			}
 {{- end}}
-{{- if endpointNeedsClientLimit .Endpoint}}
+{{- if and (endpointNeedsClientLimit .Endpoint) (not .Endpoint.UsesHTMLResponse)}}
 			// Honor --limit when the API accepts but ignores ?limit=N.
 			data = truncateJSONArray(cmd.Context(), data, flagLimit)
 {{- end}}
@@ -916,6 +916,10 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				data = applyResponsePath(data, {{printf "%q" .Endpoint.ResponsePath}})
 			}
 
+{{- end}}
+{{- if and (endpointNeedsClientLimit .Endpoint) .Endpoint.UsesHTMLResponse}}
+			// Honor --limit on extracted items, after any response-path unwrap.
+			data = truncateJSONArray(cmd.Context(), data, flagLimit)
 {{- end}}
 {{- if .IsAsync}}
 			if asyncJobID := ExtractJobID(data, "{{.Async.JobIDField}}"); asyncJobID != "" {

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -885,11 +885,6 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				data = filterJSONByFieldValues(data, {{printf "%q" .Field}}, formatCLIParamValue(flag{{camel (paramIdent .Param)}}))
 			}
 {{- end}}
-{{- if endpointNeedsClientLimit .Endpoint}}
-			// Honor --limit when the API accepts but ignores ?limit=N.
-			data = truncateJSONArray(cmd.Context(), data, flagLimit)
-{{- end}}
-
 {{- if .Endpoint.UsesHTMLResponse}}
 			if !flags.dryRun {
 				data, err = extractHTMLResponse(data, htmlExtractionOptions{
@@ -910,6 +905,10 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 					return err
 				}
 			}
+{{- end}}
+{{- if endpointNeedsClientLimit .Endpoint}}
+			// Honor --limit when the API accepts but ignores ?limit=N.
+			data = truncateJSONArray(cmd.Context(), data, flagLimit)
 {{- end}}
 
 {{- if and (not $isMutationOutput) .Endpoint.ResponsePath (not .HasStore)}}

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -911,7 +911,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			data = truncateJSONArray(cmd.Context(), data, flagLimit)
 {{- end}}
 
-{{- if and (not $isMutationOutput) .Endpoint.ResponsePath (not .HasStore)}}
+{{- if and (not $isMutationOutput) .Endpoint.ResponsePath (or (not .HasStore) .Endpoint.UsesHTMLResponse)}}
 			if !flags.dryRun {
 				data = applyResponsePath(data, {{printf "%q" .Endpoint.ResponsePath}})
 			}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -531,7 +531,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			}
 
 {{- end}}
-{{- if endpointNeedsClientLimit .Endpoint}}
+{{- if and (endpointNeedsClientLimit .Endpoint) (not .Endpoint.UsesHTMLResponse)}}
 			// Honor --limit when the API accepts but ignores ?limit=N.
 			data = truncateJSONArray(cmd.Context(), data, flagLimit)
 {{- end}}
@@ -540,6 +540,10 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				data = applyResponsePath(data, {{printf "%q" .Endpoint.ResponsePath}})
 			}
 
+{{- end}}
+{{- if and (endpointNeedsClientLimit .Endpoint) .Endpoint.UsesHTMLResponse}}
+			// Honor --limit on extracted items, after any response-path unwrap.
+			data = truncateJSONArray(cmd.Context(), data, flagLimit)
 {{- end}}
 {{- if $supportsAllPagination}}
 			outputData := collectionItemsForOutput(data, path)

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -508,10 +508,6 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				data = filterJSONByFieldValues(data, {{printf "%q" .Field}}, formatCLIParamValue(flag{{camel (paramIdent .Param)}}))
 			}
 {{- end}}
-{{- if endpointNeedsClientLimit .Endpoint}}
-			// Honor --limit when the API accepts but ignores ?limit=N.
-			data = truncateJSONArray(cmd.Context(), data, flagLimit)
-{{- end}}
 {{- if .Endpoint.UsesHTMLResponse}}
 			if !flags.dryRun {
 				data, err = extractHTMLResponse(data, htmlExtractionOptions{
@@ -534,6 +530,10 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				}
 			}
 
+{{- end}}
+{{- if endpointNeedsClientLimit .Endpoint}}
+			// Honor --limit when the API accepts but ignores ?limit=N.
+			data = truncateJSONArray(cmd.Context(), data, flagLimit)
 {{- end}}
 {{- if and (or .IsReadOnly (eq .Endpoint.Method "GET") (eq .Endpoint.Method "HEAD")) .Endpoint.ResponsePath (not .HasStore)}}
 			if !flags.dryRun {

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -535,7 +535,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			// Honor --limit when the API accepts but ignores ?limit=N.
 			data = truncateJSONArray(cmd.Context(), data, flagLimit)
 {{- end}}
-{{- if and (or .IsReadOnly (eq .Endpoint.Method "GET") (eq .Endpoint.Method "HEAD")) .Endpoint.ResponsePath (not .HasStore)}}
+{{- if and (or .IsReadOnly (eq .Endpoint.Method "GET") (eq .Endpoint.Method "HEAD")) .Endpoint.ResponsePath (or (not .HasStore) .Endpoint.UsesHTMLResponse)}}
 			if !flags.dryRun {
 				data = applyResponsePath(data, {{printf "%q" .Endpoint.ResponsePath}})
 			}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

`--limit` on html-response endpoints was a silent no-op (or could corrupt output) because generated commands ran `truncateJSONArray` on raw markup before `extractHTMLResponse`. Store-backed page endpoints with `ResponsePath` still ignored `--limit` because the resolver applied that path to raw HTML (no-op) and the command skipped reapplying it after extract.

Closes #3433

## Approach

Move client-side `truncateJSONArray` after HTML extraction. Re-run `applyResponsePath` after extract when the endpoint is HTML, including store-backed commands, so page-mode `links` arrays honor `--limit`. JSON store paths still unwrap only inside the resolver (`not .HasStore` stays in place for non-HTML). Pagination and HTML extractors are unchanged.

## Scope

Primary area: generator command templates (html-response read paths)

Why this belongs in this repo: the mis-ordering is unconditional in shared templates, so every future printed CLI with an html-response `--limit` endpoint inherits the bug until the Printing Press emits the correct order.

## Risk

Generated command source order changes for html-response endpoints that also emit `--limit`. JSON `--limit` behavior is unchanged. No MCP, auth, publish, or pagination changes.

## Output Contract

- Emitted-code assertion: `extractHTMLResponse` precedes `truncateJSONArray`; HTML commands with `ResponsePath` emit `applyResponsePath` after extract even when `HasStore` is true; store-backed JSON commands do not re-emit `applyResponsePath` after the resolver.
- Compiled generated CLI: storeless and store-backed page-mode `--limit 2` return 2 extracted items; JSON `--limit 2` still returns 2 items.

Existing golden fixtures do not snapshot these command files. All `generate-*` golden cases passed `scripts/golden.sh verify` with no fixture updates.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

- `go test ./internal/generator -run 'TestHTMLResponseLimit'` — pass
- `scripts/golden.sh verify` — all `generate-*` cases pass; remaining local misses are environment, not this reorder
- `go test ./...` — running after this revision

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40eabfe0-5ba0-464c-8016-f72d1de2423a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40eabfe0-5ba0-464c-8016-f72d1de2423a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

