### PR TITLE
fix(cli): expose a queryable bare id for parent-keyed typed tables

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -4299,7 +4299,64 @@ func (g *Generator) schemaWithDependentParents() []TableDef {
 	// domain table routed through generic storage by BuildSchema.
 	routeReservedStoreTablesToGenericOnly(domainSchema, reservedStoreObjectNames(g.Spec))
 
+	var dependent []profiler.DependentResource
+	if g.profile != nil {
+		dependent = g.profile.DependentSyncResources
+	}
+	attachBareIDColumns(schema, dependent)
+
 	return schema
+}
+
+// attachBareIDColumns adds a queryable generated bare_id to parent-keyed
+// typed tables. resourceStorageID writes id+NUL+parent as the primary key;
+// SQL that compares id to a bare API id therefore misses. The column
+// projects the same value BareResourceID returns so store queries can
+// filter without matching the hidden parent suffix.
+func attachBareIDColumns(tables []TableDef, dependent []profiler.DependentResource) {
+	parentKeyed := make(map[string]struct{})
+	for _, entry := range resourceParentKeyColumnEntries(tables, dependent) {
+		parentKeyed[entry.Name] = struct{}{}
+	}
+	for i := range tables {
+		table := &tables[i]
+		if !emitsDomainTable(*table) || !isParentKeyedTypedTable(*table, parentKeyed) {
+			continue
+		}
+		if hasNamedColumn(*table, storeBareIDColumn) {
+			continue
+		}
+		table.Columns = append(table.Columns, ColumnDef{
+			Name:      storeBareIDColumn,
+			Type:      storeBareIDType,
+			Generated: true,
+		})
+		table.Indexes = append(table.Indexes, IndexDef{
+			Name:      "idx_" + table.Name + "_" + storeBareIDColumn,
+			TableName: table.Name,
+			Columns:   storeBareIDColumn,
+		})
+	}
+}
+
+func isParentKeyedTypedTable(table TableDef, parentKeyed map[string]struct{}) bool {
+	if table.ParentKeyColumn != "" {
+		return true
+	}
+	if _, ok := parentKeyed[table.Resource]; ok {
+		return true
+	}
+	_, ok := parentKeyed[table.Name]
+	return ok
+}
+
+func hasNamedColumn(table TableDef, name string) bool {
+	for _, col := range table.Columns {
+		if col.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func (g *Generator) renderStoreFiles(schema []TableDef) error {
@@ -6025,7 +6082,19 @@ func camelToJSON(s string) string {
 	return strings.Join(parts, "")
 }
 
+func writableStoreColumns(cols []ColumnDef) []ColumnDef {
+	out := make([]ColumnDef, 0, len(cols))
+	for _, col := range cols {
+		if col.Generated {
+			continue
+		}
+		out = append(out, col)
+	}
+	return out
+}
+
 func columnNames(cols []ColumnDef) string {
+	cols = writableStoreColumns(cols)
 	names := make([]string, 0, len(cols))
 	for _, col := range cols {
 		names = append(names, safeSQLName(col.Name))
@@ -6034,6 +6103,7 @@ func columnNames(cols []ColumnDef) string {
 }
 
 func columnPlaceholders(cols []ColumnDef) string {
+	cols = writableStoreColumns(cols)
 	if len(cols) == 0 {
 		return ""
 	}
@@ -6046,7 +6116,7 @@ func columnPlaceholders(cols []ColumnDef) string {
 
 func updateSet(cols []ColumnDef) string {
 	var updates []string
-	for _, col := range cols {
+	for _, col := range writableStoreColumns(cols) {
 		if col.PrimaryKey {
 			continue
 		}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -4320,7 +4320,11 @@ func attachBareIDColumns(tables []TableDef, dependent []profiler.DependentResour
 	}
 	for i := range tables {
 		table := &tables[i]
-		if !emitsDomainTable(*table) || !isParentKeyedTypedTable(*table, parentKeyed) {
+		// JSON-only fallback keeps id/data/synced_at only; parent context
+		// for those rows lives in the generic resources table, so the
+		// parent-keyed bare_id projection must not come back after a
+		// wide-cap reset.
+		if table.JSONOnlyFallback || !emitsDomainTable(*table) || !isParentKeyedTypedTable(*table, parentKeyed) {
 			continue
 		}
 		if hasNamedColumn(*table, storeBareIDColumn) {

--- a/internal/generator/schema_builder.go
+++ b/internal/generator/schema_builder.go
@@ -34,7 +34,18 @@ type ColumnDef struct {
 	Type       string
 	PrimaryKey bool
 	NotNull    bool
+	// Generated marks a SQLite generated column. Writers must omit it from
+	// INSERT/UPDATE; the engine computes it from other columns on read.
+	Generated bool
 }
+
+const (
+	storeBareIDColumn = "bare_id"
+	// VIRTUAL so existing databases can ADD COLUMN on open. SQLite rejects
+	// ALTER TABLE ADD of a STORED generated column; the matching index
+	// materializes the value for lookups.
+	storeBareIDType = `TEXT GENERATED ALWAYS AS (substr(id, 1, coalesce(nullif(instr(id, char(0)), 0) - 1, length(id)))) VIRTUAL`
+)
 
 type IndexDef struct {
 	Name      string

--- a/internal/generator/store_bare_id_test.go
+++ b/internal/generator/store_bare_id_test.go
@@ -1,0 +1,309 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWritableStoreColumnsOmitsGenerated(t *testing.T) {
+	t.Parallel()
+
+	cols := []ColumnDef{
+		{Name: "id", Type: "TEXT", PrimaryKey: true},
+		{Name: "data", Type: "JSON", NotNull: true},
+		{Name: storeBareIDColumn, Type: storeBareIDType, Generated: true},
+	}
+
+	got := writableStoreColumns(cols)
+	require.Len(t, got, 2)
+	assert.Equal(t, `"id", "data"`, columnNames(cols))
+	assert.Equal(t, "?, ?", columnPlaceholders(cols))
+	assert.Equal(t, `"data" = excluded."data"`, updateSet(cols))
+}
+
+func TestAttachBareIDColumnsAddsQueryableColumn(t *testing.T) {
+	t.Parallel()
+
+	tables := []TableDef{
+		{
+			Name:            "contacts",
+			Resource:        "contacts",
+			ParentKeyColumn: "lists_id",
+			Columns: []ColumnDef{
+				{Name: "id", Type: "TEXT", PrimaryKey: true},
+				{Name: "lists_id", Type: "TEXT", NotNull: true},
+				{Name: "data", Type: "JSON", NotNull: true},
+				{Name: "synced_at", Type: "DATETIME DEFAULT CURRENT_TIMESTAMP"},
+			},
+		},
+		{
+			Name:     "lists",
+			Resource: "lists",
+			Columns:  append([]ColumnDef(nil), baseTableColumns...),
+		},
+	}
+
+	attachBareIDColumns(tables, nil)
+
+	contacts := tables[0]
+	require.True(t, hasNamedColumn(contacts, storeBareIDColumn))
+	var bare ColumnDef
+	for _, col := range contacts.Columns {
+		if col.Name == storeBareIDColumn {
+			bare = col
+			break
+		}
+	}
+	assert.True(t, bare.Generated)
+	assert.Equal(t, storeBareIDType, bare.Type)
+	assert.Contains(t, contacts.Indexes, IndexDef{
+		Name:      "idx_contacts_bare_id",
+		TableName: "contacts",
+		Columns:   storeBareIDColumn,
+	})
+
+	assert.False(t, hasNamedColumn(tables[1], storeBareIDColumn),
+		"non-parent-keyed tables must not grow a bare_id column")
+}
+
+func TestAttachBareIDColumnsJSONOnlyFallbackDependent(t *testing.T) {
+	t.Parallel()
+
+	tables := []TableDef{{
+		Name:             "items",
+		Resource:         "items",
+		JSONOnlyFallback: true,
+		Columns:          append([]ColumnDef(nil), baseTableColumns...),
+	}}
+	attachBareIDColumns(tables, []profiler.DependentResource{{Name: "items"}})
+
+	require.True(t, hasNamedColumn(tables[0], storeBareIDColumn),
+		"JSON-only dependent tables still store a composite id and need a queryable bare_id")
+	assert.True(t, tables[0].Columns[len(tables[0].Columns)-1].Generated)
+}
+
+func TestAttachBareIDColumnsSkipsExistingBareID(t *testing.T) {
+	t.Parallel()
+
+	tables := []TableDef{{
+		Name:            "nodes",
+		Resource:        "nodes",
+		ParentKeyColumn: "files_id",
+		Columns: []ColumnDef{
+			{Name: "id", Type: "TEXT", PrimaryKey: true},
+			{Name: "files_id", Type: "TEXT", NotNull: true},
+			{Name: "data", Type: "JSON", NotNull: true},
+			{Name: "synced_at", Type: "DATETIME DEFAULT CURRENT_TIMESTAMP"},
+			{Name: storeBareIDColumn, Type: "TEXT"},
+		},
+	}}
+	attachBareIDColumns(tables, nil)
+
+	var count int
+	for _, col := range tables[0].Columns {
+		if col.Name == storeBareIDColumn {
+			count++
+			assert.False(t, col.Generated, "existing API bare_id column must stay writable")
+		}
+	}
+	assert.Equal(t, 1, count)
+}
+
+func parentKeyedBareIDSpec(name string) *spec.APISpec {
+	apiSpec := minimalSpec(name)
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Learn.Disabled = true
+	apiSpec.Resources = map[string]spec.Resource{
+		"domains": {
+			Description: "Manage domains",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/domains", Description: "List domains"},
+			},
+			SubResources: map[string]spec.Resource{
+				"verify": {
+					Description: "Verify a domain",
+					Endpoints: map[string]spec.Endpoint{
+						"get": {
+							Method:      "GET",
+							Path:        "/domains/{domainId}/verify",
+							Description: "Get verification status",
+							Params:      []spec.Param{{Name: "domainId", Type: "string", Required: true, Positional: true}},
+						},
+					},
+				},
+			},
+		},
+		"widgets": {
+			Description: "Read widgets",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/widgets",
+					Description: "List widgets",
+					Response:    spec.ResponseDef{Type: "array", Item: "Widget"},
+				},
+				"get": {
+					Method:      "GET",
+					Path:        "/widgets/{id}",
+					Description: "Get widget",
+					Params:      []spec.Param{{Name: "id", Type: "string", Required: true, PathParam: true}},
+					Response:    spec.ResponseDef{Type: "object", Item: "Widget"},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Widget": {
+			Fields: []spec.TypeField{
+				{Name: "id", Type: "string"},
+				{Name: "name", Type: "string"},
+				{Name: "description", Type: "string"},
+			},
+		},
+	}
+	return apiSpec
+}
+
+// TestGeneratedStoreBareIDQueryable proves the emitted store contract: a
+// parent-keyed typed table writes the NUL-composite primary key and exposes
+// a generated bare_id that SQL can filter on. Assertions cover emitted
+// CREATE/INSERT shape and compile-plus-runtime behavior through the real
+// UpsertBatch writer, including the existing-database ADD COLUMN path.
+func TestGeneratedStoreBareIDQueryable(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := parentKeyedBareIDSpec("bare-id-query")
+	outputDir := filepath.Join(t.TempDir(), "bare-id-query-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	storeSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	src := string(storeSrc)
+
+	require.Contains(t, src, `"bare_id" TEXT GENERATED ALWAYS AS (substr(id, 1, coalesce(nullif(instr(id, char(0)), 0) - 1, length(id)))) VIRTUAL`,
+		"parent-keyed typed table must declare a generated bare_id")
+	require.Contains(t, src, `"idx_verify_bare_id" ON "verify"("bare_id")`,
+		"bare_id must be indexed for SQL lookups")
+	require.Contains(t, src, `{table: "verify", column: "bare_id", decl: "TEXT GENERATED ALWAYS AS (substr(id, 1, coalesce(nullif(instr(id, char(0)), 0) - 1, length(id)))) VIRTUAL"}`,
+		"existing databases must backfill bare_id on open")
+	require.Contains(t, src, `INSERT INTO "verify" ("id", "domains_id", "data", "synced_at")`,
+		"generated bare_id must not appear in INSERT")
+	require.NotContains(t, src, `lookupFieldValue(obj, "bare_id")`,
+		"upsert must not write the generated bare_id column")
+	require.Contains(t, src, "WHERE bare_id = ? finds them",
+		"BareResourceID doc must point SQL callers at bare_id")
+
+	// Non-parent-keyed widgets stay on a bare primary key; no generated column.
+	require.Contains(t, src, `CREATE TABLE IF NOT EXISTS "widgets"`)
+	require.NotContains(t, src, `"idx_widgets_bare_id"`)
+	require.NotContains(t, src, `{table: "widgets", column: "bare_id"`)
+
+	testPath := filepath.Join(outputDir, "internal", "store", "bare_id_query_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(generatedBareIDQueryTest), 0o644))
+
+	// Compile the emitted store package rather than `go build ./...`:
+	// requireGeneratedCompiles also builds the MCP binary, which this
+	// store-only fixture cannot resolve under the harness tidy no-op.
+	runGoCommandRequired(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "TestBareID_", "-count=1")
+}
+
+const generatedBareIDQueryTest = `package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestBareID_UpsertBatchQueryableByBareID(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	items := []json.RawMessage{
+		json.RawMessage(` + "`" + `{"id":"rec-1","domains_id":"parent-a"}` + "`" + `),
+		json.RawMessage(` + "`" + `{"id":"rec-1","domains_id":"parent-b"}` + "`" + `),
+	}
+	if _, _, err := s.UpsertBatch("verify", items); err != nil {
+		t.Fatalf("UpsertBatch: %v", err)
+	}
+
+	db := s.DB()
+	var n int
+	if err := db.QueryRow(` + "`" + `SELECT COUNT(*) FROM "verify" WHERE id = ?` + "`" + `, "rec-1").Scan(&n); err != nil {
+		t.Fatalf("count by composite id: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("WHERE id = bare API id matched %d rows; composite primary keys must miss", n)
+	}
+	if err := db.QueryRow(` + "`" + `SELECT COUNT(*) FROM "verify" WHERE bare_id = ?` + "`" + `, "rec-1").Scan(&n); err != nil {
+		t.Fatalf("count by bare_id: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("WHERE bare_id = rec-1 matched %d rows, want 2 (one per parent)", n)
+	}
+
+	var storageID string
+	if err := db.QueryRow(` + "`" + `SELECT id FROM "verify" WHERE bare_id = ? AND domains_id = ?` + "`" + `, "rec-1", "parent-a").Scan(&storageID); err != nil {
+		t.Fatalf("select storage id: %v", err)
+	}
+	if BareResourceID(storageID) != "rec-1" {
+		t.Fatalf("BareResourceID(%q) = %q, want rec-1", storageID, BareResourceID(storageID))
+	}
+	if !strings.Contains(storageID, "\x00") {
+		t.Fatalf("storage id %q is not the NUL-composite the writer produces", storageID)
+	}
+}
+
+func TestBareID_UpgradeExistingCompositeRows(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "old.db")
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	if _, err := raw.Exec(` + "`" + `CREATE TABLE "verify" (
+		id TEXT PRIMARY KEY,
+		domains_id TEXT NOT NULL,
+		data JSON NOT NULL,
+		synced_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	)` + "`" + `); err != nil {
+		raw.Close()
+		t.Fatalf("create old table: %v", err)
+	}
+	if _, err := raw.Exec(` + "`" + `INSERT INTO "verify" (id, domains_id, data) VALUES (?, ?, ?)` + "`" + `,
+		"rec-1\x00parent-a", "parent-a", ` + "`" + `{"id":"rec-1"}` + "`" + `); err != nil {
+		raw.Close()
+		t.Fatalf("insert composite row: %v", err)
+	}
+	raw.Close()
+
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open upgraded store: %v", err)
+	}
+	defer s.Close()
+
+	var n int
+	if err := s.DB().QueryRow(` + "`" + `SELECT COUNT(*) FROM "verify" WHERE bare_id = ?` + "`" + `, "rec-1").Scan(&n); err != nil {
+		t.Fatalf("count upgraded bare_id: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("upgraded bare_id match = %d, want 1 (generated column must cover pre-existing composite rows)", n)
+	}
+}
+`

--- a/internal/generator/store_bare_id_test.go
+++ b/internal/generator/store_bare_id_test.go
@@ -83,9 +83,10 @@ func TestAttachBareIDColumnsJSONOnlyFallbackDependent(t *testing.T) {
 	}}
 	attachBareIDColumns(tables, []profiler.DependentResource{{Name: "items"}})
 
-	require.True(t, hasNamedColumn(tables[0], storeBareIDColumn),
-		"JSON-only dependent tables still store a composite id and need a queryable bare_id")
-	assert.True(t, tables[0].Columns[len(tables[0].Columns)-1].Generated)
+	assert.False(t, hasNamedColumn(tables[0], storeBareIDColumn),
+		"JSON-only fallback must keep only id/data/synced_at")
+	assert.Empty(t, tables[0].Indexes,
+		"JSON-only fallback must not grow a bare_id index")
 }
 
 func TestAttachBareIDColumnsSkipsExistingBareID(t *testing.T) {
@@ -194,6 +195,8 @@ func TestGeneratedStoreBareIDQueryable(t *testing.T) {
 		"bare_id must be indexed for SQL lookups")
 	require.Contains(t, src, `{table: "verify", column: "bare_id", decl: "TEXT GENERATED ALWAYS AS (substr(id, 1, coalesce(nullif(instr(id, char(0)), 0) - 1, length(id)))) VIRTUAL"}`,
 		"existing databases must backfill bare_id on open")
+	require.Contains(t, src, `SELECT name FROM pragma_table_xinfo(?) WHERE name=?`,
+		"ensureColumn must see generated columns; table_info omits them")
 	require.Contains(t, src, `INSERT INTO "verify" ("id", "domains_id", "data", "synced_at")`,
 		"generated bare_id must not appear in INSERT")
 	require.NotContains(t, src, `lookupFieldValue(obj, "bare_id")`,
@@ -205,6 +208,13 @@ func TestGeneratedStoreBareIDQueryable(t *testing.T) {
 	require.Contains(t, src, `CREATE TABLE IF NOT EXISTS "widgets"`)
 	require.NotContains(t, src, `"idx_widgets_bare_id"`)
 	require.NotContains(t, src, `{table: "widgets", column: "bare_id"`)
+
+	schemaTest, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "schema_version_test.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(schemaTest), `SELECT name FROM pragma_table_xinfo(?)`,
+		"upgrade verify must use table_xinfo so generated bare_id is visible")
+	require.NotContains(t, string(schemaTest), `PRAGMA table_info("verify")`,
+		"table_info hides generated columns and would false-fail the upgrade check")
 
 	testPath := filepath.Join(outputDir, "internal", "store", "bare_id_query_test.go")
 	require.NoError(t, os.WriteFile(testPath, []byte(generatedBareIDQueryTest), 0o644))

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -372,25 +372,19 @@ func (s *Store) ensureColumn(ctx context.Context, conn *sql.Conn, table, column,
 		return fmt.Errorf("checking table %s: %w", table, err)
 	}
 
-	rows, err := conn.QueryContext(ctx, fmt.Sprintf(`PRAGMA table_info("%s")`, table))
-	if err != nil {
-		return fmt.Errorf("table_info %s: %w", table, err)
+	// table_info omits generated columns (VIRTUAL/STORED). table_xinfo
+	// reports them so a later Open does not re-ADD a column CREATE TABLE
+	// already declared, and so upgrades can see a prior ADD of bare_id.
+	var existing string
+	err = conn.QueryRowContext(ctx,
+		`SELECT name FROM pragma_table_xinfo(?) WHERE name=?`,
+		table, column,
+	).Scan(&existing)
+	if err == nil {
+		return nil
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var cid int
-		var n, typ string
-		var notnull, pk int
-		var dflt sql.NullString
-		if err := rows.Scan(&cid, &n, &typ, &notnull, &dflt, &pk); err != nil {
-			return fmt.Errorf("scan table_info %s: %w", table, err)
-		}
-		if n == column {
-			return nil
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterating table_info %s: %w", table, err)
+	if err != sql.ErrNoRows {
+		return fmt.Errorf("table_xinfo %s: %w", table, err)
 	}
 
 	if _, err := conn.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE "%s" ADD COLUMN "%s" %s`, table, column, decl)); err != nil {

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1856,7 +1856,8 @@ func (s *Store) upsert{{pascal .Name}}Tx(tx *sql.Tx, id string, obj map[string]a
 		 VALUES ({{columnPlaceholders .Columns}})
 		 ON CONFLICT({{safeName "id"}}) DO UPDATE SET {{updateSet .Columns}}`,
 {{- range .Columns}}
-{{- if eq .Name "id"}}
+{{- if .Generated}}
+{{- else if eq .Name "id"}}
 		id,
 {{- else if eq .Name "data"}}
 		string(data),
@@ -2148,6 +2149,11 @@ func resourceStorageID(resourceType, id string, obj map[string]any) string {
 // returns composite keys for parent-keyed resources, so callers comparing those
 // ids against bare API ids must run them through this first. For non-composite
 // ids it returns the input unchanged, so it is safe to apply to every id.
+//
+// Parent-keyed typed tables also project this value as a generated bare_id
+// column (indexed) so SQL/store queries can filter on the entity id without
+// matching the hidden parent suffix. WHERE id = ? against a bare API id
+// misses those rows; WHERE bare_id = ? finds them.
 func BareResourceID(storageID string) string {
 	if i := strings.IndexByte(storageID, 0); i >= 0 {
 		return storageID[:i]
@@ -2521,7 +2527,8 @@ func (s *Store) GetSyncCursor(resourceType string) string {
 // ListIDs returns all IDs from a resource's domain table, or from the generic
 // resources table if no domain table exists. Used by dependent sync to iterate parents.
 // For parent-keyed resource types these are composite storage keys; run them
-// through BareResourceID before comparing against bare API ids.
+// through BareResourceID before comparing against bare API ids, or filter the
+// typed table's generated bare_id column from SQL.
 //
 // resourceType is never interpolated into SQL directly. We resolve it to a real
 // table name via a parameterized sqlite_master lookup; only that trusted name is

--- a/internal/generator/templates/store_schema_version_test.go.tmpl
+++ b/internal/generator/templates/store_schema_version_test.go.tmpl
@@ -1540,20 +1540,18 @@ func TestMigrate_AddsColumnsOnUpgrade_{{pascal $table.Name}}(t *testing.T) {
 	}
 	defer s.Close()
 
-	// The migration must have added every generated column.
-	rows, err := s.DB().Query(`PRAGMA table_info({{safeName $table.Name}})`)
+	// table_info hides generated columns; table_xinfo is the verify
+	// surface for VIRTUAL backfills such as bare_id.
+	rows, err := s.DB().Query(`SELECT name FROM pragma_table_xinfo(?)`, "{{$table.Name}}")
 	if err != nil {
-		t.Fatalf("table_info: %v", err)
+		t.Fatalf("table_xinfo: %v", err)
 	}
 	defer rows.Close()
 
 	hasColumn := make(map[string]bool)
 	for rows.Next() {
-		var cid int
-		var name, typ string
-		var notnull, pk int
-		var dflt sql.NullString
-		if err := rows.Scan(&cid, &name, &typ, &notnull, &dflt, &pk); err != nil {
+		var name string
+		if err := rows.Scan(&name); err != nil {
 			t.Fatalf("scan: %v", err)
 		}
 		hasColumn[name] = true
@@ -1571,6 +1569,20 @@ func TestMigrate_AddsColumnsOnUpgrade_{{pascal $table.Name}}(t *testing.T) {
 	} {
 		if !hasColumn[want] {
 			t.Fatalf("%s column missing from {{$table.Name}} after migrate", want)
+		}
+	}
+
+	for _, wantIdx := range []string{
+{{- range $idx := $table.Indexes}}
+		"{{$idx.Name}}",
+{{- end}}
+	} {
+		var got string
+		if err := s.DB().QueryRow(
+			`SELECT name FROM sqlite_master WHERE type='index' AND name=?`,
+			wantIdx,
+		).Scan(&got); err != nil {
+			t.Fatalf("%s index missing from {{$table.Name}} after migrate: %v", wantIdx, err)
 		}
 	}
 }

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -1770,6 +1770,11 @@ func resourceStorageID(resourceType, id string, obj map[string]any) string {
 // returns composite keys for parent-keyed resources, so callers comparing those
 // ids against bare API ids must run them through this first. For non-composite
 // ids it returns the input unchanged, so it is safe to apply to every id.
+//
+// Parent-keyed typed tables also project this value as a generated bare_id
+// column (indexed) so SQL/store queries can filter on the entity id without
+// matching the hidden parent suffix. WHERE id = ? against a bare API id
+// misses those rows; WHERE bare_id = ? finds them.
 func BareResourceID(storageID string) string {
 	if i := strings.IndexByte(storageID, 0); i >= 0 {
 		return storageID[:i]
@@ -1995,7 +2000,8 @@ func (s *Store) GetSyncCursor(resourceType string) string {
 // ListIDs returns all IDs from a resource's domain table, or from the generic
 // resources table if no domain table exists. Used by dependent sync to iterate parents.
 // For parent-keyed resource types these are composite storage keys; run them
-// through BareResourceID before comparing against bare API ids.
+// through BareResourceID before comparing against bare API ids, or filter the
+// typed table's generated bare_id column from SQL.
 //
 // resourceType is never interpolated into SQL directly. We resolve it to a real
 // table name via a parameterized sqlite_master lookup; only that trusted name is

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -357,25 +357,19 @@ func (s *Store) ensureColumn(ctx context.Context, conn *sql.Conn, table, column,
 		return fmt.Errorf("checking table %s: %w", table, err)
 	}
 
-	rows, err := conn.QueryContext(ctx, fmt.Sprintf(`PRAGMA table_info("%s")`, table))
-	if err != nil {
-		return fmt.Errorf("table_info %s: %w", table, err)
+	// table_info omits generated columns (VIRTUAL/STORED). table_xinfo
+	// reports them so a later Open does not re-ADD a column CREATE TABLE
+	// already declared, and so upgrades can see a prior ADD of bare_id.
+	var existing string
+	err = conn.QueryRowContext(ctx,
+		`SELECT name FROM pragma_table_xinfo(?) WHERE name=?`,
+		table, column,
+	).Scan(&existing)
+	if err == nil {
+		return nil
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var cid int
-		var n, typ string
-		var notnull, pk int
-		var dflt sql.NullString
-		if err := rows.Scan(&cid, &n, &typ, &notnull, &dflt, &pk); err != nil {
-			return fmt.Errorf("scan table_info %s: %w", table, err)
-		}
-		if n == column {
-			return nil
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterating table_info %s: %w", table, err)
+	if err != sql.ErrNoRows {
+		return fmt.Errorf("table_xinfo %s: %w", table, err)
 	}
 
 	if _, err := conn.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE "%s" ADD COLUMN "%s" %s`, table, column, decl)); err != nil {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -361,25 +361,19 @@ func (s *Store) ensureColumn(ctx context.Context, conn *sql.Conn, table, column,
 		return fmt.Errorf("checking table %s: %w", table, err)
 	}
 
-	rows, err := conn.QueryContext(ctx, fmt.Sprintf(`PRAGMA table_info("%s")`, table))
-	if err != nil {
-		return fmt.Errorf("table_info %s: %w", table, err)
+	// table_info omits generated columns (VIRTUAL/STORED). table_xinfo
+	// reports them so a later Open does not re-ADD a column CREATE TABLE
+	// already declared, and so upgrades can see a prior ADD of bare_id.
+	var existing string
+	err = conn.QueryRowContext(ctx,
+		`SELECT name FROM pragma_table_xinfo(?) WHERE name=?`,
+		table, column,
+	).Scan(&existing)
+	if err == nil {
+		return nil
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var cid int
-		var n, typ string
-		var notnull, pk int
-		var dflt sql.NullString
-		if err := rows.Scan(&cid, &n, &typ, &notnull, &dflt, &pk); err != nil {
-			return fmt.Errorf("scan table_info %s: %w", table, err)
-		}
-		if n == column {
-			return nil
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterating table_info %s: %w", table, err)
+	if err != sql.ErrNoRows {
+		return fmt.Errorf("table_xinfo %s: %w", table, err)
 	}
 
 	if _, err := conn.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE "%s" ADD COLUMN "%s" %s`, table, column, decl)); err != nil {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -412,6 +412,7 @@ func (s *Store) ensureColumn(ctx context.Context, conn *sql.Conn, table, column,
 func (s *Store) backfillColumns(ctx context.Context, conn *sql.Conn) error {
 	for _, c := range []struct{ table, column, decl string }{
 		{table: "leagues", column: "parent_id", decl: "TEXT"},
+		{table: "leagues", column: "bare_id", decl: "TEXT GENERATED ALWAYS AS (substr(id, 1, coalesce(nullif(instr(id, char(0)), 0) - 1, length(id)))) VIRTUAL"},
 		{table: "sync_state", column: "last_cursor", decl: "TEXT"},
 		{table: "sync_state", column: "last_synced_at", decl: "DATETIME"},
 		{table: "sync_state", column: "total_count", decl: "INTEGER DEFAULT 0"},
@@ -630,9 +631,11 @@ func (s *Store) migrate(ctx context.Context) error {
 			"id" TEXT PRIMARY KEY,
 			"data" JSON NOT NULL,
 			"synced_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
-			"parent_id" TEXT
+			"parent_id" TEXT,
+			"bare_id" TEXT GENERATED ALWAYS AS (substr(id, 1, coalesce(nullif(instr(id, char(0)), 0) - 1, length(id)))) VIRTUAL
 		)`,
 		`CREATE INDEX IF NOT EXISTS "idx_leagues_parent_id" ON "leagues"("parent_id")`,
+		`CREATE INDEX IF NOT EXISTS "idx_leagues_bare_id" ON "leagues"("bare_id")`,
 	}
 
 	// Run every migration — including the column backfill and the
@@ -1988,6 +1991,11 @@ func resourceStorageID(resourceType, id string, obj map[string]any) string {
 // returns composite keys for parent-keyed resources, so callers comparing those
 // ids against bare API ids must run them through this first. For non-composite
 // ids it returns the input unchanged, so it is safe to apply to every id.
+//
+// Parent-keyed typed tables also project this value as a generated bare_id
+// column (indexed) so SQL/store queries can filter on the entity id without
+// matching the hidden parent suffix. WHERE id = ? against a bare API id
+// misses those rows; WHERE bare_id = ? finds them.
 func BareResourceID(storageID string) string {
 	if i := strings.IndexByte(storageID, 0); i >= 0 {
 		return storageID[:i]
@@ -2250,7 +2258,8 @@ func (s *Store) GetSyncCursor(resourceType string) string {
 // ListIDs returns all IDs from a resource's domain table, or from the generic
 // resources table if no domain table exists. Used by dependent sync to iterate parents.
 // For parent-keyed resource types these are composite storage keys; run them
-// through BareResourceID before comparing against bare API ids.
+// through BareResourceID before comparing against bare API ids, or filter the
+// typed table's generated bare_id column from SQL.
 //
 // resourceType is never interpolated into SQL directly. We resolve it to a real
 // table name via a parameterized sqlite_master lookup; only that trusted name is

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -2040,6 +2040,11 @@ func resourceStorageID(resourceType, id string, obj map[string]any) string {
 // returns composite keys for parent-keyed resources, so callers comparing those
 // ids against bare API ids must run them through this first. For non-composite
 // ids it returns the input unchanged, so it is safe to apply to every id.
+//
+// Parent-keyed typed tables also project this value as a generated bare_id
+// column (indexed) so SQL/store queries can filter on the entity id without
+// matching the hidden parent suffix. WHERE id = ? against a bare API id
+// misses those rows; WHERE bare_id = ? finds them.
 func BareResourceID(storageID string) string {
 	if i := strings.IndexByte(storageID, 0); i >= 0 {
 		return storageID[:i]
@@ -2302,7 +2307,8 @@ func (s *Store) GetSyncCursor(resourceType string) string {
 // ListIDs returns all IDs from a resource's domain table, or from the generic
 // resources table if no domain table exists. Used by dependent sync to iterate parents.
 // For parent-keyed resource types these are composite storage keys; run them
-// through BareResourceID before comparing against bare API ids.
+// through BareResourceID before comparing against bare API ids, or filter the
+// typed table's generated bare_id column from SQL.
 //
 // resourceType is never interpolated into SQL directly. We resolve it to a real
 // table name via a parameterized sqlite_master lookup; only that trusted name is

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -361,25 +361,19 @@ func (s *Store) ensureColumn(ctx context.Context, conn *sql.Conn, table, column,
 		return fmt.Errorf("checking table %s: %w", table, err)
 	}
 
-	rows, err := conn.QueryContext(ctx, fmt.Sprintf(`PRAGMA table_info("%s")`, table))
-	if err != nil {
-		return fmt.Errorf("table_info %s: %w", table, err)
+	// table_info omits generated columns (VIRTUAL/STORED). table_xinfo
+	// reports them so a later Open does not re-ADD a column CREATE TABLE
+	// already declared, and so upgrades can see a prior ADD of bare_id.
+	var existing string
+	err = conn.QueryRowContext(ctx,
+		`SELECT name FROM pragma_table_xinfo(?) WHERE name=?`,
+		table, column,
+	).Scan(&existing)
+	if err == nil {
+		return nil
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var cid int
-		var n, typ string
-		var notnull, pk int
-		var dflt sql.NullString
-		if err := rows.Scan(&cid, &n, &typ, &notnull, &dflt, &pk); err != nil {
-			return fmt.Errorf("scan table_info %s: %w", table, err)
-		}
-		if n == column {
-			return nil
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterating table_info %s: %w", table, err)
+	if err != sql.ErrNoRows {
+		return fmt.Errorf("table_xinfo %s: %w", table, err)
 	}
 
 	if _, err := conn.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE "%s" ADD COLUMN "%s" %s`, table, column, decl)); err != nil {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -361,25 +361,19 @@ func (s *Store) ensureColumn(ctx context.Context, conn *sql.Conn, table, column,
 		return fmt.Errorf("checking table %s: %w", table, err)
 	}
 
-	rows, err := conn.QueryContext(ctx, fmt.Sprintf(`PRAGMA table_info("%s")`, table))
-	if err != nil {
-		return fmt.Errorf("table_info %s: %w", table, err)
+	// table_info omits generated columns (VIRTUAL/STORED). table_xinfo
+	// reports them so a later Open does not re-ADD a column CREATE TABLE
+	// already declared, and so upgrades can see a prior ADD of bare_id.
+	var existing string
+	err = conn.QueryRowContext(ctx,
+		`SELECT name FROM pragma_table_xinfo(?) WHERE name=?`,
+		table, column,
+	).Scan(&existing)
+	if err == nil {
+		return nil
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var cid int
-		var n, typ string
-		var notnull, pk int
-		var dflt sql.NullString
-		if err := rows.Scan(&cid, &n, &typ, &notnull, &dflt, &pk); err != nil {
-			return fmt.Errorf("scan table_info %s: %w", table, err)
-		}
-		if n == column {
-			return nil
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterating table_info %s: %w", table, err)
+	if err != sql.ErrNoRows {
+		return fmt.Errorf("table_xinfo %s: %w", table, err)
 	}
 
 	if _, err := conn.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE "%s" ADD COLUMN "%s" %s`, table, column, decl)); err != nil {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -412,7 +412,9 @@ func (s *Store) ensureColumn(ctx context.Context, conn *sql.Conn, table, column,
 func (s *Store) backfillColumns(ctx context.Context, conn *sql.Conn) error {
 	for _, c := range []struct{ table, column, decl string }{
 		{table: "leagues", column: "parent_id", decl: "TEXT"},
+		{table: "leagues", column: "bare_id", decl: "TEXT GENERATED ALWAYS AS (substr(id, 1, coalesce(nullif(instr(id, char(0)), 0) - 1, length(id)))) VIRTUAL"},
 		{table: "standings", column: "parent_id", decl: "TEXT"},
+		{table: "standings", column: "bare_id", decl: "TEXT GENERATED ALWAYS AS (substr(id, 1, coalesce(nullif(instr(id, char(0)), 0) - 1, length(id)))) VIRTUAL"},
 		{table: "sync_state", column: "last_cursor", decl: "TEXT"},
 		{table: "sync_state", column: "last_synced_at", decl: "DATETIME"},
 		{table: "sync_state", column: "total_count", decl: "INTEGER DEFAULT 0"},
@@ -631,16 +633,20 @@ func (s *Store) migrate(ctx context.Context) error {
 			"id" TEXT PRIMARY KEY,
 			"data" JSON NOT NULL,
 			"synced_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
-			"parent_id" TEXT
+			"parent_id" TEXT,
+			"bare_id" TEXT GENERATED ALWAYS AS (substr(id, 1, coalesce(nullif(instr(id, char(0)), 0) - 1, length(id)))) VIRTUAL
 		)`,
 		`CREATE INDEX IF NOT EXISTS "idx_leagues_parent_id" ON "leagues"("parent_id")`,
+		`CREATE INDEX IF NOT EXISTS "idx_leagues_bare_id" ON "leagues"("bare_id")`,
 		`CREATE TABLE IF NOT EXISTS "standings" (
 			"id" TEXT PRIMARY KEY,
 			"data" JSON NOT NULL,
 			"synced_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
-			"parent_id" TEXT
+			"parent_id" TEXT,
+			"bare_id" TEXT GENERATED ALWAYS AS (substr(id, 1, coalesce(nullif(instr(id, char(0)), 0) - 1, length(id)))) VIRTUAL
 		)`,
 		`CREATE INDEX IF NOT EXISTS "idx_standings_parent_id" ON "standings"("parent_id")`,
+		`CREATE INDEX IF NOT EXISTS "idx_standings_bare_id" ON "standings"("bare_id")`,
 	}
 
 	// Run every migration — including the column backfill and the
@@ -2050,6 +2056,11 @@ func resourceStorageID(resourceType, id string, obj map[string]any) string {
 // returns composite keys for parent-keyed resources, so callers comparing those
 // ids against bare API ids must run them through this first. For non-composite
 // ids it returns the input unchanged, so it is safe to apply to every id.
+//
+// Parent-keyed typed tables also project this value as a generated bare_id
+// column (indexed) so SQL/store queries can filter on the entity id without
+// matching the hidden parent suffix. WHERE id = ? against a bare API id
+// misses those rows; WHERE bare_id = ? finds them.
 func BareResourceID(storageID string) string {
 	if i := strings.IndexByte(storageID, 0); i >= 0 {
 		return storageID[:i]
@@ -2314,7 +2325,8 @@ func (s *Store) GetSyncCursor(resourceType string) string {
 // ListIDs returns all IDs from a resource's domain table, or from the generic
 // resources table if no domain table exists. Used by dependent sync to iterate parents.
 // For parent-keyed resource types these are composite storage keys; run them
-// through BareResourceID before comparing against bare API ids.
+// through BareResourceID before comparing against bare API ids, or filter the
+// typed table's generated bare_id column from SQL.
 //
 // resourceType is never interpolated into SQL directly. We resolve it to a real
 // table name via a parameterized sqlite_master lookup; only that trusted name is


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Typed SQL/store lookups on parent-keyed tables compared `id` to a bare API id and missed silently: `resourceStorageID` still writes `id + NUL + parent`, and `BareResourceID` is Go-only.

Closes #3818

## Approach

Keep the composite primary key. On parent-keyed typed tables, project the same value `BareResourceID` returns as a generated `bare_id` column plus an index.

`VIRTUAL` (not `STORED`) so existing databases can `ALTER TABLE ... ADD COLUMN` on open. SQLite rejects adding a STORED generated column. The index materializes the value for lookups.

Writers omit `bare_id` from INSERT/UPDATE. Fresh schemas declare it; older DBs get it via the existing column-backfill path. SQL that filters `WHERE bare_id = ?` finds the row without matching the hidden parent suffix.

## Scope

Primary area: generated store schema (`store.go.tmpl` + schema attach after dependent-parent enrichment).

Why this belongs in this repo: every printed CLI with parent-keyed typed tables inherits the composite key from the generator. This is a machine store-contract fix, not a printed-CLI patch.

Does not take #4427 (list/detail upsert overwrite) and does not redesign typed-table sync or pagination.

## Risk

Generated store.go changes for CLIs with parent-keyed typed tables (new column + index + backfill entry). Existing composite primary keys and upsert bindings are unchanged. Non-parent-keyed tables are untouched except for the `BareResourceID` / `ListIDs` comments.

## Output Contract

- Emitted CREATE TABLE / backfill / index for parent-keyed typed tables include `bare_id`
- INSERT/UPDATE omit the generated column
- Goldens updated: `generate-sync-walker-api`, `generate-learn-loop-api`, `generate-query-endpoint-api`, `generate-learn-disabled-api`
- Generated-output proof: `TestGeneratedStoreBareIDQueryable` (real `UpsertBatch` writer + SQL `WHERE bare_id = ?`, plus existing-DB upgrade) and `scripts/verify-generator-output.sh` on those four cases

## Verification

- [x] `go test ./internal/generator -run 'TestWritableStoreColumnsOmitsGenerated|TestAttachBareIDColumns|TestGeneratedStoreBareIDQueryable'`
- [x] `scripts/golden.sh update` (store.go fixtures only; reverted unrelated dogfood toolchain noise)
- [x] `scripts/verify-generator-output.sh generate-sync-walker-api generate-learn-loop-api generate-query-endpoint-api generate-learn-disabled-api`
- [x] `go test ./...` — all packages passed except `internal/generator` as a whole, which timed out at 10m/15m on this VM (CI shards that package). Focused generator tests above passed, including the new generated-store compile/runtime proof.

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-282fa1ab-56f9-4d89-9ab0-e170364511d8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-282fa1ab-56f9-4d89-9ab0-e170364511d8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

