### PR TITLE
fix(cli): keep hand-corrected MCP command mirrors during dogfood

### DIFF
--- a/internal/cli/dogfood.go
+++ b/internal/cli/dogfood.go
@@ -25,6 +25,7 @@ func newDogfoodCmd() *cobra.Command {
 	var authEnv string
 	var authTier string
 	var allowDestructive bool
+	var overwriteCommandMirror bool
 
 	cmd := &cobra.Command{
 		Use:   "dogfood",
@@ -79,6 +80,9 @@ func newDogfoodCmd() *cobra.Command {
 			if trafficAnalysisPath != "" {
 				opts = append(opts, pipeline.WithTrafficAnalysis(trafficAnalysisPath))
 			}
+			if overwriteCommandMirror {
+				opts = append(opts, pipeline.WithOverwriteCommandMirror())
+			}
 			report, err := pipeline.RunDogfood(dir, specPath, opts...)
 			if err != nil {
 				return &ExitError{Code: ExitGenerationError, Err: fmt.Errorf("running dogfood: %w", err)}
@@ -107,6 +111,7 @@ func newDogfoodCmd() *cobra.Command {
 	cmd.Flags().StringVar(&authEnv, "auth-env", "", "Environment variable that proves an API credential was available for the acceptance marker")
 	cmd.Flags().StringVar(&authTier, "auth-tier", "", "Credential tier for live dogfood; falls back to PP_AUTH_TIER and skips commands annotated pp:requires-tier on mismatch")
 	cmd.Flags().BoolVar(&allowDestructive, "allow-destructive", false, "Re-enable testing of endpoints classified as destructive-at-auth. Default skips them to prevent runner-credential rotation.")
+	cmd.Flags().BoolVar(&overwriteCommandMirror, "overwrite-command-mirror", false, "Overwrite a differing command_mirror_capabilities block in internal/mcp/tools.go from research.json")
 	_ = cmd.MarkFlagRequired("dir")
 	return cmd
 }

--- a/internal/cli/dogfood_test.go
+++ b/internal/cli/dogfood_test.go
@@ -92,6 +92,7 @@ func TestDogfoodHelpIncludesLiveFlags(t *testing.T) {
 	assert.Contains(t, output, "--level")
 	assert.Contains(t, output, "--auth-tier")
 	assert.Contains(t, output, "--write-acceptance")
+	assert.Contains(t, output, "--overwrite-command-mirror")
 }
 
 func TestPrintLiveDogfoodReportDistinguishesPassWithSkips(t *testing.T) {

--- a/internal/pipeline/docsync.go
+++ b/internal/pipeline/docsync.go
@@ -127,7 +127,13 @@ func SyncCLINarrativeDocs(dir, apiName string, narrative *ReadmeNarrative) ([]sy
 
 // SyncCLITranscendenceDocs rewrites generated README/SKILL transcendence
 // blocks from dogfood-verified features. Empty verified sets remove the blocks.
+// A command_mirror_capabilities block that differs from the rendered
+// research.json shape is left unmodified unless overwrite is requested.
 func SyncCLITranscendenceDocs(dir string, features []NovelFeature) ([]syncedArtifact, error) {
+	return syncCLITranscendenceDocs(dir, features, false)
+}
+
+func syncCLITranscendenceDocs(dir string, features []NovelFeature, overwriteCommandMirror bool) ([]syncedArtifact, error) {
 	var synced []syncedArtifact
 	warnBeforeDroppingDocumentedFeatures(filepath.Join(dir, "README.md"), "README.md", "## Unique Features", features)
 	changed, err := syncMarkdownFeatureSection(
@@ -165,7 +171,7 @@ func SyncCLITranscendenceDocs(dir string, features []NovelFeature) ([]syncedArti
 		synced = append(synced, syncedArtifact{Path: filepath.Join("internal", "cli", "which.go"), Detail: "whichIndex"})
 	}
 
-	changed, err = syncMCPNovelFeatureContext(filepath.Join(dir, "internal", "mcp", "tools.go"), features)
+	changed, err = syncMCPNovelFeatureContext(filepath.Join(dir, "internal", "mcp", "tools.go"), features, overwriteCommandMirror)
 	if err != nil {
 		return nil, err
 	}
@@ -530,10 +536,50 @@ func renderWhichIndex(features []NovelFeature) string {
 	return b.String()
 }
 
-func syncMCPNovelFeatureContext(path string, features []NovelFeature) (bool, error) {
-	return syncGoFile(path, func(content string) string {
-		return syncMCPMapList(content, `"command_mirror_capabilities": []map[string]string{`, renderMCPCommandMirrorCapabilities(features))
-	})
+const mcpCommandMirrorKey = `"command_mirror_capabilities": []map[string]string{`
+
+func syncMCPNovelFeatureContext(path string, features []NovelFeature, overwrite bool) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("reading %s: %w", path, err)
+	}
+	content := string(data)
+	existing, found := mcpMapListBlock(content, mcpCommandMirrorKey)
+	if !found {
+		return false, nil
+	}
+	replacement := renderMCPCommandMirrorCapabilities(features)
+	if existing == replacement {
+		return false, nil
+	}
+	if !overwrite {
+		fmt.Fprintf(os.Stderr, "dogfood: left unmodified %s (command_mirror_capabilities); on-disk block differs from research.json\n",
+			filepath.Join("internal", "mcp", "tools.go"))
+		return false, nil
+	}
+	updated := syncMCPMapList(content, mcpCommandMirrorKey, replacement)
+	if updated == content {
+		return false, nil
+	}
+	if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+		return false, fmt.Errorf("writing %s: %w", path, err)
+	}
+	return true, nil
+}
+
+func mcpMapListBlock(content, key string) (string, bool) {
+	start := strings.Index(content, key)
+	if start < 0 {
+		return "", false
+	}
+	end := findGoCompositeLiteralEnd(content, start+len(key)-1)
+	if end < 0 {
+		return "", false
+	}
+	return content[start:end], true
 }
 
 func renderMCPCommandMirrorCapabilities(features []NovelFeature) string {
@@ -542,10 +588,10 @@ func renderMCPCommandMirrorCapabilities(features []NovelFeature) string {
 		// literal rather than "" so syncMCPMapList does a normal in-place replace
 		// (preserving the surrounding indentation) instead of taking its delete
 		// branch, which would strip the leading tabs off the following map entry.
-		return "\"command_mirror_capabilities\": []map[string]string{\n\t\t},"
+		return mcpCommandMirrorKey + "\n\t\t},"
 	}
 	var b strings.Builder
-	b.WriteString(`"command_mirror_capabilities": []map[string]string{`)
+	b.WriteString(mcpCommandMirrorKey)
 	for _, feature := range features {
 		b.WriteString("\n\t\t\t{\"name\": ")
 		b.WriteString(goStringLiteral(feature.Name))

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -409,9 +409,9 @@ func WithResearchDir(dir string) DogfoodOption {
 	}
 }
 
-// WithOverwriteCommandMirror replaces a differing command_mirror_capabilities
-// block in internal/mcp/tools.go from research.json. Without it, dogfood
-// leaves a hand-corrected block unmodified and reports the path.
+// WithOverwriteCommandMirror explicitly permits dogfood to discard a
+// hand-corrected command_mirror_capabilities block in favor of research.json.
+// Without it, dogfood preserves the on-disk block and reports the path.
 func WithOverwriteCommandMirror() DogfoodOption {
 	return func(c *dogfoodConfig) {
 		c.overwriteCommandMirror = true

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -371,7 +371,7 @@ func RunDogfood(dir, specPath string, opts ...DogfoodOption) (*DogfoodReport, er
 	report.PipelineCheck = checkPipelineIntegrity(dir)
 	report.ExampleCheck = checkExamples(dir)
 	report.WiringCheck = checkWiring(dir)
-	report.NovelFeaturesCheck = checkNovelFeatures(dir, cfg.researchDir)
+	report.NovelFeaturesCheck = checkNovelFeaturesOpts(dir, cfg.researchDir, cfg.overwriteCommandMirror)
 	report.MCPSurfaceParityCheck = checkMCPSurfaceParity(dir)
 	report.ReimplementationCheck = checkReimplementation(dir, cfg.researchDir)
 	if drift := checkDescriptionDrift(dir, cfg.researchDir); shouldReportDescriptionDrift(drift) {
@@ -393,8 +393,9 @@ func RunDogfood(dir, specPath string, opts ...DogfoodOption) (*DogfoodReport, er
 }
 
 type dogfoodConfig struct {
-	researchDir         string
-	trafficAnalysisPath string
+	researchDir            string
+	trafficAnalysisPath    string
+	overwriteCommandMirror bool
 }
 
 // DogfoodOption configures optional behavior for RunDogfood.
@@ -405,6 +406,15 @@ type DogfoodOption func(*dogfoodConfig)
 func WithResearchDir(dir string) DogfoodOption {
 	return func(c *dogfoodConfig) {
 		c.researchDir = dir
+	}
+}
+
+// WithOverwriteCommandMirror replaces a differing command_mirror_capabilities
+// block in internal/mcp/tools.go from research.json. Without it, dogfood
+// leaves a hand-corrected block unmodified and reports the path.
+func WithOverwriteCommandMirror() DogfoodOption {
+	return func(c *dogfoodConfig) {
+		c.overwriteCommandMirror = true
 	}
 }
 
@@ -471,6 +481,10 @@ func checkMCPSurfaceParity(cliDir string) MCPSurfaceResult {
 // the verified list back as novel_features_built so downstream consumers
 // (README, publish) only claim what actually exists.
 func checkNovelFeatures(cliDir, researchDir string) NovelFeaturesCheckResult {
+	return checkNovelFeaturesOpts(cliDir, researchDir, false)
+}
+
+func checkNovelFeaturesOpts(cliDir, researchDir string, overwriteCommandMirror bool) NovelFeaturesCheckResult {
 	if canonicalDir, err := ResolveTargetDir(cliDir); err == nil {
 		cliDir = canonicalDir
 	}
@@ -519,7 +533,7 @@ func checkNovelFeatures(cliDir, researchDir string) NovelFeaturesCheckResult {
 		} else if changed {
 			fmt.Fprintln(os.Stderr, "dogfood: synced .printing-press.json (novel_features) from novel_features_built")
 		}
-		if artifacts, err := SyncCLITranscendenceDocs(cliDir, built); err != nil {
+		if artifacts, err := syncCLITranscendenceDocs(cliDir, built, overwriteCommandMirror); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not sync transcendence docs: %v\n", err)
 		} else {
 			for _, artifact := range artifacts {

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -2629,17 +2629,25 @@ func context() map[string]any {
 }
 `)
 
-	artifacts, err := SyncCLITranscendenceDocs(cliDir, []NovelFeature{{
+	features := []NovelFeature{{
 		Name:         "Fresh insight",
 		Command:      "fresh scan",
 		Description:  "Fresh copy from research",
 		Rationale:    "Requires current research",
 		WhyItMatters: "Agents get the current path",
 		Group:        "Analysis",
-	}})
-	require.NoError(t, err)
+	}}
+
+	var stderr string
+	artifacts := captureStderr(t, &stderr, func() []syncedArtifact {
+		got, syncErr := SyncCLITranscendenceDocs(cliDir, features)
+		require.NoError(t, syncErr)
+		return got
+	})
 	assert.Contains(t, artifacts, syncedArtifact{Path: filepath.Join("internal", "cli", "which.go"), Detail: "whichIndex"})
-	assert.Contains(t, artifacts, syncedArtifact{Path: filepath.Join("internal", "mcp", "tools.go"), Detail: "command_mirror_capabilities"})
+	assert.NotContains(t, artifacts, syncedArtifact{Path: filepath.Join("internal", "mcp", "tools.go"), Detail: "command_mirror_capabilities"})
+	assert.Contains(t, stderr, "dogfood: left unmodified "+filepath.Join("internal", "mcp", "tools.go")+" (command_mirror_capabilities)")
+	assert.Contains(t, stderr, "on-disk block differs from research.json")
 
 	whichData, err := os.ReadFile(filepath.Join(cliDir, "internal", "cli", "which.go"))
 	require.NoError(t, err)
@@ -2651,11 +2659,133 @@ func context() map[string]any {
 	mcpData, err := os.ReadFile(filepath.Join(cliDir, "internal", "mcp", "tools.go"))
 	require.NoError(t, err)
 	mcp := string(mcpData)
+	assert.Contains(t, mcp, `"name": "Old"`)
+	assert.Contains(t, mcp, `"command": "old"`)
+	assert.Contains(t, mcp, "old copy")
+	assert.Contains(t, mcp, `{"topic": "Resource discovery", "insight": "Use the target site's resource hierarchy before narrowing to records."}`)
+	assert.NotContains(t, mcp, `"name": "Fresh insight"`)
+}
+
+func TestSyncCLITranscendenceDocsOverwritesCommandMirrorWhenRequested(t *testing.T) {
+	cliDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(cliDir, "internal", "mcp"), 0o755))
+	writeTestFile(t, filepath.Join(cliDir, "internal", "mcp", "tools.go"), `package mcp
+
+func context() map[string]any {
+	return map[string]any{
+		"command_mirror_capabilities": []map[string]string{
+			{"name": "Old", "tool": "watch_run", "cli_command": "watch run", "description": "hand-corrected", "rationale": "", "via": "mcp-command-mirror"},
+		},
+		"playbook": []map[string]string{
+			{"topic": "Resource discovery", "insight": "Use the target site's resource hierarchy before narrowing to records."},
+		},
+	}
+}
+`)
+
+	artifacts, err := syncCLITranscendenceDocs(cliDir, []NovelFeature{{
+		Name:        "Fresh insight",
+		Command:     "fresh scan",
+		Description: "Fresh copy from research",
+		Rationale:   "Requires current research",
+	}}, true)
+	require.NoError(t, err)
+	assert.Contains(t, artifacts, syncedArtifact{Path: filepath.Join("internal", "mcp", "tools.go"), Detail: "command_mirror_capabilities"})
+
+	mcpData, err := os.ReadFile(filepath.Join(cliDir, "internal", "mcp", "tools.go"))
+	require.NoError(t, err)
+	mcp := string(mcpData)
 	assert.Contains(t, mcp, `"name": "Fresh insight"`)
 	assert.Contains(t, mcp, `"command": "fresh scan"`)
 	assert.Contains(t, mcp, `{"topic": "Resource discovery", "insight": "Use the target site's resource hierarchy before narrowing to records."}`)
-	assert.NotContains(t, mcp, `"topic": "Fresh insight"`)
-	assert.NotContains(t, mcp, "old copy")
+	assert.NotContains(t, mcp, `"tool": "watch_run"`)
+	assert.NotContains(t, mcp, "hand-corrected")
+}
+
+func TestSyncCLITranscendenceDocsLeavesMatchingCommandMirrorQuiet(t *testing.T) {
+	cliDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(cliDir, "internal", "mcp"), 0o755))
+	features := []NovelFeature{{
+		Name:        "Health",
+		Command:     "health",
+		Description: "See scheduling health",
+		Rationale:   "One command",
+	}}
+	matching := "package mcp\n\nfunc context() map[string]any {\n\treturn map[string]any{\n\t\t" +
+		renderMCPCommandMirrorCapabilities(features) + "\n\t}\n}\n"
+	writeTestFile(t, filepath.Join(cliDir, "internal", "mcp", "tools.go"), matching)
+
+	var stderr string
+	artifacts := captureStderr(t, &stderr, func() []syncedArtifact {
+		got, syncErr := SyncCLITranscendenceDocs(cliDir, features)
+		require.NoError(t, syncErr)
+		return got
+	})
+	assert.NotContains(t, artifacts, syncedArtifact{Path: filepath.Join("internal", "mcp", "tools.go"), Detail: "command_mirror_capabilities"})
+	assert.NotContains(t, stderr, "left unmodified")
+	assert.NotContains(t, stderr, "command_mirror_capabilities")
+
+	mcpData, err := os.ReadFile(filepath.Join(cliDir, "internal", "mcp", "tools.go"))
+	require.NoError(t, err)
+	assert.Equal(t, matching, string(mcpData))
+}
+
+func TestCheckNovelFeaturesLeavesHandCorrectedCommandMirrorUnmodified(t *testing.T) {
+	cliDir := t.TempDir()
+	cliCodeDir := filepath.Join(cliDir, "internal", "cli")
+	require.NoError(t, os.MkdirAll(cliCodeDir, 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(cliDir, "internal", "mcp"), 0o755))
+	writeTestFile(t, filepath.Join(cliCodeDir, "watch.go"),
+		`package cli
+func newWatchCmd() *cobra.Command {
+	return &cobra.Command{Use: "watch"}
+}`)
+	handCorrected := `package mcp
+
+func context() map[string]any {
+	return map[string]any{
+		"command_mirror_capabilities": []map[string]string{
+			{"name": "Watch & Diff query salvate", "tool": "watch_run", "cli_command": "watch run", "description": "Re-run a saved watch.", "rationale": "", "via": "mcp-command-mirror"},
+		},
+	}
+}
+`
+	writeTestFile(t, filepath.Join(cliDir, "internal", "mcp", "tools.go"), handCorrected)
+
+	researchDir := t.TempDir()
+	require.NoError(t, writeResearchJSON(&ResearchResult{
+		APIName: "test",
+		NovelFeatures: []NovelFeature{{
+			Name:        "Watch & Diff query salvate",
+			Command:     "watch",
+			Description: "Re-run a saved watch.",
+		}},
+	}, researchDir))
+
+	var stderr string
+	result := captureStderr(t, &stderr, func() NovelFeaturesCheckResult {
+		return checkNovelFeatures(cliDir, researchDir)
+	})
+	assert.Equal(t, 1, result.Found)
+	assert.Contains(t, stderr, "dogfood: left unmodified "+filepath.Join("internal", "mcp", "tools.go")+" (command_mirror_capabilities)")
+	assert.NotContains(t, stderr, "dogfood: synced "+filepath.Join("internal", "mcp", "tools.go")+" (command_mirror_capabilities)")
+
+	mcpData, err := os.ReadFile(filepath.Join(cliDir, "internal", "mcp", "tools.go"))
+	require.NoError(t, err)
+	assert.Equal(t, handCorrected, string(mcpData))
+
+	stderr = ""
+	_ = captureStderr(t, &stderr, func() NovelFeaturesCheckResult {
+		return checkNovelFeaturesOpts(cliDir, researchDir, true)
+	})
+	assert.Contains(t, stderr, "dogfood: synced "+filepath.Join("internal", "mcp", "tools.go")+" (command_mirror_capabilities)")
+	assert.NotContains(t, stderr, "left unmodified")
+
+	mcpData, err = os.ReadFile(filepath.Join(cliDir, "internal", "mcp", "tools.go"))
+	require.NoError(t, err)
+	mcp := string(mcpData)
+	assert.Contains(t, mcp, `"command": "watch"`)
+	assert.NotContains(t, mcp, `"tool": "watch_run"`)
 }
 
 func TestSyncCLITranscendenceDocsWarnsBeforeDroppingDocumentedCommands(t *testing.T) {

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -683,6 +683,7 @@ only to inspect the current output.
 | --- | --- | --- |
 | README `## Unique Features` | `research.json::novel_features_built[]` | Edit the underlying `research.json` feature description/example, then re-run dogfood with `--research-dir`. |
 | SKILL `## Unique Capabilities` | `research.json::novel_features_built[]` | Edit the underlying `research.json` feature description/example, then re-run dogfood with `--research-dir`. |
+| `internal/mcp/tools.go` `command_mirror_capabilities` | `research.json::novel_features_built[]` | Dogfood reports a differing on-disk block and leaves it unmodified. Pass `--overwrite-command-mirror` only to replace it from `research.json`. |
 | README Quick Start | `research.json::narrative.quickstart[]` | Edit the command/comment in `research.json`, then regenerate or re-run the dogfood/rendering step. |
 | SKILL Recipes | `research.json::narrative.recipes[]` | Edit the recipe title, command, or explanation in `research.json`, then regenerate or re-run the dogfood/rendering step. |
 | README/SKILL Troubleshooting | `research.json::narrative.troubleshoots[]` | Edit the symptom/fix pair in `research.json`, then regenerate or re-run the dogfood/rendering step. |
@@ -711,7 +712,9 @@ flag references, fix the corresponding field in that file first. For novel
 features, dogfood verifies `research.json::novel_features[]`, writes the
 surviving set to `research.json::novel_features_built[]`, and syncs README
 `## Unique Features`, SKILL `## Unique Capabilities`, `.printing-press.json`
-`novel_features`, and root help Highlights from that verified set.
+`novel_features`, and root help Highlights from that verified set. A
+differing `command_mirror_capabilities` block in `internal/mcp/tools.go` is
+left unmodified unless `--overwrite-command-mirror` is passed.
 
 #### Required sections (must be present and correct)
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -4175,8 +4175,12 @@ novel-feature description text in generated code surfaces such as
 in `$RESEARCH_DIR/research.json` (`novel_features[].description`,
 `novel_features[].narrative`, or the matching `novel_features_built` entry) and
 regenerate/sync so README "Unique Features", SKILL "Unique Capabilities",
-root help Highlights, which output, MCP tools, and `.printing-press.json` stay
-aligned. Non-description code findings keep the normal Phase 4.95 autofix path.
+root help Highlights, which output, and `.printing-press.json` stay
+aligned. `dogfood --research-dir` leaves a differing
+`command_mirror_capabilities` block in `internal/mcp/tools.go` unmodified and
+prints the path; pass `--overwrite-command-mirror` only when the operator
+intends to replace that block from `research.json`. Non-description code
+findings keep the normal Phase 4.95 autofix path.
 
 **Native timeout-boundary check.** Before reviewer dispatch, scan every hand-written file under `internal/cli/` that imports a sibling internal package (`internal/<api>/`, `internal/source/<name>/`, `internal/recipes/`, `internal/phgraphql/`, etc.) and makes live requests. Each such command file must call `boundCtx(cmd.Context(), flags)` and pass that context into the sibling client or store query path before the first request. Files that only use `flags.newClient()` / generated `internal/client` are already covered by `client.New(cfg, flags.timeout, ...)` and should not be flagged for missing `boundCtx`. Binary/stream calls on that generated client skip the default whole-call Timeout unless `--timeout` was set explicitly (including a run profile that supplies `timeout`); do not add a `boundCtx` deadline around those downloads.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

`dogfood --research-dir` was rewriting `command_mirror_capabilities` in `internal/mcp/tools.go` from `research.json` even when the on-disk block had been hand-corrected after generation (for example a `tool` + `cli_command` pair so agents can invoke `watch_run`). The sync log looked the same for a no-op and a clobber.

Closes #4037

## Approach

Fail-closed skip of a differing mirror block. `syncMCPNovelFeatureContext` compares the on-disk literal to the research.json render and, when they differ, prints the relative path and leaves the file unmodified. `--overwrite-command-mirror` is the explicit opt-in to replace it. Matching blocks stay silent and unchanged. `novel_features` schema is untouched.

## Scope

Primary area: dogfood / docsync (`cli`).

Why this belongs in this repo: the write path is machine-owned. Any printed CLI with a post-generation mirror correction is exposed.

## Risk

Default dogfood no longer updates a stale but matching-intent mirror block from research.json; operators who want that rewrite must pass the new flag. README, SKILL, which.go, and root Highlights still sync as before.

## Output Contract

N/A — no generator, template, or golden output change. Dogfood help gains `--overwrite-command-mirror`.

## Verification

- `go test ./...` — pass
- Differing on-disk block: dogfood reports `internal/mcp/tools.go` and leaves it unmodified
- Matching block: no warning and no file change
- `--overwrite-command-mirror` still writes the research.json render

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3b10d7c-f55e-48cd-9fef-940040e24386?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3b10d7c-f55e-48cd-9fef-940040e24386&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

