### PR TITLE
fix(cli): recall identifier-only teaches and keep journal sessions

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3213,7 +3213,10 @@ func (g *Generator) renderOptionalSupportFiles() error {
 		// (which teach.go's command constructors call) and initLearn(),
 		// which root.go invokes from PersistentPreRunE under the same
 		// Learn.Enabled gate.
-		if err := g.renderTemplate("learn_init.go.tmpl", filepath.Join("internal", "cli", "learn_init.go"), g.Spec); err != nil {
+		if err := g.renderTemplate("learn_init.go.tmpl", filepath.Join("internal", "cli", "learn_init.go"), learnInitTemplateData{
+			APISpec:                g.Spec,
+			ResourceIdentityFields: learnResourceIdentityFieldEntries(g.Spec, g.profile),
+		}); err != nil {
 			return fmt.Errorf("rendering learn init: %w", err)
 		}
 		if err := g.renderTemplate("learn_init_test.go.tmpl", filepath.Join("internal", "cli", "learn_init_test.go"), g.Spec); err != nil {
@@ -4477,6 +4480,109 @@ type visionRenderData struct {
 type resourceIDFieldOverrideEntry struct {
 	Name  string
 	Value string
+}
+
+type learnInitTemplateData struct {
+	*spec.APISpec
+	ResourceIdentityFields []learnIdentityFieldEntry
+}
+
+type learnIdentityFieldEntry struct {
+	ResourceType string
+	Fields       []string
+}
+
+func learnCommonIdentityFields() []string {
+	return []string{
+		"name", "title", "display_name", "full_name", "short_name", "label",
+		"slug", "key", "code", "id", "address",
+	}
+}
+
+func learnResourceIdentityFieldEntries(api *spec.APISpec, profile *profiler.APIProfile) []learnIdentityFieldEntry {
+	idByType := map[string]string{}
+	add := func(name, idField string) {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return
+		}
+		if idField != "" {
+			idByType[name] = idField
+			return
+		}
+		if _, ok := idByType[name]; !ok {
+			idByType[name] = ""
+		}
+	}
+	if api != nil {
+		var walk func(map[string]spec.Resource)
+		walk = func(resources map[string]spec.Resource) {
+			for name, res := range resources {
+				add(name, firstEndpointIDField(res))
+				if len(res.SubResources) > 0 {
+					walk(res.SubResources)
+				}
+			}
+		}
+		walk(api.Resources)
+	}
+	if profile != nil {
+		for _, r := range profile.SyncableResources {
+			add(r.Name, r.IDField)
+		}
+		for _, r := range profile.DependentSyncResources {
+			add(r.Name, r.IDField)
+		}
+	}
+	names := make([]string, 0, len(idByType))
+	for name := range idByType {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	common := learnCommonIdentityFields()
+	entries := make([]learnIdentityFieldEntry, 0, len(names))
+	for _, name := range names {
+		entries = append(entries, learnIdentityFieldEntry{
+			ResourceType: name,
+			Fields:       identityFieldsForResource(idByType[name], common),
+		})
+	}
+	return entries
+}
+
+func identityFieldsForResource(idField string, common []string) []string {
+	out := make([]string, 0, len(common)+1)
+	seen := map[string]struct{}{}
+	add := func(f string) {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			return
+		}
+		if _, ok := seen[f]; ok {
+			return
+		}
+		seen[f] = struct{}{}
+		out = append(out, f)
+	}
+	add(idField)
+	for _, f := range common {
+		add(f)
+	}
+	return out
+}
+
+func firstEndpointIDField(r spec.Resource) string {
+	names := make([]string, 0, len(r.Endpoints))
+	for name := range r.Endpoints {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if id := strings.TrimSpace(r.Endpoints[name].IDField); id != "" {
+			return id
+		}
+	}
+	return ""
 }
 
 type resourceParentKeyColumnEntry struct {

--- a/internal/generator/learn_emission_test.go
+++ b/internal/generator/learn_emission_test.go
@@ -161,6 +161,10 @@ func TestGenerateLearnCLICommandsCompileAndTest(t *testing.T) {
 
 	apiSpec := minimalSpec("learn-cli")
 	apiSpec.Learn.Enabled = true
+	apiSpec.Learn.TickerPatterns = []string{
+		`^EXAMPLE-[A-Z0-9]+(-[A-Z0-9]+)*$`,
+		`^\d{1,3}(\.\d{1,3}){3}$`,
+	}
 	outputDir := filepath.Join(t.TempDir(), "learn-cli-pp-cli")
 	gen := New(apiSpec, outputDir)
 	gen.VisionSet = VisionTemplateSet{Store: true}
@@ -241,6 +245,9 @@ func TestGenerateLearnInitWiresSpec(t *testing.T) {
 		`{Canonical: "US", Values: []string{"USA", "America"}}`,
 		`lookups.SeedFromConfig(db, seeds)`,
 		`learnInitOnce`,
+		`store.RegisterTickerPatterns(tickerPatterns)`,
+		`func learnResourceTypeFields()`,
+		`func learnIdentityFieldsFor(`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("learn_init.go missing %q\n--- emitted ---\n%s", want, got)
@@ -272,5 +279,8 @@ func TestGenerateLearnInitEmptyConfigOmitsImports(t *testing.T) {
 	}
 	if strings.Contains(got, `/learn/lookups"`) {
 		t.Errorf("learn_init.go must not import lookups when no EntityLookupSeeds declared\n--- emitted ---\n%s", got)
+	}
+	if strings.Contains(got, "store.RegisterTickerPatterns") {
+		t.Errorf("learn_init.go must not register ticker patterns when none are declared\n--- emitted ---\n%s", got)
 	}
 }

--- a/internal/generator/learn_identity_fields_test.go
+++ b/internal/generator/learn_identity_fields_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
-	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/generator/learn_identity_fields_test.go
+++ b/internal/generator/learn_identity_fields_test.go
@@ -1,0 +1,63 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLearnResourceIdentityFieldEntries_PrependsIDField(t *testing.T) {
+	t.Parallel()
+
+	api := minimalSpec("identity-fields")
+	items := api.Resources["items"]
+	list := items.Endpoints["list"]
+	list.IDField = "sku"
+	items.Endpoints["list"] = list
+	api.Resources["items"] = items
+
+	entries := learnResourceIdentityFieldEntries(api, profiler.Profile(api))
+	require.NotEmpty(t, entries)
+
+	var itemsEntry *learnIdentityFieldEntry
+	for i := range entries {
+		if entries[i].ResourceType == "items" {
+			itemsEntry = &entries[i]
+			break
+		}
+	}
+	require.NotNil(t, itemsEntry, "items must appear in the identity-field map")
+	require.NotEmpty(t, itemsEntry.Fields)
+	require.Equal(t, "sku", itemsEntry.Fields[0], "resolved IDField must lead the identity list")
+	require.Contains(t, itemsEntry.Fields, "name")
+	require.Contains(t, itemsEntry.Fields, "id")
+}
+
+func TestLearnResourceIdentityFieldEntries_DedupesIDField(t *testing.T) {
+	t.Parallel()
+
+	api := minimalSpec("identity-dedupe")
+	items := api.Resources["items"]
+	list := items.Endpoints["list"]
+	list.IDField = "id"
+	items.Endpoints["list"] = list
+	api.Resources["items"] = items
+
+	entries := learnResourceIdentityFieldEntries(api, profiler.Profile(api))
+	var itemsEntry learnIdentityFieldEntry
+	for _, e := range entries {
+		if e.ResourceType == "items" {
+			itemsEntry = e
+			break
+		}
+	}
+	count := 0
+	for _, f := range itemsEntry.Fields {
+		if f == "id" {
+			count++
+		}
+	}
+	require.Equal(t, 1, count, "id must appear once even when it is both IDField and a common key")
+}

--- a/internal/generator/learn_identity_session_test.go
+++ b/internal/generator/learn_identity_session_test.go
@@ -46,6 +46,7 @@ func TestGenerateLearnIdentityAndSessionContract(t *testing.T) {
 	recall := readEmitted(t, outputDir, "internal", "learn", "recall.go")
 	require.Contains(t, recall, "queryIdentity := QueryIdentityEntities(normalized)")
 	require.Contains(t, recall, "entitySlicesIntersect(queryIdentity, storedEntitySlice)")
+	require.Contains(t, recall, "leftoverTokensAreIdentityFragments(")
 
 	teachCLI := readEmitted(t, outputDir, "internal", "cli", "teach.go")
 	require.Contains(t, teachCLI, "learn.QueryIdentityEntities(normalized)")
@@ -65,7 +66,7 @@ func TestGenerateLearnIdentityAndSessionContract(t *testing.T) {
 	requireGeneratedCompiles(t, outputDir)
 
 	runGoCommand(t, outputDir, "test",
-		"-run", "^(TestQueryIdentityEntities_|TestRecall_IdentifierOnlyTickerFindsRow|TestValidateResourceShape_Ticker|TestNormalizeQuery_KeepsRegisteredTickersWhole|TestJournal_HarnessSessionIsHashed|TestJournal_LearnSessionOverridesHarness|TestTeachRecall_IdentifierOnlyFindsRow|TestLearnNormalizers_TickerKeepSymmetry|TestLearnIdentityFields_CommonFallback)$",
+		"-run", "^(TestQueryIdentityEntities_|TestRecall_IdentifierOnlyTickerFindsRow|TestRecall_SameIdentifierDifferentIntentDoesNotSkipDiscovery|TestLeftoverTokensAreIdentityFragments|TestValidateResourceShape_Ticker|TestNormalizeQuery_KeepsRegisteredTickersWhole|TestJournal_HarnessSessionIsHashed|TestJournal_LearnSessionOverridesHarness|TestTeachRecall_IdentifierOnlyFindsRow|TestLearnNormalizers_TickerKeepSymmetry|TestLearnIdentityFields_CommonFallback)$",
 		"./internal/learn/...", "./internal/cli/...", "./internal/store/...")
 }
 

--- a/internal/generator/learn_identity_session_test.go
+++ b/internal/generator/learn_identity_session_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/require"
 )
@@ -35,10 +34,10 @@ func TestGenerateLearnIdentityAndSessionContract(t *testing.T) {
 		t.Skip("generated-output compile-and-test skipped in -short mode")
 	}
 
-	apiSpec := identifierLearnSpec("learn-identity")
-	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	apiSpec := identifierLearnSpec("lident")
+	outputDir := filepath.Join(t.TempDir(), "lident-pp-cli")
 	gen := New(apiSpec, outputDir)
-	gen.VisionSet = VisionTemplateSet{Store: true}
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, MCP: true}
 	require.NoError(t, gen.Generate())
 
 	normalize := readEmitted(t, outputDir, "internal", "learn", "normalize.go")
@@ -73,8 +72,8 @@ func TestGenerateLearnIdentityAndSessionContract(t *testing.T) {
 func TestGenerateLearnIdentityEmitsPerResourceFields(t *testing.T) {
 	t.Parallel()
 
-	apiSpec := identifierLearnSpec("learn-fields")
-	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	apiSpec := identifierLearnSpec("lfields")
+	outputDir := filepath.Join(t.TempDir(), "lfields-pp-cli")
 	gen := New(apiSpec, outputDir)
 	gen.VisionSet = VisionTemplateSet{Store: true}
 	require.NoError(t, gen.Generate())

--- a/internal/generator/learn_identity_session_test.go
+++ b/internal/generator/learn_identity_session_test.go
@@ -46,6 +46,7 @@ func TestGenerateLearnIdentityAndSessionContract(t *testing.T) {
 	recall := readEmitted(t, outputDir, "internal", "learn", "recall.go")
 	require.Contains(t, recall, "queryIdentity := QueryIdentityEntities(normalized)")
 	require.Contains(t, recall, "entitySlicesIntersect(queryIdentity, storedEntitySlice)")
+	require.Contains(t, recall, "identifierOnlyScore(")
 	require.Contains(t, recall, "leftoverTokensAreIdentityFragments(")
 
 	teachCLI := readEmitted(t, outputDir, "internal", "cli", "teach.go")
@@ -66,7 +67,7 @@ func TestGenerateLearnIdentityAndSessionContract(t *testing.T) {
 	requireGeneratedCompiles(t, outputDir)
 
 	runGoCommand(t, outputDir, "test",
-		"-run", "^(TestQueryIdentityEntities_|TestRecall_IdentifierOnlyTickerFindsRow|TestRecall_SameIdentifierDifferentIntentDoesNotSkipDiscovery|TestLeftoverTokensAreIdentityFragments|TestValidateResourceShape_Ticker|TestNormalizeQuery_KeepsRegisteredTickersWhole|TestJournal_HarnessSessionIsHashed|TestJournal_LearnSessionOverridesHarness|TestTeachRecall_IdentifierOnlyFindsRow|TestLearnNormalizers_TickerKeepSymmetry|TestLearnIdentityFields_CommonFallback)$",
+		"-run", "^(TestQueryIdentityEntities_|TestRecall_IdentifierOnlyTickerFindsRow|TestRecall_SameIdentifierDifferentIntentDoesNotSkipDiscovery|TestLeftoverTokensAreIdentityFragments|TestIdentifierOnlyScore_IncludesLeftoverIntent|TestValidateResourceShape_Ticker|TestNormalizeQuery_KeepsRegisteredTickersWhole|TestJournal_HarnessSessionIsHashed|TestJournal_LearnSessionOverridesHarness|TestTeachRecall_IdentifierOnlyFindsRow|TestLearnNormalizers_TickerKeepSymmetry|TestLearnIdentityFields_CommonFallback)$",
 		"./internal/learn/...", "./internal/cli/...", "./internal/store/...")
 }
 

--- a/internal/generator/learn_identity_session_test.go
+++ b/internal/generator/learn_identity_session_test.go
@@ -1,0 +1,90 @@
+package generator
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func identifierLearnSpec(name string) *spec.APISpec {
+	apiSpec := incidentReplaySpec(name)
+	apiSpec.Learn.TickerPatterns = []string{
+		`^EXAMPLE-[A-Z0-9]+(-[A-Z0-9]+)*$`,
+		`^\d{1,3}(\.\d{1,3}){3}$`,
+	}
+	list := apiSpec.Resources["items"].Endpoints["list"]
+	list.IDField = "id"
+	res := apiSpec.Resources["items"]
+	res.Endpoints["list"] = list
+	apiSpec.Resources["items"] = res
+	return apiSpec
+}
+
+// TestGenerateLearnIdentityAndSessionContract asserts the emitted
+// teach/recall/journal/init files carry the identity-fold, identity-field
+// map, ticker registration, and hashed harness session helpers, then
+// compiles the generated module and runs the identifier-only + journal
+// session tests against that print.
+func TestGenerateLearnIdentityAndSessionContract(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("generated-output compile-and-test skipped in -short mode")
+	}
+
+	apiSpec := identifierLearnSpec("learn-identity")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	normalize := readEmitted(t, outputDir, "internal", "learn", "normalize.go")
+	require.Contains(t, normalize, "func QueryIdentityEntities(")
+
+	recall := readEmitted(t, outputDir, "internal", "learn", "recall.go")
+	require.Contains(t, recall, "queryIdentity := QueryIdentityEntities(normalized)")
+	require.Contains(t, recall, "entitySlicesIntersect(queryIdentity, storedEntitySlice)")
+
+	teachCLI := readEmitted(t, outputDir, "internal", "cli", "teach.go")
+	require.Contains(t, teachCLI, "learn.QueryIdentityEntities(normalized)")
+	require.Contains(t, teachCLI, "learnIdentityFieldsFor(resourceType)")
+	require.Contains(t, teachCLI, "ResourceTypeFields: learnResourceTypeFields()")
+
+	initSrc := readEmitted(t, outputDir, "internal", "cli", "learn_init.go")
+	require.Contains(t, initSrc, "store.RegisterTickerPatterns(tickerPatterns)")
+	require.Contains(t, initSrc, `func learnResourceTypeFields()`)
+	require.Contains(t, initSrc, `"items":`)
+	require.Contains(t, initSrc, `"id"`)
+
+	journal := readEmitted(t, outputDir, "internal", "learn", "journal.go")
+	require.Contains(t, journal, "JournalHarnessSessionEnvVars")
+	require.Contains(t, journal, `"h:"`)
+	require.Contains(t, journal, "CODEX_SESSION_ID")
+	requireGeneratedCompiles(t, outputDir)
+
+	runGoCommand(t, outputDir, "test",
+		"-run", "^(TestQueryIdentityEntities_|TestRecall_IdentifierOnlyTickerFindsRow|TestValidateResourceShape_Ticker|TestNormalizeQuery_KeepsRegisteredTickersWhole|TestJournal_HarnessSessionIsHashed|TestJournal_LearnSessionOverridesHarness|TestTeachRecall_IdentifierOnlyFindsRow|TestLearnNormalizers_TickerKeepSymmetry|TestLearnIdentityFields_CommonFallback)$",
+		"./internal/learn/...", "./internal/cli/...", "./internal/store/...")
+}
+
+func TestGenerateLearnIdentityEmitsPerResourceFields(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := identifierLearnSpec("learn-fields")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	initSrc := readEmitted(t, outputDir, "internal", "cli", "learn_init.go")
+	require.Contains(t, initSrc, `"items": {`)
+	// IDField leads the list, then the common identity keys.
+	idxItems := strings.Index(initSrc, `"items": {`)
+	require.GreaterOrEqual(t, idxItems, 0)
+	window := initSrc[idxItems : idxItems+200]
+	require.Contains(t, window, `"id"`)
+	require.Contains(t, window, `"name"`)
+}

--- a/internal/generator/learn_incident_replay_test.go
+++ b/internal/generator/learn_incident_replay_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -64,6 +65,7 @@ func TestIncidentReplay(t *testing.T) {
 	t.Run("AE4_phrasing_convergence", h.testAE4PhrasingConvergence)
 	t.Run("AE6_harness_silence", h.testAE6HarnessSilence)
 	t.Run("SessionKeyFallback_pid_lineage", h.testSessionKeyFallbackPidLineage)
+	t.Run("SessionKeyFallback_harness_hash_across_ppids", h.testSessionKeyHarnessHashAcrossPPIDs)
 }
 
 // incidentReplaySpec is minimalSpec plus a second endpoint so the
@@ -639,4 +641,89 @@ func (h *incidentHarness) testSessionKeyFallbackPidLineage(t *testing.T) {
 	open := h.listCandidates(home, "pid-harness", "open")
 	require.Len(t, open, 1, "pid-lineage keyed failure pair must still derive the flag_alias candidate")
 	require.Equal(t, "flag_alias", open[0].Class)
+}
+
+// runViaShell starts the CLI under a short-lived shell without exec, so
+// the CLI's PPID is the shell rather than this test process. Combined
+// with a shared harness session env and no LEARN_SESSION, this is the
+// Codex-style sibling-tool-call shape: different PPIDs, one episode.
+func (h *incidentHarness) runViaShell(home string, extraEnv []string, args ...string) (stdout, stderr string, exitCode int) {
+	h.t.Helper()
+	script := strconv.Quote(h.binary) + ` "$@"`
+	cmd := exec.Command("sh", append([]string{"-c", script, "_"}, args...)...)
+	cmd.Env = []string{
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + home,
+		"TMPDIR=" + os.TempDir(),
+		h.envPrefix + "_HOME=" + home,
+		h.envPrefix + "_BASE_URL=" + h.baseURL,
+		"MYAPI_TOKEN=dummy-token-for-harness",
+	}
+	cmd.Env = append(cmd.Env, extraEnv...)
+	var out, errBuf strings.Builder
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	exitCode = 0
+	if err != nil {
+		exitErr, ok := err.(*exec.ExitError)
+		require.True(h.t, ok, "shell invocation %v failed to run: %v", args, err)
+		exitCode = exitErr.ExitCode()
+	}
+	return out.String(), errBuf.String(), exitCode
+}
+
+func (h *incidentHarness) journalRaw(home string) string {
+	h.t.Helper()
+	segments, err := filepath.Glob(filepath.Join(home, "state", "learn", "journal-*.jsonl"))
+	require.NoError(h.t, err)
+	var b strings.Builder
+	for _, seg := range segments {
+		data, err := os.ReadFile(seg)
+		require.NoError(h.t, err)
+		b.Write(data)
+	}
+	return b.String()
+}
+
+// testSessionKeyHarnessHashAcrossPPIDs proves a recall → discover →
+// teach episode assembled across separate child processes that do not
+// share a parent pid still synthesizes exactly one quarantined
+// playbook_candidate when a harness session id is present.
+func (h *incidentHarness) testSessionKeyHarnessHashAcrossPPIDs(t *testing.T) {
+	home := t.TempDir()
+	const raw = "codex-session-raw-must-not-appear-xyz"
+	extra := []string{"CODEX_SESSION_ID=" + raw}
+
+	stdout, stderr, exit := h.runViaShell(home, extra, "recall", incidentFamilyQueryA, "--json")
+	require.Equal(t, 0, exit, "recall must exit 0; stderr:\n%s\nstdout:\n%s", stderr, stdout)
+	_, stderr, exit = h.runViaShell(home, extra, "items", "list", "--json")
+	require.Equal(t, 0, exit, "items list must exit 0; stderr:\n%s", stderr)
+	_, stderr, exit = h.runViaShell(home, extra, "teach",
+		"--query", incidentFamilyQueryA,
+		"--resource-type", "items",
+		"--resource", "alpha-recap",
+		"--json")
+	require.Equal(t, 0, exit, "teach must exit 0; stderr:\n%s", stderr)
+
+	entries := h.readJournal(home)
+	require.GreaterOrEqual(t, len(entries), 3, "recall, discovery, and teach must journal")
+	key := entries[0].SessionKey
+	require.True(t, strings.HasPrefix(key, "h:"), "harness session must hash; got %q", key)
+	for _, e := range entries {
+		require.Equal(t, key, e.SessionKey, "separate-process invocations must share the hashed harness key")
+		require.False(t, strings.HasPrefix(e.SessionKey, "ppid:"), "PPID must not win when a harness id is set")
+	}
+	rawJournal := h.journalRaw(home)
+	require.NotContains(t, rawJournal, raw, "raw harness session id must not land in the journal")
+
+	open := h.listCandidates(home, "harness-inspect", "open")
+	var playbooks int
+	for _, row := range open {
+		if row.Class == "playbook_candidate" {
+			playbooks++
+			require.Equal(t, incidentExpectedFamily, row.QueryFamily)
+		}
+	}
+	require.Equal(t, 1, playbooks, "want exactly one quarantined playbook_candidate; open=%+v", open)
 }

--- a/internal/generator/learn_journal_test.go
+++ b/internal/generator/learn_journal_test.go
@@ -49,8 +49,12 @@ func TestGenerateJournalEmitsFiles(t *testing.T) {
 		// Append path + fail-open entry point used by root.go.
 		"func AppendJournalEntry(",
 		"func JournalInvocation(",
-		// Session key: env var else parent-pid lineage.
+		// Session key: LEARN_SESSION override, else hashed harness id, else ppid.
 		"JOURNAL_EMIT_LEARN_SESSION",
+		"JournalHarnessSessionEnvVars",
+		`"h:"`,
+		"CODEX_SESSION_ID",
+		"CURSOR_SESSION_ID",
 		// Silence switches (verify/dogfood handled via cliutil).
 		"JOURNAL_EMIT_NO_LEARN",
 		"JOURNAL_EMIT_LEARN_NO_CAPTURE",

--- a/internal/generator/templates/learn/journal.go.tmpl
+++ b/internal/generator/templates/learn/journal.go.tmpl
@@ -5,6 +5,8 @@ package learn
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -150,14 +152,46 @@ func journalEnvTruthy(name string) bool {
 	return v == "true" || v == "1" || v == "yes"
 }
 
+// JournalHarnessSessionEnvVars is the first-match-wins list of
+// harness session identifiers. Exported so command-level tests can
+// clear the same set the production resolver reads. Raw values never
+// land in the journal; only a bounded hash of the first non-empty
+// value is persisted.
+var JournalHarnessSessionEnvVars = []string{
+	"CODEX_THREAD_ID",
+	"CODEX_SESSION_ID",
+	"CLAUDE_SESSION_ID",
+	"CLAUDE_CODE_SESSION",
+	"CURSOR_SESSION_ID",
+	"CURSOR_TRACE_ID",
+}
+
 // JournalSessionKey returns the session key for this invocation: the
-// session env var when set, else a parent-pid lineage string so all
-// commands spawned by the same agent shell share a key.
+// explicit LEARN_SESSION override when set, else a hashed harness
+// session identifier so sibling tool calls share a key even when each
+// has a different parent process, else a parent-pid lineage string.
 func JournalSessionKey() string {
 	if v := strings.TrimSpace(os.Getenv(journalSessionEnvVar)); v != "" {
 		return v
 	}
+	if hashed := journalHashedHarnessSession(); hashed != "" {
+		return hashed
+	}
 	return "ppid:" + strconv.Itoa(os.Getppid())
+}
+
+func journalHashedHarnessSession() string {
+	for _, name := range JournalHarnessSessionEnvVars {
+		if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+			return "h:" + hashHarnessSession(v)
+		}
+	}
+	return ""
+}
+
+func hashHarnessSession(v string) string {
+	sum := sha256.Sum256([]byte(v))
+	return hex.EncodeToString(sum[:8])
 }
 
 // JournalDir returns the journal directory (a learn/ subdir of the

--- a/internal/generator/templates/learn/journal_test.go.tmpl
+++ b/internal/generator/templates/learn/journal_test.go.tmpl
@@ -33,6 +33,9 @@ func withJournalHome(t *testing.T) string {
 	t.Setenv("{{envPrefix .Name}}_NO_LEARN", "")
 	t.Setenv("{{envPrefix .Name}}_LEARN_NO_CAPTURE", "")
 	t.Setenv("{{envPrefix .Name}}_LEARN_SESSION", "")
+	for _, name := range learn.JournalHarnessSessionEnvVars {
+		t.Setenv(name, "")
+	}
 	return dir
 }
 
@@ -142,6 +145,45 @@ func TestJournal_SessionKeyFromEnv(t *testing.T) {
 	entries := readAllJournalEntries(t)
 	if len(entries) != 1 || entries[0].SessionKey != "session-abc123" {
 		t.Errorf("session_key = %+v, want session-abc123", entries)
+	}
+}
+
+func TestJournal_HarnessSessionIsHashed(t *testing.T) {
+	withJournalHome(t)
+	raw := "raw-harness-session-id-must-not-leak"
+	t.Setenv("CODEX_SESSION_ID", raw)
+	if err := runCLI(t, "version"); err != nil {
+		t.Fatalf("version: %v", err)
+	}
+	entries := readAllJournalEntries(t)
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(entries))
+	}
+	key := entries[0].SessionKey
+	if !strings.HasPrefix(key, "h:") {
+		t.Errorf("session_key = %q, want hashed harness prefix h:", key)
+	}
+	if strings.Contains(key, raw) {
+		t.Errorf("session_key leaked the raw harness id: %q", key)
+	}
+	if strings.Contains(journalRawBytes(t), raw) {
+		t.Error("raw harness session id must not appear anywhere in the journal")
+	}
+}
+
+func TestJournal_LearnSessionOverridesHarness(t *testing.T) {
+	withJournalHome(t)
+	t.Setenv("CODEX_SESSION_ID", "harness-should-lose")
+	t.Setenv("{{envPrefix .Name}}_LEARN_SESSION", "session-abc123")
+	if err := runCLI(t, "version"); err != nil {
+		t.Fatalf("version: %v", err)
+	}
+	entries := readAllJournalEntries(t)
+	if len(entries) != 1 || entries[0].SessionKey != "session-abc123" {
+		t.Errorf("LEARN_SESSION must win over harness id; got %+v", entries)
+	}
+	if strings.Contains(journalRawBytes(t), "harness-should-lose") {
+		t.Error("raw harness session id must not appear when LEARN_SESSION is set")
 	}
 }
 

--- a/internal/generator/templates/learn/normalize.go.tmpl
+++ b/internal/generator/templates/learn/normalize.go.tmpl
@@ -80,3 +80,14 @@ func normalize(query string, cfg *entities.Config, fold bool) NormalizedQuery {
 		NonEntityNormalized: strings.Join(tokens, " "),
 	}
 }
+
+// QueryIdentityEntities returns the query-side identity tokens used at
+// teach-write and recall-match: Entities plus Tickers. Resource-side
+// extraction already folds both into one slice so a ticker-shaped
+// identifier can match the resource that is that identifier. Family
+// keys stay on NonEntityNormalized and are not affected.
+func QueryIdentityEntities(n NormalizedQuery) []string {
+	out := make([]string, 0, len(n.Entities)+len(n.Tickers))
+	out = append(out, n.Entities...)
+	return append(out, n.Tickers...)
+}

--- a/internal/generator/templates/learn/normalize_test.go.tmpl
+++ b/internal/generator/templates/learn/normalize_test.go.tmpl
@@ -187,3 +187,33 @@ func TestNormalize_OriginalPreservedThroughFold(t *testing.T) {
 		t.Errorf("Original = %q, want %q", got.Original, in)
 	}
 }
+
+func TestQueryIdentityEntities_IncludesTickers(t *testing.T) {
+	t.Parallel()
+	got := QueryIdentityEntities(Normalize("where is TICKER-ABC", testConfig()))
+	want := []string{"TICKER-ABC"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("QueryIdentityEntities = %v, want %v", got, want)
+	}
+}
+
+func TestQueryIdentityEntities_EntitiesAndTickers(t *testing.T) {
+	t.Parallel()
+	got := QueryIdentityEntities(Normalize("rate Alpha TICKER-X1", testConfig()))
+	want := []string{"Alpha", "TICKER-X1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("QueryIdentityEntities = %v, want %v", got, want)
+	}
+}
+
+func TestQueryIdentityEntities_DoesNotChangeFamily(t *testing.T) {
+	t.Parallel()
+	n := Normalize("where is TICKER-ABC", testConfig())
+	_ = QueryIdentityEntities(n)
+	if QueryFamily(n) != n.NonEntityNormalized {
+		t.Errorf("QueryFamily = %q, want NonEntityNormalized %q", QueryFamily(n), n.NonEntityNormalized)
+	}
+	if n.NonEntityNormalized != "" {
+		t.Errorf("identifier-only NonEntityNormalized = %q, want empty", n.NonEntityNormalized)
+	}
+}

--- a/internal/generator/templates/learn/recall.go.tmpl
+++ b/internal/generator/templates/learn/recall.go.tmpl
@@ -373,11 +373,14 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 		//      caught at that layer.
 		if score < jMin {
 			// Identifier-only queries normalize to an empty non-entity
-			// bag on the read side. Score on identity overlap whenever
-			// the query has no content tokens and the stored row shares
-			// an identity token, even if the write-side pattern still
-			// carries leftover tokens (punctuation-split identifiers).
-			if len(queryTokens) == 0 && entitySlicesIntersect(queryIdentity, storedEntitySlice) {
+			// bag on the read side. Score on identity overlap only when
+			// leftover stored tokens are empty or punctuation-split
+			// identifier fragments. Distinct leftover intent tokens
+			// (different resource/action, same identifier) must not
+			// become exact skip-discovery hits.
+			identityForFragments := append(append([]string{}, queryIdentity...), storedEntitySlice...)
+			if len(queryTokens) == 0 && entitySlicesIntersect(queryIdentity, storedEntitySlice) &&
+				leftoverTokensAreIdentityFragments(storedNonEntityTokens, identityForFragments) {
 				score = Jaccard(queryIdentity, storedEntitySlice)
 			} else if len(queryTokens) == 0 && len(storedNonEntityTokens) == 0 &&
 				len(queryIdentity) > 0 && len(storedEntitySlice) > 0 {
@@ -755,6 +758,63 @@ func entityMatchPriority(em string) int {
 // teach time). A naive case-sensitive comparison would miss the match.
 // Same-entity rows must not slip through the lower crossAliasMin floor
 // or get inflated by canonicalJaccard.
+// leftoverTokensAreIdentityFragments reports whether every leftover
+// stored token is an identity token or an alphanumeric fragment of
+// one. Write-side punctuation splits ("ticker" "abc" from TICKER-ABC)
+// stay eligible for the identifier-only boost; leftover intent tokens
+// do not.
+func leftoverTokensAreIdentityFragments(tokens, identity []string) bool {
+	if len(tokens) == 0 {
+		return true
+	}
+	allowed := make(map[string]struct{})
+	for _, id := range identity {
+		n := strings.ToLower(strings.TrimSpace(id))
+		if n == "" {
+			continue
+		}
+		allowed[n] = struct{}{}
+		for _, frag := range identityCharFragments(n) {
+			if frag != "" {
+				allowed[frag] = struct{}{}
+			}
+		}
+	}
+	if len(allowed) == 0 {
+		return false
+	}
+	for _, tok := range tokens {
+		t := strings.ToLower(strings.TrimSpace(tok))
+		if t == "" {
+			continue
+		}
+		if _, ok := allowed[t]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// identityCharFragments splits on non-alphanumeric runes the same way
+// the write-side query tokenizer does, so a leftover bag of identifier
+// pieces still counts as the same identity.
+func identityCharFragments(s string) []string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte(' ')
+		}
+	}
+	return strings.Fields(b.String())
+}
+
 func entitySlicesIntersect(a, b []string) bool {
 	if len(a) == 0 || len(b) == 0 {
 		return false

--- a/internal/generator/templates/learn/recall.go.tmpl
+++ b/internal/generator/templates/learn/recall.go.tmpl
@@ -373,15 +373,13 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 		//      caught at that layer.
 		if score < jMin {
 			// Identifier-only queries normalize to an empty non-entity
-			// bag on the read side. Score on identity overlap only when
-			// leftover stored tokens are empty or punctuation-split
-			// identifier fragments. Distinct leftover intent tokens
-			// (different resource/action, same identifier) must not
-			// become exact skip-discovery hits.
-			identityForFragments := append(append([]string{}, queryIdentity...), storedEntitySlice...)
-			if len(queryTokens) == 0 && entitySlicesIntersect(queryIdentity, storedEntitySlice) &&
-				leftoverTokensAreIdentityFragments(storedNonEntityTokens, identityForFragments) {
-				score = Jaccard(queryIdentity, storedEntitySlice)
+			// bag on the read side. Score identity overlap together with
+			// leftover stored tokens: punctuation-split identifier
+			// fragments stay identity-equivalent, leftover intent tokens
+			// enter the bag so same-identifier / different-intent rows
+			// cannot all become exact skip-discovery hits.
+			if len(queryTokens) == 0 && entitySlicesIntersect(queryIdentity, storedEntitySlice) {
+				score = identifierOnlyScore(queryIdentity, storedEntitySlice, storedNonEntityTokens)
 			} else if len(queryTokens) == 0 && len(storedNonEntityTokens) == 0 &&
 				len(queryIdentity) > 0 && len(storedEntitySlice) > 0 {
 				score = Jaccard(queryIdentity, storedEntitySlice)
@@ -750,11 +748,26 @@ func entityMatchPriority(em string) int {
 	}
 }
 
+// identifierOnlyScore is Jaccard of query identity against stored
+// identity plus leftover stored tokens that are not punctuation-split
+// identifier fragments. Fragment leftovers stay identity-equivalent;
+// leftover intent tokens stay in the bag.
+func identifierOnlyScore(queryIdentity, storedIdentity, leftover []string) float64 {
+	identity := append(append([]string{}, queryIdentity...), storedIdentity...)
+	storedBag := append([]string{}, storedIdentity...)
+	for _, tok := range leftover {
+		if leftoverTokensAreIdentityFragments([]string{tok}, identity) {
+			continue
+		}
+		storedBag = append(storedBag, tok)
+	}
+	return Jaccard(queryIdentity, storedBag)
+}
+
 // leftoverTokensAreIdentityFragments reports whether every leftover
 // stored token is an identity token or an alphanumeric fragment of
 // one. Write-side punctuation splits ("ticker" "abc" from TICKER-ABC)
-// stay eligible for the identifier-only boost; leftover intent tokens
-// do not.
+// stay identity-equivalent; leftover intent tokens do not.
 func leftoverTokensAreIdentityFragments(tokens, identity []string) bool {
 	if len(tokens) == 0 {
 		return true

--- a/internal/generator/templates/learn/recall.go.tmpl
+++ b/internal/generator/templates/learn/recall.go.tmpl
@@ -750,14 +750,6 @@ func entityMatchPriority(em string) int {
 	}
 }
 
-// entitySlicesIntersect reports whether two literal entity slices
-// share at least one element after case-insensitive comparison.
-// Used to detect "same literal entity" -- normalized.Entities is
-// lowercased by Normalize, but storedEntitySlice comes straight from
-// ParseStoredEntities (which preserves the case the extractor saw at
-// teach time). A naive case-sensitive comparison would miss the match.
-// Same-entity rows must not slip through the lower crossAliasMin floor
-// or get inflated by canonicalJaccard.
 // leftoverTokensAreIdentityFragments reports whether every leftover
 // stored token is an identity token or an alphanumeric fragment of
 // one. Write-side punctuation splits ("ticker" "abc" from TICKER-ABC)
@@ -815,6 +807,14 @@ func identityCharFragments(s string) []string {
 	return strings.Fields(b.String())
 }
 
+// entitySlicesIntersect reports whether two literal entity slices
+// share at least one element after case-insensitive comparison.
+// Used to detect "same literal entity" -- normalized.Entities is
+// lowercased by Normalize, but storedEntitySlice comes straight from
+// ParseStoredEntities (which preserves the case the extractor saw at
+// teach time). A naive case-sensitive comparison would miss the match.
+// Same-entity rows must not slip through the lower crossAliasMin floor
+// or get inflated by canonicalJaccard.
 func entitySlicesIntersect(a, b []string) bool {
 	if len(a) == 0 || len(b) == 0 {
 		return false

--- a/internal/generator/templates/learn/recall.go.tmpl
+++ b/internal/generator/templates/learn/recall.go.tmpl
@@ -164,10 +164,11 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 		cfg = entities.NewConfig()
 	}
 	normalized := Normalize(query, cfg)
+	queryIdentity := QueryIdentityEntities(normalized)
 	result := Result{
 		Query:         query,
 		Normalized:    normalized.NonEntityNormalized,
-		QueryEntities: append([]string(nil), normalized.Entities...),
+		QueryEntities: append([]string(nil), queryIdentity...),
 		Results:       []Hit{},
 	}
 	if result.QueryEntities == nil {
@@ -221,7 +222,8 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 	normalized = PromoteEntities(normalized, resolver)
 	result.Family = QueryFamily(normalized)
 	queryTokens := strings.Fields(normalized.NonEntityNormalized)
-	result.QueryEntities = append([]string(nil), normalized.Entities...)
+	queryIdentity = QueryIdentityEntities(normalized)
+	result.QueryEntities = append([]string(nil), queryIdentity...)
 	if result.QueryEntities == nil {
 		result.QueryEntities = []string{}
 	}
@@ -300,7 +302,7 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 		storedNorm := Normalize(queryPattern, cfg)
 		storedEntitySlice, _ := ParseStoredEntities(storedEntities)
 		if len(storedEntitySlice) == 0 {
-			storedEntitySlice = storedNorm.Entities
+			storedEntitySlice = QueryIdentityEntities(storedNorm)
 		}
 		// Opportunistic backfill for legacy null-entity rows. Rows
 		// written before symmetric teach-time promotion landed have
@@ -370,9 +372,16 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 		//      happens to canonical-overlap a stored row still gets
 		//      caught at that layer.
 		if score < jMin {
-			if len(queryTokens) == 0 && len(storedNonEntityTokens) == 0 &&
-				len(normalized.Entities) > 0 && len(storedEntitySlice) > 0 {
-				score = Jaccard(normalized.Entities, storedEntitySlice)
+			// Identifier-only queries normalize to an empty non-entity
+			// bag on the read side. Score on identity overlap whenever
+			// the query has no content tokens and the stored row shares
+			// an identity token, even if the write-side pattern still
+			// carries leftover tokens (punctuation-split identifiers).
+			if len(queryTokens) == 0 && entitySlicesIntersect(queryIdentity, storedEntitySlice) {
+				score = Jaccard(queryIdentity, storedEntitySlice)
+			} else if len(queryTokens) == 0 && len(storedNonEntityTokens) == 0 &&
+				len(queryIdentity) > 0 && len(storedEntitySlice) > 0 {
+				score = Jaccard(queryIdentity, storedEntitySlice)
 			}
 			if score < jMin {
 				// Three fallback branches, gated by the lower
@@ -402,7 +411,7 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 					// only fire when literal entities genuinely differ.
 					// Same-entity rows that miss jMin are genuine
 					// structural noise and should drop.
-					if entitySlicesIntersect(normalized.Entities, storedEntitySlice) {
+					if entitySlicesIntersect(queryIdentity, storedEntitySlice) {
 						continue
 					}
 					canonScore := canonicalJaccard(queryCanonicals, storedCanonicals)
@@ -427,7 +436,7 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 					// such rows instead -- case 1 covers the matching-
 					// canonical path, case 2 is reserved for actually
 					// different entities.
-					if entitySlicesIntersect(normalized.Entities, storedEntitySlice) {
+					if entitySlicesIntersect(queryIdentity, storedEntitySlice) {
 						continue
 					}
 					if score < crossAliasMin {
@@ -454,7 +463,7 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 			t := lastObserved.Time
 			hit.LastObservedAt = &t
 		}
-		validateResource(ctx, db, cfg, &hit, normalized.Entities, storedEntitySlice, opts.ResourceTypeFields)
+		validateResource(ctx, db, cfg, &hit, queryIdentity, storedEntitySlice, opts.ResourceTypeFields)
 		// Cross-alias promotion: if canonicals overlap, the entities
 		// are equivalent even when their literal forms differ. Override
 		// a Mismatch verdict so the learning isn't filtered into the
@@ -491,7 +500,7 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 	// Generalization layer: ask the pattern engine whether any template
 	// applies to this query. Errors are swallowed; pattern hits are
 	// additive on top of direct hits.
-	patternHits, _ := patterns.Apply(ctx, db, query, normalized.NonEntityNormalized, normalized.Entities, patterns.Opts{
+	patternHits, _ := patterns.Apply(ctx, db, query, normalized.NonEntityNormalized, queryIdentity, patterns.Opts{
 		JaccardMin:      jMin,
 		Limit:           limit,
 		AdditionalKinds: opts.PatternKinds,

--- a/internal/generator/templates/learn/recall_test.go.tmpl
+++ b/internal/generator/templates/learn/recall_test.go.tmpl
@@ -709,6 +709,55 @@ func TestRecall_HitCarriesLearningID(t *testing.T) {
 	}
 }
 
+// TestRecall_IdentifierOnlyTickerFindsRow is the identifier-only
+// teach→recall contract: the stored pattern still carries leftover
+// write-side tokens (punctuation-split identifier), but recall scores
+// on identity overlap and returns the row with the ticker in
+// query_entities. entity_match is exact when the resource JSON
+// carries the same identifier on a configured identity field.
+func TestRecall_IdentifierOnlyTickerFindsRow(t *testing.T) {
+	t.Parallel()
+	db := openRecallTestDB(t)
+	seedRecallResource(t, db, "widgets", "TICKER-ABC", `{"title":"TICKER-ABC widget","id":"TICKER-ABC"}`)
+	identity, err := json.Marshal(QueryIdentityEntities(Normalize("where is TICKER-ABC", testConfig())))
+	if err != nil {
+		t.Fatalf("marshal identity: %v", err)
+	}
+	// Simulate the write-side split: punctuation becomes spaces and
+	// the ticker is no longer a single stored token.
+	seedLearning(t, db, "where ticker abc", string(identity), "TICKER-ABC", "widgets", "boost", 3)
+
+	got, err := Recall(context.Background(), db, "where is TICKER-ABC", Opts{
+		EntityConfig:       testConfig(),
+		ResourceTypeFields: map[string][]string{"widgets": {"title", "id"}},
+	})
+	if err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+	if !got.Found {
+		t.Fatalf("want Found=true, got %+v", got)
+	}
+	if got.Family != "" {
+		t.Errorf("identifier-only family must stay empty NonEntityNormalized; Family=%q", got.Family)
+	}
+	foundIdent := false
+	for _, e := range got.QueryEntities {
+		if e == "TICKER-ABC" {
+			foundIdent = true
+			break
+		}
+	}
+	if !foundIdent {
+		t.Errorf("QueryEntities = %v, want to include TICKER-ABC", got.QueryEntities)
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("want 1 hit, got %d (%+v)", len(got.Results), got.Results)
+	}
+	if got.Results[0].EntityMatch != EntityMatchExact {
+		t.Errorf("EntityMatch = %q, want %q", got.Results[0].EntityMatch, EntityMatchExact)
+	}
+}
+
 // TestFamilyHash_StableNonReversibleEmpty pins the event-key contract:
 // deterministic, distinct across families, no family text leaking
 // through, and "" for an empty family (stored as NULL).

--- a/internal/generator/templates/learn/recall_test.go.tmpl
+++ b/internal/generator/templates/learn/recall_test.go.tmpl
@@ -758,6 +758,70 @@ func TestRecall_IdentifierOnlyTickerFindsRow(t *testing.T) {
 	}
 }
 
+func TestLeftoverTokensAreIdentityFragments(t *testing.T) {
+	t.Parallel()
+	id := []string{"TICKER-ABC"}
+	if !leftoverTokensAreIdentityFragments(nil, id) {
+		t.Fatal("empty leftover must stay eligible")
+	}
+	if !leftoverTokensAreIdentityFragments([]string{"ticker", "abc"}, id) {
+		t.Fatal("punctuation-split identifier fragments must stay eligible")
+	}
+	if leftoverTokensAreIdentityFragments([]string{"owns"}, id) {
+		t.Fatal("distinct intent leftover must not boost")
+	}
+	if leftoverTokensAreIdentityFragments([]string{"owns", "ticker"}, id) {
+		t.Fatal("intent token plus fragments must not boost")
+	}
+}
+
+// TestRecall_SameIdentifierDifferentIntentDoesNotSkipDiscovery pins
+// that two teachings sharing an identifier but naming different
+// resources and actions cannot both become exact skip-discovery hits.
+// The leftover-token identity boost is only for identifier fragments.
+func TestRecall_SameIdentifierDifferentIntentDoesNotSkipDiscovery(t *testing.T) {
+	t.Parallel()
+	db := openRecallTestDB(t)
+	seedRecallResource(t, db, "widgets", "TICKER-ABC", `{"title":"TICKER-ABC widget","id":"TICKER-ABC"}`)
+	seedRecallResource(t, db, "owners", "TICKER-ABC", `{"title":"TICKER-ABC owner","id":"TICKER-ABC"}`)
+	identity, err := json.Marshal(QueryIdentityEntities(Normalize("where is TICKER-ABC", testConfig())))
+	if err != nil {
+		t.Fatalf("marshal identity: %v", err)
+	}
+	seedLearning(t, db, "where ticker abc", string(identity), "TICKER-ABC", "widgets", "boost", 3)
+	seedLearning(t, db, "owns ticker abc", string(identity), "TICKER-ABC", "owners", "hide", 3)
+
+	got, err := Recall(context.Background(), db, "where is TICKER-ABC", Opts{
+		EntityConfig: testConfig(),
+		ResourceTypeFields: map[string][]string{
+			"widgets": {"title", "id"},
+			"owners":  {"title", "id"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+	if !got.Found {
+		t.Fatalf("want Found=true for the identifier-only where row, got %+v", got)
+	}
+	exact := 0
+	for _, h := range got.Results {
+		if h.ResourceType == "owners" || h.Action == "hide" {
+			t.Errorf("owns/owners row leaked into Results: %+v", h)
+		}
+		if h.EntityMatch != EntityMatchExact {
+			continue
+		}
+		exact++
+		if h.ResourceType != "widgets" || h.Action != "boost" {
+			t.Errorf("exact hit = %+v, want widgets/boost", h)
+		}
+	}
+	if exact != 1 {
+		t.Fatalf("want exactly 1 exact skip-discovery hit, got %d in Results=%+v", exact, got.Results)
+	}
+}
+
 // TestFamilyHash_StableNonReversibleEmpty pins the event-key contract:
 // deterministic, distinct across families, no family text leaking
 // through, and "" for an empty family (stored as NULL).

--- a/internal/generator/templates/learn/recall_test.go.tmpl
+++ b/internal/generator/templates/learn/recall_test.go.tmpl
@@ -775,6 +775,20 @@ func TestLeftoverTokensAreIdentityFragments(t *testing.T) {
 	}
 }
 
+func TestIdentifierOnlyScore_IncludesLeftoverIntent(t *testing.T) {
+	t.Parallel()
+	id := []string{"TICKER-ABC"}
+	if got := identifierOnlyScore(id, id, nil); got != 1 {
+		t.Fatalf("empty leftover: got %v, want 1", got)
+	}
+	if got := identifierOnlyScore(id, id, []string{"ticker", "abc"}); got != 1 {
+		t.Fatalf("identifier fragments: got %v, want 1", got)
+	}
+	if got := identifierOnlyScore(id, id, []string{"owns"}); got >= 0.6 {
+		t.Fatalf("intent leftover must stay below jMin; got %v", got)
+	}
+}
+
 // TestRecall_SameIdentifierDifferentIntentDoesNotSkipDiscovery pins
 // that two teachings sharing an identifier but naming different
 // resources and actions cannot both become exact skip-discovery hits.

--- a/internal/generator/templates/learn/teach.go.tmpl
+++ b/internal/generator/templates/learn/teach.go.tmpl
@@ -68,8 +68,7 @@ func ValidateResourceShape(ctx context.Context, db *sql.DB, cfg *entities.Config
 	if db == nil || resourceID == "" {
 		return nil
 	}
-	parsed := entities.Extract(query, cfg)
-	queryEntities := parsed.Entities
+	queryEntities := QueryIdentityEntities(Normalize(query, cfg))
 	if len(queryEntities) == 0 {
 		return nil
 	}

--- a/internal/generator/templates/learn/teach_test.go.tmpl
+++ b/internal/generator/templates/learn/teach_test.go.tmpl
@@ -74,6 +74,41 @@ func TestValidateResourceShape_NilDBReturnsNil(t *testing.T) {
 	}
 }
 
+func TestValidateResourceShape_TickerMismatchEmitsWarning(t *testing.T) {
+	t.Parallel()
+	db := openRecallTestDB(t)
+	seedRecallResource(t, db, "widgets", "TICKER-BR", `{"title":"TICKER-BR widget"}`)
+	got := ValidateResourceShape(
+		context.Background(), db, testConfig(),
+		"where is TICKER-AL",
+		"TICKER-BR",
+		"widgets",
+		[]string{"title"},
+	)
+	if len(got) != 1 {
+		t.Fatalf("want 1 warning, got %d: %+v", len(got), got)
+	}
+	if got[0].Code != "no_entity_overlap" {
+		t.Errorf("Code = %q, want no_entity_overlap", got[0].Code)
+	}
+}
+
+func TestValidateResourceShape_TickerOverlapNoWarning(t *testing.T) {
+	t.Parallel()
+	db := openRecallTestDB(t)
+	seedRecallResource(t, db, "widgets", "TICKER-AL", `{"title":"TICKER-AL widget"}`)
+	got := ValidateResourceShape(
+		context.Background(), db, testConfig(),
+		"where is TICKER-AL",
+		"TICKER-AL",
+		"widgets",
+		[]string{"title"},
+	)
+	if got != nil {
+		t.Errorf("matching ticker: want nil, got %+v", got)
+	}
+}
+
 func TestValidateResourceShape_EmptyResourceIDReturnsNil(t *testing.T) {
 	t.Parallel()
 	db := openRecallTestDB(t)

--- a/internal/generator/templates/learn_init.go.tmpl
+++ b/internal/generator/templates/learn_init.go.tmpl
@@ -42,11 +42,18 @@ import (
 // the store package's write-side normalizer.
 func newLearnConfig() *entities.Config {
 	cfg := entities.NewConfig()
+{{- if .Learn.TickerPatterns}}
+	var tickerPatterns []*regexp.Regexp
 {{- range .Learn.TickerPatterns}}
 	if re, err := regexp.Compile({{backtick}}{{.}}{{backtick}}); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: {{$.Name}}-pp-cli: ticker pattern %q failed to compile: %v\n", {{backtick}}{{.}}{{backtick}}, err)
 	} else {
 		cfg.RegisterTickerPattern(re)
+		tickerPatterns = append(tickerPatterns, re)
+	}
+{{- end}}
+	if len(tickerPatterns) > 0 {
+		store.RegisterTickerPatterns(tickerPatterns)
 	}
 {{- end}}
 {{- if .Learn.Stopwords}}
@@ -124,4 +131,33 @@ func runLearnInitOnce(ctx context.Context) {
 			fmt.Fprintf(os.Stderr, "warning: {{.Name}}-pp-cli: learn init: %v\n", err)
 		}
 	})
+}
+
+// learnCommonIdentityFields is the ordered, domain-neutral list
+// ResourceEntitiesFromJSON walks when a resource has no more specific
+// identity key. Missing JSON keys are skipped, so one list can serve
+// every collection.
+var learnCommonIdentityFields = []string{
+	"name", "title", "display_name", "full_name", "short_name", "label",
+	"slug", "key", "code", "id", "address",
+}
+
+// learnResourceTypeFields returns the per-resource identity-field map
+// passed to Recall so entity_match can be exact when the stored JSON
+// actually carries the identity.
+func learnResourceTypeFields() map[string][]string {
+	return map[string][]string{
+{{- range .ResourceIdentityFields}}
+		{{printf "%q" .ResourceType}}: { {{- range $i, $f := .Fields}}{{if $i}}, {{end}}{{printf "%q" $f}}{{- end}} },
+{{- end}}
+	}
+}
+
+// learnIdentityFieldsFor returns the identity fields for one resource
+// type, falling back to the common list when the type is unknown.
+func learnIdentityFieldsFor(resourceType string) []string {
+	if fields, ok := learnResourceTypeFields()[resourceType]; ok && len(fields) > 0 {
+		return fields
+	}
+	return append([]string(nil), learnCommonIdentityFields...)
 }

--- a/internal/generator/templates/learn_init_test.go.tmpl
+++ b/internal/generator/templates/learn_init_test.go.tmpl
@@ -6,6 +6,9 @@ package cli
 import (
 	"context"
 	"path/filepath"
+{{- if .Learn.TickerPatterns}}
+	"strings"
+{{- end}}
 	"testing"
 
 	"{{modulePath}}/internal/learn"
@@ -114,6 +117,47 @@ func TestLearnNormalizers_SynonymFoldSymmetry(t *testing.T) {
 		t.Error("write side folded tonight into yesterday")
 	}
 }
+
+func TestLearnIdentityFields_CommonFallback(t *testing.T) {
+	if len(learnCommonIdentityFields) == 0 {
+		t.Fatal("learnCommonIdentityFields must not be empty")
+	}
+	got := learnIdentityFieldsFor("unknown-resource-type")
+	if len(got) == 0 {
+		t.Fatal("learnIdentityFieldsFor fallback must return the common list")
+	}
+	fields := learnResourceTypeFields()
+	if fields == nil {
+		t.Fatal("learnResourceTypeFields must return a non-nil map")
+	}
+}
+
+{{- if .Learn.TickerPatterns}}
+
+func TestLearnNormalizers_TickerKeepSymmetry(t *testing.T) {
+	cfg := newLearnConfig()
+	candidates := []string{"EXAMPLE-42", "TICKER-ABC", "WIDGET-1", "10.6.1.60"}
+	for _, ident := range candidates {
+		n := learn.Normalize("where is "+ident, cfg)
+		if len(n.Tickers) != 1 || n.Tickers[0] != ident {
+			continue
+		}
+		got := store.NormalizeQuery("where is " + ident)
+		wantToken := strings.ToLower(ident)
+		if !strings.Contains(got, wantToken) {
+			t.Errorf("write side dropped ticker %q: NormalizeQuery=%q", ident, got)
+		}
+		if strings.Contains(ident, ".") || strings.Contains(ident, "-") {
+			split := strings.NewReplacer(".", " ", "-", " ").Replace(wantToken)
+			if strings.Contains(got, split) && !strings.Contains(got, wantToken) {
+				t.Errorf("write side split ticker %q into %q", ident, got)
+			}
+		}
+		return
+	}
+	t.Skip("spec ticker patterns do not match the identifier-only fixtures")
+}
+{{- end}}
 {{- if .Learn.Synonyms}}
 
 // TestLearnConfig_SpecSynonymsRegisteredBothSides pins that every

--- a/internal/generator/templates/learnings.go.tmpl
+++ b/internal/generator/templates/learnings.go.tmpl
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -95,6 +96,9 @@ var (
 	querySynonymMu    sync.RWMutex
 	querySynonyms     = copyQuerySynonymDefaults()
 	querySynonymRules = compileQuerySynonyms(querySynonyms)
+
+	queryTickerMu       sync.RWMutex
+	queryTickerPatterns []*regexp.Regexp
 )
 
 func copyQuerySynonymDefaults() map[string]string {
@@ -128,6 +132,76 @@ func RegisterQuerySynonyms(synonyms map[string]string) {
 	if changed {
 		querySynonymRules = compileQuerySynonyms(querySynonyms)
 	}
+}
+
+// RegisterTickerPatterns replaces the write-side identifier keep-list.
+// Called once at CLI startup by the generated learn-init shim with the
+// same compiled ticker patterns registered on the read-side
+// entities.Config, so NormalizeQuery keeps identifier tokens whole
+// instead of splitting them on punctuation. A nil or empty slice
+// clears the list.
+func RegisterTickerPatterns(patterns []*regexp.Regexp) {
+	queryTickerMu.Lock()
+	defer queryTickerMu.Unlock()
+
+	queryTickerPatterns = queryTickerPatterns[:0]
+	for _, re := range patterns {
+		if re != nil {
+			queryTickerPatterns = append(queryTickerPatterns, re)
+		}
+	}
+}
+
+func queryHasTickerPatterns() bool {
+	queryTickerMu.RLock()
+	defer queryTickerMu.RUnlock()
+	return len(queryTickerPatterns) > 0
+}
+
+func isRegisteredTicker(token string) bool {
+	queryTickerMu.RLock()
+	defer queryTickerMu.RUnlock()
+	for _, re := range queryTickerPatterns {
+		if re != nil && re.MatchString(token) {
+			return true
+		}
+	}
+	return false
+}
+
+// trimQueryTokenPunct mirrors the read-side extractor so a ticker
+// wrapped in sentence punctuation still matches the registered
+// pattern. The store package stays import-free of the learn tree.
+func trimQueryTokenPunct(s string) string {
+	return strings.TrimFunc(s, func(r rune) bool {
+		switch r {
+		case '.', ',', '?', '!', ':', ';', '\'', '"', '(', ')', '[', ']', '{', '}':
+			return true
+		}
+		return false
+	})
+}
+
+// queryTokensPreservingTickers tokenizes s the way NormalizeQuery
+// does, but keeps registered identifier tokens as a single lowercased
+// unit instead of splitting them on punctuation.
+func queryTokensPreservingTickers(s string) []string {
+	if !queryHasTickerPatterns() {
+		return queryCharTokens(s)
+	}
+	out := make([]string, 0, 8)
+	for _, raw := range strings.Fields(s) {
+		tok := trimQueryTokenPunct(raw)
+		if tok == "" {
+			continue
+		}
+		if isRegisteredTicker(tok) {
+			out = append(out, strings.ToLower(tok))
+			continue
+		}
+		out = append(out, queryCharTokens(tok)...)
+	}
+	return out
 }
 
 // compileQuerySynonyms tokenizes each pair through the normalization
@@ -242,7 +316,7 @@ func NormalizeQuery(s string) string {
 // and folding at the write path here plus the read path's
 // entities.Config fold is what keeps teach and recall keyed alike.
 func normalizeAndTokens(s string) (string, map[string]struct{}) {
-	rawTokens := foldQueryTokens(queryCharTokens(s))
+	rawTokens := foldQueryTokens(queryTokensPreservingTickers(s))
 	tokens := make(map[string]struct{}, len(rawTokens))
 	kept := make([]string, 0, len(rawTokens))
 	for _, t := range rawTokens {

--- a/internal/generator/templates/learnings_test.go.tmpl
+++ b/internal/generator/templates/learnings_test.go.tmpl
@@ -35,7 +35,7 @@ func TestNormalizeQuery_KeepsRegisteredTickersWhole(t *testing.T) {
 	}{
 		{"where is 10.6.1.60", "where 10.6.1.60"},
 		{"where is TICKER-ABC", "where ticker-abc"},
-		{"look up 10.6.1.60 now", "look 10.6.1.60 now"},
+		{"look at 10.6.1.60 now", "look 10.6.1.60 now"},
 	}
 	for _, tc := range cases {
 		got := store.NormalizeQuery(tc.in)

--- a/internal/generator/templates/learnings_test.go.tmpl
+++ b/internal/generator/templates/learnings_test.go.tmpl
@@ -6,6 +6,7 @@ package store_test
 import (
 	"context"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"{{modulePath}}/internal/store"
@@ -20,6 +21,36 @@ func openLearnings(t *testing.T) *store.Store {
 	}
 	t.Cleanup(func() { s.Close() })
 	return s
+}
+
+func TestNormalizeQuery_KeepsRegisteredTickersWhole(t *testing.T) {
+	defer store.RegisterTickerPatterns(nil)
+	store.RegisterTickerPatterns([]*regexp.Regexp{
+		regexp.MustCompile(`^\d{1,3}(\.\d{1,3}){3}$`),
+		regexp.MustCompile(`^TICKER-[A-Z0-9]+$`),
+	})
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"where is 10.6.1.60", "where 10.6.1.60"},
+		{"where is TICKER-ABC", "where ticker-abc"},
+		{"look up 10.6.1.60 now", "look 10.6.1.60 now"},
+	}
+	for _, tc := range cases {
+		got := store.NormalizeQuery(tc.in)
+		if got != tc.want {
+			t.Errorf("NormalizeQuery(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeQuery_UnregisteredIdentifierStillSplits(t *testing.T) {
+	store.RegisterTickerPatterns(nil)
+	got := store.NormalizeQuery("where is 10.6.1.60")
+	if got != "where 10 6 1 60" {
+		t.Errorf("NormalizeQuery without ticker registration = %q, want %q", got, "where 10 6 1 60")
+	}
 }
 
 func TestNormalizeQuery_StripsStopwordsAndPunctuation(t *testing.T) {

--- a/internal/generator/templates/teach.go.tmpl
+++ b/internal/generator/templates/teach.go.tmpl
@@ -246,7 +246,7 @@ Disabling: pass --no-learn or set ` + noLearnEnvVar + `=true.`,
 				}
 				learningID, _, uerr := s.UpsertLearning(cmd.Context(), store.UpsertLearningInput{
 					Query:         query,
-					QueryEntities: normalized.Entities,
+					QueryEntities: learn.QueryIdentityEntities(normalized),
 					ResourceID:    rid,
 					ResourceType:  resourceType,
 					Venue:         venueArg,
@@ -260,7 +260,7 @@ Disabling: pass --no-learn or set ` + noLearnEnvVar + `=true.`,
 				taughtRowIDs = append(taughtRowIDs, learningID)
 
 				if !noValidate {
-					for _, w := range learn.ValidateResourceShape(cmd.Context(), s.DB(), learnCfg, query, rid, resourceType, nil) {
+					for _, w := range learn.ValidateResourceShape(cmd.Context(), s.DB(), learnCfg, query, rid, resourceType, learnIdentityFieldsFor(resourceType)) {
 						if logErr := learn.AppendTeachLogWarning("teach", query, w); logErr != nil {
 							writeTeachErrLog(fmt.Sprintf("teach: warn append: %v", logErr))
 						}
@@ -485,7 +485,7 @@ when learnings exist.`,
 			if noLearnActive(flags) {
 				normalized := learn.Normalize(query, learnCfg)
 				envelope.Normalized = normalized.NonEntityNormalized
-				envelope.QueryEntities = append([]string{}, normalized.Entities...)
+				envelope.QueryEntities = append([]string{}, learn.QueryIdentityEntities(normalized)...)
 				if envelope.QueryEntities == nil {
 					envelope.QueryEntities = []string{}
 				}
@@ -499,10 +499,11 @@ when learnings exist.`,
 			defer s.Close()
 
 			result, err := learn.Recall(cmd.Context(), s.DB(), query, learn.Opts{
-				EntityConfig:    learnCfg,
-				MinConfidence:   minConf,
-				Limit:           limit,
-				DebugMismatches: debugMismatches,
+				EntityConfig:       learnCfg,
+				MinConfidence:      minConf,
+				Limit:              limit,
+				DebugMismatches:    debugMismatches,
+				ResourceTypeFields: learnResourceTypeFields(),
 			})
 			if err != nil {
 				return fmt.Errorf("recall: %w", err)

--- a/internal/generator/templates/teach_test.go.tmpl
+++ b/internal/generator/templates/teach_test.go.tmpl
@@ -575,6 +575,52 @@ func TestRecallCommand_EnvelopeCarriesQueryEntities(t *testing.T) {
 	}
 }
 
+func TestTeachRecall_IdentifierOnlyFindsRow(t *testing.T) {
+	cfg := newLearnConfig()
+	candidates := []string{"EXAMPLE-42", "TICKER-ABC", "WIDGET-1", "10.6.1.60"}
+	var ident string
+	for _, c := range candidates {
+		n := learn.Normalize("where is "+c, cfg)
+		if len(n.Tickers) == 1 && n.Tickers[0] == c {
+			ident = c
+			break
+		}
+	}
+	if ident == "" {
+		t.Skip("spec ticker patterns do not match the identifier-only fixtures")
+	}
+
+	home := withTempLearnHome(t)
+	dbPath := filepath.Join(home, "data.db")
+	query := "where is " + ident
+	if _, _, err := runRootArgs(t,
+		"teach", "--query", query,
+		"--resource", ident, "--resource-type", "items",
+		"--db", dbPath,
+	); err != nil {
+		t.Fatalf("teach: %v", err)
+	}
+	stdout, _, err := runRootArgs(t, "recall", query, "--db", dbPath, "--agent")
+	if err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+	var env recallEnvelope
+	unmarshalAgentResults(t, stdout, &env)
+	if !env.Found {
+		t.Fatalf("identifier-only recall want found=true, got %+v", env)
+	}
+	foundIdent := false
+	for _, e := range env.QueryEntities {
+		if e == ident {
+			foundIdent = true
+			break
+		}
+	}
+	if !foundIdent {
+		t.Errorf("query_entities = %v, want to include %q", env.QueryEntities, ident)
+	}
+}
+
 // Defense: assert the per-CLI entity Config the tests use is non-nil
 // by referencing the package so the unused-import lint doesn't fire
 // when the suite shrinks.

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/learn_init.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/learn_init.go
@@ -38,10 +38,15 @@ import (
 // the store package's write-side normalizer.
 func newLearnConfig() *entities.Config {
 	cfg := entities.NewConfig()
+	var tickerPatterns []*regexp.Regexp
 	if re, err := regexp.Compile(`^EXAMPLE-[A-Z0-9]+(-[A-Z0-9]+)*$`); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: learn-loop-example-pp-cli: ticker pattern %q failed to compile: %v\n", `^EXAMPLE-[A-Z0-9]+(-[A-Z0-9]+)*$`, err)
 	} else {
 		cfg.RegisterTickerPattern(re)
+		tickerPatterns = append(tickerPatterns, re)
+	}
+	if len(tickerPatterns) > 0 {
+		store.RegisterTickerPatterns(tickerPatterns)
 	}
 	cfg.RegisterStopwords(
 		"filler1",
@@ -92,4 +97,32 @@ func runLearnInitOnce(ctx context.Context) {
 			fmt.Fprintf(os.Stderr, "warning: learn-loop-example-pp-cli: learn init: %v\n", err)
 		}
 	})
+}
+
+// learnCommonIdentityFields is the ordered, domain-neutral list
+// ResourceEntitiesFromJSON walks when a resource has no more specific
+// identity key. Missing JSON keys are skipped, so one list can serve
+// every collection.
+var learnCommonIdentityFields = []string{
+	"name", "title", "display_name", "full_name", "short_name", "label",
+	"slug", "key", "code", "id", "address",
+}
+
+// learnResourceTypeFields returns the per-resource identity-field map
+// passed to Recall so entity_match can be exact when the stored JSON
+// actually carries the identity.
+func learnResourceTypeFields() map[string][]string {
+	return map[string][]string{
+		"games":   {"game_key", "name", "title", "display_name", "full_name", "short_name", "label", "slug", "key", "code", "id", "address"},
+		"leagues": {"name", "title", "display_name", "full_name", "short_name", "label", "slug", "key", "code", "id", "address"},
+	}
+}
+
+// learnIdentityFieldsFor returns the identity fields for one resource
+// type, falling back to the common list when the type is unknown.
+func learnIdentityFieldsFor(resourceType string) []string {
+	if fields, ok := learnResourceTypeFields()[resourceType]; ok && len(fields) > 0 {
+		return fields
+	}
+	return append([]string(nil), learnCommonIdentityFields...)
 }

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/teach.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/teach.go
@@ -246,7 +246,7 @@ Disabling: pass --no-learn or set ` + noLearnEnvVar + `=true.`,
 				}
 				learningID, _, uerr := s.UpsertLearning(cmd.Context(), store.UpsertLearningInput{
 					Query:         query,
-					QueryEntities: normalized.Entities,
+					QueryEntities: learn.QueryIdentityEntities(normalized),
 					ResourceID:    rid,
 					ResourceType:  resourceType,
 					Venue:         venueArg,
@@ -260,7 +260,7 @@ Disabling: pass --no-learn or set ` + noLearnEnvVar + `=true.`,
 				taughtRowIDs = append(taughtRowIDs, learningID)
 
 				if !noValidate {
-					for _, w := range learn.ValidateResourceShape(cmd.Context(), s.DB(), learnCfg, query, rid, resourceType, nil) {
+					for _, w := range learn.ValidateResourceShape(cmd.Context(), s.DB(), learnCfg, query, rid, resourceType, learnIdentityFieldsFor(resourceType)) {
 						if logErr := learn.AppendTeachLogWarning("teach", query, w); logErr != nil {
 							writeTeachErrLog(fmt.Sprintf("teach: warn append: %v", logErr))
 						}
@@ -485,7 +485,7 @@ when learnings exist.`,
 			if noLearnActive(flags) {
 				normalized := learn.Normalize(query, learnCfg)
 				envelope.Normalized = normalized.NonEntityNormalized
-				envelope.QueryEntities = append([]string{}, normalized.Entities...)
+				envelope.QueryEntities = append([]string{}, learn.QueryIdentityEntities(normalized)...)
 				if envelope.QueryEntities == nil {
 					envelope.QueryEntities = []string{}
 				}
@@ -499,10 +499,11 @@ when learnings exist.`,
 			defer s.Close()
 
 			result, err := learn.Recall(cmd.Context(), s.DB(), query, learn.Opts{
-				EntityConfig:    learnCfg,
-				MinConfidence:   minConf,
-				Limit:           limit,
-				DebugMismatches: debugMismatches,
+				EntityConfig:       learnCfg,
+				MinConfidence:      minConf,
+				Limit:              limit,
+				DebugMismatches:    debugMismatches,
+				ResourceTypeFields: learnResourceTypeFields(),
 			})
 			if err != nil {
 				return fmt.Errorf("recall: %w", err)

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/learn/journal.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/learn/journal.go
@@ -5,6 +5,8 @@ package learn
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -150,14 +152,46 @@ func journalEnvTruthy(name string) bool {
 	return v == "true" || v == "1" || v == "yes"
 }
 
+// JournalHarnessSessionEnvVars is the first-match-wins list of
+// harness session identifiers. Exported so command-level tests can
+// clear the same set the production resolver reads. Raw values never
+// land in the journal; only a bounded hash of the first non-empty
+// value is persisted.
+var JournalHarnessSessionEnvVars = []string{
+	"CODEX_THREAD_ID",
+	"CODEX_SESSION_ID",
+	"CLAUDE_SESSION_ID",
+	"CLAUDE_CODE_SESSION",
+	"CURSOR_SESSION_ID",
+	"CURSOR_TRACE_ID",
+}
+
 // JournalSessionKey returns the session key for this invocation: the
-// session env var when set, else a parent-pid lineage string so all
-// commands spawned by the same agent shell share a key.
+// explicit LEARN_SESSION override when set, else a hashed harness
+// session identifier so sibling tool calls share a key even when each
+// has a different parent process, else a parent-pid lineage string.
 func JournalSessionKey() string {
 	if v := strings.TrimSpace(os.Getenv(journalSessionEnvVar)); v != "" {
 		return v
 	}
+	if hashed := journalHashedHarnessSession(); hashed != "" {
+		return hashed
+	}
 	return "ppid:" + strconv.Itoa(os.Getppid())
+}
+
+func journalHashedHarnessSession() string {
+	for _, name := range JournalHarnessSessionEnvVars {
+		if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+			return "h:" + hashHarnessSession(v)
+		}
+	}
+	return ""
+}
+
+func hashHarnessSession(v string) string {
+	sum := sha256.Sum256([]byte(v))
+	return hex.EncodeToString(sum[:8])
 }
 
 // JournalDir returns the journal directory (a learn/ subdir of the

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/learn/recall.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/learn/recall.go
@@ -373,11 +373,14 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 		//      caught at that layer.
 		if score < jMin {
 			// Identifier-only queries normalize to an empty non-entity
-			// bag on the read side. Score on identity overlap whenever
-			// the query has no content tokens and the stored row shares
-			// an identity token, even if the write-side pattern still
-			// carries leftover tokens (punctuation-split identifiers).
-			if len(queryTokens) == 0 && entitySlicesIntersect(queryIdentity, storedEntitySlice) {
+			// bag on the read side. Score on identity overlap only when
+			// leftover stored tokens are empty or punctuation-split
+			// identifier fragments. Distinct leftover intent tokens
+			// (different resource/action, same identifier) must not
+			// become exact skip-discovery hits.
+			identityForFragments := append(append([]string{}, queryIdentity...), storedEntitySlice...)
+			if len(queryTokens) == 0 && entitySlicesIntersect(queryIdentity, storedEntitySlice) &&
+				leftoverTokensAreIdentityFragments(storedNonEntityTokens, identityForFragments) {
 				score = Jaccard(queryIdentity, storedEntitySlice)
 			} else if len(queryTokens) == 0 && len(storedNonEntityTokens) == 0 &&
 				len(queryIdentity) > 0 && len(storedEntitySlice) > 0 {
@@ -743,6 +746,63 @@ func entityMatchPriority(em string) int {
 	default:
 		return 4
 	}
+}
+
+// leftoverTokensAreIdentityFragments reports whether every leftover
+// stored token is an identity token or an alphanumeric fragment of
+// one. Write-side punctuation splits ("ticker" "abc" from TICKER-ABC)
+// stay eligible for the identifier-only boost; leftover intent tokens
+// do not.
+func leftoverTokensAreIdentityFragments(tokens, identity []string) bool {
+	if len(tokens) == 0 {
+		return true
+	}
+	allowed := make(map[string]struct{})
+	for _, id := range identity {
+		n := strings.ToLower(strings.TrimSpace(id))
+		if n == "" {
+			continue
+		}
+		allowed[n] = struct{}{}
+		for _, frag := range identityCharFragments(n) {
+			if frag != "" {
+				allowed[frag] = struct{}{}
+			}
+		}
+	}
+	if len(allowed) == 0 {
+		return false
+	}
+	for _, tok := range tokens {
+		t := strings.ToLower(strings.TrimSpace(tok))
+		if t == "" {
+			continue
+		}
+		if _, ok := allowed[t]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// identityCharFragments splits on non-alphanumeric runes the same way
+// the write-side query tokenizer does, so a leftover bag of identifier
+// pieces still counts as the same identity.
+func identityCharFragments(s string) []string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte(' ')
+		}
+	}
+	return strings.Fields(b.String())
 }
 
 // entitySlicesIntersect reports whether two literal entity slices

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/learn/recall.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/learn/recall.go
@@ -373,15 +373,13 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 		//      caught at that layer.
 		if score < jMin {
 			// Identifier-only queries normalize to an empty non-entity
-			// bag on the read side. Score on identity overlap only when
-			// leftover stored tokens are empty or punctuation-split
-			// identifier fragments. Distinct leftover intent tokens
-			// (different resource/action, same identifier) must not
-			// become exact skip-discovery hits.
-			identityForFragments := append(append([]string{}, queryIdentity...), storedEntitySlice...)
-			if len(queryTokens) == 0 && entitySlicesIntersect(queryIdentity, storedEntitySlice) &&
-				leftoverTokensAreIdentityFragments(storedNonEntityTokens, identityForFragments) {
-				score = Jaccard(queryIdentity, storedEntitySlice)
+			// bag on the read side. Score identity overlap together with
+			// leftover stored tokens: punctuation-split identifier
+			// fragments stay identity-equivalent, leftover intent tokens
+			// enter the bag so same-identifier / different-intent rows
+			// cannot all become exact skip-discovery hits.
+			if len(queryTokens) == 0 && entitySlicesIntersect(queryIdentity, storedEntitySlice) {
+				score = identifierOnlyScore(queryIdentity, storedEntitySlice, storedNonEntityTokens)
 			} else if len(queryTokens) == 0 && len(storedNonEntityTokens) == 0 &&
 				len(queryIdentity) > 0 && len(storedEntitySlice) > 0 {
 				score = Jaccard(queryIdentity, storedEntitySlice)
@@ -748,11 +746,26 @@ func entityMatchPriority(em string) int {
 	}
 }
 
+// identifierOnlyScore is Jaccard of query identity against stored
+// identity plus leftover stored tokens that are not punctuation-split
+// identifier fragments. Fragment leftovers stay identity-equivalent;
+// leftover intent tokens stay in the bag.
+func identifierOnlyScore(queryIdentity, storedIdentity, leftover []string) float64 {
+	identity := append(append([]string{}, queryIdentity...), storedIdentity...)
+	storedBag := append([]string{}, storedIdentity...)
+	for _, tok := range leftover {
+		if leftoverTokensAreIdentityFragments([]string{tok}, identity) {
+			continue
+		}
+		storedBag = append(storedBag, tok)
+	}
+	return Jaccard(queryIdentity, storedBag)
+}
+
 // leftoverTokensAreIdentityFragments reports whether every leftover
 // stored token is an identity token or an alphanumeric fragment of
 // one. Write-side punctuation splits ("ticker" "abc" from TICKER-ABC)
-// stay eligible for the identifier-only boost; leftover intent tokens
-// do not.
+// stay identity-equivalent; leftover intent tokens do not.
 func leftoverTokensAreIdentityFragments(tokens, identity []string) bool {
 	if len(tokens) == 0 {
 		return true

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/learn/recall.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/learn/recall.go
@@ -164,10 +164,11 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 		cfg = entities.NewConfig()
 	}
 	normalized := Normalize(query, cfg)
+	queryIdentity := QueryIdentityEntities(normalized)
 	result := Result{
 		Query:         query,
 		Normalized:    normalized.NonEntityNormalized,
-		QueryEntities: append([]string(nil), normalized.Entities...),
+		QueryEntities: append([]string(nil), queryIdentity...),
 		Results:       []Hit{},
 	}
 	if result.QueryEntities == nil {
@@ -221,7 +222,8 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 	normalized = PromoteEntities(normalized, resolver)
 	result.Family = QueryFamily(normalized)
 	queryTokens := strings.Fields(normalized.NonEntityNormalized)
-	result.QueryEntities = append([]string(nil), normalized.Entities...)
+	queryIdentity = QueryIdentityEntities(normalized)
+	result.QueryEntities = append([]string(nil), queryIdentity...)
 	if result.QueryEntities == nil {
 		result.QueryEntities = []string{}
 	}
@@ -300,7 +302,7 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 		storedNorm := Normalize(queryPattern, cfg)
 		storedEntitySlice, _ := ParseStoredEntities(storedEntities)
 		if len(storedEntitySlice) == 0 {
-			storedEntitySlice = storedNorm.Entities
+			storedEntitySlice = QueryIdentityEntities(storedNorm)
 		}
 		// Opportunistic backfill for legacy null-entity rows. Rows
 		// written before symmetric teach-time promotion landed have
@@ -370,9 +372,16 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 		//      happens to canonical-overlap a stored row still gets
 		//      caught at that layer.
 		if score < jMin {
-			if len(queryTokens) == 0 && len(storedNonEntityTokens) == 0 &&
-				len(normalized.Entities) > 0 && len(storedEntitySlice) > 0 {
-				score = Jaccard(normalized.Entities, storedEntitySlice)
+			// Identifier-only queries normalize to an empty non-entity
+			// bag on the read side. Score on identity overlap whenever
+			// the query has no content tokens and the stored row shares
+			// an identity token, even if the write-side pattern still
+			// carries leftover tokens (punctuation-split identifiers).
+			if len(queryTokens) == 0 && entitySlicesIntersect(queryIdentity, storedEntitySlice) {
+				score = Jaccard(queryIdentity, storedEntitySlice)
+			} else if len(queryTokens) == 0 && len(storedNonEntityTokens) == 0 &&
+				len(queryIdentity) > 0 && len(storedEntitySlice) > 0 {
+				score = Jaccard(queryIdentity, storedEntitySlice)
 			}
 			if score < jMin {
 				// Three fallback branches, gated by the lower
@@ -402,7 +411,7 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 					// only fire when literal entities genuinely differ.
 					// Same-entity rows that miss jMin are genuine
 					// structural noise and should drop.
-					if entitySlicesIntersect(normalized.Entities, storedEntitySlice) {
+					if entitySlicesIntersect(queryIdentity, storedEntitySlice) {
 						continue
 					}
 					canonScore := canonicalJaccard(queryCanonicals, storedCanonicals)
@@ -427,7 +436,7 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 					// such rows instead -- case 1 covers the matching-
 					// canonical path, case 2 is reserved for actually
 					// different entities.
-					if entitySlicesIntersect(normalized.Entities, storedEntitySlice) {
+					if entitySlicesIntersect(queryIdentity, storedEntitySlice) {
 						continue
 					}
 					if score < crossAliasMin {
@@ -454,7 +463,7 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 			t := lastObserved.Time
 			hit.LastObservedAt = &t
 		}
-		validateResource(ctx, db, cfg, &hit, normalized.Entities, storedEntitySlice, opts.ResourceTypeFields)
+		validateResource(ctx, db, cfg, &hit, queryIdentity, storedEntitySlice, opts.ResourceTypeFields)
 		// Cross-alias promotion: if canonicals overlap, the entities
 		// are equivalent even when their literal forms differ. Override
 		// a Mismatch verdict so the learning isn't filtered into the
@@ -491,7 +500,7 @@ func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, e
 	// Generalization layer: ask the pattern engine whether any template
 	// applies to this query. Errors are swallowed; pattern hits are
 	// additive on top of direct hits.
-	patternHits, _ := patterns.Apply(ctx, db, query, normalized.NonEntityNormalized, normalized.Entities, patterns.Opts{
+	patternHits, _ := patterns.Apply(ctx, db, query, normalized.NonEntityNormalized, queryIdentity, patterns.Opts{
 		JaccardMin:      jMin,
 		Limit:           limit,
 		AdditionalKinds: opts.PatternKinds,

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/learnings.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/learnings.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -95,6 +96,9 @@ var (
 	querySynonymMu    sync.RWMutex
 	querySynonyms     = copyQuerySynonymDefaults()
 	querySynonymRules = compileQuerySynonyms(querySynonyms)
+
+	queryTickerMu       sync.RWMutex
+	queryTickerPatterns []*regexp.Regexp
 )
 
 func copyQuerySynonymDefaults() map[string]string {
@@ -128,6 +132,76 @@ func RegisterQuerySynonyms(synonyms map[string]string) {
 	if changed {
 		querySynonymRules = compileQuerySynonyms(querySynonyms)
 	}
+}
+
+// RegisterTickerPatterns replaces the write-side identifier keep-list.
+// Called once at CLI startup by the generated learn-init shim with the
+// same compiled ticker patterns registered on the read-side
+// entities.Config, so NormalizeQuery keeps identifier tokens whole
+// instead of splitting them on punctuation. A nil or empty slice
+// clears the list.
+func RegisterTickerPatterns(patterns []*regexp.Regexp) {
+	queryTickerMu.Lock()
+	defer queryTickerMu.Unlock()
+
+	queryTickerPatterns = queryTickerPatterns[:0]
+	for _, re := range patterns {
+		if re != nil {
+			queryTickerPatterns = append(queryTickerPatterns, re)
+		}
+	}
+}
+
+func queryHasTickerPatterns() bool {
+	queryTickerMu.RLock()
+	defer queryTickerMu.RUnlock()
+	return len(queryTickerPatterns) > 0
+}
+
+func isRegisteredTicker(token string) bool {
+	queryTickerMu.RLock()
+	defer queryTickerMu.RUnlock()
+	for _, re := range queryTickerPatterns {
+		if re != nil && re.MatchString(token) {
+			return true
+		}
+	}
+	return false
+}
+
+// trimQueryTokenPunct mirrors the read-side extractor so a ticker
+// wrapped in sentence punctuation still matches the registered
+// pattern. The store package stays import-free of the learn tree.
+func trimQueryTokenPunct(s string) string {
+	return strings.TrimFunc(s, func(r rune) bool {
+		switch r {
+		case '.', ',', '?', '!', ':', ';', '\'', '"', '(', ')', '[', ']', '{', '}':
+			return true
+		}
+		return false
+	})
+}
+
+// queryTokensPreservingTickers tokenizes s the way NormalizeQuery
+// does, but keeps registered identifier tokens as a single lowercased
+// unit instead of splitting them on punctuation.
+func queryTokensPreservingTickers(s string) []string {
+	if !queryHasTickerPatterns() {
+		return queryCharTokens(s)
+	}
+	out := make([]string, 0, 8)
+	for _, raw := range strings.Fields(s) {
+		tok := trimQueryTokenPunct(raw)
+		if tok == "" {
+			continue
+		}
+		if isRegisteredTicker(tok) {
+			out = append(out, strings.ToLower(tok))
+			continue
+		}
+		out = append(out, queryCharTokens(tok)...)
+	}
+	return out
 }
 
 // compileQuerySynonyms tokenizes each pair through the normalization
@@ -242,7 +316,7 @@ func NormalizeQuery(s string) string {
 // and folding at the write path here plus the read path's
 // entities.Config fold is what keeps teach and recall keyed alike.
 func normalizeAndTokens(s string) (string, map[string]struct{}) {
-	rawTokens := foldQueryTokens(queryCharTokens(s))
+	rawTokens := foldQueryTokens(queryTokensPreservingTickers(s))
 	tokens := make(map[string]struct{}, len(rawTokens))
 	kept := make([]string, 0, len(rawTokens))
 	for _, t := range rawTokens {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/learnings_test.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/learnings_test.go
@@ -6,6 +6,7 @@ package store_test
 import (
 	"context"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"learn-loop-example-pp-cli/internal/store"
@@ -20,6 +21,36 @@ func openLearnings(t *testing.T) *store.Store {
 	}
 	t.Cleanup(func() { s.Close() })
 	return s
+}
+
+func TestNormalizeQuery_KeepsRegisteredTickersWhole(t *testing.T) {
+	defer store.RegisterTickerPatterns(nil)
+	store.RegisterTickerPatterns([]*regexp.Regexp{
+		regexp.MustCompile(`^\d{1,3}(\.\d{1,3}){3}$`),
+		regexp.MustCompile(`^TICKER-[A-Z0-9]+$`),
+	})
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"where is 10.6.1.60", "where 10.6.1.60"},
+		{"where is TICKER-ABC", "where ticker-abc"},
+		{"look at 10.6.1.60 now", "look 10.6.1.60 now"},
+	}
+	for _, tc := range cases {
+		got := store.NormalizeQuery(tc.in)
+		if got != tc.want {
+			t.Errorf("NormalizeQuery(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeQuery_UnregisteredIdentifierStillSplits(t *testing.T) {
+	store.RegisterTickerPatterns(nil)
+	got := store.NormalizeQuery("where is 10.6.1.60")
+	if got != "where 10 6 1 60" {
+		t.Errorf("NormalizeQuery without ticker registration = %q, want %q", got, "where 10 6 1 60")
+	}
 }
 
 func TestNormalizeQuery_StripsStopwordsAndPunctuation(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

The generated learn loop dropped identifier-shaped tokens on the query side, never populated `ResourceTypeFields`, scored identifier-only recalls only when both token bags were empty, and keyed journal sessions on PPID. A query like `where is 10.6.1.60` taught successfully, then recall returned `found=false` / `no_learnings_for_query_family` with empty `query_entities`. Codex-style sibling processes never assembled a recall→discover→teach episode.

Closes #3675
Closes #3676
Closes #3677
Closes #3709

## Approach

- `QueryIdentityEntities` folds Entities + Tickers at teach-write, recall-match, and `ValidateResourceShape`. Family keys stay `NonEntityNormalized` only.
- Generated `learn_init` emits a per-resource identity-field map (resolved `IDField` first, then common keys) and passes it to `Recall` and `ValidateResourceShape`, so `entity_match` can be `exact` and `no_entity_overlap` can fire.
- Write-side `store.RegisterTickerPatterns` mirrors `RegisterQuerySynonyms`. Identifier-only recall scores identity overlap together with leftover stored tokens: punctuation-split identifier fragments stay identity-equivalent, leftover intent tokens enter the Jaccard bag so same-identifier / different-intent rows cannot all become exact skip-discovery hits.
- `JournalSessionKey` keeps the explicit `LEARN_SESSION` override, otherwise a bounded hash of a harness/session id (`h:…`), and PPID only as last resort. Raw harness identifiers never land in the journal.

## Scope

Primary area: generated learn loop (templates + generator wiring).

Why this belongs in this repo: every printed CLI inherits the loop from the generator. The defect is not API-specific.

## Risk

Next regen changes teach/recall envelopes (`query_entities` includes tickers), teach-time `no_entity_overlap` can now fire, and journal `session_key` may be `h:…` under Codex/Claude/Cursor instead of `ppid:…`. Family keys are unchanged.

## Output Contract

Generated-output proof:

- Emitted-code assertions plus `requireGeneratedCompiles` in `TestGenerateLearnIdentityAndSessionContract`
- Identifier-only recall, same-identifier different-intent (not all exact hits), leftover-intent score, ticker-keep, `ValidateResourceShape` ticker overlap, and hashed-session tests in the generated learn/cli/store packages
- `TestIncidentReplay/SessionKeyFallback_harness_hash_across_ppids` drives recall + discovery + teach through separate `sh -c` children and expects exactly one quarantined `playbook_candidate`
- `generate-learn-loop-api` goldens updated for identifier-only leftover-token scoring (only `internal/learn/recall.go` in that case)
- `scripts/verify-generator-output.sh generate-learn-loop-api` compiled the printed CLI

## Published-library sweep

This adds generator-owned exports (`QueryIdentityEntities`, `JournalHarnessSessionEnvVars`, `RegisterTickerPatterns`). Fresh prints get them automatically; already-published CLIs drift until a sweep runs. Do not land the library sweep from this generator PR.

Tracking issue: https://github.com/mvanhorn/printing-press-library/issues/1872

Anchors for that sweep: `func QueryIdentityEntities(` in `internal/learn/normalize.go`; `var JournalHarnessSessionEnvVars` and `"h:"` in `internal/learn/journal.go`; `func RegisterTickerPatterns(` in `internal/store/learnings.go`; `store.RegisterTickerPatterns(` / `learnResourceTypeFields` / `learnIdentityFieldsFor` in `internal/cli/learn_init.go`. Idempotent second run must be zero diff.

## Verification

- [x] `go test ./internal/generator/ -run TestGenerateLearnIdentityAndSessionContract`
- [x] Generated `internal/learn` identifier-only + leftover-intent tests on the learn-loop-api print
- [x] `generate-learn-loop-api` golden refreshed for `recall.go` only
- [x] `scripts/verify-generator-output.sh generate-learn-loop-api`
- [x] `scripts/verify-learn-purity.sh`

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0aad4a31-a6f9-497f-ab5a-425a4b4e33f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0aad4a31-a6f9-497f-ab5a-425a4b4e33f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

