### PR TITLE
fix(cli): keep verify --json stdout pure with --fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,7 @@ The same lockstep applies to the learn-loop templates under `internal/generator/
 - `docs/RELEASE.md` - release-please / goreleaser flow
 - `docs/ATTRIBUTION.md` - Creator + contributors model: resolver fallback, validation layers, legacy-field dual-write window
 - `docs/ARTIFACTS.md` - Local library, manuscripts, and public-library flow
+- `docs/STUDIO_COMMAND_JSON.md` - Stable `--json` argv/exit/stdout shapes for Press Studio (and other subprocess consumers); product contract stays in MLX-Studio
 - `docs/DOCS.md` - Doc-authoring rules, including pointer-rot prevention
 - `docs/solutions/` - Documented solutions to past problems (bugs, design patterns, best practices, conventions), organized by category subdir with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in documented areas.
 

--- a/docs/ARTIFACTS.md
+++ b/docs/ARTIFACTS.md
@@ -35,4 +35,4 @@ Discovery methods write evidence under the run's discovery archive before genera
 
 - Browser Sniff archives traffic analysis and replayable HTTP evidence.
 - Crowd Sniff archives community-source findings and wrapper-library evidence.
-- Device Sniff archives device specs, BLE analysis reports, and redacted BLE evidence. Raw stable device identifiers and executable control payloads are sensitive; redacted evidence is the default archive shape, and raw evidence retention is opt-in.
+- Device Sniff archives device specs, BLE analysis reports, and redacted BLE evidence. Raw stable device identifiers and executable control payloads are sensitive; redacted evidence is the default archive shape, and raw evidence retention is opt-in. Machine-readable command shapes for Studio/BLE consumers: [`STUDIO_COMMAND_JSON.md`](STUDIO_COMMAND_JSON.md).

--- a/docs/BLE-PROBE.md
+++ b/docs/BLE-PROBE.md
@@ -108,3 +108,5 @@ For unknown devices, prefer this order:
 Live `inspect` records the discovered service and characteristic UUIDs but not their read/write/notify property flags — the underlying `tinygo.org/x/bluetooth` backend does not expose a characteristic property bitmask after discovery. Writability is therefore inferred from action markers and community references (the same signals the replay path uses), not auto-detected from a live GATT scan. Annotate control characteristics through those evidence fields rather than relying on `inspect` alone.
 
 The JSON files are normalized BLE evidence inputs. Use `ble-probe merge` to combine multiple capture files into one analyzer input before running `device-sniff ble`.
+
+Studio / subprocess consumers: argv, exit codes, and analyze summary shapes are documented in [`STUDIO_COMMAND_JSON.md`](STUDIO_COMMAND_JSON.md). Golden evidence fixtures live under `testdata/golden/expected/device-sniff-ble-{sample,ambiguous}/`.

--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -24,6 +24,7 @@ The extracted developer docs are:
 - `docs/RELEASE.md` — release-please / goreleaser flow
 - `docs/ATTRIBUTION.md` — creator + contributors attribution model
 - `docs/ARTIFACTS.md` — local library, manuscripts, and public-library flow
+- `docs/STUDIO_COMMAND_JSON.md` — engine `--json` surfaces for Press Studio / subprocess consumers (product contract stays in MLX-Studio)
 - `docs/CODEX.md` — installing and using Printing Press skills in Codex
 - `docs/CURSOR.md` — using printed CLIs and skills in Cursor
 - `docs/DOCS.md` — this doc-authoring guidance

--- a/docs/STUDIO_COMMAND_JSON.md
+++ b/docs/STUDIO_COMMAND_JSON.md
@@ -1,0 +1,389 @@
+# Studio command JSON surfaces
+
+Machine-readable contracts for **Press Studio** (and other subprocess consumers) that spawn `cli-printing-press` with `--json` and parse **stdout**. Product orchestration rules live in the MLX-Studio contract ([`PRESS_STUDIO_CONTRACT.md`](https://github.com/paride-cmd/MLX-Studio/blob/main/docs/PRESS_STUDIO_CONTRACT.md) §4 C3, §5 C2). This file documents **engine** argv, exit codes, and JSON shapes only.
+
+**Integration rules (engine side):**
+
+1. Prefer `--json` when the flag exists; parse a single JSON value from **stdout**.
+2. Treat **stderr** as human progress / warnings (never as the structured payload).
+3. Typed exit codes: `internal/cli/exitcodes.go` — `0` success, `1` input, `2` spec, `3` generation, `4` unknown, `5` publish. Some commands document additional exit semantics below.
+4. Do **not** expect an HTTP server from this binary in v1.
+
+Artifact roots: [`ARTIFACTS.md`](ARTIFACTS.md). BLE probe ops: [`BLE-PROBE.md`](BLE-PROBE.md).
+
+---
+
+## §4.2 checklist (verified)
+
+| Contract action | Command | `--json` | Status |
+|-----------------|---------|----------|--------|
+| List projects | `library list --json` | yes | **Verified** — clean array on stdout |
+| Full quality sweep | `shipcheck --dir <lib>/<slug> --json` | yes | **Verified** — end-of-run envelope; legs discarded in JSON mode |
+| Structural check | `dogfood --dir <path> --json` | yes | **Verified** — parse `verdict` (structural FAIL still exits `0`) |
+| Runtime check | `verify --dir <path> --json` | yes | **Verified** — fix-loop progress goes to stderr (stdout stays one JSON value) |
+| Score | `scorecard --dir <path> --json` | yes | **Verified** — grade is informational (exit not grade-gated) |
+| Generate | `generate --spec … --output … --json` | yes | **Verified** — multi-shape; see below |
+| BLE analyze | `device-sniff ble --input … --output … --json` | yes | **Verified** — summary + on-disk artifacts |
+| Publish preflight | `publish validate --dir … --json` | yes | **Verified** — fail → exit `5`, `Silent` |
+| Auth overview | `auth doctor --json` | yes | **Verified** — diagnostic; findings do not fail exit |
+| Version gate | `version --json` | yes | **Verified** |
+
+---
+
+## Global exit codes
+
+```go
+// internal/cli/exitcodes.go
+ExitSuccess = 0
+ExitInputError = 1
+ExitSpecError = 2
+ExitGenerationError = 3
+ExitUnknownError = 4
+ExitPublishError = 5
+```
+
+`ExitError.Silent` skips printing the error text when stdout already carries structured failure details (`cmd/cli-printing-press/main.go`).
+
+---
+
+## `library list`
+
+**Argv**
+
+```bash
+cli-printing-press library list --json
+```
+
+**Exit:** `0` on success (including empty library); scan failure → `1` (`ExitInputError`).
+
+**Stdout:** JSON array of `LibraryEntry` (`internal/cli/library.go`):
+
+| Field | JSON key |
+|-------|----------|
+| CLIName | `cli_name` |
+| Dir | `dir` |
+| APIName | `api_name` |
+| Category | `category` |
+| Regions | `regions` |
+| APILanguage | `api_language` |
+| Description | `description` |
+| Modified | `modified` (RFC3339 via `time.Time`) |
+
+Scans `pipeline.PublishedLibraryRoot()` (`$PRINTING_PRESS_HOME/library` or `~/printing-press/library`).
+
+---
+
+## `shipcheck`
+
+**Argv**
+
+```bash
+cli-printing-press shipcheck \
+  --dir ~/printing-press/library/<slug> \
+  [--spec <openapi-or-device.yaml>] \
+  [--research-dir <run-dir>] \
+  --json
+```
+
+**Exit:** Umbrella code = max effective leg exit (`shipcheckUmbrellaCode`). `HOLD` (unverified scorecard) can be non-zero with `Silent: true`.
+
+**Stdout:** `shipcheckJSONEnvelope` (`internal/cli/shipcheck.go`):
+
+```json
+{
+  "passed": true,
+  "exit_code": 0,
+  "verdict": "PASS",
+  "reason": "",
+  "started_at": "2026-08-25T12:00:00Z",
+  "elapsed_ms": 120000,
+  "legs": [
+    {
+      "name": "dogfood",
+      "exit_code": 0,
+      "passed": true,
+      "verdict": "PASS",
+      "detail": "",
+      "started_at": "2026-08-25T12:00:00Z",
+      "elapsed_ms": 30000,
+      "command": "cli-printing-press dogfood --dir ..."
+    }
+  ]
+}
+```
+
+`verdict`: `PASS` | `FAIL` | `HOLD`. Sensitive flag values in `legs[].command` are redacted.
+
+**JSON mode behavior:** per-leg stdout/stderr are discarded so the envelope is the only stdout payload. For per-leg JSON detail, run that leg standalone with `--json`.
+
+**Legs (order):** verify → validate-narrative → dogfood → workflow-verify → apify-audit → verify-skill → scorecard.
+
+**Artifacts:** legs may update `.printing-press.json` via `--write-manifest` when that flag is passed through.
+
+---
+
+## `dogfood`
+
+**Argv (structural — Studio §4.2)**
+
+```bash
+cli-printing-press dogfood --dir <cli-dir> [--spec <path>] [--research-dir <dir>] --json
+```
+
+**Argv (live — not required for Studio v1 list)**
+
+```bash
+cli-printing-press dogfood --dir <cli-dir> --live [--level quick|full] [--write-acceptance <path>] --json
+```
+
+**Exit**
+
+| Mode | FAIL verdict |
+|------|----------------|
+| Structural | Still **exit `0`** after a successful run — Studio **must** read `verdict` / `issues` |
+| Live | `FAIL` → exit `3` (`ExitGenerationError`) |
+| Runner error | exit `3` |
+
+**Stdout (structural):** `pipeline.DogfoodReport` (`internal/pipeline/dogfood.go`) — key fields: `dir`, `verdict`, nested `*_check` objects, `issues[]`.
+
+**Stdout (live):** `pipeline.LiveDogfoodReport` (`internal/pipeline/live_dogfood.go`) — `verdict`, `pass_rate`, `tests[]`, `matrix_size`, …
+
+**Artifacts:** optional `--write-acceptance` → Phase 5 acceptance JSON.
+
+---
+
+## `verify`
+
+**Argv (Studio)**
+
+```bash
+cli-printing-press verify --dir <cli-dir> [--spec <path>|--no-spec] [--threshold 80] [--write-manifest <path>] --json
+```
+
+Do **not** pass `--fix` for Studio v1 unless you need the fix loop. Fix-loop progress prints on **stderr** so `--json` stdout remains a single JSON value.
+
+**Exit (JSON mode):** `verdict == FAIL` → exit `3`, `Silent: true`. `WARN` → exit `0`. Human mode uses process exit `1` on FAIL (inconsistent with JSON — prefer JSON for Studio).
+
+**Stdout:**
+
+```json
+{
+  "verify": { /* pipeline.VerifyReport */ },
+  "fix_loop": { /* optional pipeline.FixLoopReport */ }
+}
+```
+
+`VerifyReport` (`internal/pipeline/runtime.go`): `mode`, `total`, `passed`, `failed`, `pass_rate`, `verdict` (`PASS`|`WARN`|`FAIL`), `results[]`, `binary`, …
+
+**Artifacts:** `--write-manifest` updates `.printing-press.json`; `--cleanup` removes transient build artifacts.
+
+---
+
+## `scorecard`
+
+**Argv**
+
+```bash
+cli-printing-press scorecard --dir <cli-dir> [--spec <path>] [--research-dir <dir>] [--live-check] [--write-manifest <path>] --json
+```
+
+**Exit:** Run errors → `1`/`3`. Low `overall_grade` does **not** force a non-zero exit.
+
+**Stdout:**
+
+```json
+{
+  "scorecard": { /* pipeline.Scorecard */ },
+  "live_check": { /* optional */ }
+}
+```
+
+`Scorecard` (`internal/pipeline/scorecard.go`): `api_name`, `steinberger`, `competitor_scores`, `overall_grade`, `gap_report`, … Treat new Steinberger dimensions as additive.
+
+---
+
+## `generate`
+
+**Argv (Studio §4.2)**
+
+```bash
+cli-printing-press generate --spec <path-or-url> --output <dir> [--force] --json
+```
+
+Also: `--docs <url>`, `--plan <file>`, or device YAML via `--spec`.
+
+**Exit:** typed `1` / `2` / `3` via `ExitError`.
+
+**Stdout:** one JSON object; **shape depends on mode** (ad-hoc maps in `internal/cli/root.go`):
+
+| Mode | Keys |
+|------|------|
+| OpenAPI / docs | `name`, `output_dir`, `spec_files`, `validated`, `polished` |
+| Plan | `name`, `output_dir`, `plan_file`, `commands` |
+| Device spec | OpenAPI keys + `protocol` |
+
+Progress and warnings print on **stderr** even with `--json`. Cancel long runs with `SIGTERM`.
+
+**Artifacts:** CLI tree under `--output` or `~/printing-press/library/<slug>/`; `.printing-press.json`; archived `openapi.*` / `device-spec.yaml`.
+
+---
+
+## `device-sniff ble` (analyze)
+
+**Argv**
+
+```bash
+cli-printing-press device-sniff ble \
+  --input evidence.json \
+  --output device.yaml \
+  [--analysis-output analysis.json] \
+  [--evidence-output redacted-evidence.json] \
+  [--redact-term '<term>'] \
+  --json
+```
+
+**Exit:** failures typically surface as untyped errors → exit `4` unless wrapped.
+
+**Stdout:** `deviceSniffSummary` (`internal/cli/device_sniff.go`) — matches contract §5.5:
+
+```json
+{
+  "device_spec_path": "/path/device.yaml",
+  "analysis_path": "/path/analysis.json",
+  "evidence_path": "/path/evidence.json",
+  "commands": 2,
+  "telemetry": 1,
+  "requires_operator_selection": false,
+  "warnings": []
+}
+```
+
+**On-disk:** DeviceSpec YAML, analysis report JSON, redacted evidence JSON (defaults under `~/.cache/printing-press/device-sniff/` when `--output` omitted).
+
+### Probe subcommands (always JSON stdout; no `--json` flag)
+
+```bash
+cli-printing-press device-sniff ble doctor
+cli-printing-press device-sniff ble scan --input fixtures.json   # or --live --duration-ms 10000
+cli-printing-press device-sniff ble inspect --live --address '<addr>'
+cli-printing-press device-sniff ble read --live --address '<addr>' --service '<uuid>' --characteristic '<uuid>'
+cli-printing-press device-sniff ble subscribe --live --address '<addr>' --service '<uuid>' --characteristic '<uuid>' --duration-ms 10000
+cli-printing-press device-sniff ble write --live --address '<addr>' --service '<uuid>' --characteristic '<uuid>' --value-hex '<hex>'
+cli-printing-press device-sniff ble merge [--redact-term '<term>'] scan.json inspect.json > evidence.json
+```
+
+| Command | Stdout type |
+|---------|-------------|
+| `doctor` | `bleprobe.DoctorReport` — `binary`, `goos`, `goarch`, `live`, `replay_supported`, `smoke_commands`, `hardware_commands` |
+| `scan` / `inspect` / `read` / `subscribe` / `write` / `merge` | `ble.EvidenceInput` |
+
+`--live` is refused under `PRINTING_PRESS_VERIFY=1`. See [`BLE-PROBE.md`](BLE-PROBE.md).
+
+### C2 evidence schema
+
+Go type: `internal/devicesniff/ble/types.go` → `EvidenceInput`.
+
+Required for v1 clients: `name`, `identity` (`advertised_names`, `address_policy`, `match_strength`). Optional: `display_name`, `redaction_terms`, `events[]`, `actions[]`, `community_references[]`.
+
+### Golden BLE fixtures (compatibility)
+
+Press Probe / Studio tests must round-trip against:
+
+| Fixture | Path |
+|---------|------|
+| Guided sample | [`testdata/golden/expected/device-sniff-ble-sample/evidence.json`](../testdata/golden/expected/device-sniff-ble-sample/evidence.json) |
+| Ambiguous multi-device | [`testdata/golden/expected/device-sniff-ble-ambiguous/evidence.json`](../testdata/golden/expected/device-sniff-ble-ambiguous/evidence.json) |
+
+Companion artifacts in the same directories: `analysis.json`, `device.yaml`, `stdout.txt`. Cases: `testdata/golden/cases/device-sniff-ble-{sample,ambiguous}/`.
+
+**Sample analysis** includes `command_candidates`, `telemetry_candidates`, `command_discovery.status: guided_candidates`. **Ambiguous** sets `requires_operator_selection` / `command_discovery.status: ambiguous_guidance` without command/telemetry candidates.
+
+---
+
+## `publish validate`
+
+**Argv**
+
+```bash
+cli-printing-press publish validate --dir ~/printing-press/library/<slug> --json
+```
+
+**Exit**
+
+| Condition | Code |
+|-----------|------|
+| Missing `--dir` | `1` (`ExitInputError`) |
+| Validation failed (`passed: false`) | **`5`** (`ExitPublishError`), `Silent: true` in JSON mode |
+| All checks passed | `0` |
+
+Human and JSON modes both use exit `5` on failure (contract §4.6).
+
+**Stdout:** `ValidateResult` (`internal/cli/publish.go`):
+
+```json
+{
+  "passed": false,
+  "cli_name": "notion-pp-cli",
+  "api_name": "notion",
+  "help_output": "...",
+  "checks": [
+    { "name": "go.mod", "passed": true },
+    { "name": "module path", "passed": false, "error": "..." }
+  ]
+}
+```
+
+Human check lines go to **stderr**; JSON mode keeps stdout clean.
+
+---
+
+## `version`
+
+**Argv**
+
+```bash
+cli-printing-press version --json
+```
+
+**Exit:** `0`.
+
+**Stdout:**
+
+```json
+{ "version": "<semver>", "go": "<runtime.Version()>" }
+```
+
+Compare against `supported-versions.txt` on `main` for the currency floor (contract §10).
+
+---
+
+## `auth doctor`
+
+**Argv**
+
+```bash
+cli-printing-press auth doctor --json
+```
+
+**Exit:** Always `0` for completed scans (including `not_set` / `suspicious`). Scan failure → `5`.
+
+**Stdout:** `{ "summary": Summary, "findings": []Finding }` via `authdoctor.RenderJSON` (`internal/authdoctor/`).
+
+`Finding`: `api`, `type`, `env_var`, `status`, `fingerprint`, `reason`. Status enum: `ok`, `suspicious`, `not_set`, `info`, `no_auth`, `unknown`.
+
+---
+
+## Remaining gaps (engine)
+
+Documented; not blocking Studio parse of §4.2 surfaces:
+
+| Gap | Guidance |
+|-----|----------|
+| Structural `dogfood` FAIL → exit `0` | Gate on `verdict` / `issues`, not exit code |
+| `generate --json` multi-shape | Branch on presence of `plan_file` / `protocol` / `spec_files` |
+| `scorecard` grade never fails exit | Use `overall_grade` / `gap_report` in UI |
+| `auth doctor` never gates | Dashboard-only |
+| Probe cmds lack `--json` flag | Always emit JSON — treat as implicit JSON mode |
+| Shipcheck umbrella omits per-leg payloads | Re-run legs with `--json` for detail |
+
+No HTTP serve surface in v1 (by contract).

--- a/internal/cli/shipcheck.go
+++ b/internal/cli/shipcheck.go
@@ -445,8 +445,8 @@ type shipcheckJSONLeg struct {
 }
 
 // shipcheckJSONEnvelope is the structured output emitted with --json. The
-// envelope is end-of-run; per-leg stdout/stderr still streams during the
-// run. Operators piping --json output to jq should redirect stderr.
+// envelope is end-of-run; in --json mode per-leg stdout/stderr are discarded
+// so the envelope is the only stdout payload (see runShipcheckLeg).
 type shipcheckJSONEnvelope struct {
 	Passed    bool               `json:"passed"`
 	ExitCode  int                `json:"exit_code"`
@@ -590,9 +590,8 @@ Each leg remains callable standalone — this command is additive orchestration.
 			for _, leg := range shipcheckLegs {
 				// Don't print the per-leg banner in JSON mode — the
 				// envelope at end-of-run is the structured signal.
-				// Per-leg stdout/stderr still streams (some legs print
-				// their own JSON or progress) so operators piping --json
-				// to jq should redirect stderr.
+				// Per-leg stdout/stderr are discarded in --json mode
+				// (runShipcheckLeg); re-run legs standalone for detail.
 				if !opts.asJSON {
 					fmt.Fprintf(os.Stdout, "\n=== %s ===\n", leg.name)
 				}

--- a/internal/cli/shipcheck_test.go
+++ b/internal/cli/shipcheck_test.go
@@ -683,14 +683,10 @@ func TestShipcheck_JSONEnvelope_AllPass(t *testing.T) {
 		}
 	})
 
-	// The output stream is mixed: stub's own stdout plus the JSON
-	// envelope at end-of-run. Find the JSON envelope by locating the
-	// final `}` and walking back to the matching `{`.
-	envelopeJSON := extractFinalJSONObject(t, out)
-
+	// --json discards per-leg stdio; stdout must be a single JSON envelope.
 	var env shipcheckJSONEnvelope
-	if err := json.Unmarshal([]byte(envelopeJSON), &env); err != nil {
-		t.Fatalf("envelope is not valid JSON: %v\n--- envelope ---\n%s", err, envelopeJSON)
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("stdout is not a single JSON envelope: %v\n--- stdout ---\n%s", err, out)
 	}
 	if !env.Passed {
 		t.Errorf("expected passed=true; got %+v", env)
@@ -930,8 +926,8 @@ func TestShipcheck_JSONEnvelopeFailureTakesPrecedenceOverHold(t *testing.T) {
 }
 
 // extractFinalJSONObject finds the last balanced `{...}` block in s.
-// The umbrella's --json mode mixes per-leg stub output with the final
-// envelope; this walks from the end back to the matching brace.
+// Defensive helper for --json envelope extraction if incidental output
+// appears before the final object.
 func extractFinalJSONObject(t *testing.T, s string) string {
 	t.Helper()
 	end := strings.LastIndex(s, "}")

--- a/internal/cli/test_helpers_test.go
+++ b/internal/cli/test_helpers_test.go
@@ -79,6 +79,48 @@ func runWithCapturedStderr(t *testing.T, fn func() error) (string, error) {
 	return out, execErr
 }
 
+// runWithCapturedStdoutAndStderr captures both streams concurrently so
+// progress banners and JSON payloads can be asserted independently.
+func runWithCapturedStdoutAndStderr(t *testing.T, fn func() error) (stdout string, stderr string, err error) {
+	t.Helper()
+	outR, outW, err := os.Pipe()
+	require.NoError(t, err)
+	errR, errW, err := os.Pipe()
+	require.NoError(t, err)
+
+	origStdout, origStderr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = outW, errW
+
+	outCh := make(chan string, 1)
+	errCh := make(chan string, 1)
+	go func() {
+		defer outR.Close()
+		b, _ := io.ReadAll(outR)
+		outCh <- string(b)
+	}()
+	go func() {
+		defer errR.Close()
+		b, _ := io.ReadAll(errR)
+		errCh <- string(b)
+	}()
+
+	restored := false
+	restore := func() {
+		if restored {
+			return
+		}
+		_ = outW.Close()
+		_ = errW.Close()
+		os.Stdout, os.Stderr = origStdout, origStderr
+		restored = true
+	}
+	defer restore()
+
+	execErr := fn()
+	restore()
+	return <-outCh, <-errCh, execErr
+}
+
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 	out, err := runWithCapturedStdout(t, func() error {

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -100,7 +100,8 @@ Use --fix to auto-patch common failures and re-test (max 3 iterations).`,
 			// Run fix loop if requested and score is below threshold
 			var fixReport *pipeline.FixLoopReport
 			if fix && shouldRunFixLoop(report) {
-				fmt.Printf("\nVerification verdict %s (pass rate %.0f%%, threshold %d%%). Running fix loop (max %d iterations)...\n\n",
+				// Progress belongs on stderr so --json stdout stays a single JSON value.
+				fmt.Fprintf(os.Stderr, "\nVerification verdict %s (pass rate %.0f%%, threshold %d%%). Running fix loop (max %d iterations)...\n\n",
 					report.Verdict, report.PassRate, threshold, maxIterations)
 				fixReport, err = opts.runFixLoop(cfg, report, maxIterations)
 				if err != nil {

--- a/internal/cli/verify_test.go
+++ b/internal/cli/verify_test.go
@@ -73,6 +73,61 @@ func TestVerifyCmdJSONFailReturnsExitErrorAfterWritingReport(t *testing.T) {
 	assert.Equal(t, "FAIL", payload.Verify.Verdict)
 }
 
+func TestVerifyCmdJSONFixLoopKeepsStdoutPure(t *testing.T) {
+	cmd := newVerifyCmdWithOptions(verifyCmdOptions{
+		runVerify: func(cfg pipeline.VerifyConfig) (*pipeline.VerifyReport, error) {
+			return &pipeline.VerifyReport{
+				Mode:     "mock",
+				Total:    2,
+				Passed:   1,
+				Failed:   1,
+				PassRate: 50,
+				Verdict:  "FAIL",
+				Binary:   filepath.Join(cfg.Dir, "sample-cli"),
+			}, nil
+		},
+		runFixLoop: func(cfg pipeline.VerifyConfig, initial *pipeline.VerifyReport, maxIterations int) (*pipeline.FixLoopReport, error) {
+			assert.Equal(t, 3, maxIterations)
+			final := &pipeline.VerifyReport{
+				Mode:     "mock",
+				Total:    2,
+				Passed:   2,
+				Failed:   0,
+				PassRate: 100,
+				Verdict:  "PASS",
+				Binary:   filepath.Join(cfg.Dir, "sample-cli"),
+			}
+			return &pipeline.FixLoopReport{
+				Iterations: []pipeline.FixIteration{{
+					Number:     1,
+					BeforeRate: initial.PassRate,
+					AfterRate:  final.PassRate,
+					Delta:      final.PassRate - initial.PassRate,
+				}},
+				FinalReport: final,
+				Improved:    true,
+			}, nil
+		},
+	})
+	cmd.SetArgs([]string{"--dir", t.TempDir(), "--json", "--fix"})
+
+	stdout, stderr, err := runWithCapturedStdoutAndStderr(t, cmd.Execute)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "Running fix loop")
+	assert.NotContains(t, stdout, "Running fix loop")
+
+	var payload struct {
+		Verify  pipeline.VerifyReport   `json:"verify"`
+		FixLoop *pipeline.FixLoopReport `json:"fix_loop"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &payload))
+	assert.Equal(t, "PASS", payload.Verify.Verdict)
+	require.NotNil(t, payload.FixLoop)
+	assert.True(t, payload.FixLoop.Improved)
+	assert.Equal(t, 1, len(payload.FixLoop.Iterations))
+}
+
 func TestVerifyCmdJSONFailSilencesRootCobraError(t *testing.T) {
 	verifyCmd := newVerifyCmdWithOptions(verifyCmdOptions{
 		runVerify: func(cfg pipeline.VerifyConfig) (*pipeline.VerifyReport, error) {


### PR DESCRIPTION
## Intent

Issue: Fixes #4352

Press Studio parses `--json` stdout as a single JSON value. `verify --fix` printed its progress banner with `fmt.Printf` (stdout), so banners could precede the JSON payload and break Studio. Prior attempt #4353 was closed as docs sprawl; this PR leads with the stdout-purity bug fix and keeps the engine-side argv/exit/JSON reference the issue asked for.

## Approach

- Route the verify fix-loop progress banner to stderr so `--json` stdout stays one JSON object (`verify` + optional `fix_loop`).
- Clarify in comments/tests that `shipcheck --json` already discards per-leg stdio and emits only the end-of-run envelope.
- Add `docs/STUDIO_COMMAND_JSON.md` for the §4.2 Studio command surface (engine shapes only; product contract stays in MLX-Studio) plus pointers from AGENTS / ARTIFACTS / BLE-PROBE / DOCS.

## Scope

Primary area: `surface:verify` / `comp:scorer` (verify + shipcheck JSON purity, Studio consumer docs)

Why this belongs in this repo: the banner is emitted by the Printing Press binary; Studio cannot reliably parse polluted stdout without this engine fix.

## Risk

Low. Human-mode verify still shows the banner (now on stderr). Shipcheck JSON behavior is unchanged; comments/tests now match the existing discard path. Docs are additive.

## Output Contract

N/A — no generator/template or golden fixture changes.

## Verification

- [x] `GOTOOLCHAIN=go1.26.6 go test ./internal/cli/ -count=1 -run 'TestVerifyCmdJSONFixLoopKeepsStdoutPure|TestVerifyCmdJSONFailReturnsExitErrorAfterWritingReport|TestShipcheck_JSONEnvelope_AllPass'`
- [x] `GOTOOLCHAIN=go1.26.6 go test ./internal/cli/ ./internal/pipeline/ -count=1 -timeout 15m`
- [x] `GOTOOLCHAIN=go1.26.6 go test $(go list ./... | grep -v '/internal/generator') -count=1 -timeout 20m`
- [ ] Full `go test ./internal/generator/` — not completed locally (suite hung past 15m with no output on this machine; package untouched by this PR)

## AI / Automation Disclosure

- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission


Made with [Cursor](https://cursor.com)