### PR TITLE
fix(cli): run clientHooks on generated MCP clients

### DIFF
--- a/internal/generator/client_hooks_mcp_test.go
+++ b/internal/generator/client_hooks_mcp_test.go
@@ -1,0 +1,181 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedMCPClientConstructorAppliesClientHooks(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("client-hooks-mcp")
+	cliName := naming.CLI(apiSpec.Name)
+	outputDir := filepath.Join(t.TempDir(), cliName)
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	rootSrc := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	require.Contains(t, rootSrc, "func ApplyClientHooks(c *client.Client) error")
+	require.Contains(t, rootSrc, "func registerClientHook(hook func(*client.Client) error)")
+	require.Contains(t, rootSrc, "if err := ApplyClientHooks(c); err != nil {")
+	require.NotContains(t, rootSrc, "registerClientHookFor")
+	require.NotContains(t, rootSrc, "clientHookSurface")
+
+	toolsSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
+	require.Contains(t, toolsSrc, "func newMCPClientFromConfig(ctx context.Context, cfg *config.Config) (*client.Client, *platform.Session, error)")
+	require.Contains(t, toolsSrc, "if err := cli.ApplyClientHooks(c); err != nil {")
+	require.Contains(t, toolsSrc, "session.ZeroCredentials()")
+	require.Contains(t, toolsSrc, "return newMCPClientFromConfig(ctx, cfg)")
+	require.NotContains(t, toolsSrc, "func newMCPClientFromConfig(cfg *config.Config) *client.Client")
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestGeneratedMCPClientRunsPreservedHooksAndStopsBeforeHTTP(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("client-hooks-mcp")
+	cliName := naming.CLI(apiSpec.Name)
+	outputDir := filepath.Join(t.TempDir(), cliName)
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	cliFixture := `package cli
+
+import "` + cliName + `/internal/client"
+
+func ResetClientHooksForTest() {
+	clientHooks = nil
+}
+
+func RegisterClientHookForTest(hook func(*client.Client) error) {
+	registerClientHook(hook)
+}
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "cli", "client_hook_fixture.go"),
+		[]byte(cliFixture),
+		0o644,
+	))
+
+	mcpTest := `package mcp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"` + cliName + `/internal/cli"
+	"` + cliName + `/internal/client"
+	"` + cliName + `/internal/config"
+	"` + cliName + `/internal/platform"
+)
+
+func TestMCPClientAppliesPreservedClientHooks(t *testing.T) {
+	cli.ResetClientHooksForTest()
+	t.Cleanup(cli.ResetClientHooksForTest)
+
+	var calls atomic.Int32
+	cli.RegisterClientHookForTest(func(*client.Client) error {
+		calls.Add(1)
+		return nil
+	})
+
+	c, session, err := newMCPClientFromConfig(context.Background(), &config.Config{})
+	if err != nil {
+		t.Fatalf("newMCPClientFromConfig() error = %v", err)
+	}
+	if c == nil {
+		t.Fatal("newMCPClientFromConfig() client is nil")
+	}
+	if session != nil {
+		t.Fatal("newMCPClientFromConfig() unexpected platform session")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("preserved client hook calls = %d, want 1", got)
+	}
+}
+
+func TestMCPClientAllowsNoClientHooks(t *testing.T) {
+	cli.ResetClientHooksForTest()
+	t.Cleanup(cli.ResetClientHooksForTest)
+
+	c, _, err := newMCPClientFromConfig(context.Background(), &config.Config{})
+	if err != nil {
+		t.Fatalf("newMCPClientFromConfig() with no hooks error = %v", err)
+	}
+	if c == nil {
+		t.Fatal("newMCPClientFromConfig() with no hooks client is nil")
+	}
+}
+
+func TestMCPClientHookFailureStopsBeforeHTTPAndClearsCredentials(t *testing.T) {
+	cli.ResetClientHooksForTest()
+	t.Cleanup(cli.ResetClientHooksForTest)
+
+	wantErr := errors.New("managed auth setup failed")
+	var laterCalls atomic.Int32
+	cli.RegisterClientHookForTest(func(*client.Client) error {
+		return wantErr
+	})
+	cli.RegisterClientHookForTest(func(*client.Client) error {
+		laterCalls.Add(1)
+		return nil
+	})
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	t.Cleanup(server.Close)
+
+	secret := []byte("super-secret")
+	bound := &platform.Session{
+		ProfileName: "fixture-tenant",
+		Source:      "fixture-source",
+		Paths:       platform.Paths{CacheDir: t.TempDir()},
+		GateOutcome: platform.GateVerified,
+		Credentials: platform.ResolvedCredentials{"token": secret},
+	}
+	ctx := platform.ContextWithSession(context.Background(), bound)
+
+	c, session, err := newMCPClientFromConfig(ctx, &config.Config{BaseURL: server.URL})
+	if c != nil {
+		_, _ = c.Get(ctx, "/probe", nil)
+	}
+	if c != nil || session != nil {
+		t.Fatalf("failed MCP initialization returned client=%v session=%v", c != nil, session != nil)
+	}
+	if err == nil || !errors.Is(err, wantErr) || !strings.Contains(err.Error(), "initializing MCP client") {
+		t.Fatalf("newMCPClientFromConfig() error = %v, want wrapped %v", err, wantErr)
+	}
+	if laterCalls.Load() != 0 {
+		t.Fatalf("hooks after failure ran %d times, want 0", laterCalls.Load())
+	}
+	if requests != 0 {
+		t.Fatalf("outbound requests after hook failure = %d, want 0", requests)
+	}
+	if _, ok := bound.Credentials["token"]; ok {
+		t.Fatal("bound credentials were not cleared after hook failure")
+	}
+	if !bytes.Equal(secret, make([]byte, len(secret))) {
+		t.Fatalf("credential buffer after Zero = %q, want zeroed", secret)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "mcp", "client_hook_contract_test.go"),
+		[]byte(mcpTest),
+		0o644,
+	))
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/mcp", "-run", "^TestMCPClient(AppliesPreservedClientHooks|AllowsNoClientHooks|HookFailureStopsBeforeHTTPAndClearsCredentials)$", "-count=1")
+}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -18847,6 +18847,10 @@ func assertNewMCPClientUsesPoliteRateLimitAndSkipsCache(t *testing.T, specSource
 		"newMCPClient must not disable rate limiting for MCP-driven calls")
 	assert.Contains(t, toolsBody, "c.NoCache = true",
 		"newMCPClient must disable the response cache so MCP-driven reads see fresh state across mutations")
+	assert.Contains(t, toolsBody, "if err := cli.ApplyClientHooks(c); err != nil {",
+		"newMCPClientFromConfig must run the same preserved clientHooks registry as the CLI")
+	assert.Contains(t, toolsBody, "session.ZeroCredentials()",
+		"newMCPClientFromConfig must clear bound credentials when a hook fails")
 	requireGeneratedCompiles(t, outputDir)
 }
 

--- a/internal/generator/paths_emission_test.go
+++ b/internal/generator/paths_emission_test.go
@@ -39,8 +39,9 @@ func TestPathsResolverEmitsAndGeneratedCLIBuilds(t *testing.T) {
 	require.Contains(t, rootSrc, "var clientHooks []func(*client.Client) error")
 	require.Contains(t, rootSrc, "func registerClientHook(hook func(*client.Client) error)")
 	require.Contains(t, rootSrc, "clientHooks = append(clientHooks, hook)")
+	require.Contains(t, rootSrc, "func ApplyClientHooks(c *client.Client) error")
 	require.Contains(t, rootSrc, "for _, hook := range clientHooks {")
-	require.Contains(t, rootSrc, "if err := hook(c); err != nil {")
+	require.Contains(t, rootSrc, "if err := ApplyClientHooks(c); err != nil {")
 
 	requireGeneratedCompiles(t, outputDir)
 	runGoCommand(t, outputDir, "test", "./internal/cliutil", "-run", "TestHomeOverrideWinsForDefaultBaseAndTildeExpansion", "-count=1")

--- a/internal/generator/role_gate_test.go
+++ b/internal/generator/role_gate_test.go
@@ -47,8 +47,10 @@ func TestRequiresRoleEmitsEndpointGate(t *testing.T) {
 	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
 	require.Contains(t, mcpSrc, "requiredRole cli.Persona")
 	require.Contains(t, mcpSrc, "cli.RequireRoleWith(nil, cfg, pathTemplate, requiredRole)")
+	require.Contains(t, mcpSrc, "c, platformSession, err := newMCPClientFromConfig(ctx, cfg)")
 	require.Contains(t, mcpSrc, "cli.PersonaAdmin")
 
+	requireGeneratedCompiles(t, outputDir)
 	runGoCommand(t, outputDir, "test", "./internal/cli", "./internal/mcp", "./internal/config")
 }
 
@@ -103,13 +105,16 @@ func TestRequiresRoleEmitsMCPOrchestrationGates(t *testing.T) {
 	codeOrchSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "code_orch.go")
 	require.Contains(t, codeOrchSrc, "RequiredRole cli.Persona")
 	require.Contains(t, codeOrchSrc, "cli.RequireRoleWith(nil, cfg, ep.ID, ep.RequiredRole)")
+	require.Contains(t, codeOrchSrc, "c, platformSession, err := newMCPClientFromConfig(ctx, cfg)")
 	require.Regexp(t, regexp.MustCompile(`RequiredRole:\s+cli\.PersonaAdmin`), codeOrchSrc)
 
 	intentsSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "intents.go")
 	require.Contains(t, intentsSrc, "requiredRole cli.Persona")
 	require.Contains(t, intentsSrc, "cli.RequireRoleWith(nil, cfg, ref, ep.requiredRole)")
+	require.Contains(t, intentsSrc, "c, platformSession, err := newMCPClientFromConfig(ctx, cfg)")
 	require.Contains(t, intentsSrc, "requiredRole: cli.PersonaAdmin")
 
+	requireGeneratedCompiles(t, outputDir)
 	runGoCommand(t, outputDir, "test", "./internal/mcp", "./internal/cli", "./internal/config")
 }
 

--- a/internal/generator/templates/mcp_code_orch.go.tmpl
+++ b/internal/generator/templates/mcp_code_orch.go.tmpl
@@ -390,8 +390,7 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 	if err := cli.RequireRoleWith(nil, cfg, ep.ID, ep.RequiredRole); err != nil {
 		return mcplib.NewToolResultError(err.Error()), nil
 	}
-	c := newMCPClientFromConfig(cfg)
-	platformSession, err := cli.BindMCPClient(ctx, c)
+	c, platformSession, err := newMCPClientFromConfig(ctx, cfg)
 	if err != nil {
 		return mcplib.NewToolResultError(err.Error()), nil
 	}

--- a/internal/generator/templates/mcp_intents.go.tmpl
+++ b/internal/generator/templates/mcp_intents.go.tmpl
@@ -84,8 +84,7 @@ func handle{{pascal .Name}}(ctx context.Context, req mcplib.CallToolRequest) (*m
 	if err != nil {
 		return mcplib.NewToolResultError(err.Error()), nil
 	}
-	c := newMCPClientFromConfig(cfg)
-	platformSession, err := cli.BindMCPClient(ctx, c)
+	c, platformSession, err := newMCPClientFromConfig(ctx, cfg)
 	if err != nil {
 		return mcplib.NewToolResultError(err.Error()), nil
 	}

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -477,8 +477,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 		if err := cli.RequireRoleWith(nil, cfg, pathTemplate, requiredRole); err != nil {
 			return mcpToolError(err.Error()), nil
 		}
-		c := newMCPClientFromConfig(cfg)
-		platformSession, err := cli.BindMCPClient(ctx, c)
+		c, platformSession, err := newMCPClientFromConfig(ctx, cfg)
 		if err != nil {
 			return mcpToolError(err.Error()), nil
 		}
@@ -1158,12 +1157,7 @@ func newMCPClient(ctx context.Context) (*client.Client, *platform.Session, error
 	if err != nil {
 		return nil, nil, err
 	}
-	c := newMCPClientFromConfig(cfg)
-	session, err := cli.BindMCPClient(ctx, c)
-	if err != nil {
-		return nil, nil, err
-	}
-	return c, session, nil
+	return newMCPClientFromConfig(ctx, cfg)
 }
 
 func newMCPConfig() (*config.Config, error) {
@@ -1174,7 +1168,7 @@ func newMCPConfig() (*config.Config, error) {
 	return cfg, nil
 }
 
-func newMCPClientFromConfig(cfg *config.Config) *client.Client {
+func newMCPClientFromConfig(ctx context.Context, cfg *config.Config) (*client.Client, *platform.Session, error) {
 	c := client.New(cfg, 60*time.Second, defaultMCPRateLimit)
 	// Agents calling through MCP need fresh data every call. The on-disk
 	// response cache survives across MCP server invocations, so a
@@ -1182,7 +1176,17 @@ func newMCPClientFromConfig(cfg *config.Config) *client.Client {
 	// pre-mutation snapshot for up to the cache TTL. The interactive CLI
 	// constructs its own client and is unaffected.
 	c.NoCache = true
-	return c
+	session, err := cli.BindMCPClient(ctx, c)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := cli.ApplyClientHooks(c); err != nil {
+		if session != nil {
+			session.ZeroCredentials()
+		}
+		return nil, nil, fmt.Errorf("initializing MCP client: %w", err)
+	}
+	return c, session, nil
 }
 
 func mcpDBPath() (string, error) {

--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -173,8 +173,8 @@ func registerClientHook(hook func(*client.Client) error) {
 	clientHooks = append(clientHooks, hook)
 }
 
-// ApplyClientHooks runs the preserved clientHooks registry. MCP constructors
-// call this so agent traffic gets the same post-construction setup as the CLI.
+// Keeps preserved post-construction setup consistent across interactive CLI
+// and MCP clients.
 func ApplyClientHooks(c *client.Client) error {
 	for _, hook := range clientHooks {
 		if err := hook(c); err != nil {

--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -173,6 +173,17 @@ func registerClientHook(hook func(*client.Client) error) {
 	clientHooks = append(clientHooks, hook)
 }
 
+// ApplyClientHooks runs the preserved clientHooks registry. MCP constructors
+// call this so agent traffic gets the same post-construction setup as the CLI.
+func ApplyClientHooks(c *client.Client) error {
+	for _, hook := range clientHooks {
+		if err := hook(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // RootCmd returns the Cobra command tree without executing it. The MCP server
 // uses this to mirror every user-facing command as an agent tool.
 func RootCmd() *cobra.Command {
@@ -964,10 +975,8 @@ func (f *rootFlags) newClient() (*client.Client, error) {
 		c.ThrottleMode = f.throttleMode
 	}
 {{- end}}
-	for _, hook := range clientHooks {
-		if err := hook(c); err != nil {
-			return nil, err
-		}
+	if err := ApplyClientHooks(c); err != nil {
+		return nil, err
 	}
 {{- if .HasCostThrottling}}
 {{- end}}

--- a/internal/pipeline/regenmerge/classify.go
+++ b/internal/pipeline/regenmerge/classify.go
@@ -58,10 +58,11 @@ func extractDecls(filename string) (declSet, error) {
 	for _, d := range file.Decls {
 		switch decl := d.(type) {
 		case *ast.FuncDecl:
-			if decl.Recv == nil && decl.Name.Name == "registerClientHook" {
-				// Client hook registration is generated scaffolding. Ignore it so
-				// a force regen can upgrade an older root while retaining a
-				// markerless package-local client extension.
+			if decl.Recv == nil && (decl.Name.Name == "registerClientHook" || decl.Name.Name == "ApplyClientHooks") {
+				// Client hook registration and application are generated
+				// scaffolding. Ignore them so a force regen can upgrade an
+				// older root while retaining a markerless package-local
+				// client extension.
 				continue
 			}
 			decls.add(canonicalFuncName(decl))

--- a/internal/pipeline/regenmerge/value_drift.go
+++ b/internal/pipeline/regenmerge/value_drift.go
@@ -216,10 +216,20 @@ func isPreferImplementedNovelCommandsASTStmt(stmt ast.Stmt) bool {
 	return ok && isIdent(call.Fun, "preferImplementedNovelCommands")
 }
 
-// isClientHooksASTStmt recognizes the generated client-extension loop. It is
-// template evolution, not authored value drift; otherwise a force regen would
-// retain an older root that has no way to run a preserved package extension.
+// isClientHooksASTStmt recognizes generated client-extension execution. Both
+// the legacy loop and ApplyClientHooks call are template evolution, not
+// authored value drift; otherwise a force regen would retain an older root
+// that has no way to run a preserved package extension on MCP.
 func isClientHooksASTStmt(stmt ast.Stmt) bool {
+	if ifStmt, ok := stmt.(*ast.IfStmt); ok && ifStmt.Init != nil && len(ifStmt.Body.List) == 1 {
+		assign, ok := ifStmt.Init.(*ast.AssignStmt)
+		if ok && len(assign.Lhs) == 1 && len(assign.Rhs) == 1 && isIdent(assign.Lhs[0], "err") {
+			if call, ok := assign.Rhs[0].(*ast.CallExpr); ok && isIdent(call.Fun, "ApplyClientHooks") {
+				return true
+			}
+		}
+	}
+
 	forStmt, ok := stmt.(*ast.RangeStmt)
 	if !ok || !isIdent(forStmt.X, "clientHooks") || len(forStmt.Body.List) != 1 {
 		return false

--- a/internal/pipeline/regenmerge/value_drift_test.go
+++ b/internal/pipeline/regenmerge/value_drift_test.go
@@ -417,6 +417,15 @@ func registerNovelCommand(hook func(root *Cmd, flags *rootFlags)) {
 
 func registerClientHook(hook func(*Client) error) { clientHooks = append(clientHooks, hook) }
 
+func ApplyClientHooks(c *Client) error {
+	for _, hook := range clientHooks {
+		if err := hook(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func newRootCmd(flags *rootFlags) *Cmd {
 	root := &Cmd{}
 	for _, hook := range novelCommandHooks { hook(root, flags) }
@@ -426,8 +435,8 @@ func newRootCmd(flags *rootFlags) *Cmd {
 
 func newClient() *Client {
 	c := &Client{}
-	for _, hook := range clientHooks {
-		if err := hook(c); err != nil { return nil }
+	if err := ApplyClientHooks(c); err != nil {
+		return nil
 	}
 	return c
 }

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/root.go
@@ -149,6 +149,17 @@ func registerClientHook(hook func(*client.Client) error) {
 	clientHooks = append(clientHooks, hook)
 }
 
+// ApplyClientHooks runs the preserved clientHooks registry. MCP constructors
+// call this so agent traffic gets the same post-construction setup as the CLI.
+func ApplyClientHooks(c *client.Client) error {
+	for _, hook := range clientHooks {
+		if err := hook(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // RootCmd returns the Cobra command tree without executing it. The MCP server
 // uses this to mirror every user-facing command as an agent tool.
 func RootCmd() *cobra.Command {
@@ -697,10 +708,8 @@ func (f *rootFlags) newClient() (*client.Client, error) {
 	if err := bindPlatformClient(c, f); err != nil {
 		return nil, err
 	}
-	for _, hook := range clientHooks {
-		if err := hook(c); err != nil {
-			return nil, err
-		}
+	if err := ApplyClientHooks(c); err != nil {
+		return nil, err
 	}
 	return c, nil
 }

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/root.go
@@ -149,8 +149,8 @@ func registerClientHook(hook func(*client.Client) error) {
 	clientHooks = append(clientHooks, hook)
 }
 
-// ApplyClientHooks runs the preserved clientHooks registry. MCP constructors
-// call this so agent traffic gets the same post-construction setup as the CLI.
+// Keeps preserved post-construction setup consistent across interactive CLI
+// and MCP clients.
 func ApplyClientHooks(c *client.Client) error {
 	for _, hook := range clientHooks {
 		if err := hook(c); err != nil {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
@@ -463,12 +463,7 @@ func newMCPClient(ctx context.Context) (*client.Client, *platform.Session, error
 	if err != nil {
 		return nil, nil, err
 	}
-	c := newMCPClientFromConfig(cfg)
-	session, err := cli.BindMCPClient(ctx, c)
-	if err != nil {
-		return nil, nil, err
-	}
-	return c, session, nil
+	return newMCPClientFromConfig(ctx, cfg)
 }
 
 func newMCPConfig() (*config.Config, error) {
@@ -479,7 +474,7 @@ func newMCPConfig() (*config.Config, error) {
 	return cfg, nil
 }
 
-func newMCPClientFromConfig(cfg *config.Config) *client.Client {
+func newMCPClientFromConfig(ctx context.Context, cfg *config.Config) (*client.Client, *platform.Session, error) {
 	c := client.New(cfg, 60*time.Second, defaultMCPRateLimit)
 	// Agents calling through MCP need fresh data every call. The on-disk
 	// response cache survives across MCP server invocations, so a
@@ -487,7 +482,17 @@ func newMCPClientFromConfig(cfg *config.Config) *client.Client {
 	// pre-mutation snapshot for up to the cache TTL. The interactive CLI
 	// constructs its own client and is unaffected.
 	c.NoCache = true
-	return c
+	session, err := cli.BindMCPClient(ctx, c)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := cli.ApplyClientHooks(c); err != nil {
+		if session != nil {
+			session.ZeroCredentials()
+		}
+		return nil, nil, fmt.Errorf("initializing MCP client: %w", err)
+	}
+	return c, session, nil
 }
 
 func mcpDBPath() (string, error) {

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
@@ -408,12 +408,7 @@ func newMCPClient(ctx context.Context) (*client.Client, *platform.Session, error
 	if err != nil {
 		return nil, nil, err
 	}
-	c := newMCPClientFromConfig(cfg)
-	session, err := cli.BindMCPClient(ctx, c)
-	if err != nil {
-		return nil, nil, err
-	}
-	return c, session, nil
+	return newMCPClientFromConfig(ctx, cfg)
 }
 
 func newMCPConfig() (*config.Config, error) {
@@ -424,7 +419,7 @@ func newMCPConfig() (*config.Config, error) {
 	return cfg, nil
 }
 
-func newMCPClientFromConfig(cfg *config.Config) *client.Client {
+func newMCPClientFromConfig(ctx context.Context, cfg *config.Config) (*client.Client, *platform.Session, error) {
 	c := client.New(cfg, 60*time.Second, defaultMCPRateLimit)
 	// Agents calling through MCP need fresh data every call. The on-disk
 	// response cache survives across MCP server invocations, so a
@@ -432,7 +427,17 @@ func newMCPClientFromConfig(cfg *config.Config) *client.Client {
 	// pre-mutation snapshot for up to the cache TTL. The interactive CLI
 	// constructs its own client and is unaffected.
 	c.NoCache = true
-	return c
+	session, err := cli.BindMCPClient(ctx, c)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := cli.ApplyClientHooks(c); err != nil {
+		if session != nil {
+			session.ZeroCredentials()
+		}
+		return nil, nil, fmt.Errorf("initializing MCP client: %w", err)
+	}
+	return c, session, nil
 }
 
 func mcpDBPath() (string, error) {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
@@ -149,8 +149,8 @@ func registerClientHook(hook func(*client.Client) error) {
 	clientHooks = append(clientHooks, hook)
 }
 
-// ApplyClientHooks runs the preserved clientHooks registry. MCP constructors
-// call this so agent traffic gets the same post-construction setup as the CLI.
+// Keeps preserved post-construction setup consistent across interactive CLI
+// and MCP clients.
 func ApplyClientHooks(c *client.Client) error {
 	for _, hook := range clientHooks {
 		if err := hook(c); err != nil {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
@@ -149,6 +149,17 @@ func registerClientHook(hook func(*client.Client) error) {
 	clientHooks = append(clientHooks, hook)
 }
 
+// ApplyClientHooks runs the preserved clientHooks registry. MCP constructors
+// call this so agent traffic gets the same post-construction setup as the CLI.
+func ApplyClientHooks(c *client.Client) error {
+	for _, hook := range clientHooks {
+		if err := hook(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // RootCmd returns the Cobra command tree without executing it. The MCP server
 // uses this to mirror every user-facing command as an agent tool.
 func RootCmd() *cobra.Command {
@@ -740,10 +751,8 @@ func (f *rootFlags) newClient() (*client.Client, error) {
 	if err := bindPlatformClient(c, f); err != nil {
 		return nil, err
 	}
-	for _, hook := range clientHooks {
-		if err := hook(c); err != nil {
-			return nil, err
-		}
+	if err := ApplyClientHooks(c); err != nil {
+		return nil, err
 	}
 	return c, nil
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
@@ -601,12 +601,7 @@ func newMCPClient(ctx context.Context) (*client.Client, *platform.Session, error
 	if err != nil {
 		return nil, nil, err
 	}
-	c := newMCPClientFromConfig(cfg)
-	session, err := cli.BindMCPClient(ctx, c)
-	if err != nil {
-		return nil, nil, err
-	}
-	return c, session, nil
+	return newMCPClientFromConfig(ctx, cfg)
 }
 
 func newMCPConfig() (*config.Config, error) {
@@ -617,7 +612,7 @@ func newMCPConfig() (*config.Config, error) {
 	return cfg, nil
 }
 
-func newMCPClientFromConfig(cfg *config.Config) *client.Client {
+func newMCPClientFromConfig(ctx context.Context, cfg *config.Config) (*client.Client, *platform.Session, error) {
 	c := client.New(cfg, 60*time.Second, defaultMCPRateLimit)
 	// Agents calling through MCP need fresh data every call. The on-disk
 	// response cache survives across MCP server invocations, so a
@@ -625,7 +620,17 @@ func newMCPClientFromConfig(cfg *config.Config) *client.Client {
 	// pre-mutation snapshot for up to the cache TTL. The interactive CLI
 	// constructs its own client and is unaffected.
 	c.NoCache = true
-	return c
+	session, err := cli.BindMCPClient(ctx, c)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := cli.ApplyClientHooks(c); err != nil {
+		if session != nil {
+			session.ZeroCredentials()
+		}
+		return nil, nil, fmt.Errorf("initializing MCP client: %w", err)
+	}
+	return c, session, nil
 }
 
 func mcpDBPath() (string, error) {

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/cli/root.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/cli/root.go
@@ -138,8 +138,8 @@ func registerClientHook(hook func(*client.Client) error) {
 	clientHooks = append(clientHooks, hook)
 }
 
-// ApplyClientHooks runs the preserved clientHooks registry. MCP constructors
-// call this so agent traffic gets the same post-construction setup as the CLI.
+// Keeps preserved post-construction setup consistent across interactive CLI
+// and MCP clients.
 func ApplyClientHooks(c *client.Client) error {
 	for _, hook := range clientHooks {
 		if err := hook(c); err != nil {

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/cli/root.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/cli/root.go
@@ -138,6 +138,17 @@ func registerClientHook(hook func(*client.Client) error) {
 	clientHooks = append(clientHooks, hook)
 }
 
+// ApplyClientHooks runs the preserved clientHooks registry. MCP constructors
+// call this so agent traffic gets the same post-construction setup as the CLI.
+func ApplyClientHooks(c *client.Client) error {
+	for _, hook := range clientHooks {
+		if err := hook(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // RootCmd returns the Cobra command tree without executing it. The MCP server
 // uses this to mirror every user-facing command as an agent tool.
 func RootCmd() *cobra.Command {
@@ -458,10 +469,8 @@ func (f *rootFlags) newClient() (*client.Client, error) {
 	if err := bindPlatformClient(c, f); err != nil {
 		return nil, err
 	}
-	for _, hook := range clientHooks {
-		if err := hook(c); err != nil {
-			return nil, err
-		}
+	if err := ApplyClientHooks(c); err != nil {
+		return nil, err
 	}
 	return c, nil
 }

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/root.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/root.go
@@ -143,6 +143,17 @@ func registerClientHook(hook func(*client.Client) error) {
 	clientHooks = append(clientHooks, hook)
 }
 
+// ApplyClientHooks runs the preserved clientHooks registry. MCP constructors
+// call this so agent traffic gets the same post-construction setup as the CLI.
+func ApplyClientHooks(c *client.Client) error {
+	for _, hook := range clientHooks {
+		if err := hook(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // RootCmd returns the Cobra command tree without executing it. The MCP server
 // uses this to mirror every user-facing command as an agent tool.
 func RootCmd() *cobra.Command {
@@ -716,10 +727,8 @@ func (f *rootFlags) newClient() (*client.Client, error) {
 	if err := bindPlatformClient(c, f); err != nil {
 		return nil, err
 	}
-	for _, hook := range clientHooks {
-		if err := hook(c); err != nil {
-			return nil, err
-		}
+	if err := ApplyClientHooks(c); err != nil {
+		return nil, err
 	}
 	return c, nil
 }

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/root.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/root.go
@@ -143,8 +143,8 @@ func registerClientHook(hook func(*client.Client) error) {
 	clientHooks = append(clientHooks, hook)
 }
 
-// ApplyClientHooks runs the preserved clientHooks registry. MCP constructors
-// call this so agent traffic gets the same post-construction setup as the CLI.
+// Keeps preserved post-construction setup consistent across interactive CLI
+// and MCP clients.
 func ApplyClientHooks(c *client.Client) error {
 	for _, hook := range clientHooks {
 		if err := hook(c); err != nil {

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
@@ -402,12 +402,7 @@ func newMCPClient(ctx context.Context) (*client.Client, *platform.Session, error
 	if err != nil {
 		return nil, nil, err
 	}
-	c := newMCPClientFromConfig(cfg)
-	session, err := cli.BindMCPClient(ctx, c)
-	if err != nil {
-		return nil, nil, err
-	}
-	return c, session, nil
+	return newMCPClientFromConfig(ctx, cfg)
 }
 
 func newMCPConfig() (*config.Config, error) {
@@ -418,7 +413,7 @@ func newMCPConfig() (*config.Config, error) {
 	return cfg, nil
 }
 
-func newMCPClientFromConfig(cfg *config.Config) *client.Client {
+func newMCPClientFromConfig(ctx context.Context, cfg *config.Config) (*client.Client, *platform.Session, error) {
 	c := client.New(cfg, 60*time.Second, defaultMCPRateLimit)
 	// Agents calling through MCP need fresh data every call. The on-disk
 	// response cache survives across MCP server invocations, so a
@@ -426,7 +421,17 @@ func newMCPClientFromConfig(cfg *config.Config) *client.Client {
 	// pre-mutation snapshot for up to the cache TTL. The interactive CLI
 	// constructs its own client and is unaffected.
 	c.NoCache = true
-	return c
+	session, err := cli.BindMCPClient(ctx, c)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := cli.ApplyClientHooks(c); err != nil {
+		if session != nil {
+			session.ZeroCredentials()
+		}
+		return nil, nil, fmt.Errorf("initializing MCP client: %w", err)
+	}
+	return c, session, nil
 }
 
 func mcpDBPath() (string, error) {

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
@@ -540,12 +540,7 @@ func newMCPClient(ctx context.Context) (*client.Client, *platform.Session, error
 	if err != nil {
 		return nil, nil, err
 	}
-	c := newMCPClientFromConfig(cfg)
-	session, err := cli.BindMCPClient(ctx, c)
-	if err != nil {
-		return nil, nil, err
-	}
-	return c, session, nil
+	return newMCPClientFromConfig(ctx, cfg)
 }
 
 func newMCPConfig() (*config.Config, error) {
@@ -556,7 +551,7 @@ func newMCPConfig() (*config.Config, error) {
 	return cfg, nil
 }
 
-func newMCPClientFromConfig(cfg *config.Config) *client.Client {
+func newMCPClientFromConfig(ctx context.Context, cfg *config.Config) (*client.Client, *platform.Session, error) {
 	c := client.New(cfg, 60*time.Second, defaultMCPRateLimit)
 	// Agents calling through MCP need fresh data every call. The on-disk
 	// response cache survives across MCP server invocations, so a
@@ -564,7 +559,17 @@ func newMCPClientFromConfig(cfg *config.Config) *client.Client {
 	// pre-mutation snapshot for up to the cache TTL. The interactive CLI
 	// constructs its own client and is unaffected.
 	c.NoCache = true
-	return c
+	session, err := cli.BindMCPClient(ctx, c)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := cli.ApplyClientHooks(c); err != nil {
+		if session != nil {
+			session.ZeroCredentials()
+		}
+		return nil, nil, fmt.Errorf("initializing MCP client: %w", err)
+	}
+	return c, session, nil
 }
 
 func mcpDBPath() (string, error) {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
@@ -428,12 +428,7 @@ func newMCPClient(ctx context.Context) (*client.Client, *platform.Session, error
 	if err != nil {
 		return nil, nil, err
 	}
-	c := newMCPClientFromConfig(cfg)
-	session, err := cli.BindMCPClient(ctx, c)
-	if err != nil {
-		return nil, nil, err
-	}
-	return c, session, nil
+	return newMCPClientFromConfig(ctx, cfg)
 }
 
 func newMCPConfig() (*config.Config, error) {
@@ -444,7 +439,7 @@ func newMCPConfig() (*config.Config, error) {
 	return cfg, nil
 }
 
-func newMCPClientFromConfig(cfg *config.Config) *client.Client {
+func newMCPClientFromConfig(ctx context.Context, cfg *config.Config) (*client.Client, *platform.Session, error) {
 	c := client.New(cfg, 60*time.Second, defaultMCPRateLimit)
 	// Agents calling through MCP need fresh data every call. The on-disk
 	// response cache survives across MCP server invocations, so a
@@ -452,7 +447,17 @@ func newMCPClientFromConfig(cfg *config.Config) *client.Client {
 	// pre-mutation snapshot for up to the cache TTL. The interactive CLI
 	// constructs its own client and is unaffected.
 	c.NoCache = true
-	return c
+	session, err := cli.BindMCPClient(ctx, c)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := cli.ApplyClientHooks(c); err != nil {
+		if session != nil {
+			session.ZeroCredentials()
+		}
+		return nil, nil, fmt.Errorf("initializing MCP client: %w", err)
+	}
+	return c, session, nil
 }
 
 func mcpDBPath() (string, error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Generated CLI clients run preserved `clientHooks` after `client.New`. Generated MCP constructors called `client.New` directly and skipped that registry, so CLI-registered setup (Peloton managed bearer/cookie/transport) never ran on MCP traffic.

Closes #4382

## Approach

Keep the existing `registerClientHook` / `clientHooks` registry. Export `ApplyClientHooks` from generated `internal/cli` and call it from every MCP construction path after `BindMCPClient`:

- `newMCPClientFromConfig` is the single MCP constructor (endpoint tools, code orchestration, intents, including required-role branches)
- Hook errors return before any request
- Bound session credentials are cleared on hook failure

No second hook registry and no CLI/MCP/both surface scopes.

## Scope

Primary area: generator templates (`root.go.tmpl`, `mcp_tools.go.tmpl`, `mcp_code_orch.go.tmpl`, `mcp_intents.go.tmpl`) and regen-merge recognition of the shared helper as template evolution.

This belongs in the Printing Press because every printed CLI inherits the MCP constructor.

## Risk

Existing `registerClientHook` registrations now also run on MCP. That is the intended contract: if a hook is unsafe on MCP, that is on the hook author. Apps with no hooks keep current behavior (empty loop).

## Output Contract

Emitted MCP constructor invokes `cli.ApplyClientHooks`. Generated-output tests compile a printed CLI and run constructor tests for shared hooks, no-hook construction, first-failure before HTTP, and credential clearing.

Golden fixtures for generated `root.go` / `mcp/tools.go` include the new constructor and hook helper. The exported-helper comment documents the cross-surface rationale.

## Verification

- [x] Generator/template change: emitted MCP constructor invokes `cli.ApplyClientHooks`; role-gated endpoint, code-orchestration, and intent call sites share `newMCPClientFromConfig(ctx, cfg)`
- [x] Generator/template change: covered no-hook, successful hook, first-failure before HTTP, and credential clearing
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:

- `go test ./... -timeout 45m -count=1`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `bash scripts/golden.sh update` (committed generate-* fixture updates only; local `verify-runtime-matrix` / `dogfood-verdict-matrix` env noise not committed)

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b53edbf-3264-4498-8ee3-97e551c0d3e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b53edbf-3264-4498-8ee3-97e551c0d3e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

