### PR TITLE
fix(cli): Windows auth remedy and cookies-file help

### DIFF
--- a/internal/generator/auth_cookies_file_test.go
+++ b/internal/generator/auth_cookies_file_test.go
@@ -33,6 +33,9 @@ func TestCookieAuthLoginEmitsCookiesFileImport(t *testing.T) {
 	assert.Contains(t, authGo, "parseCookieHeaderCookies")
 	assert.Contains(t, authGo, "cookieDomainMatches")
 	assert.Contains(t, authGo, "client.WriteCookieJarFromMap(domain, jarCookies)")
+	assert.Contains(t, authGo, "Use --cookies-file to import Playwright storage-state JSON or a raw Cookie header file.")
+	assert.Contains(t, authGo, "--chrome and --browser require a cookie extraction tool")
+	assert.NotContains(t, authGo, "Use --cookies-file to import Playwright storage-state JSON or a raw Cookie header file.\nRequires a cookie extraction tool")
 
 	readme := readGeneratedFile(t, outputDir, "README.md")
 	assert.Contains(t, readme, "auth login --cookies-file storage-state.json")

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -12527,9 +12527,17 @@ func TestGenerate_CookieAuthWindowsCompatibility(t *testing.T) {
 	assert.NotContains(t, content, `exec.Command("python3", "-c", script)`)
 	assert.Contains(t, content, `exec.Command(tool.pyBin,`)
 
-	// Windows users get a workable next step instead of the Unix install hint.
-	assert.Contains(t, content, "auth login --browser")
+	// Windows no-extractor remedy must name file import, not --browser
+	// (an alias of the --chrome path that just failed).
+	assert.Contains(t, content, "pycookiecheat does not support Windows. Import cookies from a file instead:")
+	assert.Contains(t, content, "auth login --cookies-file")
+	assert.NotContains(t, content, "Read cookies from a live Chrome session instead:")
+	assert.NotContains(t, content, "Use `auth login --browser`")
 	assert.Contains(t, content, "cookie-scoop-cli")
+
+	// Unix install hint stays on the non-Windows branch.
+	assert.Contains(t, content, "pip install pycookiecheat")
+	assert.Contains(t, content, "brew install barnardb/cookies/cookies")
 }
 
 // TestGenerate_CookieAuthFiltersAllowlistOnLogin pins that `auth login --chrome`

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -165,8 +165,8 @@ func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 
 Use --chrome to read cookies from Chrome for {{.Auth.CookieDomain}}.
 Use --browser as an alias for --chrome.
+--chrome and --browser require a cookie extraction tool (pycookiecheat, cookies, or cookie-scoop-cli).
 Use --cookies-file to import Playwright storage-state JSON or a raw Cookie header file.
-Requires a cookie extraction tool (pycookiecheat, cookies, or cookie-scoop-cli).
 
 If you have multiple Chrome profiles, pycookiecheat and cookie-scoop-cli can
 auto-detect which profile is logged in. Use --profile to select a specific
@@ -246,8 +246,8 @@ profile by name when the installed backend supports it.`,
 				fmt.Fprintln(w, red("No cookie extraction tool found."))
 				fmt.Fprintln(w, "")
 				if runtime.GOOS == "windows" {
-					fmt.Fprintln(w, "pycookiecheat does not support Windows. Read cookies from a live Chrome session instead:")
-					fmt.Fprintf(w, "\n  {{.Name}}-pp-cli auth login --browser\n\n")
+					fmt.Fprintln(w, "pycookiecheat does not support Windows. Import cookies from a file instead:")
+					fmt.Fprintf(w, "\n  {{.Name}}-pp-cli auth login --cookies-file <path>\n\n")
 					fmt.Fprintln(w, "Or install a cross-platform reader:")
 					fmt.Fprintln(w, "  cargo install cookie-scoop-cli     # Rust")
 				} else {
@@ -1982,7 +1982,7 @@ func detectCookieTool() (cookieTool, error) {
 		return cookieTool{name: "cookie-scoop"}, nil
 	}
 	if runtime.GOOS == "windows" {
-		return cookieTool{}, fmt.Errorf("no cookie extraction tool found; pycookiecheat does not support Windows. Use `auth login --browser` (live Chrome via CDP) or install cookie-scoop-cli")
+		return cookieTool{}, fmt.Errorf("no cookie extraction tool found; pycookiecheat does not support Windows. Use `auth login --cookies-file` or install cookie-scoop-cli")
 	}
 	return cookieTool{}, fmt.Errorf("no cookie extraction tool found; install one: pip install pycookiecheat")
 }

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/cli/auth.go
@@ -108,8 +108,8 @@ func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 
 Use --chrome to read cookies from Chrome for .cookie-auth.example.
 Use --browser as an alias for --chrome.
+--chrome and --browser require a cookie extraction tool (pycookiecheat, cookies, or cookie-scoop-cli).
 Use --cookies-file to import Playwright storage-state JSON or a raw Cookie header file.
-Requires a cookie extraction tool (pycookiecheat, cookies, or cookie-scoop-cli).
 
 If you have multiple Chrome profiles, pycookiecheat and cookie-scoop-cli can
 auto-detect which profile is logged in. Use --profile to select a specific
@@ -181,8 +181,8 @@ profile by name when the installed backend supports it.`,
 					fmt.Fprintln(w, red("No cookie extraction tool found."))
 					fmt.Fprintln(w, "")
 					if runtime.GOOS == "windows" {
-						fmt.Fprintln(w, "pycookiecheat does not support Windows. Read cookies from a live Chrome session instead:")
-						fmt.Fprintf(w, "\n  golden-api-cookie-auth-pp-cli auth login --browser\n\n")
+						fmt.Fprintln(w, "pycookiecheat does not support Windows. Import cookies from a file instead:")
+						fmt.Fprintf(w, "\n  golden-api-cookie-auth-pp-cli auth login --cookies-file <path>\n\n")
 						fmt.Fprintln(w, "Or install a cross-platform reader:")
 						fmt.Fprintln(w, "  cargo install cookie-scoop-cli     # Rust")
 					} else {
@@ -956,7 +956,7 @@ func detectCookieTool() (cookieTool, error) {
 		return cookieTool{name: "cookie-scoop"}, nil
 	}
 	if runtime.GOOS == "windows" {
-		return cookieTool{}, fmt.Errorf("no cookie extraction tool found; pycookiecheat does not support Windows. Use `auth login --browser` (live Chrome via CDP) or install cookie-scoop-cli")
+		return cookieTool{}, fmt.Errorf("no cookie extraction tool found; pycookiecheat does not support Windows. Use `auth login --cookies-file` or install cookie-scoop-cli")
 	}
 	return cookieTool{}, fmt.Errorf("no cookie extraction tool found; install one: pip install pycookiecheat")
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Two generated cookie-auth strings send Windows operators down a dead end.

1. `auth login --chrome` and `--browser` both exit 4 with a remedy that says run `auth login --browser`. Help documents `--browser` as an alias of `--chrome`, so the suggested command is the same failing path.
2. `--cookies-file` help says file import requires a cookie extraction tool. File import works without pycookiecheat/cookies/cookie-scoop-cli, so the working path is documented as unavailable.

Closes #4344

## Approach

Machine change in `auth_browser.go.tmpl`:

- Windows no-extractor error now names `auth login --cookies-file <path>` instead of `--browser`.
- `detectCookieTool`'s Windows error string matches that remedy.
- Login help scopes the extraction-tool prerequisite to `--chrome` / `--browser` only. `--cookies-file` no longer inherits that claim.

macOS / Linux install guidance is unchanged.

## Scope

Primary area: generated cookie / composed browser-auth login help and the Windows no-extractor fallback.

Why this belongs in this repo: every future cookie-auth printed CLI inherits these strings from the generator. A printed-CLI-only edit would not compound.

## Risk

Low. String-only template change. `--browser` remains a documented alias of `--chrome` in examples and the no-flag usage hint. Unix `--chrome` install hints are unchanged. Existing `--cookies-file` import behavior is unchanged.

## Output Contract

Emitted login help and Windows no-extractor text change.

Evidence:

- `TestGenerate_CookieAuthWindowsCompatibility` asserts the Windows remedy names `--cookies-file` and does not recommend `--browser`.
- `TestCookieAuthLoginEmitsCookiesFileImport` asserts help scopes the extraction-tool line to `--chrome` / `--browser` and does not attach it to `--cookies-file`.
- Golden fixture `generate-golden-api-cookie-auth` captures both strings in generated `internal/cli/auth.go`.
- `scripts/verify-generator-output.sh generate-golden-api-cookie-auth` compiled the generated module.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands:

- `go test ./internal/generator/ -count=1 -run 'TestGenerate_CookieAuthWindowsCompatibility|TestCookieAuthLoginEmitsCookiesFileImport'` — pass (failed on current main before the template edit)
- `go test ./... -timeout 30m` — pass
- `scripts/golden.sh update` — updated only `generate-golden-api-cookie-auth`
- `GOTOOLCHAIN=go1.26.6 bash scripts/golden.sh verify` — 37 cases pass
- `GOTOOLCHAIN=go1.26.6 bash scripts/verify-generator-output.sh generate-golden-api-cookie-auth` — pass

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-709223b1-3780-4e73-b19a-bd9d436d3145?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-709223b1-3780-4e73-b19a-bd9d436d3145&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

