### PR TITLE
fix(cli): pin go directive to a library-safe floor

### DIFF
--- a/internal/generator/go_version.go
+++ b/internal/generator/go_version.go
@@ -1,53 +1,30 @@
 package generator
 
-import (
-	"fmt"
-	"os/exec"
-	"regexp"
-	"runtime"
-	"strings"
-)
-
-var goRuntimeVersionRE = regexp.MustCompile(`go([0-9]+\.[0-9]+)(?:\.([0-9]+))?`)
+// librarySafeGoDirective is the go line emitted into every printed CLI.
+// It is the public-library CI / stdlib CVE floor (GO-2026-6090, GO-2026-6218,
+// GO-2026-6089, GO-2026-5972), not the print-host toolchain.
+const librarySafeGoDirective = "1.26.6"
 
 func currentGoDirectiveVersion() string {
-	version, _ := resolveCurrentGoDirectiveVersion()
-	return version
+	return librarySafeGoDirective
 }
 
 func currentGoToolchainVersion() string {
-	version, _ := resolveCurrentGoToolchainVersion()
-	return version
+	return "go" + librarySafeGoDirective
 }
 
 func resolveCurrentGoDirectiveVersion() (string, error) {
-	if version := goDirectiveVersionFromRuntime(runtime.Version()); version != "" {
-		return version, nil
-	}
-	out, err := exec.Command("go", "env", "GOVERSION").Output()
-	if err == nil {
-		if version := goDirectiveVersionFromRuntime(strings.TrimSpace(string(out))); version != "" {
-			return version, nil
-		}
-	}
-	return "", fmt.Errorf("could not determine Go toolchain version from runtime %q or go env GOVERSION", runtime.Version())
+	return librarySafeGoDirective, nil
 }
 
 func resolveCurrentGoToolchainVersion() (string, error) {
-	version, err := resolveCurrentGoDirectiveVersion()
-	if err != nil {
-		return "", err
-	}
-	return "go" + version, nil
+	return currentGoToolchainVersion(), nil
 }
 
-func goDirectiveVersionFromRuntime(version string) string {
-	match := goRuntimeVersionRE.FindStringSubmatch(version)
-	if match == nil {
-		return ""
-	}
-	if match[2] == "" {
-		return match[1] + ".0"
-	}
-	return match[1] + "." + match[2]
+// selectEmittedGoDirective is the printed go.mod selection policy.
+// The host or binary runtime version is accepted so tests can prove it is
+// never copied in either direction: an older host must not freeze stdlib
+// CVEs, and a newer host must not exceed library CI GOTOOLCHAIN=local.
+func selectEmittedGoDirective(_ string) string {
+	return librarySafeGoDirective
 }

--- a/internal/generator/go_version.go
+++ b/internal/generator/go_version.go
@@ -1,8 +1,7 @@
 package generator
 
-// librarySafeGoDirective is the go line emitted into every printed CLI.
-// It is the public-library CI / stdlib CVE floor (GO-2026-6090, GO-2026-6218,
-// GO-2026-6089, GO-2026-5972), not the print-host toolchain.
+// Public-library CI / stdlib CVE floor (GO-2026-6090, GO-2026-6218,
+// GO-2026-6089, GO-2026-5972). Do not derive from the print-host toolchain.
 const librarySafeGoDirective = "1.26.6"
 
 func currentGoDirectiveVersion() string {
@@ -21,10 +20,9 @@ func resolveCurrentGoToolchainVersion() (string, error) {
 	return currentGoToolchainVersion(), nil
 }
 
-// selectEmittedGoDirective is the printed go.mod selection policy.
-// The host or binary runtime version is accepted so tests can prove it is
-// never copied in either direction: an older host must not freeze stdlib
-// CVEs, and a newer host must not exceed library CI GOTOOLCHAIN=local.
+// Host or binary runtime version is accepted so tests can prove it is never
+// copied: an older host must not freeze stdlib CVEs, and a newer host must
+// not exceed library CI GOTOOLCHAIN=local.
 func selectEmittedGoDirective(_ string) string {
 	return librarySafeGoDirective
 }

--- a/internal/generator/go_version_test.go
+++ b/internal/generator/go_version_test.go
@@ -69,6 +69,8 @@ func TestGeneratedGoModUsesLibrarySafeFloor(t *testing.T) {
 	goMod := readGeneratedFile(t, outputDir, "go.mod")
 	assert.Contains(t, goMod, "\ngo "+librarySafeGoDirective+"\n")
 	assert.Contains(t, goMod, "\ntoolchain go"+librarySafeGoDirective+"\n")
+	assert.Contains(t, goMod, "\ngo 1.26.6\n")
+	assert.Contains(t, goMod, "\ntoolchain go1.26.6\n")
 	assert.NotContains(t, goMod, "\ngo 1.26\n")
 	assert.NotContains(t, goMod, "\ngo 1.26.5\n")
 	assert.NotContains(t, goMod, "\ngo 1.26.7\n")

--- a/internal/generator/go_version_test.go
+++ b/internal/generator/go_version_test.go
@@ -1,47 +1,108 @@
 package generator
 
 import (
+	"os"
 	"path/filepath"
+	"regexp"
+	"runtime"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/semver"
 )
 
-func TestGoDirectiveVersionFromRuntime(t *testing.T) {
+var testGoRuntimeVersionRE = regexp.MustCompile(`go([0-9]+\.[0-9]+)(?:\.([0-9]+))?`)
+
+func TestSelectEmittedGoDirectiveIgnoresHostToolchain(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name    string
-		version string
-		want    string
-	}{
-		{name: "patch", version: "go1.26.5", want: "1.26.5"},
-		{name: "minor", version: "go1.26", want: "1.26.0"},
-		{name: "devel", version: "devel go1.27-abc123", want: "1.27.0"},
-		{name: "suffix", version: "go1.26.5 X:cacheprog", want: "1.26.5"},
-		{name: "unknown", version: "unknown", want: ""},
+	// Older printers froze stdlib CVEs; newer printers (and release binaries
+	// built ahead of CI) exceeded library GOTOOLCHAIN=local.
+	hosts := []string{
+		"go1.26.5",
+		"go1.26.6",
+		"go1.26.7",
+		"go1.26",
+		"go1.27.0",
+		"devel go1.27-abc123",
+		"go1.26.5 X:cacheprog",
+		runtime.Version(),
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, host := range hosts {
+		t.Run(host, func(t *testing.T) {
 			t.Parallel()
-
-			assert.Equal(t, tt.want, goDirectiveVersionFromRuntime(tt.version))
+			assert.Equal(t, librarySafeGoDirective, selectEmittedGoDirective(host))
 		})
 	}
 }
 
-func TestGeneratedGoModUsesPatchGoDirective(t *testing.T) {
+func TestLibrarySafeGoDirectiveShape(t *testing.T) {
 	t.Parallel()
 
-	apiSpec := minimalSpec("patch-directive")
+	assert.Equal(t, "1.26.6", librarySafeGoDirective)
+	assert.Regexp(t, `^\d+\.\d+\.\d+$`, librarySafeGoDirective)
+	assert.GreaterOrEqual(t, semver.Compare("v"+librarySafeGoDirective, "v1.26.6"), 0)
+}
+
+func TestLibrarySafeGoDirectiveDoesNotExceedPressGoMod(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../../go.mod")
+	require.NoError(t, err)
+	mod, err := modfile.Parse("go.mod", data, nil)
+	require.NoError(t, err)
+	require.NotNil(t, mod.Go)
+	assert.LessOrEqual(t, semver.Compare("v"+librarySafeGoDirective, "v"+mod.Go.Version), 0,
+		"printed CLIs must not demand a newer Go than the Printing Press itself")
+}
+
+func TestGeneratedGoModUsesLibrarySafeFloor(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("library-safe-directive")
 	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
 	require.NoError(t, New(apiSpec, outputDir).Generate())
 
 	goMod := readGeneratedFile(t, outputDir, "go.mod")
-	assert.Contains(t, goMod, "\ngo "+currentGoDirectiveVersion()+"\n")
-	assert.Contains(t, goMod, "\ntoolchain "+currentGoToolchainVersion()+"\n")
+	assert.Contains(t, goMod, "\ngo "+librarySafeGoDirective+"\n")
+	assert.Contains(t, goMod, "\ntoolchain go"+librarySafeGoDirective+"\n")
 	assert.NotContains(t, goMod, "\ngo 1.26\n")
+	assert.NotContains(t, goMod, "\ngo 1.26.5\n")
+	assert.NotContains(t, goMod, "\ngo 1.26.7\n")
+	assert.NotContains(t, goMod, "\ntoolchain go1.26.5\n")
+	assert.NotContains(t, goMod, "\ntoolchain go1.26.7\n")
+
+	if copied := goPatchFromRuntime(runtime.Version()); copied != "" && copied != librarySafeGoDirective {
+		assert.NotContains(t, goMod, "\ngo "+copied+"\n")
+		assert.NotContains(t, goMod, "\ntoolchain go"+copied+"\n")
+	}
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestResolveGoDirectiveVersionIsTheFloor(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveCurrentGoDirectiveVersion()
+	require.NoError(t, err)
+	assert.Equal(t, librarySafeGoDirective, got)
+	assert.Equal(t, librarySafeGoDirective, currentGoDirectiveVersion())
+	assert.Equal(t, "go"+librarySafeGoDirective, currentGoToolchainVersion())
+	toolchain, err := resolveCurrentGoToolchainVersion()
+	require.NoError(t, err)
+	assert.Equal(t, "go"+librarySafeGoDirective, toolchain)
+}
+
+func goPatchFromRuntime(version string) string {
+	match := testGoRuntimeVersionRE.FindStringSubmatch(version)
+	if match == nil {
+		return ""
+	}
+	if match[2] == "" {
+		return match[1] + ".0"
+	}
+	return match[1] + "." + match[2]
 }

--- a/scripts/verify-go-floor.py
+++ b/scripts/verify-go-floor.py
@@ -106,6 +106,9 @@ def main() -> int:
                 current_line = line_text(content, match.start())
                 if is_allowed_old_fixture(rel, current_line):
                     continue
+                # NotContains names a version that must not appear; it is not a floor pin.
+                if "NotContains" in current_line:
+                    continue
                 if version != floor:
                     failures.append(
                         f"{rel}:{line_number(content, match.start())}: expected {floor}, found {version}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

The generator copied the print-host (or release-binary) Go version into every printed CLI `go.mod`. That froze older hosts onto stdlib CVEs and made newer hosts unpublishable under library CI `GOTOOLCHAIN=local`.

Closes #4282

## Approach

Replace `resolveCurrentGoDirective` / `runtime.Version()` with a maintained library-safe floor:

- Emitted `go` directive is always `1.26.6` (patch pin, not bare `1.26`)
- Emitted `toolchain` line uses the same floor so a newer print host cannot still fail `GOTOOLCHAIN=local`
- Floor is the public-library CI pin and the stdlib CVE floor (GO-2026-6090, GO-2026-6218, GO-2026-6089, GO-2026-5972)
- Reprints on varied hosts produce the same directive

`scripts/verify-go-floor.py` now skips `NotContains` lines so historical host versions used as negative examples are not treated as floor pins. `go.mod` stays `1.26.6`.

This is not “newest Go on the printer.” #4336 (stale x/net floor) is out of scope.

## Scope

Primary area: generator (`internal/generator/go_version.go`)

Why this belongs in this repo: the defect is in the Printing Press generator, not one printed CLI. Every future print inherits the floor.

## Risk

Generated `go.mod` `go` / `toolchain` lines become host-independent. Hosts already on 1.26.6 see no golden drift. Hosts that previously emitted 1.26.5 or 1.26.7 will now emit 1.26.6.

## Output Contract

Emitted `go.mod` always contains `go 1.26.6` and `toolchain go1.26.6`. Evidence: `TestGeneratedGoModUsesLibrarySafeFloor` (emitted-code assertions + `requireGeneratedCompiles`) and `TestSelectEmittedGoDirectiveIgnoresHostToolchain` (simulated host versions including 1.26.5, 1.26.7, and 1.27). Existing generate goldens already snapshot `go 1.26.6` and passed unchanged.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands actually run:

- `go test ./...` — pass (pre-CI-fix revision)
- `scripts/verify-generator-output.sh` — pass (11 cases)
- `scripts/golden.sh verify` — all `generate-*` cases pass; no fixture update
- `python3 scripts/verify-go-floor.py` — pass after scanner skip
- `go test ./internal/generator/ -run TestSelectEmittedGoDirective|TestLibrarySafeGoDirective|TestGeneratedGoModUsesLibrarySafeFloor|TestResolveGoDirectiveVersion` — pass

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff9a56fe-d002-4b0c-9e35-ba4679e2c14b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff9a56fe-d002-4b0c-9e35-ba4679e2c14b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

