### PR TITLE
fix(cli): chmod legacy cache files on cache-hit reads

### DIFF
--- a/internal/generator/client_cache_scope_test.go
+++ b/internal/generator/client_cache_scope_test.go
@@ -57,8 +57,14 @@ func TestGeneratedCacheWritesUsePrivatePermissions(t *testing.T) {
 	client := string(clientSrc)
 	require.Contains(t, client, "os.MkdirAll(resourceDir, 0o700)")
 	require.Contains(t, client, "os.WriteFile(cacheFile, []byte(data), 0o600)")
+	require.Contains(t, client, "os.Chmod(resourceDir, 0o700)",
+		"cache resource dirs must be owner-only even when a leftover 0755 dir is reused")
 	require.Contains(t, client, "os.Chmod(cacheFile, 0o600)",
 		"rewriting an existing cache file must chmod 0600; WriteFile ignores perm on an extant file")
+	require.Contains(t, clientFuncBody(t, client, "func (c *Client) readCacheWithHeaders("), "ensureCachePerms(",
+		"a cache-hit read of a leftover 0644 file must tighten perms before returning content")
+	require.Contains(t, clientFuncBody(t, client, "func (c *Client) writeCacheWithHeaders("), "ensureCachePerms(",
+		"the write path must share the same cache permission contract as the hit-read path")
 	require.NotContains(t, client, "os.MkdirAll(resourceDir, 0o755)")
 	require.NotContains(t, client, "os.WriteFile(cacheFile, []byte(data), 0o644)")
 
@@ -130,6 +136,81 @@ func TestWriteCacheWithHeadersRechmodsExistingFile(t *testing.T) {
 	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^TestWriteCacheWithHeadersRechmodsExistingFile$", "-count=1")
 }
 
+func TestReadCacheWithHeadersRechmodsFreshLegacyFile(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("cache-hit-chmod")
+	outputDir := filepath.Join(t.TempDir(), "cache-hit-chmod-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const runtimeTest = `package client
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"cache-hit-chmod-pp-cli/internal/config"
+)
+
+func TestReadCacheWithHeadersRechmodsFreshLegacyFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not preserved on Windows")
+	}
+
+	c := New(&config.Config{BaseURL: "https://api.example.invalid"}, time.Second, 0)
+	c.cacheDir = t.TempDir()
+
+	want := json.RawMessage(` + "`" + `{"ok":true}` + "`" + `)
+	c.writeCacheWithHeaders("/items", nil, nil, want)
+	matches, err := filepath.Glob(filepath.Join(c.cacheDir, "resources", "*", "*.json"))
+	if err != nil {
+		t.Fatalf("glob cache files: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("wrote %d cache files, want 1: %v", len(matches), matches)
+	}
+	cacheFile := matches[0]
+	resourceDir := filepath.Dir(cacheFile)
+	if err := os.Chmod(cacheFile, 0o644); err != nil {
+		t.Fatalf("chmod leftover 0644: %v", err)
+	}
+	if err := os.Chmod(resourceDir, 0o755); err != nil {
+		t.Fatalf("chmod leftover 0755 dir: %v", err)
+	}
+
+	got, ok := c.readCacheWithHeaders("/items", nil, nil)
+	if !ok {
+		t.Fatal("expected cache hit for a fresh leftover file")
+	}
+	if string(got) != string(want) {
+		t.Fatalf("cache hit data = %s, want %s", got, want)
+	}
+
+	info, err := os.Stat(cacheFile)
+	if err != nil {
+		t.Fatalf("stat cache-hit file: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("cache-hit file mode = %04o, want 0600", mode)
+	}
+	dirInfo, err := os.Stat(resourceDir)
+	if err != nil {
+		t.Fatalf("stat cache-hit resource dir: %v", err)
+	}
+	if mode := dirInfo.Mode().Perm(); mode != 0o700 {
+		t.Fatalf("cache-hit resource dir mode = %04o, want 0700", mode)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "cache_hit_chmod_runtime_test.go"), []byte(runtimeTest), 0o600))
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^TestReadCacheWithHeadersRechmodsFreshLegacyFile$", "-count=1")
+}
+
 func TestGeneratedClientQueryParamContractsPass(t *testing.T) {
 	t.Parallel()
 
@@ -142,8 +223,13 @@ func TestGeneratedClientQueryParamContractsPass(t *testing.T) {
 
 func clientCacheKeyForBody(t *testing.T, content string) string {
 	t.Helper()
-	start := strings.Index(content, "func (c *Client) cacheKeyFor(")
-	require.NotEqual(t, -1, start, "cacheKeyFor function must be emitted")
+	return clientFuncBody(t, content, "func (c *Client) cacheKeyFor(")
+}
+
+func clientFuncBody(t *testing.T, content, signature string) string {
+	t.Helper()
+	start := strings.Index(content, signature)
+	require.NotEqual(t, -1, start, "%s must be emitted", signature)
 	body := content[start:]
 	if next := strings.Index(body[1:], "\nfunc "); next != -1 {
 		body = body[:next+1]

--- a/internal/generator/client_cache_scope_test.go
+++ b/internal/generator/client_cache_scope_test.go
@@ -65,14 +65,18 @@ func TestGeneratedCacheWritesUsePrivatePermissions(t *testing.T) {
 		"a cache-hit read of a leftover 0644 file must tighten perms before returning content")
 	writeBody := clientFuncBody(t, client, "func (c *Client) writeCacheWithHeaders(")
 	preChmod := strings.Index(writeBody, "ensureCachePerms(")
+	removeCall := strings.Index(writeBody, "os.Remove(cacheFile)")
 	writeCall := strings.Index(writeBody, "os.WriteFile(cacheFile")
 	postChmod := strings.LastIndex(writeBody, "ensureCachePerms(")
 	require.NotEqual(t, -1, preChmod, "write path must call ensureCachePerms")
+	require.NotEqual(t, -1, removeCall, "write path must unlink a leftover cache inode before rewrite")
 	require.NotEqual(t, -1, writeCall, "write path must WriteFile the cache file")
-	require.Less(t, preChmod, writeCall,
-		"restrict a leftover 0644 file before rewriting so new contents are not world-readable")
+	require.Less(t, preChmod, removeCall,
+		"restrict a leftover 0644 file and its dir before replacing the inode")
+	require.Less(t, removeCall, writeCall,
+		"unlink the leftover inode so an open FD cannot see the new body")
 	require.Greater(t, postChmod, writeCall,
-		"WriteFile perm applies only on create; chmod again after rewrite")
+		"WriteFile perm applies only on create; chmod the new inode and dir")
 	require.NotContains(t, client, "os.MkdirAll(resourceDir, 0o755)")
 	require.NotContains(t, client, "os.WriteFile(cacheFile, []byte(data), 0o644)")
 
@@ -99,9 +103,11 @@ func TestWriteCacheWithHeadersRechmodsExistingFile(t *testing.T) {
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
+	"syscall"
 	"testing"
 	"time"
 
@@ -136,6 +142,70 @@ func TestWriteCacheWithHeadersRechmodsExistingFile(t *testing.T) {
 	}
 	if got := info.Mode().Perm(); got != 0o600 {
 		t.Fatalf("rewritten cache mode = %04o, want 0600", got)
+	}
+}
+
+func TestWriteCacheWithHeadersReplacesOpenInode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix inode replacement is not preserved on Windows")
+	}
+
+	c := New(&config.Config{BaseURL: "https://api.example.invalid"}, time.Second, 0)
+	c.cacheDir = t.TempDir()
+
+	old := json.RawMessage(` + "`" + `{"ok":"old"}` + "`" + `)
+	c.writeCacheWithHeaders("/items", nil, nil, old)
+	matches, err := filepath.Glob(filepath.Join(c.cacheDir, "resources", "*", "*.json"))
+	if err != nil {
+		t.Fatalf("glob cache files: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("wrote %d cache files, want 1: %v", len(matches), matches)
+	}
+	cacheFile := matches[0]
+	if err := os.Chmod(cacheFile, 0o644); err != nil {
+		t.Fatalf("chmod leftover 0644: %v", err)
+	}
+	held, err := os.Open(cacheFile)
+	if err != nil {
+		t.Fatalf("open leftover cache file: %v", err)
+	}
+	defer held.Close()
+	oldInfo, err := held.Stat()
+	if err != nil {
+		t.Fatalf("stat open leftover inode: %v", err)
+	}
+
+	c.writeCacheWithHeaders("/items", nil, nil, json.RawMessage(` + "`" + `{"ok":"new"}` + "`" + `))
+
+	got, err := io.ReadAll(held)
+	if err != nil {
+		t.Fatalf("read open leftover FD: %v", err)
+	}
+	if string(got) != string(old) {
+		t.Fatalf("open FD saw %s, want leftover body %s", got, old)
+	}
+	fresh, err := os.ReadFile(cacheFile)
+	if err != nil {
+		t.Fatalf("read replaced cache file: %v", err)
+	}
+	if string(fresh) != ` + "`" + `{"ok":"new"}` + "`" + ` {
+		t.Fatalf("path data = %s, want new body", fresh)
+	}
+	newInfo, err := os.Stat(cacheFile)
+	if err != nil {
+		t.Fatalf("stat replaced cache file: %v", err)
+	}
+	if mode := newInfo.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("replaced cache mode = %04o, want 0600", mode)
+	}
+	oldSys, oldOK := oldInfo.Sys().(*syscall.Stat_t)
+	newSys, newOK := newInfo.Sys().(*syscall.Stat_t)
+	if !oldOK || !newOK {
+		t.Fatal("expected syscall.Stat_t for inode comparison")
+	}
+	if oldSys.Ino == newSys.Ino {
+		t.Fatal("rewrite reused inode; an open leftover FD would see the new body")
 	}
 }
 
@@ -191,7 +261,7 @@ func TestReadCacheWithHeadersRechmodsFreshLegacyFile(t *testing.T) {
 `
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "cache_chmod_runtime_test.go"), []byte(runtimeTest), 0o600))
 	requireGeneratedCompiles(t, outputDir)
-	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^Test(WriteCacheWithHeadersRechmodsExistingFile|ReadCacheWithHeadersRechmodsFreshLegacyFile)$", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^Test(WriteCacheWithHeadersRechmodsExistingFile|WriteCacheWithHeadersReplacesOpenInode|ReadCacheWithHeadersRechmodsFreshLegacyFile)$", "-count=1")
 }
 
 func TestGeneratedClientQueryParamContractsPass(t *testing.T) {

--- a/internal/generator/client_cache_scope_test.go
+++ b/internal/generator/client_cache_scope_test.go
@@ -63,8 +63,16 @@ func TestGeneratedCacheWritesUsePrivatePermissions(t *testing.T) {
 		"rewriting an existing cache file must chmod 0600; WriteFile ignores perm on an extant file")
 	require.Contains(t, clientFuncBody(t, client, "func (c *Client) readCacheWithHeaders("), "ensureCachePerms(",
 		"a cache-hit read of a leftover 0644 file must tighten perms before returning content")
-	require.Contains(t, clientFuncBody(t, client, "func (c *Client) writeCacheWithHeaders("), "ensureCachePerms(",
-		"the write path must share the same cache permission contract as the hit-read path")
+	writeBody := clientFuncBody(t, client, "func (c *Client) writeCacheWithHeaders(")
+	preChmod := strings.Index(writeBody, "ensureCachePerms(")
+	writeCall := strings.Index(writeBody, "os.WriteFile(cacheFile")
+	postChmod := strings.LastIndex(writeBody, "ensureCachePerms(")
+	require.NotEqual(t, -1, preChmod, "write path must call ensureCachePerms")
+	require.NotEqual(t, -1, writeCall, "write path must WriteFile the cache file")
+	require.Less(t, preChmod, writeCall,
+		"restrict a leftover 0644 file before rewriting so new contents are not world-readable")
+	require.Greater(t, postChmod, writeCall,
+		"WriteFile perm applies only on create; chmod again after rewrite")
 	require.NotContains(t, client, "os.MkdirAll(resourceDir, 0o755)")
 	require.NotContains(t, client, "os.WriteFile(cacheFile, []byte(data), 0o644)")
 

--- a/internal/generator/client_cache_scope_test.go
+++ b/internal/generator/client_cache_scope_test.go
@@ -130,31 +130,6 @@ func TestWriteCacheWithHeadersRechmodsExistingFile(t *testing.T) {
 		t.Fatalf("rewritten cache mode = %04o, want 0600", got)
 	}
 }
-`
-	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "cache_chmod_runtime_test.go"), []byte(runtimeTest), 0o600))
-	requireGeneratedCompiles(t, outputDir)
-	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^TestWriteCacheWithHeadersRechmodsExistingFile$", "-count=1")
-}
-
-func TestReadCacheWithHeadersRechmodsFreshLegacyFile(t *testing.T) {
-	t.Parallel()
-
-	apiSpec := minimalSpec("cache-hit-chmod")
-	outputDir := filepath.Join(t.TempDir(), "cache-hit-chmod-pp-cli")
-	require.NoError(t, New(apiSpec, outputDir).Generate())
-
-	const runtimeTest = `package client
-
-import (
-	"encoding/json"
-	"os"
-	"path/filepath"
-	"runtime"
-	"testing"
-	"time"
-
-	"cache-hit-chmod-pp-cli/internal/config"
-)
 
 func TestReadCacheWithHeadersRechmodsFreshLegacyFile(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -206,9 +181,9 @@ func TestReadCacheWithHeadersRechmodsFreshLegacyFile(t *testing.T) {
 	}
 }
 `
-	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "cache_hit_chmod_runtime_test.go"), []byte(runtimeTest), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "cache_chmod_runtime_test.go"), []byte(runtimeTest), 0o600))
 	requireGeneratedCompiles(t, outputDir)
-	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^TestReadCacheWithHeadersRechmodsFreshLegacyFile$", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^Test(WriteCacheWithHeadersRechmodsExistingFile|ReadCacheWithHeadersRechmodsFreshLegacyFile)$", "-count=1")
 }
 
 func TestGeneratedClientQueryParamContractsPass(t *testing.T) {

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -1146,7 +1146,8 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) readCacheWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, {{if .HasHTMLExtraction}}string, {{end}}bool) {
-	cacheFile := filepath.Join(c.cacheResourceDir(path), c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
+	resourceDir := c.cacheResourceDir(path)
+	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	info, err := os.Stat(cacheFile)
 	if err != nil || time.Since(info.ModTime()) > 5*time.Minute {
 		return nil, {{if .HasHTMLExtraction}}"", {{end}}false
@@ -1158,6 +1159,8 @@ func (c *Client) readCacheWithHeaders(path string, params map[string]string, hea
 	if err != nil {
 		return nil, {{if .HasHTMLExtraction}}"", {{end}}false
 	}
+	// A leftover 0644 file can still be inside the TTL after upgrade; tighten before returning.
+	ensureCachePerms(resourceDir, cacheFile)
 {{- if .HasHTMLExtraction}}
 	contentType := c.readCacheContentType(cacheFile)
 	return json.RawMessage(data), contentType, true
@@ -1173,17 +1176,21 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 func (c *Client) writeCacheWithHeaders(path string, params map[string]string, headers map[string]string, data json.RawMessage{{if .HasHTMLExtraction}}, contentType string{{end}}) {
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
-	_ = os.Chmod(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
-	_ = os.Chmod(cacheFile, 0o600)
+	ensureCachePerms(resourceDir, cacheFile)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)
 	}
 {{- if .HasHTMLExtraction}}
 	c.writeCacheContentType(cacheFile, contentType)
 {{- end}}
+}
+
+func ensureCachePerms(resourceDir, cacheFile string) {
+	_ = os.Chmod(resourceDir, 0o700)
+	_ = os.Chmod(cacheFile, 0o600)
 }
 
 type platformCacheMetadata struct {

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -1177,10 +1177,10 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
-	// Restrict a leftover 0644 file before rewriting so new contents are not world-readable.
 	ensureCachePerms(resourceDir, cacheFile)
+	// Drop the leftover inode so an already-open 0644 FD keeps the old body.
+	_ = os.Remove(cacheFile)
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
-	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
 	ensureCachePerms(resourceDir, cacheFile)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -1177,6 +1177,8 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
+	// Restrict a leftover 0644 file before rewriting so new contents are not world-readable.
+	ensureCachePerms(resourceDir, cacheFile)
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
 	ensureCachePerms(resourceDir, cacheFile)

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -625,10 +625,10 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
-	// Restrict a leftover 0644 file before rewriting so new contents are not world-readable.
 	ensureCachePerms(resourceDir, cacheFile)
+	// Drop the leftover inode so an already-open 0644 FD keeps the old body.
+	_ = os.Remove(cacheFile)
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
-	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
 	ensureCachePerms(resourceDir, cacheFile)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -625,6 +625,8 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
+	// Restrict a leftover 0644 file before rewriting so new contents are not world-readable.
+	ensureCachePerms(resourceDir, cacheFile)
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
 	ensureCachePerms(resourceDir, cacheFile)

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -599,7 +599,8 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) readCacheWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, bool) {
-	cacheFile := filepath.Join(c.cacheResourceDir(path), c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
+	resourceDir := c.cacheResourceDir(path)
+	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	info, err := os.Stat(cacheFile)
 	if err != nil || time.Since(info.ModTime()) > 5*time.Minute {
 		return nil, false
@@ -611,6 +612,8 @@ func (c *Client) readCacheWithHeaders(path string, params map[string]string, hea
 	if err != nil {
 		return nil, false
 	}
+	// A leftover 0644 file can still be inside the TTL after upgrade; tighten before returning.
+	ensureCachePerms(resourceDir, cacheFile)
 	return json.RawMessage(data), true
 }
 
@@ -621,14 +624,18 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 func (c *Client) writeCacheWithHeaders(path string, params map[string]string, headers map[string]string, data json.RawMessage) {
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
-	_ = os.Chmod(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
-	_ = os.Chmod(cacheFile, 0o600)
+	ensureCachePerms(resourceDir, cacheFile)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)
 	}
+}
+
+func ensureCachePerms(resourceDir, cacheFile string) {
+	_ = os.Chmod(resourceDir, 0o700)
+	_ = os.Chmod(cacheFile, 0o600)
 }
 
 type platformCacheMetadata struct {

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -583,7 +583,8 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) readCacheWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, bool) {
-	cacheFile := filepath.Join(c.cacheResourceDir(path), c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
+	resourceDir := c.cacheResourceDir(path)
+	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	info, err := os.Stat(cacheFile)
 	if err != nil || time.Since(info.ModTime()) > 5*time.Minute {
 		return nil, false
@@ -595,6 +596,8 @@ func (c *Client) readCacheWithHeaders(path string, params map[string]string, hea
 	if err != nil {
 		return nil, false
 	}
+	// A leftover 0644 file can still be inside the TTL after upgrade; tighten before returning.
+	ensureCachePerms(resourceDir, cacheFile)
 	return json.RawMessage(data), true
 }
 
@@ -605,14 +608,18 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 func (c *Client) writeCacheWithHeaders(path string, params map[string]string, headers map[string]string, data json.RawMessage) {
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
-	_ = os.Chmod(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
-	_ = os.Chmod(cacheFile, 0o600)
+	ensureCachePerms(resourceDir, cacheFile)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)
 	}
+}
+
+func ensureCachePerms(resourceDir, cacheFile string) {
+	_ = os.Chmod(resourceDir, 0o700)
+	_ = os.Chmod(cacheFile, 0o600)
 }
 
 type platformCacheMetadata struct {

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -609,10 +609,10 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
-	// Restrict a leftover 0644 file before rewriting so new contents are not world-readable.
 	ensureCachePerms(resourceDir, cacheFile)
+	// Drop the leftover inode so an already-open 0644 FD keeps the old body.
+	_ = os.Remove(cacheFile)
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
-	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
 	ensureCachePerms(resourceDir, cacheFile)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)

--- a/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-authcode/printing-press-oauth2-authcode/internal/client/client.go
@@ -609,6 +609,8 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
+	// Restrict a leftover 0644 file before rewriting so new contents are not world-readable.
+	ensureCachePerms(resourceDir, cacheFile)
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
 	ensureCachePerms(resourceDir, cacheFile)

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -626,10 +626,10 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
-	// Restrict a leftover 0644 file before rewriting so new contents are not world-readable.
 	ensureCachePerms(resourceDir, cacheFile)
+	// Drop the leftover inode so an already-open 0644 FD keeps the old body.
+	_ = os.Remove(cacheFile)
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
-	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
 	ensureCachePerms(resourceDir, cacheFile)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -626,6 +626,8 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
+	// Restrict a leftover 0644 file before rewriting so new contents are not world-readable.
+	ensureCachePerms(resourceDir, cacheFile)
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
 	ensureCachePerms(resourceDir, cacheFile)

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -600,7 +600,8 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) readCacheWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, bool) {
-	cacheFile := filepath.Join(c.cacheResourceDir(path), c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
+	resourceDir := c.cacheResourceDir(path)
+	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	info, err := os.Stat(cacheFile)
 	if err != nil || time.Since(info.ModTime()) > 5*time.Minute {
 		return nil, false
@@ -612,6 +613,8 @@ func (c *Client) readCacheWithHeaders(path string, params map[string]string, hea
 	if err != nil {
 		return nil, false
 	}
+	// A leftover 0644 file can still be inside the TTL after upgrade; tighten before returning.
+	ensureCachePerms(resourceDir, cacheFile)
 	return json.RawMessage(data), true
 }
 
@@ -622,14 +625,18 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 func (c *Client) writeCacheWithHeaders(path string, params map[string]string, headers map[string]string, data json.RawMessage) {
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
-	_ = os.Chmod(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
-	_ = os.Chmod(cacheFile, 0o600)
+	ensureCachePerms(resourceDir, cacheFile)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)
 	}
+}
+
+func ensureCachePerms(resourceDir, cacheFile string) {
+	_ = os.Chmod(resourceDir, 0o700)
+	_ = os.Chmod(cacheFile, 0o600)
 }
 
 type platformCacheMetadata struct {

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -583,7 +583,8 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) readCacheWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, bool) {
-	cacheFile := filepath.Join(c.cacheResourceDir(path), c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
+	resourceDir := c.cacheResourceDir(path)
+	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	info, err := os.Stat(cacheFile)
 	if err != nil || time.Since(info.ModTime()) > 5*time.Minute {
 		return nil, false
@@ -595,6 +596,8 @@ func (c *Client) readCacheWithHeaders(path string, params map[string]string, hea
 	if err != nil {
 		return nil, false
 	}
+	// A leftover 0644 file can still be inside the TTL after upgrade; tighten before returning.
+	ensureCachePerms(resourceDir, cacheFile)
 	return json.RawMessage(data), true
 }
 
@@ -605,14 +608,18 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 func (c *Client) writeCacheWithHeaders(path string, params map[string]string, headers map[string]string, data json.RawMessage) {
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
-	_ = os.Chmod(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
-	_ = os.Chmod(cacheFile, 0o600)
+	ensureCachePerms(resourceDir, cacheFile)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)
 	}
+}
+
+func ensureCachePerms(resourceDir, cacheFile string) {
+	_ = os.Chmod(resourceDir, 0o700)
+	_ = os.Chmod(cacheFile, 0o600)
 }
 
 type platformCacheMetadata struct {

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -609,10 +609,10 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
-	// Restrict a leftover 0644 file before rewriting so new contents are not world-readable.
 	ensureCachePerms(resourceDir, cacheFile)
+	// Drop the leftover inode so an already-open 0644 FD keeps the old body.
+	_ = os.Remove(cacheFile)
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
-	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
 	ensureCachePerms(resourceDir, cacheFile)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -609,6 +609,8 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
+	// Restrict a leftover 0644 file before rewriting so new contents are not world-readable.
+	ensureCachePerms(resourceDir, cacheFile)
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
 	ensureCachePerms(resourceDir, cacheFile)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -612,6 +612,8 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
+	// Restrict a leftover 0644 file before rewriting so new contents are not world-readable.
+	ensureCachePerms(resourceDir, cacheFile)
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
 	ensureCachePerms(resourceDir, cacheFile)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -586,7 +586,8 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) readCacheWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, bool) {
-	cacheFile := filepath.Join(c.cacheResourceDir(path), c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
+	resourceDir := c.cacheResourceDir(path)
+	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	info, err := os.Stat(cacheFile)
 	if err != nil || time.Since(info.ModTime()) > 5*time.Minute {
 		return nil, false
@@ -598,6 +599,8 @@ func (c *Client) readCacheWithHeaders(path string, params map[string]string, hea
 	if err != nil {
 		return nil, false
 	}
+	// A leftover 0644 file can still be inside the TTL after upgrade; tighten before returning.
+	ensureCachePerms(resourceDir, cacheFile)
 	return json.RawMessage(data), true
 }
 
@@ -608,14 +611,18 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 func (c *Client) writeCacheWithHeaders(path string, params map[string]string, headers map[string]string, data json.RawMessage) {
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
-	_ = os.Chmod(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
-	_ = os.Chmod(cacheFile, 0o600)
+	ensureCachePerms(resourceDir, cacheFile)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)
 	}
+}
+
+func ensureCachePerms(resourceDir, cacheFile string) {
+	_ = os.Chmod(resourceDir, 0o700)
+	_ = os.Chmod(cacheFile, 0o600)
 }
 
 type platformCacheMetadata struct {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -612,10 +612,10 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
-	// Restrict a leftover 0644 file before rewriting so new contents are not world-readable.
 	ensureCachePerms(resourceDir, cacheFile)
+	// Drop the leftover inode so an already-open 0644 FD keeps the old body.
+	_ = os.Remove(cacheFile)
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
-	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
 	ensureCachePerms(resourceDir, cacheFile)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -717,6 +717,8 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
+	// Restrict a leftover 0644 file before rewriting so new contents are not world-readable.
+	ensureCachePerms(resourceDir, cacheFile)
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
 	ensureCachePerms(resourceDir, cacheFile)

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -691,7 +691,8 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) readCacheWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, bool) {
-	cacheFile := filepath.Join(c.cacheResourceDir(path), c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
+	resourceDir := c.cacheResourceDir(path)
+	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	info, err := os.Stat(cacheFile)
 	if err != nil || time.Since(info.ModTime()) > 5*time.Minute {
 		return nil, false
@@ -703,6 +704,8 @@ func (c *Client) readCacheWithHeaders(path string, params map[string]string, hea
 	if err != nil {
 		return nil, false
 	}
+	// A leftover 0644 file can still be inside the TTL after upgrade; tighten before returning.
+	ensureCachePerms(resourceDir, cacheFile)
 	return json.RawMessage(data), true
 }
 
@@ -713,14 +716,18 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 func (c *Client) writeCacheWithHeaders(path string, params map[string]string, headers map[string]string, data json.RawMessage) {
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
-	_ = os.Chmod(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
 	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
-	_ = os.Chmod(cacheFile, 0o600)
+	ensureCachePerms(resourceDir, cacheFile)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)
 	}
+}
+
+func ensureCachePerms(resourceDir, cacheFile string) {
+	_ = os.Chmod(resourceDir, 0o700)
+	_ = os.Chmod(cacheFile, 0o600)
 }
 
 type platformCacheMetadata struct {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -717,10 +717,10 @@ func (c *Client) writeCacheWithHeaders(path string, params map[string]string, he
 	resourceDir := c.cacheResourceDir(path)
 	_ = os.MkdirAll(resourceDir, 0o700)
 	cacheFile := filepath.Join(resourceDir, c.cacheKeyFor(http.MethodGet, path, params, headers, nil)+".json")
-	// Restrict a leftover 0644 file before rewriting so new contents are not world-readable.
 	ensureCachePerms(resourceDir, cacheFile)
+	// Drop the leftover inode so an already-open 0644 FD keeps the old body.
+	_ = os.Remove(cacheFile)
 	_ = os.WriteFile(cacheFile, []byte(data), 0o600)
-	// WriteFile's perm applies only on create; tighten a leftover 0644 rewrite.
 	ensureCachePerms(resourceDir, cacheFile)
 	if c.platformSession != nil {
 		c.writePlatformCacheMetadata(cacheFile)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

`readCacheWithHeaders` returned TTL-fresh cache content without tightening file mode. After upgrade, a leftover `0o644` cache file stayed world-readable until TTL expiry forced a rewrite (up to ~5 minutes). `#4428` already fixed the miss/rewrite path.

Issue: #4466

Closes #4466

## Approach

Share an `ensureCachePerms` helper used by both the hit-read and write paths.

- On a successful cache hit, chmod the cache file to `0o600` and the resource dir to `0o700` before returning content.
- On write, chmod the leftover path, **unlink it**, then `WriteFile` with `0o600` so a new inode is created. An already-open leftover `0644` FD keeps the old body and cannot see the new response. `ensureCachePerms` runs again on the resource dir and new file.

## Scope

Primary area: generated HTTP client cache (`internal/generator/templates/client.go.tmpl`)

Why this belongs in this repo: every printed CLI inherits this cache path from the generator. A printed-CLI-only patch would regress on reprint.

## Risk

Generated `internal/client/client.go` changes. Cache writes now unlink-then-create instead of truncating in place (brief miss window for a concurrent reader). Cache-hit reads still chmod leftover `0644` files. No MCP, auth, publish, verifier, or scorer contract change.

## Output Contract

- Emitted-code assertions require `readCacheWithHeaders` to call `ensureCachePerms`, and `writeCacheWithHeaders` to `Remove` the leftover inode before `WriteFile`, with `ensureCachePerms` around that pair.
- Compiled generated-CLI runtime tests: leftover `0644` hit-read becomes `0600`/`0700`; rewrite of a leftover `0644` file while an FD is held keeps the old body on that FD, replaces the inode, and leaves the path at `0600`.
- Golden fixtures that snapshot generated `client.go` updated in the same commit set.

## Verification

- [x] `go test ./internal/generator -run 'Test(GeneratedCacheWritesUsePrivatePermissions|WriteCacheWithHeadersRechmodsExistingFile|GeneratedInfraSecuritySuppressionsAreExplicit)' -count=1`
- [ ] Full package suite (running after this revision; generator is CI-sharded locally)
- [ ] `scripts/verify-generator-output.sh` (running after this revision)
- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the always-emitted cache path (HTML-extraction variant shares the same helper; snapshotted goldens do not enable that fork)
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a0939c2-0309-4402-af29-026877f6ab9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a0939c2-0309-4402-af29-026877f6ab9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

