### PR TITLE
fix(cli): reprint from current novel_features, not the last built set

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -745,7 +745,70 @@ func TestLoadResearchSourcesReturnsExplicitEmptyManifestNovelFeatures(t *testing
 	got := loadResearchSources(gen, researchDir)
 	require.NotNil(t, got, "empty built list is an explicit fresh result, not unavailable metadata")
 	assert.Empty(t, got)
-	assert.Empty(t, gen.NovelFeatures)
+	require.Len(t, gen.NovelFeatures, 1)
+	assert.Equal(t, "planned scan", gen.NovelFeatures[0].Command)
+}
+
+func TestLoadResearchSourcesScaffoldsCurrentNovelFeaturesNotBuilt(t *testing.T) {
+	t.Parallel()
+
+	researchDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(researchDir, "research.json"), []byte(`{
+  "api_name": "reprintapp",
+  "novel_features": [
+    {
+      "name": "New scanner",
+      "command": "markets scan",
+      "description": "Current planned set"
+    }
+  ],
+  "novel_features_built": [
+    {
+      "name": "Dropped dashboard",
+      "command": "health",
+      "description": "Prior run survivor"
+    }
+  ]
+}`), 0o644))
+
+	gen := generator.New(&spec.APISpec{
+		Name: "reprintapp",
+		Auth: spec.AuthConfig{Type: "none"},
+	}, t.TempDir())
+
+	got := loadResearchSources(gen, researchDir)
+	require.Len(t, gen.NovelFeatures, 1)
+	assert.Equal(t, "markets scan", gen.NovelFeatures[0].Command)
+	assert.Equal(t, "New scanner", gen.NovelFeatures[0].Name)
+	require.Len(t, got, 1)
+	assert.Equal(t, "health", got[0].Command,
+		"generate-time manifest still records the verified list when present")
+}
+
+func TestLoadResearchSourcesFirstPrintWithoutBuiltList(t *testing.T) {
+	t.Parallel()
+
+	researchDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(researchDir, "research.json"), []byte(`{
+  "api_name": "firstprint",
+  "novel_features": [
+    {
+      "name": "Item insight",
+      "command": "items insight",
+      "description": "Planned feature"
+    }
+  ]
+}`), 0o644))
+
+	gen := generator.New(&spec.APISpec{
+		Name: "firstprint",
+		Auth: spec.AuthConfig{Type: "none"},
+	}, t.TempDir())
+
+	got := loadResearchSources(gen, researchDir)
+	require.Len(t, gen.NovelFeatures, 1)
+	assert.Equal(t, "items insight", gen.NovelFeatures[0].Command)
+	assert.Nil(t, got)
 }
 
 func TestGenerateCmdHelpDescribesForceAsGeneratedOverwrite(t *testing.T) {
@@ -1584,8 +1647,14 @@ resources:
 
 	which, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "which.go"))
 	require.NoError(t, err)
-	assert.Contains(t, string(which), `Command: "items insight"`)
-	assert.NotContains(t, string(which), "items planned")
+	assert.Contains(t, string(which), `Command: "items planned"`)
+	assert.NotContains(t, string(which), "items insight")
+
+	stub, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "items_planned.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(stub), `Use:         "planned"`)
+	_, err = os.Stat(filepath.Join(outputDir, "internal", "cli", "items_insight.go"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestGenerateCmdForceRefreshesResearchSurfaces(t *testing.T) {
@@ -1627,16 +1696,16 @@ resources:
   "novel_features": [
     {
       "name": "Item insight",
-      "command": "items planned",
-      "description": "planned only",
+      "command": "`+command+`",
+      "description": "`+description+`",
       "rationale": "Requires local correlation"
     }
   ],
   "novel_features_built": [
     {
-      "name": "Item insight",
-      "command": "`+command+`",
-      "description": "`+description+`",
+      "name": "Stale insight",
+      "command": "items stale",
+      "description": "prior built set",
       "rationale": "Requires local correlation"
     }
   ]

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -3049,10 +3049,12 @@ func printPlanDryRun(planSpec *generator.PlanSpec, absOut, planFile string, comm
 }
 
 // loadResearchSources populates the generator's Sources, DiscoveryPages, and
-// NovelFeatures from a pipeline research directory. It returns only dogfood-
-// verified novel features in manifest form so publish validation cannot be
-// satisfied by planned-but-unbuilt absorb ideas. Silently skips if researchDir
-// is empty or data is unavailable.
+// NovelFeatures from a pipeline research directory. Scaffolding always uses
+// novel_features: novel_features_built is a post-dogfood verification field,
+// not a generate input. The return value is the verified list in manifest
+// form (when present) so publish validation cannot be satisfied by
+// planned-but-unbuilt absorb ideas. Silently skips if researchDir is empty
+// or data is unavailable.
 func loadResearchSources(gen *generator.Generator, researchDir string) []pipeline.NovelFeatureManifest {
 	if researchDir == "" {
 		return nil
@@ -3068,18 +3070,9 @@ func loadResearchSources(gen *generator.Generator, researchDir string) []pipelin
 				Stars:    s.Stars,
 			})
 		}
-		// Prefer verified (built) novel features over the aspirational list.
-		// novel_features_built is written by dogfood after validating which
-		// planned features actually survived the build. A nil pointer means
-		// dogfood hasn't run yet (fall back to planned). A non-nil pointer
-		// to an empty slice means dogfood ran and nothing survived (show nothing).
-		var novelSrc []pipeline.NovelFeature
-		if research.NovelFeaturesBuilt != nil {
-			novelSrc = *research.NovelFeaturesBuilt
-		} else {
-			novelSrc = research.NovelFeatures
-		}
-		for _, nf := range novelSrc {
+		// Reused research.json still carries the prior run's novel_features_built.
+		// Scaffold the current planned set so a reprint can drop/add/rename.
+		for _, nf := range research.NovelFeatures {
 			gen.NovelFeatures = append(gen.NovelFeatures, generator.NovelFeature{
 				Name:         nf.Name,
 				Command:      nf.Command,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Reprints with reused `research.json` were scaffolding the prior run's `novel_features_built` (including dropped commands) instead of the updated `novel_features` set.

Closes #3532

## Approach

`novel_features_built` is a post-dogfood verification field, not a generate input. `loadResearchSources` now scaffolds `gen.NovelFeatures` from the current `novel_features` list. The generate-time manifest still records the verified built list when present, so planned-but-unbuilt absorb ideas cannot satisfy publish validation. First prints with no built list still scaffold `novel_features` and leave the generate-time manifest empty.

#4317 (`mcp-sync` wiping `novel_features_built`) is a different command and is left alone.

## Scope

Primary area: generate/reprint research loading.

Why this belongs in this repo: the preference lives in the Printing Press generate path, not in any one printed CLI.

## Risk

Reprints that change the novel set now scaffold the new commands instead of resurrecting the last dogfood survivors. Generate-time `.printing-press.json` `novel_features` still comes from `novel_features_built` when that field is present. Live-check, dogfood, and publish still prefer the verified built list after dogfood.

## Output Contract

N/A. Selection of generator input from `research.json`; no template or golden fixture change. All `generate-*` golden cases passed. `dogfood-verdict-matrix` and `verify-runtime-matrix` failed in this environment because the fixture modules ask for `go1.24` (`toolchain not available`); that is unrelated to this change and goldens were not updated.

## Verification

- [x] `go test ./internal/cli/ -run 'TestLoadResearchSources|TestGenerateCmdCarriesVerifiedNovelFeatures|TestGenerateCmdDoesNotCarryPlannedNovelFeatures|TestGenerateCmdForceRefreshesResearchSurfaces'`
- [x] `go test ./...` — all packages passed except `internal/generator` on the parallel 10m timeout (contention). Re-ran `go test ./internal/generator/ -timeout 20m` and it passed.
- [x] `scripts/golden.sh verify` — generate-* fixtures unchanged. No `scripts/golden.sh update`.

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89b52369-bf99-4eb2-95e9-fcbaf2aa5771?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89b52369-bf99-4eb2-95e9-fcbaf2aa5771&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

