### PR TITLE
fix(cli): set multipart file-part Content-Type from extension

### DIFF
--- a/internal/generator/multipart_test.go
+++ b/internal/generator/multipart_test.go
@@ -354,9 +354,14 @@ func TestMultipartFilePartContentTypeFromExtension(t *testing.T) {
 	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
 	require.NoError(t, New(apiSpec, outputDir).Generate())
 
-	clientSrc := readGeneratedFile(t, outputDir, "internal", "cli", "assets_upload.go")
-	assert.Contains(t, clientSrc, `fileFields["assetData"] = bodyAssetData`)
-	assert.NotContains(t, clientSrc, `fields["assetData"]`)
+	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
+	assert.Contains(t, clientSrc, `mime.TypeByExtension(filepath.Ext(path))`)
+	assert.Contains(t, clientSrc, `writer.CreatePart(h)`)
+	assert.NotContains(t, clientSrc, `writer.CreateFormFile(`)
+
+	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_assets.go")
+	assert.Contains(t, endpointSrc, `fileFields["assetData"] = bodyAssetData`)
+	assert.NotContains(t, endpointSrc, `fields["assetData"]`)
 
 	const runtimeTest = `package client
 

--- a/internal/generator/multipart_test.go
+++ b/internal/generator/multipart_test.go
@@ -61,7 +61,9 @@ func TestGenerateMultipartRequestBodyUsesMultipartClient(t *testing.T) {
 
 	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
 	assert.Contains(t, clientSrc, `func (c *Client) PostMultipart(ctx context.Context, path string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error)`)
-	assert.Contains(t, clientSrc, `writer.CreateFormFile(fieldName, filepath.Base(filePath))`)
+	assert.Contains(t, clientSrc, `mime.TypeByExtension(filepath.Ext(path))`)
+	assert.Contains(t, clientSrc, `writer.CreatePart(h)`)
+	assert.NotContains(t, clientSrc, `writer.CreateFormFile(`)
 	assert.Contains(t, clientSrc, `req.Header.Set("Content-Type", contentType)`)
 
 	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "assets_upload.go")
@@ -326,6 +328,97 @@ paths:
 	assert.NotContains(t, createSrc, `c.PostMultipartWithParams`)
 
 	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestMultipartFilePartContentTypeFromExtension(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("multipart-part-type")
+	apiSpec.Resources = map[string]spec.Resource{
+		"assets": {
+			Description: "Manage assets",
+			Endpoints: map[string]spec.Endpoint{
+				"upload": {
+					Method:             "POST",
+					Path:               "/assets",
+					Description:        "Upload an asset",
+					RequestContentType: "multipart/form-data",
+					Body: []spec.Param{
+						{Name: "assetData", Type: "string", Format: "binary", Required: true, Description: "Asset file"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	clientSrc := readGeneratedFile(t, outputDir, "internal", "cli", "assets_upload.go")
+	assert.Contains(t, clientSrc, `fileFields["assetData"] = bodyAssetData`)
+	assert.NotContains(t, clientSrc, `fields["assetData"]`)
+
+	const runtimeTest = `package client
+
+import (
+	"bytes"
+	"mime"
+	"mime/multipart"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEncodeMultipartFilePartContentType(t *testing.T) {
+	dir := t.TempDir()
+	cases := []struct {
+		name string
+		ext  string
+		want string
+	}{
+		{name: "pdf", ext: ".pdf", want: "application/pdf"},
+		{name: "png", ext: ".png", want: "image/png"},
+		{name: "jpeg", ext: ".jpeg", want: "image/jpeg"},
+		{name: "unknown", ext: ".nope123", want: "application/octet-stream"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, "sample"+tc.ext)
+			if err := os.WriteFile(path, []byte("sample"), 0o600); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+			if got := multipartFileContentType(path); got != tc.want {
+				t.Fatalf("multipartFileContentType(%q) = %q, want %q", path, got, tc.want)
+			}
+			body, contentType, err := encodeMultipartBody(multipartRequestBody{
+				FileFields: map[string]string{"assetData": path},
+			})
+			if err != nil {
+				t.Fatalf("encodeMultipartBody() error = %v", err)
+			}
+			_, params, err := mime.ParseMediaType(contentType)
+			if err != nil {
+				t.Fatalf("ParseMediaType() error = %v", err)
+			}
+			part, err := multipart.NewReader(bytes.NewReader(body), params["boundary"]).NextPart()
+			if err != nil {
+				t.Fatalf("NextPart() error = %v", err)
+			}
+			got := part.Header.Get("Content-Type")
+			if got != tc.want {
+				t.Fatalf("part Content-Type = %q, want %q", got, tc.want)
+			}
+			if tc.want != "application/octet-stream" && strings.EqualFold(got, "application/octet-stream") {
+				t.Fatalf("known extension %q still encoded as application/octet-stream", tc.ext)
+			}
+		})
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "multipart_part_type_runtime_test.go"), []byte(runtimeTest), 0o600))
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^TestEncodeMultipartFilePartContentType$", "-count=1")
 }
 
 func TestGenerateBinaryResponseWritesRawBytes(t *testing.T) {

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -19,10 +19,14 @@ import (
 	"io"
 	"math"
 {{- if .HasMultipartRequest}}
+	"mime"
 	"mime/multipart"
 {{- end}}
 	"net"
 	"net/http"
+{{- if .HasMultipartRequest}}
+	"net/textproto"
+{{- end}}
 	"net/url"
 	"os"
 	"path/filepath"
@@ -1624,7 +1628,11 @@ func encodeMultipartBody(body multipartRequestBody) ([]byte, string, error) {
 			_ = writer.Close()
 			return nil, "", fmt.Errorf("opening multipart file field %q (%q): %w", fieldName, filePath, err)
 		}
-		part, err := writer.CreateFormFile(fieldName, filepath.Base(filePath))
+		h := make(textproto.MIMEHeader)
+		h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`,
+			escapeMultipartQuotes(fieldName), escapeMultipartQuotes(filepath.Base(filePath))))
+		h.Set("Content-Type", multipartFileContentType(filePath))
+		part, err := writer.CreatePart(h)
 		if err != nil {
 			_ = file.Close()
 			_ = writer.Close()
@@ -1644,6 +1652,19 @@ func encodeMultipartBody(body multipartRequestBody) ([]byte, string, error) {
 		return nil, "", fmt.Errorf("finalizing multipart body: %w", err)
 	}
 	return buf.Bytes(), writer.FormDataContentType(), nil
+}
+
+// CreateFormFile hardcodes application/octet-stream, which APIs that
+// whitelist part types reject. Derive the type from the filename.
+func multipartFileContentType(path string) string {
+	if ct := mime.TypeByExtension(filepath.Ext(path)); ct != "" {
+		return ct
+	}
+	return "application/octet-stream"
+}
+
+func escapeMultipartQuotes(s string) string {
+	return strings.NewReplacer("\\", "\\\\", `"`, "\\\"").Replace(s)
 }
 
 {{ end }}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -1654,7 +1654,7 @@ func encodeMultipartBody(body multipartRequestBody) ([]byte, string, error) {
 	return buf.Bytes(), writer.FormDataContentType(), nil
 }
 
-// APIs that whitelist part Content-Types reject a hardcoded octet-stream.
+// Needed so whitelist-style upload APIs do not 415 the file part.
 func multipartFileContentType(path string) string {
 	if ct := mime.TypeByExtension(filepath.Ext(path)); ct != "" {
 		return ct

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -1654,8 +1654,7 @@ func encodeMultipartBody(body multipartRequestBody) ([]byte, string, error) {
 	return buf.Bytes(), writer.FormDataContentType(), nil
 }
 
-// CreateFormFile hardcodes application/octet-stream, which APIs that
-// whitelist part types reject. Derive the type from the filename.
+// Whitelist-style upload APIs reject a hardcoded octet-stream part type.
 func multipartFileContentType(path string) string {
 	if ct := mime.TypeByExtension(filepath.Ext(path)); ct != "" {
 		return ct

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -1654,7 +1654,7 @@ func encodeMultipartBody(body multipartRequestBody) ([]byte, string, error) {
 	return buf.Bytes(), writer.FormDataContentType(), nil
 }
 
-// Whitelist-style upload APIs reject a hardcoded octet-stream part type.
+// APIs that whitelist part Content-Types reject a hardcoded octet-stream.
 func multipartFileContentType(path string) string {
 	if ct := mime.TypeByExtension(filepath.Ext(path)); ct != "" {
 		return ct

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -935,7 +935,7 @@ func encodeMultipartBody(body multipartRequestBody) ([]byte, string, error) {
 	return buf.Bytes(), writer.FormDataContentType(), nil
 }
 
-// Whitelist-style upload APIs reject a hardcoded octet-stream part type.
+// APIs that whitelist part Content-Types reject a hardcoded octet-stream.
 func multipartFileContentType(path string) string {
 	if ct := mime.TypeByExtension(filepath.Ext(path)); ct != "" {
 		return ct

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -935,7 +935,7 @@ func encodeMultipartBody(body multipartRequestBody) ([]byte, string, error) {
 	return buf.Bytes(), writer.FormDataContentType(), nil
 }
 
-// APIs that whitelist part Content-Types reject a hardcoded octet-stream.
+// Needed so whitelist-style upload APIs do not 415 the file part.
 func multipartFileContentType(path string) string {
 	if ct := mime.TypeByExtension(filepath.Ext(path)); ct != "" {
 		return ct

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -15,9 +15,11 @@ import (
 	"html"
 	"io"
 	"math"
+	"mime"
 	"mime/multipart"
 	"net"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -907,7 +909,11 @@ func encodeMultipartBody(body multipartRequestBody) ([]byte, string, error) {
 			_ = writer.Close()
 			return nil, "", fmt.Errorf("opening multipart file field %q (%q): %w", fieldName, filePath, err)
 		}
-		part, err := writer.CreateFormFile(fieldName, filepath.Base(filePath))
+		h := make(textproto.MIMEHeader)
+		h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`,
+			escapeMultipartQuotes(fieldName), escapeMultipartQuotes(filepath.Base(filePath))))
+		h.Set("Content-Type", multipartFileContentType(filePath))
+		part, err := writer.CreatePart(h)
 		if err != nil {
 			_ = file.Close()
 			_ = writer.Close()
@@ -927,6 +933,19 @@ func encodeMultipartBody(body multipartRequestBody) ([]byte, string, error) {
 		return nil, "", fmt.Errorf("finalizing multipart body: %w", err)
 	}
 	return buf.Bytes(), writer.FormDataContentType(), nil
+}
+
+// CreateFormFile hardcodes application/octet-stream, which APIs that
+// whitelist part types reject. Derive the type from the filename.
+func multipartFileContentType(path string) string {
+	if ct := mime.TypeByExtension(filepath.Ext(path)); ct != "" {
+		return ct
+	}
+	return "application/octet-stream"
+}
+
+func escapeMultipartQuotes(s string) string {
+	return strings.NewReplacer("\\", "\\\\", `"`, "\\\"").Replace(s)
 }
 
 // isMutatingVerb reports whether the HTTP method writes server state.

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -935,8 +935,7 @@ func encodeMultipartBody(body multipartRequestBody) ([]byte, string, error) {
 	return buf.Bytes(), writer.FormDataContentType(), nil
 }
 
-// CreateFormFile hardcodes application/octet-stream, which APIs that
-// whitelist part types reject. Derive the type from the filename.
+// Whitelist-style upload APIs reject a hardcoded octet-stream part type.
 func multipartFileContentType(path string) string {
 	if ct := mime.TypeByExtension(filepath.Ext(path)); ct != "" {
 		return ct


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Generated multipart uploads still send every file part as `application/octet-stream` because `encodeMultipartBody` uses `CreateFormFile`. After the FileFields routing fix, APIs that whitelist part types (`application/pdf`, `image/jpeg`, `image/png`) reject the generated command with 415, including the example in the command's own `--help`.

Closes #3667

## Approach

Confirm on current main that the other two #3667 findings are already fixed, then change only the live encode path:

- `format:binary` body params already route to `fileFields` via `multipartBodyMaps` / `isBinaryParam`.
- cobratree walk already visits children of `Hidden` groups while skipping `mcp:hidden`.
- Multipart `--dry-run` preview already skips FileFields IO.

Replace `writer.CreateFormFile` with `writer.CreatePart` and set `Content-Type` from `mime.TypeByExtension(filepath.Ext(path))`, falling back to `application/octet-stream` when the extension is unknown. Do not reopen the dry-run preview path.

## Scope

Primary area: `internal/generator/templates/client.go.tmpl` (`encodeMultipartBody`) plus generated-output tests and the `generate-golden-api` client golden.

Why this belongs in this repo: this is a generator-owned client emission defect. Every printed CLI with a `multipart/form-data` binary file field inherits the hardcoded octet-stream part type until the template changes.

## Risk

- Live multipart uploads of known extensions now send a matching part Content-Type. APIs that previously accepted octet-stream only should still accept the more specific type.
- Unknown extensions keep the previous octet-stream fallback.
- Dry-run preview, FileFields routing, and Hidden-group MCP walk are unchanged.
- Generated `internal/client/client.go` changes for CLIs with multipart requests (golden fixture updated).

## Output Contract

- Emitted `encodeMultipartBody` now calls `CreatePart` and `mime.TypeByExtension`; it no longer calls `CreateFormFile`.
- Evidence: `TestGenerateMultipartRequestBodyUsesMultipartClient` asserts the emitted helpers; `TestMultipartFilePartContentTypeFromExtension` compiles a generated CLI and encodes `.pdf` / `.png` / `.jpeg` / unknown parts.
- `scripts/golden.sh update` refreshed `testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go` only.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands:

- Inspected #3667 against current `main` and confirmed FileFields routing + Hidden-group walk already land.
- `gofmt -w internal/generator/multipart_test.go`
- `scripts/golden.sh update` (kept only the intended `generate-golden-api` client.go fixture; discarded unrelated dogfood-verdict-matrix drift from a local fixture-build failure)
- `go test ./internal/generator -run 'TestGenerateMultipartRequestBodyUsesMultipartClient|TestMultipartDryRunDoesNotOpenFileFields|TestMultipartFilePartContentTypeFromExtension|TestGenerateOpenAPIMultipartRequestBodyUsesMultipartClient'` — pass
- `go test -timeout 15m ./...` — all packages except `internal/generator` pass; that package exceeds a 15m unsharded budget on this runner (CI shards it)
- `go test -timeout 45m ./internal/generator` — pass (870s)
- `bash scripts/verify-generator-output.sh generate-golden-api` — pass
- `python3 .github/scripts/pr-review-state/greptile_feedback.py 4440` — READY

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3777fe0e-2e56-4193-95c2-40bb5d7f0922?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3777fe0e-2e56-4193-95c2-40bb5d7f0922&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

