### PR TITLE
fix(cli): preserve hand-authored MCP behavior during mcp-sync

### DIFF
--- a/internal/pipeline/mcpsync/preserve.go
+++ b/internal/pipeline/mcpsync/preserve.go
@@ -264,7 +264,35 @@ type intentDecl struct {
 
 func isGeneratedIntentHandler(decl ast.Decl) bool {
 	fn, ok := decl.(*ast.FuncDecl)
-	return ok && strings.HasPrefix(fn.Name.Name, "handle")
+	if !ok || fn.Type == nil || !strings.HasPrefix(fn.Name.Name, "handle") {
+		return false
+	}
+	return hasNamedType(fn.Type.Params, "CallToolRequest") && hasNamedType(fn.Type.Results, "CallToolResult")
+}
+
+func hasNamedType(fields *ast.FieldList, name string) bool {
+	if fields == nil {
+		return false
+	}
+	for _, field := range fields.List {
+		if typeIdentName(field.Type) == name {
+			return true
+		}
+	}
+	return false
+}
+
+func typeIdentName(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.SelectorExpr:
+		return t.Sel.Name
+	case *ast.StarExpr:
+		return typeIdentName(t.X)
+	default:
+		return ""
+	}
 }
 
 func expandPreservedIntentDeps(keep map[string]bool, beforeByName map[string]intentDecl, afterNames map[string]bool) {

--- a/internal/pipeline/mcpsync/preserve.go
+++ b/internal/pipeline/mcpsync/preserve.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -162,33 +163,62 @@ func mergeHandAuthoredIntentFile(before, after []byte) ([]byte, error) {
 		}
 	}
 
-	merged := string(after)
+	beforeByName := map[string]intentDecl{}
 	for _, decl := range fileBefore.Decls {
 		if isImportDecl(decl) {
 			continue
 		}
-		beforeSrc := nodeSource(fsetBefore, before, decl)
-		names := collectDeclNames(decl)
-		if declHasIntentMarkers(beforeSrc) && len(names) == 1 && afterNames[names[0]] {
-			afterSrc, ok := declSourceByName(fsetAfter, after, fileAfter, names[0])
-			if ok && afterSrc != beforeSrc {
-				merged = strings.Replace(merged, afterSrc, beforeSrc, 1)
+		item := intentDecl{decl: decl, src: nodeSource(fsetBefore, before, decl)}
+		for _, name := range collectDeclNames(decl) {
+			beforeByName[name] = item
+		}
+	}
+
+	keep := map[string]bool{}
+	for _, decl := range fileBefore.Decls {
+		if isImportDecl(decl) {
+			continue
+		}
+		src := nodeSource(fsetBefore, before, decl)
+		if !declHasIntentMarkers(src) {
+			continue
+		}
+		if isGeneratedIntentHandler(decl) {
+			for _, name := range collectDeclNames(decl) {
+				if afterNames[name] {
+					keep[name] = true
+				}
 			}
 			continue
 		}
-		allPresent := len(names) > 0
-		for _, name := range names {
-			if !afterNames[name] {
-				allPresent = false
-				break
-			}
+		for _, name := range collectDeclNames(decl) {
+			keep[name] = true
 		}
-		if !allPresent {
-			merged = strings.TrimRight(merged, "\n") + "\n\n" + beforeSrc + "\n"
-			for _, name := range names {
-				afterNames[name] = true
-			}
+	}
+	expandPreservedIntentDeps(keep, beforeByName, afterNames)
+
+	merged := string(after)
+	appended := map[string]bool{}
+	for _, name := range sortedKeepNames(keep) {
+		item, ok := beforeByName[name]
+		if !ok {
+			continue
 		}
+		if afterNames[name] {
+			if !declHasIntentMarkers(item.src) {
+				continue
+			}
+			afterSrc, found := declSourceByName(fsetAfter, after, fileAfter, name)
+			if found && afterSrc != item.src {
+				merged = strings.Replace(merged, afterSrc, item.src, 1)
+			}
+			continue
+		}
+		if appended[item.src] {
+			continue
+		}
+		merged = strings.TrimRight(merged, "\n") + "\n\n" + item.src + "\n"
+		appended[item.src] = true
 	}
 
 	for _, path := range importPaths(fileBefore) {
@@ -227,12 +257,70 @@ func collectDeclNames(decl ast.Decl) []string {
 	return nil
 }
 
+type intentDecl struct {
+	decl ast.Decl
+	src  string
+}
+
+func isGeneratedIntentHandler(decl ast.Decl) bool {
+	fn, ok := decl.(*ast.FuncDecl)
+	return ok && strings.HasPrefix(fn.Name.Name, "handle")
+}
+
+func expandPreservedIntentDeps(keep map[string]bool, beforeByName map[string]intentDecl, afterNames map[string]bool) {
+	changed := true
+	for changed {
+		changed = false
+		for name := range keep {
+			item, ok := beforeByName[name]
+			if !ok {
+				continue
+			}
+			for _, ident := range packageIdentNames(item.decl) {
+				dep, ok := beforeByName[ident]
+				if !ok {
+					continue
+				}
+				if isGeneratedIntentHandler(dep.decl) && !afterNames[ident] {
+					continue
+				}
+				if !keep[ident] {
+					keep[ident] = true
+					changed = true
+				}
+			}
+		}
+	}
+}
+
+func packageIdentNames(decl ast.Decl) []string {
+	seen := map[string]bool{}
+	var names []string
+	ast.Inspect(decl, func(node ast.Node) bool {
+		ident, ok := node.(*ast.Ident)
+		if !ok || ident.Name == "" || seen[ident.Name] {
+			return true
+		}
+		seen[ident.Name] = true
+		names = append(names, ident.Name)
+		return true
+	})
+	return names
+}
+
+func sortedKeepNames(keep map[string]bool) []string {
+	names := make([]string, 0, len(keep))
+	for name := range keep {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
 func declSourceByName(fset *token.FileSet, src []byte, file *ast.File, name string) (string, bool) {
 	for _, decl := range file.Decls {
-		for _, n := range collectDeclNames(decl) {
-			if n == name {
-				return nodeSource(fset, src, decl), true
-			}
+		if slices.Contains(collectDeclNames(decl), name) {
+			return nodeSource(fset, src, decl), true
 		}
 	}
 	return "", false

--- a/internal/pipeline/mcpsync/preserve.go
+++ b/internal/pipeline/mcpsync/preserve.go
@@ -1,0 +1,284 @@
+package mcpsync
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// mcpRuntimeSnapshot holds pre-sync copies of MCP files that may carry
+// hand-authored behavior. Description overrides still flow through
+// GenerateMCPSurface into tools.go; these snapshots are restored or
+// merged afterward so a description refresh cannot delete poll loops,
+// annotation rules, destination-flag blocklists, or HTTP timeouts.
+type mcpRuntimeSnapshot struct {
+	files map[string][]byte
+}
+
+var (
+	handAuthoredDBFlag     = regexp.MustCompile(`"db"\s*:\s*true`)
+	handAuthoredIntentMark = regexp.MustCompile(`\b(waitForIntentPoll|intentDuration|pollAfter|operationTimeout)\b`)
+)
+
+func snapshotMCPRuntime(cliDir string) (*mcpRuntimeSnapshot, error) {
+	snap := &mcpRuntimeSnapshot{files: map[string][]byte{}}
+	if err := snapshotDirGoFiles(cliDir, snap, filepath.Join("internal", "mcp", "cobratree")); err != nil {
+		return nil, err
+	}
+	if err := snapshotExistingFile(cliDir, snap, filepath.Join("internal", "mcp", "intents.go")); err != nil {
+		return nil, err
+	}
+	matches, err := filepath.Glob(filepath.Join(cliDir, "cmd", "*-pp-mcp", "main.go"))
+	if err != nil {
+		return nil, fmt.Errorf("listing MCP entrypoints: %w", err)
+	}
+	for _, abs := range matches {
+		rel, err := filepath.Rel(cliDir, abs)
+		if err != nil {
+			return nil, err
+		}
+		if err := snapshotExistingFile(cliDir, snap, rel); err != nil {
+			return nil, err
+		}
+	}
+	return snap, nil
+}
+
+func snapshotDirGoFiles(cliDir string, snap *mcpRuntimeSnapshot, relDir string) error {
+	entries, err := os.ReadDir(filepath.Join(cliDir, relDir))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("reading %s: %w", relDir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") {
+			continue
+		}
+		if err := snapshotExistingFile(cliDir, snap, filepath.Join(relDir, entry.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func snapshotExistingFile(cliDir string, snap *mcpRuntimeSnapshot, rel string) error {
+	data, err := os.ReadFile(filepath.Join(cliDir, rel))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("reading %s: %w", rel, err)
+	}
+	snap.files[filepath.ToSlash(rel)] = data
+	return nil
+}
+
+func restoreMCPRuntime(cliDir string, snap *mcpRuntimeSnapshot) error {
+	if snap == nil {
+		return nil
+	}
+	for rel, before := range snap.files {
+		abs := filepath.Join(cliDir, filepath.FromSlash(rel))
+		if isMCPIntentFile(rel) {
+			after, err := os.ReadFile(abs)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					if err := writeFileAtomic(abs, before); err != nil {
+						return err
+					}
+					continue
+				}
+				return fmt.Errorf("reading regenerated %s: %w", rel, err)
+			}
+			merged, err := mergeHandAuthoredIntentFile(before, after)
+			if err != nil {
+				return fmt.Errorf("merging hand-authored intents in %s: %w", rel, err)
+			}
+			if err := writeFileAtomic(abs, merged); err != nil {
+				return err
+			}
+			continue
+		}
+		if !hasHandAuthoredMCPBehavior(before) {
+			continue
+		}
+		if err := writeFileAtomic(abs, before); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isMCPIntentFile(rel string) bool {
+	return filepath.ToSlash(rel) == "internal/mcp/intents.go"
+}
+
+func hasHandAuthoredMCPBehavior(src []byte) bool {
+	if handAuthoredIntentMark.Match(src) {
+		return true
+	}
+	if bytes.Contains(src, []byte("func isMCPExecutionReadOnly(")) {
+		return true
+	}
+	if bytes.Contains(src, []byte("localWrite := isMCPLocalWrite")) {
+		return true
+	}
+	if bytes.Contains(src, []byte("ReadHeaderTimeout")) {
+		return true
+	}
+	return handAuthoredDBFlag.Match(src)
+}
+
+func mergeHandAuthoredIntentFile(before, after []byte) ([]byte, error) {
+	if !hasHandAuthoredMCPBehavior(before) {
+		return after, nil
+	}
+	fsetBefore := token.NewFileSet()
+	fileBefore, err := parser.ParseFile(fsetBefore, "intents.go", before, parser.ParseComments)
+	if err != nil {
+		return nil, fmt.Errorf("parsing pre-sync intents.go: %w", err)
+	}
+	fsetAfter := token.NewFileSet()
+	fileAfter, err := parser.ParseFile(fsetAfter, "intents.go", after, parser.ParseComments)
+	if err != nil {
+		return nil, fmt.Errorf("parsing regenerated intents.go: %w", err)
+	}
+
+	afterNames := map[string]bool{}
+	for _, decl := range fileAfter.Decls {
+		for _, name := range collectDeclNames(decl) {
+			afterNames[name] = true
+		}
+	}
+
+	merged := string(after)
+	for _, decl := range fileBefore.Decls {
+		if isImportDecl(decl) {
+			continue
+		}
+		beforeSrc := nodeSource(fsetBefore, before, decl)
+		names := collectDeclNames(decl)
+		if declHasIntentMarkers(beforeSrc) && len(names) == 1 && afterNames[names[0]] {
+			afterSrc, ok := declSourceByName(fsetAfter, after, fileAfter, names[0])
+			if ok && afterSrc != beforeSrc {
+				merged = strings.Replace(merged, afterSrc, beforeSrc, 1)
+			}
+			continue
+		}
+		allPresent := len(names) > 0
+		for _, name := range names {
+			if !afterNames[name] {
+				allPresent = false
+				break
+			}
+		}
+		if !allPresent {
+			merged = strings.TrimRight(merged, "\n") + "\n\n" + beforeSrc + "\n"
+			for _, name := range names {
+				afterNames[name] = true
+			}
+		}
+	}
+
+	for _, path := range importPaths(fileBefore) {
+		merged = ensureImport(merged, path)
+	}
+	formatted, err := format.Source([]byte(merged))
+	if err != nil {
+		return nil, fmt.Errorf("formatting merged intents.go: %w", err)
+	}
+	return formatted, nil
+}
+
+func isImportDecl(decl ast.Decl) bool {
+	gen, ok := decl.(*ast.GenDecl)
+	return ok && gen.Tok == token.IMPORT
+}
+
+func collectDeclNames(decl ast.Decl) []string {
+	switch d := decl.(type) {
+	case *ast.FuncDecl:
+		return []string{d.Name.Name}
+	case *ast.GenDecl:
+		var names []string
+		for _, spec := range d.Specs {
+			switch s := spec.(type) {
+			case *ast.TypeSpec:
+				names = append(names, s.Name.Name)
+			case *ast.ValueSpec:
+				for _, name := range s.Names {
+					names = append(names, name.Name)
+				}
+			}
+		}
+		return names
+	}
+	return nil
+}
+
+func declSourceByName(fset *token.FileSet, src []byte, file *ast.File, name string) (string, bool) {
+	for _, decl := range file.Decls {
+		for _, n := range collectDeclNames(decl) {
+			if n == name {
+				return nodeSource(fset, src, decl), true
+			}
+		}
+	}
+	return "", false
+}
+
+func nodeSource(fset *token.FileSet, src []byte, node ast.Node) string {
+	start := fset.Position(node.Pos()).Offset
+	end := fset.Position(node.End()).Offset
+	if start < 0 || end > len(src) || start >= end {
+		return ""
+	}
+	return string(src[start:end])
+}
+
+func declHasIntentMarkers(src string) bool {
+	return handAuthoredIntentMark.MatchString(src)
+}
+
+func importPaths(file *ast.File) []string {
+	var paths []string
+	for _, imp := range file.Imports {
+		path, err := strconv.Unquote(imp.Path.Value)
+		if err != nil {
+			continue
+		}
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+func ensureImport(src, path string) string {
+	quoted := strconv.Quote(path)
+	if strings.Contains(src, quoted) {
+		return src
+	}
+	block := regexp.MustCompile(`import \(\n`)
+	if loc := block.FindStringIndex(src); loc != nil {
+		return src[:loc[1]] + "\t" + quoted + "\n" + src[loc[1]:]
+	}
+	single := regexp.MustCompile(`(?m)^import .+\n`)
+	if loc := single.FindStringIndex(src); loc != nil {
+		return src[:loc[1]] + "import " + quoted + "\n" + src[loc[1]:]
+	}
+	pkg := regexp.MustCompile(`(?m)^package \w+\n`)
+	if loc := pkg.FindStringIndex(src); loc != nil {
+		return src[:loc[1]] + "\nimport " + quoted + "\n" + src[loc[1]:]
+	}
+	return src
+}

--- a/internal/pipeline/mcpsync/preserve_test.go
+++ b/internal/pipeline/mcpsync/preserve_test.go
@@ -96,3 +96,73 @@ func TestMergeHandAuthoredIntentFileNoopsWithoutMarkers(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, string(after), string(merged))
 }
+
+func TestMergeHandAuthoredIntentFileDropsRemovedGeneratedHandlers(t *testing.T) {
+	t.Parallel()
+
+	before := []byte(`package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+func handleOldExplicit(ctx context.Context) error {
+	_, err := waitForIntentPoll(ctx, pollAfter, operationTimeout)
+	return err
+}
+
+func handleWaitForOperation(ctx context.Context) error {
+	_, err := waitForIntentPoll(ctx, pollAfter, operationTimeout)
+	return err
+}
+
+func callIntentEndpoint(ctx context.Context) (any, error) { return nil, nil }
+
+const (
+	pollAfter        = 200 * time.Millisecond
+	operationTimeout = 5 * time.Second
+)
+
+func intentDuration(d *time.Duration) time.Duration { return 0 }
+
+func waitForIntentPoll(ctx context.Context, pollAfter, operationTimeout time.Duration) (any, error) {
+	_ = intentDuration(&operationTimeout)
+	if !intentPollComplete(nil) {
+		return nil, fmt.Errorf("unfinished")
+	}
+	return callIntentEndpoint(ctx)
+}
+
+func intentPollComplete(resp any) bool { return resp != nil }
+`)
+	after := []byte(`package mcp
+
+import (
+	"context"
+	"fmt"
+)
+
+func handleNewExplicit(ctx context.Context) error {
+	_, err := callIntentEndpoint(ctx)
+	return err
+}
+
+func handleWaitForOperation(ctx context.Context) error {
+	_, err := callIntentEndpoint(ctx)
+	return err
+}
+
+func callIntentEndpoint(ctx context.Context) (any, error) { return nil, nil }
+`)
+
+	merged, err := mergeHandAuthoredIntentFile(before, after)
+	require.NoError(t, err)
+	src := string(merged)
+	assert.Contains(t, src, "func handleNewExplicit(")
+	assert.NotContains(t, src, "func handleOldExplicit(", "removed generated handlers must not be re-appended")
+	assert.Contains(t, src, "func waitForIntentPoll(")
+	assert.Contains(t, src, "func intentPollComplete(")
+	assert.Contains(t, src, "waitForIntentPoll(ctx, pollAfter, operationTimeout)")
+}

--- a/internal/pipeline/mcpsync/preserve_test.go
+++ b/internal/pipeline/mcpsync/preserve_test.go
@@ -1,0 +1,98 @@
+package mcpsync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasHandAuthoredMCPBehavior(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, hasHandAuthoredMCPBehavior([]byte("func waitForIntentPoll() {}")))
+	assert.True(t, hasHandAuthoredMCPBehavior([]byte("localWrite := isMCPLocalWrite(cmd)")))
+	assert.True(t, hasHandAuthoredMCPBehavior([]byte("\t\"db\":           true,\n")))
+	assert.True(t, hasHandAuthoredMCPBehavior([]byte("ReadHeaderTimeout: 10 * time.Second,")))
+	assert.True(t, hasHandAuthoredMCPBehavior([]byte("func isMCPExecutionReadOnly(cmd *cobra.Command) bool { return false }")))
+	assert.False(t, hasHandAuthoredMCPBehavior([]byte("if !readOnly && isMCPLocalWrite(cmd) {")))
+	assert.False(t, hasHandAuthoredMCPBehavior([]byte("var blockedRootFlags = map[string]bool{\"token\": true}")))
+}
+
+func TestMergeHandAuthoredIntentFileKeepsPollHelpers(t *testing.T) {
+	t.Parallel()
+
+	before := []byte(`package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+func handleWaitForOperation(ctx context.Context) error {
+	_, err := waitForIntentPoll(ctx, pollAfter, operationTimeout)
+	return err
+}
+
+func callIntentEndpoint(ctx context.Context) (any, error) { return nil, nil }
+
+const (
+	pollAfter        = 200 * time.Millisecond
+	operationTimeout = 5 * time.Second
+)
+
+func intentDuration(d *time.Duration) time.Duration {
+	if d == nil {
+		return 0
+	}
+	return *d
+}
+
+func waitForIntentPoll(ctx context.Context, pollAfter, operationTimeout time.Duration) (any, error) {
+	_ = intentDuration(&operationTimeout)
+	if !intentPollComplete(nil) {
+		return nil, fmt.Errorf("unfinished")
+	}
+	return callIntentEndpoint(ctx)
+}
+
+func intentPollComplete(resp any) bool { return resp != nil }
+`)
+	after := []byte(`package mcp
+
+import (
+	"context"
+	"fmt"
+)
+
+func handleWaitForOperation(ctx context.Context) error {
+	_, err := callIntentEndpoint(ctx)
+	return err
+}
+
+func callIntentEndpoint(ctx context.Context) (any, error) { return nil, nil }
+`)
+
+	merged, err := mergeHandAuthoredIntentFile(before, after)
+	require.NoError(t, err)
+	src := string(merged)
+	assert.Contains(t, src, "func waitForIntentPoll(")
+	assert.Contains(t, src, "func intentDuration(")
+	assert.Contains(t, src, "func intentPollComplete(")
+	assert.Contains(t, src, "pollAfter")
+	assert.Contains(t, src, "operationTimeout")
+	assert.Contains(t, src, "waitForIntentPoll(ctx, pollAfter, operationTimeout)")
+	assert.Contains(t, src, `"time"`)
+	assert.NotContains(t, src, "_, err := callIntentEndpoint(ctx)")
+}
+
+func TestMergeHandAuthoredIntentFileNoopsWithoutMarkers(t *testing.T) {
+	t.Parallel()
+
+	before := []byte("package mcp\nfunc handleOld() {}\n")
+	after := []byte("package mcp\nfunc handleNew() {}\n")
+	merged, err := mergeHandAuthoredIntentFile(before, after)
+	require.NoError(t, err)
+	assert.Equal(t, string(after), string(merged))
+}

--- a/internal/pipeline/mcpsync/preserve_test.go
+++ b/internal/pipeline/mcpsync/preserve_test.go
@@ -1,6 +1,8 @@
 package mcpsync
 
 import (
+	"go/parser"
+	"go/token"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -97,6 +99,56 @@ func TestMergeHandAuthoredIntentFileNoopsWithoutMarkers(t *testing.T) {
 	assert.Equal(t, string(after), string(merged))
 }
 
+func TestIsGeneratedIntentHandler(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{
+			name: "generated mcp tool handler",
+			src: `package mcp
+func handleCreateOperation(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	return nil, nil
+}`,
+			want: true,
+		},
+		{
+			name: "hand-authored handle helper",
+			src: `package mcp
+func handleCustomPoll(ctx context.Context, c *client.Client, opID string) (bool, error) {
+	return false, nil
+}`,
+			want: false,
+		},
+		{
+			name: "handle prefix without tool signature",
+			src: `package mcp
+func handleOldExplicit(ctx context.Context) error { return nil }`,
+			want: false,
+		},
+		{
+			name: "non-handle helper",
+			src: `package mcp
+func waitForIntentPoll(ctx context.Context) error { return nil }`,
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "intents.go", tc.src, 0)
+			require.NoError(t, err)
+			require.NotEmpty(t, file.Decls)
+			assert.Equal(t, tc.want, isGeneratedIntentHandler(file.Decls[0]))
+		})
+	}
+}
+
 func TestMergeHandAuthoredIntentFileDropsRemovedGeneratedHandlers(t *testing.T) {
 	t.Parallel()
 
@@ -106,11 +158,13 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
 )
 
-func handleOldExplicit(ctx context.Context) error {
+func handleOldExplicit(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	_, err := waitForIntentPoll(ctx, pollAfter, operationTimeout)
-	return err
+	return nil, err
 }
 
 func handleWaitForOperation(ctx context.Context) error {
@@ -165,4 +219,63 @@ func callIntentEndpoint(ctx context.Context) (any, error) { return nil, nil }
 	assert.Contains(t, src, "func waitForIntentPoll(")
 	assert.Contains(t, src, "func intentPollComplete(")
 	assert.Contains(t, src, "waitForIntentPoll(ctx, pollAfter, operationTimeout)")
+}
+
+func TestMergeHandAuthoredIntentFileKeepsCustomHandleHelper(t *testing.T) {
+	t.Parallel()
+
+	before := []byte(`package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/example/fixture-pp-cli/internal/client"
+)
+
+func handleCreateOperation(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	_, err := waitForIntentPoll(ctx, nil, "op")
+	return nil, err
+}
+
+func handleCustomPoll(ctx context.Context, c *client.Client, opID string) (bool, error) {
+	return waitForIntentPoll(ctx, c, opID)
+}
+
+func handleOldExplicit(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	_, err := waitForIntentPoll(ctx, nil, "gone")
+	return nil, err
+}
+
+func waitForIntentPoll(ctx context.Context, c *client.Client, opID string) (any, error) {
+	_ = operationTimeout
+	return nil, fmt.Errorf("unfinished")
+}
+
+const operationTimeout = 5 * time.Second
+`)
+	after := []byte(`package mcp
+
+import (
+	"context"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+)
+
+func handleCreateOperation(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	return nil, nil
+}
+`)
+
+	merged, err := mergeHandAuthoredIntentFile(before, after)
+	require.NoError(t, err)
+	src := string(merged)
+	assert.Contains(t, src, "func handleCustomPoll(")
+	assert.Contains(t, src, "func waitForIntentPoll(")
+	assert.Contains(t, src, "func handleCreateOperation(")
+	assert.Contains(t, src, `waitForIntentPoll(ctx, nil, "op")`)
+	assert.NotContains(t, src, "func handleOldExplicit(")
 }

--- a/internal/pipeline/mcpsync/sync.go
+++ b/internal/pipeline/mcpsync/sync.go
@@ -180,6 +180,13 @@ func Sync(cliDir string, opts Options) (Result, error) {
 	// may have changed since the last sync. Skipping these would silently
 	// freeze stale descriptions/annotations through future regen.
 	alreadyMigrated := state.State == pipeline.MCPSurfaceRuntime
+	var runtimeSnap *mcpRuntimeSnapshot
+	if alreadyMigrated {
+		runtimeSnap, err = snapshotMCPRuntime(cliDir)
+		if err != nil {
+			return Result{}, fmt.Errorf("snapshotting hand-authored MCP behavior: %w", err)
+		}
+	}
 
 	parsed, err := loadArchivedSpec(cliDir)
 	if err != nil {
@@ -328,6 +335,9 @@ func Sync(cliDir string, opts Options) (Result, error) {
 	gen.PreserveMCPIntentFile = preserveLegacyIntentFile
 	if err := gen.GenerateMCPSurface(); err != nil {
 		return Result{}, fmt.Errorf("rendering MCP surface: %w", err)
+	}
+	if err := restoreMCPRuntime(cliDir, runtimeSnap); err != nil {
+		return Result{}, fmt.Errorf("preserving hand-authored MCP behavior: %w", err)
 	}
 	// Refresh .printing-press.json's spec-derived fields before regenerating
 	// manifest.json. WriteMCPBManifest reads provenance from disk, so

--- a/internal/pipeline/mcpsync/sync_preserve_test.go
+++ b/internal/pipeline/mcpsync/sync_preserve_test.go
@@ -1,0 +1,315 @@
+package mcpsync
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/generator"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/mcpoverrides"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+const handAuthoredOverride = "List operations with the required cursor and optional status filter for agents."
+
+// TestSyncPreservesHandAuthoredMCPBehavior locks #4501: mcp-sync on a
+// runtime-walking tree must apply mcp-descriptions.json without deleting
+// hand-authored poll loops, local-write-wins annotations, blocked
+// destination flags, HTTP server timeouts, or leftover test helpers.
+func TestSyncPreservesHandAuthoredMCPBehavior(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := handAuthoredMCPSpec()
+	cliDir := filepath.Join(t.TempDir(), "handmcp")
+	gen := generator.New(apiSpec, cliDir)
+	gen.VisionSet = generator.VisionTemplateSet{MCP: true, Store: true}
+	require.NoError(t, gen.Generate())
+	require.NoError(t, pipeline.WriteManifestForGenerate(pipeline.GenerateManifestParams{
+		APIName:   apiSpec.Name,
+		OutputDir: cliDir,
+		Spec:      apiSpec,
+	}))
+
+	specData, err := yaml.Marshal(apiSpec)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "spec.yaml"), specData, 0o644))
+
+	state, err := pipeline.InspectMCPSurface(cliDir)
+	require.NoError(t, err)
+	require.Equal(t, pipeline.MCPSurfaceRuntime, state.State, "fixture must already be on the runtime walker")
+	require.True(t, state.Pass, "fixture must already report MCP Surface PASS")
+
+	require.NoError(t, plantHandAuthoredMCPBehavior(cliDir))
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, mcpoverrides.Filename), []byte(`{
+  "descriptions": {
+    "operations_list": "`+handAuthoredOverride+`"
+  }
+}`), 0o644))
+
+	_, err = Sync(cliDir, Options{})
+	require.NoError(t, err)
+
+	intentsAfter, err := os.ReadFile(filepath.Join(cliDir, "internal", "mcp", "intents.go"))
+	require.NoError(t, err)
+	intentsSrc := string(intentsAfter)
+	assert.Contains(t, intentsSrc, "func waitForIntentPoll(", "mcp-sync must keep the hand-authored intent poll loop")
+	assert.Contains(t, intentsSrc, "func intentDuration(", "mcp-sync must keep the intentDuration accessor")
+	assert.Contains(t, intentsSrc, "pollAfter", "mcp-sync must keep pollAfter hints")
+	assert.Contains(t, intentsSrc, "operationTimeout", "mcp-sync must keep operationTimeout hints")
+	assert.Contains(t, intentsSrc, `waitForIntentPoll(ctx, c, "operations.status"`, "status step must keep polling instead of a single status call")
+
+	walkerAfter, err := os.ReadFile(filepath.Join(cliDir, "internal", "mcp", "cobratree", "walker.go"))
+	require.NoError(t, err)
+	walkerSrc := string(walkerAfter)
+	assert.Contains(t, walkerSrc, "localWrite := isMCPLocalWrite(cmd)", "local-write must be evaluated independently of read-only")
+	assert.Contains(t, walkerSrc, "if localWrite {", "local-write must win when both annotations are present")
+	assert.NotContains(t, walkerSrc, "if !readOnly && isMCPLocalWrite(cmd)", "mcp-sync must not invert the local-write vs read-only rule")
+
+	shelloutAfter, err := os.ReadFile(filepath.Join(cliDir, "internal", "mcp", "cobratree", "shellout.go"))
+	require.NoError(t, err)
+	assert.Regexp(t, `"db"\s*:\s*true`, string(shelloutAfter), "blocked destination flags must keep db")
+
+	classifyAfter, err := os.ReadFile(filepath.Join(cliDir, "internal", "mcp", "cobratree", "classify.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(classifyAfter), "func isMCPExecutionReadOnly(", "leftover classify helper must survive so go vet stays clean")
+
+	mainAfter, err := os.ReadFile(filepath.Join(cliDir, "cmd", "handmcp-pp-mcp", "main.go"))
+	require.NoError(t, err)
+	mainSrc := string(mainAfter)
+	assert.Contains(t, mainSrc, "ReadHeaderTimeout:", "HTTP server must keep ReadHeaderTimeout")
+	assert.Contains(t, mainSrc, "ReadTimeout:", "HTTP server must keep ReadTimeout")
+	assert.Contains(t, mainSrc, "WriteTimeout:", "HTTP server must keep WriteTimeout")
+	assert.Contains(t, mainSrc, "IdleTimeout:", "HTTP server must keep IdleTimeout")
+	assert.Contains(t, mainSrc, `os.Setenv("HANDMCP_LEARN_SURFACE", "mcp")`, "learn-event surface pin must survive")
+
+	toolsManifest, err := os.ReadFile(filepath.Join(cliDir, pipeline.ToolsManifestFilename))
+	require.NoError(t, err)
+	assert.Contains(t, string(toolsManifest), handAuthoredOverride, "mcp-descriptions.json overrides must still reach tools-manifest.json")
+
+	vet := exec.Command("go", "vet", "-mod=mod", "./internal/mcp/...", "./cmd/handmcp-pp-mcp")
+	vet.Dir = cliDir
+	output, err := vet.CombinedOutput()
+	require.NoError(t, err, "post-sync MCP surface must go vet cleanly: %s", output)
+}
+
+func handAuthoredMCPSpec() *spec.APISpec {
+	return &spec.APISpec{
+		Name:    "handmcp",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Learn:   spec.LearnConfig{Enabled: true, EnabledSet: true},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/handmcp-pp-cli/config.toml",
+		},
+		MCP: spec.MCPConfig{
+			Transport: []string{"stdio", "http"},
+			Intents: []spec.Intent{{
+				Name:        "wait_for_operation",
+				Description: "Start an operation and wait until it finishes.",
+				Params: []spec.IntentParam{{
+					Name:        "name",
+					Type:        "string",
+					Required:    true,
+					Description: "Operation name",
+				}},
+				Steps: []spec.IntentStep{
+					{Endpoint: "operations.start", Bind: map[string]string{"name": "${input.name}"}, Capture: "start"},
+					{Endpoint: "operations.status", Bind: map[string]string{"id": "${start.id}"}, Capture: "status"},
+				},
+				Returns: "status",
+			}},
+		},
+		Resources: map[string]spec.Resource{
+			"operations": {
+				Description: "Long-running operations",
+				Endpoints: map[string]spec.Endpoint{
+					"list":   {Method: "GET", Path: "/operations", Description: "List operations"},
+					"start":  {Method: "POST", Path: "/operations", Description: "Start an operation"},
+					"status": {Method: "GET", Path: "/operations/{id}", Description: "Get operation status"},
+				},
+			},
+		},
+	}
+}
+
+func plantHandAuthoredMCPBehavior(cliDir string) error {
+	walkerPath := filepath.Join(cliDir, "internal", "mcp", "cobratree", "walker.go")
+	walker, err := os.ReadFile(walkerPath)
+	if err != nil {
+		return err
+	}
+	walkerSrc := strings.Replace(string(walker),
+		"\t\treadOnly := isMCPReadOnly(cmd)\n\t\tif readOnly {\n\t\t\toptions = append(options, mcplib.WithReadOnlyHintAnnotation(true), mcplib.WithDestructiveHintAnnotation(false))\n\t\t}\n\t\tif !readOnly && isMCPLocalWrite(cmd) {",
+		"\t\treadOnly := isMCPReadOnly(cmd)\n\t\tlocalWrite := isMCPLocalWrite(cmd)\n\t\tif localWrite {",
+		1)
+	if walkerSrc == string(walker) {
+		return errPlant("walker.go local-write rule")
+	}
+	if err := os.WriteFile(walkerPath, []byte(walkerSrc), 0o644); err != nil {
+		return err
+	}
+
+	shelloutPath := filepath.Join(cliDir, "internal", "mcp", "cobratree", "shellout.go")
+	shellout, err := os.ReadFile(shelloutPath)
+	if err != nil {
+		return err
+	}
+	shelloutSrc := strings.Replace(string(shellout),
+		"\t\"deliver\":      true,\n",
+		"\t\"db\":           true,\n\t\"deliver\":      true,\n",
+		1)
+	if shelloutSrc == string(shellout) {
+		return errPlant("shellout.go db blocklist")
+	}
+	if err := os.WriteFile(shelloutPath, []byte(shelloutSrc), 0o644); err != nil {
+		return err
+	}
+
+	classifyPath := filepath.Join(cliDir, "internal", "mcp", "cobratree", "classify.go")
+	classify, err := os.ReadFile(classifyPath)
+	if err != nil {
+		return err
+	}
+	classifySrc := strings.TrimRight(string(classify), "\n") + `
+
+func isMCPExecutionReadOnly(cmd *cobra.Command) bool {
+	return isMCPReadOnly(cmd) && !isMCPLocalWrite(cmd)
+}
+`
+	if err := os.WriteFile(classifyPath, []byte(classifySrc), 0o644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(cliDir, "internal", "mcp", "cobratree", "classify_test.go"), []byte(`package cobratree
+
+import "testing"
+
+func TestIsMCPExecutionReadOnly(t *testing.T) {
+	if isMCPExecutionReadOnly(nil) {
+		t.Fatal("nil command should not be execution-read-only")
+	}
+}
+`), 0o644); err != nil {
+		return err
+	}
+
+	mainPath := filepath.Join(cliDir, "cmd", "handmcp-pp-mcp", "main.go")
+	mainData, err := os.ReadFile(mainPath)
+	if err != nil {
+		return err
+	}
+	mainSrc := strings.Replace(string(mainData),
+		"\t\thttpSrv := &http.Server{\n\t\t\tAddr:    bindAddr,\n\t\t\tHandler: requireBearerAuth(token, inner),\n\t\t}",
+		"\t\thttpSrv := &http.Server{\n\t\t\tAddr:              bindAddr,\n\t\t\tHandler:           requireBearerAuth(token, inner),\n\t\t\tReadHeaderTimeout: 10 * time.Second,\n\t\t\tReadTimeout:       30 * time.Second,\n\t\t\tWriteTimeout:      30 * time.Second,\n\t\t\tIdleTimeout:       120 * time.Second,\n\t\t}",
+		1)
+	if mainSrc == string(mainData) {
+		return errPlant("main.go HTTP timeouts")
+	}
+	if !strings.Contains(mainSrc, `"time"`) {
+		mainSrc = strings.Replace(mainSrc, "\t\"strings\"\n", "\t\"strings\"\n\t\"time\"\n", 1)
+	}
+	if err := os.WriteFile(mainPath, []byte(mainSrc), 0o644); err != nil {
+		return err
+	}
+
+	intentsPath := filepath.Join(cliDir, "internal", "mcp", "intents.go")
+	intents, err := os.ReadFile(intentsPath)
+	if err != nil {
+		return err
+	}
+	intentsSrc := string(intents)
+	if !strings.Contains(intentsSrc, `"time"`) {
+		intentsSrc = strings.Replace(intentsSrc, "\t\"strings\"\n", "\t\"strings\"\n\t\"time\"\n", 1)
+	}
+	oldCall := `		resp, err := callIntentEndpoint(ctx, c, "operations.status", params)
+		if err != nil {
+			return mcplib.NewToolResultError(fmt.Sprintf("step %d (operations.status) failed: %v", 2, err)), nil
+		}`
+	newCall := `		resp, err := waitForIntentPoll(ctx, c, "operations.status", params, pollAfter, operationTimeout)
+		if err != nil {
+			return mcplib.NewToolResultError(fmt.Sprintf("step %d (operations.status) failed: %v", 2, err)), nil
+		}`
+	if !strings.Contains(intentsSrc, oldCall) {
+		return errPlant("intents.go status call")
+	}
+	intentsSrc = strings.Replace(intentsSrc, oldCall, newCall, 1)
+	intentsSrc = strings.TrimRight(intentsSrc, "\n") + `
+
+const (
+	pollAfter         = 200 * time.Millisecond
+	operationTimeout  = 5 * time.Second
+)
+
+func intentDuration(d *time.Duration) time.Duration {
+	if d == nil {
+		return 0
+	}
+	return *d
+}
+
+func waitForIntentPoll(ctx context.Context, c *client.Client, ref string, params map[string]any, pollAfter, operationTimeout time.Duration) (any, error) {
+	deadline := time.Now().Add(intentDuration(&operationTimeout))
+	for {
+		resp, err := callIntentEndpoint(ctx, c, ref, params)
+		if err != nil {
+			return nil, err
+		}
+		if intentPollComplete(resp) {
+			return resp, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("operation %s still unfinished after %s", ref, operationTimeout)
+		}
+		timer := time.NewTimer(pollAfter)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func intentPollComplete(resp any) bool {
+	m, ok := resp.(map[string]any)
+	if !ok {
+		return true
+	}
+	status, _ := m["status"].(string)
+	return status == "done" || status == "complete" || status == "succeeded"
+}
+`
+	if err := os.WriteFile(intentsPath, []byte(intentsSrc), 0o644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(cliDir, "internal", "mcp", "intents_poll_test.go"), []byte(`package mcp
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIntentDuration(t *testing.T) {
+	if intentDuration(nil) != 0 {
+		t.Fatal("nil duration should be 0")
+	}
+	d := 2 * time.Second
+	if intentDuration(&d) != d {
+		t.Fatalf("intentDuration() = %s, want %s", intentDuration(&d), d)
+	}
+}
+`), 0o644)
+}
+
+type plantError string
+
+func (e plantError) Error() string { return "plant hand-authored MCP behavior: " + string(e) }
+
+func errPlant(what string) error { return plantError(what) }

--- a/internal/pipeline/mcpsync/sync_preserve_test.go
+++ b/internal/pipeline/mcpsync/sync_preserve_test.go
@@ -18,8 +18,8 @@ import (
 
 const handAuthoredOverride = "List operations with the required cursor and optional status filter for agents."
 
-// TestSyncPreservesHandAuthoredMCPBehavior locks #4501: mcp-sync on a
-// runtime-walking tree must apply mcp-descriptions.json without deleting
+// TestSyncPreservesHandAuthoredMCPBehavior verifies that mcp-sync on a
+// runtime-walking tree applies mcp-descriptions.json without deleting
 // hand-authored poll loops, local-write-wins annotations, blocked
 // destination flags, HTTP server timeouts, or leftover test helpers.
 func TestSyncPreservesHandAuthoredMCPBehavior(t *testing.T) {
@@ -96,6 +96,51 @@ func TestSyncPreservesHandAuthoredMCPBehavior(t *testing.T) {
 	vet.Dir = cliDir
 	output, err := vet.CombinedOutput()
 	require.NoError(t, err, "post-sync MCP surface must go vet cleanly: %s", output)
+}
+
+func TestSyncDropsRemovedGeneratedIntentHandler(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := handAuthoredMCPSpec()
+	apiSpec.MCP.Intents = append(apiSpec.MCP.Intents, spec.Intent{
+		Name:        "describe_operation",
+		Description: "Describe a single operation.",
+		Params: []spec.IntentParam{{
+			Name:        "id",
+			Type:        "string",
+			Required:    true,
+			Description: "Operation id",
+		}},
+		Steps: []spec.IntentStep{
+			{Endpoint: "operations.status", Bind: map[string]string{"id": "${input.id}"}, Capture: "status"},
+		},
+		Returns: "status",
+	})
+	cliDir := filepath.Join(t.TempDir(), "handmcp")
+	gen := generator.New(apiSpec, cliDir)
+	gen.VisionSet = generator.VisionTemplateSet{MCP: true, Store: true}
+	require.NoError(t, gen.Generate())
+	require.NoError(t, pipeline.WriteManifestForGenerate(pipeline.GenerateManifestParams{
+		APIName:   apiSpec.Name,
+		OutputDir: cliDir,
+		Spec:      apiSpec,
+	}))
+	require.NoError(t, plantHandAuthoredMCPBehavior(cliDir))
+
+	apiSpec.MCP.Intents = apiSpec.MCP.Intents[:1]
+	specData, err := yaml.Marshal(apiSpec)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "spec.yaml"), specData, 0o644))
+
+	_, err = Sync(cliDir, Options{})
+	require.NoError(t, err)
+
+	intentsAfter, err := os.ReadFile(filepath.Join(cliDir, "internal", "mcp", "intents.go"))
+	require.NoError(t, err)
+	src := string(intentsAfter)
+	assert.NotContains(t, src, "func handleDescribeOperation(", "removed spec intents must not leave a generated handler")
+	assert.Contains(t, src, "func waitForIntentPoll(")
+	assert.Contains(t, src, `waitForIntentPoll(ctx, c, "operations.status"`)
 }
 
 func handAuthoredMCPSpec() *spec.APISpec {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

`cli-printing-press mcp-sync` on a tree that already had MCP Surface PASS rewrote the MCP surface and deleted hand-authored behavior: the intent poll loop (`waitForIntentPoll` / `pollAfter` / `operationTimeout`), the local-write-wins annotation rule, the `db` destination blocklist, HTTP server timeouts, and leftover helpers that `go vet` still referenced.

Closes #4501

## Approach

When the target is already on the runtime walker, snapshot cobratree files, the MCP HTTP entrypoint, and `intents.go` before `GenerateMCPSurface`. After the description-bearing regen:

- restore cobratree / `main.go` files that still carry the hand-authored markers
- merge extra intent helpers and poll-loop handlers back into regenerated `intents.go`
- keep only marker-bearing helpers and the dependencies those helpers need; generated MCP tool handlers (`handle*` with `CallToolRequest` / `CallToolResult`) are restored only when the refreshed spec still emits the same handler. Hand-authored `handle*` helpers that do not use that signature are preserved even when the spec omits that name

`mcp-descriptions.json` overrides still reach `tools.go` and `tools-manifest.json`. Spec-intent refresh still works when the file has no hand-authored poll markers.

## Scope

Primary area: `internal/pipeline/mcpsync`

This belongs in this repo because mcp-sync is a Printing Press command. The generator templates are unchanged; reprint remains the path for a full surface refresh.

## Risk

Already-migrated CLIs no longer receive cobratree / MCP-entrypoint template updates from mcp-sync when those files contain hand-authored markers. That is the intended trade: description refresh must not delete working MCP behavior. First-time migrations still emit the current templates.

## Output Contract

N/A — no generator templates or golden fixtures changed.

Generated-output evidence: `TestSyncPreservesHandAuthoredMCPBehavior` plants the reported losses, runs mcp-sync, and asserts the poll loop, local-write-wins rule, `db` blocklist, HTTP timeouts, description override, and `go vet` all survive. `TestSyncDropsRemovedGeneratedIntentHandler` asserts a removed spec intent does not leave a stale generated handler. `TestMergeHandAuthoredIntentFileKeepsCustomHandleHelper` asserts a hand-authored `handle*` helper survives when the refreshed spec omits that name.

## Verification

- [x] `go test ./internal/pipeline/mcpsync/` (pass, including the preservation and removed-handler cases)
- [x] `golangci-lint run ./internal/pipeline/mcpsync/...` (0 issues; matches CI v2.11.4)
- [x] `go test ./... -timeout 30m` (pass)
- [x] No golden fixture changes

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e61a1c56-aeed-431f-a302-71e1f76cfa97?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e61a1c56-aeed-431f-a302-71e1f76cfa97&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

