### PR TITLE
fix(cli): prefer list response_path for sync resource unwrap

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -6575,10 +6575,12 @@ func globalScopeEnvName(apiName string, p spec.Param) string {
 }
 
 // responsePathCase is one deduplicated entry for the sync template's
-// responsePathForResource switch: the switch key is the resource name (the
-// syncable endpoint wins when several share a resource) and the response
-// envelope path to return for it. The live request path is not part of the
-// key, so absolute or rewritten URLs still unwrap.
+// responsePathForResource switch: the switch key is the resource name and the
+// response envelope path to return for it. When a resource declares different
+// response_path values per endpoint, the list/syncable endpoint wins so sync
+// unwraps the collection envelope; endpoint-mirror commands still bake each
+// endpoint's own ResponsePath. The live request path is not part of the key,
+// so absolute or rewritten URLs still unwrap.
 type responsePathCase struct {
 	Key          string
 	ResponsePath string
@@ -6730,8 +6732,10 @@ func syncParamDefaultCases(syncable []profiler.SyncableResource, dependents []pr
 }
 
 // responsePathCases returns deterministic switch cases deduplicated by resource
-// identity. Syncable endpoints take precedence because the generated lookup is
-// used by sync; endpoint name breaks ties to keep output stable. The request
+// identity. Sync uses this lookup, so when endpoints disagree on response_path
+// the list/syncable envelope wins and mutating endpoints (create/update/…) do
+// not steal it. Endpoint-mirror commands keep their own ResponsePath. Rank:
+// Syncable, then list-shaped names/responses, then endpoint name. The request
 // path is not part of the key so unwrap still fires when the live URL differs
 // from the spec path.
 func responsePathCases(resources map[string]spec.Resource) []responsePathCase {
@@ -6749,13 +6753,14 @@ func responsePathCases(resources map[string]spec.Resource) []responsePathCase {
 		for endpointName := range resource.Endpoints {
 			endpointNames = append(endpointNames, endpointName)
 		}
-		sort.Slice(endpointNames, func(i, j int) bool {
-			left := resource.Endpoints[endpointNames[i]]
-			right := resource.Endpoints[endpointNames[j]]
-			if left.Syncable != right.Syncable {
-				return left.Syncable
+		sort.SliceStable(endpointNames, func(i, j int) bool {
+			leftName, rightName := endpointNames[i], endpointNames[j]
+			leftRank := responsePathEndpointRank(leftName, resource.Endpoints[leftName])
+			rightRank := responsePathEndpointRank(rightName, resource.Endpoints[rightName])
+			if leftRank != rightRank {
+				return leftRank < rightRank
 			}
-			return endpointNames[i] < endpointNames[j]
+			return leftName < rightName
 		})
 		for _, endpointName := range endpointNames {
 			endpoint := resource.Endpoints[endpointName]
@@ -6770,6 +6775,43 @@ func responsePathCases(resources map[string]spec.Resource) []responsePathCase {
 		}
 	}
 	return out
+}
+
+// responsePathEndpointRank orders endpoints for the resource-level sync
+// fallback. Lower wins. Syncable still outranks non-syncable; within a band,
+// list-shaped endpoints beat create/update so alphabetical order cannot pick
+// create's envelope for list unwrap.
+func responsePathEndpointRank(name string, endpoint spec.Endpoint) int {
+	rank := 0
+	if !endpoint.Syncable {
+		rank += 1000
+	}
+	rank += responsePathListShapeRank(name, endpoint)
+	return rank
+}
+
+func responsePathListShapeRank(name string, endpoint spec.Endpoint) int {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	switch lower {
+	case "list", "all", "index":
+		return 0
+	case "search", "query", "browse", "find":
+		return 2
+	case "create", "add", "insert", "update", "patch", "replace", "delete", "remove", "destroy":
+		return 50
+	}
+	if strings.HasPrefix(lower, "list") {
+		return 1
+	}
+	if strings.EqualFold(endpoint.Method, "GET") || strings.EqualFold(endpoint.Method, "HEAD") {
+		if endpoint.Pagination != nil || strings.EqualFold(endpoint.Response.Type, "array") {
+			return 3
+		}
+	}
+	if strings.EqualFold(endpoint.Method, "POST") && endpoint.Pagination != nil {
+		return 4
+	}
+	return 10
 }
 
 func globalScopeParams(resources map[string]spec.Resource) []spec.Param {

--- a/internal/generator/sync_response_path_identity_test.go
+++ b/internal/generator/sync_response_path_identity_test.go
@@ -200,3 +200,166 @@ func TestResponsePathCasesPrefersSyncableAcrossDifferentPaths(t *testing.T) {
 		ResponsePath: "catalog.items",
 	}}, cases)
 }
+
+func TestResponsePathCasesPrefersListOverCreate(t *testing.T) {
+	t.Parallel()
+
+	cases := responsePathCases(map[string]spec.Resource{
+		"invoices": {
+			Endpoints: map[string]spec.Endpoint{
+				"create": {
+					Method:       "POST",
+					Path:         "/invoices",
+					ResponsePath: "data",
+					Response:     spec.ResponseDef{Type: "object"},
+				},
+				"list": {
+					Method:       "GET",
+					Path:         "/invoices",
+					ResponsePath: "data.list",
+					Response:     spec.ResponseDef{Type: "array"},
+				},
+			},
+		},
+	})
+
+	require.Equal(t, []responsePathCase{{
+		Key:          "invoices",
+		ResponsePath: "data.list",
+	}}, cases, "resource-level sync fallback must use list's envelope, not create's")
+}
+
+func TestResponsePathCasesUniformPathUnchanged(t *testing.T) {
+	t.Parallel()
+
+	cases := responsePathCases(map[string]spec.Resource{
+		"notes": {
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:       "GET",
+					Path:         "/notes",
+					ResponsePath: "results",
+				},
+			},
+		},
+	})
+
+	assert.Equal(t, []responsePathCase{{
+		Key:          "notes",
+		ResponsePath: "results",
+	}}, cases)
+}
+
+func TestGeneratedSyncPrefersListResponsePathWhenCreateDiffers(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("invoice-path")
+	apiSpec.Resources = map[string]spec.Resource{
+		"invoices": {
+			Description: "Invoices",
+			Endpoints: map[string]spec.Endpoint{
+				"create": {
+					Method:       "POST",
+					Path:         "/invoices",
+					Description:  "Create invoice",
+					ResponsePath: "data",
+					Response:     spec.ResponseDef{Type: "object", Item: "Invoice"},
+					Body: []spec.Param{
+						{Name: "amount", Type: "number", Required: true},
+					},
+				},
+				"list": {
+					Method:       "GET",
+					Path:         "/invoices",
+					Description:  "List invoices",
+					Syncable:     true,
+					ResponsePath: "data.list",
+					Response:     spec.ResponseDef{Type: "array", Item: "Invoice"},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Invoice": {Fields: []spec.TypeField{
+			{Name: "id", Type: "string"},
+			{Name: "amount", Type: "number"},
+		}},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	require.Contains(t, syncSrc, `case "invoices":`)
+	require.Contains(t, syncSrc, `return []string{"data.list"}`)
+	require.NotContains(t, syncSrc, `return []string{"data"}`,
+		"resource-level sync fallback must not collapse to create's envelope")
+
+	listSrc := readGeneratedFile(t, outputDir, "internal", "cli", "invoices_list.go")
+	require.Contains(t, listSrc, `"data.list"`)
+
+	createSrc := readGeneratedFile(t, outputDir, "internal", "cli", "invoices_create.go")
+	require.Contains(t, createSrc, `"data"`,
+		"create must keep its endpoint-level response_path")
+	require.NotContains(t, createSrc, `"data.list"`,
+		"create must not inherit list's response_path")
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "sync_response_path_list_pref_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"`+naming.CLI(apiSpec.Name)+`/internal/store"
+)
+
+type fakeInvoiceClient struct {
+	responses map[string]json.RawMessage
+}
+
+func (f *fakeInvoiceClient) Get(_ context.Context, path string, _ map[string]string) (json.RawMessage, error) {
+	if response, ok := f.responses[path]; ok {
+		return response, nil
+	}
+	return json.RawMessage(`+"`"+`null`+"`"+`), nil
+}
+
+func (f *fakeInvoiceClient) RateLimit() float64 { return 0 }
+
+func TestResponsePathForResourceUsesListEnvelope(t *testing.T) {
+	got := responsePathForResource("invoices", "/invoices")
+	if len(got) != 1 || got[0] != "data.list" {
+		t.Fatalf("responsePathForResource(invoices) = %#v, want [data.list]", got)
+	}
+}
+
+func TestSyncResourceUnwrapsNestedListEnvelope(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("close store: %v", err)
+		}
+	})
+	body := json.RawMessage(`+"`"+`{"data":{"list":[{"id":"inv_1","amount":10},{"id":"inv_2","amount":20}]}}`+"`"+`)
+	client := &fakeInvoiceClient{responses: map[string]json.RawMessage{"/invoices": body}}
+	var events bytes.Buffer
+	res := syncResource(context.Background(), client, db, "invoices", "", true, 0, false, false, nil, &events)
+	if res.Err != nil {
+		t.Fatalf("syncResource error: %v\nevents: %s", res.Err, events.String())
+	}
+	if res.Count != 2 {
+		t.Fatalf("syncResource count = %d, want 2; events: %s", res.Count, events.String())
+	}
+}
+`), 0o644))
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "Test(ResponsePathForResourceUsesListEnvelope|SyncResourceUnwrapsNestedListEnvelope)", "-count=1")
+}

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -4415,7 +4415,9 @@ var dataEnvelopeKeys = []string{"data", "Data", "result", "Result"}
 func responsePathForResource(resource, path string) []string {
 	// path is the live request URL and is not the unwrap key. Envelope
 	// lookup is keyed on resource identity so absolute, proxied, or
-	// otherwise rewritten paths still unwrap.
+	// otherwise rewritten paths still unwrap. When endpoints disagree on
+	// response_path, generation prefers the list/syncable envelope here;
+	// endpoint-mirror commands bake each endpoint's own path separately.
 	switch resource {
 {{- range responsePathCases .Resources}}
 	case {{printf "%q" .Key}}:

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -3457,7 +3457,9 @@ var dataEnvelopeKeys = []string{"data", "Data", "result", "Result"}
 func responsePathForResource(resource, path string) []string {
 	// path is the live request URL and is not the unwrap key. Envelope
 	// lookup is keyed on resource identity so absolute, proxied, or
-	// otherwise rewritten paths still unwrap.
+	// otherwise rewritten paths still unwrap. When endpoints disagree on
+	// response_path, generation prefers the list/syncable envelope here;
+	// endpoint-mirror commands bake each endpoint's own path separately.
 	switch resource {
 	case "tickets":
 		return []string{"items"}

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -2376,7 +2376,9 @@ var dataEnvelopeKeys = []string{"data", "Data", "result", "Result"}
 func responsePathForResource(resource, path string) []string {
 	// path is the live request URL and is not the unwrap key. Envelope
 	// lookup is keyed on resource identity so absolute, proxied, or
-	// otherwise rewritten paths still unwrap.
+	// otherwise rewritten paths still unwrap. When endpoints disagree on
+	// response_path, generation prefers the list/syncable envelope here;
+	// endpoint-mirror commands bake each endpoint's own path separately.
 	switch resource {
 	case "gadgets":
 		return []string{"QueryResponse.Gadget"}

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -3059,7 +3059,9 @@ var dataEnvelopeKeys = []string{"data", "Data", "result", "Result"}
 func responsePathForResource(resource, path string) []string {
 	// path is the live request URL and is not the unwrap key. Envelope
 	// lookup is keyed on resource identity so absolute, proxied, or
-	// otherwise rewritten paths still unwrap.
+	// otherwise rewritten paths still unwrap. When endpoints disagree on
+	// response_path, generation prefers the list/syncable envelope here;
+	// endpoint-mirror commands bake each endpoint's own path separately.
 	switch resource {
 	}
 	return nil

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -2263,7 +2263,9 @@ var dataEnvelopeKeys = []string{"data", "Data", "result", "Result"}
 func responsePathForResource(resource, path string) []string {
 	// path is the live request URL and is not the unwrap key. Envelope
 	// lookup is keyed on resource identity so absolute, proxied, or
-	// otherwise rewritten paths still unwrap.
+	// otherwise rewritten paths still unwrap. When endpoints disagree on
+	// response_path, generation prefers the list/syncable envelope here;
+	// endpoint-mirror commands bake each endpoint's own path separately.
 	switch resource {
 	}
 	return nil


### PR DESCRIPTION
## Intent

Issue: Fixes #4454

`responsePathForResource` is keyed per resource. When create and list declare different `response_path` values, alphabetical tie-breaking could pick create's envelope (`data`) for sync instead of list's (`data.list`).

## Approach

Keep the resource-level switch (sync still unwraps by resource identity, not live URL), but rank endpoints so Syncable and list-shaped names beat create/update/delete. Endpoint-mirror commands continue baking each endpoint's own `ResponsePath`.

## Scope

Primary area: `internal/generator` (`responsePathCases` + sync template comment)

Why this belongs in this repo: every printed CLI inherits `responsePathForResource` from the sync template.

## Risk

Specs where a non-list Syncable endpoint intentionally owned the resource fallback could change which envelope sync uses; list-named Syncable endpoints still win first. Endpoint CLI/MCP unwrap paths are unchanged.

## Output Contract

- Emitted `responsePathForResource` still switches on resource name; list/syncable envelope preferred when endpoints disagree.
- Golden sync.go comment updated for generate-golden-api / query-endpoint / sync-walker / tier-routing.
- Evidence: `TestResponsePathCasesPrefersListOverCreate`, `TestGeneratedSyncPrefersListResponsePathWhenCreateDiffers` (compile + runtime unwrap), existing syncable/dedup cases.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run (scoped; no `go test ./...`, no pressauth):
- `GOTOOLCHAIN=go1.26.6 go test ./internal/generator/ -run 'TestResponsePathCases|TestGenerateSyncResponsePathDedup|TestGeneratedSync' -count=1`
- `GOTOOLCHAIN=go1.26.6 bash scripts/verify-generator-output.sh generate-query-endpoint-api generate-golden-api`
- `GOTOOLCHAIN=go1.26.6 bash scripts/golden.sh verify` (decoy HOME to avoid local library attribution drift)

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

Made with [Cursor](https://cursor.com)