### PR TITLE
fix(cli): keep store upserts for id-less and detail-rich resources

### DIFF
--- a/internal/generator/html_page_sync_id_test.go
+++ b/internal/generator/html_page_sync_id_test.go
@@ -210,8 +210,25 @@ func TestSyncSingleObjectHTMLPageModeIDFallbacks(t *testing.T) {
 	}
 	assertStoredID(t, db, "ships", "ships", "IMO-123")
 
-	if err := upsertSingleObject(db, "articles", json.RawMessage(` + "`" + `{"title":"JSON article","canonical_url":"https://example.test/articles/a"}` + "`" + `)); err == nil {
-		t.Fatalf("JSON single-object resource without an id-shaped field unexpectedly succeeded")
+	if err := upsertSingleObject(db, "articles", json.RawMessage(` + "`" + `{"title":"JSON article","canonical_url":"https://example.test/articles/a"}` + "`" + `)); err != nil {
+		t.Fatalf("parameter-shaped JSON article should store: %v", err)
+	}
+	articleRows, err := db.List("articles", 10)
+	if err != nil {
+		t.Fatalf("list articles: %v", err)
+	}
+	if len(articleRows) != 1 {
+		t.Fatalf("article rows = %d, want 1", len(articleRows))
+	}
+	var articleID string
+	if err := db.DB().QueryRow("SELECT id FROM resources WHERE resource_type = ?", "articles").Scan(&articleID); err != nil {
+		t.Fatalf("article storage id: %v", err)
+	}
+	if len(articleID) < 10 || articleID[:10] != "pp:params:" {
+		t.Fatalf("article storage id = %q, want pp:params: fingerprint", articleID)
+	}
+	if articleID == "articles" || articleID == "https://example.test/articles/a" {
+		t.Fatalf("article must not use the resource name or HTML URL fallback, got %q", articleID)
 	}
 }
 `

--- a/internal/generator/schema_builder.go
+++ b/internal/generator/schema_builder.go
@@ -27,6 +27,11 @@ type TableDef struct {
 
 	JSONOnlyFallback    bool
 	OriginalColumnCount int
+
+	// ParameterKeyed is set when the resource's typed responses have no
+	// identity field. Writers then store rows under a request-equivalent
+	// fingerprint instead of failing ExtractResourceID.
+	ParameterKeyed bool
 }
 
 type ColumnDef struct {
@@ -132,9 +137,10 @@ func BuildSchema(s *spec.APISpec) []TableDef {
 		tableName := toSnakeCase(name)
 
 		table := TableDef{
-			Name:     tableName,
-			Resource: name,
-			Columns:  append([]ColumnDef(nil), baseTableColumns...),
+			Name:           tableName,
+			Resource:       name,
+			Columns:        append([]ColumnDef(nil), baseTableColumns...),
+			ParameterKeyed: resourceIsParameterKeyed(name, resource, fields),
 		}
 
 		if gravity >= 2 {
@@ -212,6 +218,7 @@ func BuildSchema(s *spec.APISpec) []TableDef {
 				effectiveName = spec.ShardedSubResourceTableName(name, subName)
 			}
 			subTable := buildSubResourceTable(effectiveName, subResource, tableName)
+			subTable.ParameterKeyed = resourceIsParameterKeyed(effectiveName, subResource, collectResponseFields(s, subResource))
 			tables = append(tables, subTable)
 		}
 	}
@@ -247,6 +254,46 @@ func BuildSchema(s *spec.APISpec) []TableDef {
 	})
 
 	return tables
+}
+
+func resourceIsParameterKeyed(name string, resource spec.Resource, fields []spec.TypeField) bool {
+	for _, endpoint := range resource.Endpoints {
+		if strings.TrimSpace(endpoint.IDField) != "" {
+			return false
+		}
+	}
+	if len(fields) == 0 {
+		return false
+	}
+	return !responseFieldsHaveStoreIdentity(name, fields)
+}
+
+func responseFieldsHaveStoreIdentity(resourceName string, fields []spec.TypeField) bool {
+	names := make(map[string]struct{}, len(fields)*2)
+	for _, field := range fields {
+		names[strings.ToLower(strings.TrimSpace(field.Name))] = struct{}{}
+		names[strings.ToLower(toSnakeCase(field.Name))] = struct{}{}
+	}
+	for _, key := range []string{"id", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"} {
+		if _, ok := names[key]; ok {
+			return true
+		}
+	}
+	base := strings.ToLower(toSnakeCase(strings.TrimSpace(resourceName)))
+	bases := []string{base}
+	if strings.HasSuffix(base, "ies") && len(base) > 3 {
+		bases = append(bases, base[:len(base)-3]+"y")
+	} else if strings.HasSuffix(base, "s") && len(base) > 1 {
+		bases = append(bases, strings.TrimSuffix(base, "s"))
+	}
+	for _, stem := range bases {
+		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+			if _, ok := names[stem+suffix]; ok {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func reservedStoreObjectNames(s *spec.APISpec) map[string]struct{} {

--- a/internal/generator/schema_builder.go
+++ b/internal/generator/schema_builder.go
@@ -28,9 +28,8 @@ type TableDef struct {
 	JSONOnlyFallback    bool
 	OriginalColumnCount int
 
-	// ParameterKeyed is set when the resource's typed responses have no
-	// identity field. Writers then store rows under a request-equivalent
-	// fingerprint instead of failing ExtractResourceID.
+	// Fingerprint storage is only for typed responses with no identity
+	// field. Unflagged resources still fail ExtractResourceID as today.
 	ParameterKeyed bool
 }
 

--- a/internal/generator/schema_builder_test.go
+++ b/internal/generator/schema_builder_test.go
@@ -702,6 +702,60 @@ func TestBuildSchema_HyphenatedParentFKColumn(t *testing.T) {
 		"helper must be stable on already-normalized parent table names")
 }
 
+func TestBuildSchemaMarksParameterKeyedResources(t *testing.T) {
+	t.Parallel()
+
+	s := &spec.APISpec{
+		Name: "param-key",
+		Resources: map[string]spec.Resource{
+			"forecast": {
+				Endpoints: map[string]spec.Endpoint{
+					"get": {Method: "GET", Path: "/v1/forecast", Response: spec.ResponseDef{Type: "object", Item: "Forecast"}},
+				},
+			},
+			"widgets": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/widgets", Response: spec.ResponseDef{Type: "array", Item: "Widget"}},
+				},
+			},
+			"currencies": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/currencies", Response: spec.ResponseDef{Type: "array", Item: "Currency"}},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Forecast": {Fields: []spec.TypeField{
+				{Name: "latitude", Type: "number"},
+				{Name: "longitude", Type: "number"},
+				{Name: "timezone", Type: "string"},
+				{Name: "hourly", Type: "object"},
+			}},
+			"Widget": {Fields: []spec.TypeField{
+				{Name: "id", Type: "string"},
+				{Name: "name", Type: "string"},
+			}},
+			"Currency": {Fields: []spec.TypeField{
+				{Name: "currency_code", Type: "string"},
+				{Name: "symbol", Type: "string"},
+			}},
+		},
+	}
+
+	tables := BuildSchema(s)
+	forecast := findTable(tables, "forecast")
+	require.NotNil(t, forecast)
+	assert.True(t, forecast.ParameterKeyed, "id-less forecast must be parameter-keyed")
+
+	widgets := findTable(tables, "widgets")
+	require.NotNil(t, widgets)
+	assert.False(t, widgets.ParameterKeyed, "id-bearing widgets must stay entity-keyed")
+
+	currencies := findTable(tables, "currencies")
+	require.NotNil(t, currencies)
+	assert.False(t, currencies.ParameterKeyed, "currency_code is a store identity suffix")
+}
+
 // findTable returns nil when no match exists so callers can render
 // a clearer assertion failure than `tables[0]` panicking.
 func findTable(tables []TableDef, name string) *TableDef {

--- a/internal/generator/store_upsert_preserve_test.go
+++ b/internal/generator/store_upsert_preserve_test.go
@@ -92,6 +92,10 @@ func TestGeneratedStoreKeepsIDLessAndRicherUpserts(t *testing.T) {
 		"conflict writes must apply the documented keep-richer merge")
 	require.Contains(t, src, "func (s *Store) mergeIncomingResourceData(",
 		"generic and typed upserts must merge against the cached blob")
+	require.Contains(t, src, `"forecast": true`,
+		"id-less forecast must be opted into parameter-fingerprint writes")
+	require.NotContains(t, src, `"mutations": true`,
+		"resources with a real id must keep ExtractResourceID keying")
 	require.Contains(t, src, `id := ResolveStorageID("forecast", obj)`,
 		"typed id-less Upsert must not require ExtractResourceID")
 	require.Contains(t, src, `data = s.mergeIncomingResourceData(tx, "forecast", storageID, data)`,
@@ -107,7 +111,7 @@ func TestGeneratedStoreKeepsIDLessAndRicherUpserts(t *testing.T) {
 	require.NoError(t, os.WriteFile(testPath, []byte(generatedIDLessRicherRuntimeTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "test", "./internal/store",
-		"-run", "Test(ResolveStorageID_ParameterShapedAndEntityIDs|UpsertBatch_StoresIDLessParameterShapedPayload|Upsert_PreservesRicherCachedDetail|MergeKeepRicherJSON|UpsertForecast_StoresIDLessPayload|UpsertMutations_ListDoesNotShrinkDetail)",
+		"-run", "Test(ResolveStorageID_KeepsEntityIDsAndRefusesUnusable|Upsert_PreservesRicherCachedDetail|MergeKeepRicherJSON|UpsertForecast_StoresIDLessPayload|UpsertForecast_BatchSameLocation|UpsertMutations_ListDoesNotShrinkDetail)",
 		"-count=1")
 }
 
@@ -144,6 +148,49 @@ const generatedIDLessRicherRuntimeTest = "package store\n\n" +
 	"\t}\n" +
 	"\tif typed != 1 {\n" +
 	"\t\tt.Fatalf(\"typed forecast rows = %d, want 1\", typed)\n" +
+	"\t}\n" +
+	"}\n\n" +
+	"func TestUpsertForecast_BatchSameLocation(t *testing.T) {\n" +
+	"\ts, err := Open(filepath.Join(t.TempDir(), \"data.db\"))\n" +
+	"\tif err != nil {\n" +
+	"\t\tt.Fatalf(\"open: %v\", err)\n" +
+	"\t}\n" +
+	"\tdefer s.Close()\n\n" +
+	"\tfirst := json.RawMessage(`{\"latitude\":52.52,\"longitude\":13.41,\"generationtime_ms\":0.1,\"hourly\":{\"temperature_2m\":[1,2]}}`)\n" +
+	"\tstored, extractFailures, err := s.UpsertBatch(\"forecast\", []json.RawMessage{first})\n" +
+	"\tif err != nil {\n" +
+	"\t\tt.Fatalf(\"UpsertBatch: %v\", err)\n" +
+	"\t}\n" +
+	"\tif stored != 1 || extractFailures != 0 {\n" +
+	"\t\tt.Fatalf(\"stored/extractFailures = %d/%d, want 1/0\", stored, extractFailures)\n" +
+	"\t}\n" +
+	"\tupdated := json.RawMessage(`{\"latitude\":52.52,\"longitude\":13.41,\"generationtime_ms\":9.9,\"hourly\":{\"temperature_2m\":[3,4]}}`)\n" +
+	"\tif stored, extractFailures, err = s.UpsertBatch(\"forecast\", []json.RawMessage{updated}); err != nil {\n" +
+	"\t\tt.Fatalf(\"update: %v\", err)\n" +
+	"\t}\n" +
+	"\tif stored != 1 || extractFailures != 0 {\n" +
+	"\t\tt.Fatalf(\"update stored/extractFailures = %d/%d, want 1/0\", stored, extractFailures)\n" +
+	"\t}\n" +
+	"\trows, err := s.List(\"forecast\", 10)\n" +
+	"\tif err != nil {\n" +
+	"\t\tt.Fatalf(\"list: %v\", err)\n" +
+	"\t}\n" +
+	"\tif len(rows) != 1 {\n" +
+	"\t\tt.Fatalf(\"same-location rows = %d, want 1\", len(rows))\n" +
+	"\t}\n" +
+	"\tother := json.RawMessage(`{\"latitude\":40.7,\"longitude\":-74.0,\"hourly\":{\"temperature_2m\":[10]}}`)\n" +
+	"\tif stored, extractFailures, err = s.UpsertBatch(\"forecast\", []json.RawMessage{other}); err != nil {\n" +
+	"\t\tt.Fatalf(\"other location: %v\", err)\n" +
+	"\t}\n" +
+	"\tif stored != 1 || extractFailures != 0 {\n" +
+	"\t\tt.Fatalf(\"other stored/extractFailures = %d/%d, want 1/0\", stored, extractFailures)\n" +
+	"\t}\n" +
+	"\trows, err = s.List(\"forecast\", 10)\n" +
+	"\tif err != nil {\n" +
+	"\t\tt.Fatalf(\"list after other: %v\", err)\n" +
+	"\t}\n" +
+	"\tif len(rows) != 2 {\n" +
+	"\t\tt.Fatalf(\"distinct-location rows = %d, want 2\", len(rows))\n" +
 	"\t}\n" +
 	"}\n\n" +
 	"func TestUpsertMutations_ListDoesNotShrinkDetail(t *testing.T) {\n" +

--- a/internal/generator/store_upsert_preserve_test.go
+++ b/internal/generator/store_upsert_preserve_test.go
@@ -106,6 +106,8 @@ func TestGeneratedStoreKeepsIDLessAndRicherUpserts(t *testing.T) {
 		"object arrays must match by a stable id, not numeric index")
 	require.Contains(t, src, "func suffixIdentityFromItemKeys(",
 		"nested items must pair on suffix identities like currency_code")
+	require.Contains(t, src, "func sharedForeignKeyStem(",
+		"item identity must skip shared FKs when an own-identity key exists")
 	require.Contains(t, src, `canonicalIDFromKey(obj, "sku")`,
 		"line items keyed by sku must keep-richer-merge")
 	require.Contains(t, src, "func indexObjectArrayByIdentity(",
@@ -119,7 +121,7 @@ func TestGeneratedStoreKeepsIDLessAndRicherUpserts(t *testing.T) {
 	require.NoError(t, os.WriteFile(testPath, []byte(generatedIDLessRicherRuntimeTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "test", "./internal/store",
-		"-run", "Test(ResolveStorageID_KeepsEntityIDsAndRefusesUnusable|Upsert_PreservesRicherCachedDetail|MergeKeepRicherJSON|UpsertForecast_StoresIDLessPayload|UpsertForecast_BatchSameLocation|UpsertMutations_ListDoesNotShrinkDetail|UpsertMutations_ArrayReorderDoesNotCorrupt|UpsertMutations_SuffixArrayIdentityKeepsDetail)",
+		"-run", "Test(ResolveStorageID_KeepsEntityIDsAndRefusesUnusable|Upsert_PreservesRicherCachedDetail|MergeKeepRicherJSON|UpsertForecast_StoresIDLessPayload|UpsertForecast_BatchSameLocation|UpsertMutations_ListDoesNotShrinkDetail|UpsertMutations_ArrayReorderDoesNotCorrupt|UpsertMutations_SuffixArrayIdentityKeepsDetail|UpsertMutations_SharedFKDoesNotStealSuffixIdentity)",
 		"-count=1")
 }
 
@@ -310,5 +312,43 @@ const generatedIDLessRicherRuntimeTest = "package store\n\n" +
 	"\t}\n" +
 	"\tif fmt.Sprint(second[\"notes\"]) != \"keep\" {\n" +
 	"\t\tt.Fatalf(\"suffix identity lost detail, stored %s\", got)\n" +
+	"\t}\n" +
+	"}\n\n" +
+	"func TestUpsertMutations_SharedFKDoesNotStealSuffixIdentity(t *testing.T) {\n" +
+	"\ts, err := Open(filepath.Join(t.TempDir(), \"data.db\"))\n" +
+	"\tif err != nil {\n" +
+	"\t\tt.Fatalf(\"open: %v\", err)\n" +
+	"\t}\n" +
+	"\tdefer s.Close()\n\n" +
+	"\tdetail := json.RawMessage(`{\"id\":\"mut-4\",\"rows\":[{\"account_id\":\"acct\",\"currency_code\":\"USD\",\"notes\":\"usd\"},{\"account_id\":\"acct\",\"currency_code\":\"EUR\",\"notes\":\"eur\"}]}`)\n" +
+	"\tif err := s.UpsertMutations(detail); err != nil {\n" +
+	"\t\tt.Fatalf(\"detail: %v\", err)\n" +
+	"\t}\n" +
+	"\tlist := json.RawMessage(`{\"id\":\"mut-4\",\"rows\":[{\"account_id\":\"acct\",\"currency_code\":\"EUR\"},{\"account_id\":\"acct\",\"currency_code\":\"USD\"}]}`)\n" +
+	"\tif err := s.UpsertMutations(list); err != nil {\n" +
+	"\t\tt.Fatalf(\"list: %v\", err)\n" +
+	"\t}\n" +
+	"\tgot, err := s.Get(\"mutations\", \"mut-4\")\n" +
+	"\tif err != nil {\n" +
+	"\t\tt.Fatalf(\"get: %v\", err)\n" +
+	"\t}\n" +
+	"\tvar obj map[string]any\n" +
+	"\tif err := json.Unmarshal(got, &obj); err != nil {\n" +
+	"\t\tt.Fatalf(\"unmarshal: %v\", err)\n" +
+	"\t}\n" +
+	"\trows, _ := obj[\"rows\"].([]any)\n" +
+	"\tif len(rows) != 2 {\n" +
+	"\t\tt.Fatalf(\"length must follow incoming, got %d stored %s\", len(rows), got)\n" +
+	"\t}\n" +
+	"\tfirst, _ := rows[0].(map[string]any)\n" +
+	"\tsecond, _ := rows[1].(map[string]any)\n" +
+	"\tif fmt.Sprint(first[\"currency_code\"]) != \"EUR\" || fmt.Sprint(second[\"currency_code\"]) != \"USD\" {\n" +
+	"\t\tt.Fatalf(\"must pair on currency_code, stored %s\", got)\n" +
+	"\t}\n" +
+	"\tif fmt.Sprint(first[\"notes\"]) != \"eur\" {\n" +
+	"\t\tt.Fatalf(\"EUR row lost its notes, stored %s\", got)\n" +
+	"\t}\n" +
+	"\tif fmt.Sprint(second[\"notes\"]) != \"usd\" {\n" +
+	"\t\tt.Fatalf(\"USD row lost its notes, stored %s\", got)\n" +
 	"\t}\n" +
 	"}\n"

--- a/internal/generator/store_upsert_preserve_test.go
+++ b/internal/generator/store_upsert_preserve_test.go
@@ -71,8 +71,8 @@ func idlessAndDetailStoreSpec() *spec.APISpec {
 	return apiSpec
 }
 
-// TestGeneratedStoreKeepsIDLessAndRicherUpserts proves the emitted store
-// contract for parameter-shaped writes and keep-richer list/detail merges.
+// Emitted store must compile and honor id-less fingerprint writes plus
+// keep-richer list/detail merges, including identity-keyed array merge.
 func TestGeneratedStoreKeepsIDLessAndRicherUpserts(t *testing.T) {
 	t.Parallel()
 
@@ -102,6 +102,10 @@ func TestGeneratedStoreKeepsIDLessAndRicherUpserts(t *testing.T) {
 		"typed upsert must merge before projecting columns")
 	require.Contains(t, src, `item = s.mergeIncomingResourceData(tx, resourceType, storageID, item)`,
 		"batch upsert must merge before both generic and typed writes")
+	require.Contains(t, src, "func arrayItemIdentity(",
+		"object arrays must match by a stable id, not numeric index")
+	require.Contains(t, src, "func indexObjectArrayByIdentity(",
+		"cached array leftovers must be indexed by identity for keep-richer pairing")
 	require.NotContains(t, src, `id := ExtractResourceID("forecast", obj)`,
 		"typed forecast writer must not still key only on ExtractResourceID")
 
@@ -111,13 +115,14 @@ func TestGeneratedStoreKeepsIDLessAndRicherUpserts(t *testing.T) {
 	require.NoError(t, os.WriteFile(testPath, []byte(generatedIDLessRicherRuntimeTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "test", "./internal/store",
-		"-run", "Test(ResolveStorageID_KeepsEntityIDsAndRefusesUnusable|Upsert_PreservesRicherCachedDetail|MergeKeepRicherJSON|UpsertForecast_StoresIDLessPayload|UpsertForecast_BatchSameLocation|UpsertMutations_ListDoesNotShrinkDetail)",
+		"-run", "Test(ResolveStorageID_KeepsEntityIDsAndRefusesUnusable|Upsert_PreservesRicherCachedDetail|MergeKeepRicherJSON|UpsertForecast_StoresIDLessPayload|UpsertForecast_BatchSameLocation|UpsertMutations_ListDoesNotShrinkDetail|UpsertMutations_ArrayReorderDoesNotCorrupt)",
 		"-count=1")
 }
 
 const generatedIDLessRicherRuntimeTest = "package store\n\n" +
 	"import (\n" +
 	"\t\"encoding/json\"\n" +
+	"\t\"fmt\"\n" +
 	"\t\"path/filepath\"\n" +
 	"\t\"strings\"\n" +
 	"\t\"testing\"\n" +
@@ -223,5 +228,49 @@ const generatedIDLessRicherRuntimeTest = "package store\n\n" +
 	"\t}\n" +
 	"\tif !strings.Contains(typedData, \"rows\") {\n" +
 	"\t\tt.Fatalf(\"typed table lost rows, got %s\", typedData)\n" +
+	"\t}\n" +
+	"}\n\n" +
+	"func TestUpsertMutations_ArrayReorderDoesNotCorrupt(t *testing.T) {\n" +
+	"\ts, err := Open(filepath.Join(t.TempDir(), \"data.db\"))\n" +
+	"\tif err != nil {\n" +
+	"\t\tt.Fatalf(\"open: %v\", err)\n" +
+	"\t}\n" +
+	"\tdefer s.Close()\n\n" +
+	"\tdetail := json.RawMessage(`{\"id\":\"mut-2\",\"name\":\"Invoice\",\"rows\":[{\"id\":\"a\",\"vat\":21,\"notes\":\"keep\"},{\"id\":\"b\",\"vat\":9},{\"id\":\"c\",\"vat\":0}]}`)\n" +
+	"\tif err := s.UpsertMutations(detail); err != nil {\n" +
+	"\t\tt.Fatalf(\"detail UpsertMutations: %v\", err)\n" +
+	"\t}\n" +
+	"\treordered := json.RawMessage(`{\"id\":\"mut-2\",\"rows\":[{\"id\":\"c\",\"vat\":0},{\"id\":\"a\",\"vat\":22}]}`)\n" +
+	"\tif err := s.UpsertMutations(reordered); err != nil {\n" +
+	"\t\tt.Fatalf(\"reordered UpsertMutations: %v\", err)\n" +
+	"\t}\n" +
+	"\tgot, err := s.Get(\"mutations\", \"mut-2\")\n" +
+	"\tif err != nil {\n" +
+	"\t\tt.Fatalf(\"get: %v\", err)\n" +
+	"\t}\n" +
+	"\tvar obj map[string]any\n" +
+	"\tif err := json.Unmarshal(got, &obj); err != nil {\n" +
+	"\t\tt.Fatalf(\"unmarshal: %v\", err)\n" +
+	"\t}\n" +
+	"\trows, _ := obj[\"rows\"].([]any)\n" +
+	"\tif len(rows) != 2 {\n" +
+	"\t\tt.Fatalf(\"array length must follow incoming, got %d stored %s\", len(rows), got)\n" +
+	"\t}\n" +
+	"\tfirst, _ := rows[0].(map[string]any)\n" +
+	"\tsecond, _ := rows[1].(map[string]any)\n" +
+	"\tif fmt.Sprint(first[\"id\"]) != \"c\" || fmt.Sprint(second[\"id\"]) != \"a\" {\n" +
+	"\t\tt.Fatalf(\"array order must follow incoming, stored %s\", got)\n" +
+	"\t}\n" +
+	"\tif fmt.Sprint(second[\"vat\"]) != \"22\" {\n" +
+	"\t\tt.Fatalf(\"incoming scalar on matched object should win, stored %s\", got)\n" +
+	"\t}\n" +
+	"\tif fmt.Sprint(second[\"notes\"]) != \"keep\" {\n" +
+	"\t\tt.Fatalf(\"keep-richer lost notes on id match, stored %s\", got)\n" +
+	"\t}\n" +
+	"\tfor _, row := range rows {\n" +
+	"\t\tobj, _ := row.(map[string]any)\n" +
+	"\t\tif fmt.Sprint(obj[\"id\"]) == \"b\" {\n" +
+	"\t\t\tt.Fatalf(\"dropped middle entry must not remain, stored %s\", got)\n" +
+	"\t\t}\n" +
 	"\t}\n" +
 	"}\n"

--- a/internal/generator/store_upsert_preserve_test.go
+++ b/internal/generator/store_upsert_preserve_test.go
@@ -104,6 +104,10 @@ func TestGeneratedStoreKeepsIDLessAndRicherUpserts(t *testing.T) {
 		"batch upsert must merge before both generic and typed writes")
 	require.Contains(t, src, "func arrayItemIdentity(",
 		"object arrays must match by a stable id, not numeric index")
+	require.Contains(t, src, "func suffixIdentityFromItemKeys(",
+		"nested items must pair on suffix identities like currency_code")
+	require.Contains(t, src, `canonicalIDFromKey(obj, "sku")`,
+		"line items keyed by sku must keep-richer-merge")
 	require.Contains(t, src, "func indexObjectArrayByIdentity(",
 		"cached array leftovers must be indexed by identity for keep-richer pairing")
 	require.NotContains(t, src, `id := ExtractResourceID("forecast", obj)`,
@@ -115,7 +119,7 @@ func TestGeneratedStoreKeepsIDLessAndRicherUpserts(t *testing.T) {
 	require.NoError(t, os.WriteFile(testPath, []byte(generatedIDLessRicherRuntimeTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "test", "./internal/store",
-		"-run", "Test(ResolveStorageID_KeepsEntityIDsAndRefusesUnusable|Upsert_PreservesRicherCachedDetail|MergeKeepRicherJSON|UpsertForecast_StoresIDLessPayload|UpsertForecast_BatchSameLocation|UpsertMutations_ListDoesNotShrinkDetail|UpsertMutations_ArrayReorderDoesNotCorrupt)",
+		"-run", "Test(ResolveStorageID_KeepsEntityIDsAndRefusesUnusable|Upsert_PreservesRicherCachedDetail|MergeKeepRicherJSON|UpsertForecast_StoresIDLessPayload|UpsertForecast_BatchSameLocation|UpsertMutations_ListDoesNotShrinkDetail|UpsertMutations_ArrayReorderDoesNotCorrupt|UpsertMutations_SuffixArrayIdentityKeepsDetail)",
 		"-count=1")
 }
 
@@ -272,5 +276,39 @@ const generatedIDLessRicherRuntimeTest = "package store\n\n" +
 	"\t\tif fmt.Sprint(obj[\"id\"]) == \"b\" {\n" +
 	"\t\t\tt.Fatalf(\"dropped middle entry must not remain, stored %s\", got)\n" +
 	"\t\t}\n" +
+	"\t}\n" +
+	"}\n\n" +
+	"func TestUpsertMutations_SuffixArrayIdentityKeepsDetail(t *testing.T) {\n" +
+	"\ts, err := Open(filepath.Join(t.TempDir(), \"data.db\"))\n" +
+	"\tif err != nil {\n" +
+	"\t\tt.Fatalf(\"open: %v\", err)\n" +
+	"\t}\n" +
+	"\tdefer s.Close()\n\n" +
+	"\tdetail := json.RawMessage(`{\"id\":\"mut-3\",\"rows\":[{\"currency_code\":\"USD\",\"notes\":\"keep\"},{\"currency_code\":\"EUR\"},{\"currency_code\":\"GBP\"}]}`)\n" +
+	"\tif err := s.UpsertMutations(detail); err != nil {\n" +
+	"\t\tt.Fatalf(\"detail: %v\", err)\n" +
+	"\t}\n" +
+	"\tlist := json.RawMessage(`{\"id\":\"mut-3\",\"rows\":[{\"currency_code\":\"EUR\"},{\"currency_code\":\"USD\"}]}`)\n" +
+	"\tif err := s.UpsertMutations(list); err != nil {\n" +
+	"\t\tt.Fatalf(\"list: %v\", err)\n" +
+	"\t}\n" +
+	"\tgot, err := s.Get(\"mutations\", \"mut-3\")\n" +
+	"\tif err != nil {\n" +
+	"\t\tt.Fatalf(\"get: %v\", err)\n" +
+	"\t}\n" +
+	"\tvar obj map[string]any\n" +
+	"\tif err := json.Unmarshal(got, &obj); err != nil {\n" +
+	"\t\tt.Fatalf(\"unmarshal: %v\", err)\n" +
+	"\t}\n" +
+	"\trows, _ := obj[\"rows\"].([]any)\n" +
+	"\tif len(rows) != 2 {\n" +
+	"\t\tt.Fatalf(\"length must follow incoming, got %d stored %s\", len(rows), got)\n" +
+	"\t}\n" +
+	"\tsecond, _ := rows[1].(map[string]any)\n" +
+	"\tif fmt.Sprint(second[\"currency_code\"]) != \"USD\" {\n" +
+	"\t\tt.Fatalf(\"order must follow incoming, stored %s\", got)\n" +
+	"\t}\n" +
+	"\tif fmt.Sprint(second[\"notes\"]) != \"keep\" {\n" +
+	"\t\tt.Fatalf(\"suffix identity lost detail, stored %s\", got)\n" +
 	"\t}\n" +
 	"}\n"

--- a/internal/generator/store_upsert_preserve_test.go
+++ b/internal/generator/store_upsert_preserve_test.go
@@ -112,6 +112,8 @@ func TestGeneratedStoreKeepsIDLessAndRicherUpserts(t *testing.T) {
 		"line items keyed by sku must keep-richer-merge")
 	require.Contains(t, src, "func indexObjectArrayByIdentity(",
 		"cached array leftovers must be indexed by identity for keep-richer pairing")
+	require.Contains(t, src, "func qualifyArrayItemIdentity(",
+		"array identity keys must include the field that produced them")
 	require.NotContains(t, src, `id := ExtractResourceID("forecast", obj)`,
 		"typed forecast writer must not still key only on ExtractResourceID")
 
@@ -121,7 +123,7 @@ func TestGeneratedStoreKeepsIDLessAndRicherUpserts(t *testing.T) {
 	require.NoError(t, os.WriteFile(testPath, []byte(generatedIDLessRicherRuntimeTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "test", "./internal/store",
-		"-run", "Test(ResolveStorageID_KeepsEntityIDsAndRefusesUnusable|Upsert_PreservesRicherCachedDetail|MergeKeepRicherJSON|UpsertForecast_StoresIDLessPayload|UpsertForecast_BatchSameLocation|UpsertMutations_ListDoesNotShrinkDetail|UpsertMutations_ArrayReorderDoesNotCorrupt|UpsertMutations_SuffixArrayIdentityKeepsDetail|UpsertMutations_SharedFKDoesNotStealSuffixIdentity)",
+		"-run", "Test(ResolveStorageID_KeepsEntityIDsAndRefusesUnusable|Upsert_PreservesRicherCachedDetail|MergeKeepRicherJSON|UpsertForecast_StoresIDLessPayload|UpsertForecast_BatchSameLocation|UpsertMutations_ListDoesNotShrinkDetail|UpsertMutations_ArrayReorderDoesNotCorrupt|UpsertMutations_SuffixArrayIdentityKeepsDetail|UpsertMutations_SharedFKDoesNotStealSuffixIdentity|UpsertMutations_CrossFieldIdentitiesDoNotCollide)",
 		"-count=1")
 }
 
@@ -350,5 +352,52 @@ const generatedIDLessRicherRuntimeTest = "package store\n\n" +
 	"\t}\n" +
 	"\tif fmt.Sprint(second[\"notes\"]) != \"usd\" {\n" +
 	"\t\tt.Fatalf(\"USD row lost its notes, stored %s\", got)\n" +
+	"\t}\n" +
+	"}\n\n" +
+	"func TestUpsertMutations_CrossFieldIdentitiesDoNotCollide(t *testing.T) {\n" +
+	"\ts, err := Open(filepath.Join(t.TempDir(), \"data.db\"))\n" +
+	"\tif err != nil {\n" +
+	"\t\tt.Fatalf(\"open: %v\", err)\n" +
+	"\t}\n" +
+	"\tdefer s.Close()\n\n" +
+	"\tdetail := json.RawMessage(`{\"id\":\"mut-5\",\"rows\":[{\"id\":\"USD\",\"notes\":\"from-id\"},{\"currency_code\":\"USD\",\"notes\":\"from-code\"}]}`)\n" +
+	"\tif err := s.UpsertMutations(detail); err != nil {\n" +
+	"\t\tt.Fatalf(\"detail: %v\", err)\n" +
+	"\t}\n" +
+	"\tlist := json.RawMessage(`{\"id\":\"mut-5\",\"rows\":[{\"currency_code\":\"USD\"},{\"id\":\"USD\"}]}`)\n" +
+	"\tif err := s.UpsertMutations(list); err != nil {\n" +
+	"\t\tt.Fatalf(\"list: %v\", err)\n" +
+	"\t}\n" +
+	"\tgot, err := s.Get(\"mutations\", \"mut-5\")\n" +
+	"\tif err != nil {\n" +
+	"\t\tt.Fatalf(\"get: %v\", err)\n" +
+	"\t}\n" +
+	"\tvar obj map[string]any\n" +
+	"\tif err := json.Unmarshal(got, &obj); err != nil {\n" +
+	"\t\tt.Fatalf(\"unmarshal: %v\", err)\n" +
+	"\t}\n" +
+	"\trows, _ := obj[\"rows\"].([]any)\n" +
+	"\tif len(rows) != 2 {\n" +
+	"\t\tt.Fatalf(\"length must follow incoming, got %d stored %s\", len(rows), got)\n" +
+	"\t}\n" +
+	"\tfirst, _ := rows[0].(map[string]any)\n" +
+	"\tsecond, _ := rows[1].(map[string]any)\n" +
+	"\tif fmt.Sprint(first[\"currency_code\"]) != \"USD\" {\n" +
+	"\t\tt.Fatalf(\"first row must stay the currency_code item, stored %s\", got)\n" +
+	"\t}\n" +
+	"\tif _, hasID := first[\"id\"]; hasID {\n" +
+	"\t\tt.Fatalf(\"currency_code row must not absorb the id sibling, stored %s\", got)\n" +
+	"\t}\n" +
+	"\tif fmt.Sprint(first[\"notes\"]) != \"from-code\" {\n" +
+	"\t\tt.Fatalf(\"currency_code row lost its notes, stored %s\", got)\n" +
+	"\t}\n" +
+	"\tif fmt.Sprint(second[\"id\"]) != \"USD\" {\n" +
+	"\t\tt.Fatalf(\"second row must stay the id item, stored %s\", got)\n" +
+	"\t}\n" +
+	"\tif _, hasCode := second[\"currency_code\"]; hasCode {\n" +
+	"\t\tt.Fatalf(\"id row must not absorb the currency_code sibling, stored %s\", got)\n" +
+	"\t}\n" +
+	"\tif fmt.Sprint(second[\"notes\"]) != \"from-id\" {\n" +
+	"\t\tt.Fatalf(\"id row lost its notes, stored %s\", got)\n" +
 	"\t}\n" +
 	"}\n"

--- a/internal/generator/store_upsert_preserve_test.go
+++ b/internal/generator/store_upsert_preserve_test.go
@@ -1,0 +1,180 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func idlessAndDetailStoreSpec() *spec.APISpec {
+	apiSpec := minimalSpec("idless-richer-store")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Learn.Disabled = true
+	apiSpec.Resources = map[string]spec.Resource{
+		"forecast": {
+			Description: "Parameter-shaped forecast",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/v1/forecast",
+					Description: "Get forecast",
+					Response:    spec.ResponseDef{Type: "object", Item: "Forecast"},
+				},
+			},
+		},
+		"mutations": {
+			Description: "Mutations with richer detail than list",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/mutations",
+					Description: "List mutations",
+					Response:    spec.ResponseDef{Type: "array", Item: "Mutation"},
+				},
+				"get": {
+					Method:      "GET",
+					Path:        "/mutations/{id}",
+					Description: "Get mutation",
+					Params:      []spec.Param{{Name: "id", Type: "string", Required: true, PathParam: true}},
+					Response:    spec.ResponseDef{Type: "object", Item: "Mutation"},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Forecast": {
+			Fields: []spec.TypeField{
+				{Name: "latitude", Type: "number"},
+				{Name: "longitude", Type: "number"},
+				{Name: "timezone", Type: "string"},
+				{Name: "timezone_abbreviation", Type: "string"},
+				{Name: "elevation", Type: "number"},
+				{Name: "utc_offset_seconds", Type: "integer"},
+				{Name: "hourly", Type: "object"},
+				{Name: "current", Type: "object"},
+			},
+		},
+		"Mutation": {
+			Fields: []spec.TypeField{
+				{Name: "id", Type: "string"},
+				{Name: "name", Type: "string"},
+				{Name: "description", Type: "string"},
+				{Name: "status", Type: "string"},
+				{Name: "rows", Type: "array"},
+			},
+		},
+	}
+	return apiSpec
+}
+
+// TestGeneratedStoreKeepsIDLessAndRicherUpserts proves the emitted store
+// contract for parameter-shaped writes and keep-richer list/detail merges.
+func TestGeneratedStoreKeepsIDLessAndRicherUpserts(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := idlessAndDetailStoreSpec()
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	storeSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	src := string(storeSrc)
+
+	require.Contains(t, src, "func ResolveStorageID(",
+		"id-less writers must share ResolveStorageID")
+	require.Contains(t, src, "func parameterSnapshotID(",
+		"parameter-shaped rows must be keyed by a request-equivalent fingerprint")
+	require.Contains(t, src, "func mergeKeepRicherJSON(",
+		"conflict writes must apply the documented keep-richer merge")
+	require.Contains(t, src, "func (s *Store) mergeIncomingResourceData(",
+		"generic and typed upserts must merge against the cached blob")
+	require.Contains(t, src, `id := ResolveStorageID("forecast", obj)`,
+		"typed id-less Upsert must not require ExtractResourceID")
+	require.Contains(t, src, `data = s.mergeIncomingResourceData(tx, "forecast", storageID, data)`,
+		"typed upsert must merge before projecting columns")
+	require.Contains(t, src, `item = s.mergeIncomingResourceData(tx, resourceType, storageID, item)`,
+		"batch upsert must merge before both generic and typed writes")
+	require.NotContains(t, src, `id := ExtractResourceID("forecast", obj)`,
+		"typed forecast writer must not still key only on ExtractResourceID")
+
+	requireGeneratedCompiles(t, outputDir)
+
+	testPath := filepath.Join(outputDir, "internal", "store", "idless_richer_runtime_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(generatedIDLessRicherRuntimeTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "test", "./internal/store",
+		"-run", "Test(ResolveStorageID_ParameterShapedAndEntityIDs|UpsertBatch_StoresIDLessParameterShapedPayload|Upsert_PreservesRicherCachedDetail|MergeKeepRicherJSON|UpsertForecast_StoresIDLessPayload|UpsertMutations_ListDoesNotShrinkDetail)",
+		"-count=1")
+}
+
+const generatedIDLessRicherRuntimeTest = "package store\n\n" +
+	"import (\n" +
+	"\t\"encoding/json\"\n" +
+	"\t\"path/filepath\"\n" +
+	"\t\"strings\"\n" +
+	"\t\"testing\"\n" +
+	")\n\n" +
+	"func TestUpsertForecast_StoresIDLessPayload(t *testing.T) {\n" +
+	"\ts, err := Open(filepath.Join(t.TempDir(), \"data.db\"))\n" +
+	"\tif err != nil {\n" +
+	"\t\tt.Fatalf(\"open: %v\", err)\n" +
+	"\t}\n" +
+	"\tdefer s.Close()\n\n" +
+	"\tpayload := json.RawMessage(`{\"latitude\":52.52,\"longitude\":13.41,\"timezone\":\"Europe/Berlin\",\"hourly\":{\"temperature_2m\":[12.1]}}`)\n" +
+	"\tif err := s.UpsertForecast(payload); err != nil {\n" +
+	"\t\tt.Fatalf(\"UpsertForecast: %v\", err)\n" +
+	"\t}\n" +
+	"\trows, err := s.List(\"forecast\", 10)\n" +
+	"\tif err != nil {\n" +
+	"\t\tt.Fatalf(\"list: %v\", err)\n" +
+	"\t}\n" +
+	"\tif len(rows) != 1 {\n" +
+	"\t\tt.Fatalf(\"forecast rows = %d, want 1\", len(rows))\n" +
+	"\t}\n" +
+	"\tif !strings.Contains(string(rows[0]), \"Europe/Berlin\") {\n" +
+	"\t\tt.Fatalf(\"stored forecast missing payload, got %s\", rows[0])\n" +
+	"\t}\n\n" +
+	"\tvar typed int\n" +
+	"\tif err := s.DB().QueryRow(`SELECT COUNT(*) FROM \"forecast\"`).Scan(&typed); err != nil {\n" +
+	"\t\tt.Fatalf(\"typed count: %v\", err)\n" +
+	"\t}\n" +
+	"\tif typed != 1 {\n" +
+	"\t\tt.Fatalf(\"typed forecast rows = %d, want 1\", typed)\n" +
+	"\t}\n" +
+	"}\n\n" +
+	"func TestUpsertMutations_ListDoesNotShrinkDetail(t *testing.T) {\n" +
+	"\ts, err := Open(filepath.Join(t.TempDir(), \"data.db\"))\n" +
+	"\tif err != nil {\n" +
+	"\t\tt.Fatalf(\"open: %v\", err)\n" +
+	"\t}\n" +
+	"\tdefer s.Close()\n\n" +
+	"\tdetail := json.RawMessage(`{\"id\":\"mut-1\",\"name\":\"Invoice\",\"rows\":[{\"vat\":21,\"amount\":100}]}`)\n" +
+	"\tif err := s.UpsertMutations(detail); err != nil {\n" +
+	"\t\tt.Fatalf(\"detail UpsertMutations: %v\", err)\n" +
+	"\t}\n" +
+	"\tlist := json.RawMessage(`{\"id\":\"mut-1\",\"name\":\"Invoice list\"}`)\n" +
+	"\tif err := s.UpsertMutations(list); err != nil {\n" +
+	"\t\tt.Fatalf(\"list UpsertMutations: %v\", err)\n" +
+	"\t}\n" +
+	"\tgot, err := s.Get(\"mutations\", \"mut-1\")\n" +
+	"\tif err != nil {\n" +
+	"\t\tt.Fatalf(\"get: %v\", err)\n" +
+	"\t}\n" +
+	"\tif !strings.Contains(string(got), \"rows\") || !strings.Contains(string(got), \"vat\") {\n" +
+	"\t\tt.Fatalf(\"list upsert destroyed detail, got %s\", got)\n" +
+	"\t}\n" +
+	"\tif !strings.Contains(string(got), \"Invoice list\") {\n" +
+	"\t\tt.Fatalf(\"incoming list scalar should win, got %s\", got)\n" +
+	"\t}\n\n" +
+	"\tvar typedData string\n" +
+	"\tif err := s.DB().QueryRow(`SELECT data FROM \"mutations\" WHERE id = ?`, \"mut-1\").Scan(&typedData); err != nil {\n" +
+	"\t\tt.Fatalf(\"typed get: %v\", err)\n" +
+	"\t}\n" +
+	"\tif !strings.Contains(typedData, \"rows\") {\n" +
+	"\t\tt.Fatalf(\"typed table lost rows, got %s\", typedData)\n" +
+	"\t}\n" +
+	"}\n"

--- a/internal/generator/store_upsert_preserve_test.go
+++ b/internal/generator/store_upsert_preserve_test.go
@@ -114,6 +114,8 @@ func TestGeneratedStoreKeepsIDLessAndRicherUpserts(t *testing.T) {
 		"cached array leftovers must be indexed by identity for keep-richer pairing")
 	require.Contains(t, src, "func qualifyArrayItemIdentity(",
 		"array identity keys must include the field that produced them")
+	require.Contains(t, src, "func canonicalGenericIDField(",
+		"id/ID/_id/id_ must share one qualified array identity key")
 	require.NotContains(t, src, `id := ExtractResourceID("forecast", obj)`,
 		"typed forecast writer must not still key only on ExtractResourceID")
 
@@ -123,7 +125,7 @@ func TestGeneratedStoreKeepsIDLessAndRicherUpserts(t *testing.T) {
 	require.NoError(t, os.WriteFile(testPath, []byte(generatedIDLessRicherRuntimeTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "test", "./internal/store",
-		"-run", "Test(ResolveStorageID_KeepsEntityIDsAndRefusesUnusable|Upsert_PreservesRicherCachedDetail|MergeKeepRicherJSON|UpsertForecast_StoresIDLessPayload|UpsertForecast_BatchSameLocation|UpsertMutations_ListDoesNotShrinkDetail|UpsertMutations_ArrayReorderDoesNotCorrupt|UpsertMutations_SuffixArrayIdentityKeepsDetail|UpsertMutations_SharedFKDoesNotStealSuffixIdentity|UpsertMutations_CrossFieldIdentitiesDoNotCollide)",
+		"-run", "Test(ResolveStorageID_KeepsEntityIDsAndRefusesUnusable|Upsert_PreservesRicherCachedDetail|MergeKeepRicherJSON|UpsertForecast_StoresIDLessPayload|UpsertForecast_BatchSameLocation|UpsertMutations_ListDoesNotShrinkDetail|UpsertMutations_ArrayReorderDoesNotCorrupt|UpsertMutations_SuffixArrayIdentityKeepsDetail|UpsertMutations_SharedFKDoesNotStealSuffixIdentity|UpsertMutations_CrossFieldIdentitiesDoNotCollide|UpsertMutations_GenericIDAliasesKeepDetail)",
 		"-count=1")
 }
 
@@ -400,4 +402,53 @@ const generatedIDLessRicherRuntimeTest = "package store\n\n" +
 	"\tif fmt.Sprint(second[\"notes\"]) != \"from-id\" {\n" +
 	"\t\tt.Fatalf(\"id row lost its notes, stored %s\", got)\n" +
 	"\t}\n" +
+	"}\n\n" +
+	"func TestUpsertMutations_GenericIDAliasesKeepDetail(t *testing.T) {\n" +
+	"\tassertAlias := func(label, id, existingJSON, incomingJSON, incomingIDKey string) {\n" +
+	"\t\tt.Helper()\n" +
+	"\t\ts, err := Open(filepath.Join(t.TempDir(), \"data.db\"))\n" +
+	"\t\tif err != nil {\n" +
+	"\t\t\tt.Fatalf(\"%s open: %v\", label, err)\n" +
+	"\t\t}\n" +
+	"\t\tdefer s.Close()\n" +
+	"\t\tif err := s.UpsertMutations(json.RawMessage(existingJSON)); err != nil {\n" +
+	"\t\t\tt.Fatalf(\"%s detail: %v\", label, err)\n" +
+	"\t\t}\n" +
+	"\t\tif err := s.UpsertMutations(json.RawMessage(incomingJSON)); err != nil {\n" +
+	"\t\t\tt.Fatalf(\"%s list: %v\", label, err)\n" +
+	"\t\t}\n" +
+	"\t\tgot, err := s.Get(\"mutations\", id)\n" +
+	"\t\tif err != nil {\n" +
+	"\t\t\tt.Fatalf(\"%s get: %v\", label, err)\n" +
+	"\t\t}\n" +
+	"\t\tvar obj map[string]any\n" +
+	"\t\tif err := json.Unmarshal(got, &obj); err != nil {\n" +
+	"\t\t\tt.Fatalf(\"%s unmarshal: %v\", label, err)\n" +
+	"\t\t}\n" +
+	"\t\trows, _ := obj[\"rows\"].([]any)\n" +
+	"\t\tif len(rows) != 1 {\n" +
+	"\t\t\tt.Fatalf(\"%s length must follow incoming, got %d stored %s\", label, len(rows), got)\n" +
+	"\t\t}\n" +
+	"\t\titem, _ := rows[0].(map[string]any)\n" +
+	"\t\tif fmt.Sprint(item[incomingIDKey]) != \"x\" {\n" +
+	"\t\t\tt.Fatalf(\"%s incoming identity must remain, stored %s\", label, got)\n" +
+	"\t\t}\n" +
+	"\t\tif fmt.Sprint(item[\"notes\"]) != \"keep\" {\n" +
+	"\t\t\tt.Fatalf(\"%s id alias lost detail, stored %s\", label, got)\n" +
+	"\t\t}\n" +
+	"\t}\n" +
+	"\tassertAlias(\n" +
+	"\t\t\"id vs _id\",\n" +
+	"\t\t\"mut-6\",\n" +
+	"\t\t`{\"id\":\"mut-6\",\"rows\":[{\"id\":\"x\",\"notes\":\"keep\"}]}`,\n" +
+	"\t\t`{\"id\":\"mut-6\",\"rows\":[{\"_id\":\"x\"}]}`,\n" +
+	"\t\t\"_id\",\n" +
+	"\t)\n" +
+	"\tassertAlias(\n" +
+	"\t\t\"id vs ID\",\n" +
+	"\t\t\"mut-7\",\n" +
+	"\t\t`{\"id\":\"mut-7\",\"rows\":[{\"id\":\"x\",\"notes\":\"keep\"}]}`,\n" +
+	"\t\t`{\"id\":\"mut-7\",\"rows\":[{\"ID\":\"x\"}]}`,\n" +
+	"\t\t\"ID\",\n" +
+	"\t)\n" +
 	"}\n"

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -9,7 +9,9 @@ package store
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
@@ -1047,6 +1049,26 @@ func isSQLiteBusy(err error) bool {
 		strings.Contains(msg, "database table is locked")
 }
 
+// mergeIncomingResourceData applies the keep-richer policy against any row
+// already cached for this (resourceType, id). First write returns incoming
+// unchanged. Callers must use the result for both the generic resources
+// blob and the typed-table projection so list sync cannot shrink detail.
+func (s *Store) mergeIncomingResourceData(tx *sql.Tx, resourceType, id string, incoming json.RawMessage) json.RawMessage {
+	var existing string
+	err := tx.QueryRow(
+		`SELECT data FROM resources WHERE resource_type = ? AND id = ?`,
+		resourceType, id,
+	).Scan(&existing)
+	if err != nil || existing == "" {
+		return incoming
+	}
+	merged, ok := mergeKeepRicherJSON(json.RawMessage(existing), incoming)
+	if !ok {
+		return incoming
+	}
+	return merged
+}
+
 func (s *Store) upsertGenericResourceTx(tx *sql.Tx, resourceType, id string, data json.RawMessage) error {
 	_, err := tx.Exec(
 		`INSERT INTO resources (id, resource_type, data, synced_at, updated_at)
@@ -1086,7 +1108,7 @@ func (s *Store) Upsert(resourceType, id string, data json.RawMessage) error {
 	}
 	defer tx.Rollback()
 
-	if err := s.upsertGenericResourceTx(tx, resourceType, id, data); err != nil {
+	if err := s.upsertGenericResourceTx(tx, resourceType, id, s.mergeIncomingResourceData(tx, resourceType, id, data)); err != nil {
 		return err
 	}
 
@@ -1890,7 +1912,7 @@ func (s *Store) Upsert{{pascal .Name}}(data json.RawMessage) error {
 		return fmt.Errorf("unmarshaling {{.Name}}: %w", err)
 	}
 
-	id := ExtractResourceID("{{.Resource}}", obj)
+	id := ResolveStorageID("{{.Resource}}", obj)
 	if id == "" {
 		return fmt.Errorf("missing id for {{.Name}}")
 	}
@@ -1903,6 +1925,11 @@ func (s *Store) Upsert{{pascal .Name}}(data json.RawMessage) error {
 		return err
 	}
 	defer tx.Rollback()
+
+	data = s.mergeIncomingResourceData(tx, "{{.Resource}}", storageID, data)
+	if merged, err := DecodeJSONObject(data); err == nil {
+		obj = merged
+	}
 
 	if err := s.upsertGenericResourceTx(tx, "{{.Resource}}", storageID, data); err != nil {
 		return err
@@ -1985,6 +2012,289 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 		}
 	}
 	return mapKeyIDFallback(obj)
+}
+
+// ResolveStorageID is the writer-side identity. ExtractResourceID wins when
+// the payload has a real resource id. Parameter-shaped / id-less payloads
+// (no identity-candidate keys at all) get a fingerprint of their top-level
+// scalars so Upsert can store a row without inventing a field. Identity
+// probes such as unwrap and sync extractID must keep using ExtractResourceID
+// so a fingerprint is never mistaken for an entity id.
+//
+// Objects that carry an identity-shaped key whose value was refused
+// (timestamp, zero, empty) still return "" — fingerprinting those would
+// hide a rejected entity id.
+func ResolveStorageID(resourceType string, obj map[string]any) string {
+	if id := ExtractResourceID(resourceType, obj); id != "" {
+		return id
+	}
+	if identityKeyPresent(resourceType, obj) {
+		return ""
+	}
+	return parameterSnapshotID(obj)
+}
+
+func identityKeyPresent(resourceType string, obj map[string]any) bool {
+	if obj == nil {
+		return false
+	}
+	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
+		if _, found := lookupRawFieldValue(obj, override); found {
+			return true
+		}
+	}
+	for _, key := range genericIDFieldFallbacks {
+		if _, found := lookupRawFieldValue(obj, key); found {
+			return true
+		}
+	}
+	if suffixIdentityKeyPresent(resourceType, obj) {
+		return true
+	}
+	for _, key := range genericDescriptiveIDFieldFallbacks {
+		if _, found := lookupRawFieldValue(obj, key); found {
+			return true
+		}
+	}
+	if _, found := obj[MapKeyIDField]; found {
+		return true
+	}
+	return false
+}
+
+func suffixIdentityKeyPresent(resourceType string, obj map[string]any) bool {
+	for _, base := range resourceIDBaseNames(resourceType) {
+		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+			if _, found := lookupRawFieldValue(obj, base+suffix); found {
+				return true
+			}
+		}
+		camelBase := lowerCamelResourceIDBase(base)
+		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+			if _, found := lookupRawFieldValue(obj, camelBase+suffix); found {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// parameterSnapshotID keys an id-less payload by a hash of its top-level
+// scalars — the request-equivalent identity (lat/lon, timezone) — and
+// excludes nested blocks (hourly, current, results) so a later fetch of
+// the same parameters updates the same row. Volatile telemetry keys
+// (*_ms, *_at, timestamp, generationtime*) are omitted from the key.
+// When the object has no stable scalars the whole payload is hashed so
+// the row can still be stored.
+func parameterSnapshotID(obj map[string]any) string {
+	if len(obj) == 0 {
+		return ""
+	}
+	fields := parameterFingerprintFields(obj)
+	var payload any
+	if len(fields) > 0 {
+		payload = fields
+	} else {
+		payload = obj
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil || len(raw) == 0 || string(raw) == "null" || string(raw) == "{}" {
+		return ""
+	}
+	sum := sha256.Sum256(raw)
+	return "pp:params:" + hex.EncodeToString(sum[:16])
+}
+
+func parameterFingerprintFields(obj map[string]any) map[string]any {
+	out := make(map[string]any, len(obj))
+	for key, value := range obj {
+		if isVolatileParameterKey(key) {
+			continue
+		}
+		if scalar, ok := fingerprintScalar(value); ok {
+			out[key] = scalar
+		}
+	}
+	return out
+}
+
+func isVolatileParameterKey(key string) bool {
+	k := strings.ToLower(strings.TrimSpace(key))
+	switch {
+	case strings.HasSuffix(k, "_ms"), strings.HasSuffix(k, "_at"):
+		return true
+	case k == "timestamp", k == "generated", k == "generation_time", k == "generationtime":
+		return true
+	default:
+		return strings.HasPrefix(k, "generationtime")
+	}
+}
+
+func fingerprintScalar(value any) (any, bool) {
+	switch t := value.(type) {
+	case nil:
+		return nil, false
+	case string:
+		return t, t != ""
+	case bool:
+		return t, true
+	case json.Number:
+		return t, t.String() != ""
+	case float64, float32, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return t, true
+	default:
+		return nil, false
+	}
+}
+
+// mergeKeepRicherJSON combines a previously cached JSON blob with an
+// incoming write so a thinner list-shaped payload cannot destroy richer
+// detail already stored for the same id.
+//
+// Policy (do-not-shrink / keep-richer):
+//   - First write (no existing) stores incoming unchanged.
+//   - Object keys present only on existing are kept.
+//   - Objects merge recursively; incoming keys go through the same policy
+//     rather than wholesale replacement.
+//   - A container (object/array) is never replaced by a scalar or null.
+//   - An incoming empty array does not replace a non-empty existing array.
+//   - Arrays of objects merge element-wise; extra existing elements are
+//     kept when incoming is shorter.
+//   - Arrays of non-objects: the longer array wins; equal length prefers
+//     incoming (authoritative remote refresh of the same collection).
+//   - Incoming scalars replace existing scalars.
+func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, bool) {
+	if len(existing) == 0 {
+		return incoming, len(incoming) > 0
+	}
+	if len(incoming) == 0 {
+		return existing, true
+	}
+	existingVal, err := decodeJSONValue(existing)
+	if err != nil {
+		return incoming, len(incoming) > 0
+	}
+	incomingVal, err := decodeJSONValue(incoming)
+	if err != nil {
+		return existing, true
+	}
+	merged, err := json.Marshal(mergeKeepRicherValue(existingVal, incomingVal))
+	if err != nil {
+		return incoming, len(incoming) > 0
+	}
+	return merged, true
+}
+
+func decodeJSONValue(data json.RawMessage) (any, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	var value any
+	if err := dec.Decode(&value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func mergeKeepRicherValue(existing, incoming any) any {
+	if incoming == nil {
+		if existing != nil {
+			return existing
+		}
+		return incoming
+	}
+	existingObj, existingIsObj := existing.(map[string]any)
+	incomingObj, incomingIsObj := incoming.(map[string]any)
+	if existingIsObj && incomingIsObj {
+		return mergeKeepRicherObject(existingObj, incomingObj)
+	}
+	existingArr, existingIsArr := existing.([]any)
+	incomingArr, incomingIsArr := incoming.([]any)
+	if existingIsArr && incomingIsArr {
+		return mergeKeepRicherArray(existingArr, incomingArr)
+	}
+	if isJSONContainer(existing) && !isJSONContainer(incoming) {
+		return existing
+	}
+	if isJSONEmpty(incoming) && !isJSONEmpty(existing) {
+		return existing
+	}
+	return incoming
+}
+
+func mergeKeepRicherObject(existing, incoming map[string]any) map[string]any {
+	out := make(map[string]any, len(existing)+len(incoming))
+	for key, value := range existing {
+		out[key] = value
+	}
+	for key, incomingVal := range incoming {
+		if existingVal, ok := out[key]; ok {
+			out[key] = mergeKeepRicherValue(existingVal, incomingVal)
+			continue
+		}
+		out[key] = incomingVal
+	}
+	return out
+}
+
+func mergeKeepRicherArray(existing, incoming []any) []any {
+	if len(incoming) == 0 && len(existing) > 0 {
+		return existing
+	}
+	if !arrayItemsAreObjects(existing) && !arrayItemsAreObjects(incoming) {
+		if len(incoming) < len(existing) {
+			return existing
+		}
+		return incoming
+	}
+	n := len(incoming)
+	if len(existing) > n {
+		n = len(existing)
+	}
+	out := make([]any, n)
+	for i := 0; i < n; i++ {
+		switch {
+		case i < len(existing) && i < len(incoming):
+			out[i] = mergeKeepRicherValue(existing[i], incoming[i])
+		case i < len(existing):
+			out[i] = existing[i]
+		default:
+			out[i] = incoming[i]
+		}
+	}
+	return out
+}
+
+func arrayItemsAreObjects(items []any) bool {
+	for _, item := range items {
+		if _, ok := item.(map[string]any); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func isJSONContainer(value any) bool {
+	switch value.(type) {
+	case map[string]any, []any:
+		return true
+	default:
+		return false
+	}
+}
+
+func isJSONEmpty(value any) bool {
+	switch t := value.(type) {
+	case nil:
+		return true
+	case string:
+		return t == ""
+	case map[string]any:
+		return len(t) == 0
+	case []any:
+		return len(t) == 0
+	default:
+		return false
+	}
 }
 
 // suffixIDFieldFallback resolves an id-less resource that keys on its own
@@ -2243,11 +2553,18 @@ func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage
 			}
 		}
 		if id == "" {
+			id = ResolveStorageID(resourceType, obj)
+		}
+		if id == "" {
 			skippedCount++
 			extractFailures++
 			continue
 		}
 		storageID := resourceStorageID(resourceType, id, obj)
+		item = s.mergeIncomingResourceData(tx, resourceType, storageID, item)
+		if merged, err := DecodeJSONObject(item); err == nil {
+			obj = merged
+		}
 
 		if err := s.upsertGenericResourceTx(tx, resourceType, storageID, item); err != nil {
 			// Return the running stored count rather than zero so callers

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1061,7 +1061,7 @@ func (s *Store) mergeIncomingResourceData(tx *sql.Tx, resourceType, id string, i
 	if err != nil || existing == "" {
 		return incoming
 	}
-	merged, ok := mergeKeepRicherJSON(json.RawMessage(existing), incoming)
+	merged, ok := mergeKeepRicherJSON(resourceType, json.RawMessage(existing), incoming)
 	if !ok {
 		return incoming
 	}
@@ -2167,14 +2167,16 @@ func fingerprintScalar(value any) (any, bool) {
 //   - A container (object/array) is never replaced by a scalar or null.
 //   - An incoming empty array does not replace a non-empty existing array
 //     (list omitted the collection vs sent a new one).
-//   - Object arrays match by a stable id key when present, then apply the
-//     same object policy to the pair. Result order and length follow
-//     incoming so a reorder or middle delete cannot join unrelated
-//     objects or keep leftover old entries.
+//   - Object arrays match by the same identity stack as ExtractResourceID
+//     (configured / dotted override, generic id, resource-scoped suffix)
+//     plus item-local suffix keys (currency_code, accountId) and sku.
+//     Display name is not an array identity. Result order and length
+//     follow incoming so a reorder or middle delete cannot join
+//     unrelated objects or keep leftover old entries.
 //   - Arrays without identity keys, and scalar arrays, take incoming
 //     wholesale. Index-wise merge would pair unrelated items.
 //   - Incoming scalars replace existing scalars.
-func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, bool) {
+func mergeKeepRicherJSON(resourceType string, existing, incoming json.RawMessage) (json.RawMessage, bool) {
 	if len(existing) == 0 {
 		return incoming, len(incoming) > 0
 	}
@@ -2189,7 +2191,7 @@ func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, b
 	if err != nil {
 		return existing, true
 	}
-	merged, err := json.Marshal(mergeKeepRicherValue(existingVal, incomingVal))
+	merged, err := json.Marshal(mergeKeepRicherValue(resourceType, existingVal, incomingVal))
 	if err != nil {
 		return incoming, len(incoming) > 0
 	}
@@ -2206,7 +2208,7 @@ func decodeJSONValue(data json.RawMessage) (any, error) {
 	return value, nil
 }
 
-func mergeKeepRicherValue(existing, incoming any) any {
+func mergeKeepRicherValue(resourceType string, existing, incoming any) any {
 	if incoming == nil {
 		if existing != nil {
 			return existing
@@ -2216,12 +2218,12 @@ func mergeKeepRicherValue(existing, incoming any) any {
 	existingObj, existingIsObj := existing.(map[string]any)
 	incomingObj, incomingIsObj := incoming.(map[string]any)
 	if existingIsObj && incomingIsObj {
-		return mergeKeepRicherObject(existingObj, incomingObj)
+		return mergeKeepRicherObject(resourceType, existingObj, incomingObj)
 	}
 	existingArr, existingIsArr := existing.([]any)
 	incomingArr, incomingIsArr := incoming.([]any)
 	if existingIsArr && incomingIsArr {
-		return mergeKeepRicherArray(existingArr, incomingArr)
+		return mergeKeepRicherArray(resourceType, existingArr, incomingArr)
 	}
 	if isJSONContainer(existing) && !isJSONContainer(incoming) {
 		return existing
@@ -2232,14 +2234,14 @@ func mergeKeepRicherValue(existing, incoming any) any {
 	return incoming
 }
 
-func mergeKeepRicherObject(existing, incoming map[string]any) map[string]any {
+func mergeKeepRicherObject(resourceType string, existing, incoming map[string]any) map[string]any {
 	out := make(map[string]any, len(existing)+len(incoming))
 	for key, value := range existing {
 		out[key] = value
 	}
 	for key, incomingVal := range incoming {
 		if existingVal, ok := out[key]; ok {
-			out[key] = mergeKeepRicherValue(existingVal, incomingVal)
+			out[key] = mergeKeepRicherValue(resourceType, existingVal, incomingVal)
 			continue
 		}
 		out[key] = incomingVal
@@ -2247,11 +2249,11 @@ func mergeKeepRicherObject(existing, incoming map[string]any) map[string]any {
 	return out
 }
 
-func mergeKeepRicherArray(existing, incoming []any) []any {
+func mergeKeepRicherArray(resourceType string, existing, incoming []any) []any {
 	if len(incoming) == 0 && len(existing) > 0 {
 		return existing
 	}
-	existingByID := indexObjectArrayByIdentity(existing)
+	existingByID := indexObjectArrayByIdentity(resourceType, existing)
 	if len(existingByID) == 0 {
 		return incoming
 	}
@@ -2262,26 +2264,26 @@ func mergeKeepRicherArray(existing, incoming []any) []any {
 			out[i] = item
 			continue
 		}
-		id := arrayItemIdentity(incomingObj)
+		id := arrayItemIdentity(resourceType, incomingObj)
 		existingObj, ok := existingByID[id]
 		if id == "" || !ok {
 			out[i] = item
 			continue
 		}
 		delete(existingByID, id)
-		out[i] = mergeKeepRicherObject(existingObj, incomingObj)
+		out[i] = mergeKeepRicherObject(resourceType, existingObj, incomingObj)
 	}
 	return out
 }
 
-func indexObjectArrayByIdentity(items []any) map[string]map[string]any {
+func indexObjectArrayByIdentity(resourceType string, items []any) map[string]map[string]any {
 	out := make(map[string]map[string]any)
 	for _, item := range items {
 		obj, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
-		id := arrayItemIdentity(obj)
+		id := arrayItemIdentity(resourceType, obj)
 		if id == "" {
 			continue
 		}
@@ -2293,10 +2295,68 @@ func indexObjectArrayByIdentity(items []any) map[string]map[string]any {
 	return out
 }
 
-func arrayItemIdentity(obj map[string]any) string {
+func arrayItemIdentity(resourceType string, obj map[string]any) string {
+	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
+		if s := canonicalIDFromKey(obj, override); s != "" {
+			return s
+		}
+	}
 	for _, key := range genericIDFieldFallbacks {
 		if s := canonicalIDFromKey(obj, key); s != "" {
 			return s
+		}
+	}
+	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
+		return s
+	}
+	if s := suffixIdentityFromItemKeys(obj); s != "" {
+		return s
+	}
+	if s := canonicalIDFromKey(obj, "sku"); s != "" {
+		return s
+	}
+	for _, key := range []string{"slug", "key", "code"} {
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func suffixIdentityFromItemKeys(obj map[string]any) string {
+	if obj == nil {
+		return ""
+	}
+	keys := make([]string, 0, len(obj))
+	for key := range obj {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		stem := identitySuffixStem(key)
+		if stem == "" || stem == "parent" {
+			continue
+		}
+		if s := suffixIDFieldFallback(stem, obj); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func identitySuffixStem(key string) string {
+	k := strings.TrimSpace(key)
+	if k == "" {
+		return ""
+	}
+	for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return strings.TrimSuffix(k, suffix)
+		}
+	}
+	for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return strings.ToLower(k[:len(k)-len(suffix)])
 		}
 	}
 	return ""

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -2170,9 +2170,13 @@ func fingerprintScalar(value any) (any, bool) {
 //   - Object arrays match by the same identity stack as ExtractResourceID
 //     (configured / dotted override, generic id, resource-scoped suffix)
 //     plus item-local suffix keys (currency_code, accountId) and sku.
-//     Display name is not an array identity. Result order and length
-//     follow incoming so a reorder or middle delete cannot join
-//     unrelated objects or keep leftover old entries.
+//     Own-identity suffixes (_code/_slug/_key) win over shared foreign
+//     keys so sibling rows that share account_id still pair on
+//     currency_code. A lone accountId remains identity when it is the
+//     only identity-shaped field. Display name is not an array
+//     identity. Result order and length follow incoming so a reorder
+//     or middle delete cannot join unrelated objects or keep leftover
+//     old entries.
 //   - Arrays without identity keys, and scalar arrays, take incoming
 //     wholesale. Index-wise merge would pair unrelated items.
 //   - Incoming scalars replace existing scalars.
@@ -2332,16 +2336,86 @@ func suffixIdentityFromItemKeys(obj map[string]any) string {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
+	var own, localID, sharedID string
 	for _, key := range keys {
 		stem := identitySuffixStem(key)
 		if stem == "" || stem == "parent" {
 			continue
 		}
-		if s := suffixIDFieldFallback(stem, obj); s != "" {
-			return s
+		s := suffixIDFieldFallback(stem, obj)
+		if s == "" {
+			continue
+		}
+		switch itemKeyIdentityKind(key) {
+		case itemIdentOwn:
+			if own == "" {
+				own = s
+			}
+		case itemIdentLocalID:
+			if localID == "" {
+				localID = s
+			}
+		case itemIdentSharedID:
+			if sharedID == "" {
+				sharedID = s
+			}
 		}
 	}
-	return ""
+	if own != "" {
+		return own
+	}
+	if localID != "" {
+		return localID
+	}
+	return sharedID
+}
+
+type itemIdentKind int
+
+const (
+	itemIdentNone itemIdentKind = iota
+	itemIdentOwn
+	itemIdentLocalID
+	itemIdentSharedID
+)
+
+func itemKeyIdentityKind(key string) itemIdentKind {
+	if itemKeyLooksLikeOwnIdentity(key) {
+		return itemIdentOwn
+	}
+	stem := identitySuffixStem(key)
+	if stem == "" {
+		return itemIdentNone
+	}
+	if sharedForeignKeyStem(stem) {
+		return itemIdentSharedID
+	}
+	return itemIdentLocalID
+}
+
+func itemKeyLooksLikeOwnIdentity(key string) bool {
+	k := strings.TrimSpace(key)
+	for _, suffix := range []string{"_code", "_key", "_slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return true
+		}
+	}
+	for _, suffix := range []string{"Code", "Key", "Slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func sharedForeignKeyStem(stem string) bool {
+	switch strings.ToLower(stem) {
+	case "parent", "account", "owner", "org", "organization", "user",
+		"customer", "workspace", "tenant", "team", "company", "member":
+		return true
+	default:
+		return false
+	}
 }
 
 func identitySuffixStem(key string) string {

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -2173,10 +2173,11 @@ func fingerprintScalar(value any) (any, bool) {
 //     Own-identity suffixes (_code/_slug/_key) win over shared foreign
 //     keys so sibling rows that share account_id still pair on
 //     currency_code. A lone accountId remains identity when it is the
-//     only identity-shaped field. Display name is not an array
-//     identity. Result order and length follow incoming so a reorder
-//     or middle delete cannot join unrelated objects or keep leftover
-//     old entries.
+//     only identity-shaped field. Identity map keys include the field
+//     that produced them so id:"USD" and currency_code:"USD" cannot
+//     share a slot. Display name is not an array identity. Result
+//     order and length follow incoming so a reorder or middle delete
+//     cannot join unrelated objects or keep leftover old entries.
 //   - Arrays without identity keys, and scalar arrays, take incoming
 //     wholesale. Index-wise merge would pair unrelated items.
 //   - Incoming scalars replace existing scalars.
@@ -2302,45 +2303,54 @@ func indexObjectArrayByIdentity(resourceType string, items []any) map[string]map
 func arrayItemIdentity(resourceType string, obj map[string]any) string {
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
 		if s := canonicalIDFromKey(obj, override); s != "" {
-			return s
+			return qualifyArrayItemIdentity(override, s)
 		}
 	}
 	for _, key := range genericIDFieldFallbacks {
 		if s := canonicalIDFromKey(obj, key); s != "" {
-			return s
+			return qualifyArrayItemIdentity(key, s)
 		}
 	}
 	// Item-local own identity wins over the parent resource's suffix.
 	// mergeKeepRicherJSON threads the parent type through nested arrays,
 	// so suffixIDFieldFallback("accounts") would treat a copied
 	// account_id as every child's id and collide sibling rates.
-	if s := suffixIdentityFromItemKeys(obj); s != "" {
-		return s
+	if field, s := suffixIdentityFromItemKeys(obj); s != "" {
+		return qualifyArrayItemIdentity(field, s)
 	}
-	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
-		return s
+	if field, s := suffixIDFieldAndName(resourceType, obj); s != "" {
+		return qualifyArrayItemIdentity(field, s)
 	}
 	if s := canonicalIDFromKey(obj, "sku"); s != "" {
-		return s
+		return qualifyArrayItemIdentity("sku", s)
 	}
 	for _, key := range []string{"slug", "key", "code"} {
 		if s := canonicalIDFromKey(obj, key); s != "" {
-			return s
+			return qualifyArrayItemIdentity(key, s)
 		}
 	}
 	return ""
 }
 
-func suffixIdentityFromItemKeys(obj map[string]any) string {
-	if obj == nil {
+const arrayItemIdentitySep = "\x1f"
+
+func qualifyArrayItemIdentity(field, value string) string {
+	if field == "" || value == "" {
 		return ""
+	}
+	return field + arrayItemIdentitySep + value
+}
+
+func suffixIdentityFromItemKeys(obj map[string]any) (string, string) {
+	if obj == nil {
+		return "", ""
 	}
 	keys := make([]string, 0, len(obj))
 	for key := range obj {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	var own, localID, sharedID string
+	var ownField, own, localField, localID, sharedField, sharedID string
 	for _, key := range keys {
 		stem := identitySuffixStem(key)
 		if stem == "" || stem == "parent" {
@@ -2350,28 +2360,49 @@ func suffixIdentityFromItemKeys(obj map[string]any) string {
 		if s == "" {
 			continue
 		}
+		field := canonicalArrayIdentityField(key)
 		switch itemKeyIdentityKind(key) {
 		case itemIdentOwn:
 			if own == "" {
-				own = s
+				ownField, own = field, s
 			}
 		case itemIdentLocalID:
 			if localID == "" {
-				localID = s
+				localField, localID = field, s
 			}
 		case itemIdentSharedID:
 			if sharedID == "" {
-				sharedID = s
+				sharedField, sharedID = field, s
 			}
 		}
 	}
 	if own != "" {
-		return own
+		return ownField, own
 	}
 	if localID != "" {
-		return localID
+		return localField, localID
 	}
-	return sharedID
+	return sharedField, sharedID
+}
+
+func canonicalArrayIdentityField(key string) string {
+	k := strings.TrimSpace(key)
+	stem := identitySuffixStem(k)
+	if stem == "" {
+		return k
+	}
+	switch {
+	case strings.HasSuffix(k, "_id") || strings.HasSuffix(k, "Id") || strings.HasSuffix(k, "ID"):
+		return stem + "_id"
+	case strings.HasSuffix(k, "_code") || strings.HasSuffix(k, "Code"):
+		return stem + "_code"
+	case strings.HasSuffix(k, "_key") || strings.HasSuffix(k, "Key"):
+		return stem + "_key"
+	case strings.HasSuffix(k, "_slug") || strings.HasSuffix(k, "Slug"):
+		return stem + "_slug"
+	default:
+		return k
+	}
 }
 
 type itemIdentKind int
@@ -2471,20 +2502,27 @@ func isJSONEmpty(value any) bool {
 // promoted to the primary key, and it walks the same key spellings as
 // LookupFieldValue in a fixed suffix order so the chosen id is deterministic.
 func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
+	_, value := suffixIDFieldAndName(resourceType, obj)
+	return value
+}
+
+func suffixIDFieldAndName(resourceType string, obj map[string]any) (string, string) {
 	for _, base := range resourceIDBaseNames(resourceType) {
 		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
-			if s := canonicalScalarIDFromKey(obj, base+suffix); s != "" {
-				return s
+			key := base + suffix
+			if s := canonicalScalarIDFromKey(obj, key); s != "" {
+				return canonicalArrayIdentityField(key), s
 			}
 		}
 		camelBase := lowerCamelResourceIDBase(base)
 		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
-			if s := canonicalScalarIDFromKey(obj, camelBase+suffix); s != "" {
-				return s
+			key := camelBase + suffix
+			if s := canonicalScalarIDFromKey(obj, key); s != "" {
+				return canonicalArrayIdentityField(key), s
 			}
 		}
 	}
-	return ""
+	return "", ""
 }
 
 func canonicalScalarIDFromKey(obj map[string]any, key string) string {

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -2310,10 +2310,14 @@ func arrayItemIdentity(resourceType string, obj map[string]any) string {
 			return s
 		}
 	}
-	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
+	// Item-local own identity wins over the parent resource's suffix.
+	// mergeKeepRicherJSON threads the parent type through nested arrays,
+	// so suffixIDFieldFallback("accounts") would treat a copied
+	// account_id as every child's id and collide sibling rates.
+	if s := suffixIdentityFromItemKeys(obj); s != "" {
 		return s
 	}
-	if s := suffixIdentityFromItemKeys(obj); s != "" {
+	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
 		return s
 	}
 	if s := canonicalIDFromKey(obj, "sku"); s != "" {

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1959,6 +1959,18 @@ var resourceIDFieldOverrides = map[string]string{
 {{- end}}
 }
 
+// parameterKeyedResources are typed resources whose responses have no
+// identity field. Upsert stores those rows under a parameter fingerprint
+// instead of failing ExtractResourceID. Unlisted resources keep today's
+// extract-failure contract for items with no usable id.
+var parameterKeyedResources = map[string]bool{
+{{- range .Tables}}
+{{- if .ParameterKeyed}}
+	{{printf "%q" .Resource}}: true,
+{{- end}}
+{{- end}}
+}
+
 // Generic ID fields are split around the resource-specific suffix probe.
 // Stable vendor identifiers win first; then fields derived from the resource
 // name (accountId, workspaceId); descriptive fallbacks are last. Keeping name
@@ -2027,6 +2039,9 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 func ResolveStorageID(resourceType string, obj map[string]any) string {
 	if id := ExtractResourceID(resourceType, obj); id != "" {
 		return id
+	}
+	if !parameterKeyedResources[resourceType] {
+		return ""
 	}
 	if identityKeyPresent(resourceType, obj) {
 		return ""

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1049,10 +1049,9 @@ func isSQLiteBusy(err error) bool {
 		strings.Contains(msg, "database table is locked")
 }
 
-// mergeIncomingResourceData applies the keep-richer policy against any row
-// already cached for this (resourceType, id). First write returns incoming
-// unchanged. Callers must use the result for both the generic resources
-// blob and the typed-table projection so list sync cannot shrink detail.
+// A later list-shaped write must not shrink a richer cached blob. First
+// write is incoming as-is. Callers apply the result to both the generic
+// resources blob and the typed-table projection.
 func (s *Store) mergeIncomingResourceData(tx *sql.Tx, resourceType, id string, incoming json.RawMessage) json.RawMessage {
 	var existing string
 	err := tx.QueryRow(
@@ -1959,10 +1958,9 @@ var resourceIDFieldOverrides = map[string]string{
 {{- end}}
 }
 
-// parameterKeyedResources are typed resources whose responses have no
-// identity field. Upsert stores those rows under a parameter fingerprint
-// instead of failing ExtractResourceID. Unlisted resources keep today's
-// extract-failure contract for items with no usable id.
+// Only typed resources with no identity field may be stored under a
+// parameter fingerprint. Unlisted resources still increment extractFailures
+// when an item has no usable id.
 var parameterKeyedResources = map[string]bool{
 {{- range .Tables}}
 {{- if .ParameterKeyed}}
@@ -2026,16 +2024,14 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 	return mapKeyIDFallback(obj)
 }
 
-// ResolveStorageID is the writer-side identity. ExtractResourceID wins when
-// the payload has a real resource id. Parameter-shaped / id-less payloads
-// (no identity-candidate keys at all) get a fingerprint of their top-level
-// scalars so Upsert can store a row without inventing a field. Identity
-// probes such as unwrap and sync extractID must keep using ExtractResourceID
-// so a fingerprint is never mistaken for an entity id.
+// Writer identity prefers a real resource id. A parameter-shaped payload
+// with no identity-candidate keys is fingerprinted from top-level scalars
+// so the row can be stored without inventing a field. Unwrap and sync
+// extractID must keep using ExtractResourceID so a fingerprint is never
+// mistaken for an entity id.
 //
-// Objects that carry an identity-shaped key whose value was refused
-// (timestamp, zero, empty) still return "" — fingerprinting those would
-// hide a rejected entity id.
+// An identity-shaped key whose value was refused (timestamp, zero, empty)
+// still returns "" — fingerprinting those would hide a rejected entity id.
 func ResolveStorageID(resourceType string, obj map[string]any) string {
 	if id := ExtractResourceID(resourceType, obj); id != "" {
 		return id
@@ -2094,13 +2090,11 @@ func suffixIdentityKeyPresent(resourceType string, obj map[string]any) bool {
 	return false
 }
 
-// parameterSnapshotID keys an id-less payload by a hash of its top-level
-// scalars — the request-equivalent identity (lat/lon, timezone) — and
-// excludes nested blocks (hourly, current, results) so a later fetch of
-// the same parameters updates the same row. Volatile telemetry keys
-// (*_ms, *_at, timestamp, generationtime*) are omitted from the key.
-// When the object has no stable scalars the whole payload is hashed so
-// the row can still be stored.
+// Id-less rows key on a hash of top-level scalars (lat/lon, timezone)
+// and omit nested blocks so a later fetch of the same parameters updates
+// the same row. Volatile telemetry keys (*_ms, *_at, timestamp,
+// generationtime*) stay out of the key. No stable scalars means the
+// whole payload is hashed so the row can still be stored.
 func parameterSnapshotID(obj map[string]any) string {
 	if len(obj) == 0 {
 		return ""
@@ -2162,9 +2156,8 @@ func fingerprintScalar(value any) (any, bool) {
 	}
 }
 
-// mergeKeepRicherJSON combines a previously cached JSON blob with an
-// incoming write so a thinner list-shaped payload cannot destroy richer
-// detail already stored for the same id.
+// A thinner list-shaped payload cannot destroy richer detail already
+// stored for the same id.
 //
 // Policy (do-not-shrink / keep-richer):
 //   - First write (no existing) stores incoming unchanged.
@@ -2172,11 +2165,14 @@ func fingerprintScalar(value any) (any, bool) {
 //   - Objects merge recursively; incoming keys go through the same policy
 //     rather than wholesale replacement.
 //   - A container (object/array) is never replaced by a scalar or null.
-//   - An incoming empty array does not replace a non-empty existing array.
-//   - Arrays of objects merge element-wise; extra existing elements are
-//     kept when incoming is shorter.
-//   - Arrays of non-objects: the longer array wins; equal length prefers
-//     incoming (authoritative remote refresh of the same collection).
+//   - An incoming empty array does not replace a non-empty existing array
+//     (list omitted the collection vs sent a new one).
+//   - Object arrays match by a stable id key when present, then apply the
+//     same object policy to the pair. Result order and length follow
+//     incoming so a reorder or middle delete cannot join unrelated
+//     objects or keep leftover old entries.
+//   - Arrays without identity keys, and scalar arrays, take incoming
+//     wholesale. Index-wise merge would pair unrelated items.
 //   - Incoming scalars replace existing scalars.
 func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, bool) {
 	if len(existing) == 0 {
@@ -2255,37 +2251,55 @@ func mergeKeepRicherArray(existing, incoming []any) []any {
 	if len(incoming) == 0 && len(existing) > 0 {
 		return existing
 	}
-	if !arrayItemsAreObjects(existing) && !arrayItemsAreObjects(incoming) {
-		if len(incoming) < len(existing) {
-			return existing
-		}
+	existingByID := indexObjectArrayByIdentity(existing)
+	if len(existingByID) == 0 {
 		return incoming
 	}
-	n := len(incoming)
-	if len(existing) > n {
-		n = len(existing)
-	}
-	out := make([]any, n)
-	for i := 0; i < n; i++ {
-		switch {
-		case i < len(existing) && i < len(incoming):
-			out[i] = mergeKeepRicherValue(existing[i], incoming[i])
-		case i < len(existing):
-			out[i] = existing[i]
-		default:
-			out[i] = incoming[i]
+	out := make([]any, len(incoming))
+	for i, item := range incoming {
+		incomingObj, ok := item.(map[string]any)
+		if !ok {
+			out[i] = item
+			continue
 		}
+		id := arrayItemIdentity(incomingObj)
+		existingObj, ok := existingByID[id]
+		if id == "" || !ok {
+			out[i] = item
+			continue
+		}
+		delete(existingByID, id)
+		out[i] = mergeKeepRicherObject(existingObj, incomingObj)
 	}
 	return out
 }
 
-func arrayItemsAreObjects(items []any) bool {
+func indexObjectArrayByIdentity(items []any) map[string]map[string]any {
+	out := make(map[string]map[string]any)
 	for _, item := range items {
-		if _, ok := item.(map[string]any); ok {
-			return true
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		id := arrayItemIdentity(obj)
+		if id == "" {
+			continue
+		}
+		if _, exists := out[id]; exists {
+			continue
+		}
+		out[id] = obj
+	}
+	return out
+}
+
+func arrayItemIdentity(obj map[string]any) string {
+	for _, key := range genericIDFieldFallbacks {
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
-	return false
+	return ""
 }
 
 func isJSONContainer(value any) bool {

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -2308,7 +2308,7 @@ func arrayItemIdentity(resourceType string, obj map[string]any) string {
 	}
 	for _, key := range genericIDFieldFallbacks {
 		if s := canonicalIDFromKey(obj, key); s != "" {
-			return qualifyArrayItemIdentity(key, s)
+			return qualifyArrayItemIdentity(canonicalGenericIDField(key), s)
 		}
 	}
 	// Item-local own identity wins over the parent resource's suffix.
@@ -2339,6 +2339,17 @@ func qualifyArrayItemIdentity(field, value string) string {
 		return ""
 	}
 	return field + arrayItemIdentitySep + value
+}
+
+// lookupRawFieldValue("id") finds Id/id_ via fieldKeySpellings but not
+// _id or ID, so those probes would otherwise mint distinct map keys.
+func canonicalGenericIDField(probe string) string {
+	switch strings.TrimSpace(probe) {
+	case "id", "ID", "_id", "id_", "Id":
+		return "id"
+	default:
+		return probe
+	}
 }
 
 func suffixIdentityFromItemKeys(obj map[string]any) (string, string) {

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -699,6 +699,41 @@ func TestMergeKeepRicherJSON(t *testing.T) {
 		t.Fatalf("id row must keep its own notes, stored %s", crossField)
 	}
 
+	assertGenericIDAliasKeepRicher := func(label, existingJSON, incomingJSON, incomingIDKey string) {
+		t.Helper()
+		got, ok := mergeKeepRicherJSON("mutations", json.RawMessage(existingJSON), json.RawMessage(incomingJSON))
+		if !ok {
+			t.Fatalf("%s: merge returned !ok", label)
+		}
+		var obj map[string]any
+		if err := json.Unmarshal(got, &obj); err != nil {
+			t.Fatalf("%s: unmarshal: %v", label, err)
+		}
+		items, _ := obj["rows"].([]any)
+		if len(items) != 1 {
+			t.Fatalf("%s: length must follow incoming, got %d stored %s", label, len(items), got)
+		}
+		item, _ := items[0].(map[string]any)
+		if fmt.Sprint(item[incomingIDKey]) != "x" {
+			t.Fatalf("%s: incoming identity must remain, stored %s", label, got)
+		}
+		if fmt.Sprint(item["notes"]) != "keep" {
+			t.Fatalf("%s: id alias must keep-richer-merge, stored %s", label, got)
+		}
+	}
+	assertGenericIDAliasKeepRicher(
+		"id vs _id",
+		`{"id":"1","rows":[{"id":"x","notes":"keep"}]}`,
+		`{"id":"1","rows":[{"_id":"x"}]}`,
+		"_id",
+	)
+	assertGenericIDAliasKeepRicher(
+		"id vs ID",
+		`{"id":"1","rows":[{"id":"x","notes":"keep"}]}`,
+		`{"id":"1","rows":[{"ID":"x"}]}`,
+		"ID",
+	)
+
 	prevOverride, hadOverride := resourceIDFieldOverrides["widgets"]
 	resourceIDFieldOverrides["widgets"] = "entityInfo.entityId"
 	defer func() {

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -388,10 +388,13 @@ func TestUpsertBatch_PreservesLargeIntegerResourceIDs(t *testing.T) {
 	}
 }
 
-// TestUpsertBatch_ExtractFailuresReturnedForPerItemMisses pins extractFailures
-// to payloads that still cannot be stored: empty objects, and items whose
-// identity-shaped key was refused (timestamp/zero). Parameter-shaped
-// objects with no identity keys are stored via ResolveStorageID instead.
+// TestUpsertBatch_ExtractFailuresReturnedForPerItemMisses pins the third
+// return value: items that survive JSON unmarshal but have no extractable
+// PK (templated override AND generic fallback both miss) bump
+// extractFailures. The sync.go.tmpl call site uses this to emit the
+// per-resource primary_key_unresolved sync_anomaly the first time silent
+// drops occur. Parameter-shaped resources are opted in separately via
+// parameterKeyedResources and are not covered here.
 func TestUpsertBatch_ExtractFailuresReturnedForPerItemMisses(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "data.db")
 	s, err := Open(dbPath)
@@ -402,42 +405,23 @@ func TestUpsertBatch_ExtractFailuresReturnedForPerItemMisses(t *testing.T) {
 
 	items := []json.RawMessage{
 		json.RawMessage(`{"id": "ok-1"}`),
-		json.RawMessage(`{}`),
+		json.RawMessage(`{"some_random_field": "no-pk-here"}`),
 		json.RawMessage(`{"id": "ok-2"}`),
-		json.RawMessage(`{"id": 0}`),
+		json.RawMessage(`{"another_field": 42}`),
 	}
 	stored, extractFailures, err := s.UpsertBatch("mixed_extraction", items)
 	if err != nil {
 		t.Fatalf("UpsertBatch: %v", err)
 	}
 	if stored != 2 {
-		t.Fatalf("stored = %d, want 2 (only items with a usable id should land)", stored)
+		t.Fatalf("stored = %d, want 2 (only items with id should land)", stored)
 	}
 	if extractFailures != 2 {
-		t.Fatalf("extractFailures = %d, want 2 (empty object and refused identity)", extractFailures)
+		t.Fatalf("extractFailures = %d, want 2 (two items have no extractable PK)", extractFailures)
 	}
 }
 
-func TestResolveStorageID_ParameterShapedAndEntityIDs(t *testing.T) {
-	forecast := map[string]any{
-		"latitude":         json.Number("52.52"),
-		"longitude":        json.Number("13.41"),
-		"generationtime_ms": json.Number("0.12"),
-		"hourly":           map[string]any{"temperature_2m": []any{json.Number("1")}},
-	}
-	id := ResolveStorageID("forecast", forecast)
-	if id == "" || !strings.HasPrefix(id, "pp:params:") {
-		t.Fatalf("id-less forecast id = %q, want pp:params: fingerprint", id)
-	}
-	sameLocation := map[string]any{
-		"latitude":         json.Number("52.52"),
-		"longitude":        json.Number("13.41"),
-		"generationtime_ms": json.Number("9.9"),
-		"hourly":           map[string]any{"temperature_2m": []any{json.Number("3"), json.Number("4")}},
-	}
-	if got := ResolveStorageID("forecast", sameLocation); got != id {
-		t.Fatalf("same-location fingerprint = %q, want %q", got, id)
-	}
+func TestResolveStorageID_KeepsEntityIDsAndRefusesUnusable(t *testing.T) {
 	if got := ResolveStorageID("widgets", map[string]any{"id": "w-1", "name": "kept"}); got != "w-1" {
 		t.Fatalf("entity id = %q, want w-1", got)
 	}
@@ -447,63 +431,8 @@ func TestResolveStorageID_ParameterShapedAndEntityIDs(t *testing.T) {
 	if got := ResolveStorageID("empty", map[string]any{}); got != "" {
 		t.Fatalf("empty object id = %q, want empty", got)
 	}
-}
-
-func TestUpsertBatch_StoresIDLessParameterShapedPayload(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "data.db")
-	s, err := Open(dbPath)
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
-	defer s.Close()
-
-	first := json.RawMessage(`{"latitude":52.52,"longitude":13.41,"generationtime_ms":0.1,"hourly":{"temperature_2m":[1,2]}}`)
-	stored, extractFailures, err := s.UpsertBatch("forecast", []json.RawMessage{first})
-	if err != nil {
-		t.Fatalf("UpsertBatch: %v", err)
-	}
-	if stored != 1 || extractFailures != 0 {
-		t.Fatalf("stored/extractFailures = %d/%d, want 1/0", stored, extractFailures)
-	}
-	rows, err := s.List("forecast", 10)
-	if err != nil {
-		t.Fatalf("list: %v", err)
-	}
-	if len(rows) != 1 {
-		t.Fatalf("forecast rows = %d, want 1", len(rows))
-	}
-
-	updated := json.RawMessage(`{"latitude":52.52,"longitude":13.41,"generationtime_ms":9.9,"hourly":{"temperature_2m":[3,4]}}`)
-	if stored, extractFailures, err = s.UpsertBatch("forecast", []json.RawMessage{updated}); err != nil {
-		t.Fatalf("update upsert: %v", err)
-	}
-	if stored != 1 || extractFailures != 0 {
-		t.Fatalf("update stored/extractFailures = %d/%d, want 1/0", stored, extractFailures)
-	}
-	rows, err = s.List("forecast", 10)
-	if err != nil {
-		t.Fatalf("list after update: %v", err)
-	}
-	if len(rows) != 1 {
-		t.Fatalf("same-location rows = %d, want 1", len(rows))
-	}
-	if !strings.Contains(string(rows[0]), "[3,4]") && !strings.Contains(string(rows[0]), `"3"`) {
-		t.Fatalf("updated forecast missing new hourly values, got %s", rows[0])
-	}
-
-	other := json.RawMessage(`{"latitude":40.7,"longitude":-74.0,"hourly":{"temperature_2m":[10]}}`)
-	if stored, extractFailures, err = s.UpsertBatch("forecast", []json.RawMessage{other}); err != nil {
-		t.Fatalf("other location upsert: %v", err)
-	}
-	if stored != 1 || extractFailures != 0 {
-		t.Fatalf("other location stored/extractFailures = %d/%d, want 1/0", stored, extractFailures)
-	}
-	rows, err = s.List("forecast", 10)
-	if err != nil {
-		t.Fatalf("list after other location: %v", err)
-	}
-	if len(rows) != 2 {
-		t.Fatalf("distinct-location rows = %d, want 2", len(rows))
+	if got := ResolveStorageID("dropped_ticker", map[string]any{"ticker": "AAPL"}); got != "" {
+		t.Fatalf("unflagged id-less payload must not fingerprint, got %q", got)
 	}
 }
 

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -388,12 +388,10 @@ func TestUpsertBatch_PreservesLargeIntegerResourceIDs(t *testing.T) {
 	}
 }
 
-// TestUpsertBatch_ExtractFailuresReturnedForPerItemMisses pins the third
-// return value: items that survive JSON unmarshal but have no extractable
-// PK (templated override AND generic fallback both miss) bump
-// extractFailures. The sync.go.tmpl call site uses this to emit the
-// per-resource primary_key_unresolved sync_anomaly the first time silent
-// drops occur.
+// TestUpsertBatch_ExtractFailuresReturnedForPerItemMisses pins extractFailures
+// to payloads that still cannot be stored: empty objects, and items whose
+// identity-shaped key was refused (timestamp/zero). Parameter-shaped
+// objects with no identity keys are stored via ResolveStorageID instead.
 func TestUpsertBatch_ExtractFailuresReturnedForPerItemMisses(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "data.db")
 	s, err := Open(dbPath)
@@ -404,19 +402,195 @@ func TestUpsertBatch_ExtractFailuresReturnedForPerItemMisses(t *testing.T) {
 
 	items := []json.RawMessage{
 		json.RawMessage(`{"id": "ok-1"}`),
-		json.RawMessage(`{"some_random_field": "no-pk-here"}`),
+		json.RawMessage(`{}`),
 		json.RawMessage(`{"id": "ok-2"}`),
-		json.RawMessage(`{"another_field": 42}`),
+		json.RawMessage(`{"id": 0}`),
 	}
 	stored, extractFailures, err := s.UpsertBatch("mixed_extraction", items)
 	if err != nil {
 		t.Fatalf("UpsertBatch: %v", err)
 	}
 	if stored != 2 {
-		t.Fatalf("stored = %d, want 2 (only items with id should land)", stored)
+		t.Fatalf("stored = %d, want 2 (only items with a usable id should land)", stored)
 	}
 	if extractFailures != 2 {
-		t.Fatalf("extractFailures = %d, want 2 (two items have no extractable PK)", extractFailures)
+		t.Fatalf("extractFailures = %d, want 2 (empty object and refused identity)", extractFailures)
+	}
+}
+
+func TestResolveStorageID_ParameterShapedAndEntityIDs(t *testing.T) {
+	forecast := map[string]any{
+		"latitude":         json.Number("52.52"),
+		"longitude":        json.Number("13.41"),
+		"generationtime_ms": json.Number("0.12"),
+		"hourly":           map[string]any{"temperature_2m": []any{json.Number("1")}},
+	}
+	id := ResolveStorageID("forecast", forecast)
+	if id == "" || !strings.HasPrefix(id, "pp:params:") {
+		t.Fatalf("id-less forecast id = %q, want pp:params: fingerprint", id)
+	}
+	sameLocation := map[string]any{
+		"latitude":         json.Number("52.52"),
+		"longitude":        json.Number("13.41"),
+		"generationtime_ms": json.Number("9.9"),
+		"hourly":           map[string]any{"temperature_2m": []any{json.Number("3"), json.Number("4")}},
+	}
+	if got := ResolveStorageID("forecast", sameLocation); got != id {
+		t.Fatalf("same-location fingerprint = %q, want %q", got, id)
+	}
+	if got := ResolveStorageID("widgets", map[string]any{"id": "w-1", "name": "kept"}); got != "w-1" {
+		t.Fatalf("entity id = %q, want w-1", got)
+	}
+	if got := ResolveStorageID("restore_points", map[string]any{"id": 0, "label": "zero"}); got != "" {
+		t.Fatalf("refused identity must not fingerprint, got %q", got)
+	}
+	if got := ResolveStorageID("empty", map[string]any{}); got != "" {
+		t.Fatalf("empty object id = %q, want empty", got)
+	}
+}
+
+func TestUpsertBatch_StoresIDLessParameterShapedPayload(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	first := json.RawMessage(`{"latitude":52.52,"longitude":13.41,"generationtime_ms":0.1,"hourly":{"temperature_2m":[1,2]}}`)
+	stored, extractFailures, err := s.UpsertBatch("forecast", []json.RawMessage{first})
+	if err != nil {
+		t.Fatalf("UpsertBatch: %v", err)
+	}
+	if stored != 1 || extractFailures != 0 {
+		t.Fatalf("stored/extractFailures = %d/%d, want 1/0", stored, extractFailures)
+	}
+	rows, err := s.List("forecast", 10)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("forecast rows = %d, want 1", len(rows))
+	}
+
+	updated := json.RawMessage(`{"latitude":52.52,"longitude":13.41,"generationtime_ms":9.9,"hourly":{"temperature_2m":[3,4]}}`)
+	if stored, extractFailures, err = s.UpsertBatch("forecast", []json.RawMessage{updated}); err != nil {
+		t.Fatalf("update upsert: %v", err)
+	}
+	if stored != 1 || extractFailures != 0 {
+		t.Fatalf("update stored/extractFailures = %d/%d, want 1/0", stored, extractFailures)
+	}
+	rows, err = s.List("forecast", 10)
+	if err != nil {
+		t.Fatalf("list after update: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("same-location rows = %d, want 1", len(rows))
+	}
+	if !strings.Contains(string(rows[0]), "[3,4]") && !strings.Contains(string(rows[0]), `"3"`) {
+		t.Fatalf("updated forecast missing new hourly values, got %s", rows[0])
+	}
+
+	other := json.RawMessage(`{"latitude":40.7,"longitude":-74.0,"hourly":{"temperature_2m":[10]}}`)
+	if stored, extractFailures, err = s.UpsertBatch("forecast", []json.RawMessage{other}); err != nil {
+		t.Fatalf("other location upsert: %v", err)
+	}
+	if stored != 1 || extractFailures != 0 {
+		t.Fatalf("other location stored/extractFailures = %d/%d, want 1/0", stored, extractFailures)
+	}
+	rows, err = s.List("forecast", 10)
+	if err != nil {
+		t.Fatalf("list after other location: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("distinct-location rows = %d, want 2", len(rows))
+	}
+}
+
+func TestUpsert_PreservesRicherCachedDetail(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	detail := json.RawMessage(`{"id":"mut-1","name":"Invoice","rows":[{"vat":21,"amount":100}]}`)
+	if stored, extractFailures, err := s.UpsertBatch("mutations", []json.RawMessage{detail}); err != nil {
+		t.Fatalf("detail upsert: %v", err)
+	} else if stored != 1 || extractFailures != 0 {
+		t.Fatalf("detail stored/extractFailures = %d/%d, want 1/0", stored, extractFailures)
+	}
+
+	list := json.RawMessage(`{"id":"mut-1","name":"Invoice list"}`)
+	if stored, extractFailures, err := s.UpsertBatch("mutations", []json.RawMessage{list}); err != nil {
+		t.Fatalf("list upsert: %v", err)
+	} else if stored != 1 || extractFailures != 0 {
+		t.Fatalf("list stored/extractFailures = %d/%d, want 1/0", stored, extractFailures)
+	}
+
+	got, err := s.Get("mutations", "mut-1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(got, &obj); err != nil {
+		t.Fatalf("unmarshal stored: %v", err)
+	}
+	if obj["name"] != "Invoice list" {
+		t.Fatalf("name = %v, want refreshed list value", obj["name"])
+	}
+	rows, ok := obj["rows"].([]any)
+	if !ok || len(rows) != 1 {
+		t.Fatalf("rows not preserved, stored %s", got)
+	}
+	row, _ := rows[0].(map[string]any)
+	if fmt.Sprint(row["vat"]) != "21" {
+		t.Fatalf("rich vat field lost, stored %s", got)
+	}
+
+	if stored, extractFailures, err := s.UpsertBatch("others", []json.RawMessage{
+		json.RawMessage(`{"id":"o-1","name":"Thin"}`),
+	}); err != nil {
+		t.Fatalf("list-only first write: %v", err)
+	} else if stored != 1 || extractFailures != 0 {
+		t.Fatalf("list-only stored/extractFailures = %d/%d, want 1/0", stored, extractFailures)
+	}
+	thin, err := s.Get("others", "o-1")
+	if err != nil {
+		t.Fatalf("get thin: %v", err)
+	}
+	if !strings.Contains(string(thin), `"Thin"`) {
+		t.Fatalf("list-only first write missing payload, got %s", thin)
+	}
+}
+
+func TestMergeKeepRicherJSON(t *testing.T) {
+	merged, ok := mergeKeepRicherJSON(
+		json.RawMessage(`{"id":"1","rows":[{"vat":21}],"meta":{"a":1,"b":2}}`),
+		json.RawMessage(`{"id":"1","name":"list","meta":{"a":9}}`),
+	)
+	if !ok {
+		t.Fatal("mergeKeepRicherJSON returned !ok")
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(merged, &obj); err != nil {
+		t.Fatalf("unmarshal merge: %v", err)
+	}
+	if obj["name"] != "list" {
+		t.Fatalf("incoming scalar should win, name=%v", obj["name"])
+	}
+	if _, ok := obj["rows"]; !ok {
+		t.Fatalf("existing rows must be kept, got %s", merged)
+	}
+	meta, _ := obj["meta"].(map[string]any)
+	if fmt.Sprint(meta["a"]) != "9" || fmt.Sprint(meta["b"]) != "2" {
+		t.Fatalf("nested object merge failed, meta=%v", meta)
+	}
+
+	first, ok := mergeKeepRicherJSON(nil, json.RawMessage(`{"id":"1","name":"only"}`))
+	if !ok || !strings.Contains(string(first), `"only"`) {
+		t.Fatalf("first write should store incoming, ok=%v got %s", ok, first)
 	}
 }
 

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -661,6 +661,44 @@ func TestMergeKeepRicherJSON(t *testing.T) {
 		t.Fatalf("USD row must keep its own notes, stored %s", sharedFK)
 	}
 
+	// Same scalar on different identity fields must not share a map key.
+	crossField, ok := mergeKeepRicherJSON(
+		"mutations",
+		json.RawMessage(`{"id":"1","rows":[{"id":"USD","notes":"from-id"},{"currency_code":"USD","notes":"from-code"}]}`),
+		json.RawMessage(`{"id":"1","rows":[{"currency_code":"USD"},{"id":"USD"}]}`),
+	)
+	if !ok {
+		t.Fatal("cross-field identity merge returned !ok")
+	}
+	var crossObj map[string]any
+	if err := json.Unmarshal(crossField, &crossObj); err != nil {
+		t.Fatalf("unmarshal cross-field merge: %v", err)
+	}
+	crossRows, _ := crossObj["rows"].([]any)
+	if len(crossRows) != 2 {
+		t.Fatalf("cross-field array length must follow incoming, stored %s", crossField)
+	}
+	crossFirst, _ := crossRows[0].(map[string]any)
+	crossSecond, _ := crossRows[1].(map[string]any)
+	if fmt.Sprint(crossFirst["currency_code"]) != "USD" {
+		t.Fatalf("first row must stay the currency_code item, stored %s", crossField)
+	}
+	if _, hasID := crossFirst["id"]; hasID {
+		t.Fatalf("currency_code row must not absorb the id sibling, stored %s", crossField)
+	}
+	if fmt.Sprint(crossFirst["notes"]) != "from-code" {
+		t.Fatalf("currency_code row must keep its own notes, stored %s", crossField)
+	}
+	if fmt.Sprint(crossSecond["id"]) != "USD" {
+		t.Fatalf("second row must stay the id item, stored %s", crossField)
+	}
+	if _, hasCode := crossSecond["currency_code"]; hasCode {
+		t.Fatalf("id row must not absorb the currency_code sibling, stored %s", crossField)
+	}
+	if fmt.Sprint(crossSecond["notes"]) != "from-id" {
+		t.Fatalf("id row must keep its own notes, stored %s", crossField)
+	}
+
 	prevOverride, hadOverride := resourceIDFieldOverrides["widgets"]
 	resourceIDFieldOverrides["widgets"] = "entityInfo.entityId"
 	defer func() {

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -496,6 +496,7 @@ func TestUpsert_PreservesRicherCachedDetail(t *testing.T) {
 
 func TestMergeKeepRicherJSON(t *testing.T) {
 	merged, ok := mergeKeepRicherJSON(
+		"mutations",
 		json.RawMessage(`{"id":"1","rows":[{"vat":21}],"meta":{"a":1,"b":2}}`),
 		json.RawMessage(`{"id":"1","name":"list","meta":{"a":9}}`),
 	)
@@ -517,7 +518,7 @@ func TestMergeKeepRicherJSON(t *testing.T) {
 		t.Fatalf("nested object merge failed, meta=%v", meta)
 	}
 
-	first, ok := mergeKeepRicherJSON(nil, json.RawMessage(`{"id":"1","name":"only"}`))
+	first, ok := mergeKeepRicherJSON("mutations", nil, json.RawMessage(`{"id":"1","name":"only"}`))
 	if !ok || !strings.Contains(string(first), `"only"`) {
 		t.Fatalf("first write should store incoming, ok=%v got %s", ok, first)
 	}
@@ -525,6 +526,7 @@ func TestMergeKeepRicherJSON(t *testing.T) {
 	// Reorder + drop the middle id-bearing object: match by id, keep
 	// richer fields on the surviving pair, follow incoming order/length.
 	reordered, ok := mergeKeepRicherJSON(
+		"mutations",
 		json.RawMessage(`{"id":"1","rows":[{"id":"a","vat":21,"notes":"keep"},{"id":"b","vat":9},{"id":"c","vat":0}]}`),
 		json.RawMessage(`{"id":"1","rows":[{"id":"c","vat":0},{"id":"a","vat":22}]}`),
 	)
@@ -560,6 +562,7 @@ func TestMergeKeepRicherJSON(t *testing.T) {
 	// No identity keys: incoming collection is authoritative. Index merge
 	// would attach the first cached extra field onto the first incoming item.
 	idless, ok := mergeKeepRicherJSON(
+		"mutations",
 		json.RawMessage(`{"id":"1","rows":[{"name":"x","extra":1},{"name":"y","extra":2}]}`),
 		json.RawMessage(`{"id":"1","rows":[{"name":"y"},{"name":"x"}]}`),
 	)
@@ -580,6 +583,82 @@ func TestMergeKeepRicherJSON(t *testing.T) {
 	}
 	if _, ok := firstIDLess["extra"]; ok {
 		t.Fatalf("id-less arrays must not merge by index, stored %s", idless)
+	}
+
+	assertArrayKeepRicher := func(label, resourceType, existingJSON, incomingJSON, idKey, idA, idB string) {
+		t.Helper()
+		got, ok := mergeKeepRicherJSON(resourceType, json.RawMessage(existingJSON), json.RawMessage(incomingJSON))
+		if !ok {
+			t.Fatalf("%s: merge returned !ok", label)
+		}
+		var obj map[string]any
+		if err := json.Unmarshal(got, &obj); err != nil {
+			t.Fatalf("%s: unmarshal: %v", label, err)
+		}
+		items, _ := obj["rows"].([]any)
+		if len(items) != 2 {
+			t.Fatalf("%s: length must follow incoming, got %d stored %s", label, len(items), got)
+		}
+		firstItem, _ := items[0].(map[string]any)
+		secondItem, _ := items[1].(map[string]any)
+		if fmt.Sprint(firstItem[idKey]) != idB || fmt.Sprint(secondItem[idKey]) != idA {
+			t.Fatalf("%s: order must follow incoming, stored %s", label, got)
+		}
+		if fmt.Sprint(secondItem["notes"]) != "keep" {
+			t.Fatalf("%s: keep-richer lost detail on identity match, stored %s", label, got)
+		}
+	}
+
+	assertArrayKeepRicher(
+		"currency_code",
+		"accounts",
+		`{"id":"1","rows":[{"currency_code":"USD","notes":"keep"},{"currency_code":"EUR"},{"currency_code":"GBP"}]}`,
+		`{"id":"1","rows":[{"currency_code":"EUR"},{"currency_code":"USD"}]}`,
+		"currency_code", "USD", "EUR",
+	)
+	assertArrayKeepRicher(
+		"accountId",
+		"teams",
+		`{"id":"1","rows":[{"accountId":"a1","notes":"keep"},{"accountId":"a2"},{"accountId":"a3"}]}`,
+		`{"id":"1","rows":[{"accountId":"a3"},{"accountId":"a1"}]}`,
+		"accountId", "a1", "a3",
+	)
+	assertArrayKeepRicher(
+		"sku",
+		"orders",
+		`{"id":"1","rows":[{"sku":"sku-a","notes":"keep"},{"sku":"sku-b"},{"sku":"sku-c"}]}`,
+		`{"id":"1","rows":[{"sku":"sku-c"},{"sku":"sku-a"}]}`,
+		"sku", "sku-a", "sku-c",
+	)
+
+	prevOverride, hadOverride := resourceIDFieldOverrides["widgets"]
+	resourceIDFieldOverrides["widgets"] = "entityInfo.entityId"
+	defer func() {
+		if hadOverride {
+			resourceIDFieldOverrides["widgets"] = prevOverride
+		} else {
+			delete(resourceIDFieldOverrides, "widgets")
+		}
+	}()
+	dotted, ok := mergeKeepRicherJSON(
+		"widgets",
+		json.RawMessage(`{"id":"1","rows":[{"entityInfo":{"entityId":"e-a"},"notes":"keep"},{"entityInfo":{"entityId":"e-b"}},{"entityInfo":{"entityId":"e-c"}}]}`),
+		json.RawMessage(`{"id":"1","rows":[{"entityInfo":{"entityId":"e-c"}},{"entityInfo":{"entityId":"e-a"}}]}`),
+	)
+	if !ok {
+		t.Fatal("dotted configured identity merge returned !ok")
+	}
+	var dottedObj map[string]any
+	if err := json.Unmarshal(dotted, &dottedObj); err != nil {
+		t.Fatalf("unmarshal dotted merge: %v", err)
+	}
+	dottedRows, _ := dottedObj["rows"].([]any)
+	if len(dottedRows) != 2 {
+		t.Fatalf("dotted array length must follow incoming, stored %s", dotted)
+	}
+	dottedSecond, _ := dottedRows[1].(map[string]any)
+	if fmt.Sprint(dottedSecond["notes"]) != "keep" {
+		t.Fatalf("dotted identity must keep-richer-merge, stored %s", dotted)
 	}
 }
 

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -521,6 +521,66 @@ func TestMergeKeepRicherJSON(t *testing.T) {
 	if !ok || !strings.Contains(string(first), `"only"`) {
 		t.Fatalf("first write should store incoming, ok=%v got %s", ok, first)
 	}
+
+	// Reorder + drop the middle id-bearing object: match by id, keep
+	// richer fields on the surviving pair, follow incoming order/length.
+	reordered, ok := mergeKeepRicherJSON(
+		json.RawMessage(`{"id":"1","rows":[{"id":"a","vat":21,"notes":"keep"},{"id":"b","vat":9},{"id":"c","vat":0}]}`),
+		json.RawMessage(`{"id":"1","rows":[{"id":"c","vat":0},{"id":"a","vat":22}]}`),
+	)
+	if !ok {
+		t.Fatal("identity-keyed array merge returned !ok")
+	}
+	var reorderObj map[string]any
+	if err := json.Unmarshal(reordered, &reorderObj); err != nil {
+		t.Fatalf("unmarshal reorder merge: %v", err)
+	}
+	rows, _ := reorderObj["rows"].([]any)
+	if len(rows) != 2 {
+		t.Fatalf("array length must follow incoming, got %d stored %s", len(rows), reordered)
+	}
+	firstRow, _ := rows[0].(map[string]any)
+	secondRow, _ := rows[1].(map[string]any)
+	if fmt.Sprint(firstRow["id"]) != "c" || fmt.Sprint(secondRow["id"]) != "a" {
+		t.Fatalf("array order must follow incoming, stored %s", reordered)
+	}
+	if fmt.Sprint(secondRow["vat"]) != "22" {
+		t.Fatalf("incoming scalar on matched object should win, stored %s", reordered)
+	}
+	if fmt.Sprint(secondRow["notes"]) != "keep" {
+		t.Fatalf("keep-richer must preserve unmatched fields on the id match, stored %s", reordered)
+	}
+	for _, row := range rows {
+		obj, _ := row.(map[string]any)
+		if fmt.Sprint(obj["id"]) == "b" {
+			t.Fatalf("dropped middle entry must not be kept, stored %s", reordered)
+		}
+	}
+
+	// No identity keys: incoming collection is authoritative. Index merge
+	// would attach the first cached extra field onto the first incoming item.
+	idless, ok := mergeKeepRicherJSON(
+		json.RawMessage(`{"id":"1","rows":[{"name":"x","extra":1},{"name":"y","extra":2}]}`),
+		json.RawMessage(`{"id":"1","rows":[{"name":"y"},{"name":"x"}]}`),
+	)
+	if !ok {
+		t.Fatal("id-less array merge returned !ok")
+	}
+	var idlessObj map[string]any
+	if err := json.Unmarshal(idless, &idlessObj); err != nil {
+		t.Fatalf("unmarshal id-less merge: %v", err)
+	}
+	idlessRows, _ := idlessObj["rows"].([]any)
+	if len(idlessRows) != 2 {
+		t.Fatalf("id-less array length must follow incoming, stored %s", idless)
+	}
+	firstIDLess, _ := idlessRows[0].(map[string]any)
+	if firstIDLess["name"] != "y" {
+		t.Fatalf("id-less array order must follow incoming, stored %s", idless)
+	}
+	if _, ok := firstIDLess["extra"]; ok {
+		t.Fatalf("id-less arrays must not merge by index, stored %s", idless)
+	}
 }
 
 func TestLookupFieldValue_DottedPathAndTrailingUnderscore(t *testing.T) {

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -631,6 +631,36 @@ func TestMergeKeepRicherJSON(t *testing.T) {
 		"sku", "sku-a", "sku-c",
 	)
 
+	// Shared FK + own identity: alphabetical first-key would pick
+	// account_id for every sibling and merge USD detail into EUR.
+	sharedFK, ok := mergeKeepRicherJSON(
+		"accounts",
+		json.RawMessage(`{"id":"1","rows":[{"account_id":"acct","currency_code":"USD","notes":"usd"},{"account_id":"acct","currency_code":"EUR","notes":"eur"}]}`),
+		json.RawMessage(`{"id":"1","rows":[{"account_id":"acct","currency_code":"EUR"},{"account_id":"acct","currency_code":"USD"}]}`),
+	)
+	if !ok {
+		t.Fatal("shared FK + currency_code merge returned !ok")
+	}
+	var sharedObj map[string]any
+	if err := json.Unmarshal(sharedFK, &sharedObj); err != nil {
+		t.Fatalf("unmarshal shared FK merge: %v", err)
+	}
+	sharedRows, _ := sharedObj["rows"].([]any)
+	if len(sharedRows) != 2 {
+		t.Fatalf("shared FK array length must follow incoming, stored %s", sharedFK)
+	}
+	sharedFirst, _ := sharedRows[0].(map[string]any)
+	sharedSecond, _ := sharedRows[1].(map[string]any)
+	if fmt.Sprint(sharedFirst["currency_code"]) != "EUR" || fmt.Sprint(sharedSecond["currency_code"]) != "USD" {
+		t.Fatalf("shared FK must pair on currency_code, stored %s", sharedFK)
+	}
+	if fmt.Sprint(sharedFirst["notes"]) != "eur" {
+		t.Fatalf("EUR row must keep its own notes, stored %s", sharedFK)
+	}
+	if fmt.Sprint(sharedSecond["notes"]) != "usd" {
+		t.Fatalf("USD row must keep its own notes, stored %s", sharedFK)
+	}
+
 	prevOverride, hadOverride := resourceIDFieldOverrides["widgets"]
 	resourceIDFieldOverrides["widgets"] = "entityInfo.entityId"
 	defer func() {

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -1780,9 +1780,14 @@ func fingerprintScalar(value any) (any, bool) {
 //   - Object arrays match by the same identity stack as ExtractResourceID
 //     (configured / dotted override, generic id, resource-scoped suffix)
 //     plus item-local suffix keys (currency_code, accountId) and sku.
-//     Display name is not an array identity. Result order and length
-//     follow incoming so a reorder or middle delete cannot join
-//     unrelated objects or keep leftover old entries.
+//     Own-identity suffixes (_code/_slug/_key) win over shared foreign
+//     keys so sibling rows that share account_id still pair on
+//     currency_code. A lone accountId remains identity when it is the
+//     only identity-shaped field. Identity map keys include the field
+//     that produced them so id:"USD" and currency_code:"USD" cannot
+//     share a slot. Display name is not an array identity. Result
+//     order and length follow incoming so a reorder or middle delete
+//     cannot join unrelated objects or keep leftover old entries.
 //   - Arrays without identity keys, and scalar arrays, take incoming
 //     wholesale. Index-wise merge would pair unrelated items.
 //   - Incoming scalars replace existing scalars.
@@ -1908,50 +1913,154 @@ func indexObjectArrayByIdentity(resourceType string, items []any) map[string]map
 func arrayItemIdentity(resourceType string, obj map[string]any) string {
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
 		if s := canonicalIDFromKey(obj, override); s != "" {
-			return s
+			return qualifyArrayItemIdentity(override, s)
 		}
 	}
 	for _, key := range genericIDFieldFallbacks {
 		if s := canonicalIDFromKey(obj, key); s != "" {
-			return s
+			return qualifyArrayItemIdentity(key, s)
 		}
 	}
-	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
-		return s
+	// Item-local own identity wins over the parent resource's suffix.
+	// mergeKeepRicherJSON threads the parent type through nested arrays,
+	// so suffixIDFieldFallback("accounts") would treat a copied
+	// account_id as every child's id and collide sibling rates.
+	if field, s := suffixIdentityFromItemKeys(obj); s != "" {
+		return qualifyArrayItemIdentity(field, s)
 	}
-	if s := suffixIdentityFromItemKeys(obj); s != "" {
-		return s
+	if field, s := suffixIDFieldAndName(resourceType, obj); s != "" {
+		return qualifyArrayItemIdentity(field, s)
 	}
 	if s := canonicalIDFromKey(obj, "sku"); s != "" {
-		return s
+		return qualifyArrayItemIdentity("sku", s)
 	}
 	for _, key := range []string{"slug", "key", "code"} {
 		if s := canonicalIDFromKey(obj, key); s != "" {
-			return s
+			return qualifyArrayItemIdentity(key, s)
 		}
 	}
 	return ""
 }
 
-func suffixIdentityFromItemKeys(obj map[string]any) string {
-	if obj == nil {
+const arrayItemIdentitySep = "\x1f"
+
+func qualifyArrayItemIdentity(field, value string) string {
+	if field == "" || value == "" {
 		return ""
+	}
+	return field + arrayItemIdentitySep + value
+}
+
+func suffixIdentityFromItemKeys(obj map[string]any) (string, string) {
+	if obj == nil {
+		return "", ""
 	}
 	keys := make([]string, 0, len(obj))
 	for key := range obj {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
+	var ownField, own, localField, localID, sharedField, sharedID string
 	for _, key := range keys {
 		stem := identitySuffixStem(key)
 		if stem == "" || stem == "parent" {
 			continue
 		}
-		if s := suffixIDFieldFallback(stem, obj); s != "" {
-			return s
+		s := suffixIDFieldFallback(stem, obj)
+		if s == "" {
+			continue
+		}
+		field := canonicalArrayIdentityField(key)
+		switch itemKeyIdentityKind(key) {
+		case itemIdentOwn:
+			if own == "" {
+				ownField, own = field, s
+			}
+		case itemIdentLocalID:
+			if localID == "" {
+				localField, localID = field, s
+			}
+		case itemIdentSharedID:
+			if sharedID == "" {
+				sharedField, sharedID = field, s
+			}
 		}
 	}
-	return ""
+	if own != "" {
+		return ownField, own
+	}
+	if localID != "" {
+		return localField, localID
+	}
+	return sharedField, sharedID
+}
+
+func canonicalArrayIdentityField(key string) string {
+	k := strings.TrimSpace(key)
+	stem := identitySuffixStem(k)
+	if stem == "" {
+		return k
+	}
+	switch {
+	case strings.HasSuffix(k, "_id") || strings.HasSuffix(k, "Id") || strings.HasSuffix(k, "ID"):
+		return stem + "_id"
+	case strings.HasSuffix(k, "_code") || strings.HasSuffix(k, "Code"):
+		return stem + "_code"
+	case strings.HasSuffix(k, "_key") || strings.HasSuffix(k, "Key"):
+		return stem + "_key"
+	case strings.HasSuffix(k, "_slug") || strings.HasSuffix(k, "Slug"):
+		return stem + "_slug"
+	default:
+		return k
+	}
+}
+
+type itemIdentKind int
+
+const (
+	itemIdentNone itemIdentKind = iota
+	itemIdentOwn
+	itemIdentLocalID
+	itemIdentSharedID
+)
+
+func itemKeyIdentityKind(key string) itemIdentKind {
+	if itemKeyLooksLikeOwnIdentity(key) {
+		return itemIdentOwn
+	}
+	stem := identitySuffixStem(key)
+	if stem == "" {
+		return itemIdentNone
+	}
+	if sharedForeignKeyStem(stem) {
+		return itemIdentSharedID
+	}
+	return itemIdentLocalID
+}
+
+func itemKeyLooksLikeOwnIdentity(key string) bool {
+	k := strings.TrimSpace(key)
+	for _, suffix := range []string{"_code", "_key", "_slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return true
+		}
+	}
+	for _, suffix := range []string{"Code", "Key", "Slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func sharedForeignKeyStem(stem string) bool {
+	switch strings.ToLower(stem) {
+	case "parent", "account", "owner", "org", "organization", "user",
+		"customer", "workspace", "tenant", "team", "company", "member":
+		return true
+	default:
+		return false
+	}
 }
 
 func identitySuffixStem(key string) string {
@@ -2003,20 +2112,27 @@ func isJSONEmpty(value any) bool {
 // promoted to the primary key, and it walks the same key spellings as
 // LookupFieldValue in a fixed suffix order so the chosen id is deterministic.
 func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
+	_, value := suffixIDFieldAndName(resourceType, obj)
+	return value
+}
+
+func suffixIDFieldAndName(resourceType string, obj map[string]any) (string, string) {
 	for _, base := range resourceIDBaseNames(resourceType) {
 		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
-			if s := canonicalScalarIDFromKey(obj, base+suffix); s != "" {
-				return s
+			key := base + suffix
+			if s := canonicalScalarIDFromKey(obj, key); s != "" {
+				return canonicalArrayIdentityField(key), s
 			}
 		}
 		camelBase := lowerCamelResourceIDBase(base)
 		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
-			if s := canonicalScalarIDFromKey(obj, camelBase+suffix); s != "" {
-				return s
+			key := camelBase + suffix
+			if s := canonicalScalarIDFromKey(obj, key); s != "" {
+				return canonicalArrayIdentityField(key), s
 			}
 		}
 	}
-	return ""
+	return "", ""
 }
 
 func canonicalScalarIDFromKey(obj map[string]any, key string) string {

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -9,7 +9,9 @@ package store
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
@@ -803,6 +805,26 @@ func isSQLiteBusy(err error) bool {
 		strings.Contains(msg, "database table is locked")
 }
 
+// mergeIncomingResourceData applies the keep-richer policy against any row
+// already cached for this (resourceType, id). First write returns incoming
+// unchanged. Callers must use the result for both the generic resources
+// blob and the typed-table projection so list sync cannot shrink detail.
+func (s *Store) mergeIncomingResourceData(tx *sql.Tx, resourceType, id string, incoming json.RawMessage) json.RawMessage {
+	var existing string
+	err := tx.QueryRow(
+		`SELECT data FROM resources WHERE resource_type = ? AND id = ?`,
+		resourceType, id,
+	).Scan(&existing)
+	if err != nil || existing == "" {
+		return incoming
+	}
+	merged, ok := mergeKeepRicherJSON(json.RawMessage(existing), incoming)
+	if !ok {
+		return incoming
+	}
+	return merged
+}
+
 func (s *Store) upsertGenericResourceTx(tx *sql.Tx, resourceType, id string, data json.RawMessage) error {
 	_, err := tx.Exec(
 		`INSERT INTO resources (id, resource_type, data, synced_at, updated_at)
@@ -842,7 +864,7 @@ func (s *Store) Upsert(resourceType, id string, data json.RawMessage) error {
 	}
 	defer tx.Rollback()
 
-	if err := s.upsertGenericResourceTx(tx, resourceType, id, data); err != nil {
+	if err := s.upsertGenericResourceTx(tx, resourceType, id, s.mergeIncomingResourceData(tx, resourceType, id, data)); err != nil {
 		return err
 	}
 
@@ -1561,6 +1583,12 @@ var resourceIDFieldOverrides = map[string]string{
 	"games": "game_key",
 }
 
+// parameterKeyedResources are typed resources whose responses have no
+// identity field. Upsert stores those rows under a parameter fingerprint
+// instead of failing ExtractResourceID. Unlisted resources keep today's
+// extract-failure contract for items with no usable id.
+var parameterKeyedResources = map[string]bool{}
+
 // Generic ID fields are split around the resource-specific suffix probe.
 // Stable vendor identifiers win first; then fields derived from the resource
 // name (accountId, workspaceId); descriptive fallbacks are last. Keeping name
@@ -1606,6 +1634,292 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 		}
 	}
 	return mapKeyIDFallback(obj)
+}
+
+// ResolveStorageID is the writer-side identity. ExtractResourceID wins when
+// the payload has a real resource id. Parameter-shaped / id-less payloads
+// (no identity-candidate keys at all) get a fingerprint of their top-level
+// scalars so Upsert can store a row without inventing a field. Identity
+// probes such as unwrap and sync extractID must keep using ExtractResourceID
+// so a fingerprint is never mistaken for an entity id.
+//
+// Objects that carry an identity-shaped key whose value was refused
+// (timestamp, zero, empty) still return "" — fingerprinting those would
+// hide a rejected entity id.
+func ResolveStorageID(resourceType string, obj map[string]any) string {
+	if id := ExtractResourceID(resourceType, obj); id != "" {
+		return id
+	}
+	if !parameterKeyedResources[resourceType] {
+		return ""
+	}
+	if identityKeyPresent(resourceType, obj) {
+		return ""
+	}
+	return parameterSnapshotID(obj)
+}
+
+func identityKeyPresent(resourceType string, obj map[string]any) bool {
+	if obj == nil {
+		return false
+	}
+	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
+		if _, found := lookupRawFieldValue(obj, override); found {
+			return true
+		}
+	}
+	for _, key := range genericIDFieldFallbacks {
+		if _, found := lookupRawFieldValue(obj, key); found {
+			return true
+		}
+	}
+	if suffixIdentityKeyPresent(resourceType, obj) {
+		return true
+	}
+	for _, key := range genericDescriptiveIDFieldFallbacks {
+		if _, found := lookupRawFieldValue(obj, key); found {
+			return true
+		}
+	}
+	if _, found := obj[MapKeyIDField]; found {
+		return true
+	}
+	return false
+}
+
+func suffixIdentityKeyPresent(resourceType string, obj map[string]any) bool {
+	for _, base := range resourceIDBaseNames(resourceType) {
+		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+			if _, found := lookupRawFieldValue(obj, base+suffix); found {
+				return true
+			}
+		}
+		camelBase := lowerCamelResourceIDBase(base)
+		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+			if _, found := lookupRawFieldValue(obj, camelBase+suffix); found {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// parameterSnapshotID keys an id-less payload by a hash of its top-level
+// scalars — the request-equivalent identity (lat/lon, timezone) — and
+// excludes nested blocks (hourly, current, results) so a later fetch of
+// the same parameters updates the same row. Volatile telemetry keys
+// (*_ms, *_at, timestamp, generationtime*) are omitted from the key.
+// When the object has no stable scalars the whole payload is hashed so
+// the row can still be stored.
+func parameterSnapshotID(obj map[string]any) string {
+	if len(obj) == 0 {
+		return ""
+	}
+	fields := parameterFingerprintFields(obj)
+	var payload any
+	if len(fields) > 0 {
+		payload = fields
+	} else {
+		payload = obj
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil || len(raw) == 0 || string(raw) == "null" || string(raw) == "{}" {
+		return ""
+	}
+	sum := sha256.Sum256(raw)
+	return "pp:params:" + hex.EncodeToString(sum[:16])
+}
+
+func parameterFingerprintFields(obj map[string]any) map[string]any {
+	out := make(map[string]any, len(obj))
+	for key, value := range obj {
+		if isVolatileParameterKey(key) {
+			continue
+		}
+		if scalar, ok := fingerprintScalar(value); ok {
+			out[key] = scalar
+		}
+	}
+	return out
+}
+
+func isVolatileParameterKey(key string) bool {
+	k := strings.ToLower(strings.TrimSpace(key))
+	switch {
+	case strings.HasSuffix(k, "_ms"), strings.HasSuffix(k, "_at"):
+		return true
+	case k == "timestamp", k == "generated", k == "generation_time", k == "generationtime":
+		return true
+	default:
+		return strings.HasPrefix(k, "generationtime")
+	}
+}
+
+func fingerprintScalar(value any) (any, bool) {
+	switch t := value.(type) {
+	case nil:
+		return nil, false
+	case string:
+		return t, t != ""
+	case bool:
+		return t, true
+	case json.Number:
+		return t, t.String() != ""
+	case float64, float32, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return t, true
+	default:
+		return nil, false
+	}
+}
+
+// mergeKeepRicherJSON combines a previously cached JSON blob with an
+// incoming write so a thinner list-shaped payload cannot destroy richer
+// detail already stored for the same id.
+//
+// Policy (do-not-shrink / keep-richer):
+//   - First write (no existing) stores incoming unchanged.
+//   - Object keys present only on existing are kept.
+//   - Objects merge recursively; incoming keys go through the same policy
+//     rather than wholesale replacement.
+//   - A container (object/array) is never replaced by a scalar or null.
+//   - An incoming empty array does not replace a non-empty existing array.
+//   - Arrays of objects merge element-wise; extra existing elements are
+//     kept when incoming is shorter.
+//   - Arrays of non-objects: the longer array wins; equal length prefers
+//     incoming (authoritative remote refresh of the same collection).
+//   - Incoming scalars replace existing scalars.
+func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, bool) {
+	if len(existing) == 0 {
+		return incoming, len(incoming) > 0
+	}
+	if len(incoming) == 0 {
+		return existing, true
+	}
+	existingVal, err := decodeJSONValue(existing)
+	if err != nil {
+		return incoming, len(incoming) > 0
+	}
+	incomingVal, err := decodeJSONValue(incoming)
+	if err != nil {
+		return existing, true
+	}
+	merged, err := json.Marshal(mergeKeepRicherValue(existingVal, incomingVal))
+	if err != nil {
+		return incoming, len(incoming) > 0
+	}
+	return merged, true
+}
+
+func decodeJSONValue(data json.RawMessage) (any, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	var value any
+	if err := dec.Decode(&value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func mergeKeepRicherValue(existing, incoming any) any {
+	if incoming == nil {
+		if existing != nil {
+			return existing
+		}
+		return incoming
+	}
+	existingObj, existingIsObj := existing.(map[string]any)
+	incomingObj, incomingIsObj := incoming.(map[string]any)
+	if existingIsObj && incomingIsObj {
+		return mergeKeepRicherObject(existingObj, incomingObj)
+	}
+	existingArr, existingIsArr := existing.([]any)
+	incomingArr, incomingIsArr := incoming.([]any)
+	if existingIsArr && incomingIsArr {
+		return mergeKeepRicherArray(existingArr, incomingArr)
+	}
+	if isJSONContainer(existing) && !isJSONContainer(incoming) {
+		return existing
+	}
+	if isJSONEmpty(incoming) && !isJSONEmpty(existing) {
+		return existing
+	}
+	return incoming
+}
+
+func mergeKeepRicherObject(existing, incoming map[string]any) map[string]any {
+	out := make(map[string]any, len(existing)+len(incoming))
+	for key, value := range existing {
+		out[key] = value
+	}
+	for key, incomingVal := range incoming {
+		if existingVal, ok := out[key]; ok {
+			out[key] = mergeKeepRicherValue(existingVal, incomingVal)
+			continue
+		}
+		out[key] = incomingVal
+	}
+	return out
+}
+
+func mergeKeepRicherArray(existing, incoming []any) []any {
+	if len(incoming) == 0 && len(existing) > 0 {
+		return existing
+	}
+	if !arrayItemsAreObjects(existing) && !arrayItemsAreObjects(incoming) {
+		if len(incoming) < len(existing) {
+			return existing
+		}
+		return incoming
+	}
+	n := len(incoming)
+	if len(existing) > n {
+		n = len(existing)
+	}
+	out := make([]any, n)
+	for i := 0; i < n; i++ {
+		switch {
+		case i < len(existing) && i < len(incoming):
+			out[i] = mergeKeepRicherValue(existing[i], incoming[i])
+		case i < len(existing):
+			out[i] = existing[i]
+		default:
+			out[i] = incoming[i]
+		}
+	}
+	return out
+}
+
+func arrayItemsAreObjects(items []any) bool {
+	for _, item := range items {
+		if _, ok := item.(map[string]any); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func isJSONContainer(value any) bool {
+	switch value.(type) {
+	case map[string]any, []any:
+		return true
+	default:
+		return false
+	}
+}
+
+func isJSONEmpty(value any) bool {
+	switch t := value.(type) {
+	case nil:
+		return true
+	case string:
+		return t == ""
+	case map[string]any:
+		return len(t) == 0
+	case []any:
+		return len(t) == 0
+	default:
+		return false
+	}
 }
 
 // suffixIDFieldFallback resolves an id-less resource that keys on its own
@@ -1856,11 +2170,18 @@ func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage
 			}
 		}
 		if id == "" {
+			id = ResolveStorageID(resourceType, obj)
+		}
+		if id == "" {
 			skippedCount++
 			extractFailures++
 			continue
 		}
 		storageID := resourceStorageID(resourceType, id, obj)
+		item = s.mergeIncomingResourceData(tx, resourceType, storageID, item)
+		if merged, err := DecodeJSONObject(item); err == nil {
+			obj = merged
+		}
 
 		if err := s.upsertGenericResourceTx(tx, resourceType, storageID, item); err != nil {
 			// Return the running stored count rather than zero so callers

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -1918,7 +1918,7 @@ func arrayItemIdentity(resourceType string, obj map[string]any) string {
 	}
 	for _, key := range genericIDFieldFallbacks {
 		if s := canonicalIDFromKey(obj, key); s != "" {
-			return qualifyArrayItemIdentity(key, s)
+			return qualifyArrayItemIdentity(canonicalGenericIDField(key), s)
 		}
 	}
 	// Item-local own identity wins over the parent resource's suffix.
@@ -1949,6 +1949,17 @@ func qualifyArrayItemIdentity(field, value string) string {
 		return ""
 	}
 	return field + arrayItemIdentitySep + value
+}
+
+// lookupRawFieldValue("id") finds Id/id_ via fieldKeySpellings but not
+// _id or ID, so those probes would otherwise mint distinct map keys.
+func canonicalGenericIDField(probe string) string {
+	switch strings.TrimSpace(probe) {
+	case "id", "ID", "_id", "id_", "Id":
+		return "id"
+	default:
+		return probe
+	}
 }
 
 func suffixIdentityFromItemKeys(obj map[string]any) (string, string) {

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -817,7 +817,7 @@ func (s *Store) mergeIncomingResourceData(tx *sql.Tx, resourceType, id string, i
 	if err != nil || existing == "" {
 		return incoming
 	}
-	merged, ok := mergeKeepRicherJSON(json.RawMessage(existing), incoming)
+	merged, ok := mergeKeepRicherJSON(resourceType, json.RawMessage(existing), incoming)
 	if !ok {
 		return incoming
 	}
@@ -1777,14 +1777,16 @@ func fingerprintScalar(value any) (any, bool) {
 //   - A container (object/array) is never replaced by a scalar or null.
 //   - An incoming empty array does not replace a non-empty existing array
 //     (list omitted the collection vs sent a new one).
-//   - Object arrays match by a stable id key when present, then apply the
-//     same object policy to the pair. Result order and length follow
-//     incoming so a reorder or middle delete cannot join unrelated
-//     objects or keep leftover old entries.
+//   - Object arrays match by the same identity stack as ExtractResourceID
+//     (configured / dotted override, generic id, resource-scoped suffix)
+//     plus item-local suffix keys (currency_code, accountId) and sku.
+//     Display name is not an array identity. Result order and length
+//     follow incoming so a reorder or middle delete cannot join
+//     unrelated objects or keep leftover old entries.
 //   - Arrays without identity keys, and scalar arrays, take incoming
 //     wholesale. Index-wise merge would pair unrelated items.
 //   - Incoming scalars replace existing scalars.
-func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, bool) {
+func mergeKeepRicherJSON(resourceType string, existing, incoming json.RawMessage) (json.RawMessage, bool) {
 	if len(existing) == 0 {
 		return incoming, len(incoming) > 0
 	}
@@ -1799,7 +1801,7 @@ func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, b
 	if err != nil {
 		return existing, true
 	}
-	merged, err := json.Marshal(mergeKeepRicherValue(existingVal, incomingVal))
+	merged, err := json.Marshal(mergeKeepRicherValue(resourceType, existingVal, incomingVal))
 	if err != nil {
 		return incoming, len(incoming) > 0
 	}
@@ -1816,7 +1818,7 @@ func decodeJSONValue(data json.RawMessage) (any, error) {
 	return value, nil
 }
 
-func mergeKeepRicherValue(existing, incoming any) any {
+func mergeKeepRicherValue(resourceType string, existing, incoming any) any {
 	if incoming == nil {
 		if existing != nil {
 			return existing
@@ -1826,12 +1828,12 @@ func mergeKeepRicherValue(existing, incoming any) any {
 	existingObj, existingIsObj := existing.(map[string]any)
 	incomingObj, incomingIsObj := incoming.(map[string]any)
 	if existingIsObj && incomingIsObj {
-		return mergeKeepRicherObject(existingObj, incomingObj)
+		return mergeKeepRicherObject(resourceType, existingObj, incomingObj)
 	}
 	existingArr, existingIsArr := existing.([]any)
 	incomingArr, incomingIsArr := incoming.([]any)
 	if existingIsArr && incomingIsArr {
-		return mergeKeepRicherArray(existingArr, incomingArr)
+		return mergeKeepRicherArray(resourceType, existingArr, incomingArr)
 	}
 	if isJSONContainer(existing) && !isJSONContainer(incoming) {
 		return existing
@@ -1842,14 +1844,14 @@ func mergeKeepRicherValue(existing, incoming any) any {
 	return incoming
 }
 
-func mergeKeepRicherObject(existing, incoming map[string]any) map[string]any {
+func mergeKeepRicherObject(resourceType string, existing, incoming map[string]any) map[string]any {
 	out := make(map[string]any, len(existing)+len(incoming))
 	for key, value := range existing {
 		out[key] = value
 	}
 	for key, incomingVal := range incoming {
 		if existingVal, ok := out[key]; ok {
-			out[key] = mergeKeepRicherValue(existingVal, incomingVal)
+			out[key] = mergeKeepRicherValue(resourceType, existingVal, incomingVal)
 			continue
 		}
 		out[key] = incomingVal
@@ -1857,11 +1859,11 @@ func mergeKeepRicherObject(existing, incoming map[string]any) map[string]any {
 	return out
 }
 
-func mergeKeepRicherArray(existing, incoming []any) []any {
+func mergeKeepRicherArray(resourceType string, existing, incoming []any) []any {
 	if len(incoming) == 0 && len(existing) > 0 {
 		return existing
 	}
-	existingByID := indexObjectArrayByIdentity(existing)
+	existingByID := indexObjectArrayByIdentity(resourceType, existing)
 	if len(existingByID) == 0 {
 		return incoming
 	}
@@ -1872,26 +1874,26 @@ func mergeKeepRicherArray(existing, incoming []any) []any {
 			out[i] = item
 			continue
 		}
-		id := arrayItemIdentity(incomingObj)
+		id := arrayItemIdentity(resourceType, incomingObj)
 		existingObj, ok := existingByID[id]
 		if id == "" || !ok {
 			out[i] = item
 			continue
 		}
 		delete(existingByID, id)
-		out[i] = mergeKeepRicherObject(existingObj, incomingObj)
+		out[i] = mergeKeepRicherObject(resourceType, existingObj, incomingObj)
 	}
 	return out
 }
 
-func indexObjectArrayByIdentity(items []any) map[string]map[string]any {
+func indexObjectArrayByIdentity(resourceType string, items []any) map[string]map[string]any {
 	out := make(map[string]map[string]any)
 	for _, item := range items {
 		obj, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
-		id := arrayItemIdentity(obj)
+		id := arrayItemIdentity(resourceType, obj)
 		if id == "" {
 			continue
 		}
@@ -1903,10 +1905,68 @@ func indexObjectArrayByIdentity(items []any) map[string]map[string]any {
 	return out
 }
 
-func arrayItemIdentity(obj map[string]any) string {
+func arrayItemIdentity(resourceType string, obj map[string]any) string {
+	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
+		if s := canonicalIDFromKey(obj, override); s != "" {
+			return s
+		}
+	}
 	for _, key := range genericIDFieldFallbacks {
 		if s := canonicalIDFromKey(obj, key); s != "" {
 			return s
+		}
+	}
+	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
+		return s
+	}
+	if s := suffixIdentityFromItemKeys(obj); s != "" {
+		return s
+	}
+	if s := canonicalIDFromKey(obj, "sku"); s != "" {
+		return s
+	}
+	for _, key := range []string{"slug", "key", "code"} {
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func suffixIdentityFromItemKeys(obj map[string]any) string {
+	if obj == nil {
+		return ""
+	}
+	keys := make([]string, 0, len(obj))
+	for key := range obj {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		stem := identitySuffixStem(key)
+		if stem == "" || stem == "parent" {
+			continue
+		}
+		if s := suffixIDFieldFallback(stem, obj); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func identitySuffixStem(key string) string {
+	k := strings.TrimSpace(key)
+	if k == "" {
+		return ""
+	}
+	for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return strings.TrimSuffix(k, suffix)
+		}
+	}
+	for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return strings.ToLower(k[:len(k)-len(suffix)])
 		}
 	}
 	return ""

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -805,10 +805,9 @@ func isSQLiteBusy(err error) bool {
 		strings.Contains(msg, "database table is locked")
 }
 
-// mergeIncomingResourceData applies the keep-richer policy against any row
-// already cached for this (resourceType, id). First write returns incoming
-// unchanged. Callers must use the result for both the generic resources
-// blob and the typed-table projection so list sync cannot shrink detail.
+// A later list-shaped write must not shrink a richer cached blob. First
+// write is incoming as-is. Callers apply the result to both the generic
+// resources blob and the typed-table projection.
 func (s *Store) mergeIncomingResourceData(tx *sql.Tx, resourceType, id string, incoming json.RawMessage) json.RawMessage {
 	var existing string
 	err := tx.QueryRow(
@@ -1583,10 +1582,9 @@ var resourceIDFieldOverrides = map[string]string{
 	"games": "game_key",
 }
 
-// parameterKeyedResources are typed resources whose responses have no
-// identity field. Upsert stores those rows under a parameter fingerprint
-// instead of failing ExtractResourceID. Unlisted resources keep today's
-// extract-failure contract for items with no usable id.
+// Only typed resources with no identity field may be stored under a
+// parameter fingerprint. Unlisted resources still increment extractFailures
+// when an item has no usable id.
 var parameterKeyedResources = map[string]bool{}
 
 // Generic ID fields are split around the resource-specific suffix probe.
@@ -1636,16 +1634,14 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 	return mapKeyIDFallback(obj)
 }
 
-// ResolveStorageID is the writer-side identity. ExtractResourceID wins when
-// the payload has a real resource id. Parameter-shaped / id-less payloads
-// (no identity-candidate keys at all) get a fingerprint of their top-level
-// scalars so Upsert can store a row without inventing a field. Identity
-// probes such as unwrap and sync extractID must keep using ExtractResourceID
-// so a fingerprint is never mistaken for an entity id.
+// Writer identity prefers a real resource id. A parameter-shaped payload
+// with no identity-candidate keys is fingerprinted from top-level scalars
+// so the row can be stored without inventing a field. Unwrap and sync
+// extractID must keep using ExtractResourceID so a fingerprint is never
+// mistaken for an entity id.
 //
-// Objects that carry an identity-shaped key whose value was refused
-// (timestamp, zero, empty) still return "" — fingerprinting those would
-// hide a rejected entity id.
+// An identity-shaped key whose value was refused (timestamp, zero, empty)
+// still returns "" — fingerprinting those would hide a rejected entity id.
 func ResolveStorageID(resourceType string, obj map[string]any) string {
 	if id := ExtractResourceID(resourceType, obj); id != "" {
 		return id
@@ -1704,13 +1700,11 @@ func suffixIdentityKeyPresent(resourceType string, obj map[string]any) bool {
 	return false
 }
 
-// parameterSnapshotID keys an id-less payload by a hash of its top-level
-// scalars — the request-equivalent identity (lat/lon, timezone) — and
-// excludes nested blocks (hourly, current, results) so a later fetch of
-// the same parameters updates the same row. Volatile telemetry keys
-// (*_ms, *_at, timestamp, generationtime*) are omitted from the key.
-// When the object has no stable scalars the whole payload is hashed so
-// the row can still be stored.
+// Id-less rows key on a hash of top-level scalars (lat/lon, timezone)
+// and omit nested blocks so a later fetch of the same parameters updates
+// the same row. Volatile telemetry keys (*_ms, *_at, timestamp,
+// generationtime*) stay out of the key. No stable scalars means the
+// whole payload is hashed so the row can still be stored.
 func parameterSnapshotID(obj map[string]any) string {
 	if len(obj) == 0 {
 		return ""
@@ -1772,9 +1766,8 @@ func fingerprintScalar(value any) (any, bool) {
 	}
 }
 
-// mergeKeepRicherJSON combines a previously cached JSON blob with an
-// incoming write so a thinner list-shaped payload cannot destroy richer
-// detail already stored for the same id.
+// A thinner list-shaped payload cannot destroy richer detail already
+// stored for the same id.
 //
 // Policy (do-not-shrink / keep-richer):
 //   - First write (no existing) stores incoming unchanged.
@@ -1782,11 +1775,14 @@ func fingerprintScalar(value any) (any, bool) {
 //   - Objects merge recursively; incoming keys go through the same policy
 //     rather than wholesale replacement.
 //   - A container (object/array) is never replaced by a scalar or null.
-//   - An incoming empty array does not replace a non-empty existing array.
-//   - Arrays of objects merge element-wise; extra existing elements are
-//     kept when incoming is shorter.
-//   - Arrays of non-objects: the longer array wins; equal length prefers
-//     incoming (authoritative remote refresh of the same collection).
+//   - An incoming empty array does not replace a non-empty existing array
+//     (list omitted the collection vs sent a new one).
+//   - Object arrays match by a stable id key when present, then apply the
+//     same object policy to the pair. Result order and length follow
+//     incoming so a reorder or middle delete cannot join unrelated
+//     objects or keep leftover old entries.
+//   - Arrays without identity keys, and scalar arrays, take incoming
+//     wholesale. Index-wise merge would pair unrelated items.
 //   - Incoming scalars replace existing scalars.
 func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, bool) {
 	if len(existing) == 0 {
@@ -1865,37 +1861,55 @@ func mergeKeepRicherArray(existing, incoming []any) []any {
 	if len(incoming) == 0 && len(existing) > 0 {
 		return existing
 	}
-	if !arrayItemsAreObjects(existing) && !arrayItemsAreObjects(incoming) {
-		if len(incoming) < len(existing) {
-			return existing
-		}
+	existingByID := indexObjectArrayByIdentity(existing)
+	if len(existingByID) == 0 {
 		return incoming
 	}
-	n := len(incoming)
-	if len(existing) > n {
-		n = len(existing)
-	}
-	out := make([]any, n)
-	for i := 0; i < n; i++ {
-		switch {
-		case i < len(existing) && i < len(incoming):
-			out[i] = mergeKeepRicherValue(existing[i], incoming[i])
-		case i < len(existing):
-			out[i] = existing[i]
-		default:
-			out[i] = incoming[i]
+	out := make([]any, len(incoming))
+	for i, item := range incoming {
+		incomingObj, ok := item.(map[string]any)
+		if !ok {
+			out[i] = item
+			continue
 		}
+		id := arrayItemIdentity(incomingObj)
+		existingObj, ok := existingByID[id]
+		if id == "" || !ok {
+			out[i] = item
+			continue
+		}
+		delete(existingByID, id)
+		out[i] = mergeKeepRicherObject(existingObj, incomingObj)
 	}
 	return out
 }
 
-func arrayItemsAreObjects(items []any) bool {
+func indexObjectArrayByIdentity(items []any) map[string]map[string]any {
+	out := make(map[string]map[string]any)
 	for _, item := range items {
-		if _, ok := item.(map[string]any); ok {
-			return true
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		id := arrayItemIdentity(obj)
+		if id == "" {
+			continue
+		}
+		if _, exists := out[id]; exists {
+			continue
+		}
+		out[id] = obj
+	}
+	return out
+}
+
+func arrayItemIdentity(obj map[string]any) string {
+	for _, key := range genericIDFieldFallbacks {
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
-	return false
+	return ""
 }
 
 func isJSONContainer(value any) bool {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -982,7 +982,7 @@ func (s *Store) mergeIncomingResourceData(tx *sql.Tx, resourceType, id string, i
 	if err != nil || existing == "" {
 		return incoming
 	}
-	merged, ok := mergeKeepRicherJSON(json.RawMessage(existing), incoming)
+	merged, ok := mergeKeepRicherJSON(resourceType, json.RawMessage(existing), incoming)
 	if !ok {
 		return incoming
 	}
@@ -2003,14 +2003,16 @@ func fingerprintScalar(value any) (any, bool) {
 //   - A container (object/array) is never replaced by a scalar or null.
 //   - An incoming empty array does not replace a non-empty existing array
 //     (list omitted the collection vs sent a new one).
-//   - Object arrays match by a stable id key when present, then apply the
-//     same object policy to the pair. Result order and length follow
-//     incoming so a reorder or middle delete cannot join unrelated
-//     objects or keep leftover old entries.
+//   - Object arrays match by the same identity stack as ExtractResourceID
+//     (configured / dotted override, generic id, resource-scoped suffix)
+//     plus item-local suffix keys (currency_code, accountId) and sku.
+//     Display name is not an array identity. Result order and length
+//     follow incoming so a reorder or middle delete cannot join
+//     unrelated objects or keep leftover old entries.
 //   - Arrays without identity keys, and scalar arrays, take incoming
 //     wholesale. Index-wise merge would pair unrelated items.
 //   - Incoming scalars replace existing scalars.
-func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, bool) {
+func mergeKeepRicherJSON(resourceType string, existing, incoming json.RawMessage) (json.RawMessage, bool) {
 	if len(existing) == 0 {
 		return incoming, len(incoming) > 0
 	}
@@ -2025,7 +2027,7 @@ func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, b
 	if err != nil {
 		return existing, true
 	}
-	merged, err := json.Marshal(mergeKeepRicherValue(existingVal, incomingVal))
+	merged, err := json.Marshal(mergeKeepRicherValue(resourceType, existingVal, incomingVal))
 	if err != nil {
 		return incoming, len(incoming) > 0
 	}
@@ -2042,7 +2044,7 @@ func decodeJSONValue(data json.RawMessage) (any, error) {
 	return value, nil
 }
 
-func mergeKeepRicherValue(existing, incoming any) any {
+func mergeKeepRicherValue(resourceType string, existing, incoming any) any {
 	if incoming == nil {
 		if existing != nil {
 			return existing
@@ -2052,12 +2054,12 @@ func mergeKeepRicherValue(existing, incoming any) any {
 	existingObj, existingIsObj := existing.(map[string]any)
 	incomingObj, incomingIsObj := incoming.(map[string]any)
 	if existingIsObj && incomingIsObj {
-		return mergeKeepRicherObject(existingObj, incomingObj)
+		return mergeKeepRicherObject(resourceType, existingObj, incomingObj)
 	}
 	existingArr, existingIsArr := existing.([]any)
 	incomingArr, incomingIsArr := incoming.([]any)
 	if existingIsArr && incomingIsArr {
-		return mergeKeepRicherArray(existingArr, incomingArr)
+		return mergeKeepRicherArray(resourceType, existingArr, incomingArr)
 	}
 	if isJSONContainer(existing) && !isJSONContainer(incoming) {
 		return existing
@@ -2068,14 +2070,14 @@ func mergeKeepRicherValue(existing, incoming any) any {
 	return incoming
 }
 
-func mergeKeepRicherObject(existing, incoming map[string]any) map[string]any {
+func mergeKeepRicherObject(resourceType string, existing, incoming map[string]any) map[string]any {
 	out := make(map[string]any, len(existing)+len(incoming))
 	for key, value := range existing {
 		out[key] = value
 	}
 	for key, incomingVal := range incoming {
 		if existingVal, ok := out[key]; ok {
-			out[key] = mergeKeepRicherValue(existingVal, incomingVal)
+			out[key] = mergeKeepRicherValue(resourceType, existingVal, incomingVal)
 			continue
 		}
 		out[key] = incomingVal
@@ -2083,11 +2085,11 @@ func mergeKeepRicherObject(existing, incoming map[string]any) map[string]any {
 	return out
 }
 
-func mergeKeepRicherArray(existing, incoming []any) []any {
+func mergeKeepRicherArray(resourceType string, existing, incoming []any) []any {
 	if len(incoming) == 0 && len(existing) > 0 {
 		return existing
 	}
-	existingByID := indexObjectArrayByIdentity(existing)
+	existingByID := indexObjectArrayByIdentity(resourceType, existing)
 	if len(existingByID) == 0 {
 		return incoming
 	}
@@ -2098,26 +2100,26 @@ func mergeKeepRicherArray(existing, incoming []any) []any {
 			out[i] = item
 			continue
 		}
-		id := arrayItemIdentity(incomingObj)
+		id := arrayItemIdentity(resourceType, incomingObj)
 		existingObj, ok := existingByID[id]
 		if id == "" || !ok {
 			out[i] = item
 			continue
 		}
 		delete(existingByID, id)
-		out[i] = mergeKeepRicherObject(existingObj, incomingObj)
+		out[i] = mergeKeepRicherObject(resourceType, existingObj, incomingObj)
 	}
 	return out
 }
 
-func indexObjectArrayByIdentity(items []any) map[string]map[string]any {
+func indexObjectArrayByIdentity(resourceType string, items []any) map[string]map[string]any {
 	out := make(map[string]map[string]any)
 	for _, item := range items {
 		obj, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
-		id := arrayItemIdentity(obj)
+		id := arrayItemIdentity(resourceType, obj)
 		if id == "" {
 			continue
 		}
@@ -2129,10 +2131,68 @@ func indexObjectArrayByIdentity(items []any) map[string]map[string]any {
 	return out
 }
 
-func arrayItemIdentity(obj map[string]any) string {
+func arrayItemIdentity(resourceType string, obj map[string]any) string {
+	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
+		if s := canonicalIDFromKey(obj, override); s != "" {
+			return s
+		}
+	}
 	for _, key := range genericIDFieldFallbacks {
 		if s := canonicalIDFromKey(obj, key); s != "" {
 			return s
+		}
+	}
+	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
+		return s
+	}
+	if s := suffixIdentityFromItemKeys(obj); s != "" {
+		return s
+	}
+	if s := canonicalIDFromKey(obj, "sku"); s != "" {
+		return s
+	}
+	for _, key := range []string{"slug", "key", "code"} {
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func suffixIdentityFromItemKeys(obj map[string]any) string {
+	if obj == nil {
+		return ""
+	}
+	keys := make([]string, 0, len(obj))
+	for key := range obj {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		stem := identitySuffixStem(key)
+		if stem == "" || stem == "parent" {
+			continue
+		}
+		if s := suffixIDFieldFallback(stem, obj); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func identitySuffixStem(key string) string {
+	k := strings.TrimSpace(key)
+	if k == "" {
+		return ""
+	}
+	for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return strings.TrimSuffix(k, suffix)
+		}
+	}
+	for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return strings.ToLower(k[:len(k)-len(suffix)])
 		}
 	}
 	return ""

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -970,10 +970,9 @@ func isSQLiteBusy(err error) bool {
 		strings.Contains(msg, "database table is locked")
 }
 
-// mergeIncomingResourceData applies the keep-richer policy against any row
-// already cached for this (resourceType, id). First write returns incoming
-// unchanged. Callers must use the result for both the generic resources
-// blob and the typed-table projection so list sync cannot shrink detail.
+// A later list-shaped write must not shrink a richer cached blob. First
+// write is incoming as-is. Callers apply the result to both the generic
+// resources blob and the typed-table projection.
 func (s *Store) mergeIncomingResourceData(tx *sql.Tx, resourceType, id string, incoming json.RawMessage) json.RawMessage {
 	var existing string
 	err := tx.QueryRow(
@@ -1805,10 +1804,9 @@ var resourceIDFieldOverrides = map[string]string{
 	"games": "game_key",
 }
 
-// parameterKeyedResources are typed resources whose responses have no
-// identity field. Upsert stores those rows under a parameter fingerprint
-// instead of failing ExtractResourceID. Unlisted resources keep today's
-// extract-failure contract for items with no usable id.
+// Only typed resources with no identity field may be stored under a
+// parameter fingerprint. Unlisted resources still increment extractFailures
+// when an item has no usable id.
 var parameterKeyedResources = map[string]bool{}
 
 // Generic ID fields are split around the resource-specific suffix probe.
@@ -1862,16 +1860,14 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 	return mapKeyIDFallback(obj)
 }
 
-// ResolveStorageID is the writer-side identity. ExtractResourceID wins when
-// the payload has a real resource id. Parameter-shaped / id-less payloads
-// (no identity-candidate keys at all) get a fingerprint of their top-level
-// scalars so Upsert can store a row without inventing a field. Identity
-// probes such as unwrap and sync extractID must keep using ExtractResourceID
-// so a fingerprint is never mistaken for an entity id.
+// Writer identity prefers a real resource id. A parameter-shaped payload
+// with no identity-candidate keys is fingerprinted from top-level scalars
+// so the row can be stored without inventing a field. Unwrap and sync
+// extractID must keep using ExtractResourceID so a fingerprint is never
+// mistaken for an entity id.
 //
-// Objects that carry an identity-shaped key whose value was refused
-// (timestamp, zero, empty) still return "" — fingerprinting those would
-// hide a rejected entity id.
+// An identity-shaped key whose value was refused (timestamp, zero, empty)
+// still returns "" — fingerprinting those would hide a rejected entity id.
 func ResolveStorageID(resourceType string, obj map[string]any) string {
 	if id := ExtractResourceID(resourceType, obj); id != "" {
 		return id
@@ -1930,13 +1926,11 @@ func suffixIdentityKeyPresent(resourceType string, obj map[string]any) bool {
 	return false
 }
 
-// parameterSnapshotID keys an id-less payload by a hash of its top-level
-// scalars — the request-equivalent identity (lat/lon, timezone) — and
-// excludes nested blocks (hourly, current, results) so a later fetch of
-// the same parameters updates the same row. Volatile telemetry keys
-// (*_ms, *_at, timestamp, generationtime*) are omitted from the key.
-// When the object has no stable scalars the whole payload is hashed so
-// the row can still be stored.
+// Id-less rows key on a hash of top-level scalars (lat/lon, timezone)
+// and omit nested blocks so a later fetch of the same parameters updates
+// the same row. Volatile telemetry keys (*_ms, *_at, timestamp,
+// generationtime*) stay out of the key. No stable scalars means the
+// whole payload is hashed so the row can still be stored.
 func parameterSnapshotID(obj map[string]any) string {
 	if len(obj) == 0 {
 		return ""
@@ -1998,9 +1992,8 @@ func fingerprintScalar(value any) (any, bool) {
 	}
 }
 
-// mergeKeepRicherJSON combines a previously cached JSON blob with an
-// incoming write so a thinner list-shaped payload cannot destroy richer
-// detail already stored for the same id.
+// A thinner list-shaped payload cannot destroy richer detail already
+// stored for the same id.
 //
 // Policy (do-not-shrink / keep-richer):
 //   - First write (no existing) stores incoming unchanged.
@@ -2008,11 +2001,14 @@ func fingerprintScalar(value any) (any, bool) {
 //   - Objects merge recursively; incoming keys go through the same policy
 //     rather than wholesale replacement.
 //   - A container (object/array) is never replaced by a scalar or null.
-//   - An incoming empty array does not replace a non-empty existing array.
-//   - Arrays of objects merge element-wise; extra existing elements are
-//     kept when incoming is shorter.
-//   - Arrays of non-objects: the longer array wins; equal length prefers
-//     incoming (authoritative remote refresh of the same collection).
+//   - An incoming empty array does not replace a non-empty existing array
+//     (list omitted the collection vs sent a new one).
+//   - Object arrays match by a stable id key when present, then apply the
+//     same object policy to the pair. Result order and length follow
+//     incoming so a reorder or middle delete cannot join unrelated
+//     objects or keep leftover old entries.
+//   - Arrays without identity keys, and scalar arrays, take incoming
+//     wholesale. Index-wise merge would pair unrelated items.
 //   - Incoming scalars replace existing scalars.
 func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, bool) {
 	if len(existing) == 0 {
@@ -2091,37 +2087,55 @@ func mergeKeepRicherArray(existing, incoming []any) []any {
 	if len(incoming) == 0 && len(existing) > 0 {
 		return existing
 	}
-	if !arrayItemsAreObjects(existing) && !arrayItemsAreObjects(incoming) {
-		if len(incoming) < len(existing) {
-			return existing
-		}
+	existingByID := indexObjectArrayByIdentity(existing)
+	if len(existingByID) == 0 {
 		return incoming
 	}
-	n := len(incoming)
-	if len(existing) > n {
-		n = len(existing)
-	}
-	out := make([]any, n)
-	for i := 0; i < n; i++ {
-		switch {
-		case i < len(existing) && i < len(incoming):
-			out[i] = mergeKeepRicherValue(existing[i], incoming[i])
-		case i < len(existing):
-			out[i] = existing[i]
-		default:
-			out[i] = incoming[i]
+	out := make([]any, len(incoming))
+	for i, item := range incoming {
+		incomingObj, ok := item.(map[string]any)
+		if !ok {
+			out[i] = item
+			continue
 		}
+		id := arrayItemIdentity(incomingObj)
+		existingObj, ok := existingByID[id]
+		if id == "" || !ok {
+			out[i] = item
+			continue
+		}
+		delete(existingByID, id)
+		out[i] = mergeKeepRicherObject(existingObj, incomingObj)
 	}
 	return out
 }
 
-func arrayItemsAreObjects(items []any) bool {
+func indexObjectArrayByIdentity(items []any) map[string]map[string]any {
+	out := make(map[string]map[string]any)
 	for _, item := range items {
-		if _, ok := item.(map[string]any); ok {
-			return true
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		id := arrayItemIdentity(obj)
+		if id == "" {
+			continue
+		}
+		if _, exists := out[id]; exists {
+			continue
+		}
+		out[id] = obj
+	}
+	return out
+}
+
+func arrayItemIdentity(obj map[string]any) string {
+	for _, key := range genericIDFieldFallbacks {
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
-	return false
+	return ""
 }
 
 func isJSONContainer(value any) bool {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -2144,7 +2144,7 @@ func arrayItemIdentity(resourceType string, obj map[string]any) string {
 	}
 	for _, key := range genericIDFieldFallbacks {
 		if s := canonicalIDFromKey(obj, key); s != "" {
-			return qualifyArrayItemIdentity(key, s)
+			return qualifyArrayItemIdentity(canonicalGenericIDField(key), s)
 		}
 	}
 	// Item-local own identity wins over the parent resource's suffix.
@@ -2175,6 +2175,17 @@ func qualifyArrayItemIdentity(field, value string) string {
 		return ""
 	}
 	return field + arrayItemIdentitySep + value
+}
+
+// lookupRawFieldValue("id") finds Id/id_ via fieldKeySpellings but not
+// _id or ID, so those probes would otherwise mint distinct map keys.
+func canonicalGenericIDField(probe string) string {
+	switch strings.TrimSpace(probe) {
+	case "id", "ID", "_id", "id_", "Id":
+		return "id"
+	default:
+		return probe
+	}
 }
 
 func suffixIdentityFromItemKeys(obj map[string]any) (string, string) {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -9,7 +9,9 @@ package store
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
@@ -968,6 +970,26 @@ func isSQLiteBusy(err error) bool {
 		strings.Contains(msg, "database table is locked")
 }
 
+// mergeIncomingResourceData applies the keep-richer policy against any row
+// already cached for this (resourceType, id). First write returns incoming
+// unchanged. Callers must use the result for both the generic resources
+// blob and the typed-table projection so list sync cannot shrink detail.
+func (s *Store) mergeIncomingResourceData(tx *sql.Tx, resourceType, id string, incoming json.RawMessage) json.RawMessage {
+	var existing string
+	err := tx.QueryRow(
+		`SELECT data FROM resources WHERE resource_type = ? AND id = ?`,
+		resourceType, id,
+	).Scan(&existing)
+	if err != nil || existing == "" {
+		return incoming
+	}
+	merged, ok := mergeKeepRicherJSON(json.RawMessage(existing), incoming)
+	if !ok {
+		return incoming
+	}
+	return merged
+}
+
 func (s *Store) upsertGenericResourceTx(tx *sql.Tx, resourceType, id string, data json.RawMessage) error {
 	_, err := tx.Exec(
 		`INSERT INTO resources (id, resource_type, data, synced_at, updated_at)
@@ -1007,7 +1029,7 @@ func (s *Store) Upsert(resourceType, id string, data json.RawMessage) error {
 	}
 	defer tx.Rollback()
 
-	if err := s.upsertGenericResourceTx(tx, resourceType, id, data); err != nil {
+	if err := s.upsertGenericResourceTx(tx, resourceType, id, s.mergeIncomingResourceData(tx, resourceType, id, data)); err != nil {
 		return err
 	}
 
@@ -1741,7 +1763,7 @@ func (s *Store) UpsertLeagues(data json.RawMessage) error {
 		return fmt.Errorf("unmarshaling leagues: %w", err)
 	}
 
-	id := ExtractResourceID("leagues", obj)
+	id := ResolveStorageID("leagues", obj)
 	if id == "" {
 		return fmt.Errorf("missing id for leagues")
 	}
@@ -1754,6 +1776,11 @@ func (s *Store) UpsertLeagues(data json.RawMessage) error {
 		return err
 	}
 	defer tx.Rollback()
+
+	data = s.mergeIncomingResourceData(tx, "leagues", storageID, data)
+	if merged, err := DecodeJSONObject(data); err == nil {
+		obj = merged
+	}
 
 	if err := s.upsertGenericResourceTx(tx, "leagues", storageID, data); err != nil {
 		return err
@@ -1777,6 +1804,12 @@ func (s *Store) UpsertLeagues(data json.RawMessage) error {
 var resourceIDFieldOverrides = map[string]string{
 	"games": "game_key",
 }
+
+// parameterKeyedResources are typed resources whose responses have no
+// identity field. Upsert stores those rows under a parameter fingerprint
+// instead of failing ExtractResourceID. Unlisted resources keep today's
+// extract-failure contract for items with no usable id.
+var parameterKeyedResources = map[string]bool{}
 
 // Generic ID fields are split around the resource-specific suffix probe.
 // Stable vendor identifiers win first; then fields derived from the resource
@@ -1827,6 +1860,292 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 		}
 	}
 	return mapKeyIDFallback(obj)
+}
+
+// ResolveStorageID is the writer-side identity. ExtractResourceID wins when
+// the payload has a real resource id. Parameter-shaped / id-less payloads
+// (no identity-candidate keys at all) get a fingerprint of their top-level
+// scalars so Upsert can store a row without inventing a field. Identity
+// probes such as unwrap and sync extractID must keep using ExtractResourceID
+// so a fingerprint is never mistaken for an entity id.
+//
+// Objects that carry an identity-shaped key whose value was refused
+// (timestamp, zero, empty) still return "" — fingerprinting those would
+// hide a rejected entity id.
+func ResolveStorageID(resourceType string, obj map[string]any) string {
+	if id := ExtractResourceID(resourceType, obj); id != "" {
+		return id
+	}
+	if !parameterKeyedResources[resourceType] {
+		return ""
+	}
+	if identityKeyPresent(resourceType, obj) {
+		return ""
+	}
+	return parameterSnapshotID(obj)
+}
+
+func identityKeyPresent(resourceType string, obj map[string]any) bool {
+	if obj == nil {
+		return false
+	}
+	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
+		if _, found := lookupRawFieldValue(obj, override); found {
+			return true
+		}
+	}
+	for _, key := range genericIDFieldFallbacks {
+		if _, found := lookupRawFieldValue(obj, key); found {
+			return true
+		}
+	}
+	if suffixIdentityKeyPresent(resourceType, obj) {
+		return true
+	}
+	for _, key := range genericDescriptiveIDFieldFallbacks {
+		if _, found := lookupRawFieldValue(obj, key); found {
+			return true
+		}
+	}
+	if _, found := obj[MapKeyIDField]; found {
+		return true
+	}
+	return false
+}
+
+func suffixIdentityKeyPresent(resourceType string, obj map[string]any) bool {
+	for _, base := range resourceIDBaseNames(resourceType) {
+		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+			if _, found := lookupRawFieldValue(obj, base+suffix); found {
+				return true
+			}
+		}
+		camelBase := lowerCamelResourceIDBase(base)
+		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+			if _, found := lookupRawFieldValue(obj, camelBase+suffix); found {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// parameterSnapshotID keys an id-less payload by a hash of its top-level
+// scalars — the request-equivalent identity (lat/lon, timezone) — and
+// excludes nested blocks (hourly, current, results) so a later fetch of
+// the same parameters updates the same row. Volatile telemetry keys
+// (*_ms, *_at, timestamp, generationtime*) are omitted from the key.
+// When the object has no stable scalars the whole payload is hashed so
+// the row can still be stored.
+func parameterSnapshotID(obj map[string]any) string {
+	if len(obj) == 0 {
+		return ""
+	}
+	fields := parameterFingerprintFields(obj)
+	var payload any
+	if len(fields) > 0 {
+		payload = fields
+	} else {
+		payload = obj
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil || len(raw) == 0 || string(raw) == "null" || string(raw) == "{}" {
+		return ""
+	}
+	sum := sha256.Sum256(raw)
+	return "pp:params:" + hex.EncodeToString(sum[:16])
+}
+
+func parameterFingerprintFields(obj map[string]any) map[string]any {
+	out := make(map[string]any, len(obj))
+	for key, value := range obj {
+		if isVolatileParameterKey(key) {
+			continue
+		}
+		if scalar, ok := fingerprintScalar(value); ok {
+			out[key] = scalar
+		}
+	}
+	return out
+}
+
+func isVolatileParameterKey(key string) bool {
+	k := strings.ToLower(strings.TrimSpace(key))
+	switch {
+	case strings.HasSuffix(k, "_ms"), strings.HasSuffix(k, "_at"):
+		return true
+	case k == "timestamp", k == "generated", k == "generation_time", k == "generationtime":
+		return true
+	default:
+		return strings.HasPrefix(k, "generationtime")
+	}
+}
+
+func fingerprintScalar(value any) (any, bool) {
+	switch t := value.(type) {
+	case nil:
+		return nil, false
+	case string:
+		return t, t != ""
+	case bool:
+		return t, true
+	case json.Number:
+		return t, t.String() != ""
+	case float64, float32, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return t, true
+	default:
+		return nil, false
+	}
+}
+
+// mergeKeepRicherJSON combines a previously cached JSON blob with an
+// incoming write so a thinner list-shaped payload cannot destroy richer
+// detail already stored for the same id.
+//
+// Policy (do-not-shrink / keep-richer):
+//   - First write (no existing) stores incoming unchanged.
+//   - Object keys present only on existing are kept.
+//   - Objects merge recursively; incoming keys go through the same policy
+//     rather than wholesale replacement.
+//   - A container (object/array) is never replaced by a scalar or null.
+//   - An incoming empty array does not replace a non-empty existing array.
+//   - Arrays of objects merge element-wise; extra existing elements are
+//     kept when incoming is shorter.
+//   - Arrays of non-objects: the longer array wins; equal length prefers
+//     incoming (authoritative remote refresh of the same collection).
+//   - Incoming scalars replace existing scalars.
+func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, bool) {
+	if len(existing) == 0 {
+		return incoming, len(incoming) > 0
+	}
+	if len(incoming) == 0 {
+		return existing, true
+	}
+	existingVal, err := decodeJSONValue(existing)
+	if err != nil {
+		return incoming, len(incoming) > 0
+	}
+	incomingVal, err := decodeJSONValue(incoming)
+	if err != nil {
+		return existing, true
+	}
+	merged, err := json.Marshal(mergeKeepRicherValue(existingVal, incomingVal))
+	if err != nil {
+		return incoming, len(incoming) > 0
+	}
+	return merged, true
+}
+
+func decodeJSONValue(data json.RawMessage) (any, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	var value any
+	if err := dec.Decode(&value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func mergeKeepRicherValue(existing, incoming any) any {
+	if incoming == nil {
+		if existing != nil {
+			return existing
+		}
+		return incoming
+	}
+	existingObj, existingIsObj := existing.(map[string]any)
+	incomingObj, incomingIsObj := incoming.(map[string]any)
+	if existingIsObj && incomingIsObj {
+		return mergeKeepRicherObject(existingObj, incomingObj)
+	}
+	existingArr, existingIsArr := existing.([]any)
+	incomingArr, incomingIsArr := incoming.([]any)
+	if existingIsArr && incomingIsArr {
+		return mergeKeepRicherArray(existingArr, incomingArr)
+	}
+	if isJSONContainer(existing) && !isJSONContainer(incoming) {
+		return existing
+	}
+	if isJSONEmpty(incoming) && !isJSONEmpty(existing) {
+		return existing
+	}
+	return incoming
+}
+
+func mergeKeepRicherObject(existing, incoming map[string]any) map[string]any {
+	out := make(map[string]any, len(existing)+len(incoming))
+	for key, value := range existing {
+		out[key] = value
+	}
+	for key, incomingVal := range incoming {
+		if existingVal, ok := out[key]; ok {
+			out[key] = mergeKeepRicherValue(existingVal, incomingVal)
+			continue
+		}
+		out[key] = incomingVal
+	}
+	return out
+}
+
+func mergeKeepRicherArray(existing, incoming []any) []any {
+	if len(incoming) == 0 && len(existing) > 0 {
+		return existing
+	}
+	if !arrayItemsAreObjects(existing) && !arrayItemsAreObjects(incoming) {
+		if len(incoming) < len(existing) {
+			return existing
+		}
+		return incoming
+	}
+	n := len(incoming)
+	if len(existing) > n {
+		n = len(existing)
+	}
+	out := make([]any, n)
+	for i := 0; i < n; i++ {
+		switch {
+		case i < len(existing) && i < len(incoming):
+			out[i] = mergeKeepRicherValue(existing[i], incoming[i])
+		case i < len(existing):
+			out[i] = existing[i]
+		default:
+			out[i] = incoming[i]
+		}
+	}
+	return out
+}
+
+func arrayItemsAreObjects(items []any) bool {
+	for _, item := range items {
+		if _, ok := item.(map[string]any); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func isJSONContainer(value any) bool {
+	switch value.(type) {
+	case map[string]any, []any:
+		return true
+	default:
+		return false
+	}
+}
+
+func isJSONEmpty(value any) bool {
+	switch t := value.(type) {
+	case nil:
+		return true
+	case string:
+		return t == ""
+	case map[string]any:
+		return len(t) == 0
+	case []any:
+		return len(t) == 0
+	default:
+		return false
+	}
 }
 
 // suffixIDFieldFallback resolves an id-less resource that keys on its own
@@ -2079,11 +2398,18 @@ func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage
 			}
 		}
 		if id == "" {
+			id = ResolveStorageID(resourceType, obj)
+		}
+		if id == "" {
 			skippedCount++
 			extractFailures++
 			continue
 		}
 		storageID := resourceStorageID(resourceType, id, obj)
+		item = s.mergeIncomingResourceData(tx, resourceType, storageID, item)
+		if merged, err := DecodeJSONObject(item); err == nil {
+			obj = merged
+		}
 
 		if err := s.upsertGenericResourceTx(tx, resourceType, storageID, item); err != nil {
 			// Return the running stored count rather than zero so callers

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -2006,9 +2006,14 @@ func fingerprintScalar(value any) (any, bool) {
 //   - Object arrays match by the same identity stack as ExtractResourceID
 //     (configured / dotted override, generic id, resource-scoped suffix)
 //     plus item-local suffix keys (currency_code, accountId) and sku.
-//     Display name is not an array identity. Result order and length
-//     follow incoming so a reorder or middle delete cannot join
-//     unrelated objects or keep leftover old entries.
+//     Own-identity suffixes (_code/_slug/_key) win over shared foreign
+//     keys so sibling rows that share account_id still pair on
+//     currency_code. A lone accountId remains identity when it is the
+//     only identity-shaped field. Identity map keys include the field
+//     that produced them so id:"USD" and currency_code:"USD" cannot
+//     share a slot. Display name is not an array identity. Result
+//     order and length follow incoming so a reorder or middle delete
+//     cannot join unrelated objects or keep leftover old entries.
 //   - Arrays without identity keys, and scalar arrays, take incoming
 //     wholesale. Index-wise merge would pair unrelated items.
 //   - Incoming scalars replace existing scalars.
@@ -2134,50 +2139,154 @@ func indexObjectArrayByIdentity(resourceType string, items []any) map[string]map
 func arrayItemIdentity(resourceType string, obj map[string]any) string {
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
 		if s := canonicalIDFromKey(obj, override); s != "" {
-			return s
+			return qualifyArrayItemIdentity(override, s)
 		}
 	}
 	for _, key := range genericIDFieldFallbacks {
 		if s := canonicalIDFromKey(obj, key); s != "" {
-			return s
+			return qualifyArrayItemIdentity(key, s)
 		}
 	}
-	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
-		return s
+	// Item-local own identity wins over the parent resource's suffix.
+	// mergeKeepRicherJSON threads the parent type through nested arrays,
+	// so suffixIDFieldFallback("accounts") would treat a copied
+	// account_id as every child's id and collide sibling rates.
+	if field, s := suffixIdentityFromItemKeys(obj); s != "" {
+		return qualifyArrayItemIdentity(field, s)
 	}
-	if s := suffixIdentityFromItemKeys(obj); s != "" {
-		return s
+	if field, s := suffixIDFieldAndName(resourceType, obj); s != "" {
+		return qualifyArrayItemIdentity(field, s)
 	}
 	if s := canonicalIDFromKey(obj, "sku"); s != "" {
-		return s
+		return qualifyArrayItemIdentity("sku", s)
 	}
 	for _, key := range []string{"slug", "key", "code"} {
 		if s := canonicalIDFromKey(obj, key); s != "" {
-			return s
+			return qualifyArrayItemIdentity(key, s)
 		}
 	}
 	return ""
 }
 
-func suffixIdentityFromItemKeys(obj map[string]any) string {
-	if obj == nil {
+const arrayItemIdentitySep = "\x1f"
+
+func qualifyArrayItemIdentity(field, value string) string {
+	if field == "" || value == "" {
 		return ""
+	}
+	return field + arrayItemIdentitySep + value
+}
+
+func suffixIdentityFromItemKeys(obj map[string]any) (string, string) {
+	if obj == nil {
+		return "", ""
 	}
 	keys := make([]string, 0, len(obj))
 	for key := range obj {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
+	var ownField, own, localField, localID, sharedField, sharedID string
 	for _, key := range keys {
 		stem := identitySuffixStem(key)
 		if stem == "" || stem == "parent" {
 			continue
 		}
-		if s := suffixIDFieldFallback(stem, obj); s != "" {
-			return s
+		s := suffixIDFieldFallback(stem, obj)
+		if s == "" {
+			continue
+		}
+		field := canonicalArrayIdentityField(key)
+		switch itemKeyIdentityKind(key) {
+		case itemIdentOwn:
+			if own == "" {
+				ownField, own = field, s
+			}
+		case itemIdentLocalID:
+			if localID == "" {
+				localField, localID = field, s
+			}
+		case itemIdentSharedID:
+			if sharedID == "" {
+				sharedField, sharedID = field, s
+			}
 		}
 	}
-	return ""
+	if own != "" {
+		return ownField, own
+	}
+	if localID != "" {
+		return localField, localID
+	}
+	return sharedField, sharedID
+}
+
+func canonicalArrayIdentityField(key string) string {
+	k := strings.TrimSpace(key)
+	stem := identitySuffixStem(k)
+	if stem == "" {
+		return k
+	}
+	switch {
+	case strings.HasSuffix(k, "_id") || strings.HasSuffix(k, "Id") || strings.HasSuffix(k, "ID"):
+		return stem + "_id"
+	case strings.HasSuffix(k, "_code") || strings.HasSuffix(k, "Code"):
+		return stem + "_code"
+	case strings.HasSuffix(k, "_key") || strings.HasSuffix(k, "Key"):
+		return stem + "_key"
+	case strings.HasSuffix(k, "_slug") || strings.HasSuffix(k, "Slug"):
+		return stem + "_slug"
+	default:
+		return k
+	}
+}
+
+type itemIdentKind int
+
+const (
+	itemIdentNone itemIdentKind = iota
+	itemIdentOwn
+	itemIdentLocalID
+	itemIdentSharedID
+)
+
+func itemKeyIdentityKind(key string) itemIdentKind {
+	if itemKeyLooksLikeOwnIdentity(key) {
+		return itemIdentOwn
+	}
+	stem := identitySuffixStem(key)
+	if stem == "" {
+		return itemIdentNone
+	}
+	if sharedForeignKeyStem(stem) {
+		return itemIdentSharedID
+	}
+	return itemIdentLocalID
+}
+
+func itemKeyLooksLikeOwnIdentity(key string) bool {
+	k := strings.TrimSpace(key)
+	for _, suffix := range []string{"_code", "_key", "_slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return true
+		}
+	}
+	for _, suffix := range []string{"Code", "Key", "Slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func sharedForeignKeyStem(stem string) bool {
+	switch strings.ToLower(stem) {
+	case "parent", "account", "owner", "org", "organization", "user",
+		"customer", "workspace", "tenant", "team", "company", "member":
+		return true
+	default:
+		return false
+	}
 }
 
 func identitySuffixStem(key string) string {
@@ -2229,20 +2338,27 @@ func isJSONEmpty(value any) bool {
 // promoted to the primary key, and it walks the same key spellings as
 // LookupFieldValue in a fixed suffix order so the chosen id is deterministic.
 func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
+	_, value := suffixIDFieldAndName(resourceType, obj)
+	return value
+}
+
+func suffixIDFieldAndName(resourceType string, obj map[string]any) (string, string) {
 	for _, base := range resourceIDBaseNames(resourceType) {
 		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
-			if s := canonicalScalarIDFromKey(obj, base+suffix); s != "" {
-				return s
+			key := base + suffix
+			if s := canonicalScalarIDFromKey(obj, key); s != "" {
+				return canonicalArrayIdentityField(key), s
 			}
 		}
 		camelBase := lowerCamelResourceIDBase(base)
 		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
-			if s := canonicalScalarIDFromKey(obj, camelBase+suffix); s != "" {
-				return s
+			key := camelBase + suffix
+			if s := canonicalScalarIDFromKey(obj, key); s != "" {
+				return canonicalArrayIdentityField(key), s
 			}
 		}
 	}
-	return ""
+	return "", ""
 }
 
 func canonicalScalarIDFromKey(obj map[string]any, key string) string {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -973,10 +973,9 @@ func isSQLiteBusy(err error) bool {
 		strings.Contains(msg, "database table is locked")
 }
 
-// mergeIncomingResourceData applies the keep-richer policy against any row
-// already cached for this (resourceType, id). First write returns incoming
-// unchanged. Callers must use the result for both the generic resources
-// blob and the typed-table projection so list sync cannot shrink detail.
+// A later list-shaped write must not shrink a richer cached blob. First
+// write is incoming as-is. Callers apply the result to both the generic
+// resources blob and the typed-table projection.
 func (s *Store) mergeIncomingResourceData(tx *sql.Tx, resourceType, id string, incoming json.RawMessage) json.RawMessage {
 	var existing string
 	err := tx.QueryRow(
@@ -1863,10 +1862,9 @@ func (s *Store) UpsertWidgets(data json.RawMessage) error {
 // path-item.
 var resourceIDFieldOverrides = map[string]string{}
 
-// parameterKeyedResources are typed resources whose responses have no
-// identity field. Upsert stores those rows under a parameter fingerprint
-// instead of failing ExtractResourceID. Unlisted resources keep today's
-// extract-failure contract for items with no usable id.
+// Only typed resources with no identity field may be stored under a
+// parameter fingerprint. Unlisted resources still increment extractFailures
+// when an item has no usable id.
 var parameterKeyedResources = map[string]bool{}
 
 // Generic ID fields are split around the resource-specific suffix probe.
@@ -1916,16 +1914,14 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 	return mapKeyIDFallback(obj)
 }
 
-// ResolveStorageID is the writer-side identity. ExtractResourceID wins when
-// the payload has a real resource id. Parameter-shaped / id-less payloads
-// (no identity-candidate keys at all) get a fingerprint of their top-level
-// scalars so Upsert can store a row without inventing a field. Identity
-// probes such as unwrap and sync extractID must keep using ExtractResourceID
-// so a fingerprint is never mistaken for an entity id.
+// Writer identity prefers a real resource id. A parameter-shaped payload
+// with no identity-candidate keys is fingerprinted from top-level scalars
+// so the row can be stored without inventing a field. Unwrap and sync
+// extractID must keep using ExtractResourceID so a fingerprint is never
+// mistaken for an entity id.
 //
-// Objects that carry an identity-shaped key whose value was refused
-// (timestamp, zero, empty) still return "" — fingerprinting those would
-// hide a rejected entity id.
+// An identity-shaped key whose value was refused (timestamp, zero, empty)
+// still returns "" — fingerprinting those would hide a rejected entity id.
 func ResolveStorageID(resourceType string, obj map[string]any) string {
 	if id := ExtractResourceID(resourceType, obj); id != "" {
 		return id
@@ -1984,13 +1980,11 @@ func suffixIdentityKeyPresent(resourceType string, obj map[string]any) bool {
 	return false
 }
 
-// parameterSnapshotID keys an id-less payload by a hash of its top-level
-// scalars — the request-equivalent identity (lat/lon, timezone) — and
-// excludes nested blocks (hourly, current, results) so a later fetch of
-// the same parameters updates the same row. Volatile telemetry keys
-// (*_ms, *_at, timestamp, generationtime*) are omitted from the key.
-// When the object has no stable scalars the whole payload is hashed so
-// the row can still be stored.
+// Id-less rows key on a hash of top-level scalars (lat/lon, timezone)
+// and omit nested blocks so a later fetch of the same parameters updates
+// the same row. Volatile telemetry keys (*_ms, *_at, timestamp,
+// generationtime*) stay out of the key. No stable scalars means the
+// whole payload is hashed so the row can still be stored.
 func parameterSnapshotID(obj map[string]any) string {
 	if len(obj) == 0 {
 		return ""
@@ -2052,9 +2046,8 @@ func fingerprintScalar(value any) (any, bool) {
 	}
 }
 
-// mergeKeepRicherJSON combines a previously cached JSON blob with an
-// incoming write so a thinner list-shaped payload cannot destroy richer
-// detail already stored for the same id.
+// A thinner list-shaped payload cannot destroy richer detail already
+// stored for the same id.
 //
 // Policy (do-not-shrink / keep-richer):
 //   - First write (no existing) stores incoming unchanged.
@@ -2062,11 +2055,14 @@ func fingerprintScalar(value any) (any, bool) {
 //   - Objects merge recursively; incoming keys go through the same policy
 //     rather than wholesale replacement.
 //   - A container (object/array) is never replaced by a scalar or null.
-//   - An incoming empty array does not replace a non-empty existing array.
-//   - Arrays of objects merge element-wise; extra existing elements are
-//     kept when incoming is shorter.
-//   - Arrays of non-objects: the longer array wins; equal length prefers
-//     incoming (authoritative remote refresh of the same collection).
+//   - An incoming empty array does not replace a non-empty existing array
+//     (list omitted the collection vs sent a new one).
+//   - Object arrays match by a stable id key when present, then apply the
+//     same object policy to the pair. Result order and length follow
+//     incoming so a reorder or middle delete cannot join unrelated
+//     objects or keep leftover old entries.
+//   - Arrays without identity keys, and scalar arrays, take incoming
+//     wholesale. Index-wise merge would pair unrelated items.
 //   - Incoming scalars replace existing scalars.
 func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, bool) {
 	if len(existing) == 0 {
@@ -2145,37 +2141,55 @@ func mergeKeepRicherArray(existing, incoming []any) []any {
 	if len(incoming) == 0 && len(existing) > 0 {
 		return existing
 	}
-	if !arrayItemsAreObjects(existing) && !arrayItemsAreObjects(incoming) {
-		if len(incoming) < len(existing) {
-			return existing
-		}
+	existingByID := indexObjectArrayByIdentity(existing)
+	if len(existingByID) == 0 {
 		return incoming
 	}
-	n := len(incoming)
-	if len(existing) > n {
-		n = len(existing)
-	}
-	out := make([]any, n)
-	for i := 0; i < n; i++ {
-		switch {
-		case i < len(existing) && i < len(incoming):
-			out[i] = mergeKeepRicherValue(existing[i], incoming[i])
-		case i < len(existing):
-			out[i] = existing[i]
-		default:
-			out[i] = incoming[i]
+	out := make([]any, len(incoming))
+	for i, item := range incoming {
+		incomingObj, ok := item.(map[string]any)
+		if !ok {
+			out[i] = item
+			continue
 		}
+		id := arrayItemIdentity(incomingObj)
+		existingObj, ok := existingByID[id]
+		if id == "" || !ok {
+			out[i] = item
+			continue
+		}
+		delete(existingByID, id)
+		out[i] = mergeKeepRicherObject(existingObj, incomingObj)
 	}
 	return out
 }
 
-func arrayItemsAreObjects(items []any) bool {
+func indexObjectArrayByIdentity(items []any) map[string]map[string]any {
+	out := make(map[string]map[string]any)
 	for _, item := range items {
-		if _, ok := item.(map[string]any); ok {
-			return true
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		id := arrayItemIdentity(obj)
+		if id == "" {
+			continue
+		}
+		if _, exists := out[id]; exists {
+			continue
+		}
+		out[id] = obj
+	}
+	return out
+}
+
+func arrayItemIdentity(obj map[string]any) string {
+	for _, key := range genericIDFieldFallbacks {
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
-	return false
+	return ""
 }
 
 func isJSONContainer(value any) bool {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -985,7 +985,7 @@ func (s *Store) mergeIncomingResourceData(tx *sql.Tx, resourceType, id string, i
 	if err != nil || existing == "" {
 		return incoming
 	}
-	merged, ok := mergeKeepRicherJSON(json.RawMessage(existing), incoming)
+	merged, ok := mergeKeepRicherJSON(resourceType, json.RawMessage(existing), incoming)
 	if !ok {
 		return incoming
 	}
@@ -2057,14 +2057,16 @@ func fingerprintScalar(value any) (any, bool) {
 //   - A container (object/array) is never replaced by a scalar or null.
 //   - An incoming empty array does not replace a non-empty existing array
 //     (list omitted the collection vs sent a new one).
-//   - Object arrays match by a stable id key when present, then apply the
-//     same object policy to the pair. Result order and length follow
-//     incoming so a reorder or middle delete cannot join unrelated
-//     objects or keep leftover old entries.
+//   - Object arrays match by the same identity stack as ExtractResourceID
+//     (configured / dotted override, generic id, resource-scoped suffix)
+//     plus item-local suffix keys (currency_code, accountId) and sku.
+//     Display name is not an array identity. Result order and length
+//     follow incoming so a reorder or middle delete cannot join
+//     unrelated objects or keep leftover old entries.
 //   - Arrays without identity keys, and scalar arrays, take incoming
 //     wholesale. Index-wise merge would pair unrelated items.
 //   - Incoming scalars replace existing scalars.
-func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, bool) {
+func mergeKeepRicherJSON(resourceType string, existing, incoming json.RawMessage) (json.RawMessage, bool) {
 	if len(existing) == 0 {
 		return incoming, len(incoming) > 0
 	}
@@ -2079,7 +2081,7 @@ func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, b
 	if err != nil {
 		return existing, true
 	}
-	merged, err := json.Marshal(mergeKeepRicherValue(existingVal, incomingVal))
+	merged, err := json.Marshal(mergeKeepRicherValue(resourceType, existingVal, incomingVal))
 	if err != nil {
 		return incoming, len(incoming) > 0
 	}
@@ -2096,7 +2098,7 @@ func decodeJSONValue(data json.RawMessage) (any, error) {
 	return value, nil
 }
 
-func mergeKeepRicherValue(existing, incoming any) any {
+func mergeKeepRicherValue(resourceType string, existing, incoming any) any {
 	if incoming == nil {
 		if existing != nil {
 			return existing
@@ -2106,12 +2108,12 @@ func mergeKeepRicherValue(existing, incoming any) any {
 	existingObj, existingIsObj := existing.(map[string]any)
 	incomingObj, incomingIsObj := incoming.(map[string]any)
 	if existingIsObj && incomingIsObj {
-		return mergeKeepRicherObject(existingObj, incomingObj)
+		return mergeKeepRicherObject(resourceType, existingObj, incomingObj)
 	}
 	existingArr, existingIsArr := existing.([]any)
 	incomingArr, incomingIsArr := incoming.([]any)
 	if existingIsArr && incomingIsArr {
-		return mergeKeepRicherArray(existingArr, incomingArr)
+		return mergeKeepRicherArray(resourceType, existingArr, incomingArr)
 	}
 	if isJSONContainer(existing) && !isJSONContainer(incoming) {
 		return existing
@@ -2122,14 +2124,14 @@ func mergeKeepRicherValue(existing, incoming any) any {
 	return incoming
 }
 
-func mergeKeepRicherObject(existing, incoming map[string]any) map[string]any {
+func mergeKeepRicherObject(resourceType string, existing, incoming map[string]any) map[string]any {
 	out := make(map[string]any, len(existing)+len(incoming))
 	for key, value := range existing {
 		out[key] = value
 	}
 	for key, incomingVal := range incoming {
 		if existingVal, ok := out[key]; ok {
-			out[key] = mergeKeepRicherValue(existingVal, incomingVal)
+			out[key] = mergeKeepRicherValue(resourceType, existingVal, incomingVal)
 			continue
 		}
 		out[key] = incomingVal
@@ -2137,11 +2139,11 @@ func mergeKeepRicherObject(existing, incoming map[string]any) map[string]any {
 	return out
 }
 
-func mergeKeepRicherArray(existing, incoming []any) []any {
+func mergeKeepRicherArray(resourceType string, existing, incoming []any) []any {
 	if len(incoming) == 0 && len(existing) > 0 {
 		return existing
 	}
-	existingByID := indexObjectArrayByIdentity(existing)
+	existingByID := indexObjectArrayByIdentity(resourceType, existing)
 	if len(existingByID) == 0 {
 		return incoming
 	}
@@ -2152,26 +2154,26 @@ func mergeKeepRicherArray(existing, incoming []any) []any {
 			out[i] = item
 			continue
 		}
-		id := arrayItemIdentity(incomingObj)
+		id := arrayItemIdentity(resourceType, incomingObj)
 		existingObj, ok := existingByID[id]
 		if id == "" || !ok {
 			out[i] = item
 			continue
 		}
 		delete(existingByID, id)
-		out[i] = mergeKeepRicherObject(existingObj, incomingObj)
+		out[i] = mergeKeepRicherObject(resourceType, existingObj, incomingObj)
 	}
 	return out
 }
 
-func indexObjectArrayByIdentity(items []any) map[string]map[string]any {
+func indexObjectArrayByIdentity(resourceType string, items []any) map[string]map[string]any {
 	out := make(map[string]map[string]any)
 	for _, item := range items {
 		obj, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
-		id := arrayItemIdentity(obj)
+		id := arrayItemIdentity(resourceType, obj)
 		if id == "" {
 			continue
 		}
@@ -2183,10 +2185,68 @@ func indexObjectArrayByIdentity(items []any) map[string]map[string]any {
 	return out
 }
 
-func arrayItemIdentity(obj map[string]any) string {
+func arrayItemIdentity(resourceType string, obj map[string]any) string {
+	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
+		if s := canonicalIDFromKey(obj, override); s != "" {
+			return s
+		}
+	}
 	for _, key := range genericIDFieldFallbacks {
 		if s := canonicalIDFromKey(obj, key); s != "" {
 			return s
+		}
+	}
+	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
+		return s
+	}
+	if s := suffixIdentityFromItemKeys(obj); s != "" {
+		return s
+	}
+	if s := canonicalIDFromKey(obj, "sku"); s != "" {
+		return s
+	}
+	for _, key := range []string{"slug", "key", "code"} {
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func suffixIdentityFromItemKeys(obj map[string]any) string {
+	if obj == nil {
+		return ""
+	}
+	keys := make([]string, 0, len(obj))
+	for key := range obj {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		stem := identitySuffixStem(key)
+		if stem == "" || stem == "parent" {
+			continue
+		}
+		if s := suffixIDFieldFallback(stem, obj); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func identitySuffixStem(key string) string {
+	k := strings.TrimSpace(key)
+	if k == "" {
+		return ""
+	}
+	for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return strings.TrimSuffix(k, suffix)
+		}
+	}
+	for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return strings.ToLower(k[:len(k)-len(suffix)])
 		}
 	}
 	return ""

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -9,7 +9,9 @@ package store
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
@@ -971,6 +973,26 @@ func isSQLiteBusy(err error) bool {
 		strings.Contains(msg, "database table is locked")
 }
 
+// mergeIncomingResourceData applies the keep-richer policy against any row
+// already cached for this (resourceType, id). First write returns incoming
+// unchanged. Callers must use the result for both the generic resources
+// blob and the typed-table projection so list sync cannot shrink detail.
+func (s *Store) mergeIncomingResourceData(tx *sql.Tx, resourceType, id string, incoming json.RawMessage) json.RawMessage {
+	var existing string
+	err := tx.QueryRow(
+		`SELECT data FROM resources WHERE resource_type = ? AND id = ?`,
+		resourceType, id,
+	).Scan(&existing)
+	if err != nil || existing == "" {
+		return incoming
+	}
+	merged, ok := mergeKeepRicherJSON(json.RawMessage(existing), incoming)
+	if !ok {
+		return incoming
+	}
+	return merged
+}
+
 func (s *Store) upsertGenericResourceTx(tx *sql.Tx, resourceType, id string, data json.RawMessage) error {
 	_, err := tx.Exec(
 		`INSERT INTO resources (id, resource_type, data, synced_at, updated_at)
@@ -1010,7 +1032,7 @@ func (s *Store) Upsert(resourceType, id string, data json.RawMessage) error {
 	}
 	defer tx.Rollback()
 
-	if err := s.upsertGenericResourceTx(tx, resourceType, id, data); err != nil {
+	if err := s.upsertGenericResourceTx(tx, resourceType, id, s.mergeIncomingResourceData(tx, resourceType, id, data)); err != nil {
 		return err
 	}
 
@@ -1744,7 +1766,7 @@ func (s *Store) UpsertGadgets(data json.RawMessage) error {
 		return fmt.Errorf("unmarshaling gadgets: %w", err)
 	}
 
-	id := ExtractResourceID("gadgets", obj)
+	id := ResolveStorageID("gadgets", obj)
 	if id == "" {
 		return fmt.Errorf("missing id for gadgets")
 	}
@@ -1757,6 +1779,11 @@ func (s *Store) UpsertGadgets(data json.RawMessage) error {
 		return err
 	}
 	defer tx.Rollback()
+
+	data = s.mergeIncomingResourceData(tx, "gadgets", storageID, data)
+	if merged, err := DecodeJSONObject(data); err == nil {
+		obj = merged
+	}
 
 	if err := s.upsertGenericResourceTx(tx, "gadgets", storageID, data); err != nil {
 		return err
@@ -1796,7 +1823,7 @@ func (s *Store) UpsertWidgets(data json.RawMessage) error {
 		return fmt.Errorf("unmarshaling widgets: %w", err)
 	}
 
-	id := ExtractResourceID("widgets", obj)
+	id := ResolveStorageID("widgets", obj)
 	if id == "" {
 		return fmt.Errorf("missing id for widgets")
 	}
@@ -1809,6 +1836,11 @@ func (s *Store) UpsertWidgets(data json.RawMessage) error {
 		return err
 	}
 	defer tx.Rollback()
+
+	data = s.mergeIncomingResourceData(tx, "widgets", storageID, data)
+	if merged, err := DecodeJSONObject(data); err == nil {
+		obj = merged
+	}
 
 	if err := s.upsertGenericResourceTx(tx, "widgets", storageID, data); err != nil {
 		return err
@@ -1830,6 +1862,12 @@ func (s *Store) UpsertWidgets(data json.RawMessage) error {
 // child path-item annotated with x-resource-id resolves the same as a flat
 // path-item.
 var resourceIDFieldOverrides = map[string]string{}
+
+// parameterKeyedResources are typed resources whose responses have no
+// identity field. Upsert stores those rows under a parameter fingerprint
+// instead of failing ExtractResourceID. Unlisted resources keep today's
+// extract-failure contract for items with no usable id.
+var parameterKeyedResources = map[string]bool{}
 
 // Generic ID fields are split around the resource-specific suffix probe.
 // Stable vendor identifiers win first; then fields derived from the resource
@@ -1876,6 +1914,292 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 		}
 	}
 	return mapKeyIDFallback(obj)
+}
+
+// ResolveStorageID is the writer-side identity. ExtractResourceID wins when
+// the payload has a real resource id. Parameter-shaped / id-less payloads
+// (no identity-candidate keys at all) get a fingerprint of their top-level
+// scalars so Upsert can store a row without inventing a field. Identity
+// probes such as unwrap and sync extractID must keep using ExtractResourceID
+// so a fingerprint is never mistaken for an entity id.
+//
+// Objects that carry an identity-shaped key whose value was refused
+// (timestamp, zero, empty) still return "" — fingerprinting those would
+// hide a rejected entity id.
+func ResolveStorageID(resourceType string, obj map[string]any) string {
+	if id := ExtractResourceID(resourceType, obj); id != "" {
+		return id
+	}
+	if !parameterKeyedResources[resourceType] {
+		return ""
+	}
+	if identityKeyPresent(resourceType, obj) {
+		return ""
+	}
+	return parameterSnapshotID(obj)
+}
+
+func identityKeyPresent(resourceType string, obj map[string]any) bool {
+	if obj == nil {
+		return false
+	}
+	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
+		if _, found := lookupRawFieldValue(obj, override); found {
+			return true
+		}
+	}
+	for _, key := range genericIDFieldFallbacks {
+		if _, found := lookupRawFieldValue(obj, key); found {
+			return true
+		}
+	}
+	if suffixIdentityKeyPresent(resourceType, obj) {
+		return true
+	}
+	for _, key := range genericDescriptiveIDFieldFallbacks {
+		if _, found := lookupRawFieldValue(obj, key); found {
+			return true
+		}
+	}
+	if _, found := obj[MapKeyIDField]; found {
+		return true
+	}
+	return false
+}
+
+func suffixIdentityKeyPresent(resourceType string, obj map[string]any) bool {
+	for _, base := range resourceIDBaseNames(resourceType) {
+		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+			if _, found := lookupRawFieldValue(obj, base+suffix); found {
+				return true
+			}
+		}
+		camelBase := lowerCamelResourceIDBase(base)
+		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+			if _, found := lookupRawFieldValue(obj, camelBase+suffix); found {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// parameterSnapshotID keys an id-less payload by a hash of its top-level
+// scalars — the request-equivalent identity (lat/lon, timezone) — and
+// excludes nested blocks (hourly, current, results) so a later fetch of
+// the same parameters updates the same row. Volatile telemetry keys
+// (*_ms, *_at, timestamp, generationtime*) are omitted from the key.
+// When the object has no stable scalars the whole payload is hashed so
+// the row can still be stored.
+func parameterSnapshotID(obj map[string]any) string {
+	if len(obj) == 0 {
+		return ""
+	}
+	fields := parameterFingerprintFields(obj)
+	var payload any
+	if len(fields) > 0 {
+		payload = fields
+	} else {
+		payload = obj
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil || len(raw) == 0 || string(raw) == "null" || string(raw) == "{}" {
+		return ""
+	}
+	sum := sha256.Sum256(raw)
+	return "pp:params:" + hex.EncodeToString(sum[:16])
+}
+
+func parameterFingerprintFields(obj map[string]any) map[string]any {
+	out := make(map[string]any, len(obj))
+	for key, value := range obj {
+		if isVolatileParameterKey(key) {
+			continue
+		}
+		if scalar, ok := fingerprintScalar(value); ok {
+			out[key] = scalar
+		}
+	}
+	return out
+}
+
+func isVolatileParameterKey(key string) bool {
+	k := strings.ToLower(strings.TrimSpace(key))
+	switch {
+	case strings.HasSuffix(k, "_ms"), strings.HasSuffix(k, "_at"):
+		return true
+	case k == "timestamp", k == "generated", k == "generation_time", k == "generationtime":
+		return true
+	default:
+		return strings.HasPrefix(k, "generationtime")
+	}
+}
+
+func fingerprintScalar(value any) (any, bool) {
+	switch t := value.(type) {
+	case nil:
+		return nil, false
+	case string:
+		return t, t != ""
+	case bool:
+		return t, true
+	case json.Number:
+		return t, t.String() != ""
+	case float64, float32, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return t, true
+	default:
+		return nil, false
+	}
+}
+
+// mergeKeepRicherJSON combines a previously cached JSON blob with an
+// incoming write so a thinner list-shaped payload cannot destroy richer
+// detail already stored for the same id.
+//
+// Policy (do-not-shrink / keep-richer):
+//   - First write (no existing) stores incoming unchanged.
+//   - Object keys present only on existing are kept.
+//   - Objects merge recursively; incoming keys go through the same policy
+//     rather than wholesale replacement.
+//   - A container (object/array) is never replaced by a scalar or null.
+//   - An incoming empty array does not replace a non-empty existing array.
+//   - Arrays of objects merge element-wise; extra existing elements are
+//     kept when incoming is shorter.
+//   - Arrays of non-objects: the longer array wins; equal length prefers
+//     incoming (authoritative remote refresh of the same collection).
+//   - Incoming scalars replace existing scalars.
+func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, bool) {
+	if len(existing) == 0 {
+		return incoming, len(incoming) > 0
+	}
+	if len(incoming) == 0 {
+		return existing, true
+	}
+	existingVal, err := decodeJSONValue(existing)
+	if err != nil {
+		return incoming, len(incoming) > 0
+	}
+	incomingVal, err := decodeJSONValue(incoming)
+	if err != nil {
+		return existing, true
+	}
+	merged, err := json.Marshal(mergeKeepRicherValue(existingVal, incomingVal))
+	if err != nil {
+		return incoming, len(incoming) > 0
+	}
+	return merged, true
+}
+
+func decodeJSONValue(data json.RawMessage) (any, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	var value any
+	if err := dec.Decode(&value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func mergeKeepRicherValue(existing, incoming any) any {
+	if incoming == nil {
+		if existing != nil {
+			return existing
+		}
+		return incoming
+	}
+	existingObj, existingIsObj := existing.(map[string]any)
+	incomingObj, incomingIsObj := incoming.(map[string]any)
+	if existingIsObj && incomingIsObj {
+		return mergeKeepRicherObject(existingObj, incomingObj)
+	}
+	existingArr, existingIsArr := existing.([]any)
+	incomingArr, incomingIsArr := incoming.([]any)
+	if existingIsArr && incomingIsArr {
+		return mergeKeepRicherArray(existingArr, incomingArr)
+	}
+	if isJSONContainer(existing) && !isJSONContainer(incoming) {
+		return existing
+	}
+	if isJSONEmpty(incoming) && !isJSONEmpty(existing) {
+		return existing
+	}
+	return incoming
+}
+
+func mergeKeepRicherObject(existing, incoming map[string]any) map[string]any {
+	out := make(map[string]any, len(existing)+len(incoming))
+	for key, value := range existing {
+		out[key] = value
+	}
+	for key, incomingVal := range incoming {
+		if existingVal, ok := out[key]; ok {
+			out[key] = mergeKeepRicherValue(existingVal, incomingVal)
+			continue
+		}
+		out[key] = incomingVal
+	}
+	return out
+}
+
+func mergeKeepRicherArray(existing, incoming []any) []any {
+	if len(incoming) == 0 && len(existing) > 0 {
+		return existing
+	}
+	if !arrayItemsAreObjects(existing) && !arrayItemsAreObjects(incoming) {
+		if len(incoming) < len(existing) {
+			return existing
+		}
+		return incoming
+	}
+	n := len(incoming)
+	if len(existing) > n {
+		n = len(existing)
+	}
+	out := make([]any, n)
+	for i := 0; i < n; i++ {
+		switch {
+		case i < len(existing) && i < len(incoming):
+			out[i] = mergeKeepRicherValue(existing[i], incoming[i])
+		case i < len(existing):
+			out[i] = existing[i]
+		default:
+			out[i] = incoming[i]
+		}
+	}
+	return out
+}
+
+func arrayItemsAreObjects(items []any) bool {
+	for _, item := range items {
+		if _, ok := item.(map[string]any); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func isJSONContainer(value any) bool {
+	switch value.(type) {
+	case map[string]any, []any:
+		return true
+	default:
+		return false
+	}
+}
+
+func isJSONEmpty(value any) bool {
+	switch t := value.(type) {
+	case nil:
+		return true
+	case string:
+		return t == ""
+	case map[string]any:
+		return len(t) == 0
+	case []any:
+		return len(t) == 0
+	default:
+		return false
+	}
 }
 
 // suffixIDFieldFallback resolves an id-less resource that keys on its own
@@ -2126,11 +2450,18 @@ func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage
 			}
 		}
 		if id == "" {
+			id = ResolveStorageID(resourceType, obj)
+		}
+		if id == "" {
 			skippedCount++
 			extractFailures++
 			continue
 		}
 		storageID := resourceStorageID(resourceType, id, obj)
+		item = s.mergeIncomingResourceData(tx, resourceType, storageID, item)
+		if merged, err := DecodeJSONObject(item); err == nil {
+			obj = merged
+		}
 
 		if err := s.upsertGenericResourceTx(tx, resourceType, storageID, item); err != nil {
 			// Return the running stored count rather than zero so callers

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -2198,7 +2198,7 @@ func arrayItemIdentity(resourceType string, obj map[string]any) string {
 	}
 	for _, key := range genericIDFieldFallbacks {
 		if s := canonicalIDFromKey(obj, key); s != "" {
-			return qualifyArrayItemIdentity(key, s)
+			return qualifyArrayItemIdentity(canonicalGenericIDField(key), s)
 		}
 	}
 	// Item-local own identity wins over the parent resource's suffix.
@@ -2229,6 +2229,17 @@ func qualifyArrayItemIdentity(field, value string) string {
 		return ""
 	}
 	return field + arrayItemIdentitySep + value
+}
+
+// lookupRawFieldValue("id") finds Id/id_ via fieldKeySpellings but not
+// _id or ID, so those probes would otherwise mint distinct map keys.
+func canonicalGenericIDField(probe string) string {
+	switch strings.TrimSpace(probe) {
+	case "id", "ID", "_id", "id_", "Id":
+		return "id"
+	default:
+		return probe
+	}
 }
 
 func suffixIdentityFromItemKeys(obj map[string]any) (string, string) {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -2060,9 +2060,14 @@ func fingerprintScalar(value any) (any, bool) {
 //   - Object arrays match by the same identity stack as ExtractResourceID
 //     (configured / dotted override, generic id, resource-scoped suffix)
 //     plus item-local suffix keys (currency_code, accountId) and sku.
-//     Display name is not an array identity. Result order and length
-//     follow incoming so a reorder or middle delete cannot join
-//     unrelated objects or keep leftover old entries.
+//     Own-identity suffixes (_code/_slug/_key) win over shared foreign
+//     keys so sibling rows that share account_id still pair on
+//     currency_code. A lone accountId remains identity when it is the
+//     only identity-shaped field. Identity map keys include the field
+//     that produced them so id:"USD" and currency_code:"USD" cannot
+//     share a slot. Display name is not an array identity. Result
+//     order and length follow incoming so a reorder or middle delete
+//     cannot join unrelated objects or keep leftover old entries.
 //   - Arrays without identity keys, and scalar arrays, take incoming
 //     wholesale. Index-wise merge would pair unrelated items.
 //   - Incoming scalars replace existing scalars.
@@ -2188,50 +2193,154 @@ func indexObjectArrayByIdentity(resourceType string, items []any) map[string]map
 func arrayItemIdentity(resourceType string, obj map[string]any) string {
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
 		if s := canonicalIDFromKey(obj, override); s != "" {
-			return s
+			return qualifyArrayItemIdentity(override, s)
 		}
 	}
 	for _, key := range genericIDFieldFallbacks {
 		if s := canonicalIDFromKey(obj, key); s != "" {
-			return s
+			return qualifyArrayItemIdentity(key, s)
 		}
 	}
-	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
-		return s
+	// Item-local own identity wins over the parent resource's suffix.
+	// mergeKeepRicherJSON threads the parent type through nested arrays,
+	// so suffixIDFieldFallback("accounts") would treat a copied
+	// account_id as every child's id and collide sibling rates.
+	if field, s := suffixIdentityFromItemKeys(obj); s != "" {
+		return qualifyArrayItemIdentity(field, s)
 	}
-	if s := suffixIdentityFromItemKeys(obj); s != "" {
-		return s
+	if field, s := suffixIDFieldAndName(resourceType, obj); s != "" {
+		return qualifyArrayItemIdentity(field, s)
 	}
 	if s := canonicalIDFromKey(obj, "sku"); s != "" {
-		return s
+		return qualifyArrayItemIdentity("sku", s)
 	}
 	for _, key := range []string{"slug", "key", "code"} {
 		if s := canonicalIDFromKey(obj, key); s != "" {
-			return s
+			return qualifyArrayItemIdentity(key, s)
 		}
 	}
 	return ""
 }
 
-func suffixIdentityFromItemKeys(obj map[string]any) string {
-	if obj == nil {
+const arrayItemIdentitySep = "\x1f"
+
+func qualifyArrayItemIdentity(field, value string) string {
+	if field == "" || value == "" {
 		return ""
+	}
+	return field + arrayItemIdentitySep + value
+}
+
+func suffixIdentityFromItemKeys(obj map[string]any) (string, string) {
+	if obj == nil {
+		return "", ""
 	}
 	keys := make([]string, 0, len(obj))
 	for key := range obj {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
+	var ownField, own, localField, localID, sharedField, sharedID string
 	for _, key := range keys {
 		stem := identitySuffixStem(key)
 		if stem == "" || stem == "parent" {
 			continue
 		}
-		if s := suffixIDFieldFallback(stem, obj); s != "" {
-			return s
+		s := suffixIDFieldFallback(stem, obj)
+		if s == "" {
+			continue
+		}
+		field := canonicalArrayIdentityField(key)
+		switch itemKeyIdentityKind(key) {
+		case itemIdentOwn:
+			if own == "" {
+				ownField, own = field, s
+			}
+		case itemIdentLocalID:
+			if localID == "" {
+				localField, localID = field, s
+			}
+		case itemIdentSharedID:
+			if sharedID == "" {
+				sharedField, sharedID = field, s
+			}
 		}
 	}
-	return ""
+	if own != "" {
+		return ownField, own
+	}
+	if localID != "" {
+		return localField, localID
+	}
+	return sharedField, sharedID
+}
+
+func canonicalArrayIdentityField(key string) string {
+	k := strings.TrimSpace(key)
+	stem := identitySuffixStem(k)
+	if stem == "" {
+		return k
+	}
+	switch {
+	case strings.HasSuffix(k, "_id") || strings.HasSuffix(k, "Id") || strings.HasSuffix(k, "ID"):
+		return stem + "_id"
+	case strings.HasSuffix(k, "_code") || strings.HasSuffix(k, "Code"):
+		return stem + "_code"
+	case strings.HasSuffix(k, "_key") || strings.HasSuffix(k, "Key"):
+		return stem + "_key"
+	case strings.HasSuffix(k, "_slug") || strings.HasSuffix(k, "Slug"):
+		return stem + "_slug"
+	default:
+		return k
+	}
+}
+
+type itemIdentKind int
+
+const (
+	itemIdentNone itemIdentKind = iota
+	itemIdentOwn
+	itemIdentLocalID
+	itemIdentSharedID
+)
+
+func itemKeyIdentityKind(key string) itemIdentKind {
+	if itemKeyLooksLikeOwnIdentity(key) {
+		return itemIdentOwn
+	}
+	stem := identitySuffixStem(key)
+	if stem == "" {
+		return itemIdentNone
+	}
+	if sharedForeignKeyStem(stem) {
+		return itemIdentSharedID
+	}
+	return itemIdentLocalID
+}
+
+func itemKeyLooksLikeOwnIdentity(key string) bool {
+	k := strings.TrimSpace(key)
+	for _, suffix := range []string{"_code", "_key", "_slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return true
+		}
+	}
+	for _, suffix := range []string{"Code", "Key", "Slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func sharedForeignKeyStem(stem string) bool {
+	switch strings.ToLower(stem) {
+	case "parent", "account", "owner", "org", "organization", "user",
+		"customer", "workspace", "tenant", "team", "company", "member":
+		return true
+	default:
+		return false
+	}
 }
 
 func identitySuffixStem(key string) string {
@@ -2283,20 +2392,27 @@ func isJSONEmpty(value any) bool {
 // promoted to the primary key, and it walks the same key spellings as
 // LookupFieldValue in a fixed suffix order so the chosen id is deterministic.
 func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
+	_, value := suffixIDFieldAndName(resourceType, obj)
+	return value
+}
+
+func suffixIDFieldAndName(resourceType string, obj map[string]any) (string, string) {
 	for _, base := range resourceIDBaseNames(resourceType) {
 		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
-			if s := canonicalScalarIDFromKey(obj, base+suffix); s != "" {
-				return s
+			key := base + suffix
+			if s := canonicalScalarIDFromKey(obj, key); s != "" {
+				return canonicalArrayIdentityField(key), s
 			}
 		}
 		camelBase := lowerCamelResourceIDBase(base)
 		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
-			if s := canonicalScalarIDFromKey(obj, camelBase+suffix); s != "" {
-				return s
+			key := camelBase + suffix
+			if s := canonicalScalarIDFromKey(obj, key); s != "" {
+				return canonicalArrayIdentityField(key), s
 			}
 		}
 	}
-	return ""
+	return "", ""
 }
 
 func canonicalScalarIDFromKey(obj map[string]any, key string) string {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -981,10 +981,9 @@ func isSQLiteBusy(err error) bool {
 		strings.Contains(msg, "database table is locked")
 }
 
-// mergeIncomingResourceData applies the keep-richer policy against any row
-// already cached for this (resourceType, id). First write returns incoming
-// unchanged. Callers must use the result for both the generic resources
-// blob and the typed-table projection so list sync cannot shrink detail.
+// A later list-shaped write must not shrink a richer cached blob. First
+// write is incoming as-is. Callers apply the result to both the generic
+// resources blob and the typed-table projection.
 func (s *Store) mergeIncomingResourceData(tx *sql.Tx, resourceType, id string, incoming json.RawMessage) json.RawMessage {
 	var existing string
 	err := tx.QueryRow(
@@ -1873,10 +1872,9 @@ var resourceIDFieldOverrides = map[string]string{
 	"games": "game_key",
 }
 
-// parameterKeyedResources are typed resources whose responses have no
-// identity field. Upsert stores those rows under a parameter fingerprint
-// instead of failing ExtractResourceID. Unlisted resources keep today's
-// extract-failure contract for items with no usable id.
+// Only typed resources with no identity field may be stored under a
+// parameter fingerprint. Unlisted resources still increment extractFailures
+// when an item has no usable id.
 var parameterKeyedResources = map[string]bool{}
 
 // Generic ID fields are split around the resource-specific suffix probe.
@@ -1932,16 +1930,14 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 	return mapKeyIDFallback(obj)
 }
 
-// ResolveStorageID is the writer-side identity. ExtractResourceID wins when
-// the payload has a real resource id. Parameter-shaped / id-less payloads
-// (no identity-candidate keys at all) get a fingerprint of their top-level
-// scalars so Upsert can store a row without inventing a field. Identity
-// probes such as unwrap and sync extractID must keep using ExtractResourceID
-// so a fingerprint is never mistaken for an entity id.
+// Writer identity prefers a real resource id. A parameter-shaped payload
+// with no identity-candidate keys is fingerprinted from top-level scalars
+// so the row can be stored without inventing a field. Unwrap and sync
+// extractID must keep using ExtractResourceID so a fingerprint is never
+// mistaken for an entity id.
 //
-// Objects that carry an identity-shaped key whose value was refused
-// (timestamp, zero, empty) still return "" — fingerprinting those would
-// hide a rejected entity id.
+// An identity-shaped key whose value was refused (timestamp, zero, empty)
+// still returns "" — fingerprinting those would hide a rejected entity id.
 func ResolveStorageID(resourceType string, obj map[string]any) string {
 	if id := ExtractResourceID(resourceType, obj); id != "" {
 		return id
@@ -2000,13 +1996,11 @@ func suffixIdentityKeyPresent(resourceType string, obj map[string]any) bool {
 	return false
 }
 
-// parameterSnapshotID keys an id-less payload by a hash of its top-level
-// scalars — the request-equivalent identity (lat/lon, timezone) — and
-// excludes nested blocks (hourly, current, results) so a later fetch of
-// the same parameters updates the same row. Volatile telemetry keys
-// (*_ms, *_at, timestamp, generationtime*) are omitted from the key.
-// When the object has no stable scalars the whole payload is hashed so
-// the row can still be stored.
+// Id-less rows key on a hash of top-level scalars (lat/lon, timezone)
+// and omit nested blocks so a later fetch of the same parameters updates
+// the same row. Volatile telemetry keys (*_ms, *_at, timestamp,
+// generationtime*) stay out of the key. No stable scalars means the
+// whole payload is hashed so the row can still be stored.
 func parameterSnapshotID(obj map[string]any) string {
 	if len(obj) == 0 {
 		return ""
@@ -2068,9 +2062,8 @@ func fingerprintScalar(value any) (any, bool) {
 	}
 }
 
-// mergeKeepRicherJSON combines a previously cached JSON blob with an
-// incoming write so a thinner list-shaped payload cannot destroy richer
-// detail already stored for the same id.
+// A thinner list-shaped payload cannot destroy richer detail already
+// stored for the same id.
 //
 // Policy (do-not-shrink / keep-richer):
 //   - First write (no existing) stores incoming unchanged.
@@ -2078,11 +2071,14 @@ func fingerprintScalar(value any) (any, bool) {
 //   - Objects merge recursively; incoming keys go through the same policy
 //     rather than wholesale replacement.
 //   - A container (object/array) is never replaced by a scalar or null.
-//   - An incoming empty array does not replace a non-empty existing array.
-//   - Arrays of objects merge element-wise; extra existing elements are
-//     kept when incoming is shorter.
-//   - Arrays of non-objects: the longer array wins; equal length prefers
-//     incoming (authoritative remote refresh of the same collection).
+//   - An incoming empty array does not replace a non-empty existing array
+//     (list omitted the collection vs sent a new one).
+//   - Object arrays match by a stable id key when present, then apply the
+//     same object policy to the pair. Result order and length follow
+//     incoming so a reorder or middle delete cannot join unrelated
+//     objects or keep leftover old entries.
+//   - Arrays without identity keys, and scalar arrays, take incoming
+//     wholesale. Index-wise merge would pair unrelated items.
 //   - Incoming scalars replace existing scalars.
 func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, bool) {
 	if len(existing) == 0 {
@@ -2161,37 +2157,55 @@ func mergeKeepRicherArray(existing, incoming []any) []any {
 	if len(incoming) == 0 && len(existing) > 0 {
 		return existing
 	}
-	if !arrayItemsAreObjects(existing) && !arrayItemsAreObjects(incoming) {
-		if len(incoming) < len(existing) {
-			return existing
-		}
+	existingByID := indexObjectArrayByIdentity(existing)
+	if len(existingByID) == 0 {
 		return incoming
 	}
-	n := len(incoming)
-	if len(existing) > n {
-		n = len(existing)
-	}
-	out := make([]any, n)
-	for i := 0; i < n; i++ {
-		switch {
-		case i < len(existing) && i < len(incoming):
-			out[i] = mergeKeepRicherValue(existing[i], incoming[i])
-		case i < len(existing):
-			out[i] = existing[i]
-		default:
-			out[i] = incoming[i]
+	out := make([]any, len(incoming))
+	for i, item := range incoming {
+		incomingObj, ok := item.(map[string]any)
+		if !ok {
+			out[i] = item
+			continue
 		}
+		id := arrayItemIdentity(incomingObj)
+		existingObj, ok := existingByID[id]
+		if id == "" || !ok {
+			out[i] = item
+			continue
+		}
+		delete(existingByID, id)
+		out[i] = mergeKeepRicherObject(existingObj, incomingObj)
 	}
 	return out
 }
 
-func arrayItemsAreObjects(items []any) bool {
+func indexObjectArrayByIdentity(items []any) map[string]map[string]any {
+	out := make(map[string]map[string]any)
 	for _, item := range items {
-		if _, ok := item.(map[string]any); ok {
-			return true
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		id := arrayItemIdentity(obj)
+		if id == "" {
+			continue
+		}
+		if _, exists := out[id]; exists {
+			continue
+		}
+		out[id] = obj
+	}
+	return out
+}
+
+func arrayItemIdentity(obj map[string]any) string {
+	for _, key := range genericIDFieldFallbacks {
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
 		}
 	}
-	return false
+	return ""
 }
 
 func isJSONContainer(value any) bool {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -2076,9 +2076,14 @@ func fingerprintScalar(value any) (any, bool) {
 //   - Object arrays match by the same identity stack as ExtractResourceID
 //     (configured / dotted override, generic id, resource-scoped suffix)
 //     plus item-local suffix keys (currency_code, accountId) and sku.
-//     Display name is not an array identity. Result order and length
-//     follow incoming so a reorder or middle delete cannot join
-//     unrelated objects or keep leftover old entries.
+//     Own-identity suffixes (_code/_slug/_key) win over shared foreign
+//     keys so sibling rows that share account_id still pair on
+//     currency_code. A lone accountId remains identity when it is the
+//     only identity-shaped field. Identity map keys include the field
+//     that produced them so id:"USD" and currency_code:"USD" cannot
+//     share a slot. Display name is not an array identity. Result
+//     order and length follow incoming so a reorder or middle delete
+//     cannot join unrelated objects or keep leftover old entries.
 //   - Arrays without identity keys, and scalar arrays, take incoming
 //     wholesale. Index-wise merge would pair unrelated items.
 //   - Incoming scalars replace existing scalars.
@@ -2204,50 +2209,154 @@ func indexObjectArrayByIdentity(resourceType string, items []any) map[string]map
 func arrayItemIdentity(resourceType string, obj map[string]any) string {
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
 		if s := canonicalIDFromKey(obj, override); s != "" {
-			return s
+			return qualifyArrayItemIdentity(override, s)
 		}
 	}
 	for _, key := range genericIDFieldFallbacks {
 		if s := canonicalIDFromKey(obj, key); s != "" {
-			return s
+			return qualifyArrayItemIdentity(key, s)
 		}
 	}
-	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
-		return s
+	// Item-local own identity wins over the parent resource's suffix.
+	// mergeKeepRicherJSON threads the parent type through nested arrays,
+	// so suffixIDFieldFallback("accounts") would treat a copied
+	// account_id as every child's id and collide sibling rates.
+	if field, s := suffixIdentityFromItemKeys(obj); s != "" {
+		return qualifyArrayItemIdentity(field, s)
 	}
-	if s := suffixIdentityFromItemKeys(obj); s != "" {
-		return s
+	if field, s := suffixIDFieldAndName(resourceType, obj); s != "" {
+		return qualifyArrayItemIdentity(field, s)
 	}
 	if s := canonicalIDFromKey(obj, "sku"); s != "" {
-		return s
+		return qualifyArrayItemIdentity("sku", s)
 	}
 	for _, key := range []string{"slug", "key", "code"} {
 		if s := canonicalIDFromKey(obj, key); s != "" {
-			return s
+			return qualifyArrayItemIdentity(key, s)
 		}
 	}
 	return ""
 }
 
-func suffixIdentityFromItemKeys(obj map[string]any) string {
-	if obj == nil {
+const arrayItemIdentitySep = "\x1f"
+
+func qualifyArrayItemIdentity(field, value string) string {
+	if field == "" || value == "" {
 		return ""
+	}
+	return field + arrayItemIdentitySep + value
+}
+
+func suffixIdentityFromItemKeys(obj map[string]any) (string, string) {
+	if obj == nil {
+		return "", ""
 	}
 	keys := make([]string, 0, len(obj))
 	for key := range obj {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
+	var ownField, own, localField, localID, sharedField, sharedID string
 	for _, key := range keys {
 		stem := identitySuffixStem(key)
 		if stem == "" || stem == "parent" {
 			continue
 		}
-		if s := suffixIDFieldFallback(stem, obj); s != "" {
-			return s
+		s := suffixIDFieldFallback(stem, obj)
+		if s == "" {
+			continue
+		}
+		field := canonicalArrayIdentityField(key)
+		switch itemKeyIdentityKind(key) {
+		case itemIdentOwn:
+			if own == "" {
+				ownField, own = field, s
+			}
+		case itemIdentLocalID:
+			if localID == "" {
+				localField, localID = field, s
+			}
+		case itemIdentSharedID:
+			if sharedID == "" {
+				sharedField, sharedID = field, s
+			}
 		}
 	}
-	return ""
+	if own != "" {
+		return ownField, own
+	}
+	if localID != "" {
+		return localField, localID
+	}
+	return sharedField, sharedID
+}
+
+func canonicalArrayIdentityField(key string) string {
+	k := strings.TrimSpace(key)
+	stem := identitySuffixStem(k)
+	if stem == "" {
+		return k
+	}
+	switch {
+	case strings.HasSuffix(k, "_id") || strings.HasSuffix(k, "Id") || strings.HasSuffix(k, "ID"):
+		return stem + "_id"
+	case strings.HasSuffix(k, "_code") || strings.HasSuffix(k, "Code"):
+		return stem + "_code"
+	case strings.HasSuffix(k, "_key") || strings.HasSuffix(k, "Key"):
+		return stem + "_key"
+	case strings.HasSuffix(k, "_slug") || strings.HasSuffix(k, "Slug"):
+		return stem + "_slug"
+	default:
+		return k
+	}
+}
+
+type itemIdentKind int
+
+const (
+	itemIdentNone itemIdentKind = iota
+	itemIdentOwn
+	itemIdentLocalID
+	itemIdentSharedID
+)
+
+func itemKeyIdentityKind(key string) itemIdentKind {
+	if itemKeyLooksLikeOwnIdentity(key) {
+		return itemIdentOwn
+	}
+	stem := identitySuffixStem(key)
+	if stem == "" {
+		return itemIdentNone
+	}
+	if sharedForeignKeyStem(stem) {
+		return itemIdentSharedID
+	}
+	return itemIdentLocalID
+}
+
+func itemKeyLooksLikeOwnIdentity(key string) bool {
+	k := strings.TrimSpace(key)
+	for _, suffix := range []string{"_code", "_key", "_slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return true
+		}
+	}
+	for _, suffix := range []string{"Code", "Key", "Slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func sharedForeignKeyStem(stem string) bool {
+	switch strings.ToLower(stem) {
+	case "parent", "account", "owner", "org", "organization", "user",
+		"customer", "workspace", "tenant", "team", "company", "member":
+		return true
+	default:
+		return false
+	}
 }
 
 func identitySuffixStem(key string) string {
@@ -2299,20 +2408,27 @@ func isJSONEmpty(value any) bool {
 // promoted to the primary key, and it walks the same key spellings as
 // LookupFieldValue in a fixed suffix order so the chosen id is deterministic.
 func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
+	_, value := suffixIDFieldAndName(resourceType, obj)
+	return value
+}
+
+func suffixIDFieldAndName(resourceType string, obj map[string]any) (string, string) {
 	for _, base := range resourceIDBaseNames(resourceType) {
 		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
-			if s := canonicalScalarIDFromKey(obj, base+suffix); s != "" {
-				return s
+			key := base + suffix
+			if s := canonicalScalarIDFromKey(obj, key); s != "" {
+				return canonicalArrayIdentityField(key), s
 			}
 		}
 		camelBase := lowerCamelResourceIDBase(base)
 		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
-			if s := canonicalScalarIDFromKey(obj, camelBase+suffix); s != "" {
-				return s
+			key := camelBase + suffix
+			if s := canonicalScalarIDFromKey(obj, key); s != "" {
+				return canonicalArrayIdentityField(key), s
 			}
 		}
 	}
-	return ""
+	return "", ""
 }
 
 func canonicalScalarIDFromKey(obj map[string]any, key string) string {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -2214,7 +2214,7 @@ func arrayItemIdentity(resourceType string, obj map[string]any) string {
 	}
 	for _, key := range genericIDFieldFallbacks {
 		if s := canonicalIDFromKey(obj, key); s != "" {
-			return qualifyArrayItemIdentity(key, s)
+			return qualifyArrayItemIdentity(canonicalGenericIDField(key), s)
 		}
 	}
 	// Item-local own identity wins over the parent resource's suffix.
@@ -2245,6 +2245,17 @@ func qualifyArrayItemIdentity(field, value string) string {
 		return ""
 	}
 	return field + arrayItemIdentitySep + value
+}
+
+// lookupRawFieldValue("id") finds Id/id_ via fieldKeySpellings but not
+// _id or ID, so those probes would otherwise mint distinct map keys.
+func canonicalGenericIDField(probe string) string {
+	switch strings.TrimSpace(probe) {
+	case "id", "ID", "_id", "id_", "Id":
+		return "id"
+	default:
+		return probe
+	}
 }
 
 func suffixIdentityFromItemKeys(obj map[string]any) (string, string) {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -9,7 +9,9 @@ package store
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
@@ -979,6 +981,26 @@ func isSQLiteBusy(err error) bool {
 		strings.Contains(msg, "database table is locked")
 }
 
+// mergeIncomingResourceData applies the keep-richer policy against any row
+// already cached for this (resourceType, id). First write returns incoming
+// unchanged. Callers must use the result for both the generic resources
+// blob and the typed-table projection so list sync cannot shrink detail.
+func (s *Store) mergeIncomingResourceData(tx *sql.Tx, resourceType, id string, incoming json.RawMessage) json.RawMessage {
+	var existing string
+	err := tx.QueryRow(
+		`SELECT data FROM resources WHERE resource_type = ? AND id = ?`,
+		resourceType, id,
+	).Scan(&existing)
+	if err != nil || existing == "" {
+		return incoming
+	}
+	merged, ok := mergeKeepRicherJSON(json.RawMessage(existing), incoming)
+	if !ok {
+		return incoming
+	}
+	return merged
+}
+
 func (s *Store) upsertGenericResourceTx(tx *sql.Tx, resourceType, id string, data json.RawMessage) error {
 	_, err := tx.Exec(
 		`INSERT INTO resources (id, resource_type, data, synced_at, updated_at)
@@ -1018,7 +1040,7 @@ func (s *Store) Upsert(resourceType, id string, data json.RawMessage) error {
 	}
 	defer tx.Rollback()
 
-	if err := s.upsertGenericResourceTx(tx, resourceType, id, data); err != nil {
+	if err := s.upsertGenericResourceTx(tx, resourceType, id, s.mergeIncomingResourceData(tx, resourceType, id, data)); err != nil {
 		return err
 	}
 
@@ -1752,7 +1774,7 @@ func (s *Store) UpsertLeagues(data json.RawMessage) error {
 		return fmt.Errorf("unmarshaling leagues: %w", err)
 	}
 
-	id := ExtractResourceID("leagues", obj)
+	id := ResolveStorageID("leagues", obj)
 	if id == "" {
 		return fmt.Errorf("missing id for leagues")
 	}
@@ -1765,6 +1787,11 @@ func (s *Store) UpsertLeagues(data json.RawMessage) error {
 		return err
 	}
 	defer tx.Rollback()
+
+	data = s.mergeIncomingResourceData(tx, "leagues", storageID, data)
+	if merged, err := DecodeJSONObject(data); err == nil {
+		obj = merged
+	}
 
 	if err := s.upsertGenericResourceTx(tx, "leagues", storageID, data); err != nil {
 		return err
@@ -1804,7 +1831,7 @@ func (s *Store) UpsertStandings(data json.RawMessage) error {
 		return fmt.Errorf("unmarshaling standings: %w", err)
 	}
 
-	id := ExtractResourceID("standings", obj)
+	id := ResolveStorageID("standings", obj)
 	if id == "" {
 		return fmt.Errorf("missing id for standings")
 	}
@@ -1817,6 +1844,11 @@ func (s *Store) UpsertStandings(data json.RawMessage) error {
 		return err
 	}
 	defer tx.Rollback()
+
+	data = s.mergeIncomingResourceData(tx, "standings", storageID, data)
+	if merged, err := DecodeJSONObject(data); err == nil {
+		obj = merged
+	}
 
 	if err := s.upsertGenericResourceTx(tx, "standings", storageID, data); err != nil {
 		return err
@@ -1840,6 +1872,12 @@ func (s *Store) UpsertStandings(data json.RawMessage) error {
 var resourceIDFieldOverrides = map[string]string{
 	"games": "game_key",
 }
+
+// parameterKeyedResources are typed resources whose responses have no
+// identity field. Upsert stores those rows under a parameter fingerprint
+// instead of failing ExtractResourceID. Unlisted resources keep today's
+// extract-failure contract for items with no usable id.
+var parameterKeyedResources = map[string]bool{}
 
 // Generic ID fields are split around the resource-specific suffix probe.
 // Stable vendor identifiers win first; then fields derived from the resource
@@ -1892,6 +1930,292 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 		}
 	}
 	return mapKeyIDFallback(obj)
+}
+
+// ResolveStorageID is the writer-side identity. ExtractResourceID wins when
+// the payload has a real resource id. Parameter-shaped / id-less payloads
+// (no identity-candidate keys at all) get a fingerprint of their top-level
+// scalars so Upsert can store a row without inventing a field. Identity
+// probes such as unwrap and sync extractID must keep using ExtractResourceID
+// so a fingerprint is never mistaken for an entity id.
+//
+// Objects that carry an identity-shaped key whose value was refused
+// (timestamp, zero, empty) still return "" — fingerprinting those would
+// hide a rejected entity id.
+func ResolveStorageID(resourceType string, obj map[string]any) string {
+	if id := ExtractResourceID(resourceType, obj); id != "" {
+		return id
+	}
+	if !parameterKeyedResources[resourceType] {
+		return ""
+	}
+	if identityKeyPresent(resourceType, obj) {
+		return ""
+	}
+	return parameterSnapshotID(obj)
+}
+
+func identityKeyPresent(resourceType string, obj map[string]any) bool {
+	if obj == nil {
+		return false
+	}
+	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
+		if _, found := lookupRawFieldValue(obj, override); found {
+			return true
+		}
+	}
+	for _, key := range genericIDFieldFallbacks {
+		if _, found := lookupRawFieldValue(obj, key); found {
+			return true
+		}
+	}
+	if suffixIdentityKeyPresent(resourceType, obj) {
+		return true
+	}
+	for _, key := range genericDescriptiveIDFieldFallbacks {
+		if _, found := lookupRawFieldValue(obj, key); found {
+			return true
+		}
+	}
+	if _, found := obj[MapKeyIDField]; found {
+		return true
+	}
+	return false
+}
+
+func suffixIdentityKeyPresent(resourceType string, obj map[string]any) bool {
+	for _, base := range resourceIDBaseNames(resourceType) {
+		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+			if _, found := lookupRawFieldValue(obj, base+suffix); found {
+				return true
+			}
+		}
+		camelBase := lowerCamelResourceIDBase(base)
+		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+			if _, found := lookupRawFieldValue(obj, camelBase+suffix); found {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// parameterSnapshotID keys an id-less payload by a hash of its top-level
+// scalars — the request-equivalent identity (lat/lon, timezone) — and
+// excludes nested blocks (hourly, current, results) so a later fetch of
+// the same parameters updates the same row. Volatile telemetry keys
+// (*_ms, *_at, timestamp, generationtime*) are omitted from the key.
+// When the object has no stable scalars the whole payload is hashed so
+// the row can still be stored.
+func parameterSnapshotID(obj map[string]any) string {
+	if len(obj) == 0 {
+		return ""
+	}
+	fields := parameterFingerprintFields(obj)
+	var payload any
+	if len(fields) > 0 {
+		payload = fields
+	} else {
+		payload = obj
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil || len(raw) == 0 || string(raw) == "null" || string(raw) == "{}" {
+		return ""
+	}
+	sum := sha256.Sum256(raw)
+	return "pp:params:" + hex.EncodeToString(sum[:16])
+}
+
+func parameterFingerprintFields(obj map[string]any) map[string]any {
+	out := make(map[string]any, len(obj))
+	for key, value := range obj {
+		if isVolatileParameterKey(key) {
+			continue
+		}
+		if scalar, ok := fingerprintScalar(value); ok {
+			out[key] = scalar
+		}
+	}
+	return out
+}
+
+func isVolatileParameterKey(key string) bool {
+	k := strings.ToLower(strings.TrimSpace(key))
+	switch {
+	case strings.HasSuffix(k, "_ms"), strings.HasSuffix(k, "_at"):
+		return true
+	case k == "timestamp", k == "generated", k == "generation_time", k == "generationtime":
+		return true
+	default:
+		return strings.HasPrefix(k, "generationtime")
+	}
+}
+
+func fingerprintScalar(value any) (any, bool) {
+	switch t := value.(type) {
+	case nil:
+		return nil, false
+	case string:
+		return t, t != ""
+	case bool:
+		return t, true
+	case json.Number:
+		return t, t.String() != ""
+	case float64, float32, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return t, true
+	default:
+		return nil, false
+	}
+}
+
+// mergeKeepRicherJSON combines a previously cached JSON blob with an
+// incoming write so a thinner list-shaped payload cannot destroy richer
+// detail already stored for the same id.
+//
+// Policy (do-not-shrink / keep-richer):
+//   - First write (no existing) stores incoming unchanged.
+//   - Object keys present only on existing are kept.
+//   - Objects merge recursively; incoming keys go through the same policy
+//     rather than wholesale replacement.
+//   - A container (object/array) is never replaced by a scalar or null.
+//   - An incoming empty array does not replace a non-empty existing array.
+//   - Arrays of objects merge element-wise; extra existing elements are
+//     kept when incoming is shorter.
+//   - Arrays of non-objects: the longer array wins; equal length prefers
+//     incoming (authoritative remote refresh of the same collection).
+//   - Incoming scalars replace existing scalars.
+func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, bool) {
+	if len(existing) == 0 {
+		return incoming, len(incoming) > 0
+	}
+	if len(incoming) == 0 {
+		return existing, true
+	}
+	existingVal, err := decodeJSONValue(existing)
+	if err != nil {
+		return incoming, len(incoming) > 0
+	}
+	incomingVal, err := decodeJSONValue(incoming)
+	if err != nil {
+		return existing, true
+	}
+	merged, err := json.Marshal(mergeKeepRicherValue(existingVal, incomingVal))
+	if err != nil {
+		return incoming, len(incoming) > 0
+	}
+	return merged, true
+}
+
+func decodeJSONValue(data json.RawMessage) (any, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	var value any
+	if err := dec.Decode(&value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func mergeKeepRicherValue(existing, incoming any) any {
+	if incoming == nil {
+		if existing != nil {
+			return existing
+		}
+		return incoming
+	}
+	existingObj, existingIsObj := existing.(map[string]any)
+	incomingObj, incomingIsObj := incoming.(map[string]any)
+	if existingIsObj && incomingIsObj {
+		return mergeKeepRicherObject(existingObj, incomingObj)
+	}
+	existingArr, existingIsArr := existing.([]any)
+	incomingArr, incomingIsArr := incoming.([]any)
+	if existingIsArr && incomingIsArr {
+		return mergeKeepRicherArray(existingArr, incomingArr)
+	}
+	if isJSONContainer(existing) && !isJSONContainer(incoming) {
+		return existing
+	}
+	if isJSONEmpty(incoming) && !isJSONEmpty(existing) {
+		return existing
+	}
+	return incoming
+}
+
+func mergeKeepRicherObject(existing, incoming map[string]any) map[string]any {
+	out := make(map[string]any, len(existing)+len(incoming))
+	for key, value := range existing {
+		out[key] = value
+	}
+	for key, incomingVal := range incoming {
+		if existingVal, ok := out[key]; ok {
+			out[key] = mergeKeepRicherValue(existingVal, incomingVal)
+			continue
+		}
+		out[key] = incomingVal
+	}
+	return out
+}
+
+func mergeKeepRicherArray(existing, incoming []any) []any {
+	if len(incoming) == 0 && len(existing) > 0 {
+		return existing
+	}
+	if !arrayItemsAreObjects(existing) && !arrayItemsAreObjects(incoming) {
+		if len(incoming) < len(existing) {
+			return existing
+		}
+		return incoming
+	}
+	n := len(incoming)
+	if len(existing) > n {
+		n = len(existing)
+	}
+	out := make([]any, n)
+	for i := 0; i < n; i++ {
+		switch {
+		case i < len(existing) && i < len(incoming):
+			out[i] = mergeKeepRicherValue(existing[i], incoming[i])
+		case i < len(existing):
+			out[i] = existing[i]
+		default:
+			out[i] = incoming[i]
+		}
+	}
+	return out
+}
+
+func arrayItemsAreObjects(items []any) bool {
+	for _, item := range items {
+		if _, ok := item.(map[string]any); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func isJSONContainer(value any) bool {
+	switch value.(type) {
+	case map[string]any, []any:
+		return true
+	default:
+		return false
+	}
+}
+
+func isJSONEmpty(value any) bool {
+	switch t := value.(type) {
+	case nil:
+		return true
+	case string:
+		return t == ""
+	case map[string]any:
+		return len(t) == 0
+	case []any:
+		return len(t) == 0
+	default:
+		return false
+	}
 }
 
 // suffixIDFieldFallback resolves an id-less resource that keys on its own
@@ -2144,11 +2468,18 @@ func (s *Store) UpsertBatchDetailed(resourceType string, items []json.RawMessage
 			}
 		}
 		if id == "" {
+			id = ResolveStorageID(resourceType, obj)
+		}
+		if id == "" {
 			skippedCount++
 			extractFailures++
 			continue
 		}
 		storageID := resourceStorageID(resourceType, id, obj)
+		item = s.mergeIncomingResourceData(tx, resourceType, storageID, item)
+		if merged, err := DecodeJSONObject(item); err == nil {
+			obj = merged
+		}
 
 		if err := s.upsertGenericResourceTx(tx, resourceType, storageID, item); err != nil {
 			// Return the running stored count rather than zero so callers

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -993,7 +993,7 @@ func (s *Store) mergeIncomingResourceData(tx *sql.Tx, resourceType, id string, i
 	if err != nil || existing == "" {
 		return incoming
 	}
-	merged, ok := mergeKeepRicherJSON(json.RawMessage(existing), incoming)
+	merged, ok := mergeKeepRicherJSON(resourceType, json.RawMessage(existing), incoming)
 	if !ok {
 		return incoming
 	}
@@ -2073,14 +2073,16 @@ func fingerprintScalar(value any) (any, bool) {
 //   - A container (object/array) is never replaced by a scalar or null.
 //   - An incoming empty array does not replace a non-empty existing array
 //     (list omitted the collection vs sent a new one).
-//   - Object arrays match by a stable id key when present, then apply the
-//     same object policy to the pair. Result order and length follow
-//     incoming so a reorder or middle delete cannot join unrelated
-//     objects or keep leftover old entries.
+//   - Object arrays match by the same identity stack as ExtractResourceID
+//     (configured / dotted override, generic id, resource-scoped suffix)
+//     plus item-local suffix keys (currency_code, accountId) and sku.
+//     Display name is not an array identity. Result order and length
+//     follow incoming so a reorder or middle delete cannot join
+//     unrelated objects or keep leftover old entries.
 //   - Arrays without identity keys, and scalar arrays, take incoming
 //     wholesale. Index-wise merge would pair unrelated items.
 //   - Incoming scalars replace existing scalars.
-func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, bool) {
+func mergeKeepRicherJSON(resourceType string, existing, incoming json.RawMessage) (json.RawMessage, bool) {
 	if len(existing) == 0 {
 		return incoming, len(incoming) > 0
 	}
@@ -2095,7 +2097,7 @@ func mergeKeepRicherJSON(existing, incoming json.RawMessage) (json.RawMessage, b
 	if err != nil {
 		return existing, true
 	}
-	merged, err := json.Marshal(mergeKeepRicherValue(existingVal, incomingVal))
+	merged, err := json.Marshal(mergeKeepRicherValue(resourceType, existingVal, incomingVal))
 	if err != nil {
 		return incoming, len(incoming) > 0
 	}
@@ -2112,7 +2114,7 @@ func decodeJSONValue(data json.RawMessage) (any, error) {
 	return value, nil
 }
 
-func mergeKeepRicherValue(existing, incoming any) any {
+func mergeKeepRicherValue(resourceType string, existing, incoming any) any {
 	if incoming == nil {
 		if existing != nil {
 			return existing
@@ -2122,12 +2124,12 @@ func mergeKeepRicherValue(existing, incoming any) any {
 	existingObj, existingIsObj := existing.(map[string]any)
 	incomingObj, incomingIsObj := incoming.(map[string]any)
 	if existingIsObj && incomingIsObj {
-		return mergeKeepRicherObject(existingObj, incomingObj)
+		return mergeKeepRicherObject(resourceType, existingObj, incomingObj)
 	}
 	existingArr, existingIsArr := existing.([]any)
 	incomingArr, incomingIsArr := incoming.([]any)
 	if existingIsArr && incomingIsArr {
-		return mergeKeepRicherArray(existingArr, incomingArr)
+		return mergeKeepRicherArray(resourceType, existingArr, incomingArr)
 	}
 	if isJSONContainer(existing) && !isJSONContainer(incoming) {
 		return existing
@@ -2138,14 +2140,14 @@ func mergeKeepRicherValue(existing, incoming any) any {
 	return incoming
 }
 
-func mergeKeepRicherObject(existing, incoming map[string]any) map[string]any {
+func mergeKeepRicherObject(resourceType string, existing, incoming map[string]any) map[string]any {
 	out := make(map[string]any, len(existing)+len(incoming))
 	for key, value := range existing {
 		out[key] = value
 	}
 	for key, incomingVal := range incoming {
 		if existingVal, ok := out[key]; ok {
-			out[key] = mergeKeepRicherValue(existingVal, incomingVal)
+			out[key] = mergeKeepRicherValue(resourceType, existingVal, incomingVal)
 			continue
 		}
 		out[key] = incomingVal
@@ -2153,11 +2155,11 @@ func mergeKeepRicherObject(existing, incoming map[string]any) map[string]any {
 	return out
 }
 
-func mergeKeepRicherArray(existing, incoming []any) []any {
+func mergeKeepRicherArray(resourceType string, existing, incoming []any) []any {
 	if len(incoming) == 0 && len(existing) > 0 {
 		return existing
 	}
-	existingByID := indexObjectArrayByIdentity(existing)
+	existingByID := indexObjectArrayByIdentity(resourceType, existing)
 	if len(existingByID) == 0 {
 		return incoming
 	}
@@ -2168,26 +2170,26 @@ func mergeKeepRicherArray(existing, incoming []any) []any {
 			out[i] = item
 			continue
 		}
-		id := arrayItemIdentity(incomingObj)
+		id := arrayItemIdentity(resourceType, incomingObj)
 		existingObj, ok := existingByID[id]
 		if id == "" || !ok {
 			out[i] = item
 			continue
 		}
 		delete(existingByID, id)
-		out[i] = mergeKeepRicherObject(existingObj, incomingObj)
+		out[i] = mergeKeepRicherObject(resourceType, existingObj, incomingObj)
 	}
 	return out
 }
 
-func indexObjectArrayByIdentity(items []any) map[string]map[string]any {
+func indexObjectArrayByIdentity(resourceType string, items []any) map[string]map[string]any {
 	out := make(map[string]map[string]any)
 	for _, item := range items {
 		obj, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
-		id := arrayItemIdentity(obj)
+		id := arrayItemIdentity(resourceType, obj)
 		if id == "" {
 			continue
 		}
@@ -2199,10 +2201,68 @@ func indexObjectArrayByIdentity(items []any) map[string]map[string]any {
 	return out
 }
 
-func arrayItemIdentity(obj map[string]any) string {
+func arrayItemIdentity(resourceType string, obj map[string]any) string {
+	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
+		if s := canonicalIDFromKey(obj, override); s != "" {
+			return s
+		}
+	}
 	for _, key := range genericIDFieldFallbacks {
 		if s := canonicalIDFromKey(obj, key); s != "" {
 			return s
+		}
+	}
+	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
+		return s
+	}
+	if s := suffixIdentityFromItemKeys(obj); s != "" {
+		return s
+	}
+	if s := canonicalIDFromKey(obj, "sku"); s != "" {
+		return s
+	}
+	for _, key := range []string{"slug", "key", "code"} {
+		if s := canonicalIDFromKey(obj, key); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func suffixIdentityFromItemKeys(obj map[string]any) string {
+	if obj == nil {
+		return ""
+	}
+	keys := make([]string, 0, len(obj))
+	for key := range obj {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		stem := identitySuffixStem(key)
+		if stem == "" || stem == "parent" {
+			continue
+		}
+		if s := suffixIDFieldFallback(stem, obj); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func identitySuffixStem(key string) string {
+	k := strings.TrimSpace(key)
+	if k == "" {
+		return ""
+	}
+	for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return strings.TrimSuffix(k, suffix)
+		}
+	}
+	for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+		if strings.HasSuffix(k, suffix) && len(k) > len(suffix) {
+			return strings.ToLower(k[:len(k)-len(suffix)])
 		}
 	}
 	return ""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Parameter-shaped API responses have no resource id, so generated typed `Upsert*` and batch writes either errored (`missing id for `) or skipped every row. After a detail GET cached nested fields, a later list sync also replaced the stored blob wholesale and lost that richer data.

This keeps both write paths honest:

- **Id-less / parameter-shaped resources** are flagged at schema build time when the typed response has no identity field. Those writes use a fingerprint of top-level scalars (lat/lon, timezone) instead of a fictional id. Resources that already have a real id still key the same way. Unflagged items without a usable id still increment `extractFailures` (ticker, parent-id, empty envelopes).
- **List-vs-detail conflict** applies a documented keep-richer / do-not-shrink merge: incoming scalars update, missing nested object fields stay, and a list-only first write is unchanged.
- **Object arrays** match by the same identity stack as `ExtractResourceID` (configured/dotted override, generic id, resource-scoped suffix) plus item-local suffix keys (`currency_code`, `accountId`) and `sku`. Own-identity suffixes (`_code`/`_slug`/`_key`) win over shared foreign keys such as `account_id` when both exist; a lone `accountId` still keys the row. Identity map keys are field-qualified so `id:"USD"` and `currency_code:"USD"` cannot share a slot. Generic id aliases (`id`/`Id`/`ID`/`_id`/`id_`) share one qualified key so a later list spelling cannot drop cached detail. Result order and length follow incoming so a later reorder or middle delete cannot join unrelated objects or keep leftover old entries. Arrays without identity keys take incoming wholesale. Display name is not an array identity.

Generated-output proof is in `TestGeneratedStoreKeepsIDLessAndRicherUpserts` (`requireGeneratedCompiles` plus typed `UpsertForecast` / `UpsertMutations` runtime tests, including reorder, mid-array removal, suffix identities, shared-FK vs `currency_code` pairing, cross-field scalar collisions, and generic id aliases). Printed-CLI store tests cover the merge contract. Store goldens are updated with `scripts/golden.sh update`.

Closes #4470
Closes #4427

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c326e01d-5377-45ea-a640-bfcf0fe04dc4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c326e01d-5377-45ea-a640-bfcf0fe04dc4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

