### PR TITLE
fix(cli): align local reads, output modes, and which exits

### DIFF
--- a/internal/generator/binary_response_output_test.go
+++ b/internal/generator/binary_response_output_test.go
@@ -151,7 +151,6 @@ func TestPromotedBinaryResponseOutputModes(t *testing.T) {
 	}{
 		{name: "json", args: []string{"--json"}},
 		{name: "compact", args: []string{"--compact"}},
-		{name: "plain", args: []string{"--plain"}},
 		{name: "select", args: []string{"--select", "_pp_binary,encoding,data"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -167,6 +166,17 @@ func TestPromotedBinaryResponseOutputModes(t *testing.T) {
 		want := "_pp_binary,bytes,content_type,data,encoding\ntrue,23,application/pdf,JVBERi0xLjcKYmluYXJ5IGZpeHR1cmU=,base64\n"
 		if string(stdout) != want {
 			t.Fatalf("csv output changed:\n got: %s\nwant: %s", stdout, want)
+		}
+	})
+
+	t.Run("plain", func(t *testing.T) {
+		stdout, stderr, err := runBinaryCommand(t, "certificate", "--plain")
+		if err != nil {
+			t.Fatalf("certificate --plain failed: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+		}
+		want := "_pp_binary\tbytes\tcontent_type\tdata\tencoding\ntrue\t23\tapplication/pdf\tJVBERi0xLjcKYmluYXJ5IGZpeHR1cmU=\tbase64\n"
+		if string(stdout) != want {
+			t.Fatalf("plain output changed:\n got: %s\nwant: %s", stdout, want)
 		}
 	})
 

--- a/internal/generator/generated_examples.go
+++ b/internal/generator/generated_examples.go
@@ -122,7 +122,7 @@ func compactFieldNames(typeName string, types map[string]spec.TypeDef) []string 
 	seen := make(map[string]struct{}, len(typeDef.Fields))
 	for _, field := range typeDef.Fields {
 		name := strings.TrimSpace(field.Name)
-		if name == "" {
+		if name == "" || !isCompactGravityField(name) {
 			continue
 		}
 		if _, ok := seen[name]; ok {
@@ -132,6 +132,35 @@ func compactFieldNames(typeName string, types map[string]spec.TypeDef) []string 
 		fields = append(fields, name)
 	}
 	return fields
+}
+
+func isCompactGravityField(name string) bool {
+	switch name {
+	case "id", "name", "title", "identifier", "code", "slug", "key",
+		"status", "state", "type", "kind", "priority",
+		"url", "email",
+		"price", "amount", "cost", "fare", "rate", "currency",
+		"rating", "score", "count",
+		"language", "locale", "country", "region", "city", "domain",
+		"created_at", "updated_at", "createdAt", "updatedAt", "date",
+		"version":
+		return true
+	}
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower == "" {
+		return false
+	}
+	for _, suffix := range []string{"_id", "_name", "_at", "_status", "_state", "_slug", "_key", "_title", "_code", "_count", "_url"} {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+	for _, suffix := range []string{"Id", "Name", "At", "Status", "State", "Slug", "Key", "Title", "Code", "Count", "URL", "Url"} {
+		if strings.HasSuffix(name, suffix) && len(name) > len(suffix) {
+			return true
+		}
+	}
+	return false
 }
 
 func compactFieldMapLiteral(typeName string, types map[string]spec.TypeDef) string {

--- a/internal/generator/generated_examples_test.go
+++ b/internal/generator/generated_examples_test.go
@@ -98,7 +98,7 @@ func TestCompactFieldMapLiteralUsesDocumentedWireFields(t *testing.T) {
 		}},
 	}
 
-	assert.Equal(t, `map[string]bool{"id": true, "odds": true, "event_name": true}`, compactFieldMapLiteral("Event", types))
+	assert.Equal(t, `map[string]bool{"id": true, "event_name": true}`, compactFieldMapLiteral("Event", types))
 	assert.Equal(t, "nil", compactFieldMapLiteral("Missing", types))
 }
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10536,8 +10536,14 @@ func TestGeneratedOutput_WorkflowArchiveDelegatesToSyncResource(t *testing.T) {
 			"syncResource should expose an event writer parameter for wrapper callers")
 		assert.Contains(t, syncSrc, "syncEventWriter := cmd.OutOrStdout()",
 			"direct sync should honor Cobra's stdout writer")
+		assert.Contains(t, syncSrc, "machineFormat := wantsMachineOutput(flags)",
+			"direct sync --json must detect the shared machine-format contract")
+		assert.Contains(t, syncSrc, "syncEventWriter = cmd.ErrOrStderr()",
+			"direct sync --json should route NDJSON events off stdout")
+		assert.Contains(t, syncSrc, "printJSONFiltered(cmd.OutOrStdout()",
+			"direct sync --json should emit one JSON summary document on stdout")
 		assert.Contains(t, syncSrc, "userParams, syncEventWriter)",
-			"direct sync --json should keep emitting NDJSON events on stdout")
+			"direct sync must pass the wrapper-selected event writer into syncResource")
 		assert.Contains(t, syncSrc, `fmt.Fprintf(syncEvents, `+"`"+`{"event":"sync_start"`,
 			"syncResource events should write through the selected event writer")
 
@@ -10759,11 +10765,15 @@ func TestGeneratedOutput_WorkflowArchiveJSONKeepsSyncEventsOffStdout(t *testing.
 
 	syncJSONDB := filepath.Join(t.TempDir(), "sync-json.db")
 	stdout, stderr = runGeneratedBinary(t, binaryPath, "sync", "--json", "--db", syncJSONDB)
-	assert.Empty(t, stderr)
-	assert.Contains(t, stdout, `"event":"sync_start"`,
-		"direct sync --json should keep streaming sync events to stdout")
-	assert.Contains(t, stdout, `"event":"sync_complete"`)
-	assert.Contains(t, stdout, `"event":"sync_summary"`)
+	assert.NotContains(t, stdout, `"event":"sync_`,
+		"direct sync --json stdout must be a single JSON document, not sync NDJSON")
+	assert.Contains(t, stderr, `"event":"sync_start"`,
+		"direct sync --json should still surface sync progress on stderr")
+	var syncSummary map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &syncSummary),
+		"direct sync --json stdout should be exactly one JSON document")
+	_, hasRecords := syncSummary["total_records"]
+	assert.True(t, hasRecords, "sync --json summary must include total_records, got %v", syncSummary)
 
 	syncHumanDB := filepath.Join(t.TempDir(), "sync-human.db")
 	stdout, stderr = runGeneratedBinary(t, binaryPath, "sync", "--human-friendly", "--db", syncHumanDB)

--- a/internal/generator/local_output_which_contract_test.go
+++ b/internal/generator/local_output_which_contract_test.go
@@ -19,6 +19,7 @@ func TestGeneratedLocalReadsAndWhichHonorSharedRuntimeContracts(t *testing.T) {
 		Version: "0.1.0",
 		BaseURL: "https://api.example.com",
 		Auth:    spec.AuthConfig{Type: "none"},
+		Learn:   spec.LearnConfig{Disabled: true},
 		Config: spec.ConfigSpec{
 			Format: "toml",
 			Path:   "~/.config/shopsapi-pp-cli/config.toml",
@@ -199,6 +200,5 @@ func TestResolveLocalWarnsOnUnsupportedCursor(t *testing.T) {
 func ioDiscard() io.Writer { return io.Discard }
 `), 0o644))
 
-	requireGeneratedCompiles(t, outputDir)
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestResolveLocal|TestWhichJSONNoMatchExits2|TestWhichHumanNoMatchExits2WithoutJSON|TestPrintOutputWithFlagsQuietPrintsIdentityValues", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestResolveLocal|TestWhichJSONNoMatchExits2|TestWhichPipedNoMatchExits2WithEmptyEnvelope", "-count=1")
 }

--- a/internal/generator/local_output_which_contract_test.go
+++ b/internal/generator/local_output_which_contract_test.go
@@ -78,6 +78,10 @@ func TestGeneratedLocalReadsAndWhichHonorSharedRuntimeContracts(t *testing.T) {
 		"resolveLocal must distinguish collection paths from object IDs")
 	assert.Contains(t, dataSrc, "func applyLocalListFilters(",
 		"local list reads must apply supported query filters")
+	assert.Contains(t, dataSrc, "func applyLocalParentScope(",
+		"nested collection paths must constrain List results to the parent segment")
+	assert.Contains(t, dataSrc, "localListControlParams",
+		"query controls such as sort/order/search must not become equality filters")
 	assert.NotContains(t, dataSrc, "local data is unfiltered")
 
 	whichSrc := readGeneratedFile(t, outputDir, "internal", "cli", "which.go")
@@ -194,6 +198,105 @@ func TestResolveLocalWarnsOnUnsupportedCursor(t *testing.T) {
 	}
 	if !strings.Contains(warn.String(), "cursor") {
 		t.Fatalf("expected unsupported-cursor warning, got %q", warn.String())
+	}
+}
+
+func seedNestedShopsStore(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+
+	db, err := store.OpenWithContext(context.Background(), defaultDBPath("shopsapi-pp-cli"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	rows := []struct {
+		id   string
+		body string
+	}{
+		{"s1\x00t1", `+"`"+`{"id":"s1","name":"Team One","status":"active","parent_id":"t1"}`+"`"+`},
+		{"s2\x00t2", `+"`"+`{"id":"s2","name":"Team Two","status":"active","parent_id":"t2"}`+"`"+`},
+		{"s3\x00t1", `+"`"+`{"id":"s3","name":"Team One B","status":"paused","parent_id":"t1"}`+"`"+`},
+	}
+	for _, row := range rows {
+		if err := db.Upsert("shops", row.id, json.RawMessage(row.body)); err != nil {
+			t.Fatalf("upsert %s: %v", row.id, err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+}
+
+func TestResolveLocalNestedCollectionStaysInParentScope(t *testing.T) {
+	seedNestedShopsStore(t)
+	data, _, err := resolveLocal(context.Background(), nil, ioDiscard(), "shops", true, "/teams/t1/shops", nil, "test")
+	if err != nil {
+		t.Fatalf("resolveLocal nested collection: %v", err)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(data, &items); err != nil {
+		t.Fatalf("expected a JSON array, got %s: %v", data, err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("listed %d shops for team t1, want 2: %s", len(items), data)
+	}
+	for _, item := range items {
+		if item["parent_id"] != "t1" {
+			t.Fatalf("nested list leaked shop %#v", item)
+		}
+	}
+}
+
+func TestResolveLocalQueryControlsDoNotEmptyTheList(t *testing.T) {
+	seedShopsStore(t)
+	var warn bytes.Buffer
+	data, _, err := resolveLocal(context.Background(), nil, &warn, "shops", true, "/shops", map[string]string{
+		"sort":   "name",
+		"order":  "asc",
+		"fields": "id,name",
+		"search": "alpha",
+	}, "test")
+	if err != nil {
+		t.Fatalf("resolveLocal query controls: %v", err)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(data, &items); err != nil {
+		t.Fatalf("expected a JSON array, got %s: %v", data, err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("query controls emptied the list: %s", data)
+	}
+	for _, key := range []string{"sort", "order", "fields", "search"} {
+		if !strings.Contains(warn.String(), key) {
+			t.Fatalf("expected unsupported %s warning, got %q", key, warn.String())
+		}
+	}
+}
+
+func TestResolveLocalUnmatchedEqualityKeyDoesNotEmptyTheList(t *testing.T) {
+	seedShopsStore(t)
+	var warn bytes.Buffer
+	data, _, err := resolveLocal(context.Background(), nil, &warn, "shops", true, "/shops", map[string]string{
+		"not_a_field": "x",
+	}, "test")
+	if err != nil {
+		t.Fatalf("resolveLocal unmatched key: %v", err)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(data, &items); err != nil {
+		t.Fatalf("expected a JSON array, got %s: %v", data, err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("unmatched equality key emptied the list: %s", data)
+	}
+	if !strings.Contains(warn.String(), "not_a_field") {
+		t.Fatalf("expected unmatched-key warning, got %q", warn.String())
 	}
 }
 

--- a/internal/generator/local_output_which_contract_test.go
+++ b/internal/generator/local_output_which_contract_test.go
@@ -1,0 +1,204 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedLocalReadsAndWhichHonorSharedRuntimeContracts(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "shopsapi",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/shopsapi-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"shops": {
+				Description: "Shops",
+				Endpoints: map[string]spec.Endpoint{
+					"index": {
+						Method:      "GET",
+						Path:        "/shops",
+						Description: "List shops",
+						Params: []spec.Param{
+							{Name: "status", Type: "string"},
+							{Name: "per_page", Type: "integer"},
+						},
+						Response: spec.ResponseDef{Type: "array", Item: "Shop"},
+					},
+					"get": {
+						Method:      "GET",
+						Path:        "/shops/{id}",
+						Description: "Get a shop",
+						Params:      []spec.Param{{Name: "id", Type: "string", Positional: true, PathParam: true}},
+						Response:    spec.ResponseDef{Type: "object", Item: "Shop"},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Shop": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "string"},
+					{Name: "name", Type: "string"},
+					{Name: "status", Type: "string"},
+					{Name: "description", Type: "string"},
+					{Name: "revenue", Type: "number"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	gen.NovelFeatures = []NovelFeature{
+		{Name: "Search shops", Command: "search", Description: "Full-text search across synced shops", Group: "Local state"},
+	}
+	require.NoError(t, gen.Generate())
+
+	indexSrc := readGeneratedFile(t, outputDir, "internal", "cli", "shops_index.go")
+	assert.Contains(t, indexSrc, `"shops", false, path, params`,
+		"an unscoped collection not named list must still be generated as isList=false; resolveLocal has to recover the collection path")
+
+	dataSrc := readGeneratedFile(t, outputDir, "internal", "cli", "data_source.go")
+	assert.Contains(t, dataSrc, "func localReadPathIsCollection(",
+		"resolveLocal must distinguish collection paths from object IDs")
+	assert.Contains(t, dataSrc, "func applyLocalListFilters(",
+		"local list reads must apply supported query filters")
+	assert.NotContains(t, dataSrc, "local data is unfiltered")
+
+	whichSrc := readGeneratedFile(t, outputDir, "internal", "cli", "which.go")
+	assert.Contains(t, whichSrc, `return usageErr(fmt.Errorf("no match for %q;`)
+	assert.Contains(t, whichSrc, `"matches": []whichMatch{}`)
+	assert.NotContains(t, whichSrc, "Under --json, return an empty matches envelope at exit 0")
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	assert.Contains(t, syncSrc, "machineFormat := wantsMachineOutput(flags)")
+	assert.Contains(t, syncSrc, "printJSONFiltered(cmd.OutOrStdout()")
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "issue3549_runtime_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"shopsapi-pp-cli/internal/store"
+)
+
+func seedShopsStore(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+
+	db, err := store.OpenWithContext(context.Background(), defaultDBPath("shopsapi-pp-cli"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	rows := []struct {
+		id   string
+		body string
+	}{
+		{"s1", `+"`"+`{"id":"s1","name":"Alpha","status":"active","description":"verbose","revenue":10}`+"`"+`},
+		{"s2", `+"`"+`{"id":"s2","name":"Beta","status":"paused","description":"verbose","revenue":20}`+"`"+`},
+	}
+	for _, row := range rows {
+		if err := db.Upsert("shops", row.id, json.RawMessage(row.body)); err != nil {
+			t.Fatalf("upsert %s: %v", row.id, err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+}
+
+func TestResolveLocalCollectionPathDoesNotUseResourceNameAsID(t *testing.T) {
+	seedShopsStore(t)
+	data, _, err := resolveLocal(context.Background(), nil, ioDiscard(), "shops", false, "/shops", nil, "test")
+	if err != nil {
+		t.Fatalf("resolveLocal collection path: %v", err)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(data, &items); err != nil {
+		t.Fatalf("expected a JSON array, got %s: %v", data, err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("listed %d shops, want 2: %s", len(items), data)
+	}
+}
+
+func TestResolveLocalAppliesEqualityAndLimitFilters(t *testing.T) {
+	seedShopsStore(t)
+	data, _, err := resolveLocal(context.Background(), nil, ioDiscard(), "shops", true, "/shops", map[string]string{
+		"status":   "active",
+		"per_page": "1",
+	}, "test")
+	if err != nil {
+		t.Fatalf("resolveLocal filters: %v", err)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(data, &items); err != nil {
+		t.Fatalf("expected a JSON array, got %s: %v", data, err)
+	}
+	if len(items) != 1 || items[0]["id"] != "s1" {
+		t.Fatalf("filtered shops = %#v, want the active row only", items)
+	}
+}
+
+func TestResolveLocalGetByIDStillWorks(t *testing.T) {
+	seedShopsStore(t)
+	data, _, err := resolveLocal(context.Background(), nil, ioDiscard(), "shops", false, "/shops/s2", nil, "test")
+	if err != nil {
+		t.Fatalf("resolveLocal get: %v", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("expected a JSON object, got %s: %v", data, err)
+	}
+	if obj["id"] != "s2" {
+		t.Fatalf("got %#v, want shop s2", obj)
+	}
+}
+
+func TestResolveLocalWarnsOnUnsupportedCursor(t *testing.T) {
+	seedShopsStore(t)
+	var warn bytes.Buffer
+	_, _, err := resolveLocal(context.Background(), nil, &warn, "shops", true, "/shops", map[string]string{
+		"cursor": "abc",
+	}, "test")
+	if err != nil {
+		t.Fatalf("resolveLocal cursor: %v", err)
+	}
+	if !strings.Contains(warn.String(), "cursor") {
+		t.Fatalf("expected unsupported-cursor warning, got %q", warn.String())
+	}
+}
+
+func ioDiscard() io.Writer { return io.Discard }
+`), 0o644))
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestResolveLocal|TestWhichJSONNoMatchExits2|TestWhichHumanNoMatchExits2WithoutJSON|TestPrintOutputWithFlagsQuietPrintsIdentityValues", "-count=1")
+}

--- a/internal/generator/local_output_which_contract_test.go
+++ b/internal/generator/local_output_which_contract_test.go
@@ -63,7 +63,7 @@ func TestGeneratedLocalReadsAndWhichHonorSharedRuntimeContracts(t *testing.T) {
 
 	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
 	gen := New(apiSpec, outputDir)
-	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, MCP: true}
 	gen.NovelFeatures = []NovelFeature{
 		{Name: "Search shops", Command: "search", Description: "Full-text search across synced shops", Group: "Local state"},
 	}
@@ -80,9 +80,14 @@ func TestGeneratedLocalReadsAndWhichHonorSharedRuntimeContracts(t *testing.T) {
 		"local list reads must apply supported query filters")
 	assert.Contains(t, dataSrc, "func applyLocalParentScope(",
 		"nested collection paths must constrain List results to the parent segment")
+	assert.Contains(t, dataSrc, "func localItemStoredParentMatches(",
+		"parent scope must use stored parent_id / path parent FK, not every *_id field")
+	assert.NotContains(t, dataSrc, "localFieldLooksLikeParentKey")
 	assert.Contains(t, dataSrc, "localListControlParams",
 		"query controls such as sort/order/search must not become equality filters")
 	assert.NotContains(t, dataSrc, "local data is unfiltered")
+
+	requireGeneratedCompiles(t, outputDir)
 
 	whichSrc := readGeneratedFile(t, outputDir, "internal", "cli", "which.go")
 	assert.Contains(t, whichSrc, `return usageErr(fmt.Errorf("no match for %q;`)
@@ -220,7 +225,7 @@ func seedNestedShopsStore(t *testing.T) {
 		body string
 	}{
 		{"s1\x00t1", `+"`"+`{"id":"s1","name":"Team One","status":"active","parent_id":"t1"}`+"`"+`},
-		{"s2\x00t2", `+"`"+`{"id":"s2","name":"Team Two","status":"active","parent_id":"t2"}`+"`"+`},
+		{"s2\x00t2", `+"`"+`{"id":"s2","name":"Team Two","status":"active","parent_id":"t2","owner_id":"t1"}`+"`"+`},
 		{"s3\x00t1", `+"`"+`{"id":"s3","name":"Team One B","status":"paused","parent_id":"t1"}`+"`"+`},
 	}
 	for _, row := range rows {
@@ -249,6 +254,9 @@ func TestResolveLocalNestedCollectionStaysInParentScope(t *testing.T) {
 	for _, item := range items {
 		if item["parent_id"] != "t1" {
 			t.Fatalf("nested list leaked shop %#v", item)
+		}
+		if item["id"] == "s2" {
+			t.Fatalf("owner_id t1 must not pull a t2-scoped shop into /teams/t1/shops: %#v", item)
 		}
 	}
 }

--- a/internal/generator/local_output_which_contract_test.go
+++ b/internal/generator/local_output_which_contract_test.go
@@ -82,6 +82,8 @@ func TestGeneratedLocalReadsAndWhichHonorSharedRuntimeContracts(t *testing.T) {
 		"nested collection paths must constrain List results to the parent segment")
 	assert.Contains(t, dataSrc, "func localItemStoredParentMatches(",
 		"parent scope must use stored parent_id / path parent FK, not every *_id field")
+	assert.Contains(t, dataSrc, "func localReadImmediateParent(",
+		"composite and JSON parent matches must use the immediate path parent, not any ancestor ID")
 	assert.NotContains(t, dataSrc, "localFieldLooksLikeParentKey")
 	assert.Contains(t, dataSrc, "localListControlParams",
 		"query controls such as sort/order/search must not become equality filters")
@@ -258,6 +260,53 @@ func TestResolveLocalNestedCollectionStaysInParentScope(t *testing.T) {
 		if item["id"] == "s2" {
 			t.Fatalf("owner_id t1 must not pull a t2-scoped shop into /teams/t1/shops: %#v", item)
 		}
+	}
+}
+
+func seedDeepNestedShopsStore(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+
+	db, err := store.OpenWithContext(context.Background(), defaultDBPath("shopsapi-pp-cli"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	rows := []struct {
+		id   string
+		body string
+	}{
+		{"s1\x00m1", `+"`"+`{"id":"s1","name":"Message One","parent_id":"m1","channel_id":"c1"}`+"`"+`},
+		{"s2\x00c1", `+"`"+`{"id":"s2","name":"Channel Scoped","parent_id":"c1"}`+"`"+`},
+		{"s3\x00m2", `+"`"+`{"id":"s3","name":"Message Two","parent_id":"m2","channel_id":"c1"}`+"`"+`},
+	}
+	for _, row := range rows {
+		if err := db.Upsert("shops", row.id, json.RawMessage(row.body)); err != nil {
+			t.Fatalf("upsert %s: %v", row.id, err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+}
+
+func TestResolveLocalNestedCollectionUsesImmediateParent(t *testing.T) {
+	seedDeepNestedShopsStore(t)
+	data, _, err := resolveLocal(context.Background(), nil, ioDiscard(), "shops", true, "/channels/c1/messages/m1/shops", nil, "test")
+	if err != nil {
+		t.Fatalf("resolveLocal deep nested collection: %v", err)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(data, &items); err != nil {
+		t.Fatalf("expected a JSON array, got %s: %v", data, err)
+	}
+	if len(items) != 1 || items[0]["id"] != "s1" {
+		t.Fatalf("deep nested list = %#v, want only the m1-scoped row", items)
 	}
 }
 

--- a/internal/generator/output_flags_contract_test.go
+++ b/internal/generator/output_flags_contract_test.go
@@ -137,15 +137,70 @@ func TestPrintOutputWithFlagsMachineEmptyArrayIsValidJSON(t *testing.T) {
 	}
 }
 
-func TestPrintOutputWithFlagsCSVSingleObjectKeepsJSONFallback(t *testing.T) {
+func TestPrintOutputWithFlagsCSVSingleObjectIsOneRow(t *testing.T) {
 	data := json.RawMessage("{\"id\":\"one\"}")
 	var out bytes.Buffer
 
 	if err := printOutputWithFlags(&out, data, &rootFlags{csv: true}); err != nil {
 		t.Fatalf("printOutputWithFlags returned error: %v", err)
 	}
-	if got, want := out.String(), "{\"id\":\"one\"}\n"; got != want {
-		t.Fatalf("--csv should keep the single-object JSON fallback, got %q want %q", got, want)
+	got := out.String()
+	if !strings.Contains(got, "id\n") || !strings.Contains(got, "one\n") {
+		t.Fatalf("--csv should render a single object as one CSV row, got %q", got)
+	}
+	if strings.Contains(got, "{") {
+		t.Fatalf("--csv should not fall back to JSON for a single object, got %q", got)
+	}
+}
+
+func TestPrintOutputWithFlagsCSVUnwrapsCollectionEnvelope(t *testing.T) {
+	data := json.RawMessage("{\"results\":[{\"id\":\"one\",\"name\":\"Alpha\"}],\"meta\":{\"total\":1}}")
+	var out bytes.Buffer
+	if err := printOutputWithFlags(&out, data, &rootFlags{csv: true}); err != nil {
+		t.Fatalf("printOutputWithFlags returned error: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "id,name\n") && !strings.Contains(got, "name,id\n") {
+		t.Fatalf("--csv should unwrap collection envelopes, got %q", got)
+	}
+	if strings.Contains(got, "results") || strings.Contains(got, "{") {
+		t.Fatalf("--csv should not emit the JSON envelope, got %q", got)
+	}
+}
+
+func TestPrintOutputWithFlagsQuietPrintsIdentityValues(t *testing.T) {
+	data := json.RawMessage("[{\"id\":\"one\",\"name\":\"Alpha\"},{\"id\":\"two\",\"name\":\"Beta\"}]")
+	var out bytes.Buffer
+	if err := printOutputWithFlags(&out, data, &rootFlags{quiet: true}); err != nil {
+		t.Fatalf("printOutputWithFlags returned error: %v", err)
+	}
+	got := out.String()
+	if got != "one\ntwo\n" {
+		t.Fatalf("--quiet should print one id per line, got %q", got)
+	}
+}
+
+func TestPrintOutputWithFlagsCompactReducesDocumentedLists(t *testing.T) {
+	data := json.RawMessage("[{\"id\":\"s1\",\"name\":\"Shop\",\"description\":\"verbose\",\"revenue\":99,\"listings\":[1,2,3]}]")
+	documented := map[string]bool{"id": true, "name": true, "description": true, "revenue": true, "listings": true}
+	var out bytes.Buffer
+	if err := printOutputWithFlagsMeta(&out, data, &rootFlags{asJSON: true, compact: true}, map[string]any{"source": "local"}, documented); err != nil {
+		t.Fatalf("printOutputWithFlagsMeta returned error: %v", err)
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal(out.Bytes(), &rows); err != nil {
+		t.Fatalf("compact output is not JSON: %v\n%s", err, out.String())
+	}
+	if len(rows) != 1 {
+		t.Fatalf("compact rows = %#v", rows)
+	}
+	if rows[0]["id"] != "s1" || rows[0]["name"] != "Shop" {
+		t.Fatalf("compact dropped identity fields: %#v", rows[0])
+	}
+	for _, key := range []string{"description", "revenue", "listings"} {
+		if _, ok := rows[0][key]; ok {
+			t.Fatalf("schema-aware --compact kept non-gravity %s: %#v", key, rows[0])
+		}
 	}
 }
 
@@ -246,7 +301,7 @@ func TestTerminalControlCharactersRemainInJSONOutput(t *testing.T) {
 }
 `), 0o644))
 
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPrintOutputWithFlagsPlainRendersTSV|TestPrintOutputWithFlagsPlainEmptyArrayIsEmpty|TestPrintOutputWithFlagsCSVEmptyArrayIsEmpty|TestPrintOutputWithFlagsCSVEmptyArrayWritesDeclaredHeader|TestPrintOutputWithFlagsCSVEmptyArrayEscapesDeclaredHeader|TestPrintOutputWithFlagsCSVNonEmptyArrayUsesCSV|TestPrintOutputWithFlagsCSVQuotesCarriageReturnInValues|TestPrintOutputWithFlagsMachineEmptyArrayIsValidJSON|TestPrintOutputWithFlagsCSVSingleObjectKeepsJSONFallback|TestHumanFriendlyForcesTableAndNoColorStripsANSI|TestTerminalControl", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPrintOutputWithFlagsPlainRendersTSV|TestPrintOutputWithFlagsPlainEmptyArrayIsEmpty|TestPrintOutputWithFlagsCSVEmptyArrayIsEmpty|TestPrintOutputWithFlagsCSVEmptyArrayWritesDeclaredHeader|TestPrintOutputWithFlagsCSVEmptyArrayEscapesDeclaredHeader|TestPrintOutputWithFlagsCSVNonEmptyArrayUsesCSV|TestPrintOutputWithFlagsCSVQuotesCarriageReturnInValues|TestPrintOutputWithFlagsMachineEmptyArrayIsValidJSON|TestPrintOutputWithFlagsCSVSingleObjectIsOneRow|TestPrintOutputWithFlagsCSVUnwrapsCollectionEnvelope|TestPrintOutputWithFlagsQuietPrintsIdentityValues|TestPrintOutputWithFlagsCompactReducesDocumentedLists|TestHumanFriendlyForcesTableAndNoColorStripsANSI|TestTerminalControl", "-count=1")
 	requireGeneratedCompiles(t, outputDir)
 }
 

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -755,6 +755,9 @@ func resolveLocal(ctx context.Context, flags *rootFlags, hintWriter io.Writer, r
 		if len(items) == 0 {
 			return nil, DataProvenance{}, fmt.Errorf("no local data for %q. {{if syncHintInvocation}}Run '{{goString (syncHintInvocation)}}' first{{else}}Populate the local store through a custom store-backed command first.{{end}}", resourceType)
 		}
+		if parentIDs := localReadPathParentIDs(resourceType, path); len(parentIDs) > 0 {
+			items = applyLocalParentScope(db, resourceType, items, parentIDs)
+		}
 		items, unsupported := applyLocalListFilters(items, params)
 		if len(unsupported) > 0 {
 			warnWriter := hintWriter
@@ -798,6 +801,133 @@ func localReadPathIsCollection(resourceType, path string, isList bool) bool {
 	return strings.EqualFold(parts[len(parts)-1], resourceType)
 }
 
+func localReadPathParentIDs(resourceType, path string) []string {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) == 0 || (len(parts) == 1 && parts[0] == "") {
+		return nil
+	}
+	if strings.EqualFold(parts[len(parts)-1], resourceType) {
+		parts = parts[:len(parts)-1]
+	} else if len(parts) >= 2 && strings.EqualFold(parts[len(parts)-2], resourceType) {
+		parts = parts[:len(parts)-2]
+	} else {
+		return nil
+	}
+	stripped := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" || localReadPathPrefixSegment(part) {
+			continue
+		}
+		stripped = append(stripped, part)
+	}
+	var parents []string
+	for i := 1; i < len(stripped); i += 2 {
+		if stripped[i] != "" {
+			parents = append(parents, stripped[i])
+		}
+	}
+	return parents
+}
+
+func localReadPathPrefixSegment(seg string) bool {
+	s := strings.ToLower(seg)
+	switch s {
+	case "api", "rest", "graphql", "public", "private":
+		return true
+	}
+	if len(s) >= 2 && s[0] == 'v' {
+		for _, r := range s[1:] {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func applyLocalParentScope(db *store.Store, resourceType string, items []json.RawMessage, parentIDs []string) []json.RawMessage {
+	parentSet := make(map[string]bool, len(parentIDs))
+	for _, id := range parentIDs {
+		parentSet[id] = true
+	}
+	allowedBare := map[string]bool{}
+	if ids, err := db.ListIDs(resourceType); err == nil {
+		for _, id := range ids {
+			bare, parent, ok := splitLocalCompositeID(id)
+			if ok && parentSet[parent] {
+				allowedBare[bare] = true
+			}
+		}
+	}
+	out := make([]json.RawMessage, 0, len(items))
+	for _, raw := range items {
+		var obj map[string]any
+		if json.Unmarshal(raw, &obj) != nil {
+			continue
+		}
+		if localItemJSONMatchesParents(obj, parentSet) {
+			out = append(out, raw)
+			continue
+		}
+		if childID := localItemID(obj); childID != "" && allowedBare[childID] {
+			out = append(out, raw)
+		}
+	}
+	return out
+}
+
+func splitLocalCompositeID(id string) (bare, parent string, ok bool) {
+	i := strings.IndexByte(id, 0)
+	if i <= 0 || i == len(id)-1 {
+		return "", "", false
+	}
+	return id[:i], id[i+1:], true
+}
+
+func localItemID(obj map[string]any) string {
+	got, ok := localObjectField(obj, "id")
+	if !ok {
+		return ""
+	}
+	if s, ok := got.(string); ok {
+		return s
+	}
+	return strings.TrimSpace(fmt.Sprint(got))
+}
+
+func localItemJSONMatchesParents(obj map[string]any, parentSet map[string]bool) bool {
+	for key, val := range obj {
+		if !localFieldLooksLikeParentKey(key) {
+			continue
+		}
+		if localValueInParentSet(val, parentSet) {
+			return true
+		}
+	}
+	return false
+}
+
+func localFieldLooksLikeParentKey(key string) bool {
+	canon := localParamCanon(key)
+	switch canon {
+	case "id", "uuid", "gid", "sid", "uid", "guid", "api_id":
+		return false
+	case "parent", "parent_id":
+		return true
+	}
+	return strings.HasSuffix(canon, "_id") || (strings.HasSuffix(canon, "id") && len(canon) > 2)
+}
+
+func localValueInParentSet(val any, parentSet map[string]bool) bool {
+	for parent := range parentSet {
+		if localFieldEquals(val, parent) {
+			return true
+		}
+	}
+	return false
+}
+
 var localListLimitParams = map[string]bool{
 	"limit": true, "per_page": true, "perpage": true, "page_size": true, "pagesize": true,
 }
@@ -814,11 +944,25 @@ var localListCursorParams = map[string]bool{
 	"cursor": true, "after": true, "before": true,
 	"page_token": true, "pagetoken": true,
 	"starting_after": true, "ending_before": true,
-	"next_cursor": true, "start_cursor": true,
+	"next_cursor": true, "start_cursor": true, "next": true,
+}
+
+var localListControlParams = map[string]bool{
+	"sort": true, "order": true, "order_by": true, "orderby": true,
+	"fields": true, "field": true, "select": true,
+	"include": true, "expand": true,
+	"q": true, "query": true, "search": true,
 }
 
 func localParamCanon(key string) string {
 	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(key), "-", "_"))
+}
+
+func localListControlParam(canon string) bool {
+	if localListControlParams[canon] {
+		return true
+	}
+	return localListControlParams[strings.ReplaceAll(canon, "_", "")]
 }
 
 func applyLocalListFilters(items []json.RawMessage, params map[string]string) ([]json.RawMessage, []string) {
@@ -838,6 +982,8 @@ func applyLocalListFilters(items []json.RawMessage, params map[string]string) ([
 		canon := localParamCanon(key)
 		switch {
 		case localListCursorParams[canon]:
+			unsupported = append(unsupported, key)
+		case localListControlParam(canon):
 			unsupported = append(unsupported, key)
 		case localListLimitParams[canon]:
 			n, err := strconv.Atoi(val)
@@ -869,35 +1015,48 @@ func applyLocalListFilters(items []json.RawMessage, params map[string]string) ([
 		page = 0
 	}
 	if len(equality) > 0 {
-		filtered := make([]json.RawMessage, 0, len(items))
-		matchedKeys := map[string]bool{}
-		for _, raw := range items {
+		presentKeys := map[string]bool{}
+		parsed := make([]map[string]any, len(items))
+		valid := make([]bool, len(items))
+		for i, raw := range items {
 			var obj map[string]any
 			if json.Unmarshal(raw, &obj) != nil {
 				continue
 			}
-			keep := true
-			for key, want := range equality {
-				got, ok := localObjectField(obj, key)
-				if !ok {
-					keep = false
-					continue
+			parsed[i] = obj
+			valid[i] = true
+			for key := range equality {
+				if _, ok := localObjectField(obj, key); ok {
+					presentKeys[key] = true
 				}
-				matchedKeys[key] = true
-				if !localFieldEquals(got, want) {
-					keep = false
-				}
-			}
-			if keep {
-				filtered = append(filtered, raw)
 			}
 		}
 		for key := range equality {
-			if !matchedKeys[key] {
+			if !presentKeys[key] {
 				unsupported = append(unsupported, key)
+				delete(equality, key)
 			}
 		}
-		items = filtered
+		if len(equality) > 0 {
+			filtered := make([]json.RawMessage, 0, len(items))
+			for i, raw := range items {
+				if !valid[i] {
+					continue
+				}
+				keep := true
+				for key, want := range equality {
+					got, ok := localObjectField(parsed[i], key)
+					if !ok || !localFieldEquals(got, want) {
+						keep = false
+						break
+					}
+				}
+				if keep {
+					filtered = append(filtered, raw)
+				}
+			}
+			items = filtered
+		}
 	}
 	if page > 1 && limit >= 0 {
 		offset += (page - 1) * limit

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -853,9 +853,9 @@ func localReadPathPrefixSegment(seg string) bool {
 }
 
 func applyLocalParentScope(db *store.Store, resourceType string, items []json.RawMessage, parents []localPathParent) []json.RawMessage {
-	parentSet := make(map[string]bool, len(parents))
-	for _, parent := range parents {
-		parentSet[parent.ID] = true
+	immediate, ok := localReadImmediateParent(parents)
+	if !ok {
+		return items
 	}
 	var scopedIDs []string
 	sawComposite := false
@@ -866,7 +866,7 @@ func applyLocalParentScope(db *store.Store, resourceType string, items []json.Ra
 				continue
 			}
 			sawComposite = true
-			if parentSet[parent] {
+			if parent == immediate.ID {
 				scopedIDs = append(scopedIDs, id)
 			}
 		}
@@ -892,11 +892,18 @@ func applyLocalParentScope(db *store.Store, resourceType string, items []json.Ra
 		if json.Unmarshal(raw, &obj) != nil {
 			continue
 		}
-		if localItemStoredParentMatches(obj, parents, parentSet) {
+		if localItemStoredParentMatches(obj, immediate) {
 			out = append(out, raw)
 		}
 	}
 	return out
+}
+
+func localReadImmediateParent(parents []localPathParent) (localPathParent, bool) {
+	if len(parents) == 0 {
+		return localPathParent{}, false
+	}
+	return parents[len(parents)-1], true
 }
 
 func splitLocalCompositeID(id string) (bare, parent string, ok bool) {
@@ -907,17 +914,17 @@ func splitLocalCompositeID(id string) (bare, parent string, ok bool) {
 	return id[:i], id[i+1:], true
 }
 
-func localItemStoredParentMatches(obj map[string]any, parents []localPathParent, parentSet map[string]bool) bool {
-	for _, key := range localStoredParentFieldKeys(parents) {
+func localItemStoredParentMatches(obj map[string]any, parent localPathParent) bool {
+	for _, key := range localStoredParentFieldKeys(parent) {
 		got, ok := localObjectField(obj, key)
-		if ok && localValueInParentSet(got, parentSet) {
+		if ok && localFieldEquals(got, parent.ID) {
 			return true
 		}
 	}
 	return false
 }
 
-func localStoredParentFieldKeys(parents []localPathParent) []string {
+func localStoredParentFieldKeys(parent localPathParent) []string {
 	keys := []string{"parent_id", "parent"}
 	seen := map[string]bool{"parent_id": true, "parent": true}
 	add := func(key string) {
@@ -928,25 +935,13 @@ func localStoredParentFieldKeys(parents []localPathParent) []string {
 		seen[canon] = true
 		keys = append(keys, key)
 	}
-	for _, parent := range parents {
-		if parent.Type == "" {
-			continue
-		}
+	if parent.Type != "" {
 		add(parent.Type + "_id")
 		if singular := strings.TrimSuffix(parent.Type, "s"); singular != parent.Type && singular != "" {
 			add(singular + "_id")
 		}
 	}
 	return keys
-}
-
-func localValueInParentSet(val any, parentSet map[string]bool) bool {
-	for parent := range parentSet {
-		if localFieldEquals(val, parent) {
-			return true
-		}
-	}
-	return false
 }
 
 var localListLimitParams = map[string]bool{

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -755,8 +755,8 @@ func resolveLocal(ctx context.Context, flags *rootFlags, hintWriter io.Writer, r
 		if len(items) == 0 {
 			return nil, DataProvenance{}, fmt.Errorf("no local data for %q. {{if syncHintInvocation}}Run '{{goString (syncHintInvocation)}}' first{{else}}Populate the local store through a custom store-backed command first.{{end}}", resourceType)
 		}
-		if parentIDs := localReadPathParentIDs(resourceType, path); len(parentIDs) > 0 {
-			items = applyLocalParentScope(db, resourceType, items, parentIDs)
+		if parents := localReadPathParents(resourceType, path); len(parents) > 0 {
+			items = applyLocalParentScope(db, resourceType, items, parents)
 		}
 		items, unsupported := applyLocalListFilters(items, params)
 		if len(unsupported) > 0 {
@@ -801,7 +801,12 @@ func localReadPathIsCollection(resourceType, path string, isList bool) bool {
 	return strings.EqualFold(parts[len(parts)-1], resourceType)
 }
 
-func localReadPathParentIDs(resourceType, path string) []string {
+type localPathParent struct {
+	Type string
+	ID   string
+}
+
+func localReadPathParents(resourceType, path string) []localPathParent {
 	parts := strings.Split(strings.Trim(path, "/"), "/")
 	if len(parts) == 0 || (len(parts) == 1 && parts[0] == "") {
 		return nil
@@ -820,11 +825,12 @@ func localReadPathParentIDs(resourceType, path string) []string {
 		}
 		stripped = append(stripped, part)
 	}
-	var parents []string
+	var parents []localPathParent
 	for i := 1; i < len(stripped); i += 2 {
-		if stripped[i] != "" {
-			parents = append(parents, stripped[i])
+		if stripped[i] == "" {
+			continue
 		}
+		parents = append(parents, localPathParent{Type: stripped[i-1], ID: stripped[i]})
 	}
 	return parents
 }
@@ -846,19 +852,39 @@ func localReadPathPrefixSegment(seg string) bool {
 	return false
 }
 
-func applyLocalParentScope(db *store.Store, resourceType string, items []json.RawMessage, parentIDs []string) []json.RawMessage {
-	parentSet := make(map[string]bool, len(parentIDs))
-	for _, id := range parentIDs {
-		parentSet[id] = true
+func applyLocalParentScope(db *store.Store, resourceType string, items []json.RawMessage, parents []localPathParent) []json.RawMessage {
+	parentSet := make(map[string]bool, len(parents))
+	for _, parent := range parents {
+		parentSet[parent.ID] = true
 	}
-	allowedBare := map[string]bool{}
+	var scopedIDs []string
+	sawComposite := false
 	if ids, err := db.ListIDs(resourceType); err == nil {
 		for _, id := range ids {
-			bare, parent, ok := splitLocalCompositeID(id)
-			if ok && parentSet[parent] {
-				allowedBare[bare] = true
+			_, parent, ok := splitLocalCompositeID(id)
+			if !ok {
+				continue
+			}
+			sawComposite = true
+			if parentSet[parent] {
+				scopedIDs = append(scopedIDs, id)
 			}
 		}
+	}
+	if sawComposite {
+		out := make([]json.RawMessage, 0, len(scopedIDs))
+		for _, id := range scopedIDs {
+			item, err := db.Get(resourceType, id)
+			if err != nil {
+				continue
+			}
+			trimmed := strings.TrimSpace(string(item))
+			if trimmed == "" || trimmed == "null" || trimmed == "[]" || trimmed == "{}" {
+				continue
+			}
+			out = append(out, item)
+		}
+		return out
 	}
 	out := make([]json.RawMessage, 0, len(items))
 	for _, raw := range items {
@@ -866,11 +892,7 @@ func applyLocalParentScope(db *store.Store, resourceType string, items []json.Ra
 		if json.Unmarshal(raw, &obj) != nil {
 			continue
 		}
-		if localItemJSONMatchesParents(obj, parentSet) {
-			out = append(out, raw)
-			continue
-		}
-		if childID := localItemID(obj); childID != "" && allowedBare[childID] {
+		if localItemStoredParentMatches(obj, parents, parentSet) {
 			out = append(out, raw)
 		}
 	}
@@ -885,38 +907,37 @@ func splitLocalCompositeID(id string) (bare, parent string, ok bool) {
 	return id[:i], id[i+1:], true
 }
 
-func localItemID(obj map[string]any) string {
-	got, ok := localObjectField(obj, "id")
-	if !ok {
-		return ""
-	}
-	if s, ok := got.(string); ok {
-		return s
-	}
-	return strings.TrimSpace(fmt.Sprint(got))
-}
-
-func localItemJSONMatchesParents(obj map[string]any, parentSet map[string]bool) bool {
-	for key, val := range obj {
-		if !localFieldLooksLikeParentKey(key) {
-			continue
-		}
-		if localValueInParentSet(val, parentSet) {
+func localItemStoredParentMatches(obj map[string]any, parents []localPathParent, parentSet map[string]bool) bool {
+	for _, key := range localStoredParentFieldKeys(parents) {
+		got, ok := localObjectField(obj, key)
+		if ok && localValueInParentSet(got, parentSet) {
 			return true
 		}
 	}
 	return false
 }
 
-func localFieldLooksLikeParentKey(key string) bool {
-	canon := localParamCanon(key)
-	switch canon {
-	case "id", "uuid", "gid", "sid", "uid", "guid", "api_id":
-		return false
-	case "parent", "parent_id":
-		return true
+func localStoredParentFieldKeys(parents []localPathParent) []string {
+	keys := []string{"parent_id", "parent"}
+	seen := map[string]bool{"parent_id": true, "parent": true}
+	add := func(key string) {
+		canon := localParamCanon(key)
+		if canon == "" || seen[canon] {
+			return
+		}
+		seen[canon] = true
+		keys = append(keys, key)
 	}
-	return strings.HasSuffix(canon, "_id") || (strings.HasSuffix(canon, "id") && len(canon) > 2)
+	for _, parent := range parents {
+		if parent.Type == "" {
+			continue
+		}
+		add(parent.Type + "_id")
+		if singular := strings.TrimSuffix(parent.Type, "s"); singular != parent.Type && singular != "" {
+			add(singular + "_id")
+		}
+	}
+	return keys
 }
 
 func localValueInParentSet(val any, parentSet map[string]bool) bool {

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -14,6 +14,8 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -713,9 +715,10 @@ func mutationResponseHasID(resourceType string, data json.RawMessage) bool {
 }
 
 // resolveLocal reads data from the local SQLite store.
-// Note: local reads return ALL synced data for the resource type. Endpoint-specific
-// filters (query params, path scoping like /teams/{id}/users) are NOT applied locally.
-// The provenance metadata includes "unscoped":true when params were present but not applied.
+// Collection paths (isList, or a path whose last segment is the resource type)
+// list synced rows and apply supported query filters locally. Object paths
+// fetch by the trailing ID. Cursor-style params cannot be replayed locally
+// and are reported on stderr instead of silently ignored.
 func resolveLocal(ctx context.Context, flags *rootFlags, hintWriter io.Writer, resourceType string, isList bool, path string, params map[string]string, reason string) (json.RawMessage, DataProvenance, error) {
 	db, err := openStoreForRead(ctx, "{{.Name}}-pp-cli")
 	if err != nil {
@@ -734,12 +737,7 @@ func resolveLocal(ctx context.Context, flags *rootFlags, hintWriter io.Writer, r
 
 	prov := localProvenance(db, resourceType, reason)
 
-	// Warn if endpoint had filters that local reads can't reproduce
-	if len(params) > 0 {
-		fmt.Fprintf(os.Stderr, "warning: local data is unfiltered — endpoint filters are not applied to cached data\n")
-	}
-
-	if isList {
+	if localReadPathIsCollection(resourceType, path, isList) {
 		raw, err := db.List(resourceType, 0) // 0 = no limit, return all synced data
 		if err != nil {
 			return nil, DataProvenance{}, fmt.Errorf("querying local store: %w", err)
@@ -757,7 +755,17 @@ func resolveLocal(ctx context.Context, flags *rootFlags, hintWriter io.Writer, r
 		if len(items) == 0 {
 			return nil, DataProvenance{}, fmt.Errorf("no local data for %q. {{if syncHintInvocation}}Run '{{goString (syncHintInvocation)}}' first{{else}}Populate the local store through a custom store-backed command first.{{end}}", resourceType)
 		}
-		// Marshal []json.RawMessage into a single JSON array
+		items, unsupported := applyLocalListFilters(items, params)
+		if len(unsupported) > 0 {
+			warnWriter := hintWriter
+			if warnWriter == nil {
+				warnWriter = os.Stderr
+			}
+			fmt.Fprintf(warnWriter, "warning: local data could not apply filter(s) %s\n", strings.Join(unsupported, ", "))
+		}
+		if len(items) == 0 {
+			return json.RawMessage("[]"), prov, nil
+		}
 		data, err := json.Marshal(items)
 		if err != nil {
 			return nil, DataProvenance{}, fmt.Errorf("marshaling local data: %w", err)
@@ -765,8 +773,7 @@ func resolveLocal(ctx context.Context, flags *rootFlags, hintWriter io.Writer, r
 		return data, prov, nil
 	}
 
-	// Get by ID — extract the last path segment as the ID
-	parts := strings.Split(strings.TrimRight(path, "/"), "/")
+	parts := strings.Split(strings.Trim(path, "/"), "/")
 	id := parts[len(parts)-1]
 
 	item, err := db.Get(resourceType, id)
@@ -777,6 +784,176 @@ func resolveLocal(ctx context.Context, flags *rootFlags, hintWriter io.Writer, r
 		return nil, DataProvenance{}, fmt.Errorf("querying local store: %w", err)
 	}
 	return item, prov, nil
+}
+
+func localReadPathIsCollection(resourceType, path string, isList bool) bool {
+	if isList {
+		return true
+	}
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return true
+	}
+	parts := strings.Split(trimmed, "/")
+	return strings.EqualFold(parts[len(parts)-1], resourceType)
+}
+
+var localListLimitParams = map[string]bool{
+	"limit": true, "per_page": true, "perpage": true, "page_size": true, "pagesize": true,
+}
+
+var localListOffsetParams = map[string]bool{
+	"offset": true, "skip": true,
+}
+
+var localListPageParams = map[string]bool{
+	"page": true, "page_number": true, "pagenumber": true,
+}
+
+var localListCursorParams = map[string]bool{
+	"cursor": true, "after": true, "before": true,
+	"page_token": true, "pagetoken": true,
+	"starting_after": true, "ending_before": true,
+	"next_cursor": true, "start_cursor": true,
+}
+
+func localParamCanon(key string) string {
+	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(key), "-", "_"))
+}
+
+func applyLocalListFilters(items []json.RawMessage, params map[string]string) ([]json.RawMessage, []string) {
+	if len(params) == 0 {
+		return items, nil
+	}
+	equality := map[string]string{}
+	unsupported := make([]string, 0)
+	limit := -1
+	offset := 0
+	page := 0
+	for key, val := range params {
+		val = strings.TrimSpace(val)
+		if val == "" {
+			continue
+		}
+		canon := localParamCanon(key)
+		switch {
+		case localListCursorParams[canon]:
+			unsupported = append(unsupported, key)
+		case localListLimitParams[canon]:
+			n, err := strconv.Atoi(val)
+			if err != nil || n < 0 {
+				unsupported = append(unsupported, key)
+				continue
+			}
+			limit = n
+		case localListOffsetParams[canon]:
+			n, err := strconv.Atoi(val)
+			if err != nil || n < 0 {
+				unsupported = append(unsupported, key)
+				continue
+			}
+			offset = n
+		case localListPageParams[canon]:
+			n, err := strconv.Atoi(val)
+			if err != nil || n < 1 {
+				unsupported = append(unsupported, key)
+				continue
+			}
+			page = n
+		default:
+			equality[key] = val
+		}
+	}
+	if page > 1 && limit < 0 {
+		unsupported = append(unsupported, "page")
+		page = 0
+	}
+	if len(equality) > 0 {
+		filtered := make([]json.RawMessage, 0, len(items))
+		matchedKeys := map[string]bool{}
+		for _, raw := range items {
+			var obj map[string]any
+			if json.Unmarshal(raw, &obj) != nil {
+				continue
+			}
+			keep := true
+			for key, want := range equality {
+				got, ok := localObjectField(obj, key)
+				if !ok {
+					keep = false
+					continue
+				}
+				matchedKeys[key] = true
+				if !localFieldEquals(got, want) {
+					keep = false
+				}
+			}
+			if keep {
+				filtered = append(filtered, raw)
+			}
+		}
+		for key := range equality {
+			if !matchedKeys[key] {
+				unsupported = append(unsupported, key)
+			}
+		}
+		items = filtered
+	}
+	if page > 1 && limit >= 0 {
+		offset += (page - 1) * limit
+	}
+	if offset > 0 {
+		if offset >= len(items) {
+			items = items[:0]
+		} else {
+			items = items[offset:]
+		}
+	}
+	if limit >= 0 && len(items) > limit {
+		items = items[:limit]
+	}
+	sort.Strings(unsupported)
+	return items, unsupported
+}
+
+func localObjectField(obj map[string]any, key string) (any, bool) {
+	if v, ok := obj[key]; ok {
+		return v, true
+	}
+	for k, v := range obj {
+		if strings.EqualFold(k, key) {
+			return v, true
+		}
+	}
+	canon := localParamCanon(key)
+	for k, v := range obj {
+		if localParamCanon(k) == canon {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func localFieldEquals(got any, want string) bool {
+	if got == nil {
+		return want == "" || strings.EqualFold(want, "null")
+	}
+	switch v := got.(type) {
+	case bool:
+		return strings.EqualFold(want, strconv.FormatBool(v))
+	case float64:
+		return want == strconv.FormatFloat(v, 'f', -1, 64)
+	case json.Number:
+		return want == v.String()
+	case string:
+		return v == want
+	default:
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprint(v) == want
+		}
+		return string(encoded) == want
+	}
 }
 
 // Ensure time import is used (compilation guard).

--- a/internal/generator/templates/deliver.go.tmpl
+++ b/internal/generator/templates/deliver.go.tmpl
@@ -123,10 +123,8 @@ func deliverFile(path string, body []byte) error {
 }
 
 func deliverWebhook(url string, body []byte, compact bool) error {
+	_ = compact
 	contentType := "application/json"
-	if compact {
-		contentType = "application/x-ndjson"
-	}
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("building webhook request: %w", err)

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -2907,9 +2907,9 @@ func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlag
 		}
 		data = wrapped
 	}
-	// --quiet: suppress all output, exit code communicates result
+	// --quiet: one identity value per row (id, then name/slug/title).
 	if flags.quiet {
-		return nil
+		return printQuiet(w, data)
 	}
 	// --csv: render as CSV
 	if flags.csv {
@@ -3002,6 +3002,39 @@ func compactFields(data json.RawMessage, documentedFields ...map[string]bool) js
 	return data
 }
 
+// isCompactGravityField reports whether a schema field belongs on the
+// --compact allow-list. Endpoint-mirror commands pass documented fields
+// into compactListFields; keeping every schema key would make --compact a
+// no-op on homogeneous API lists.
+func isCompactGravityField(name string) bool {
+	switch name {
+	case "id", "name", "title", "identifier", "code", "slug", "key",
+		"status", "state", "type", "kind", "priority",
+		"url", "email",
+		"price", "amount", "cost", "fare", "rate", "currency",
+		"rating", "score", "count",
+		"language", "locale", "country", "region", "city", "domain",
+		"created_at", "updated_at", "createdAt", "updatedAt", "date",
+		"version":
+		return true
+	}
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower == "" {
+		return false
+	}
+	for _, suffix := range []string{"_id", "_name", "_at", "_status", "_state", "_slug", "_key", "_title", "_code", "_count", "_url"} {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+	for _, suffix := range []string{"Id", "Name", "At", "Status", "State", "Slug", "Key", "Title", "Code", "Count", "URL", "Url"} {
+		if strings.HasSuffix(name, suffix) && len(name) > len(suffix) {
+			return true
+		}
+	}
+	return false
+}
+
 // compactListFields keeps only high-gravity fields for array responses.
 //
 // Two-layer keep rule:
@@ -3046,10 +3079,19 @@ func compactListFields(items []map[string]any, documentedFields ...map[string]bo
 	}
 	for _, fields := range documentedFields {
 		for field := range fields {
-			keepFields[field] = true
+			if isCompactGravityField(field) {
+				keepFields[field] = true
+			}
 		}
 	}
-	if len(items) > 0 {
+	schemaAware := false
+	for _, fields := range documentedFields {
+		if len(fields) > 0 {
+			schemaAware = true
+			break
+		}
+	}
+	if !schemaAware && len(items) > 0 {
 		keyCounts := map[string]int{}
 		for _, item := range items {
 			for k := range item {
@@ -3188,30 +3230,27 @@ func compactObjectArrayValue(v any, documentedFields ...map[string]bool) (any, b
 	return compacted, true
 }
 
-// printCSV renders JSON arrays as CSV with header row.
 func printCSV(w io.Writer, data json.RawMessage, documentedFields ...map[string]bool) error {
-	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil {
-		// Single object or invalid JSON - just print as JSON
+	items, ok := tabularObjectRows(data)
+	if !ok {
 		fmt.Fprintln(w, string(data))
 		return nil
 	}
 	if len(items) == 0 {
-		// A valid empty array is a header-only CSV stream so consumers can
-		// distinguish success-with-no-rows from failure. Keys come from
-		// declared record fields; without those the stream stays empty.
-		if bytes.HasPrefix(bytes.TrimSpace(data), []byte("[")) {
-			keys := csvDeclaredHeader(documentedFields...)
-			if len(keys) == 0 {
-				return nil
-			}
-			writeCSVRow(w, keys)
+		keys := csvDeclaredHeader(documentedFields...)
+		if len(keys) == 0 {
 			return nil
 		}
-		fmt.Fprintln(w, string(data))
+		writeCSVRow(w, keys)
 		return nil
 	}
-	// Collect all keys for header
+	return writeCSVRows(w, items)
+}
+
+func writeCSVRows(w io.Writer, items []map[string]any) error {
+	if len(items) == 0 {
+		return nil
+	}
 	keySet := map[string]bool{}
 	for _, item := range items {
 		for k := range item {
@@ -3270,11 +3309,9 @@ func csvDeclaredHeader(documentedFields ...map[string]bool) []string {
 	return keys
 }
 
-// printPlain renders JSON arrays as tab-separated text with a header row.
 func printPlain(w io.Writer, data json.RawMessage) error {
-	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil {
-		// Single object - just print as JSON
+	items, ok := tabularObjectRows(data)
+	if !ok {
 		fmt.Fprintln(w, string(data))
 		return nil
 	}
@@ -3301,6 +3338,133 @@ func printPlain(w io.Writer, data json.RawMessage) error {
 		fmt.Fprintln(w, strings.Join(vals, "\t"))
 	}
 	return nil
+}
+
+func printQuiet(w io.Writer, data json.RawMessage) error {
+	items, ok := tabularObjectRows(data)
+	if ok {
+		for _, item := range items {
+			if v := quietRowValue(item); v != "" {
+				fmt.Fprintln(w, v)
+			}
+		}
+		return nil
+	}
+	var scalars []any
+	if err := json.Unmarshal(data, &scalars); err == nil {
+		for _, v := range scalars {
+			if m, ok := v.(map[string]any); ok {
+				if s := quietRowValue(m); s != "" {
+					fmt.Fprintln(w, s)
+				}
+				continue
+			}
+			if v == nil {
+				continue
+			}
+			fmt.Fprintln(w, fmt.Sprint(v))
+		}
+		return nil
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err == nil {
+		if v := quietRowValue(obj); v != "" {
+			fmt.Fprintln(w, v)
+		}
+		return nil
+	}
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" || trimmed == "null" {
+		return nil
+	}
+	fmt.Fprintln(w, trimmed)
+	return nil
+}
+
+func quietRowValue(item map[string]any) string {
+	for _, key := range []string{"id", "ID", "Id", "identifier", "slug", "key", "name", "title", "code"} {
+		if v, ok := item[key]; ok {
+			if s := quietScalar(v); s != "" {
+				return s
+			}
+		}
+	}
+	for k, v := range item {
+		lower := strings.ToLower(k)
+		if strings.HasSuffix(lower, "_id") || strings.HasSuffix(k, "Id") {
+			if s := quietScalar(v); s != "" {
+				return s
+			}
+		}
+	}
+	for _, v := range item {
+		if s := quietScalar(v); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func quietScalar(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch t := v.(type) {
+	case string:
+		return t
+	case bool:
+		return strconv.FormatBool(t)
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	case json.Number:
+		return t.String()
+	default:
+		return ""
+	}
+}
+
+func tabularObjectRows(data json.RawMessage) ([]map[string]any, bool) {
+	projected := unwrapSingleKeyArray(collectionItemsForOutput(data, ""))
+	var items []map[string]any
+	if err := json.Unmarshal(projected, &items); err == nil && (len(items) > 0 || bytes.HasPrefix(bytes.TrimSpace(projected), []byte("["))) {
+		return items, true
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(projected, &obj); err != nil || len(obj) == 0 {
+		return nil, false
+	}
+	if rows, ok := objectEnvelopeRows(obj); ok {
+		return rows, true
+	}
+	return []map[string]any{obj}, true
+}
+
+func objectEnvelopeRows(obj map[string]any) ([]map[string]any, bool) {
+	found := 0
+	var rows []map[string]any
+	for k, v := range obj {
+		if envelopeMetadataKeys[k] || envelopeMetadataArrayKeys[k] {
+			continue
+		}
+		rawItems, ok := v.([]any)
+		if !ok {
+			continue
+		}
+		items := make([]map[string]any, 0, len(rawItems))
+		for _, raw := range rawItems {
+			item, ok := raw.(map[string]any)
+			if !ok {
+				return nil, false
+			}
+			items = append(items, item)
+		}
+		rows = items
+		found++
+	}
+	if found != 1 {
+		return nil, false
+	}
+	return rows, true
 }
 
 func plainCellValue(v any) string {

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -3002,10 +3002,8 @@ func compactFields(data json.RawMessage, documentedFields ...map[string]bool) js
 	return data
 }
 
-// isCompactGravityField reports whether a schema field belongs on the
-// --compact allow-list. Endpoint-mirror commands pass documented fields
-// into compactListFields; keeping every schema key would make --compact a
-// no-op on homogeneous API lists.
+// Endpoint-mirror commands pass documented fields into compactListFields;
+// keeping every schema key would make --compact a no-op on homogeneous API lists.
 func isCompactGravityField(name string) bool {
 	switch name {
 	case "id", "name", "title", "identifier", "code", "slug", "key",

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -543,6 +543,9 @@ The local store's schema version stamp is one-way: once this version of `{{$.Nam
 Every command supports these output flags:
 
 - `--json` — structured output for scripting and agents
+- `--compact` — keep identity, status, and timestamp fields
+- `--csv` / `--plain` — tabular rows (collection envelopes unwrap)
+- `--quiet` — one identity value per line
 - `--select <field>[,<field>...]` — filter to specific fields
 - `--dry-run` — preview the request without sending
 - `--agent` — JSON + compact + non-interactive in one flag

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -181,7 +181,7 @@ When you know what you want to do but not which command does it, ask the CLI dir
 {{.Name}}-pp-cli which "<capability in your own words>"
 ```
 
-`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
+`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query. `--json` (and other machine formats) keep that exit-2 contract and write `{"matches":[]}` on stdout so agents can inspect the envelope without treating a miss as success.
 {{- if .ExtraCommands}}
 
 ## Hand-written Extensions
@@ -333,6 +333,13 @@ Run `{{.Name}}-pp-cli doctor` to verify setup.
 ## Agent Mode
 
 Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color`.
+
+Global format flags share one contract on promoted, novel, sync, and `--deliver` paths:
+
+- `--json` — one JSON document on stdout (sync progress events go to stderr)
+- `--compact` — keep identity/status/timestamp fields; does not change the document vs stream shape
+- `--csv` / `--plain` — tabular rows (collection envelopes unwrap to the row array)
+- `--quiet` — one identity value per row, no envelope
 
 - **Pipeable** — JSON on stdout, errors on stderr
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
@@ -625,7 +632,7 @@ Every command accepts `--deliver <sink>`. The output goes to the named sink in a
 |------|--------|
 | `stdout` | Default; write to stdout only |
 | `file:<path>` | Atomically write output to `<path>` (tmp + rename). Binary-response commands write decoded payload bytes (not the base64 JSON envelope) and print a small JSON receipt on stdout; `--json`/`--csv` do not refuse when this sink is set. |
-| `webhook:<url>` | POST the output body to the URL (`application/json` or `application/x-ndjson` when `--compact`) |
+| `webhook:<url>` | POST the output body to the URL (`application/json`) |
 
 Unknown schemes are refused with a structured error naming the supported set. Webhook failures return non-zero and log the URL + HTTP status on stderr.
 

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -269,6 +269,10 @@ Resource scoping:
 			defer db.Close()
 
 			syncEventWriter := cmd.OutOrStdout()
+			machineFormat := wantsMachineOutput(flags)
+			if machineFormat {
+				syncEventWriter = cmd.ErrOrStderr()
+			}
 
 {{- if .DependentSyncResources}}
 			// Snapshot before defaults expand, so an empty user filter stays empty
@@ -581,6 +585,18 @@ Resource scoping:
 						errCount, strings.ReplaceAll(msg, `"`, `\"`))
 				} else {
 					fmt.Fprintf(os.Stderr, "warning: %d resource(s) failed but exit code is 0 because the new default treats non-critical failures as warnings. Pass --strict to restore the old behavior, or annotate critical resources with x-critical: true.\n", errCount)
+				}
+			}
+			if machineFormat {
+				if err := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+					"total_records": totalSynced,
+					"resources":     totalResources,
+					"success":       successCount,
+					"warned":        warnCount,
+					"errored":       errCount,
+					"duration_ms":   elapsed.Milliseconds(),
+				}, flags); err != nil {
+					return err
 				}
 			}
 			return nil

--- a/internal/generator/templates/which.go.tmpl
+++ b/internal/generator/templates/which.go.tmpl
@@ -322,7 +322,8 @@ func newWhichCmd(flags *rootFlags) *cobra.Command {
 
 Exit codes:
   0  at least one match found
-  2  no confident match - the query did not score against any indexed capability; fall back to '--help' or 'search' if this CLI has one`,
+  2  no confident match - the query did not score against any indexed capability; fall back to '--help' or 'search' if this CLI has one. Machine output (--json/--csv/--plain/--quiet, or a pipe) still exits 2 and writes {"matches":[]} (or the equivalent empty table) to stdout.`,
+		SilenceUsage: true,
 		Example: `  {{.Name}}-pp-cli which "stale tickets"
   {{.Name}}-pp-cli which "bottleneck"
   {{.Name}}-pp-cli which --limit 1 "send message"
@@ -340,14 +341,22 @@ Exit codes:
 			}
 
 			if len(matches) == 0 {
-				// Under --json, return an empty matches envelope at exit 0
-				// so agents can branch on `matches.length == 0` instead of
-				// parsing a usage error message. Non-JSON keeps the typed
-				// exit-2 path so terminal users see the help hint.
-				if flags.asJSON {
-					return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+				// Machine output still uses the typed exit-2 no-match path.
+				// --json (and piped auto-JSON) emit {"matches":[]} on stdout
+				// so agents can branch on the envelope without treating exit 0
+				// as success. Human terminals keep the usage error only.
+				asJSON := flags.asJSON
+				if !asJSON && !isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain {
+					asJSON = true
+				}
+				if asJSON || flags.csv || flags.plain || flags.quiet {
+					outputFlags := *flags
+					outputFlags.asJSON = asJSON || flags.asJSON
+					if err := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
 						"matches": []whichMatch{},
-					}, flags)
+					}, &outputFlags); err != nil {
+						return err
+					}
 				}
 				return usageErr(fmt.Errorf("no match for %q; try '%s --help' for the full command list", query, cmd.Root().Name()))
 			}

--- a/internal/generator/templates/which_test.go.tmpl
+++ b/internal/generator/templates/which_test.go.tmpl
@@ -235,7 +235,7 @@ func TestWhichJSONNoMatchExits2(t *testing.T) {
 	}
 }
 
-func TestWhichHumanNoMatchExits2WithoutJSON(t *testing.T) {
+func TestWhichPipedNoMatchExits2WithEmptyEnvelope(t *testing.T) {
 	old := whichIndex
 	whichIndex = whichTestIndex
 	t.Cleanup(func() { whichIndex = old })
@@ -253,8 +253,13 @@ func TestWhichHumanNoMatchExits2WithoutJSON(t *testing.T) {
 	if got := ExitCode(err); got != 2 {
 		t.Fatalf("ExitCode = %d, want 2", got)
 	}
-	if strings.Contains(stdout.String(), `"matches"`) {
-		t.Fatalf("human no-match must not write a JSON envelope, got %q", stdout.String())
+	var envelope map[string]any
+	if json.Unmarshal(stdout.Bytes(), &envelope) != nil {
+		t.Fatalf("piped no-match must write {\"matches\":[]} so agents can inspect the miss, got %q", stdout.String())
+	}
+	matches, _ := envelope["matches"].([]any)
+	if len(matches) != 0 {
+		t.Fatalf("matches = %#v, want empty array", envelope["matches"])
 	}
 }
 

--- a/internal/generator/templates/which_test.go.tmpl
+++ b/internal/generator/templates/which_test.go.tmpl
@@ -4,6 +4,8 @@
 package cli
 
 import (
+	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -202,6 +204,57 @@ func TestRankWhich_WriteSynonymsAreNotPenalized(t *testing.T) {
 	got := rankWhich(index, "edit project", 1)
 	if len(got) != 1 || got[0].Entry.Command != "projects edit" {
 		t.Fatalf("explicit write intent should select the edit command, got %+v", got)
+	}
+}
+
+func TestWhichJSONNoMatchExits2(t *testing.T) {
+	old := whichIndex
+	whichIndex = whichTestIndex
+	t.Cleanup(func() { whichIndex = old })
+
+	var stdout, stderr bytes.Buffer
+	flags := &rootFlags{asJSON: true}
+	cmd := newWhichCmd(flags)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"teleport a rhinoceros"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected no-match to return a typed error")
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("ExitCode = %d, want 2 (typed no-match)", got)
+	}
+	var envelope map[string]any
+	if json.Unmarshal(stdout.Bytes(), &envelope) != nil {
+		t.Fatalf("no-match --json stdout must be a JSON envelope, got %q", stdout.String())
+	}
+	matches, _ := envelope["matches"].([]any)
+	if len(matches) != 0 {
+		t.Fatalf("matches = %#v, want empty array", envelope["matches"])
+	}
+}
+
+func TestWhichHumanNoMatchExits2WithoutJSON(t *testing.T) {
+	old := whichIndex
+	whichIndex = whichTestIndex
+	t.Cleanup(func() { whichIndex = old })
+
+	var stdout bytes.Buffer
+	flags := &rootFlags{}
+	cmd := newWhichCmd(flags)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"teleport a rhinoceros"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected no-match to return a typed error")
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("ExitCode = %d, want 2", got)
+	}
+	if strings.Contains(stdout.String(), `"matches"`) {
+		t.Fatalf("human no-match must not write a JSON envelope, got %q", stdout.String())
 	}
 }
 

--- a/internal/generator/wrapped_projection_test.go
+++ b/internal/generator/wrapped_projection_test.go
@@ -194,7 +194,7 @@ func TestCompactFieldsProjectsHALEmbeddedArrays(t *testing.T) {
 
 func TestCompactFieldsPreservesDocumentedSparseFields(t *testing.T) {
 	input := json.RawMessage(`+"`"+`[
-		{"id":"row-1","name":"One","odds":1.5,"ranking":7,"lean":"up","segment":"rare","undocumented":"drop"},
+		{"id":"row-1","name":"One","event_name":"Open","shop_id":"s1","odds":1.5,"ranking":7,"undocumented":"drop"},
 		{"id":"row-2","name":"Two"},
 		{"id":"row-3","name":"Three"},
 		{"id":"row-4","name":"Four"},
@@ -207,20 +207,22 @@ func TestCompactFieldsPreservesDocumentedSparseFields(t *testing.T) {
 	]`+"`"+`)
 
 	got := compactFields(input, map[string]bool{
-		"odds": true, "ranking": true, "lean": true, "segment": true,
+		"event_name": true, "shop_id": true, "odds": true, "ranking": true,
 	})
 	var rows []map[string]any
 	if err := json.Unmarshal(got, &rows); err != nil {
 		t.Fatalf("compactFields returned invalid JSON: %v\n%s", err, got)
 	}
 	first := rows[0]
-	for _, key := range []string{"odds", "ranking", "lean", "segment"} {
+	for _, key := range []string{"event_name", "shop_id"} {
 		if _, ok := first[key]; !ok {
-			t.Fatalf("documented sparse field %q was dropped: %#v", key, first)
+			t.Fatalf("documented sparse gravity field %q was dropped: %#v", key, first)
 		}
 	}
-	if _, ok := first["undocumented"]; ok {
-		t.Fatalf("undocumented sparse field survived compact projection: %#v", first)
+	for _, key := range []string{"odds", "ranking", "undocumented"} {
+		if _, ok := first[key]; ok {
+			t.Fatalf("non-gravity or undocumented sparse field %q survived compact projection: %#v", key, first)
+		}
 	}
 }
 

--- a/testdata/golden/expected/generate-collection-item-collision/collection-item-collision/internal/cli/users_email.go
+++ b/testdata/golden/expected/generate-collection-item-collision/collection-item-collision/internal/cli/users_email.go
@@ -50,7 +50,7 @@ func newUsersEmailCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered, map[string]bool{"exists": true})
+					filtered = compactFields(filtered, nil)
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -79,7 +79,7 @@ func newUsersEmailCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, map[string]bool{"exists": true})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, nil)
 		},
 	}
 

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
@@ -71,7 +71,7 @@ func newCustomersGetCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered, map[string]bool{"email": true, "id": true, "subscriptions": true})
+					filtered = compactFields(filtered, map[string]bool{"email": true, "id": true})
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -100,7 +100,7 @@ func newCustomersGetCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, map[string]bool{"email": true, "id": true, "subscriptions": true})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, map[string]bool{"email": true, "id": true})
 		},
 	}
 

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -2292,9 +2292,9 @@ func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlag
 		}
 		data = wrapped
 	}
-	// --quiet: suppress all output, exit code communicates result
+	// --quiet: one identity value per row (id, then name/slug/title).
 	if flags.quiet {
-		return nil
+		return printQuiet(w, data)
 	}
 	// --csv: render as CSV
 	if flags.csv {
@@ -2357,6 +2357,37 @@ func compactFields(data json.RawMessage, documentedFields ...map[string]bool) js
 	return data
 }
 
+// Endpoint-mirror commands pass documented fields into compactListFields;
+// keeping every schema key would make --compact a no-op on homogeneous API lists.
+func isCompactGravityField(name string) bool {
+	switch name {
+	case "id", "name", "title", "identifier", "code", "slug", "key",
+		"status", "state", "type", "kind", "priority",
+		"url", "email",
+		"price", "amount", "cost", "fare", "rate", "currency",
+		"rating", "score", "count",
+		"language", "locale", "country", "region", "city", "domain",
+		"created_at", "updated_at", "createdAt", "updatedAt", "date",
+		"version":
+		return true
+	}
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower == "" {
+		return false
+	}
+	for _, suffix := range []string{"_id", "_name", "_at", "_status", "_state", "_slug", "_key", "_title", "_code", "_count", "_url"} {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+	for _, suffix := range []string{"Id", "Name", "At", "Status", "State", "Slug", "Key", "Title", "Code", "Count", "URL", "Url"} {
+		if strings.HasSuffix(name, suffix) && len(name) > len(suffix) {
+			return true
+		}
+	}
+	return false
+}
+
 // compactListFields keeps only high-gravity fields for array responses.
 //
 // Two-layer keep rule:
@@ -2401,10 +2432,19 @@ func compactListFields(items []map[string]any, documentedFields ...map[string]bo
 	}
 	for _, fields := range documentedFields {
 		for field := range fields {
-			keepFields[field] = true
+			if isCompactGravityField(field) {
+				keepFields[field] = true
+			}
 		}
 	}
-	if len(items) > 0 {
+	schemaAware := false
+	for _, fields := range documentedFields {
+		if len(fields) > 0 {
+			schemaAware = true
+			break
+		}
+	}
+	if !schemaAware && len(items) > 0 {
 		keyCounts := map[string]int{}
 		for _, item := range items {
 			for k := range item {
@@ -2543,30 +2583,27 @@ func compactObjectArrayValue(v any, documentedFields ...map[string]bool) (any, b
 	return compacted, true
 }
 
-// printCSV renders JSON arrays as CSV with header row.
 func printCSV(w io.Writer, data json.RawMessage, documentedFields ...map[string]bool) error {
-	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil {
-		// Single object or invalid JSON - just print as JSON
+	items, ok := tabularObjectRows(data)
+	if !ok {
 		fmt.Fprintln(w, string(data))
 		return nil
 	}
 	if len(items) == 0 {
-		// A valid empty array is a header-only CSV stream so consumers can
-		// distinguish success-with-no-rows from failure. Keys come from
-		// declared record fields; without those the stream stays empty.
-		if bytes.HasPrefix(bytes.TrimSpace(data), []byte("[")) {
-			keys := csvDeclaredHeader(documentedFields...)
-			if len(keys) == 0 {
-				return nil
-			}
-			writeCSVRow(w, keys)
+		keys := csvDeclaredHeader(documentedFields...)
+		if len(keys) == 0 {
 			return nil
 		}
-		fmt.Fprintln(w, string(data))
+		writeCSVRow(w, keys)
 		return nil
 	}
-	// Collect all keys for header
+	return writeCSVRows(w, items)
+}
+
+func writeCSVRows(w io.Writer, items []map[string]any) error {
+	if len(items) == 0 {
+		return nil
+	}
 	keySet := map[string]bool{}
 	for _, item := range items {
 		for k := range item {
@@ -2625,11 +2662,9 @@ func csvDeclaredHeader(documentedFields ...map[string]bool) []string {
 	return keys
 }
 
-// printPlain renders JSON arrays as tab-separated text with a header row.
 func printPlain(w io.Writer, data json.RawMessage) error {
-	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil {
-		// Single object - just print as JSON
+	items, ok := tabularObjectRows(data)
+	if !ok {
 		fmt.Fprintln(w, string(data))
 		return nil
 	}
@@ -2656,6 +2691,133 @@ func printPlain(w io.Writer, data json.RawMessage) error {
 		fmt.Fprintln(w, strings.Join(vals, "\t"))
 	}
 	return nil
+}
+
+func printQuiet(w io.Writer, data json.RawMessage) error {
+	items, ok := tabularObjectRows(data)
+	if ok {
+		for _, item := range items {
+			if v := quietRowValue(item); v != "" {
+				fmt.Fprintln(w, v)
+			}
+		}
+		return nil
+	}
+	var scalars []any
+	if err := json.Unmarshal(data, &scalars); err == nil {
+		for _, v := range scalars {
+			if m, ok := v.(map[string]any); ok {
+				if s := quietRowValue(m); s != "" {
+					fmt.Fprintln(w, s)
+				}
+				continue
+			}
+			if v == nil {
+				continue
+			}
+			fmt.Fprintln(w, fmt.Sprint(v))
+		}
+		return nil
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err == nil {
+		if v := quietRowValue(obj); v != "" {
+			fmt.Fprintln(w, v)
+		}
+		return nil
+	}
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" || trimmed == "null" {
+		return nil
+	}
+	fmt.Fprintln(w, trimmed)
+	return nil
+}
+
+func quietRowValue(item map[string]any) string {
+	for _, key := range []string{"id", "ID", "Id", "identifier", "slug", "key", "name", "title", "code"} {
+		if v, ok := item[key]; ok {
+			if s := quietScalar(v); s != "" {
+				return s
+			}
+		}
+	}
+	for k, v := range item {
+		lower := strings.ToLower(k)
+		if strings.HasSuffix(lower, "_id") || strings.HasSuffix(k, "Id") {
+			if s := quietScalar(v); s != "" {
+				return s
+			}
+		}
+	}
+	for _, v := range item {
+		if s := quietScalar(v); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func quietScalar(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch t := v.(type) {
+	case string:
+		return t
+	case bool:
+		return strconv.FormatBool(t)
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	case json.Number:
+		return t.String()
+	default:
+		return ""
+	}
+}
+
+func tabularObjectRows(data json.RawMessage) ([]map[string]any, bool) {
+	projected := unwrapSingleKeyArray(collectionItemsForOutput(data, ""))
+	var items []map[string]any
+	if err := json.Unmarshal(projected, &items); err == nil && (len(items) > 0 || bytes.HasPrefix(bytes.TrimSpace(projected), []byte("["))) {
+		return items, true
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(projected, &obj); err != nil || len(obj) == 0 {
+		return nil, false
+	}
+	if rows, ok := objectEnvelopeRows(obj); ok {
+		return rows, true
+	}
+	return []map[string]any{obj}, true
+}
+
+func objectEnvelopeRows(obj map[string]any) ([]map[string]any, bool) {
+	found := 0
+	var rows []map[string]any
+	for k, v := range obj {
+		if envelopeMetadataKeys[k] || envelopeMetadataArrayKeys[k] {
+			continue
+		}
+		rawItems, ok := v.([]any)
+		if !ok {
+			continue
+		}
+		items := make([]map[string]any, 0, len(rawItems))
+		for _, raw := range rawItems {
+			item, ok := raw.(map[string]any)
+			if !ok {
+				return nil, false
+			}
+			items = append(items, item)
+		}
+		rows = items
+		found++
+	}
+	if found != 1 {
+		return nil, false
+	}
+	return rows, true
 }
 
 func plainCellValue(v any) string {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
@@ -71,7 +71,7 @@ func newPagesGetCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered, map[string]bool{"children": true, "id": true, "title": true})
+					filtered = compactFields(filtered, map[string]bool{"id": true, "title": true})
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -100,7 +100,7 @@ func newPagesGetCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, map[string]bool{"children": true, "id": true, "title": true})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, map[string]bool{"id": true, "title": true})
 		},
 	}
 

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
@@ -71,7 +71,7 @@ func newPlaylistsGetCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered, map[string]bool{"id": true, "name": true, "tracks": true})
+					filtered = compactFields(filtered, map[string]bool{"id": true, "name": true})
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -100,7 +100,7 @@ func newPlaylistsGetCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, map[string]bool{"id": true, "name": true, "tracks": true})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, map[string]bool{"id": true, "name": true})
 		},
 	}
 

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/SKILL.md
@@ -50,7 +50,7 @@ When you know what you want to do but not which command does it, ask the CLI dir
 printing-press-oauth2-pp-cli which "<capability in your own words>"
 ```
 
-`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
+`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query. `--json` (and other machine formats) keep that exit-2 contract and write `{"matches":[]}` on stdout so agents can inspect the envelope without treating a miss as success.
 
 ## Auth Setup
 
@@ -68,6 +68,13 @@ Run `printing-press-oauth2-pp-cli doctor` to verify setup.
 ## Agent Mode
 
 Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color`.
+
+Global format flags share one contract on promoted, novel, sync, and `--deliver` paths:
+
+- `--json` — one JSON document on stdout (sync progress events go to stderr)
+- `--compact` — keep identity/status/timestamp fields; does not change the document vs stream shape
+- `--csv` / `--plain` — tabular rows (collection envelopes unwrap to the row array)
+- `--quiet` — one identity value per row, no envelope
 
 - **Pipeable** — JSON on stdout, errors on stderr
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
@@ -334,7 +341,7 @@ Every command accepts `--deliver <sink>`. The output goes to the named sink in a
 |------|--------|
 | `stdout` | Default; write to stdout only |
 | `file:<path>` | Atomically write output to `<path>` (tmp + rename). Binary-response commands write decoded payload bytes (not the base64 JSON envelope) and print a small JSON receipt on stdout; `--json`/`--csv` do not refuse when this sink is set. |
-| `webhook:<url>` | POST the output body to the URL (`application/json` or `application/x-ndjson` when `--compact`) |
+| `webhook:<url>` | POST the output body to the URL (`application/json`) |
 
 Unknown schemes are refused with a structured error naming the supported set. Webhook failures return non-zero and log the URL + HTTP status on stderr.
 

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/SKILL.md
@@ -50,7 +50,7 @@ When you know what you want to do but not which command does it, ask the CLI dir
 printing-press-rich-pp-cli which "<capability in your own words>"
 ```
 
-`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
+`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query. `--json` (and other machine formats) keep that exit-2 contract and write `{"matches":[]}` on stdout so agents can inspect the envelope without treating a miss as success.
 
 ## Auth Setup
 Run `printing-press-rich-pp-cli auth setup` to print the URL and steps for getting a key (add `--launch` to open the URL). Then set:
@@ -65,6 +65,13 @@ Run `printing-press-rich-pp-cli doctor` to verify setup.
 ## Agent Mode
 
 Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color`.
+
+Global format flags share one contract on promoted, novel, sync, and `--deliver` paths:
+
+- `--json` — one JSON document on stdout (sync progress events go to stderr)
+- `--compact` — keep identity/status/timestamp fields; does not change the document vs stream shape
+- `--csv` / `--plain` — tabular rows (collection envelopes unwrap to the row array)
+- `--quiet` — one identity value per row, no envelope
 
 - **Pipeable** — JSON on stdout, errors on stderr
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
@@ -331,7 +338,7 @@ Every command accepts `--deliver <sink>`. The output goes to the named sink in a
 |------|--------|
 | `stdout` | Default; write to stdout only |
 | `file:<path>` | Atomically write output to `<path>` (tmp + rename). Binary-response commands write decoded payload bytes (not the base64 JSON envelope) and print a small JSON receipt on stdout; `--json`/`--csv` do not refuse when this sink is set. |
-| `webhook:<url>` | POST the output body to the URL (`application/json` or `application/x-ndjson` when `--compact`) |
+| `webhook:<url>` | POST the output body to the URL (`application/json`) |
 
 Unknown schemes are refused with a structured error naming the supported set. Webhook failures return non-zero and log the URL + HTTP status on stderr.
 

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -2133,9 +2133,9 @@ func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlag
 		}
 		data = wrapped
 	}
-	// --quiet: suppress all output, exit code communicates result
+	// --quiet: one identity value per row (id, then name/slug/title).
 	if flags.quiet {
-		return nil
+		return printQuiet(w, data)
 	}
 	// --csv: render as CSV
 	if flags.csv {
@@ -2198,6 +2198,37 @@ func compactFields(data json.RawMessage, documentedFields ...map[string]bool) js
 	return data
 }
 
+// Endpoint-mirror commands pass documented fields into compactListFields;
+// keeping every schema key would make --compact a no-op on homogeneous API lists.
+func isCompactGravityField(name string) bool {
+	switch name {
+	case "id", "name", "title", "identifier", "code", "slug", "key",
+		"status", "state", "type", "kind", "priority",
+		"url", "email",
+		"price", "amount", "cost", "fare", "rate", "currency",
+		"rating", "score", "count",
+		"language", "locale", "country", "region", "city", "domain",
+		"created_at", "updated_at", "createdAt", "updatedAt", "date",
+		"version":
+		return true
+	}
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower == "" {
+		return false
+	}
+	for _, suffix := range []string{"_id", "_name", "_at", "_status", "_state", "_slug", "_key", "_title", "_code", "_count", "_url"} {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+	for _, suffix := range []string{"Id", "Name", "At", "Status", "State", "Slug", "Key", "Title", "Code", "Count", "URL", "Url"} {
+		if strings.HasSuffix(name, suffix) && len(name) > len(suffix) {
+			return true
+		}
+	}
+	return false
+}
+
 // compactListFields keeps only high-gravity fields for array responses.
 //
 // Two-layer keep rule:
@@ -2242,10 +2273,19 @@ func compactListFields(items []map[string]any, documentedFields ...map[string]bo
 	}
 	for _, fields := range documentedFields {
 		for field := range fields {
-			keepFields[field] = true
+			if isCompactGravityField(field) {
+				keepFields[field] = true
+			}
 		}
 	}
-	if len(items) > 0 {
+	schemaAware := false
+	for _, fields := range documentedFields {
+		if len(fields) > 0 {
+			schemaAware = true
+			break
+		}
+	}
+	if !schemaAware && len(items) > 0 {
 		keyCounts := map[string]int{}
 		for _, item := range items {
 			for k := range item {
@@ -2384,30 +2424,27 @@ func compactObjectArrayValue(v any, documentedFields ...map[string]bool) (any, b
 	return compacted, true
 }
 
-// printCSV renders JSON arrays as CSV with header row.
 func printCSV(w io.Writer, data json.RawMessage, documentedFields ...map[string]bool) error {
-	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil {
-		// Single object or invalid JSON - just print as JSON
+	items, ok := tabularObjectRows(data)
+	if !ok {
 		fmt.Fprintln(w, string(data))
 		return nil
 	}
 	if len(items) == 0 {
-		// A valid empty array is a header-only CSV stream so consumers can
-		// distinguish success-with-no-rows from failure. Keys come from
-		// declared record fields; without those the stream stays empty.
-		if bytes.HasPrefix(bytes.TrimSpace(data), []byte("[")) {
-			keys := csvDeclaredHeader(documentedFields...)
-			if len(keys) == 0 {
-				return nil
-			}
-			writeCSVRow(w, keys)
+		keys := csvDeclaredHeader(documentedFields...)
+		if len(keys) == 0 {
 			return nil
 		}
-		fmt.Fprintln(w, string(data))
+		writeCSVRow(w, keys)
 		return nil
 	}
-	// Collect all keys for header
+	return writeCSVRows(w, items)
+}
+
+func writeCSVRows(w io.Writer, items []map[string]any) error {
+	if len(items) == 0 {
+		return nil
+	}
 	keySet := map[string]bool{}
 	for _, item := range items {
 		for k := range item {
@@ -2466,11 +2503,9 @@ func csvDeclaredHeader(documentedFields ...map[string]bool) []string {
 	return keys
 }
 
-// printPlain renders JSON arrays as tab-separated text with a header row.
 func printPlain(w io.Writer, data json.RawMessage) error {
-	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil {
-		// Single object - just print as JSON
+	items, ok := tabularObjectRows(data)
+	if !ok {
 		fmt.Fprintln(w, string(data))
 		return nil
 	}
@@ -2497,6 +2532,133 @@ func printPlain(w io.Writer, data json.RawMessage) error {
 		fmt.Fprintln(w, strings.Join(vals, "\t"))
 	}
 	return nil
+}
+
+func printQuiet(w io.Writer, data json.RawMessage) error {
+	items, ok := tabularObjectRows(data)
+	if ok {
+		for _, item := range items {
+			if v := quietRowValue(item); v != "" {
+				fmt.Fprintln(w, v)
+			}
+		}
+		return nil
+	}
+	var scalars []any
+	if err := json.Unmarshal(data, &scalars); err == nil {
+		for _, v := range scalars {
+			if m, ok := v.(map[string]any); ok {
+				if s := quietRowValue(m); s != "" {
+					fmt.Fprintln(w, s)
+				}
+				continue
+			}
+			if v == nil {
+				continue
+			}
+			fmt.Fprintln(w, fmt.Sprint(v))
+		}
+		return nil
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err == nil {
+		if v := quietRowValue(obj); v != "" {
+			fmt.Fprintln(w, v)
+		}
+		return nil
+	}
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" || trimmed == "null" {
+		return nil
+	}
+	fmt.Fprintln(w, trimmed)
+	return nil
+}
+
+func quietRowValue(item map[string]any) string {
+	for _, key := range []string{"id", "ID", "Id", "identifier", "slug", "key", "name", "title", "code"} {
+		if v, ok := item[key]; ok {
+			if s := quietScalar(v); s != "" {
+				return s
+			}
+		}
+	}
+	for k, v := range item {
+		lower := strings.ToLower(k)
+		if strings.HasSuffix(lower, "_id") || strings.HasSuffix(k, "Id") {
+			if s := quietScalar(v); s != "" {
+				return s
+			}
+		}
+	}
+	for _, v := range item {
+		if s := quietScalar(v); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func quietScalar(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch t := v.(type) {
+	case string:
+		return t
+	case bool:
+		return strconv.FormatBool(t)
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	case json.Number:
+		return t.String()
+	default:
+		return ""
+	}
+}
+
+func tabularObjectRows(data json.RawMessage) ([]map[string]any, bool) {
+	projected := unwrapSingleKeyArray(collectionItemsForOutput(data, ""))
+	var items []map[string]any
+	if err := json.Unmarshal(projected, &items); err == nil && (len(items) > 0 || bytes.HasPrefix(bytes.TrimSpace(projected), []byte("["))) {
+		return items, true
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(projected, &obj); err != nil || len(obj) == 0 {
+		return nil, false
+	}
+	if rows, ok := objectEnvelopeRows(obj); ok {
+		return rows, true
+	}
+	return []map[string]any{obj}, true
+}
+
+func objectEnvelopeRows(obj map[string]any) ([]map[string]any, bool) {
+	found := 0
+	var rows []map[string]any
+	for k, v := range obj {
+		if envelopeMetadataKeys[k] || envelopeMetadataArrayKeys[k] {
+			continue
+		}
+		rawItems, ok := v.([]any)
+		if !ok {
+			continue
+		}
+		items := make([]map[string]any, 0, len(rawItems))
+		for _, raw := range rawItems {
+			item, ok := raw.(map[string]any)
+			if !ok {
+				return nil, false
+			}
+			items = append(items, item)
+		}
+		rows = items
+		found++
+	}
+	if found != 1 {
+		return nil, false
+	}
+	return rows, true
 }
 
 func plainCellValue(v any) string {

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 96
+    "total": 103
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
@@ -84,7 +84,7 @@ When you know what you want to do but not which command does it, ask the CLI dir
 printing-press-golden-pp-cli which "<capability in your own words>"
 ```
 
-`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
+`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query. `--json` (and other machine formats) keep that exit-2 contract and write `{"matches":[]}` on stdout so agents can inspect the envelope without treating a miss as success.
 
 ## Auth Setup
 Run `printing-press-golden-pp-cli auth setup` to print the URL and steps for getting a key (add `--launch` to open the URL). Then set:
@@ -99,6 +99,13 @@ Run `printing-press-golden-pp-cli doctor` to verify setup.
 ## Agent Mode
 
 Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color`.
+
+Global format flags share one contract on promoted, novel, sync, and `--deliver` paths:
+
+- `--json` — one JSON document on stdout (sync progress events go to stderr)
+- `--compact` — keep identity/status/timestamp fields; does not change the document vs stream shape
+- `--csv` / `--plain` — tabular rows (collection envelopes unwrap to the row array)
+- `--quiet` — one identity value per row, no envelope
 
 - **Pipeable** — JSON on stdout, errors on stderr
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
@@ -366,7 +373,7 @@ Every command accepts `--deliver <sink>`. The output goes to the named sink in a
 |------|--------|
 | `stdout` | Default; write to stdout only |
 | `file:<path>` | Atomically write output to `<path>` (tmp + rename). Binary-response commands write decoded payload bytes (not the base64 JSON envelope) and print a small JSON receipt on stdout; `--json`/`--csv` do not refuse when this sink is set. |
-| `webhook:<url>` | POST the output body to the URL (`application/json` or `application/x-ndjson` when `--compact`) |
+| `webhook:<url>` | POST the output body to the URL (`application/json`) |
 
 Unknown schemes are refused with a structured error naming the supported set. Webhook failures return non-zero and log the URL + HTTP status on stderr.
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -753,8 +753,8 @@ func resolveLocal(ctx context.Context, flags *rootFlags, hintWriter io.Writer, r
 		if len(items) == 0 {
 			return nil, DataProvenance{}, fmt.Errorf("no local data for %q. Run 'printing-press-golden-pp-cli sync' first", resourceType)
 		}
-		if parentIDs := localReadPathParentIDs(resourceType, path); len(parentIDs) > 0 {
-			items = applyLocalParentScope(db, resourceType, items, parentIDs)
+		if parents := localReadPathParents(resourceType, path); len(parents) > 0 {
+			items = applyLocalParentScope(db, resourceType, items, parents)
 		}
 		items, unsupported := applyLocalListFilters(items, params)
 		if len(unsupported) > 0 {
@@ -799,7 +799,12 @@ func localReadPathIsCollection(resourceType, path string, isList bool) bool {
 	return strings.EqualFold(parts[len(parts)-1], resourceType)
 }
 
-func localReadPathParentIDs(resourceType, path string) []string {
+type localPathParent struct {
+	Type string
+	ID   string
+}
+
+func localReadPathParents(resourceType, path string) []localPathParent {
 	parts := strings.Split(strings.Trim(path, "/"), "/")
 	if len(parts) == 0 || (len(parts) == 1 && parts[0] == "") {
 		return nil
@@ -818,11 +823,12 @@ func localReadPathParentIDs(resourceType, path string) []string {
 		}
 		stripped = append(stripped, part)
 	}
-	var parents []string
+	var parents []localPathParent
 	for i := 1; i < len(stripped); i += 2 {
-		if stripped[i] != "" {
-			parents = append(parents, stripped[i])
+		if stripped[i] == "" {
+			continue
 		}
+		parents = append(parents, localPathParent{Type: stripped[i-1], ID: stripped[i]})
 	}
 	return parents
 }
@@ -844,19 +850,39 @@ func localReadPathPrefixSegment(seg string) bool {
 	return false
 }
 
-func applyLocalParentScope(db *store.Store, resourceType string, items []json.RawMessage, parentIDs []string) []json.RawMessage {
-	parentSet := make(map[string]bool, len(parentIDs))
-	for _, id := range parentIDs {
-		parentSet[id] = true
+func applyLocalParentScope(db *store.Store, resourceType string, items []json.RawMessage, parents []localPathParent) []json.RawMessage {
+	parentSet := make(map[string]bool, len(parents))
+	for _, parent := range parents {
+		parentSet[parent.ID] = true
 	}
-	allowedBare := map[string]bool{}
+	var scopedIDs []string
+	sawComposite := false
 	if ids, err := db.ListIDs(resourceType); err == nil {
 		for _, id := range ids {
-			bare, parent, ok := splitLocalCompositeID(id)
-			if ok && parentSet[parent] {
-				allowedBare[bare] = true
+			_, parent, ok := splitLocalCompositeID(id)
+			if !ok {
+				continue
+			}
+			sawComposite = true
+			if parentSet[parent] {
+				scopedIDs = append(scopedIDs, id)
 			}
 		}
+	}
+	if sawComposite {
+		out := make([]json.RawMessage, 0, len(scopedIDs))
+		for _, id := range scopedIDs {
+			item, err := db.Get(resourceType, id)
+			if err != nil {
+				continue
+			}
+			trimmed := strings.TrimSpace(string(item))
+			if trimmed == "" || trimmed == "null" || trimmed == "[]" || trimmed == "{}" {
+				continue
+			}
+			out = append(out, item)
+		}
+		return out
 	}
 	out := make([]json.RawMessage, 0, len(items))
 	for _, raw := range items {
@@ -864,11 +890,7 @@ func applyLocalParentScope(db *store.Store, resourceType string, items []json.Ra
 		if json.Unmarshal(raw, &obj) != nil {
 			continue
 		}
-		if localItemJSONMatchesParents(obj, parentSet) {
-			out = append(out, raw)
-			continue
-		}
-		if childID := localItemID(obj); childID != "" && allowedBare[childID] {
+		if localItemStoredParentMatches(obj, parents, parentSet) {
 			out = append(out, raw)
 		}
 	}
@@ -883,38 +905,37 @@ func splitLocalCompositeID(id string) (bare, parent string, ok bool) {
 	return id[:i], id[i+1:], true
 }
 
-func localItemID(obj map[string]any) string {
-	got, ok := localObjectField(obj, "id")
-	if !ok {
-		return ""
-	}
-	if s, ok := got.(string); ok {
-		return s
-	}
-	return strings.TrimSpace(fmt.Sprint(got))
-}
-
-func localItemJSONMatchesParents(obj map[string]any, parentSet map[string]bool) bool {
-	for key, val := range obj {
-		if !localFieldLooksLikeParentKey(key) {
-			continue
-		}
-		if localValueInParentSet(val, parentSet) {
+func localItemStoredParentMatches(obj map[string]any, parents []localPathParent, parentSet map[string]bool) bool {
+	for _, key := range localStoredParentFieldKeys(parents) {
+		got, ok := localObjectField(obj, key)
+		if ok && localValueInParentSet(got, parentSet) {
 			return true
 		}
 	}
 	return false
 }
 
-func localFieldLooksLikeParentKey(key string) bool {
-	canon := localParamCanon(key)
-	switch canon {
-	case "id", "uuid", "gid", "sid", "uid", "guid", "api_id":
-		return false
-	case "parent", "parent_id":
-		return true
+func localStoredParentFieldKeys(parents []localPathParent) []string {
+	keys := []string{"parent_id", "parent"}
+	seen := map[string]bool{"parent_id": true, "parent": true}
+	add := func(key string) {
+		canon := localParamCanon(key)
+		if canon == "" || seen[canon] {
+			return
+		}
+		seen[canon] = true
+		keys = append(keys, key)
 	}
-	return strings.HasSuffix(canon, "_id") || (strings.HasSuffix(canon, "id") && len(canon) > 2)
+	for _, parent := range parents {
+		if parent.Type == "" {
+			continue
+		}
+		add(parent.Type + "_id")
+		if singular := strings.TrimSuffix(parent.Type, "s"); singular != parent.Type && singular != "" {
+			add(singular + "_id")
+		}
+	}
+	return keys
 }
 
 func localValueInParentSet(val any, parentSet map[string]bool) bool {
@@ -942,7 +963,7 @@ var localListCursorParams = map[string]bool{
 	"cursor": true, "after": true, "before": true,
 	"page_token": true, "pagetoken": true,
 	"starting_after": true, "ending_before": true,
-	"next_cursor": true, "start_cursor": true,
+	"next_cursor": true, "start_cursor": true, "next": true,
 }
 
 var localListControlParams = map[string]bool{

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -14,6 +14,8 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -713,9 +715,10 @@ func mutationResponseHasID(resourceType string, data json.RawMessage) bool {
 }
 
 // resolveLocal reads data from the local SQLite store.
-// Note: local reads return ALL synced data for the resource type. Endpoint-specific
-// filters (query params, path scoping like /teams/{id}/users) are NOT applied locally.
-// The provenance metadata includes "unscoped":true when params were present but not applied.
+// Collection paths (isList, or a path whose last segment is the resource type)
+// list synced rows and apply supported query filters locally. Object paths
+// fetch by the trailing ID. Cursor-style params cannot be replayed locally
+// and are reported on stderr instead of silently ignored.
 func resolveLocal(ctx context.Context, flags *rootFlags, hintWriter io.Writer, resourceType string, isList bool, path string, params map[string]string, reason string) (json.RawMessage, DataProvenance, error) {
 	db, err := openStoreForRead(ctx, "printing-press-golden-pp-cli")
 	if err != nil {
@@ -732,12 +735,7 @@ func resolveLocal(ctx context.Context, flags *rootFlags, hintWriter io.Writer, r
 
 	prov := localProvenance(db, resourceType, reason)
 
-	// Warn if endpoint had filters that local reads can't reproduce
-	if len(params) > 0 {
-		fmt.Fprintf(os.Stderr, "warning: local data is unfiltered — endpoint filters are not applied to cached data\n")
-	}
-
-	if isList {
+	if localReadPathIsCollection(resourceType, path, isList) {
 		raw, err := db.List(resourceType, 0) // 0 = no limit, return all synced data
 		if err != nil {
 			return nil, DataProvenance{}, fmt.Errorf("querying local store: %w", err)
@@ -755,7 +753,17 @@ func resolveLocal(ctx context.Context, flags *rootFlags, hintWriter io.Writer, r
 		if len(items) == 0 {
 			return nil, DataProvenance{}, fmt.Errorf("no local data for %q. Run 'printing-press-golden-pp-cli sync' first", resourceType)
 		}
-		// Marshal []json.RawMessage into a single JSON array
+		items, unsupported := applyLocalListFilters(items, params)
+		if len(unsupported) > 0 {
+			warnWriter := hintWriter
+			if warnWriter == nil {
+				warnWriter = os.Stderr
+			}
+			fmt.Fprintf(warnWriter, "warning: local data could not apply filter(s) %s\n", strings.Join(unsupported, ", "))
+		}
+		if len(items) == 0 {
+			return json.RawMessage("[]"), prov, nil
+		}
 		data, err := json.Marshal(items)
 		if err != nil {
 			return nil, DataProvenance{}, fmt.Errorf("marshaling local data: %w", err)
@@ -763,8 +771,7 @@ func resolveLocal(ctx context.Context, flags *rootFlags, hintWriter io.Writer, r
 		return data, prov, nil
 	}
 
-	// Get by ID — extract the last path segment as the ID
-	parts := strings.Split(strings.TrimRight(path, "/"), "/")
+	parts := strings.Split(strings.Trim(path, "/"), "/")
 	id := parts[len(parts)-1]
 
 	item, err := db.Get(resourceType, id)
@@ -775,6 +782,176 @@ func resolveLocal(ctx context.Context, flags *rootFlags, hintWriter io.Writer, r
 		return nil, DataProvenance{}, fmt.Errorf("querying local store: %w", err)
 	}
 	return item, prov, nil
+}
+
+func localReadPathIsCollection(resourceType, path string, isList bool) bool {
+	if isList {
+		return true
+	}
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return true
+	}
+	parts := strings.Split(trimmed, "/")
+	return strings.EqualFold(parts[len(parts)-1], resourceType)
+}
+
+var localListLimitParams = map[string]bool{
+	"limit": true, "per_page": true, "perpage": true, "page_size": true, "pagesize": true,
+}
+
+var localListOffsetParams = map[string]bool{
+	"offset": true, "skip": true,
+}
+
+var localListPageParams = map[string]bool{
+	"page": true, "page_number": true, "pagenumber": true,
+}
+
+var localListCursorParams = map[string]bool{
+	"cursor": true, "after": true, "before": true,
+	"page_token": true, "pagetoken": true,
+	"starting_after": true, "ending_before": true,
+	"next_cursor": true, "start_cursor": true,
+}
+
+func localParamCanon(key string) string {
+	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(key), "-", "_"))
+}
+
+func applyLocalListFilters(items []json.RawMessage, params map[string]string) ([]json.RawMessage, []string) {
+	if len(params) == 0 {
+		return items, nil
+	}
+	equality := map[string]string{}
+	unsupported := make([]string, 0)
+	limit := -1
+	offset := 0
+	page := 0
+	for key, val := range params {
+		val = strings.TrimSpace(val)
+		if val == "" {
+			continue
+		}
+		canon := localParamCanon(key)
+		switch {
+		case localListCursorParams[canon]:
+			unsupported = append(unsupported, key)
+		case localListLimitParams[canon]:
+			n, err := strconv.Atoi(val)
+			if err != nil || n < 0 {
+				unsupported = append(unsupported, key)
+				continue
+			}
+			limit = n
+		case localListOffsetParams[canon]:
+			n, err := strconv.Atoi(val)
+			if err != nil || n < 0 {
+				unsupported = append(unsupported, key)
+				continue
+			}
+			offset = n
+		case localListPageParams[canon]:
+			n, err := strconv.Atoi(val)
+			if err != nil || n < 1 {
+				unsupported = append(unsupported, key)
+				continue
+			}
+			page = n
+		default:
+			equality[key] = val
+		}
+	}
+	if page > 1 && limit < 0 {
+		unsupported = append(unsupported, "page")
+		page = 0
+	}
+	if len(equality) > 0 {
+		filtered := make([]json.RawMessage, 0, len(items))
+		matchedKeys := map[string]bool{}
+		for _, raw := range items {
+			var obj map[string]any
+			if json.Unmarshal(raw, &obj) != nil {
+				continue
+			}
+			keep := true
+			for key, want := range equality {
+				got, ok := localObjectField(obj, key)
+				if !ok {
+					keep = false
+					continue
+				}
+				matchedKeys[key] = true
+				if !localFieldEquals(got, want) {
+					keep = false
+				}
+			}
+			if keep {
+				filtered = append(filtered, raw)
+			}
+		}
+		for key := range equality {
+			if !matchedKeys[key] {
+				unsupported = append(unsupported, key)
+			}
+		}
+		items = filtered
+	}
+	if page > 1 && limit >= 0 {
+		offset += (page - 1) * limit
+	}
+	if offset > 0 {
+		if offset >= len(items) {
+			items = items[:0]
+		} else {
+			items = items[offset:]
+		}
+	}
+	if limit >= 0 && len(items) > limit {
+		items = items[:limit]
+	}
+	sort.Strings(unsupported)
+	return items, unsupported
+}
+
+func localObjectField(obj map[string]any, key string) (any, bool) {
+	if v, ok := obj[key]; ok {
+		return v, true
+	}
+	for k, v := range obj {
+		if strings.EqualFold(k, key) {
+			return v, true
+		}
+	}
+	canon := localParamCanon(key)
+	for k, v := range obj {
+		if localParamCanon(k) == canon {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func localFieldEquals(got any, want string) bool {
+	if got == nil {
+		return want == "" || strings.EqualFold(want, "null")
+	}
+	switch v := got.(type) {
+	case bool:
+		return strings.EqualFold(want, strconv.FormatBool(v))
+	case float64:
+		return want == strconv.FormatFloat(v, 'f', -1, 64)
+	case json.Number:
+		return want == v.String()
+	case string:
+		return v == want
+	default:
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprint(v) == want
+		}
+		return string(encoded) == want
+	}
 }
 
 // Ensure time import is used (compilation guard).

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -753,6 +753,9 @@ func resolveLocal(ctx context.Context, flags *rootFlags, hintWriter io.Writer, r
 		if len(items) == 0 {
 			return nil, DataProvenance{}, fmt.Errorf("no local data for %q. Run 'printing-press-golden-pp-cli sync' first", resourceType)
 		}
+		if parentIDs := localReadPathParentIDs(resourceType, path); len(parentIDs) > 0 {
+			items = applyLocalParentScope(db, resourceType, items, parentIDs)
+		}
 		items, unsupported := applyLocalListFilters(items, params)
 		if len(unsupported) > 0 {
 			warnWriter := hintWriter
@@ -796,6 +799,133 @@ func localReadPathIsCollection(resourceType, path string, isList bool) bool {
 	return strings.EqualFold(parts[len(parts)-1], resourceType)
 }
 
+func localReadPathParentIDs(resourceType, path string) []string {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) == 0 || (len(parts) == 1 && parts[0] == "") {
+		return nil
+	}
+	if strings.EqualFold(parts[len(parts)-1], resourceType) {
+		parts = parts[:len(parts)-1]
+	} else if len(parts) >= 2 && strings.EqualFold(parts[len(parts)-2], resourceType) {
+		parts = parts[:len(parts)-2]
+	} else {
+		return nil
+	}
+	stripped := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" || localReadPathPrefixSegment(part) {
+			continue
+		}
+		stripped = append(stripped, part)
+	}
+	var parents []string
+	for i := 1; i < len(stripped); i += 2 {
+		if stripped[i] != "" {
+			parents = append(parents, stripped[i])
+		}
+	}
+	return parents
+}
+
+func localReadPathPrefixSegment(seg string) bool {
+	s := strings.ToLower(seg)
+	switch s {
+	case "api", "rest", "graphql", "public", "private":
+		return true
+	}
+	if len(s) >= 2 && s[0] == 'v' {
+		for _, r := range s[1:] {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func applyLocalParentScope(db *store.Store, resourceType string, items []json.RawMessage, parentIDs []string) []json.RawMessage {
+	parentSet := make(map[string]bool, len(parentIDs))
+	for _, id := range parentIDs {
+		parentSet[id] = true
+	}
+	allowedBare := map[string]bool{}
+	if ids, err := db.ListIDs(resourceType); err == nil {
+		for _, id := range ids {
+			bare, parent, ok := splitLocalCompositeID(id)
+			if ok && parentSet[parent] {
+				allowedBare[bare] = true
+			}
+		}
+	}
+	out := make([]json.RawMessage, 0, len(items))
+	for _, raw := range items {
+		var obj map[string]any
+		if json.Unmarshal(raw, &obj) != nil {
+			continue
+		}
+		if localItemJSONMatchesParents(obj, parentSet) {
+			out = append(out, raw)
+			continue
+		}
+		if childID := localItemID(obj); childID != "" && allowedBare[childID] {
+			out = append(out, raw)
+		}
+	}
+	return out
+}
+
+func splitLocalCompositeID(id string) (bare, parent string, ok bool) {
+	i := strings.IndexByte(id, 0)
+	if i <= 0 || i == len(id)-1 {
+		return "", "", false
+	}
+	return id[:i], id[i+1:], true
+}
+
+func localItemID(obj map[string]any) string {
+	got, ok := localObjectField(obj, "id")
+	if !ok {
+		return ""
+	}
+	if s, ok := got.(string); ok {
+		return s
+	}
+	return strings.TrimSpace(fmt.Sprint(got))
+}
+
+func localItemJSONMatchesParents(obj map[string]any, parentSet map[string]bool) bool {
+	for key, val := range obj {
+		if !localFieldLooksLikeParentKey(key) {
+			continue
+		}
+		if localValueInParentSet(val, parentSet) {
+			return true
+		}
+	}
+	return false
+}
+
+func localFieldLooksLikeParentKey(key string) bool {
+	canon := localParamCanon(key)
+	switch canon {
+	case "id", "uuid", "gid", "sid", "uid", "guid", "api_id":
+		return false
+	case "parent", "parent_id":
+		return true
+	}
+	return strings.HasSuffix(canon, "_id") || (strings.HasSuffix(canon, "id") && len(canon) > 2)
+}
+
+func localValueInParentSet(val any, parentSet map[string]bool) bool {
+	for parent := range parentSet {
+		if localFieldEquals(val, parent) {
+			return true
+		}
+	}
+	return false
+}
+
 var localListLimitParams = map[string]bool{
 	"limit": true, "per_page": true, "perpage": true, "page_size": true, "pagesize": true,
 }
@@ -815,8 +945,22 @@ var localListCursorParams = map[string]bool{
 	"next_cursor": true, "start_cursor": true,
 }
 
+var localListControlParams = map[string]bool{
+	"sort": true, "order": true, "order_by": true, "orderby": true,
+	"fields": true, "field": true, "select": true,
+	"include": true, "expand": true,
+	"q": true, "query": true, "search": true,
+}
+
 func localParamCanon(key string) string {
 	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(key), "-", "_"))
+}
+
+func localListControlParam(canon string) bool {
+	if localListControlParams[canon] {
+		return true
+	}
+	return localListControlParams[strings.ReplaceAll(canon, "_", "")]
 }
 
 func applyLocalListFilters(items []json.RawMessage, params map[string]string) ([]json.RawMessage, []string) {
@@ -836,6 +980,8 @@ func applyLocalListFilters(items []json.RawMessage, params map[string]string) ([
 		canon := localParamCanon(key)
 		switch {
 		case localListCursorParams[canon]:
+			unsupported = append(unsupported, key)
+		case localListControlParam(canon):
 			unsupported = append(unsupported, key)
 		case localListLimitParams[canon]:
 			n, err := strconv.Atoi(val)
@@ -867,35 +1013,48 @@ func applyLocalListFilters(items []json.RawMessage, params map[string]string) ([
 		page = 0
 	}
 	if len(equality) > 0 {
-		filtered := make([]json.RawMessage, 0, len(items))
-		matchedKeys := map[string]bool{}
-		for _, raw := range items {
+		presentKeys := map[string]bool{}
+		parsed := make([]map[string]any, len(items))
+		valid := make([]bool, len(items))
+		for i, raw := range items {
 			var obj map[string]any
 			if json.Unmarshal(raw, &obj) != nil {
 				continue
 			}
-			keep := true
-			for key, want := range equality {
-				got, ok := localObjectField(obj, key)
-				if !ok {
-					keep = false
-					continue
+			parsed[i] = obj
+			valid[i] = true
+			for key := range equality {
+				if _, ok := localObjectField(obj, key); ok {
+					presentKeys[key] = true
 				}
-				matchedKeys[key] = true
-				if !localFieldEquals(got, want) {
-					keep = false
-				}
-			}
-			if keep {
-				filtered = append(filtered, raw)
 			}
 		}
 		for key := range equality {
-			if !matchedKeys[key] {
+			if !presentKeys[key] {
 				unsupported = append(unsupported, key)
+				delete(equality, key)
 			}
 		}
-		items = filtered
+		if len(equality) > 0 {
+			filtered := make([]json.RawMessage, 0, len(items))
+			for i, raw := range items {
+				if !valid[i] {
+					continue
+				}
+				keep := true
+				for key, want := range equality {
+					got, ok := localObjectField(parsed[i], key)
+					if !ok || !localFieldEquals(got, want) {
+						keep = false
+						break
+					}
+				}
+				if keep {
+					filtered = append(filtered, raw)
+				}
+			}
+			items = filtered
+		}
 	}
 	if page > 1 && limit >= 0 {
 		offset += (page - 1) * limit

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -851,9 +851,9 @@ func localReadPathPrefixSegment(seg string) bool {
 }
 
 func applyLocalParentScope(db *store.Store, resourceType string, items []json.RawMessage, parents []localPathParent) []json.RawMessage {
-	parentSet := make(map[string]bool, len(parents))
-	for _, parent := range parents {
-		parentSet[parent.ID] = true
+	immediate, ok := localReadImmediateParent(parents)
+	if !ok {
+		return items
 	}
 	var scopedIDs []string
 	sawComposite := false
@@ -864,7 +864,7 @@ func applyLocalParentScope(db *store.Store, resourceType string, items []json.Ra
 				continue
 			}
 			sawComposite = true
-			if parentSet[parent] {
+			if parent == immediate.ID {
 				scopedIDs = append(scopedIDs, id)
 			}
 		}
@@ -890,11 +890,18 @@ func applyLocalParentScope(db *store.Store, resourceType string, items []json.Ra
 		if json.Unmarshal(raw, &obj) != nil {
 			continue
 		}
-		if localItemStoredParentMatches(obj, parents, parentSet) {
+		if localItemStoredParentMatches(obj, immediate) {
 			out = append(out, raw)
 		}
 	}
 	return out
+}
+
+func localReadImmediateParent(parents []localPathParent) (localPathParent, bool) {
+	if len(parents) == 0 {
+		return localPathParent{}, false
+	}
+	return parents[len(parents)-1], true
 }
 
 func splitLocalCompositeID(id string) (bare, parent string, ok bool) {
@@ -905,17 +912,17 @@ func splitLocalCompositeID(id string) (bare, parent string, ok bool) {
 	return id[:i], id[i+1:], true
 }
 
-func localItemStoredParentMatches(obj map[string]any, parents []localPathParent, parentSet map[string]bool) bool {
-	for _, key := range localStoredParentFieldKeys(parents) {
+func localItemStoredParentMatches(obj map[string]any, parent localPathParent) bool {
+	for _, key := range localStoredParentFieldKeys(parent) {
 		got, ok := localObjectField(obj, key)
-		if ok && localValueInParentSet(got, parentSet) {
+		if ok && localFieldEquals(got, parent.ID) {
 			return true
 		}
 	}
 	return false
 }
 
-func localStoredParentFieldKeys(parents []localPathParent) []string {
+func localStoredParentFieldKeys(parent localPathParent) []string {
 	keys := []string{"parent_id", "parent"}
 	seen := map[string]bool{"parent_id": true, "parent": true}
 	add := func(key string) {
@@ -926,25 +933,13 @@ func localStoredParentFieldKeys(parents []localPathParent) []string {
 		seen[canon] = true
 		keys = append(keys, key)
 	}
-	for _, parent := range parents {
-		if parent.Type == "" {
-			continue
-		}
+	if parent.Type != "" {
 		add(parent.Type + "_id")
 		if singular := strings.TrimSuffix(parent.Type, "s"); singular != parent.Type && singular != "" {
 			add(singular + "_id")
 		}
 	}
 	return keys
-}
-
-func localValueInParentSet(val any, parentSet map[string]bool) bool {
-	for parent := range parentSet {
-		if localFieldEquals(val, parent) {
-			return true
-		}
-	}
-	return false
 }
 
 var localListLimitParams = map[string]bool{

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/deliver.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/deliver.go
@@ -124,10 +124,8 @@ func deliverFile(path string, body []byte) error {
 }
 
 func deliverWebhook(url string, body []byte, compact bool) error {
+	_ = compact
 	contentType := "application/json"
-	if compact {
-		contentType = "application/x-ndjson"
-	}
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("building webhook request: %w", err)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -2248,9 +2248,9 @@ func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlag
 		}
 		data = wrapped
 	}
-	// --quiet: suppress all output, exit code communicates result
+	// --quiet: one identity value per row (id, then name/slug/title).
 	if flags.quiet {
-		return nil
+		return printQuiet(w, data)
 	}
 	// --csv: render as CSV
 	if flags.csv {
@@ -2313,6 +2313,37 @@ func compactFields(data json.RawMessage, documentedFields ...map[string]bool) js
 	return data
 }
 
+// Endpoint-mirror commands pass documented fields into compactListFields;
+// keeping every schema key would make --compact a no-op on homogeneous API lists.
+func isCompactGravityField(name string) bool {
+	switch name {
+	case "id", "name", "title", "identifier", "code", "slug", "key",
+		"status", "state", "type", "kind", "priority",
+		"url", "email",
+		"price", "amount", "cost", "fare", "rate", "currency",
+		"rating", "score", "count",
+		"language", "locale", "country", "region", "city", "domain",
+		"created_at", "updated_at", "createdAt", "updatedAt", "date",
+		"version":
+		return true
+	}
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower == "" {
+		return false
+	}
+	for _, suffix := range []string{"_id", "_name", "_at", "_status", "_state", "_slug", "_key", "_title", "_code", "_count", "_url"} {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+	for _, suffix := range []string{"Id", "Name", "At", "Status", "State", "Slug", "Key", "Title", "Code", "Count", "URL", "Url"} {
+		if strings.HasSuffix(name, suffix) && len(name) > len(suffix) {
+			return true
+		}
+	}
+	return false
+}
+
 // compactListFields keeps only high-gravity fields for array responses.
 //
 // Two-layer keep rule:
@@ -2357,10 +2388,19 @@ func compactListFields(items []map[string]any, documentedFields ...map[string]bo
 	}
 	for _, fields := range documentedFields {
 		for field := range fields {
-			keepFields[field] = true
+			if isCompactGravityField(field) {
+				keepFields[field] = true
+			}
 		}
 	}
-	if len(items) > 0 {
+	schemaAware := false
+	for _, fields := range documentedFields {
+		if len(fields) > 0 {
+			schemaAware = true
+			break
+		}
+	}
+	if !schemaAware && len(items) > 0 {
 		keyCounts := map[string]int{}
 		for _, item := range items {
 			for k := range item {
@@ -2499,30 +2539,27 @@ func compactObjectArrayValue(v any, documentedFields ...map[string]bool) (any, b
 	return compacted, true
 }
 
-// printCSV renders JSON arrays as CSV with header row.
 func printCSV(w io.Writer, data json.RawMessage, documentedFields ...map[string]bool) error {
-	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil {
-		// Single object or invalid JSON - just print as JSON
+	items, ok := tabularObjectRows(data)
+	if !ok {
 		fmt.Fprintln(w, string(data))
 		return nil
 	}
 	if len(items) == 0 {
-		// A valid empty array is a header-only CSV stream so consumers can
-		// distinguish success-with-no-rows from failure. Keys come from
-		// declared record fields; without those the stream stays empty.
-		if bytes.HasPrefix(bytes.TrimSpace(data), []byte("[")) {
-			keys := csvDeclaredHeader(documentedFields...)
-			if len(keys) == 0 {
-				return nil
-			}
-			writeCSVRow(w, keys)
+		keys := csvDeclaredHeader(documentedFields...)
+		if len(keys) == 0 {
 			return nil
 		}
-		fmt.Fprintln(w, string(data))
+		writeCSVRow(w, keys)
 		return nil
 	}
-	// Collect all keys for header
+	return writeCSVRows(w, items)
+}
+
+func writeCSVRows(w io.Writer, items []map[string]any) error {
+	if len(items) == 0 {
+		return nil
+	}
 	keySet := map[string]bool{}
 	for _, item := range items {
 		for k := range item {
@@ -2581,11 +2618,9 @@ func csvDeclaredHeader(documentedFields ...map[string]bool) []string {
 	return keys
 }
 
-// printPlain renders JSON arrays as tab-separated text with a header row.
 func printPlain(w io.Writer, data json.RawMessage) error {
-	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil {
-		// Single object - just print as JSON
+	items, ok := tabularObjectRows(data)
+	if !ok {
 		fmt.Fprintln(w, string(data))
 		return nil
 	}
@@ -2612,6 +2647,133 @@ func printPlain(w io.Writer, data json.RawMessage) error {
 		fmt.Fprintln(w, strings.Join(vals, "\t"))
 	}
 	return nil
+}
+
+func printQuiet(w io.Writer, data json.RawMessage) error {
+	items, ok := tabularObjectRows(data)
+	if ok {
+		for _, item := range items {
+			if v := quietRowValue(item); v != "" {
+				fmt.Fprintln(w, v)
+			}
+		}
+		return nil
+	}
+	var scalars []any
+	if err := json.Unmarshal(data, &scalars); err == nil {
+		for _, v := range scalars {
+			if m, ok := v.(map[string]any); ok {
+				if s := quietRowValue(m); s != "" {
+					fmt.Fprintln(w, s)
+				}
+				continue
+			}
+			if v == nil {
+				continue
+			}
+			fmt.Fprintln(w, fmt.Sprint(v))
+		}
+		return nil
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err == nil {
+		if v := quietRowValue(obj); v != "" {
+			fmt.Fprintln(w, v)
+		}
+		return nil
+	}
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" || trimmed == "null" {
+		return nil
+	}
+	fmt.Fprintln(w, trimmed)
+	return nil
+}
+
+func quietRowValue(item map[string]any) string {
+	for _, key := range []string{"id", "ID", "Id", "identifier", "slug", "key", "name", "title", "code"} {
+		if v, ok := item[key]; ok {
+			if s := quietScalar(v); s != "" {
+				return s
+			}
+		}
+	}
+	for k, v := range item {
+		lower := strings.ToLower(k)
+		if strings.HasSuffix(lower, "_id") || strings.HasSuffix(k, "Id") {
+			if s := quietScalar(v); s != "" {
+				return s
+			}
+		}
+	}
+	for _, v := range item {
+		if s := quietScalar(v); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func quietScalar(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch t := v.(type) {
+	case string:
+		return t
+	case bool:
+		return strconv.FormatBool(t)
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	case json.Number:
+		return t.String()
+	default:
+		return ""
+	}
+}
+
+func tabularObjectRows(data json.RawMessage) ([]map[string]any, bool) {
+	projected := unwrapSingleKeyArray(collectionItemsForOutput(data, ""))
+	var items []map[string]any
+	if err := json.Unmarshal(projected, &items); err == nil && (len(items) > 0 || bytes.HasPrefix(bytes.TrimSpace(projected), []byte("["))) {
+		return items, true
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(projected, &obj); err != nil || len(obj) == 0 {
+		return nil, false
+	}
+	if rows, ok := objectEnvelopeRows(obj); ok {
+		return rows, true
+	}
+	return []map[string]any{obj}, true
+}
+
+func objectEnvelopeRows(obj map[string]any) ([]map[string]any, bool) {
+	found := 0
+	var rows []map[string]any
+	for k, v := range obj {
+		if envelopeMetadataKeys[k] || envelopeMetadataArrayKeys[k] {
+			continue
+		}
+		rawItems, ok := v.([]any)
+		if !ok {
+			continue
+		}
+		items := make([]map[string]any, 0, len(rawItems))
+		for _, raw := range rawItems {
+			item, ok := raw.(map[string]any)
+			if !ok {
+				return nil, false
+			}
+			items = append(items, item)
+		}
+		rows = items
+		found++
+	}
+	if found != 1 {
+		return nil, false
+	}
+	return rows, true
 }
 
 func plainCellValue(v any) string {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
@@ -201,7 +201,7 @@ func newProjectsCreateCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered, map[string]bool{"id": true, "name": true, "status": true, "visibility": true})
+					filtered = compactFields(filtered, map[string]bool{"id": true, "name": true, "status": true})
 				}
 				if len(filtered) > 0 {
 					var parsed any

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
@@ -78,7 +78,7 @@ func newProjectsListCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered, map[string]bool{"id": true, "name": true, "status": true, "visibility": true})
+					filtered = compactFields(filtered, map[string]bool{"id": true, "name": true, "status": true})
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -107,7 +107,7 @@ func newProjectsListCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, map[string]bool{"id": true, "name": true, "status": true, "visibility": true})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, map[string]bool{"id": true, "name": true, "status": true})
 		},
 	}
 	cmd.Flags().StringVar(&flagXApiVersion, "x-api-version", "2026-04-01", "Required API version header.")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_tickets.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_tickets.go
@@ -108,7 +108,7 @@ func newTicketsPromotedCmd(flags *rootFlags) *cobra.Command {
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)
 				} else if flags.compact {
-					filtered = compactFields(filtered, map[string]bool{"id": true, "summary": true})
+					filtered = compactFields(filtered, map[string]bool{"id": true})
 				}
 				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
 				if wrapErr != nil {
@@ -136,7 +136,7 @@ func newTicketsPromotedCmd(flags *rootFlags) *cobra.Command {
 			if flags.csv || flags.plain {
 				formatData = outputData
 			}
-			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, map[string]bool{"id": true, "summary": true})
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), formatData, flags, map[string]any{"source": "live"}, map[string]bool{"id": true})
 		},
 	}
 	cmd.Flags().StringVar(&flagXApiVersion, "x-api-version", "2026-04-01", "Required API version header.")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -135,6 +135,10 @@ Resource scoping:
 			defer db.Close()
 
 			syncEventWriter := cmd.OutOrStdout()
+			machineFormat := wantsMachineOutput(flags)
+			if machineFormat {
+				syncEventWriter = cmd.ErrOrStderr()
+			}
 			// Snapshot before defaults expand, so an empty user filter stays empty
 			// and dependents inherit "sync everything" instead of the default list.
 			parentFilter := append([]string(nil), resources...)
@@ -392,6 +396,18 @@ Resource scoping:
 						errCount, strings.ReplaceAll(msg, `"`, `\"`))
 				} else {
 					fmt.Fprintf(os.Stderr, "warning: %d resource(s) failed but exit code is 0 because the new default treats non-critical failures as warnings. Pass --strict to restore the old behavior, or annotate critical resources with x-critical: true.\n", errCount)
+				}
+			}
+			if machineFormat {
+				if err := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+					"total_records": totalSynced,
+					"resources":     totalResources,
+					"success":       successCount,
+					"warned":        warnCount,
+					"errored":       errCount,
+					"duration_ms":   elapsed.Milliseconds(),
+				}, flags); err != nil {
+					return err
 				}
 			}
 			return nil

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
@@ -318,7 +318,8 @@ func newWhichCmd(flags *rootFlags) *cobra.Command {
 
 Exit codes:
   0  at least one match found
-  2  no confident match - the query did not score against any indexed capability; fall back to '--help' or 'search' if this CLI has one`,
+  2  no confident match - the query did not score against any indexed capability; fall back to '--help' or 'search' if this CLI has one. Machine output (--json/--csv/--plain/--quiet, or a pipe) still exits 2 and writes {"matches":[]} (or the equivalent empty table) to stdout.`,
+		SilenceUsage: true,
 		Example: `  printing-press-golden-pp-cli which "stale tickets"
   printing-press-golden-pp-cli which "bottleneck"
   printing-press-golden-pp-cli which --limit 1 "send message"
@@ -336,14 +337,22 @@ Exit codes:
 			}
 
 			if len(matches) == 0 {
-				// Under --json, return an empty matches envelope at exit 0
-				// so agents can branch on `matches.length == 0` instead of
-				// parsing a usage error message. Non-JSON keeps the typed
-				// exit-2 path so terminal users see the help hint.
-				if flags.asJSON {
-					return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+				// Machine output still uses the typed exit-2 no-match path.
+				// --json (and piped auto-JSON) emit {"matches":[]} on stdout
+				// so agents can branch on the envelope without treating exit 0
+				// as success. Human terminals keep the usage error only.
+				asJSON := flags.asJSON
+				if !asJSON && !isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain {
+					asJSON = true
+				}
+				if asJSON || flags.csv || flags.plain || flags.quiet {
+					outputFlags := *flags
+					outputFlags.asJSON = asJSON || flags.asJSON
+					if err := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
 						"matches": []whichMatch{},
-					}, flags)
+					}, &outputFlags); err != nil {
+						return err
+					}
 				}
 				return usageErr(fmt.Errorf("no match for %q; try '%s --help' for the full command list", query, cmd.Root().Name()))
 			}

--- a/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/SKILL.md
+++ b/testdata/golden/expected/generate-learn-disabled-api/learn-disabled-example/SKILL.md
@@ -58,7 +58,7 @@ When you know what you want to do but not which command does it, ask the CLI dir
 learn-disabled-example-pp-cli which "<capability in your own words>"
 ```
 
-`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
+`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query. `--json` (and other machine formats) keep that exit-2 contract and write `{"matches":[]}` on stdout so agents can inspect the envelope without treating a miss as success.
 
 ## Auth Setup
 
@@ -75,6 +75,13 @@ Run `learn-disabled-example-pp-cli doctor` to verify setup.
 ## Agent Mode
 
 Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color`.
+
+Global format flags share one contract on promoted, novel, sync, and `--deliver` paths:
+
+- `--json` — one JSON document on stdout (sync progress events go to stderr)
+- `--compact` — keep identity/status/timestamp fields; does not change the document vs stream shape
+- `--csv` / `--plain` — tabular rows (collection envelopes unwrap to the row array)
+- `--quiet` — one identity value per row, no envelope
 
 - **Pipeable** — JSON on stdout, errors on stderr
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
@@ -149,7 +156,7 @@ Every command accepts `--deliver <sink>`. The output goes to the named sink in a
 |------|--------|
 | `stdout` | Default; write to stdout only |
 | `file:<path>` | Atomically write output to `<path>` (tmp + rename). Binary-response commands write decoded payload bytes (not the base64 JSON envelope) and print a small JSON receipt on stdout; `--json`/`--csv` do not refuse when this sink is set. |
-| `webhook:<url>` | POST the output body to the URL (`application/json` or `application/x-ndjson` when `--compact`) |
+| `webhook:<url>` | POST the output body to the URL (`application/json`) |
 
 Unknown schemes are refused with a structured error naming the supported set. Webhook failures return non-zero and log the URL + HTTP status on stderr.
 

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/SKILL.md
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/SKILL.md
@@ -65,7 +65,7 @@ When you know what you want to do but not which command does it, ask the CLI dir
 learn-loop-example-pp-cli which "<capability in your own words>"
 ```
 
-`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
+`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query. `--json` (and other machine formats) keep that exit-2 contract and write `{"matches":[]}` on stdout so agents can inspect the envelope without treating a miss as success.
 
 ## Auth Setup
 
@@ -82,6 +82,13 @@ Run `learn-loop-example-pp-cli doctor` to verify setup.
 ## Agent Mode
 
 Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color`.
+
+Global format flags share one contract on promoted, novel, sync, and `--deliver` paths:
+
+- `--json` — one JSON document on stdout (sync progress events go to stderr)
+- `--compact` — keep identity/status/timestamp fields; does not change the document vs stream shape
+- `--csv` / `--plain` — tabular rows (collection envelopes unwrap to the row array)
+- `--quiet` — one identity value per row, no envelope
 
 - **Pipeable** — JSON on stdout, errors on stderr
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
@@ -348,7 +355,7 @@ Every command accepts `--deliver <sink>`. The output goes to the named sink in a
 |------|--------|
 | `stdout` | Default; write to stdout only |
 | `file:<path>` | Atomically write output to `<path>` (tmp + rename). Binary-response commands write decoded payload bytes (not the base64 JSON envelope) and print a small JSON receipt on stdout; `--json`/`--csv` do not refuse when this sink is set. |
-| `webhook:<url>` | POST the output body to the URL (`application/json` or `application/x-ndjson` when `--compact`) |
+| `webhook:<url>` | POST the output body to the URL (`application/json`) |
 
 Unknown schemes are refused with a structured error naming the supported set. Webhook failures return non-zero and log the URL + HTTP status on stderr.
 

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/SKILL.md
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/SKILL.md
@@ -47,7 +47,7 @@ When you know what you want to do but not which command does it, ask the CLI dir
 public-param-golden-pp-cli which "<capability in your own words>"
 ```
 
-`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
+`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query. `--json` (and other machine formats) keep that exit-2 contract and write `{"matches":[]}` on stdout so agents can inspect the envelope without treating a miss as success.
 
 ## Auth Setup
 
@@ -58,6 +58,13 @@ Run `public-param-golden-pp-cli doctor` to verify setup.
 ## Agent Mode
 
 Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color`.
+
+Global format flags share one contract on promoted, novel, sync, and `--deliver` paths:
+
+- `--json` — one JSON document on stdout (sync progress events go to stderr)
+- `--compact` — keep identity/status/timestamp fields; does not change the document vs stream shape
+- `--csv` / `--plain` — tabular rows (collection envelopes unwrap to the row array)
+- `--quiet` — one identity value per row, no envelope
 
 - **Pipeable** — JSON on stdout, errors on stderr
 - **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
@@ -325,7 +332,7 @@ Every command accepts `--deliver <sink>`. The output goes to the named sink in a
 |------|--------|
 | `stdout` | Default; write to stdout only |
 | `file:<path>` | Atomically write output to `<path>` (tmp + rename). Binary-response commands write decoded payload bytes (not the base64 JSON envelope) and print a small JSON receipt on stdout; `--json`/`--csv` do not refuse when this sink is set. |
-| `webhook:<url>` | POST the output body to the URL (`application/json` or `application/x-ndjson` when `--compact`) |
+| `webhook:<url>` | POST the output body to the URL (`application/json`) |
 
 Unknown schemes are refused with a structured error naming the supported set. Webhook failures return non-zero and log the URL + HTTP status on stderr.
 

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
@@ -2207,9 +2207,9 @@ func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlag
 		}
 		data = wrapped
 	}
-	// --quiet: suppress all output, exit code communicates result
+	// --quiet: one identity value per row (id, then name/slug/title).
 	if flags.quiet {
-		return nil
+		return printQuiet(w, data)
 	}
 	// --csv: render as CSV
 	if flags.csv {
@@ -2272,6 +2272,37 @@ func compactFields(data json.RawMessage, documentedFields ...map[string]bool) js
 	return data
 }
 
+// Endpoint-mirror commands pass documented fields into compactListFields;
+// keeping every schema key would make --compact a no-op on homogeneous API lists.
+func isCompactGravityField(name string) bool {
+	switch name {
+	case "id", "name", "title", "identifier", "code", "slug", "key",
+		"status", "state", "type", "kind", "priority",
+		"url", "email",
+		"price", "amount", "cost", "fare", "rate", "currency",
+		"rating", "score", "count",
+		"language", "locale", "country", "region", "city", "domain",
+		"created_at", "updated_at", "createdAt", "updatedAt", "date",
+		"version":
+		return true
+	}
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower == "" {
+		return false
+	}
+	for _, suffix := range []string{"_id", "_name", "_at", "_status", "_state", "_slug", "_key", "_title", "_code", "_count", "_url"} {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+	for _, suffix := range []string{"Id", "Name", "At", "Status", "State", "Slug", "Key", "Title", "Code", "Count", "URL", "Url"} {
+		if strings.HasSuffix(name, suffix) && len(name) > len(suffix) {
+			return true
+		}
+	}
+	return false
+}
+
 // compactListFields keeps only high-gravity fields for array responses.
 //
 // Two-layer keep rule:
@@ -2316,10 +2347,19 @@ func compactListFields(items []map[string]any, documentedFields ...map[string]bo
 	}
 	for _, fields := range documentedFields {
 		for field := range fields {
-			keepFields[field] = true
+			if isCompactGravityField(field) {
+				keepFields[field] = true
+			}
 		}
 	}
-	if len(items) > 0 {
+	schemaAware := false
+	for _, fields := range documentedFields {
+		if len(fields) > 0 {
+			schemaAware = true
+			break
+		}
+	}
+	if !schemaAware && len(items) > 0 {
 		keyCounts := map[string]int{}
 		for _, item := range items {
 			for k := range item {
@@ -2458,30 +2498,27 @@ func compactObjectArrayValue(v any, documentedFields ...map[string]bool) (any, b
 	return compacted, true
 }
 
-// printCSV renders JSON arrays as CSV with header row.
 func printCSV(w io.Writer, data json.RawMessage, documentedFields ...map[string]bool) error {
-	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil {
-		// Single object or invalid JSON - just print as JSON
+	items, ok := tabularObjectRows(data)
+	if !ok {
 		fmt.Fprintln(w, string(data))
 		return nil
 	}
 	if len(items) == 0 {
-		// A valid empty array is a header-only CSV stream so consumers can
-		// distinguish success-with-no-rows from failure. Keys come from
-		// declared record fields; without those the stream stays empty.
-		if bytes.HasPrefix(bytes.TrimSpace(data), []byte("[")) {
-			keys := csvDeclaredHeader(documentedFields...)
-			if len(keys) == 0 {
-				return nil
-			}
-			writeCSVRow(w, keys)
+		keys := csvDeclaredHeader(documentedFields...)
+		if len(keys) == 0 {
 			return nil
 		}
-		fmt.Fprintln(w, string(data))
+		writeCSVRow(w, keys)
 		return nil
 	}
-	// Collect all keys for header
+	return writeCSVRows(w, items)
+}
+
+func writeCSVRows(w io.Writer, items []map[string]any) error {
+	if len(items) == 0 {
+		return nil
+	}
 	keySet := map[string]bool{}
 	for _, item := range items {
 		for k := range item {
@@ -2540,11 +2577,9 @@ func csvDeclaredHeader(documentedFields ...map[string]bool) []string {
 	return keys
 }
 
-// printPlain renders JSON arrays as tab-separated text with a header row.
 func printPlain(w io.Writer, data json.RawMessage) error {
-	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil {
-		// Single object - just print as JSON
+	items, ok := tabularObjectRows(data)
+	if !ok {
 		fmt.Fprintln(w, string(data))
 		return nil
 	}
@@ -2571,6 +2606,133 @@ func printPlain(w io.Writer, data json.RawMessage) error {
 		fmt.Fprintln(w, strings.Join(vals, "\t"))
 	}
 	return nil
+}
+
+func printQuiet(w io.Writer, data json.RawMessage) error {
+	items, ok := tabularObjectRows(data)
+	if ok {
+		for _, item := range items {
+			if v := quietRowValue(item); v != "" {
+				fmt.Fprintln(w, v)
+			}
+		}
+		return nil
+	}
+	var scalars []any
+	if err := json.Unmarshal(data, &scalars); err == nil {
+		for _, v := range scalars {
+			if m, ok := v.(map[string]any); ok {
+				if s := quietRowValue(m); s != "" {
+					fmt.Fprintln(w, s)
+				}
+				continue
+			}
+			if v == nil {
+				continue
+			}
+			fmt.Fprintln(w, fmt.Sprint(v))
+		}
+		return nil
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err == nil {
+		if v := quietRowValue(obj); v != "" {
+			fmt.Fprintln(w, v)
+		}
+		return nil
+	}
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" || trimmed == "null" {
+		return nil
+	}
+	fmt.Fprintln(w, trimmed)
+	return nil
+}
+
+func quietRowValue(item map[string]any) string {
+	for _, key := range []string{"id", "ID", "Id", "identifier", "slug", "key", "name", "title", "code"} {
+		if v, ok := item[key]; ok {
+			if s := quietScalar(v); s != "" {
+				return s
+			}
+		}
+	}
+	for k, v := range item {
+		lower := strings.ToLower(k)
+		if strings.HasSuffix(lower, "_id") || strings.HasSuffix(k, "Id") {
+			if s := quietScalar(v); s != "" {
+				return s
+			}
+		}
+	}
+	for _, v := range item {
+		if s := quietScalar(v); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func quietScalar(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch t := v.(type) {
+	case string:
+		return t
+	case bool:
+		return strconv.FormatBool(t)
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	case json.Number:
+		return t.String()
+	default:
+		return ""
+	}
+}
+
+func tabularObjectRows(data json.RawMessage) ([]map[string]any, bool) {
+	projected := unwrapSingleKeyArray(collectionItemsForOutput(data, ""))
+	var items []map[string]any
+	if err := json.Unmarshal(projected, &items); err == nil && (len(items) > 0 || bytes.HasPrefix(bytes.TrimSpace(projected), []byte("["))) {
+		return items, true
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(projected, &obj); err != nil || len(obj) == 0 {
+		return nil, false
+	}
+	if rows, ok := objectEnvelopeRows(obj); ok {
+		return rows, true
+	}
+	return []map[string]any{obj}, true
+}
+
+func objectEnvelopeRows(obj map[string]any) ([]map[string]any, bool) {
+	found := 0
+	var rows []map[string]any
+	for k, v := range obj {
+		if envelopeMetadataKeys[k] || envelopeMetadataArrayKeys[k] {
+			continue
+		}
+		rawItems, ok := v.([]any)
+		if !ok {
+			continue
+		}
+		items := make([]map[string]any, 0, len(rawItems))
+		for _, raw := range rawItems {
+			item, ok := raw.(map[string]any)
+			if !ok {
+				return nil, false
+			}
+			items = append(items, item)
+		}
+		rows = items
+		found++
+	}
+	if found != 1 {
+		return nil, false
+	}
+	return rows, true
 }
 
 func plainCellValue(v any) string {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -132,6 +132,10 @@ Resource scoping:
 			defer db.Close()
 
 			syncEventWriter := cmd.OutOrStdout()
+			machineFormat := wantsMachineOutput(flags)
+			if machineFormat {
+				syncEventWriter = cmd.ErrOrStderr()
+			}
 
 			// If no specific resources, sync top-level resources
 			if len(resources) == 0 {
@@ -352,6 +356,18 @@ Resource scoping:
 						errCount, strings.ReplaceAll(msg, `"`, `\"`))
 				} else {
 					fmt.Fprintf(os.Stderr, "warning: %d resource(s) failed but exit code is 0 because the new default treats non-critical failures as warnings. Pass --strict to restore the old behavior, or annotate critical resources with x-critical: true.\n", errCount)
+				}
+			}
+			if machineFormat {
+				if err := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+					"total_records": totalSynced,
+					"resources":     totalResources,
+					"success":       successCount,
+					"warned":        warnCount,
+					"errored":       errCount,
+					"duration_ms":   elapsed.Milliseconds(),
+				}, flags); err != nil {
+					return err
 				}
 			}
 			return nil

--- a/testdata/golden/expected/generate-sync-history-filter/sync-history-filter/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-history-filter/sync-history-filter/internal/cli/sync.go
@@ -131,6 +131,10 @@ Resource scoping:
 			defer db.Close()
 
 			syncEventWriter := cmd.OutOrStdout()
+			machineFormat := wantsMachineOutput(flags)
+			if machineFormat {
+				syncEventWriter = cmd.ErrOrStderr()
+			}
 
 			// If no specific resources, sync top-level resources
 			if len(resources) == 0 {
@@ -340,6 +344,18 @@ Resource scoping:
 						errCount, strings.ReplaceAll(msg, `"`, `\"`))
 				} else {
 					fmt.Fprintf(os.Stderr, "warning: %d resource(s) failed but exit code is 0 because the new default treats non-critical failures as warnings. Pass --strict to restore the old behavior, or annotate critical resources with x-critical: true.\n", errCount)
+				}
+			}
+			if machineFormat {
+				if err := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+					"total_records": totalSynced,
+					"resources":     totalResources,
+					"success":       successCount,
+					"warned":        warnCount,
+					"errored":       errCount,
+					"duration_ms":   elapsed.Milliseconds(),
+				}, flags); err != nil {
+					return err
 				}
 			}
 			return nil

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -134,6 +134,10 @@ Resource scoping:
 			defer db.Close()
 
 			syncEventWriter := cmd.OutOrStdout()
+			machineFormat := wantsMachineOutput(flags)
+			if machineFormat {
+				syncEventWriter = cmd.ErrOrStderr()
+			}
 			// Snapshot before defaults expand, so an empty user filter stays empty
 			// and dependents inherit "sync everything" instead of the default list.
 			parentFilter := append([]string(nil), resources...)
@@ -391,6 +395,18 @@ Resource scoping:
 						errCount, strings.ReplaceAll(msg, `"`, `\"`))
 				} else {
 					fmt.Fprintf(os.Stderr, "warning: %d resource(s) failed but exit code is 0 because the new default treats non-critical failures as warnings. Pass --strict to restore the old behavior, or annotate critical resources with x-critical: true.\n", errCount)
+				}
+			}
+			if machineFormat {
+				if err := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+					"total_records": totalSynced,
+					"resources":     totalResources,
+					"success":       successCount,
+					"warned":        warnCount,
+					"errored":       errCount,
+					"duration_ms":   elapsed.Milliseconds(),
+				}, flags); err != nil {
+					return err
 				}
 			}
 			return nil

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -132,6 +132,10 @@ Resource scoping:
 			defer db.Close()
 
 			syncEventWriter := cmd.OutOrStdout()
+			machineFormat := wantsMachineOutput(flags)
+			if machineFormat {
+				syncEventWriter = cmd.ErrOrStderr()
+			}
 
 			// If no specific resources, sync top-level resources
 			if len(resources) == 0 {
@@ -352,6 +356,18 @@ Resource scoping:
 						errCount, strings.ReplaceAll(msg, `"`, `\"`))
 				} else {
 					fmt.Fprintf(os.Stderr, "warning: %d resource(s) failed but exit code is 0 because the new default treats non-critical failures as warnings. Pass --strict to restore the old behavior, or annotate critical resources with x-critical: true.\n", errCount)
+				}
+			}
+			if machineFormat {
+				if err := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+					"total_records": totalSynced,
+					"resources":     totalResources,
+					"success":       successCount,
+					"warned":        warnCount,
+					"errored":       errCount,
+					"duration_ms":   elapsed.Milliseconds(),
+				}, flags); err != nil {
+					return err
 				}
 			}
 			return nil


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Issue: Closes #3549

EverBee dogfood (`printing-press-library#1492`) showed three generated-runtime contract failures that reproduce across the catalog:

1. Local list reads resolved a collection path as an object ID (`resource "shops" with ID "shops" not found`) after a successful sync.
2. Global format flags violated their docs: `--compact` did not shrink homogeneous lists, `--csv`/`--plain` could emit JSON envelopes, `--quiet` emitted nothing, and `sync --json` wrote JSONL events on stdout.
3. `which` advertised typed exits `0,2`, but `--json` no-match returned an empty envelope at exit 0.

All three legs were still broken on current `main`; this PR fixes them together in the generated runtime.

## Approach

Shared runtime, not a printed-CLI patch:

- **Local reads.** Keep `localReadIsList` unchanged (`index`/`all` stay non-list at codegen). `resolveLocal` now treats a path whose last segment equals the resource type as a collection, lists the store, and applies equality / `limit` / `offset` / `page` filters. Nested collection paths such as `/teams/t1/shops` stay in parent scope via composite storage keys (`id\x00parent`) when present, otherwise `parent_id` / `parent` and the path parent type FK (`teams` → `teams_id` / `team_id`) — not every payload field ending in `_id`. Query controls (`sort`, `order`, `fields`, `search`, …) and equality keys that match no response field warn instead of emptying the list. Cursor params also warn instead of failing closed.
- **Output flags.** `--csv`/`--plain` unwrap collection envelopes to rows (and render single objects as one row, including binary envelopes); `--quiet` prints one identity value per row; schema-aware `--compact` keeps gravity fields instead of unioning the whole schema (novel payloads without documented fields still use the 80% frequency rule). `sync --json` emits one JSON summary on stdout and routes NDJSON events to stderr, matching `workflow archive --json`. Webhook `--deliver` stays `application/json`.
- **`which`.** No-match still writes `{"matches":[]}` (or the empty table) for machine output, including piped auto-JSON, then returns `usageErr` (exit 2). Help, SKILL, annotations, and tests agree.

## Scope

Primary area: generated CLI runtime (`resolveLocal`, root output helpers, `which` RunE, sync/deliver).

Why this belongs in this repo: these contracts are emitted into every printed CLI. Fixing one catalog entry would not compound.

## Risk

Regen changes `data_source.go`, `helpers.go`, `which.go` / `which_test.go`, `sync.go`, `deliver.go`, README, and SKILL across future prints. Goldens move for those artifacts. Existing scripts that treated `which --json` no-match as exit 0, or parsed `sync --json` as NDJSON on stdout, will need to follow the documented contract.

## Output Contract

- Emitted-code assertions plus `requireGeneratedCompiles` and compiled generated CLI tests in `local_output_which_contract_test.go` (collection-path `index` endpoint, local filters, nested parent scope including owner_id non-match, query-control warnings, `which` exit 2).
- Runtime helper tests in `output_flags_contract_test.go` (CSV object/envelope, quiet identities, schema-aware compact).
- `TestGeneratedOutput_WorkflowArchiveJSONKeepsSyncEventsOffStdout` pins direct `sync --json` as one JSON document.
- Golden fixtures updated for helpers, `resolveLocal`, `which`, `sync`, compact field maps, and SKILL format docs. `generate-golden-api` `data_source.go` is refreshed through the golden normalizer (the previous raw copy missed `"next"` on cursor params and failed full-golden).

## Verification

- [x] Generator/template change: emitted-code assertions, `requireGeneratedCompiles`, and compiled generated CLI cases
- [x] Generator/template change: covered the `index` (isList=false) collection-path fallback, not only endpoints named `list`
- [x] Generator/template change: nested `/teams/{id}/shops` parent-scope uses stored parent keys; `owner_id` coincidence does not leak rows
- [x] Generator/template change: query-control fallbacks, not only unscoped equality filters
- [x] Generator/template change: `resolveLocal`, `printOutputWithFlags`, `which` RunE, and `sync` machine-format gates updated together
- [x] `go test ./internal/generator -run TestGeneratedLocalReadsAndWhichHonorSharedRuntimeContracts`
- [x] `generate-golden-api` `data_source.go` golden refreshed via the same normalize pipeline `scripts/golden.sh` uses

Local `scripts/golden.sh verify` still fails `dogfood-verdict-matrix` because this environment cannot download that fixture's pinned `go 1.24` toolchain. That fixture was not regenerated; CI that can fetch the toolchain should keep the existing expected artifact. `verify-runtime-matrix` passed on the previous full-golden run.

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1be067d-fa87-4643-8b26-c7ace1df5729?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1be067d-fa87-4643-8b26-c7ace1df5729&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

