### PR TITLE
fix(cli): required-param guards honor resolved flag values

### DIFF
--- a/internal/generator/body_map_test.go
+++ b/internal/generator/body_map_test.go
@@ -627,7 +627,7 @@ func TestBodyRequiredChecks_OptionalNestedObject(t *testing.T) {
 		}},
 	}, "\t\t\t")
 	require.Contains(t, got, `if (cmd.Flags().Changed("start-date-time") || bodyStartDateTime != "") || (cmd.Flags().Changed("start-time-zone") || bodyStartTimeZone != "") {`)
-	require.Contains(t, got, `if !cmd.Flags().Changed("start-date-time") && !flags.dryRun {`)
+	require.Contains(t, got, `if !cmd.Flags().Changed("start-date-time") && bodyStartDateTime == "" && !flags.dryRun {`)
 	require.Contains(t, got, `"required flag \"%s\" not set", "start-date-time"`)
 }
 
@@ -644,7 +644,7 @@ func TestBodyRequiredChecks_OptionalNestedObjectDefaultActivatesParent(t *testin
 		}},
 	}, "\t\t\t")
 	require.Contains(t, got, `if (cmd.Flags().Changed("start-date-time") || bodyStartDateTime != "") || (cmd.Flags().Changed("start-time-zone") || bodyStartTimeZone != "") {`)
-	require.Contains(t, got, `if !cmd.Flags().Changed("start-date-time") && !flags.dryRun {`)
+	require.Contains(t, got, `if !cmd.Flags().Changed("start-date-time") && bodyStartDateTime == "" && !flags.dryRun {`)
 }
 
 func TestBodyRequiredChecks_RecursiveOptionalObjects(t *testing.T) {
@@ -668,7 +668,7 @@ func TestBodyRequiredChecks_RecursiveOptionalObjects(t *testing.T) {
 	}, "\t\t\t")
 	require.Contains(t, got, `if (cmd.Flags().Changed("outer-label") || bodyOuterLabel != "") || (cmd.Flags().Changed("outer-config-mode") || bodyOuterConfigMode != "") || (cmd.Flags().Changed("outer-config-note") || bodyOuterConfigNote != "") {`)
 	require.Contains(t, got, `if (cmd.Flags().Changed("outer-config-mode") || bodyOuterConfigMode != "") || (cmd.Flags().Changed("outer-config-note") || bodyOuterConfigNote != "") {`)
-	require.Contains(t, got, `if !cmd.Flags().Changed("outer-config-mode") && !flags.dryRun {`)
+	require.Contains(t, got, `if !cmd.Flags().Changed("outer-config-mode") && bodyOuterConfigMode == "" && !flags.dryRun {`)
 }
 
 func TestBodyRequiredChecks_RequiredNestedObjectRemainsUnconditional(t *testing.T) {
@@ -685,7 +685,7 @@ func TestBodyRequiredChecks_RequiredNestedObjectRemainsUnconditional(t *testing.
 		}},
 	}, "\t\t\t")
 	require.NotContains(t, got, `cmd.Flags().Changed("start-time-zone")`)
-	require.Contains(t, got, `if !cmd.Flags().Changed("start-date-time") && !flags.dryRun {`)
+	require.Contains(t, got, `if !cmd.Flags().Changed("start-date-time") && bodyStartDateTime == "" && !flags.dryRun {`)
 }
 
 func TestMCPBodyInputParams_NestedRequiredFollowsParent(t *testing.T) {
@@ -727,8 +727,8 @@ func TestBodyRequiredChecks_TopLevelKeepsAliasOR(t *testing.T) {
 			{Name: "name", Type: "string", Required: true, Aliases: []string{"n"}},
 		},
 	}, "\t\t\t")
-	if !strings.Contains(got, `(cmd.Flags().Changed("name") || cmd.Flags().Changed("n"))`) {
-		t.Errorf("expected alias-OR in required check, got:\n%s", got)
+	if !strings.Contains(got, `!(cmd.Flags().Changed("name") || cmd.Flags().Changed("n")) && bodyName == "" && !flags.dryRun`) {
+		t.Errorf("expected alias-OR plus resolved-value check, got:\n%s", got)
 	}
 }
 
@@ -1039,8 +1039,8 @@ func TestMCPParamBindings_BodyJSONFallback(t *testing.T) {
 func TestBodyJSONFallback_RequiredChecks_RequiredBody(t *testing.T) {
 	t.Parallel()
 	got := bodyRequiredChecks(spec.Endpoint{BodyJSONFallback: true, BodyRequired: true}, "\t\t\t")
-	if !strings.Contains(got, `cmd.Flags().Changed("body-json")`) {
-		t.Errorf("expected Changed check on body-json for required body, got:%q", got)
+	if !strings.Contains(got, `!cmd.Flags().Changed("body-json") && flagBodyJSON == "" && !flags.dryRun`) {
+		t.Errorf("expected value-aware body-json required check, got:%q", got)
 	}
 	if !strings.Contains(got, `"required flag \"%s\" not set", "body-json"`) {
 		t.Errorf("expected body-json in error message, got:%q", got)

--- a/internal/generator/body_nested_object_test.go
+++ b/internal/generator/body_nested_object_test.go
@@ -179,7 +179,7 @@ func TestOptionalNestedRequiredRuntime(t *testing.T) {
 	require.NoError(t, New(promotedSpec, promotedOutputDir).Generate())
 	promoted := readGeneratedFile(t, promotedOutputDir, "internal", "cli", "promoted_events.go")
 	require.Contains(t, promoted, `if (cmd.Flags().Changed("start-date-time") || bodyStartDateTime != "") || (cmd.Flags().Changed("start-time-zone") || bodyStartTimeZone != "") {`)
-	require.Contains(t, promoted, `if !cmd.Flags().Changed("start-date-time") && !flags.dryRun {`)
+	require.Contains(t, promoted, `if !cmd.Flags().Changed("start-date-time") && bodyStartDateTime == "" && !flags.dryRun {`)
 	requireGeneratedCompiles(t, promotedOutputDir)
 }
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -439,6 +439,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"publicFlagName":               publicFlagName,
 		"publicFlagAliases":            publicFlagAliases,
 		"flagChangedExpr":              flagChangedExpr,
+		"flagRequiredUnsatisfiedExpr":  flagRequiredUnsatisfiedExpr,
 		"graphqlListParams":            graphqlListParams,
 		"graphqlLatestParams":          graphqlLatestParams,
 		"graphqlVariableType":          graphqlVariableType,
@@ -6793,6 +6794,15 @@ func flagChangedExpr(p spec.Param) string {
 		return parts[0]
 	}
 	return "(" + strings.Join(parts, " || ") + ")"
+}
+
+// flagRequiredUnsatisfiedExpr is the generated required-flag guard condition.
+// Changed alone is not enough: a PreRunE or other resolver can write the
+// bound value without flipping cobra's Changed bit.
+func flagRequiredUnsatisfiedExpr(p spec.Param) string {
+	zero := zeroValForParamRequired(p.Name, p.Type, p.Required, paramHasDefault(p))
+	return fmt.Sprintf("!%s && flag%s == %s && !flags.dryRun",
+		flagChangedExpr(p), toCamel(paramIdent(p)), zero)
 }
 
 func mcpParamBindings(endpoint spec.Endpoint, pathTemplate string) []mcpParamBinding {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -7775,7 +7775,7 @@ func bodyRequiredChecks(endpoint spec.Endpoint, indent string) string {
 	var b strings.Builder
 	if endpoint.BodyJSONFallback {
 		if endpoint.BodyRequired {
-			fmt.Fprintf(&b, "\n%sif !cmd.Flags().Changed(\"body-json\") && !flags.dryRun {", indent)
+			fmt.Fprintf(&b, "\n%sif !cmd.Flags().Changed(\"body-json\") && flagBodyJSON == \"\" && !flags.dryRun {", indent)
 			fmt.Fprintf(&b, "\n%s\treturn fmt.Errorf(\"required flag \\\"%%s\\\" not set\", \"body-json\")", indent)
 			fmt.Fprintf(&b, "\n%s}", indent)
 		}
@@ -7783,7 +7783,7 @@ func bodyRequiredChecks(endpoint spec.Endpoint, indent string) string {
 	}
 	if bodyUsesFlatEmission(endpoint) {
 		for _, p := range endpoint.Body {
-			renderFlatBodyRequiredCheck(&b, p, indent, "", true)
+			renderFlatBodyRequiredCheck(&b, p, indent, "", "", true)
 		}
 		return b.String()
 	}
@@ -7817,7 +7817,7 @@ func renderBodyRequiredChecks(b *strings.Builder, body []spec.Param, depth int, 
 			fmt.Fprintf(b, "\n%s}", indent)
 			continue
 		}
-		renderFlatBodyRequiredCheck(b, p, indent, flagPrefix, topLevel)
+		renderFlatBodyRequiredCheck(b, p, indent, flagPrefix, identPrefix, topLevel)
 	}
 }
 
@@ -7878,18 +7878,19 @@ func walkBodyExceedsDepth(body []spec.Param, depth int) bool {
 	return false
 }
 
-func renderFlatBodyRequiredCheck(b *strings.Builder, p spec.Param, indent, flagPrefix string, topLevel bool) {
+func renderFlatBodyRequiredCheck(b *strings.Builder, p spec.Param, indent, flagPrefix, identPrefix string, topLevel bool) {
 	if !p.Required || p.Default != nil {
 		return
 	}
 	flag := joinFlag(flagPrefix, publicFlagName(p))
+	ident := identPrefix + toCamel(paramIdent(p))
 	var changedExpr string
 	if topLevel {
 		changedExpr = flagChangedExpr(p)
 	} else {
-		changedExpr = fmt.Sprintf("cmd.Flags().Changed(\"%s\")", flag)
+		changedExpr = fmt.Sprintf("cmd.Flags().Changed(%q)", flag)
 	}
-	fmt.Fprintf(b, "\n%sif !%s && !flags.dryRun {", indent, changedExpr)
+	fmt.Fprintf(b, "\n%sif !%s && body%s == %s && !flags.dryRun {", indent, changedExpr, ident, zeroValForBodyParam(p))
 	fmt.Fprintf(b, "\n%s\treturn fmt.Errorf(\"required flag \\\"%%s\\\" not set\", \"%s\")", indent, flag)
 	fmt.Fprintf(b, "\n%s}", indent)
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -19144,7 +19144,7 @@ func TestGeneratePublicParamNamesAcrossCLISurfaces(t *testing.T) {
 	assert.Contains(t, findSource, `StringVar(&flagS, "address", "", "Street address")`)
 	assert.Contains(t, findSource, `StringVar(&flagS, "s", "", "Street address")`)
 	assert.Contains(t, findSource, `_ = cmd.Flags().MarkHidden("s")`)
-	assert.Contains(t, findSource, `if !(cmd.Flags().Changed("address") || cmd.Flags().Changed("s")) && !flags.dryRun`)
+	assert.Contains(t, findSource, `if !(cmd.Flags().Changed("address") || cmd.Flags().Changed("s")) && flagS == "" && !flags.dryRun`)
 	assert.Contains(t, findSource, `params["s"] = formatCLIParamValue(flagS)`)
 	assert.NotContains(t, findSource, `required flag "s" not set`)
 

--- a/internal/generator/required_flag_guard_test.go
+++ b/internal/generator/required_flag_guard_test.go
@@ -63,6 +63,23 @@ func TestFlagRequiredUnsatisfiedExpr(t *testing.T) {
 	}
 }
 
+func TestBodyRequiredChecksHonorResolvedValue(t *testing.T) {
+	t.Parallel()
+
+	got := bodyRequiredChecks(spec.Endpoint{
+		Body: []spec.Param{
+			{Name: "name", Type: "string", Required: true},
+			{Name: "visibility", Type: "string", Required: true},
+			{Name: "filter", Type: "array", Required: true},
+			{Name: "store_code", FlagName: "store-code", Aliases: []string{"code"}, Type: "string", Required: true},
+		},
+	}, "\t\t\t")
+	assert.Contains(t, got, `!cmd.Flags().Changed("name") && bodyName == "" && !flags.dryRun`)
+	assert.Contains(t, got, `!cmd.Flags().Changed("visibility") && bodyVisibility == "" && !flags.dryRun`)
+	assert.Contains(t, got, `!cmd.Flags().Changed("filter") && bodyFilter == "" && !flags.dryRun`)
+	assert.Contains(t, got, `!(cmd.Flags().Changed("store-code") || cmd.Flags().Changed("code")) && bodyStoreCode == "" && !flags.dryRun`)
+}
+
 func TestGeneratedOutput_RequiredFlagGuardHonorsResolvedValue(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/required_flag_guard_test.go
+++ b/internal/generator/required_flag_guard_test.go
@@ -71,6 +71,7 @@ func TestGeneratedOutput_RequiredFlagGuardHonorsResolvedValue(t *testing.T) {
 		Version: "0.1.0",
 		BaseURL: "https://api.example.com",
 		Auth:    spec.AuthConfig{Type: "none"},
+		Learn:   spec.LearnConfig{Disabled: true},
 		Config:  spec.ConfigSpec{Format: "toml", Path: "~/.config/reqguard-pp-cli/config.toml"},
 		Types: map[string]spec.TypeDef{
 			"Tenant": {
@@ -150,14 +151,14 @@ func TestGeneratedOutput_RequiredFlagGuardHonorsResolvedValue(t *testing.T) {
 	guard := `!cmd.Flags().Changed("instance-key") && flagInstanceKey == "" && !flags.dryRun`
 	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "tenants_list.go")
 	assert.Contains(t, endpointSrc, guard)
-	assert.Contains(t, endpointSrc, `required flag "%s" not set", "instance-key"`)
-	assert.NotContains(t, endpointSrc, `required flag "%s" not set", "label"`)
+	assert.Contains(t, endpointSrc, `return fmt.Errorf("required flag \"%s\" not set", "instance-key")`)
+	assert.NotContains(t, endpointSrc, `return fmt.Errorf("required flag \"%s\" not set", "label")`)
 	assert.NotContains(t, endpointSrc, `.MarkFlagRequired("`)
 
 	promotedSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_whoami.go")
 	assert.Contains(t, promotedSrc, guard)
-	assert.Contains(t, promotedSrc, `required flag "%s" not set", "instance-key"`)
-	assert.NotContains(t, promotedSrc, `required flag "%s" not set", "label"`)
+	assert.Contains(t, promotedSrc, `return fmt.Errorf("required flag \"%s\" not set", "instance-key")`)
+	assert.NotContains(t, promotedSrc, `return fmt.Errorf("required flag \"%s\" not set", "label")`)
 
 	requireGeneratedCompiles(t, outputDir)
 

--- a/internal/generator/required_flag_guard_test.go
+++ b/internal/generator/required_flag_guard_test.go
@@ -1,0 +1,259 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlagRequiredUnsatisfiedExpr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		p    spec.Param
+		want string
+	}{
+		{
+			name: "required string",
+			p:    spec.Param{Name: "instance-key", Type: "string", Required: true},
+			want: `!cmd.Flags().Changed("instance-key") && flagInstanceKey == "" && !flags.dryRun`,
+		},
+		{
+			name: "required string with alias",
+			p: spec.Param{
+				Name:     "s",
+				FlagName: "address",
+				Aliases:  []string{"s"},
+				Type:     "string",
+				Required: true,
+			},
+			want: `!(cmd.Flags().Changed("address") || cmd.Flags().Changed("s")) && flagS == "" && !flags.dryRun`,
+		},
+		{
+			name: "required integer",
+			p:    spec.Param{Name: "year", Type: "integer", Required: true},
+			want: `!cmd.Flags().Changed("year") && flagYear == 0 && !flags.dryRun`,
+		},
+		{
+			name: "required bool uses string zero",
+			p:    spec.Param{Name: "enabled", Type: "boolean", Required: true},
+			want: `!cmd.Flags().Changed("enabled") && flagEnabled == "" && !flags.dryRun`,
+		},
+		{
+			name: "global-scope string keeps env-default value check",
+			p: spec.Param{
+				Name:        "TenantFilter",
+				Type:        "string",
+				Required:    true,
+				GlobalScope: true,
+			},
+			want: `!cmd.Flags().Changed("tenant-filter") && flagTenantFilter == "" && !flags.dryRun`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, flagRequiredUnsatisfiedExpr(tt.p))
+		})
+	}
+}
+
+func TestGeneratedOutput_RequiredFlagGuardHonorsResolvedValue(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "reqguard",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config:  spec.ConfigSpec{Format: "toml", Path: "~/.config/reqguard-pp-cli/config.toml"},
+		Types: map[string]spec.TypeDef{
+			"Tenant": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "string"},
+					{Name: "name", Type: "string"},
+				},
+			},
+		},
+		Resources: map[string]spec.Resource{
+			"tenants": {
+				Description: "Tenant records",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/tenants",
+						Description: "List tenants",
+						Response:    spec.ResponseDef{Type: "array", Item: "Tenant"},
+						Params: []spec.Param{
+							{
+								Name:        "instance-key",
+								Type:        "string",
+								Required:    true,
+								Description: "Tenant instance key",
+							},
+							{
+								Name:        "label",
+								Type:        "string",
+								Description: "Optional label",
+							},
+						},
+					},
+					"get": {
+						Method:      "GET",
+						Path:        "/tenants/{id}",
+						Description: "Get tenant",
+						Response:    spec.ResponseDef{Type: "object", Item: "Tenant"},
+						Params: []spec.Param{{
+							Name:       "id",
+							Type:       "string",
+							Required:   true,
+							Positional: true,
+						}},
+					},
+				},
+			},
+			"whoami": {
+				Description: "Current tenant",
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method:      "GET",
+						Path:        "/whoami",
+						Description: "Current tenant identity",
+						Response:    spec.ResponseDef{Type: "object", Item: "Tenant"},
+						Params: []spec.Param{
+							{
+								Name:        "instance-key",
+								Type:        "string",
+								Required:    true,
+								Description: "Tenant instance key",
+							},
+							{
+								Name:        "label",
+								Type:        "string",
+								Description: "Optional label",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "reqguard-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	guard := `!cmd.Flags().Changed("instance-key") && flagInstanceKey == "" && !flags.dryRun`
+	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "tenants_list.go")
+	assert.Contains(t, endpointSrc, guard)
+	assert.Contains(t, endpointSrc, `required flag "%s" not set", "instance-key"`)
+	assert.NotContains(t, endpointSrc, `required flag "%s" not set", "label"`)
+	assert.NotContains(t, endpointSrc, `.MarkFlagRequired("`)
+
+	promotedSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_whoami.go")
+	assert.Contains(t, promotedSrc, guard)
+	assert.Contains(t, promotedSrc, `required flag "%s" not set", "instance-key"`)
+	assert.NotContains(t, promotedSrc, `required flag "%s" not set", "label"`)
+
+	requireGeneratedCompiles(t, outputDir)
+
+	inlineTest := `package cli
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRequiredFlagGuardResolvedAndMissing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("instance-key"); got != "tenant-a" {
+			t.Fatalf("instance-key query = %q, want tenant-a", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/whoami" {
+			_, _ = w.Write([]byte(` + "`" + `{"id":"1","name":"Ada"}` + "`" + `))
+			return
+		}
+		_, _ = w.Write([]byte(` + "`" + `[{"id":"1","name":"Ada"}]` + "`" + `))
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("REQGUARD_BASE_URL", server.URL)
+
+	cases := []struct {
+		name     string
+		path     []string
+		args     []string
+		setValue bool
+		value    string
+		wantErr  string
+	}{
+		{name: "endpoint missing", path: []string{"tenants", "list"}, args: []string{"tenants", "list", "--label", "x", "--json"}, wantErr: ` + "`" + `required flag "instance-key" not set` + "`" + `},
+		{name: "promoted missing", path: []string{"whoami"}, args: []string{"whoami", "--label", "x", "--json"}, wantErr: ` + "`" + `required flag "instance-key" not set` + "`" + `},
+		{name: "endpoint resolved", path: []string{"tenants", "list"}, args: []string{"tenants", "list", "--label", "x", "--json"}, setValue: true, value: "tenant-a"},
+		{name: "promoted resolved", path: []string{"whoami"}, args: []string{"whoami", "--label", "x", "--json"}, setValue: true, value: "tenant-a"},
+		{name: "endpoint empty resolve", path: []string{"tenants", "list"}, args: []string{"tenants", "list", "--label", "x", "--json"}, setValue: true, value: "", wantErr: ` + "`" + `required flag "instance-key" not set` + "`" + `},
+		{name: "endpoint cli flag", path: []string{"tenants", "list"}, args: []string{"tenants", "list", "--instance-key", "tenant-a", "--label", "x", "--json"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := RootCmd()
+			if tc.setValue {
+				if err := attachResolvedFlag(root, tc.path, "instance-key", tc.value); err != nil {
+					t.Fatal(err)
+				}
+			}
+			var stdout, stderr bytes.Buffer
+			root.SetOut(&stdout)
+			root.SetErr(&stderr)
+			root.SetArgs(tc.args)
+			err := root.Execute()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("execute: %v; stderr=%s stdout=%s", err, stderr.String(), stdout.String())
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected %q, got success; stdout=%s", tc.wantErr, stdout.String())
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func attachResolvedFlag(root *cobra.Command, path []string, name, value string) error {
+	cmd, _, err := root.Find(path)
+	if err != nil {
+		return err
+	}
+	cmd.PreRunE = func(c *cobra.Command, _ []string) error {
+		f := c.Flags().Lookup(name)
+		if f == nil {
+			return fmt.Errorf("flag %q not found", name)
+		}
+		if err := f.Value.Set(value); err != nil {
+			return err
+		}
+		if f.Changed {
+			return fmt.Errorf("Value.Set unexpectedly set Changed on %q", name)
+		}
+		return nil
+	}
+	return nil
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "required_flag_guard_runtime_test.go"), []byte(inlineTest), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "TestRequiredFlagGuardResolvedAndMissing", "-count=1")
+}

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -124,15 +124,9 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- range .Endpoint.Params}}
 {{- if and .Required (not .Positional) (not .Default)}}
-{{- if paramHasEnvDefault .}}
-			if !{{flagChangedExpr .}} && flag{{camel (paramIdent .)}} == "" && !flags.dryRun {
+			if {{flagRequiredUnsatisfiedExpr .}} {
 				return fmt.Errorf("required flag \"%s\" not set", "{{publicFlagName .}}")
 			}
-{{- else}}
-			if !{{flagChangedExpr .}} && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "{{publicFlagName .}}")
-			}
-{{- end}}
 {{- end}}
 {{- end}}
 {{- range .Endpoint.Params}}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -93,7 +93,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- range .Endpoint.Params}}
 {{- if and .Required (not .Positional) (not .Default)}}
-			if !{{flagChangedExpr .}} && !flags.dryRun {
+			if {{flagRequiredUnsatisfiedExpr .}} {
 				return fmt.Errorf("required flag \"%s\" not set", "{{publicFlagName .}}")
 			}
 {{- end}}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
@@ -46,10 +46,10 @@ func newProjectsCreateCmd(flags *rootFlags) *cobra.Command {
 				return cmd.Help()
 			}
 			if !stdinBody {
-				if !cmd.Flags().Changed("name") && !flags.dryRun {
+				if !cmd.Flags().Changed("name") && bodyName == "" && !flags.dryRun {
 					return fmt.Errorf("required flag \"%s\" not set", "name")
 				}
-				if !cmd.Flags().Changed("visibility") && !flags.dryRun {
+				if !cmd.Flags().Changed("visibility") && bodyVisibility == "" && !flags.dryRun {
 					return fmt.Errorf("required flag \"%s\" not set", "visibility")
 				}
 			}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_tickets.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_tickets.go
@@ -42,7 +42,7 @@ func newTicketsPromotedCmd(flags *rootFlags) *cobra.Command {
 				}
 				return cmd.Help()
 			}
-			if !cmd.Flags().Changed("filter") && !flags.dryRun {
+			if !cmd.Flags().Changed("filter") && bodyFilter == "" && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "filter")
 			}
 			c, err := flags.newClient()

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
@@ -41,7 +41,7 @@ func newReportsExportReportYearCmd(flags *rootFlags) *cobra.Command {
 				}
 				return cmd.Help()
 			}
-			if !cmd.Flags().Changed("year") && !flags.dryRun {
+			if !cmd.Flags().Changed("year") && flagYear == 0 && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "year")
 			}
 			path := "/reports/{year}/export"

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
@@ -43,7 +43,7 @@ func newStoresCreateCmd(flags *rootFlags) *cobra.Command {
 				return cmd.Help()
 			}
 			if !stdinBody {
-				if !(cmd.Flags().Changed("store-code") || cmd.Flags().Changed("code")) && !flags.dryRun {
+				if !(cmd.Flags().Changed("store-code") || cmd.Flags().Changed("code")) && bodyStoreCode == "" && !flags.dryRun {
 					return fmt.Errorf("required flag \"%s\" not set", "store-code")
 				}
 			}

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
@@ -43,13 +43,13 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 				}
 				return cmd.Help()
 			}
-			if !(cmd.Flags().Changed("address") || cmd.Flags().Changed("s")) && !flags.dryRun {
+			if !(cmd.Flags().Changed("address") || cmd.Flags().Changed("s")) && flagS == "" && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "address")
 			}
-			if !(cmd.Flags().Changed("city") || cmd.Flags().Changed("c")) && !flags.dryRun {
+			if !(cmd.Flags().Changed("city") || cmd.Flags().Changed("c")) && flagC == "" && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "city")
 			}
-			if !cmd.Flags().Changed("location-id") && !flags.dryRun {
+			if !cmd.Flags().Changed("location-id") && flagLocationId == "" && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "location-id")
 			}
 			path := "/power/store-locator"

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_standings.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_standings.go
@@ -39,7 +39,7 @@ func newStandingsPromotedCmd(flags *rootFlags) *cobra.Command {
 				}
 				return cmd.Help()
 			}
-			if !cmd.Flags().Changed("game-id") && !flags.dryRun {
+			if !cmd.Flags().Changed("game-id") && flagGameId == "" && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "game-id")
 			}
 			c, err := flags.newClient()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Generated required-flag guards tested cobra's `Changed` bit only. A root-level PreRunE / resolver that writes the correct value into the bound flag does not set `Changed`, so required commands still failed with `required flag "..." not set` even though the value was present. That blocks the multi-tenant root-flag-plus-env pattern.

Closes #4455

## Approach

Prefer the value-based contract: a required flag is missing only when `Changed` is false **and** the bound value is still at its type zero. A PreRunE (or env default, or any other supplier) that writes a non-zero value satisfies the guard without flipping cobra internals. Omitting the parameter entirely still fails with the same `required flag "..." not set` message.

Which parameters are marked required is unchanged. The same contract now applies to query/path/header params **and** body required-field checks (including `--body-json`). Enum/JSON `Changed` presence gates are unchanged.

## Scope

Primary area: generator command templates, `flagRequiredUnsatisfiedExpr`, and `bodyRequiredChecks` / `renderFlatBodyRequiredCheck`.

Why this belongs in this repo: every printed CLI inherits the required-guard from the Printing Press. The defect is in generated command bodies, not one API.

## Risk

Generated required-flag `if` conditions gain a zero-value conjunct. CLI users who pass the flag still pass via `Changed`. Explicit empty/zero CLI values still count as set. Goldens that snapshot those command files are updated via `scripts/golden.sh update`.

## Output Contract

- Helper unit tests lock the emitted expression for string, alias, int, required-bool, global-scope params, and required body fields (`name`, `visibility`, `filter`, `store-code`).
- `TestGeneratedOutput_RequiredFlagGuardHonorsResolvedValue` generates endpoint + promoted commands, asserts the emitted guard, compiles the module, and runs positive (PreRunE `Value.Set` without `Changed`) and negative (omitted / empty resolve) cases on the generated CLI.
- `scripts/golden.sh update` refreshed every generate-case fixture the current generator actually changes. Required-flag snapshots now include:
  - `reports_export_report-year.go`, `stores_find.go`, `promoted_standings.go` (param guards)
  - `projects_create.go`, `promoted_tickets.go`, `stores_create.go` (body-field guards)

## Verification

- [x] Generator/template change: emitted-code assertions plus compiled generated CLI runtime cases
- [x] Generator/template change: covered missing value, resolved non-zero value, empty resolve, and explicit CLI flag
- [x] Generator/template change: param and body required-flag call sites share the value-aware contract; enum/JSON/`flagChangedExpr` presence checks left on `Changed`
- [x] `scripts/golden.sh update` run; remaining required-flag fixtures committed
- [ ] `go test ./...` running on this revision

Unrelated `dogfood-verdict-matrix` / `verify-runtime-matrix` fixtures still fail locally because those fixtures pin `go 1.24` and this environment cannot download that toolchain. Those files were not updated.

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-133c17d7-26ba-4f7d-bf81-821793f22969?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-133c17d7-26ba-4f7d-bf81-821793f22969&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

