### PR TITLE
fix(cli): truncate on rune boundaries

### DIFF
--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1279,14 +1279,16 @@ func classifyDeleteError(w io.Writer, err error, flags *rootFlags) error {
 }
 {{- end}}
 
+// Byte slicing splits multi-byte runes and corrupts table/JSON display.
 func truncate(s string, max int) string {
-	if len(s) <= max {
+	runes := []rune(s)
+	if len(runes) <= max {
 		return s
 	}
 	if max <= 3 {
-		return s[:max]
+		return string(runes[:max])
 	}
-	return s[:max-3] + "..."
+	return string(runes[:max-3]) + "..."
 }
 
 func newTabWriter(w io.Writer) *tabwriter.Writer {

--- a/internal/generator/truncate_display_test.go
+++ b/internal/generator/truncate_display_test.go
@@ -20,8 +20,10 @@ func TestGeneratedTruncateCutsOnRuneBoundaries(t *testing.T) {
 	body := emittedTruncateBody(t, helpersSrc)
 	require.Contains(t, body, "[]rune(s)", "display truncate must count runes, not bytes")
 	require.NotContains(t, body, "len(s)", "byte-length width checks truncate CJK that still fits the column")
-	require.NotContains(t, body, "s[:max]", "byte slices split multi-byte runes")
-	require.NotContains(t, body, "s[:max-3]", "byte slices split multi-byte runes")
+	require.False(t, containsBareIdentSlice(body, "s[:max]"),
+		"byte slices of s split multi-byte runes; runes[:max] is the safe form")
+	require.False(t, containsBareIdentSlice(body, "s[:max-3]"),
+		"byte slices of s split multi-byte runes; runes[:max-3] is the safe form")
 
 	const runtimeTest = `package cli
 
@@ -74,6 +76,46 @@ func TestTruncateASCIIUnchanged(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "truncate_runtime_test.go"), []byte(runtimeTest), 0o600))
 	requireGeneratedCompiles(t, outputDir)
 	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "^TestTruncate(CJKValidUTF8AndFitsColumn|ASCIIUnchanged)$", "-count=1")
+}
+
+// containsBareIdentSlice reports whether expr (e.g. "s[:max]") appears as its
+// own identifier, not as a suffix of a longer name such as runes[:max].
+func containsBareIdentSlice(body, expr string) bool {
+	for i := 0; ; {
+		idx := strings.Index(body[i:], expr)
+		if idx < 0 {
+			return false
+		}
+		abs := i + idx
+		if abs == 0 || !isIdentByte(body[abs-1]) {
+			return true
+		}
+		i = abs + len(expr)
+	}
+}
+
+func isIdentByte(b byte) bool {
+	return b == '_' || (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+}
+
+func TestContainsBareIdentSliceDistinguishesRunesFromString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		body string
+		expr string
+		want bool
+	}{
+		{body: `return s[:max]`, expr: "s[:max]", want: true},
+		{body: `return s[:max-3] + "..."`, expr: "s[:max-3]", want: true},
+		{body: `return string(runes[:max])`, expr: "s[:max]", want: false},
+		{body: `return string(runes[:max-3]) + "..."`, expr: "s[:max-3]", want: false},
+	}
+	for _, tc := range cases {
+		if got := containsBareIdentSlice(tc.body, tc.expr); got != tc.want {
+			t.Fatalf("containsBareIdentSlice(%q, %q) = %v, want %v", tc.body, tc.expr, got, tc.want)
+		}
+	}
 }
 
 func emittedTruncateBody(t *testing.T, helpersSrc string) string {

--- a/internal/generator/truncate_display_test.go
+++ b/internal/generator/truncate_display_test.go
@@ -1,0 +1,89 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedTruncateCutsOnRuneBoundaries(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("truncate-runes")
+	outputDir := filepath.Join(t.TempDir(), "truncate-runes-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	helpersSrc := readGeneratedFile(t, outputDir, "internal", "cli", "helpers.go")
+	body := emittedTruncateBody(t, helpersSrc)
+	require.Contains(t, body, "[]rune(s)", "display truncate must count runes, not bytes")
+	require.NotContains(t, body, "len(s)", "byte-length width checks truncate CJK that still fits the column")
+	require.NotContains(t, body, "s[:max]", "byte slices split multi-byte runes")
+	require.NotContains(t, body, "s[:max-3]", "byte slices split multi-byte runes")
+
+	const runtimeTest = `package cli
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncateCJKValidUTF8AndFitsColumn(t *testing.T) {
+	twenty := strings.Repeat("测", 20)
+	if got := truncate(twenty, 40); got != twenty {
+		t.Fatalf("20-rune CJK in a 40-wide column was truncated: %q", got)
+	}
+
+	long := "测试文字更长的输入"
+	got := truncate(long, 5)
+	if !utf8.ValidString(got) {
+		t.Fatalf("CJK truncate produced invalid UTF-8: %q", got)
+	}
+	if n := utf8.RuneCountInString(got); n > 5 {
+		t.Fatalf("CJK truncate returned %d runes, want at most 5: %q", n, got)
+	}
+	if strings.ContainsRune(got, '\uFFFD') {
+		t.Fatalf("CJK truncate inserted replacement runes: %q", got)
+	}
+}
+
+func TestTruncateASCIIUnchanged(t *testing.T) {
+	cases := []struct {
+		in   string
+		max  int
+		want string
+	}{
+		{in: "hello", max: 40, want: "hello"},
+		{in: "hello", max: 5, want: "hello"},
+		{in: "hello world extra", max: 10, want: "hello w..."},
+		{in: "abcd", max: 3, want: "abc"},
+		{in: "abcd", max: 2, want: "ab"},
+		{in: "abcd", max: 1, want: "a"},
+		{in: "abcd", max: 0, want: ""},
+	}
+	for _, tc := range cases {
+		if got := truncate(tc.in, tc.max); got != tc.want {
+			t.Fatalf("truncate(%q, %d) = %q, want %q", tc.in, tc.max, got, tc.want)
+		}
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "truncate_runtime_test.go"), []byte(runtimeTest), 0o600))
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "^TestTruncate(CJKValidUTF8AndFitsColumn|ASCIIUnchanged)$", "-count=1")
+}
+
+func emittedTruncateBody(t *testing.T, helpersSrc string) string {
+	t.Helper()
+	const sig = "func truncate(s string, max int) string {"
+	start := strings.Index(helpersSrc, sig)
+	require.NotEqual(t, -1, start, "generated helpers.go must emit truncate")
+	body := helpersSrc[start:]
+	if next := strings.Index(body[1:], "\nfunc "); next != -1 {
+		body = body[:next+1]
+	}
+	return body
+}

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -667,14 +667,16 @@ func classifyAPIError(w io.Writer, err error, flags *rootFlags) error {
 	return classified
 }
 
+// Byte slicing splits multi-byte runes and corrupts table/JSON display.
 func truncate(s string, max int) string {
-	if len(s) <= max {
+	runes := []rune(s)
+	if len(runes) <= max {
 		return s
 	}
 	if max <= 3 {
-		return s[:max]
+		return string(runes[:max])
 	}
-	return s[:max-3] + "..."
+	return string(runes[:max-3]) + "..."
 }
 
 func newTabWriter(w io.Writer) *tabwriter.Writer {

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -666,14 +666,16 @@ func classifyAPIError(w io.Writer, err error, flags *rootFlags) error {
 	return classified
 }
 
+// Byte slicing splits multi-byte runes and corrupts table/JSON display.
 func truncate(s string, max int) string {
-	if len(s) <= max {
+	runes := []rune(s)
+	if len(runes) <= max {
 		return s
 	}
 	if max <= 3 {
-		return s[:max]
+		return string(runes[:max])
 	}
-	return s[:max-3] + "..."
+	return string(runes[:max-3]) + "..."
 }
 
 func newTabWriter(w io.Writer) *tabwriter.Writer {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -750,14 +750,16 @@ func classifyAPIError(w io.Writer, err error, flags *rootFlags) error {
 	return classified
 }
 
+// Byte slicing splits multi-byte runes and corrupts table/JSON display.
 func truncate(s string, max int) string {
-	if len(s) <= max {
+	runes := []rune(s)
+	if len(runes) <= max {
 		return s
 	}
 	if max <= 3 {
-		return s[:max]
+		return string(runes[:max])
 	}
-	return s[:max-3] + "..."
+	return string(runes[:max-3]) + "..."
 }
 
 func newTabWriter(w io.Writer) *tabwriter.Writer {

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
@@ -741,14 +741,16 @@ func classifyAPIError(w io.Writer, err error, flags *rootFlags) error {
 	return classified
 }
 
+// Byte slicing splits multi-byte runes and corrupts table/JSON display.
 func truncate(s string, max int) string {
-	if len(s) <= max {
+	runes := []rune(s)
+	if len(runes) <= max {
 		return s
 	}
 	if max <= 3 {
-		return s[:max]
+		return string(runes[:max])
 	}
-	return s[:max-3] + "..."
+	return string(runes[:max-3]) + "..."
 }
 
 func newTabWriter(w io.Writer) *tabwriter.Writer {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Printed CLI tables and `--json` output were corrupting any truncated non-ASCII value: human tables showed mojibake and JSON emitted U+FFFD, because generated `truncate` sliced by byte. A 20-rune CJK field was also clipped in a 40-wide column even though it fits.

Closes #4421

## Approach

The emitted `truncate` helper now counts and cuts on runes (`[]rune`), keeps the existing `...` suffix accounting, and leaves ASCII output — including the `max <= 3` path — byte-identical. East-Asian display-width is out of scope; stored and transmitted values are untouched.

The generated-output source assertion now treats `s[:max]` as a byte slice of the string parameter only when `s` is a bare identifier, so the correct `runes[:max]` form no longer fails the check.

## Scope

Primary area: generator display helper (`templates/helpers.go.tmpl`).

Why this belongs in this repo: every printed CLI inherits this helper, so a one-CLI patch would not compound.

## Risk

Generated `internal/cli/helpers.go` changes in every future print. ASCII table/JSON output stays the same. Call sites are unchanged.

## Output Contract

- Emitted-code assertion: generated `truncate` uses `[]rune` and does not byte-slice the string parameter `s`.
- Compile-level generated CLI test: CJK cut is valid UTF-8 of at most `max` runes; 20-rune string is not truncated at width 40; ASCII cases including `max <= 3` stay identical.
- Golden fixtures for the four `helpers.go` snapshots updated to the new helper.

## Verification

- [x] `scripts/golden.sh update` (kept only the four `helpers.go` fixture diffs)
- [x] `go test ./internal/generator -run 'TestGeneratedTruncateCutsOnRuneBoundaries|TestContainsBareIdentSliceDistinguishesRunesFromString' -count=1`
- [x] Generator/template change: emitted-code assertions plus compiled generated CLI runtime cases
- [x] Generator/template change: covered CJK positive and ASCII negative, including `max <= 3`
- [x] Generator/template change: `truncate` call sites stay gated the same; only the helper body changed

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54062548-936a-49e8-9b97-998e9b4b22eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54062548-936a-49e8-9b97-998e9b4b22eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

