### PR TITLE
fix(cli): align profiler IDField with store date rejection

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -1382,9 +1382,14 @@ Rules:
   then the first solo-usable required scalar. A date-shaped required field
   (OpenAPI `format: date` / `date-time`, a date-like name such as `date` /
   `created_at`, or an ISO-date example) is never selected as a solo IDField:
-  if later required string fields exist, they are joined with `+` as a
-  composite identity; otherwise IDField stays empty so runtime fallbacks
-  apply. URL-shaped keys qualify only
+  if later required identity fields exist (string or numeric, excluding
+  mutable/metric names such as `status` or `total_tokens`), they are joined
+  with `+` as a composite identity; otherwise IDField stays empty so runtime
+  fallbacks apply. Generated `ExtractResourceID` joins part *values* with `+`
+  after escaping `\` and `+` inside each part so distinct tuples cannot
+  collide. Date-shaped parts are allowed inside a
+  composite; a solo date field is not, because `CanonicalResourceID`
+  rejects ISO-date values. URL-shaped keys qualify only
   when the field schema is a plausible ID and either the field is required or
   its name, title, description, or format carries an identifier hint; an
   optional generic `url` therefore falls through to `name`.

--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -1359,7 +1359,11 @@ Rules:
 - Optional.
 - Must be a string. A dotted path (`entityInfo.entityId`) is stored verbatim
   and walked at runtime by `LookupFieldValue`; it is not limited to a
-  single top-level key.
+  single top-level key. A `+`-separated list (`date+model_permaslug`) is a
+  composite identity: generated `ExtractResourceID` joins the part values
+  with `+` at storage time. Date-shaped parts are allowed inside a
+  composite; a solo date field is not, because `CanonicalResourceID`
+  rejects ISO-date values.
 - Leading and trailing whitespace is trimmed.
 - Non-string values emit a warning and are ignored.
 - A non-empty `x-resource-id` wins over every automatic response-schema
@@ -1375,7 +1379,12 @@ Rules:
   on `/sites` falls through; two own-stem spellings stay ambiguous); then
   URL-shaped
   identifier keys `uri`, `self`, `selfLink`, `href`, and `url`; then `name`;
-  then the first plausible required scalar field. URL-shaped keys qualify only
+  then the first solo-usable required scalar. A date-shaped required field
+  (OpenAPI `format: date` / `date-time`, a date-like name such as `date` /
+  `created_at`, or an ISO-date example) is never selected as a solo IDField:
+  if later required string fields exist, they are joined with `+` as a
+  composite identity; otherwise IDField stays empty so runtime fallbacks
+  apply. URL-shaped keys qualify only
   when the field schema is a plausible ID and either the field is required or
   its name, title, description, or format carries an identifier hint; an
   optional generic `url` therefore falls through to `name`.
@@ -1412,6 +1421,21 @@ paths:
     x-resource-id: entityInfo.entityId
     get:
       operationId: listEntities
+      responses:
+        "200":
+          description: OK
+```
+
+Composite identities use the same extension with `+`-separated field names.
+Generated extraction joins the part values with `+` so a date-shaped column
+can participate in the row key without becoming a solo ID:
+
+```yaml
+paths:
+  /datasets/rankings-daily:
+    x-resource-id: date+model_permaslug
+    get:
+      operationId: listRankingsDaily
       responses:
         "200":
           description: OK

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -4573,11 +4573,36 @@ func identityFieldsForResource(idField string, common []string) []string {
 		seen[f] = struct{}{}
 		out = append(out, f)
 	}
-	add(idField)
+	for _, part := range splitResourceIDFieldOverride(idField) {
+		add(part)
+	}
 	for _, f := range common {
 		add(f)
 	}
 	return out
+}
+
+func splitResourceIDFieldOverride(idField string) []string {
+	idField = strings.TrimSpace(idField)
+	if idField == "" {
+		return nil
+	}
+	if !strings.Contains(idField, "+") {
+		return []string{idField}
+	}
+	raw := strings.Split(idField, "+")
+	parts := make([]string, 0, len(raw))
+	for _, part := range raw {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return []string{idField}
+		}
+		parts = append(parts, part)
+	}
+	if len(parts) < 2 {
+		return []string{idField}
+	}
+	return parts
 }
 
 func firstEndpointIDField(r spec.Resource) string {

--- a/internal/generator/learn_identity_fields_test.go
+++ b/internal/generator/learn_identity_fields_test.go
@@ -60,3 +60,27 @@ func TestLearnResourceIdentityFieldEntries_DedupesIDField(t *testing.T) {
 	}
 	require.Equal(t, 1, count, "id must appear once even when it is both IDField and a common key")
 }
+
+func TestLearnResourceIdentityFieldEntries_SplitsCompositeIDField(t *testing.T) {
+	t.Parallel()
+
+	api := minimalSpec("identity-composite")
+	items := api.Resources["items"]
+	list := items.Endpoints["list"]
+	list.IDField = "date+model_permaslug"
+	items.Endpoints["list"] = list
+	api.Resources["items"] = items
+
+	entries := learnResourceIdentityFieldEntries(api, profiler.Profile(api))
+	var itemsEntry *learnIdentityFieldEntry
+	for i := range entries {
+		if entries[i].ResourceType == "items" {
+			itemsEntry = &entries[i]
+			break
+		}
+	}
+	require.NotNil(t, itemsEntry, "items must appear in the identity-field map")
+	require.Equal(t, "date", itemsEntry.Fields[0], "composite IDField must split so the first part leads")
+	require.Contains(t, itemsEntry.Fields, "model_permaslug")
+	require.NotContains(t, itemsEntry.Fields, "date+model_permaslug")
+}

--- a/internal/generator/store_resource_id_resolution_test.go
+++ b/internal/generator/store_resource_id_resolution_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
@@ -83,7 +84,7 @@ func TestGeneratedStoreResolvesNestedAndUnusableRecordIDs(t *testing.T) {
 	requireGeneratedCompiles(t, outputDir)
 
 	runGoCommandRequired(t, outputDir, "test", "./internal/store",
-		"-run", "Test(LookupFieldValue_DottedPathAndTrailingUnderscore|ExtractResourceID_NestedOverrideAndIDUnderscore|ExtractResourceID_RefusesUnusableValues|UpsertBatch_NestedOverrideStoresRows|UpsertBatch_RefusesUnusableIDsInsteadOfWritingThem|UpsertBatch_GenericFallbackList|UpsertBatch_TemplatedIDFieldOverrideWins)",
+		"-run", "Test(LookupFieldValue_DottedPathAndTrailingUnderscore|ExtractResourceID_NestedOverrideAndIDUnderscore|ExtractResourceID_RefusesUnusableValues|ExtractResourceID_CompositeDateAndSlug|UpsertBatch_NestedOverrideStoresRows|UpsertBatch_RefusesUnusableIDsInsteadOfWritingThem|UpsertBatch_CompositeDateIDStoresDistinctRows|UpsertBatch_GenericFallbackList|UpsertBatch_TemplatedIDFieldOverrideWins)",
 		"-count=1")
 }
 
@@ -157,4 +158,87 @@ paths:
 	assert.Regexp(t, resolvedOverride, syncContent)
 
 	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestGeneratedStoreCompositeDateIDFieldSyncsRows(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := openapi.Parse([]byte(`openapi: "3.0.3"
+info:
+  title: Rankings Daily
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /rankings-daily:
+    get:
+      operationId: listRankingsDaily
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required: [date, model_permaslug, total_tokens]
+                  properties:
+                    date: {type: string}
+                    model_permaslug: {type: string}
+                    total_tokens: {type: integer}
+  /rankings-only-date:
+    get:
+      operationId: listRankingsOnlyDate
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required: [date]
+                  properties:
+                    date: {type: string}
+                    model_permaslug: {type: string}
+`))
+	require.NoError(t, err)
+	profile := profiler.Profile(apiSpec)
+	byName := make(map[string]string, len(profile.SyncableResources))
+	for _, resource := range profile.SyncableResources {
+		byName[resource.Name] = resource.IDField
+	}
+	require.Equal(t, "date+model_permaslug", byName["rankings-daily"],
+		"profiler must compose date with the remaining string identity")
+	require.Empty(t, byName["rankings-only-date"],
+		"a date-shaped field must not be selected as a solo IDField")
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	storeGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	storeContent := string(storeGo)
+	syncContent := string(syncGo)
+	compositeOverride := regexp.MustCompile(`"rankings-daily":\s+"date\+model_permaslug"`)
+	assert.Regexp(t, compositeOverride, storeContent)
+	assert.Regexp(t, compositeOverride, syncContent)
+	overrideStart := strings.Index(storeContent, `var resourceIDFieldOverrides = map[string]string{`)
+	require.GreaterOrEqual(t, overrideStart, 0)
+	overrideEnd := strings.Index(storeContent[overrideStart:], "\n}")
+	require.GreaterOrEqual(t, overrideEnd, 0)
+	overrideBlock := storeContent[overrideStart : overrideStart+overrideEnd]
+	assert.NotContains(t, overrideBlock, `"rankings-only-date"`)
+	assert.Contains(t, storeContent, "func canonicalCompositeIDFromOverride(")
+	assert.Contains(t, storeContent, "func splitResourceIDFieldOverride(")
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommandRequired(t, outputDir, "test", "./internal/store",
+		"-run", "Test(ExtractResourceID_CompositeDateAndSlug|ExtractResourceID_RefusesUnusableValues|UpsertBatch_CompositeDateIDStoresDistinctRows)",
+		"-count=1")
 }

--- a/internal/generator/store_resource_id_resolution_test.go
+++ b/internal/generator/store_resource_id_resolution_test.go
@@ -236,9 +236,11 @@ paths:
 	assert.NotContains(t, overrideBlock, `"rankings-only-date"`)
 	assert.Contains(t, storeContent, "func canonicalCompositeIDFromOverride(")
 	assert.Contains(t, storeContent, "func splitResourceIDFieldOverride(")
+	assert.Contains(t, storeContent, "func encodeCompositeResourceIDPart(")
+	assert.Contains(t, storeContent, "func joinCompositeResourceID(")
 
 	requireGeneratedCompiles(t, outputDir)
 	runGoCommandRequired(t, outputDir, "test", "./internal/store",
-		"-run", "Test(ExtractResourceID_CompositeDateAndSlug|ExtractResourceID_RefusesUnusableValues|UpsertBatch_CompositeDateIDStoresDistinctRows)",
+		"-run", "Test(ExtractResourceID_CompositeDateAndSlug|ExtractResourceID_CompositePartsDoNotCollide|ExtractResourceID_CompositeNumericPart|ExtractResourceID_RefusesUnusableValues|UpsertBatch_CompositeDateIDStoresDistinctRows)",
 		"-count=1")
 }

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1869,7 +1869,21 @@ func canonicalCompositeIDFromOverride(obj map[string]any, override string) strin
 		}
 		values = append(values, s)
 	}
-	return CanonicalResourceID(strings.Join(values, "+"))
+	return CanonicalResourceID(joinCompositeResourceID(values))
+}
+
+func encodeCompositeResourceIDPart(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `+`, `\+`)
+	return s
+}
+
+func joinCompositeResourceID(values []string) string {
+	encoded := make([]string, len(values))
+	for i, v := range values {
+		encoded[i] = encodeCompositeResourceIDPart(v)
+	}
+	return strings.Join(encoded, "+")
 }
 
 // ResourceIDString returns the stable text form used for resources.id.

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1804,6 +1804,74 @@ func canonicalIDFromKey(obj map[string]any, key string) string {
 	return CanonicalResourceID(v)
 }
 
+func canonicalIDFromOverride(obj map[string]any, override string) string {
+	if s := canonicalIDFromKey(obj, override); s != "" {
+		return s
+	}
+	return canonicalCompositeIDFromOverride(obj, override)
+}
+
+func overrideIdentityPresent(obj map[string]any, override string) bool {
+	if _, found := lookupRawFieldValue(obj, override); found {
+		return true
+	}
+	parts := splitResourceIDFieldOverride(override)
+	if len(parts) < 2 {
+		return false
+	}
+	for _, part := range parts {
+		if _, found := lookupRawFieldValue(obj, part); !found {
+			return false
+		}
+	}
+	return true
+}
+
+func splitResourceIDFieldOverride(override string) []string {
+	override = strings.TrimSpace(override)
+	if override == "" || !strings.Contains(override, "+") {
+		return nil
+	}
+	raw := strings.Split(override, "+")
+	parts := make([]string, 0, len(raw))
+	for _, part := range raw {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil
+		}
+		parts = append(parts, part)
+	}
+	if len(parts) < 2 {
+		return nil
+	}
+	return parts
+}
+
+func canonicalCompositeIDFromOverride(obj map[string]any, override string) string {
+	parts := splitResourceIDFieldOverride(override)
+	if len(parts) < 2 {
+		return ""
+	}
+	values := make([]string, 0, len(parts))
+	for _, key := range parts {
+		v, ok := lookupRawFieldValue(obj, key)
+		if !ok {
+			return ""
+		}
+		s := strings.TrimSpace(ResourceIDString(v))
+		if s == "" || s == "<nil>" {
+			return ""
+		}
+		// Date-shaped parts are allowed inside a composite; CanonicalResourceID
+		// still refuses a solo ISO date after the join.
+		if f, err := strconv.ParseFloat(s, 64); err == nil && f == 0 {
+			return ""
+		}
+		values = append(values, s)
+	}
+	return CanonicalResourceID(strings.Join(values, "+"))
+}
+
 // ResourceIDString returns the stable text form used for resources.id.
 func ResourceIDString(v any) string {
 	switch t := v.(type) {
@@ -2004,7 +2072,7 @@ var resourceParentKeyColumns = map[string][]string{
 // non-entity envelopes into the batch path.
 func ExtractResourceID(resourceType string, obj map[string]any) string {
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
-		if s := canonicalIDFromKey(obj, override); s != "" {
+		if s := canonicalIDFromOverride(obj, override); s != "" {
 			return s
 		}
 	}
@@ -2050,7 +2118,7 @@ func identityKeyPresent(resourceType string, obj map[string]any) bool {
 		return false
 	}
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
-		if _, found := lookupRawFieldValue(obj, override); found {
+		if overrideIdentityPresent(obj, override) {
 			return true
 		}
 	}

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -832,6 +832,92 @@ func TestExtractResourceID_RefusesUnusableValues(t *testing.T) {
 	}
 }
 
+func TestExtractResourceID_CompositeDateAndSlug(t *testing.T) {
+	prev, hadPrev := resourceIDFieldOverrides["rankings-daily"]
+	resourceIDFieldOverrides["rankings-daily"] = "date+model_permaslug"
+	defer func() {
+		if hadPrev {
+			resourceIDFieldOverrides["rankings-daily"] = prev
+		} else {
+			delete(resourceIDFieldOverrides, "rankings-daily")
+		}
+	}()
+
+	obj := map[string]any{
+		"date":             "2026-08-22",
+		"model_permaslug":  "openrouter/auto",
+		"total_tokens":     json.Number("1530"),
+	}
+	got := ExtractResourceID("rankings-daily", obj)
+	want := "2026-08-22+openrouter/auto"
+	if got != want {
+		t.Fatalf("composite ExtractResourceID = %q, want %q", got, want)
+	}
+	if CanonicalResourceID("2026-08-22") != "" {
+		t.Fatal("solo ISO date must still be unusable as an ID")
+	}
+
+	dateOnly := map[string]any{"date": "2026-08-22"}
+	if got := ExtractResourceID("rankings-daily", dateOnly); got != "" {
+		t.Fatalf("incomplete composite must not extract, got %q", got)
+	}
+
+	resourceIDFieldOverrides["rankings-daily"] = "date"
+	if got := ExtractResourceID("rankings-daily", obj); got != "" {
+		t.Fatalf("date-only override must still be refused, got %q", got)
+	}
+}
+
+func TestUpsertBatch_CompositeDateIDStoresDistinctRows(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	prev, hadPrev := resourceIDFieldOverrides["rankings-daily"]
+	resourceIDFieldOverrides["rankings-daily"] = "date+model_permaslug"
+	defer func() {
+		if hadPrev {
+			resourceIDFieldOverrides["rankings-daily"] = prev
+		} else {
+			delete(resourceIDFieldOverrides, "rankings-daily")
+		}
+	}()
+
+	items := []json.RawMessage{
+		json.RawMessage(`{"date":"2026-08-22","model_permaslug":"openrouter/auto","total_tokens":10}`),
+		json.RawMessage(`{"date":"2026-08-23","model_permaslug":"openrouter/auto","total_tokens":20}`),
+		json.RawMessage(`{"date":"2026-08-22","model_permaslug":"acme/model","total_tokens":30}`),
+		json.RawMessage(`{"date":"2026-08-22","model_permaslug":"openrouter/auto","total_tokens":11}`),
+	}
+	stored, extractFailures, err := s.UpsertBatch("rankings-daily", items)
+	if err != nil {
+		t.Fatalf("UpsertBatch: %v", err)
+	}
+	if extractFailures != 0 {
+		t.Fatalf("extractFailures = %d, want 0", extractFailures)
+	}
+	if stored != 4 {
+		t.Fatalf("stored = %d, want 4 (3 distinct keys, last row upserts)", stored)
+	}
+	var count int
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM resources WHERE resource_type = ?`, "rankings-daily").Scan(&count); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("distinct rows = %d, want 3", count)
+	}
+	row, err := s.Get("rankings-daily", "2026-08-22+openrouter/auto")
+	if err != nil {
+		t.Fatalf("Get composite id: %v", err)
+	}
+	if !strings.Contains(string(row), `"total_tokens":11`) && !strings.Contains(string(row), `"total_tokens": 11`) {
+		t.Fatalf("upserted composite row missing updated tokens, got %s", row)
+	}
+}
+
 func TestUpsertBatch_NestedOverrideStoresRows(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "data.db")
 	s, err := Open(dbPath)

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -868,6 +868,65 @@ func TestExtractResourceID_CompositeDateAndSlug(t *testing.T) {
 	}
 }
 
+func TestExtractResourceID_CompositePartsDoNotCollide(t *testing.T) {
+	prev, hadPrev := resourceIDFieldOverrides["rankings-daily"]
+	resourceIDFieldOverrides["rankings-daily"] = "ts+model"
+	defer func() {
+		if hadPrev {
+			resourceIDFieldOverrides["rankings-daily"] = prev
+		} else {
+			delete(resourceIDFieldOverrides, "rankings-daily")
+		}
+	}()
+
+	offsetTZ := map[string]any{
+		"ts":    "2026-08-22T12:00:00+01:00",
+		"model": "model",
+	}
+	splitPlus := map[string]any{
+		"ts":    "2026-08-22T12:00:00",
+		"model": "01:00+model",
+	}
+	gotOffset := ExtractResourceID("rankings-daily", offsetTZ)
+	gotSplit := ExtractResourceID("rankings-daily", splitPlus)
+	if gotOffset == "" || gotSplit == "" {
+		t.Fatalf("composite extraction returned empty: offset=%q split=%q", gotOffset, gotSplit)
+	}
+	if gotOffset == gotSplit {
+		t.Fatalf("distinct composite tuples collided: both %q", gotOffset)
+	}
+	wantOffset := `2026-08-22T12:00:00\+01:00+model`
+	wantSplit := `2026-08-22T12:00:00+01:00\+model`
+	if gotOffset != wantOffset {
+		t.Fatalf("offset-tz composite = %q, want %q", gotOffset, wantOffset)
+	}
+	if gotSplit != wantSplit {
+		t.Fatalf("split-plus composite = %q, want %q", gotSplit, wantSplit)
+	}
+}
+
+func TestExtractResourceID_CompositeNumericPart(t *testing.T) {
+	prev, hadPrev := resourceIDFieldOverrides["orders"]
+	resourceIDFieldOverrides["orders"] = "delivery_date+order_number"
+	defer func() {
+		if hadPrev {
+			resourceIDFieldOverrides["orders"] = prev
+		} else {
+			delete(resourceIDFieldOverrides, "orders")
+		}
+	}()
+
+	obj := map[string]any{
+		"delivery_date": "2026-08-22",
+		"order_number":  json.Number("42"),
+	}
+	got := ExtractResourceID("orders", obj)
+	want := "2026-08-22+42"
+	if got != want {
+		t.Fatalf("numeric composite ExtractResourceID = %q, want %q", got, want)
+	}
+}
+
 func TestUpsertBatch_CompositeDateIDStoresDistinctRows(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "data.db")
 	s, err := Open(dbPath)

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -30,7 +31,14 @@ var (
 	endpointLimitExplicit        = false // true when user set --max-endpoints-per-resource
 	globalScopeParamNormalizerRE = regexp.MustCompile(`[^a-zA-Z0-9]+`)
 	authFormatPlaceholderRE      = regexp.MustCompile(`\{([A-Za-z_][A-Za-z0-9_]*)\}`)
+	// Must stay aligned with generated store.unusableResourceID / isoDatePattern.
+	isoDatePattern = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}(?:[T ][0-9:.+-Zz]+)?$`)
 )
+
+// resourceIDFieldCompositeSep joins composite identity fields in IDField and
+// x-resource-id (e.g. date+model_permaslug). Must stay aligned with the
+// generated store's splitResourceIDFieldOverride.
+const resourceIDFieldCompositeSep = "+"
 
 type additionalHeaderFallbackMode int
 
@@ -6160,7 +6168,7 @@ func responsePropertyForPathParam(schema *openapi3.Schema, paramName string) str
 	if schema == nil || paramName == "" {
 		return ""
 	}
-	if propRef, ok := schema.Properties[paramName]; ok && propRef != nil && isPlausibleIDFieldSchema(schemaRefValue(propRef)) {
+	if propRef, ok := schema.Properties[paramName]; ok && propRef != nil && isSoloUsableIDField(paramName, schemaRefValue(propRef)) {
 		return paramName
 	}
 	paramSnake := toSnakeCase(paramName)
@@ -6173,7 +6181,7 @@ func responsePropertyForPathParam(schema *openapi3.Schema, paramName string) str
 		if toSnakeCase(propName) != paramSnake {
 			continue
 		}
-		if propRef := schema.Properties[propName]; propRef != nil && isPlausibleIDFieldSchema(schemaRefValue(propRef)) {
+		if propRef := schema.Properties[propName]; propRef != nil && isSoloUsableIDField(propName, schemaRefValue(propRef)) {
 			return propName
 		}
 	}
@@ -6201,8 +6209,11 @@ func responseItemSchema(op *openapi3.Operation) *openapi3.Schema {
 // `uid` / `uuid` / `guid`), then a sole remaining `<own>_uid` field whose
 // stem is the resource's collection noun, then a URL-shaped identifier
 // (`uri` / `self` / `selfLink` / `href` / `url`), then "name", then the first
-// scalar field listed in the response schema's `required:` array (walking
-// properties in their schema order).
+// solo-usable required scalar. When the first required identity field is
+// date-shaped (format, name, or ISO-date example) and later required string
+// fields exist, those fields are joined with `+` so the store can key the
+// real composite row identity; a date-shaped field is never emitted as a
+// solo IDField because CanonicalResourceID rejects ISO-date values.
 // Returns "" when no field qualifies; templates fall through to runtime list
 // scanning. Tier 1 (`x-resource-id` extension) is handled separately by the
 // caller — it overrides every tier here.
@@ -6268,28 +6279,10 @@ func resolveIDFieldFromResponseSchema(op *openapi3.Operation, resourceName strin
 		return "name"
 	}
 
-	// Tier 6: first plausible-PK scalar field appearing in the schema's
-	// required[] array, matched against properties in their schema-declared
-	// order. kin-openapi preserves YAML/JSON property order in MapKeys/Extensions
-	// but not via range over Properties (it's a Go map). Fall back to iterating
-	// the required[] slice itself: that order is stable and is what spec authors
-	// intend when they care about which field "wins."
-	//
-	// "Plausible-PK" excludes boolean, enum, and date/date-time fields even
-	// though they are scalar — they are structurally low-cardinality or
-	// non-identifier-shaped, so committing them as a runtime override
-	// collapses unrelated rows onto the same PK during upsert.
-	for _, fieldName := range itemSchema.Required {
-		propRef, ok := itemSchema.Properties[fieldName]
-		if !ok || propRef == nil || propRef.Value == nil {
-			continue
-		}
-		if isPlausibleIDFieldSchema(propRef.Value) {
-			return fieldName
-		}
-	}
-
-	return ""
+	// Tier 6: first solo-usable required scalar, or a composite when the
+	// first identity field is date-shaped. required[] order is stable;
+	// ranging Properties is not.
+	return resolveRequiredIDField(itemSchema)
 }
 
 type idSchemaFields struct {
@@ -6633,12 +6626,12 @@ func isScalarSchema(schema *openapi3.Schema) bool {
 	return false
 }
 
-// isPlausibleIDFieldSchema is the tier-5 PK predicate: a scalar that is also
-// not boolean, not enum-restricted, and not date/date-time formatted. Booleans
-// have cardinality 2 (true/false), enums have hand-picked low cardinality, and
-// date/date-time fields are timestamps — none can serve as a primary key
-// without collapsing distinct rows during upsert. See profiler.resourceIDFieldOverrides
-// and store.UpsertBatch.
+// isPlausibleIDFieldSchema is the schema-only PK predicate: a scalar that is
+// also not boolean, not enum-restricted, and not date/date-time formatted.
+// Name- and example-shaped dates are rejected separately by
+// isDateShapedIDField so a required `date` string without format cannot
+// become a solo IDField. See profiler.resourceIDFieldOverrides and
+// store.UpsertBatch.
 func isPlausibleIDFieldSchema(schema *openapi3.Schema) bool {
 	if !isScalarSchema(schema) {
 		return false
@@ -6654,6 +6647,104 @@ func isPlausibleIDFieldSchema(schema *openapi3.Schema) bool {
 		return false
 	}
 	return true
+}
+
+func isSoloUsableIDField(name string, schema *openapi3.Schema) bool {
+	return isPlausibleIDFieldSchema(schema) && !isDateShapedIDField(name, schema)
+}
+
+func resolveRequiredIDField(itemSchema *openapi3.Schema) string {
+	if itemSchema == nil {
+		return ""
+	}
+	var compositeParts []string
+	composing := false
+	for _, fieldName := range itemSchema.Required {
+		propRef, ok := itemSchema.Properties[fieldName]
+		if !ok || propRef == nil || propRef.Value == nil {
+			continue
+		}
+		schema := propRef.Value
+		if !isIdentityCapableScalar(schema) {
+			continue
+		}
+		if composing {
+			if isCompositeIDPartSchema(schema) {
+				compositeParts = append(compositeParts, fieldName)
+			}
+			continue
+		}
+		if isDateShapedIDField(fieldName, schema) {
+			composing = true
+			if isCompositeIDPartSchema(schema) {
+				compositeParts = append(compositeParts, fieldName)
+			}
+			continue
+		}
+		if isPlausibleIDFieldSchema(schema) {
+			return fieldName
+		}
+	}
+	if composing && len(compositeParts) >= 2 {
+		return strings.Join(compositeParts, resourceIDFieldCompositeSep)
+	}
+	return ""
+}
+
+func isIdentityCapableScalar(schema *openapi3.Schema) bool {
+	if !isScalarSchema(schema) {
+		return false
+	}
+	if schema.Type.Includes(openapi3.TypeBoolean) {
+		return false
+	}
+	return len(schema.Enum) == 0
+}
+
+func isCompositeIDPartSchema(schema *openapi3.Schema) bool {
+	if schema == nil || schema.Type == nil {
+		return false
+	}
+	if !schema.Type.Includes(openapi3.TypeString) {
+		return false
+	}
+	return len(schema.Enum) == 0
+}
+
+func isDateShapedIDField(name string, schema *openapi3.Schema) bool {
+	if schema != nil {
+		format := strings.ToLower(schema.Format)
+		if format == "date" || format == "date-time" {
+			return true
+		}
+		if exampleLooksLikeISODate(schema.Example) {
+			return true
+		}
+	}
+	return isDateShapedIDFieldName(name)
+}
+
+func isDateShapedIDFieldName(name string) bool {
+	n := strings.ToLower(toSnakeCase(name))
+	switch n {
+	case "date", "datetime", "date_time", "timestamp":
+		return true
+	}
+	return strings.HasSuffix(n, "_date") ||
+		strings.HasSuffix(n, "_at") ||
+		strings.HasSuffix(n, "_datetime") ||
+		strings.HasSuffix(n, "_timestamp")
+}
+
+func exampleLooksLikeISODate(example any) bool {
+	switch v := example.(type) {
+	case string:
+		return isoDatePattern.MatchString(strings.TrimSpace(v))
+	case time.Time:
+		return true
+	default:
+		return false
+	}
 }
 
 func mapTypes(doc *openapi3.T, out *spec.APISpec) {

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -6728,7 +6728,7 @@ func isVolatileCompositeFieldName(name string) bool {
 		"name", "display_name", "full_name", "short_name":
 		return true
 	}
-	for _, tok := range strings.Split(n, "_") {
+	for tok := range strings.SplitSeq(n, "_") {
 		switch tok {
 		case "token", "tokens", "count", "total", "amount", "price",
 			"quantity", "sum", "avg", "average", "score", "weight",

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -6669,7 +6669,10 @@ func resolveRequiredIDField(itemSchema *openapi3.Schema) string {
 			continue
 		}
 		if composing {
-			if isCompositeIDPartSchema(schema) {
+			if isDateShapedIDField(fieldName, schema) {
+				continue
+			}
+			if isPlausibleIDFieldSchema(schema) && !isVolatileCompositeFieldName(fieldName) {
 				compositeParts = append(compositeParts, fieldName)
 			}
 			continue
@@ -6705,10 +6708,35 @@ func isCompositeIDPartSchema(schema *openapi3.Schema) bool {
 	if schema == nil || schema.Type == nil {
 		return false
 	}
-	if !schema.Type.Includes(openapi3.TypeString) {
+	if len(schema.Enum) > 0 {
 		return false
 	}
-	return len(schema.Enum) == 0
+	if schema.Type.Includes(openapi3.TypeBoolean) {
+		return false
+	}
+	return schema.Type.Includes(openapi3.TypeString) ||
+		schema.Type.Includes(openapi3.TypeInteger) ||
+		schema.Type.Includes(openapi3.TypeNumber)
+}
+
+func isVolatileCompositeFieldName(name string) bool {
+	n := strings.ToLower(toSnakeCase(name))
+	switch n {
+	case "status", "state", "type", "kind", "mode", "phase", "stage",
+		"result", "outcome", "message", "description", "title", "label",
+		"note", "comment", "reason", "visibility", "severity", "priority",
+		"name", "display_name", "full_name", "short_name":
+		return true
+	}
+	for _, tok := range strings.Split(n, "_") {
+		switch tok {
+		case "token", "tokens", "count", "total", "amount", "price",
+			"quantity", "sum", "avg", "average", "score", "weight",
+			"volume", "size", "percent", "ratio", "balance", "qty":
+			return true
+		}
+	}
+	return false
 }
 
 func isDateShapedIDField(name string, schema *openapi3.Schema) bool {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -8901,6 +8901,33 @@ func TestParseIDFieldFallbackChain(t *testing.T) {
 			wantID: "date+model_permaslug",
 		},
 		{
+			// After a date-shaped field starts composing, a later numeric
+			// identifier must still join (stringified at storage time).
+			name: "tier 6: date-shaped field composes with a later numeric identity",
+			schemaYAML: `                  type: object
+                  required: [delivery_date, order_number]
+                  properties:
+                    delivery_date:
+                      type: string
+                      format: date
+                    order_number: {type: integer}
+`,
+			wantID: "delivery_date+order_number",
+		},
+		{
+			// Mutable/status strings must not enter the composite; a later
+			// status change would otherwise mint a new storage key.
+			name: "tier 6: composing skips mutable status after a stable identity",
+			schemaYAML: `                  type: object
+                  required: [date, model_permaslug, status]
+                  properties:
+                    date: {type: string}
+                    model_permaslug: {type: string}
+                    status: {type: string}
+`,
+			wantID: "date+model_permaslug",
+		},
+		{
 			name: "tier 6: ISO-date example marks a field unusable as a solo ID",
 			schemaYAML: `                  type: object
                   required: [day, model]

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -8047,10 +8047,10 @@ func TestParseReadsXResourceIDCriticalAndSyncable(t *testing.T) {
 			wantSyncable: true,
 		},
 		{
-			name: "x-resource-id dotted path is preserved as a field path",
-			extraExt: `    x-resource-id: entityInfo.entityId
+			name: "x-resource-id composite identity is preserved",
+			extraExt: `    x-resource-id: date+model_permaslug
 `,
-			wantIDField: "entityInfo.entityId",
+			wantIDField: "date+model_permaslug",
 		},
 	}
 
@@ -8859,10 +8859,11 @@ func TestParseIDFieldFallbackChain(t *testing.T) {
 			wantID: "ticker",
 		},
 		{
-			// A required date-time field must not be picked — timestamps are
-			// structurally non-identifier-shaped and often shared across
-			// batches of records.
-			name: "tier 5: date-time formatted field is skipped",
+			// A required date-time field is not a solo PK. When later
+			// required string fields exist, compose them so the store can
+			// key the real row identity instead of collapsing on the next
+			// scalar or rejecting ISO-date values.
+			name: "tier 6: date-time required field composes with the next string identity",
 			schemaYAML: `                  type: object
                   required: [created_at, order_number]
                   properties:
@@ -8871,12 +8872,10 @@ func TestParseIDFieldFallbackChain(t *testing.T) {
                       format: date-time
                     order_number: {type: string}
 `,
-			wantID: "order_number",
+			wantID: "created_at+order_number",
 		},
 		{
-			// Date-only format must also be skipped — same uniqueness concern
-			// as date-time.
-			name: "tier 5: date-only formatted field is skipped",
+			name: "tier 6: date-only required field composes with the next string identity",
 			schemaYAML: `                  type: object
                   required: [delivery_date, tracking_code]
                   properties:
@@ -8885,7 +8884,55 @@ func TestParseIDFieldFallbackChain(t *testing.T) {
                       format: date
                     tracking_code: {type: string}
 `,
-			wantID: "tracking_code",
+			wantID: "delivery_date+tracking_code",
+		},
+		{
+			// Rankings-style rows: `date` is a required string without
+			// format: date, so schema-format filtering alone would pick it
+			// and the store would then refuse every ISO-date value.
+			name: "tier 6: date-named string without format composes with remaining string identity",
+			schemaYAML: `                  type: object
+                  required: [date, model_permaslug, total_tokens]
+                  properties:
+                    date: {type: string}
+                    model_permaslug: {type: string}
+                    total_tokens: {type: integer}
+`,
+			wantID: "date+model_permaslug",
+		},
+		{
+			name: "tier 6: ISO-date example marks a field unusable as a solo ID",
+			schemaYAML: `                  type: object
+                  required: [day, model]
+                  properties:
+                    day:
+                      type: string
+                      example: "2024-01-15"
+                    model: {type: string}
+`,
+			wantID: "day+model",
+		},
+		{
+			name: "tier 6: date-named string without format is not a solo ID",
+			schemaYAML: `                  type: object
+                  required: [date]
+                  properties:
+                    date: {type: string}
+                    model_permaslug: {type: string}
+`,
+			wantID: "",
+		},
+		{
+			name: "tier 6: later date field does not displace an earlier solo-usable ID",
+			schemaYAML: `                  type: object
+                  required: [ticker, created_at]
+                  properties:
+                    ticker: {type: string}
+                    created_at:
+                      type: string
+                      format: date-time
+`,
+			wantID: "ticker",
 		},
 		{
 			// All required fields are non-plausible-PK — empty result so

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -1516,6 +1516,74 @@ func canonicalIDFromKey(obj map[string]any, key string) string {
 	return CanonicalResourceID(v)
 }
 
+func canonicalIDFromOverride(obj map[string]any, override string) string {
+	if s := canonicalIDFromKey(obj, override); s != "" {
+		return s
+	}
+	return canonicalCompositeIDFromOverride(obj, override)
+}
+
+func overrideIdentityPresent(obj map[string]any, override string) bool {
+	if _, found := lookupRawFieldValue(obj, override); found {
+		return true
+	}
+	parts := splitResourceIDFieldOverride(override)
+	if len(parts) < 2 {
+		return false
+	}
+	for _, part := range parts {
+		if _, found := lookupRawFieldValue(obj, part); !found {
+			return false
+		}
+	}
+	return true
+}
+
+func splitResourceIDFieldOverride(override string) []string {
+	override = strings.TrimSpace(override)
+	if override == "" || !strings.Contains(override, "+") {
+		return nil
+	}
+	raw := strings.Split(override, "+")
+	parts := make([]string, 0, len(raw))
+	for _, part := range raw {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil
+		}
+		parts = append(parts, part)
+	}
+	if len(parts) < 2 {
+		return nil
+	}
+	return parts
+}
+
+func canonicalCompositeIDFromOverride(obj map[string]any, override string) string {
+	parts := splitResourceIDFieldOverride(override)
+	if len(parts) < 2 {
+		return ""
+	}
+	values := make([]string, 0, len(parts))
+	for _, key := range parts {
+		v, ok := lookupRawFieldValue(obj, key)
+		if !ok {
+			return ""
+		}
+		s := strings.TrimSpace(ResourceIDString(v))
+		if s == "" || s == "<nil>" {
+			return ""
+		}
+		// Date-shaped parts are allowed inside a composite; CanonicalResourceID
+		// still refuses a solo ISO date after the join.
+		if f, err := strconv.ParseFloat(s, 64); err == nil && f == 0 {
+			return ""
+		}
+		values = append(values, s)
+	}
+	return CanonicalResourceID(strings.Join(values, "+"))
+}
+
 // ResourceIDString returns the stable text form used for resources.id.
 func ResourceIDString(v any) string {
 	switch t := v.(type) {
@@ -1614,7 +1682,7 @@ var resourceParentKeyColumns = map[string][]string{}
 // non-entity envelopes into the batch path.
 func ExtractResourceID(resourceType string, obj map[string]any) string {
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
-		if s := canonicalIDFromKey(obj, override); s != "" {
+		if s := canonicalIDFromOverride(obj, override); s != "" {
 			return s
 		}
 	}
@@ -1660,7 +1728,7 @@ func identityKeyPresent(resourceType string, obj map[string]any) bool {
 		return false
 	}
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
-		if _, found := lookupRawFieldValue(obj, override); found {
+		if overrideIdentityPresent(obj, override) {
 			return true
 		}
 	}

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/internal/store/store.go
@@ -1581,7 +1581,21 @@ func canonicalCompositeIDFromOverride(obj map[string]any, override string) strin
 		}
 		values = append(values, s)
 	}
-	return CanonicalResourceID(strings.Join(values, "+"))
+	return CanonicalResourceID(joinCompositeResourceID(values))
+}
+
+func encodeCompositeResourceIDPart(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `+`, `\+`)
+	return s
+}
+
+func joinCompositeResourceID(values []string) string {
+	encoded := make([]string, len(values))
+	for i, v := range values {
+		encoded[i] = encodeCompositeResourceIDPart(v)
+	}
+	return strings.Join(encoded, "+")
 }
 
 // ResourceIDString returns the stable text form used for resources.id.

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1746,7 +1746,21 @@ func canonicalCompositeIDFromOverride(obj map[string]any, override string) strin
 		}
 		values = append(values, s)
 	}
-	return CanonicalResourceID(strings.Join(values, "+"))
+	return CanonicalResourceID(joinCompositeResourceID(values))
+}
+
+func encodeCompositeResourceIDPart(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `+`, `\+`)
+	return s
+}
+
+func joinCompositeResourceID(values []string) string {
+	encoded := make([]string, len(values))
+	for i, v := range values {
+		encoded[i] = encodeCompositeResourceIDPart(v)
+	}
+	return strings.Join(encoded, "+")
 }
 
 // ResourceIDString returns the stable text form used for resources.id.

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1681,6 +1681,74 @@ func canonicalIDFromKey(obj map[string]any, key string) string {
 	return CanonicalResourceID(v)
 }
 
+func canonicalIDFromOverride(obj map[string]any, override string) string {
+	if s := canonicalIDFromKey(obj, override); s != "" {
+		return s
+	}
+	return canonicalCompositeIDFromOverride(obj, override)
+}
+
+func overrideIdentityPresent(obj map[string]any, override string) bool {
+	if _, found := lookupRawFieldValue(obj, override); found {
+		return true
+	}
+	parts := splitResourceIDFieldOverride(override)
+	if len(parts) < 2 {
+		return false
+	}
+	for _, part := range parts {
+		if _, found := lookupRawFieldValue(obj, part); !found {
+			return false
+		}
+	}
+	return true
+}
+
+func splitResourceIDFieldOverride(override string) []string {
+	override = strings.TrimSpace(override)
+	if override == "" || !strings.Contains(override, "+") {
+		return nil
+	}
+	raw := strings.Split(override, "+")
+	parts := make([]string, 0, len(raw))
+	for _, part := range raw {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil
+		}
+		parts = append(parts, part)
+	}
+	if len(parts) < 2 {
+		return nil
+	}
+	return parts
+}
+
+func canonicalCompositeIDFromOverride(obj map[string]any, override string) string {
+	parts := splitResourceIDFieldOverride(override)
+	if len(parts) < 2 {
+		return ""
+	}
+	values := make([]string, 0, len(parts))
+	for _, key := range parts {
+		v, ok := lookupRawFieldValue(obj, key)
+		if !ok {
+			return ""
+		}
+		s := strings.TrimSpace(ResourceIDString(v))
+		if s == "" || s == "<nil>" {
+			return ""
+		}
+		// Date-shaped parts are allowed inside a composite; CanonicalResourceID
+		// still refuses a solo ISO date after the join.
+		if f, err := strconv.ParseFloat(s, 64); err == nil && f == 0 {
+			return ""
+		}
+		values = append(values, s)
+	}
+	return CanonicalResourceID(strings.Join(values, "+"))
+}
+
 // ResourceIDString returns the stable text form used for resources.id.
 func ResourceIDString(v any) string {
 	switch t := v.(type) {
@@ -1840,7 +1908,7 @@ var resourceParentKeyColumns = map[string][]string{
 // non-entity envelopes into the batch path.
 func ExtractResourceID(resourceType string, obj map[string]any) string {
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
-		if s := canonicalIDFromKey(obj, override); s != "" {
+		if s := canonicalIDFromOverride(obj, override); s != "" {
 			return s
 		}
 	}
@@ -1886,7 +1954,7 @@ func identityKeyPresent(resourceType string, obj map[string]any) bool {
 		return false
 	}
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
-		if _, found := lookupRawFieldValue(obj, override); found {
+		if overrideIdentityPresent(obj, override) {
 			return true
 		}
 	}

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1684,6 +1684,74 @@ func canonicalIDFromKey(obj map[string]any, key string) string {
 	return CanonicalResourceID(v)
 }
 
+func canonicalIDFromOverride(obj map[string]any, override string) string {
+	if s := canonicalIDFromKey(obj, override); s != "" {
+		return s
+	}
+	return canonicalCompositeIDFromOverride(obj, override)
+}
+
+func overrideIdentityPresent(obj map[string]any, override string) bool {
+	if _, found := lookupRawFieldValue(obj, override); found {
+		return true
+	}
+	parts := splitResourceIDFieldOverride(override)
+	if len(parts) < 2 {
+		return false
+	}
+	for _, part := range parts {
+		if _, found := lookupRawFieldValue(obj, part); !found {
+			return false
+		}
+	}
+	return true
+}
+
+func splitResourceIDFieldOverride(override string) []string {
+	override = strings.TrimSpace(override)
+	if override == "" || !strings.Contains(override, "+") {
+		return nil
+	}
+	raw := strings.Split(override, "+")
+	parts := make([]string, 0, len(raw))
+	for _, part := range raw {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil
+		}
+		parts = append(parts, part)
+	}
+	if len(parts) < 2 {
+		return nil
+	}
+	return parts
+}
+
+func canonicalCompositeIDFromOverride(obj map[string]any, override string) string {
+	parts := splitResourceIDFieldOverride(override)
+	if len(parts) < 2 {
+		return ""
+	}
+	values := make([]string, 0, len(parts))
+	for _, key := range parts {
+		v, ok := lookupRawFieldValue(obj, key)
+		if !ok {
+			return ""
+		}
+		s := strings.TrimSpace(ResourceIDString(v))
+		if s == "" || s == "<nil>" {
+			return ""
+		}
+		// Date-shaped parts are allowed inside a composite; CanonicalResourceID
+		// still refuses a solo ISO date after the join.
+		if f, err := strconv.ParseFloat(s, 64); err == nil && f == 0 {
+			return ""
+		}
+		values = append(values, s)
+	}
+	return CanonicalResourceID(strings.Join(values, "+"))
+}
+
 // ResourceIDString returns the stable text form used for resources.id.
 func ResourceIDString(v any) string {
 	switch t := v.(type) {
@@ -1894,7 +1962,7 @@ var resourceParentKeyColumns = map[string][]string{}
 // non-entity envelopes into the batch path.
 func ExtractResourceID(resourceType string, obj map[string]any) string {
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
-		if s := canonicalIDFromKey(obj, override); s != "" {
+		if s := canonicalIDFromOverride(obj, override); s != "" {
 			return s
 		}
 	}
@@ -1940,7 +2008,7 @@ func identityKeyPresent(resourceType string, obj map[string]any) bool {
 		return false
 	}
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
-		if _, found := lookupRawFieldValue(obj, override); found {
+		if overrideIdentityPresent(obj, override) {
 			return true
 		}
 	}

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1749,7 +1749,21 @@ func canonicalCompositeIDFromOverride(obj map[string]any, override string) strin
 		}
 		values = append(values, s)
 	}
-	return CanonicalResourceID(strings.Join(values, "+"))
+	return CanonicalResourceID(joinCompositeResourceID(values))
+}
+
+func encodeCompositeResourceIDPart(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `+`, `\+`)
+	return s
+}
+
+func joinCompositeResourceID(values []string) string {
+	encoded := make([]string, len(values))
+	for i, v := range values {
+		encoded[i] = encodeCompositeResourceIDPart(v)
+	}
+	return strings.Join(encoded, "+")
 }
 
 // ResourceIDString returns the stable text form used for resources.id.

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1757,7 +1757,21 @@ func canonicalCompositeIDFromOverride(obj map[string]any, override string) strin
 		}
 		values = append(values, s)
 	}
-	return CanonicalResourceID(strings.Join(values, "+"))
+	return CanonicalResourceID(joinCompositeResourceID(values))
+}
+
+func encodeCompositeResourceIDPart(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `+`, `\+`)
+	return s
+}
+
+func joinCompositeResourceID(values []string) string {
+	encoded := make([]string, len(values))
+	for i, v := range values {
+		encoded[i] = encodeCompositeResourceIDPart(v)
+	}
+	return strings.Join(encoded, "+")
 }
 
 // ResourceIDString returns the stable text form used for resources.id.

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1692,6 +1692,74 @@ func canonicalIDFromKey(obj map[string]any, key string) string {
 	return CanonicalResourceID(v)
 }
 
+func canonicalIDFromOverride(obj map[string]any, override string) string {
+	if s := canonicalIDFromKey(obj, override); s != "" {
+		return s
+	}
+	return canonicalCompositeIDFromOverride(obj, override)
+}
+
+func overrideIdentityPresent(obj map[string]any, override string) bool {
+	if _, found := lookupRawFieldValue(obj, override); found {
+		return true
+	}
+	parts := splitResourceIDFieldOverride(override)
+	if len(parts) < 2 {
+		return false
+	}
+	for _, part := range parts {
+		if _, found := lookupRawFieldValue(obj, part); !found {
+			return false
+		}
+	}
+	return true
+}
+
+func splitResourceIDFieldOverride(override string) []string {
+	override = strings.TrimSpace(override)
+	if override == "" || !strings.Contains(override, "+") {
+		return nil
+	}
+	raw := strings.Split(override, "+")
+	parts := make([]string, 0, len(raw))
+	for _, part := range raw {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil
+		}
+		parts = append(parts, part)
+	}
+	if len(parts) < 2 {
+		return nil
+	}
+	return parts
+}
+
+func canonicalCompositeIDFromOverride(obj map[string]any, override string) string {
+	parts := splitResourceIDFieldOverride(override)
+	if len(parts) < 2 {
+		return ""
+	}
+	values := make([]string, 0, len(parts))
+	for _, key := range parts {
+		v, ok := lookupRawFieldValue(obj, key)
+		if !ok {
+			return ""
+		}
+		s := strings.TrimSpace(ResourceIDString(v))
+		if s == "" || s == "<nil>" {
+			return ""
+		}
+		// Date-shaped parts are allowed inside a composite; CanonicalResourceID
+		// still refuses a solo ISO date after the join.
+		if f, err := strconv.ParseFloat(s, 64); err == nil && f == 0 {
+			return ""
+		}
+		values = append(values, s)
+	}
+	return CanonicalResourceID(strings.Join(values, "+"))
+}
+
 // ResourceIDString returns the stable text form used for resources.id.
 func ResourceIDString(v any) string {
 	switch t := v.(type) {
@@ -1910,7 +1978,7 @@ var resourceParentKeyColumns = map[string][]string{
 // non-entity envelopes into the batch path.
 func ExtractResourceID(resourceType string, obj map[string]any) string {
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
-		if s := canonicalIDFromKey(obj, override); s != "" {
+		if s := canonicalIDFromOverride(obj, override); s != "" {
 			return s
 		}
 	}
@@ -1956,7 +2024,7 @@ func identityKeyPresent(resourceType string, obj map[string]any) bool {
 		return false
 	}
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
-		if _, found := lookupRawFieldValue(obj, override); found {
+		if overrideIdentityPresent(obj, override) {
 			return true
 		}
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

The profiler could select a date-shaped field as `IDField` (for example OpenRouter `GET /datasets/rankings-daily` with rows `{date, model_permaslug, total_tokens}`). At sync time `CanonicalResourceID` / `unusableResourceID` rejects ISO-date values, so `ExtractResourceID` returns empty for every row, the syncer reports `consumed N but stored 0`, and the run exits as `IntegrityFailure`. `x-critical: false` does not downgrade that failure.

Issue: #4532

Closes #4532

## Approach

One contract: the parser must not emit an IDField the store will refuse as a solo ID.

- Date-shaped fields (OpenAPI `format: date` / `date-time`, names like `date` / `*_at` / `*_date`, or an ISO-date example) are never selected as a solo IDField.
- When a date-shaped field is the first required identity field and later required identity fields exist, IDField becomes the composite (`date+model_permaslug`).
- Generated `ExtractResourceID` joins composite part values after escaping `\` and `+` inside each part so distinct tuples cannot collide. Date-shaped *parts* are allowed; a solo ISO date is still refused.
- Numeric identifiers (for example `order_number`) can join as stringified composite parts. Mutable/metric names such as `status` and `total_tokens` are not appended, so a status change cannot mint a new storage key.
- Explicit `x-resource-id: date+model_permaslug` is preserved and extracted the same way.

## Scope

Primary area: OpenAPI IDField resolution and generated store identity extraction.

Why this belongs in this repo: this is a machine contract between profiler/parser ID selection and store extraction. It generalizes across APIs whose list rows have a date plus another identity field, not an OpenRouter-only printed-CLI patch.

## Risk

Generated `store.go` and store upsert tests change for every printed CLI. Existing resources whose first required field was a formatted date and whose next required field was a string ID will now key on the composite instead of the later field alone. That preserves uniqueness and avoids the integrity failure; it can change stored `resources.id` values on the next sync of those resources. Composite keys that previously joined with a raw `+` will also change when a part itself contains `+` (timezone offsets).

## Output Contract

- Parser tests cover date-named strings without format, formatted dates, ISO-date examples, date-only required fields (empty IDField), later dates that must not displace an earlier solo-usable ID, numeric composite companions, and mutable `status` exclusion.
- `TestGeneratedStoreCompositeDateIDFieldSyncsRows` generates a CLI from that shape, asserts `resourceIDFieldOverrides`, compiles the module, and runs generated store extraction/upsert tests including `+` collision and numeric parts.
- Golden `store.go` fixtures updated for `generate-learn-loop-api`, `generate-learn-disabled-api`, `generate-query-endpoint-api`, and `generate-sync-walker-api`.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output (`TestGeneratedStoreCompositeDateIDFieldSyncsRows`)
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures (date without format, formatted date, example, solo date, later date, numeric companion, mutable status, escaped `+` collision)
- [x] Generator/template change: checked emitted definitions and call sites for matching gates (`ExtractResourceID`, `joinCompositeResourceID`, `identityKeyPresent`, learn identity split)
- `go test ./... -timeout 25m`: passed on the Greptile P1 head
- `scripts/verify-generator-output.sh` for the four store-snapshot generate cases: passed
- `scripts/golden.sh verify`: the four `store.go` generate cases passed; `dogfood-verdict-matrix` / `verify-runtime-matrix` diffs are the local toolchain skip (could not build printed CLI binary) and were not committed
- Follow-up `8557458b`: `isVolatileCompositeFieldName` ranges over `strings.SplitSeq` to satisfy golangci-lint `modernize/stringsseq`. `go test ./internal/openapi -run TestParseIDFieldFallbackChain` passed on that commit.

Do not add `ready-to-merge` from this agent.

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90f8269a-9cda-436f-b355-c2d6044999bf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90f8269a-9cda-436f-b355-c2d6044999bf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

