### PR TITLE
fix(cli): keep which specificity from zeroing single-token leaves

### DIFF
--- a/internal/generator/local_output_which_contract_test.go
+++ b/internal/generator/local_output_which_contract_test.go
@@ -97,6 +97,8 @@ func TestGeneratedLocalReadsAndWhichHonorSharedRuntimeContracts(t *testing.T) {
 	assert.NotContains(t, whichSrc, "Under --json, return an empty matches envelope at exit 0")
 	assert.Contains(t, whichSrc, "if len(leafTokens) < 2 && unmatched >= score {",
 		"single-token leaves must keep a positive score when specificity is the only remaining penalty")
+	assert.Contains(t, whichSrc, "func whichIncidentalToken(token string) bool {",
+		"incidental query words must not create a which match")
 
 	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
 	assert.Contains(t, syncSrc, "machineFormat := wantsMachineOutput(flags)")
@@ -362,5 +364,5 @@ func TestResolveLocalUnmatchedEqualityKeyDoesNotEmptyTheList(t *testing.T) {
 func ioDiscard() io.Writer { return io.Discard }
 `), 0o644))
 
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestResolveLocal|TestWhichJSONNoMatchExits2|TestWhichPipedNoMatchExits2WithEmptyEnvelope|TestRankWhich_SingleTokenLeaf|TestRankWhich_CompositeLeafLosesWhenQueryOmitsCapabilityTokens|TestRankWhich_ProseCreditDoesNotDoubleCount", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestResolveLocal|TestWhichJSONNoMatchExits2|TestWhichPipedNoMatchExits2WithEmptyEnvelope|TestRankWhich_SingleTokenLeaf|TestRankWhich_CompositeLeafLosesWhenQueryOmitsCapabilityTokens|TestRankWhich_ProseCreditDoesNotDoubleCount|TestRankWhich_IncidentalDescriptionWordDoesNotAdmitEntry", "-count=1")
 }

--- a/internal/generator/local_output_which_contract_test.go
+++ b/internal/generator/local_output_which_contract_test.go
@@ -95,6 +95,8 @@ func TestGeneratedLocalReadsAndWhichHonorSharedRuntimeContracts(t *testing.T) {
 	assert.Contains(t, whichSrc, `return usageErr(fmt.Errorf("no match for %q;`)
 	assert.Contains(t, whichSrc, `"matches": []whichMatch{}`)
 	assert.NotContains(t, whichSrc, "Under --json, return an empty matches envelope at exit 0")
+	assert.Contains(t, whichSrc, "if len(leafTokens) < 2 {",
+		"single-token leaves must skip the specificity penalty so a description hit is not zeroed")
 
 	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
 	assert.Contains(t, syncSrc, "machineFormat := wantsMachineOutput(flags)")
@@ -360,5 +362,5 @@ func TestResolveLocalUnmatchedEqualityKeyDoesNotEmptyTheList(t *testing.T) {
 func ioDiscard() io.Writer { return io.Discard }
 `), 0o644))
 
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestResolveLocal|TestWhichJSONNoMatchExits2|TestWhichPipedNoMatchExits2WithEmptyEnvelope", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestResolveLocal|TestWhichJSONNoMatchExits2|TestWhichPipedNoMatchExits2WithEmptyEnvelope|TestRankWhich_SingleTokenLeaf|TestRankWhich_CompositeLeafLosesWhenQueryOmitsCapabilityTokens", "-count=1")
 }

--- a/internal/generator/local_output_which_contract_test.go
+++ b/internal/generator/local_output_which_contract_test.go
@@ -99,8 +99,12 @@ func TestGeneratedLocalReadsAndWhichHonorSharedRuntimeContracts(t *testing.T) {
 		"single-token leaves must keep a positive score when specificity is the only remaining penalty")
 	assert.Contains(t, whichSrc, "func whichIncidentalToken(token string) bool {",
 		"incidental query words must not create a which match")
-	assert.Contains(t, whichSrc, "whichIncidentalToken(qt) && !whichTokensContain(qt, cmdTokens)",
-		"one-character command leaves must still match when the query names them")
+	assert.Contains(t, whichSrc, "whichIncidentalToken(qt) && !whichTokenMatch(qt, leaf)",
+		"filler words credit a command only when they are the whole unsplit leaf")
+	assert.Contains(t, whichSrc, "whichIncidentalToken(qt) && !whichTokenMatch(qt, group)",
+		"filler words credit a group only when they are the whole group name")
+	assert.NotContains(t, whichSrc, "func whichTokensContain(",
+		"hyphen-split sub-tokens must not grant filler command credit")
 
 	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
 	assert.Contains(t, syncSrc, "machineFormat := wantsMachineOutput(flags)")
@@ -366,5 +370,5 @@ func TestResolveLocalUnmatchedEqualityKeyDoesNotEmptyTheList(t *testing.T) {
 func ioDiscard() io.Writer { return io.Discard }
 `), 0o644))
 
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestResolveLocal|TestWhichJSONNoMatchExits2|TestWhichPipedNoMatchExits2WithEmptyEnvelope|TestRankWhich_SingleTokenLeaf|TestRankWhich_CompositeLeafLosesWhenQueryOmitsCapabilityTokens|TestRankWhich_ProseCreditDoesNotDoubleCount|TestRankWhich_IncidentalDescriptionWordDoesNotAdmitEntry|TestRankWhich_OneCharacterCommandLeafMatches", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestResolveLocal|TestWhichJSONNoMatchExits2|TestWhichPipedNoMatchExits2WithEmptyEnvelope|TestRankWhich_SingleTokenLeaf|TestRankWhich_CompositeLeafLosesWhenQueryOmitsCapabilityTokens|TestRankWhich_ProseCreditDoesNotDoubleCount|TestRankWhich_IncidentalDescriptionWordDoesNotAdmitEntry|TestRankWhich_OneCharacterCommandLeafMatches|TestRankWhich_FillerSubtokenDoesNotAdmitHyphenatedLeaf", "-count=1")
 }

--- a/internal/generator/local_output_which_contract_test.go
+++ b/internal/generator/local_output_which_contract_test.go
@@ -99,6 +99,8 @@ func TestGeneratedLocalReadsAndWhichHonorSharedRuntimeContracts(t *testing.T) {
 		"single-token leaves must keep a positive score when specificity is the only remaining penalty")
 	assert.Contains(t, whichSrc, "func whichIncidentalToken(token string) bool {",
 		"incidental query words must not create a which match")
+	assert.Contains(t, whichSrc, "whichIncidentalToken(qt) && !whichTokensContain(qt, cmdTokens)",
+		"one-character command leaves must still match when the query names them")
 
 	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
 	assert.Contains(t, syncSrc, "machineFormat := wantsMachineOutput(flags)")
@@ -364,5 +366,5 @@ func TestResolveLocalUnmatchedEqualityKeyDoesNotEmptyTheList(t *testing.T) {
 func ioDiscard() io.Writer { return io.Discard }
 `), 0o644))
 
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestResolveLocal|TestWhichJSONNoMatchExits2|TestWhichPipedNoMatchExits2WithEmptyEnvelope|TestRankWhich_SingleTokenLeaf|TestRankWhich_CompositeLeafLosesWhenQueryOmitsCapabilityTokens|TestRankWhich_ProseCreditDoesNotDoubleCount|TestRankWhich_IncidentalDescriptionWordDoesNotAdmitEntry", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestResolveLocal|TestWhichJSONNoMatchExits2|TestWhichPipedNoMatchExits2WithEmptyEnvelope|TestRankWhich_SingleTokenLeaf|TestRankWhich_CompositeLeafLosesWhenQueryOmitsCapabilityTokens|TestRankWhich_ProseCreditDoesNotDoubleCount|TestRankWhich_IncidentalDescriptionWordDoesNotAdmitEntry|TestRankWhich_OneCharacterCommandLeafMatches", "-count=1")
 }

--- a/internal/generator/local_output_which_contract_test.go
+++ b/internal/generator/local_output_which_contract_test.go
@@ -95,8 +95,8 @@ func TestGeneratedLocalReadsAndWhichHonorSharedRuntimeContracts(t *testing.T) {
 	assert.Contains(t, whichSrc, `return usageErr(fmt.Errorf("no match for %q;`)
 	assert.Contains(t, whichSrc, `"matches": []whichMatch{}`)
 	assert.NotContains(t, whichSrc, "Under --json, return an empty matches envelope at exit 0")
-	assert.Contains(t, whichSrc, "if len(leafTokens) < 2 {",
-		"single-token leaves must skip the specificity penalty so a description hit is not zeroed")
+	assert.Contains(t, whichSrc, "if len(leafTokens) < 2 && unmatched >= score {",
+		"single-token leaves must keep a positive score when specificity is the only remaining penalty")
 
 	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
 	assert.Contains(t, syncSrc, "machineFormat := wantsMachineOutput(flags)")
@@ -362,5 +362,5 @@ func TestResolveLocalUnmatchedEqualityKeyDoesNotEmptyTheList(t *testing.T) {
 func ioDiscard() io.Writer { return io.Discard }
 `), 0o644))
 
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestResolveLocal|TestWhichJSONNoMatchExits2|TestWhichPipedNoMatchExits2WithEmptyEnvelope|TestRankWhich_SingleTokenLeaf|TestRankWhich_CompositeLeafLosesWhenQueryOmitsCapabilityTokens", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestResolveLocal|TestWhichJSONNoMatchExits2|TestWhichPipedNoMatchExits2WithEmptyEnvelope|TestRankWhich_SingleTokenLeaf|TestRankWhich_CompositeLeafLosesWhenQueryOmitsCapabilityTokens|TestRankWhich_ProseCreditDoesNotDoubleCount", "-count=1")
 }

--- a/internal/generator/templates/which.go.tmpl
+++ b/internal/generator/templates/which.go.tmpl
@@ -117,7 +117,7 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 
 	// Exact token match on the command path (any token).
 	for _, qt := range qTokens {
-		if whichIncidentalToken(qt) {
+		if whichIncidentalToken(qt) && !whichTokensContain(qt, cmdTokens) {
 			continue
 		}
 		for _, ct := range cmdTokens {
@@ -154,7 +154,7 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 	groupTokens := whichSubTokens(group)
 	groupMatched := false
 	for _, qt := range qTokens {
-		if whichIncidentalToken(qt) {
+		if whichIncidentalToken(qt) && !whichTokensContain(qt, groupTokens) {
 			continue
 		}
 		for _, gt := range groupTokens {
@@ -295,10 +295,19 @@ func whichSubTokens(cmd string) []string {
 
 func whichIncidentalToken(token string) bool {
 	token = strings.Trim(strings.ToLower(token), ".,:;!?()[]{}\"'")
-	if token == "" || len(token) < 2 {
+	if token == "" {
 		return true
 	}
 	return whichIncidentalTokens[token]
+}
+
+func whichTokensContain(token string, tokens []string) bool {
+	for _, candidate := range tokens {
+		if whichTokenMatch(token, candidate) {
+			return true
+		}
+	}
+	return false
 }
 
 // The closed API-verb set for write-shaped commands. A request that never
@@ -322,7 +331,7 @@ var whichTokenAliases = map[string]string{
 // aliases (my/mine/me/current) stay significant so authenticated-scoped
 // commands can still outrank generic listings.
 var whichIncidentalTokens = map[string]bool{
-	"a": true, "an": true, "the": true,
+	"a": true, "an": true, "the": true, "i": true,
 	"is": true, "are": true, "was": true, "were": true, "be": true, "been": true, "being": true,
 	"of": true, "to": true, "in": true, "on": true, "at": true, "for": true, "with": true, "from": true, "by": true, "about": true,
 	"what": true, "which": true, "who": true, "whom": true, "whose": true, "how": true, "when": true, "why": true, "where": true,

--- a/internal/generator/templates/which.go.tmpl
+++ b/internal/generator/templates/which.go.tmpl
@@ -204,14 +204,11 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 	// used is a variant, not the canonical answer ("activity-list-repos-
 	// starred-by-authenticated" for a repositories ask). Parent resource tokens
 	// are excluded so a valid nested command is not erased by its path. A
-	// single-token leaf has no variant to disambiguate; penalizing it would
-	// zero a description/path hit for a multi-word query.
+	// single-token leaf has no variant to disambiguate; the penalty may still
+	// down-rank it but must not zero a description/path hit by itself.
 	if score > 0 && len(qTokens) > 1 {
 		commandParts := strings.Fields(cmd)
 		leafTokens := whichSubTokens(commandParts[len(commandParts)-1])
-		if len(leafTokens) < 2 {
-			return score
-		}
 		unmatched := 0
 		for _, ct := range leafTokens {
 			hit := false
@@ -227,6 +224,9 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 		}
 		if unmatched > 3 {
 			unmatched = 3
+		}
+		if len(leafTokens) < 2 && unmatched >= score {
+			unmatched = score - 1
 		}
 		score -= unmatched
 	}

--- a/internal/generator/templates/which.go.tmpl
+++ b/internal/generator/templates/which.go.tmpl
@@ -117,6 +117,9 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 
 	// Exact token match on the command path (any token).
 	for _, qt := range qTokens {
+		if whichIncidentalToken(qt) {
+			continue
+		}
 		for _, ct := range cmdTokens {
 			if whichTokenMatch(qt, ct) {
 				score += 3
@@ -151,6 +154,9 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 	groupTokens := whichSubTokens(group)
 	groupMatched := false
 	for _, qt := range qTokens {
+		if whichIncidentalToken(qt) {
+			continue
+		}
 		for _, gt := range groupTokens {
 			if whichTokenMatch(qt, gt) {
 				score += 1
@@ -237,6 +243,9 @@ func whichFieldCredit(qTokens, fieldTokens []string) int {
 	credit := 0
 	matched := make(map[string]struct{})
 	for _, qt := range qTokens {
+		if whichIncidentalToken(qt) {
+			continue
+		}
 		for _, ft := range fieldTokens {
 			if whichTokenMatch(qt, ft) {
 				key := whichTokenKey(ft)
@@ -284,6 +293,14 @@ func whichSubTokens(cmd string) []string {
 	})
 }
 
+func whichIncidentalToken(token string) bool {
+	token = strings.Trim(strings.ToLower(token), ".,:;!?()[]{}\"'")
+	if token == "" || len(token) < 2 {
+		return true
+	}
+	return whichIncidentalTokens[token]
+}
+
 // The closed API-verb set for write-shaped commands. A request that never
 // asked for a write must not tie-break into a destructive command.
 var whichWriteVerbs = map[string]bool{
@@ -299,6 +316,20 @@ var whichWriteVerbs = map[string]bool{
 
 var whichTokenAliases = map[string]string{
 	"repo": "repository", "repos": "repository", "repository": "repository", "repositories": "repository",
+}
+
+// Filler words that must not create a which match by themselves. Possessive
+// aliases (my/mine/me/current) stay significant so authenticated-scoped
+// commands can still outrank generic listings.
+var whichIncidentalTokens = map[string]bool{
+	"a": true, "an": true, "the": true,
+	"is": true, "are": true, "was": true, "were": true, "be": true, "been": true, "being": true,
+	"of": true, "to": true, "in": true, "on": true, "at": true, "for": true, "with": true, "from": true, "by": true, "about": true,
+	"what": true, "which": true, "who": true, "whom": true, "whose": true, "how": true, "when": true, "why": true, "where": true,
+	"will": true, "would": true, "could": true, "should": true, "may": true, "might": true, "can": true, "shall": true,
+	"do": true, "does": true, "did": true, "have": true, "has": true, "had": true,
+	"and": true, "or": true, "but": true, "if": true, "then": true, "than": true,
+	"this": true, "that": true, "these": true, "those": true, "it": true, "its": true,
 }
 
 func whichSingular(s string) string {

--- a/internal/generator/templates/which.go.tmpl
+++ b/internal/generator/templates/which.go.tmpl
@@ -109,15 +109,22 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 	// matchable by the words a human asks with, or every command in a group
 	// ties on the group token alone and index order decides the answer.
 	cmdTokens := whichSubTokens(cmd)
+	commandParts := strings.Fields(cmd)
+	leaf := ""
+	if len(commandParts) > 0 {
+		leaf = commandParts[len(commandParts)-1]
+	}
 	desc := strings.ToLower(e.Description)
 	descTokens := whichSubTokens(desc)
 	why := strings.ToLower(e.WhyItMatters)
 	whyTokens := whichSubTokens(why)
 	group := strings.ToLower(e.Group)
 
-	// Exact token match on the command path (any token).
+	// Exact token match on the command path (any token). Filler words
+	// credit a command only when they are the whole unsplit leaf
+	// ("run a" → "a"), not a hyphenated sub-token ("in" vs "check-in").
 	for _, qt := range qTokens {
-		if whichIncidentalToken(qt) && !whichTokensContain(qt, cmdTokens) {
+		if whichIncidentalToken(qt) && !whichTokenMatch(qt, leaf) {
 			continue
 		}
 		for _, ct := range cmdTokens {
@@ -128,8 +135,12 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 		}
 	}
 	// Substring match on the full command (covers hyphenated leaves).
+	// An incidental-only query must still name the whole command or leaf
+	// so "in" does not admit "check-in" via the trailing fragment.
 	if strings.Contains(cmd, query) {
-		score += 2
+		if !whichAllIncidental(qTokens) || whichTokenMatch(query, leaf) || whichTokenMatch(query, cmd) {
+			score += 2
+		}
 	}
 	// Description and rationale are correlated prose fields. Share the existing
 	// per-token cap so repeating the same query in both fields cannot outweigh
@@ -151,10 +162,11 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 		score += descCredit
 	}
 	// Group tag match requires a whole token, not an arbitrary substring.
+	// Filler words credit a group only when they are the whole group name.
 	groupTokens := whichSubTokens(group)
 	groupMatched := false
 	for _, qt := range qTokens {
-		if whichIncidentalToken(qt) && !whichTokensContain(qt, groupTokens) {
+		if whichIncidentalToken(qt) && !whichTokenMatch(qt, group) {
 			continue
 		}
 		for _, gt := range groupTokens {
@@ -213,8 +225,7 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 	// single-token leaf has no variant to disambiguate; the penalty may still
 	// down-rank it but must not zero a description/path hit by itself.
 	if score > 0 && len(qTokens) > 1 {
-		commandParts := strings.Fields(cmd)
-		leafTokens := whichSubTokens(commandParts[len(commandParts)-1])
+		leafTokens := whichSubTokens(leaf)
 		unmatched := 0
 		for _, ct := range leafTokens {
 			hit := false
@@ -301,13 +312,16 @@ func whichIncidentalToken(token string) bool {
 	return whichIncidentalTokens[token]
 }
 
-func whichTokensContain(token string, tokens []string) bool {
-	for _, candidate := range tokens {
-		if whichTokenMatch(token, candidate) {
-			return true
+func whichAllIncidental(qTokens []string) bool {
+	if len(qTokens) == 0 {
+		return false
+	}
+	for _, qt := range qTokens {
+		if !whichIncidentalToken(qt) {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 // The closed API-verb set for write-shaped commands. A request that never

--- a/internal/generator/templates/which.go.tmpl
+++ b/internal/generator/templates/which.go.tmpl
@@ -203,11 +203,16 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 	// Specificity: a command leaf carrying capability sub-tokens the request never
 	// used is a variant, not the canonical answer ("activity-list-repos-
 	// starred-by-authenticated" for a repositories ask). Parent resource tokens
-	// are excluded so a valid nested command is not erased by its path.
+	// are excluded so a valid nested command is not erased by its path. A
+	// single-token leaf has no variant to disambiguate; penalizing it would
+	// zero a description/path hit for a multi-word query.
 	if score > 0 && len(qTokens) > 1 {
-		unmatched := 0
 		commandParts := strings.Fields(cmd)
 		leafTokens := whichSubTokens(commandParts[len(commandParts)-1])
+		if len(leafTokens) < 2 {
+			return score
+		}
+		unmatched := 0
 		for _, ct := range leafTokens {
 			hit := false
 			for _, qt := range qTokens {

--- a/internal/generator/templates/which_test.go.tmpl
+++ b/internal/generator/templates/which_test.go.tmpl
@@ -139,6 +139,32 @@ func TestRankWhich_OneCharacterCommandLeafMatches(t *testing.T) {
 	if len(got) != 0 {
 		t.Fatalf("incidental filler must not admit a match, got %+v", got)
 	}
+	fillerLeaf := make([]whichEntry, 0, 2)
+	fillerLeaf = append(fillerLeaf, whichEntry{Command: "a", Description: "Run the a capability"})
+	fillerLeaf = append(fillerLeaf, whichEntry{Command: "stale", Description: "Find tickets that have not moved in a while"})
+	got = rankWhich(fillerLeaf, "run a", 3)
+	if len(got) == 0 || got[0].Entry.Command != "a" || got[0].Score <= 0 {
+		t.Fatalf("one-character filler leaf must match when the query names it, got %+v", got)
+	}
+}
+
+func TestRankWhich_FillerSubtokenDoesNotAdmitHyphenatedLeaf(t *testing.T) {
+	index := []whichEntry{
+		{Command: "check-in", Description: "Mark who showed up today"},
+		{Command: "sort-by", Description: "Order result rows"},
+		{Command: "to-do", Description: "List leftover tasks"},
+	}
+	queries := []string{"stay in", "sorted by date", "go to", "in", "teleport a rhinoceros"}
+	for _, query := range queries {
+		got := rankWhich(index, query, 3)
+		if len(got) != 0 {
+			t.Fatalf("filler-as-subtoken query %q must not admit a hyphenated leaf, got %+v", query, got)
+		}
+	}
+	got := rankWhich(index, "check-in", 3)
+	if len(got) == 0 || got[0].Entry.Command != "check-in" || got[0].Score <= 0 {
+		t.Fatalf("naming the hyphenated leaf itself must still match, got %+v", got)
+	}
 }
 
 func TestRankWhich_WhyItMattersCreditDeduplicatesEquivalentTokens(t *testing.T) {

--- a/internal/generator/templates/which_test.go.tmpl
+++ b/internal/generator/templates/which_test.go.tmpl
@@ -254,7 +254,7 @@ func TestWhichJSONNoMatchExits2(t *testing.T) {
 	cmd := newWhichCmd(flags)
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
-	cmd.SetArgs([]string{"teleport a rhinoceros"})
+	cmd.SetArgs([]string{"teleport rhinoceros xyzzy"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected no-match to return a typed error")
@@ -282,7 +282,7 @@ func TestWhichPipedNoMatchExits2WithEmptyEnvelope(t *testing.T) {
 	cmd := newWhichCmd(flags)
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&bytes.Buffer{})
-	cmd.SetArgs([]string{"teleport a rhinoceros"})
+	cmd.SetArgs([]string{"teleport rhinoceros xyzzy"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected no-match to return a typed error")

--- a/internal/generator/templates/which_test.go.tmpl
+++ b/internal/generator/templates/which_test.go.tmpl
@@ -120,6 +120,13 @@ func TestRankWhich_IncidentalWhyItMattersTokenDoesNotAdmitEntry(t *testing.T) {
 	}
 }
 
+func TestRankWhich_IncidentalDescriptionWordDoesNotAdmitEntry(t *testing.T) {
+	got := rankWhich(whichTestIndex, "teleport a rhinoceros", 3)
+	if len(got) != 0 {
+		t.Fatalf("incidental description word must not become a which match, got %+v", got)
+	}
+}
+
 func TestRankWhich_WhyItMattersCreditDeduplicatesEquivalentTokens(t *testing.T) {
 	index := []whichEntry{
 		{Command: "risk", WhyItMatters: "Use this to coordinate repositories"},
@@ -254,7 +261,7 @@ func TestWhichJSONNoMatchExits2(t *testing.T) {
 	cmd := newWhichCmd(flags)
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
-	cmd.SetArgs([]string{"teleport rhinoceros xyzzy"})
+	cmd.SetArgs([]string{"teleport a rhinoceros"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected no-match to return a typed error")
@@ -282,7 +289,7 @@ func TestWhichPipedNoMatchExits2WithEmptyEnvelope(t *testing.T) {
 	cmd := newWhichCmd(flags)
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&bytes.Buffer{})
-	cmd.SetArgs([]string{"teleport rhinoceros xyzzy"})
+	cmd.SetArgs([]string{"teleport a rhinoceros"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected no-match to return a typed error")

--- a/internal/generator/templates/which_test.go.tmpl
+++ b/internal/generator/templates/which_test.go.tmpl
@@ -197,6 +197,43 @@ func TestRankWhich_NestedResourceMatchSurvivesSpecificity(t *testing.T) {
 	}
 }
 
+func TestRankWhich_SingleTokenLeafSurvivesMultiWordQuery(t *testing.T) {
+	index := make([]whichEntry, 0, 1)
+	index = append(index, whichEntry{Command: "product", Description: "Look up items by ean and gtin"})
+	got := rankWhich(index, "ean gtin", 3)
+	if len(got) != 1 || got[0].Entry.Command != "product" || got[0].Score <= 0 {
+		t.Fatalf("single-token leaf matched via description must survive a multi-word query, got %+v", got)
+	}
+}
+
+func TestRankWhich_SingleTokenLeafDescriptionHitIsNotZeroed(t *testing.T) {
+	index := make([]whichEntry, 0, 1)
+	index = append(index, whichEntry{Command: "product", Description: "Look up items by ean"})
+	got := rankWhich(index, "ean gtin", 3)
+	if len(got) != 1 || got[0].Entry.Command != "product" || got[0].Score <= 0 {
+		t.Fatalf("specificity must not erase a single-token leaf on a one-point description hit, got %+v", got)
+	}
+}
+
+func TestRankWhich_CompositeLeafLosesWhenQueryOmitsCapabilityTokens(t *testing.T) {
+	index := make([]whichEntry, 0, 2)
+	index = append(index, whichEntry{
+		Command:     "activity list-repos-starred-by-authenticated",
+		Description: "List repositories starred by the authenticated user",
+	})
+	index = append(index, whichEntry{Command: "repos list", Description: "List repositories"})
+	got := rankWhich(index, "list repositories", 3)
+	if len(got) < 2 {
+		t.Fatalf("expected both the canonical command and the variant to remain matches, got %+v", got)
+	}
+	if got[0].Entry.Command != "repos list" {
+		t.Fatalf("canonical command should beat a long variant the query did not ask for, got %+v", got)
+	}
+	if got[0].Score <= got[1].Score {
+		t.Fatalf("specificity should down-rank the omitted-capability variant, got %+v", got)
+	}
+}
+
 func TestRankWhich_WriteSynonymsAreNotPenalized(t *testing.T) {
 	index := make([]whichEntry, 0, 2)
 	index = append(index, whichEntry{Command: "projects list", Description: "List projects"})

--- a/internal/generator/templates/which_test.go.tmpl
+++ b/internal/generator/templates/which_test.go.tmpl
@@ -127,6 +127,20 @@ func TestRankWhich_IncidentalDescriptionWordDoesNotAdmitEntry(t *testing.T) {
 	}
 }
 
+func TestRankWhich_OneCharacterCommandLeafMatches(t *testing.T) {
+	index := make([]whichEntry, 0, 2)
+	index = append(index, whichEntry{Command: "x", Description: "Run the x capability"})
+	index = append(index, whichEntry{Command: "stale", Description: "Find tickets that have not moved in a while"})
+	got := rankWhich(index, "run x", 3)
+	if len(got) == 0 || got[0].Entry.Command != "x" || got[0].Score <= 0 {
+		t.Fatalf("one-character command leaf must match when the query names it, got %+v", got)
+	}
+	got = rankWhich(index, "teleport a rhinoceros", 3)
+	if len(got) != 0 {
+		t.Fatalf("incidental filler must not admit a match, got %+v", got)
+	}
+}
+
 func TestRankWhich_WhyItMattersCreditDeduplicatesEquivalentTokens(t *testing.T) {
 	index := []whichEntry{
 		{Command: "risk", WhyItMatters: "Use this to coordinate repositories"},

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
@@ -199,11 +199,13 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 	// Specificity: a command leaf carrying capability sub-tokens the request never
 	// used is a variant, not the canonical answer ("activity-list-repos-
 	// starred-by-authenticated" for a repositories ask). Parent resource tokens
-	// are excluded so a valid nested command is not erased by its path.
+	// are excluded so a valid nested command is not erased by its path. A
+	// single-token leaf has no variant to disambiguate; the penalty may still
+	// down-rank it but must not zero a description/path hit by itself.
 	if score > 0 && len(qTokens) > 1 {
-		unmatched := 0
 		commandParts := strings.Fields(cmd)
 		leafTokens := whichSubTokens(commandParts[len(commandParts)-1])
+		unmatched := 0
 		for _, ct := range leafTokens {
 			hit := false
 			for _, qt := range qTokens {
@@ -218,6 +220,9 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 		}
 		if unmatched > 3 {
 			unmatched = 3
+		}
+		if len(leafTokens) < 2 && unmatched >= score {
+			unmatched = score - 1
 		}
 		score -= unmatched
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
@@ -105,15 +105,22 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 	// matchable by the words a human asks with, or every command in a group
 	// ties on the group token alone and index order decides the answer.
 	cmdTokens := whichSubTokens(cmd)
+	commandParts := strings.Fields(cmd)
+	leaf := ""
+	if len(commandParts) > 0 {
+		leaf = commandParts[len(commandParts)-1]
+	}
 	desc := strings.ToLower(e.Description)
 	descTokens := whichSubTokens(desc)
 	why := strings.ToLower(e.WhyItMatters)
 	whyTokens := whichSubTokens(why)
 	group := strings.ToLower(e.Group)
 
-	// Exact token match on the command path (any token).
+	// Exact token match on the command path (any token). Filler words
+	// credit a command only when they are the whole unsplit leaf
+	// ("run a" → "a"), not a hyphenated sub-token ("in" vs "check-in").
 	for _, qt := range qTokens {
-		if whichIncidentalToken(qt) && !whichTokensContain(qt, cmdTokens) {
+		if whichIncidentalToken(qt) && !whichTokenMatch(qt, leaf) {
 			continue
 		}
 		for _, ct := range cmdTokens {
@@ -124,8 +131,12 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 		}
 	}
 	// Substring match on the full command (covers hyphenated leaves).
+	// An incidental-only query must still name the whole command or leaf
+	// so "in" does not admit "check-in" via the trailing fragment.
 	if strings.Contains(cmd, query) {
-		score += 2
+		if !whichAllIncidental(qTokens) || whichTokenMatch(query, leaf) || whichTokenMatch(query, cmd) {
+			score += 2
+		}
 	}
 	// Description and rationale are correlated prose fields. Share the existing
 	// per-token cap so repeating the same query in both fields cannot outweigh
@@ -147,10 +158,11 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 		score += descCredit
 	}
 	// Group tag match requires a whole token, not an arbitrary substring.
+	// Filler words credit a group only when they are the whole group name.
 	groupTokens := whichSubTokens(group)
 	groupMatched := false
 	for _, qt := range qTokens {
-		if whichIncidentalToken(qt) && !whichTokensContain(qt, groupTokens) {
+		if whichIncidentalToken(qt) && !whichTokenMatch(qt, group) {
 			continue
 		}
 		for _, gt := range groupTokens {
@@ -209,8 +221,7 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 	// single-token leaf has no variant to disambiguate; the penalty may still
 	// down-rank it but must not zero a description/path hit by itself.
 	if score > 0 && len(qTokens) > 1 {
-		commandParts := strings.Fields(cmd)
-		leafTokens := whichSubTokens(commandParts[len(commandParts)-1])
+		leafTokens := whichSubTokens(leaf)
 		unmatched := 0
 		for _, ct := range leafTokens {
 			hit := false
@@ -297,13 +308,16 @@ func whichIncidentalToken(token string) bool {
 	return whichIncidentalTokens[token]
 }
 
-func whichTokensContain(token string, tokens []string) bool {
-	for _, candidate := range tokens {
-		if whichTokenMatch(token, candidate) {
-			return true
+func whichAllIncidental(qTokens []string) bool {
+	if len(qTokens) == 0 {
+		return false
+	}
+	for _, qt := range qTokens {
+		if !whichIncidentalToken(qt) {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 // The closed API-verb set for write-shaped commands. A request that never

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
@@ -113,6 +113,9 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 
 	// Exact token match on the command path (any token).
 	for _, qt := range qTokens {
+		if whichIncidentalToken(qt) {
+			continue
+		}
 		for _, ct := range cmdTokens {
 			if whichTokenMatch(qt, ct) {
 				score += 3
@@ -147,6 +150,9 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 	groupTokens := whichSubTokens(group)
 	groupMatched := false
 	for _, qt := range qTokens {
+		if whichIncidentalToken(qt) {
+			continue
+		}
 		for _, gt := range groupTokens {
 			if whichTokenMatch(qt, gt) {
 				score += 1
@@ -233,6 +239,9 @@ func whichFieldCredit(qTokens, fieldTokens []string) int {
 	credit := 0
 	matched := make(map[string]struct{})
 	for _, qt := range qTokens {
+		if whichIncidentalToken(qt) {
+			continue
+		}
 		for _, ft := range fieldTokens {
 			if whichTokenMatch(qt, ft) {
 				key := whichTokenKey(ft)
@@ -280,6 +289,14 @@ func whichSubTokens(cmd string) []string {
 	})
 }
 
+func whichIncidentalToken(token string) bool {
+	token = strings.Trim(strings.ToLower(token), ".,:;!?()[]{}\"'")
+	if token == "" || len(token) < 2 {
+		return true
+	}
+	return whichIncidentalTokens[token]
+}
+
 // The closed API-verb set for write-shaped commands. A request that never
 // asked for a write must not tie-break into a destructive command.
 var whichWriteVerbs = map[string]bool{
@@ -295,6 +312,20 @@ var whichWriteVerbs = map[string]bool{
 
 var whichTokenAliases = map[string]string{
 	"repo": "repository", "repos": "repository", "repository": "repository", "repositories": "repository",
+}
+
+// Filler words that must not create a which match by themselves. Possessive
+// aliases (my/mine/me/current) stay significant so authenticated-scoped
+// commands can still outrank generic listings.
+var whichIncidentalTokens = map[string]bool{
+	"a": true, "an": true, "the": true,
+	"is": true, "are": true, "was": true, "were": true, "be": true, "been": true, "being": true,
+	"of": true, "to": true, "in": true, "on": true, "at": true, "for": true, "with": true, "from": true, "by": true, "about": true,
+	"what": true, "which": true, "who": true, "whom": true, "whose": true, "how": true, "when": true, "why": true, "where": true,
+	"will": true, "would": true, "could": true, "should": true, "may": true, "might": true, "can": true, "shall": true,
+	"do": true, "does": true, "did": true, "have": true, "has": true, "had": true,
+	"and": true, "or": true, "but": true, "if": true, "then": true, "than": true,
+	"this": true, "that": true, "these": true, "those": true, "it": true, "its": true,
 }
 
 func whichSingular(s string) string {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
@@ -113,7 +113,7 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 
 	// Exact token match on the command path (any token).
 	for _, qt := range qTokens {
-		if whichIncidentalToken(qt) {
+		if whichIncidentalToken(qt) && !whichTokensContain(qt, cmdTokens) {
 			continue
 		}
 		for _, ct := range cmdTokens {
@@ -150,7 +150,7 @@ func whichScoreEntry(e whichEntry, query string, qTokens []string) int {
 	groupTokens := whichSubTokens(group)
 	groupMatched := false
 	for _, qt := range qTokens {
-		if whichIncidentalToken(qt) {
+		if whichIncidentalToken(qt) && !whichTokensContain(qt, groupTokens) {
 			continue
 		}
 		for _, gt := range groupTokens {
@@ -291,10 +291,19 @@ func whichSubTokens(cmd string) []string {
 
 func whichIncidentalToken(token string) bool {
 	token = strings.Trim(strings.ToLower(token), ".,:;!?()[]{}\"'")
-	if token == "" || len(token) < 2 {
+	if token == "" {
 		return true
 	}
 	return whichIncidentalTokens[token]
+}
+
+func whichTokensContain(token string, tokens []string) bool {
+	for _, candidate := range tokens {
+		if whichTokenMatch(token, candidate) {
+			return true
+		}
+	}
+	return false
 }
 
 // The closed API-verb set for write-shaped commands. A request that never
@@ -318,7 +327,7 @@ var whichTokenAliases = map[string]string{
 // aliases (my/mine/me/current) stay significant so authenticated-scoped
 // commands can still outrank generic listings.
 var whichIncidentalTokens = map[string]bool{
-	"a": true, "an": true, "the": true,
+	"a": true, "an": true, "the": true, "i": true,
 	"is": true, "are": true, "was": true, "were": true, "be": true, "been": true, "being": true,
 	"of": true, "to": true, "in": true, "on": true, "at": true, "for": true, "with": true, "from": true, "by": true, "about": true,
 	"what": true, "which": true, "who": true, "whom": true, "whose": true, "how": true, "when": true, "why": true, "where": true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Generated `which` ranking subtracted unmatched command-leaf sub-tokens from the score. That is the right down-rank for composite/variant leaves (`activity-list-repos-starred-by-authenticated` vs a plain repositories ask). It also fired when the leaf was a **single** token, where there is no variant to disambiguate.

Combined with dropping `score == 0` matches, a correct single-token command that matched via description or path disappeared for multi-word natural-language queries — the input `which` exists to serve.

Closes #3988

## Approach

Keep the specificity subtraction for ranking, including single-token leaves, so a prose-only hit still loses to a real command match. When the leaf has fewer than two sub-tokens, floor the penalty so it cannot be the only thing that takes a positive score to zero. Skip incidental query tokens (articles, copulas, prepositions, other closed filler words) when scoring description hits so filler words such as "a" cannot become matches.

Filler words credit a **command** only when they are the whole unsplit leaf (`run a` → `a`, `run x` → `x`). They do not credit hyphenated or multi-token sub-tokens, so query word "in" / "by" / "to" does not admit `check-in`, `sort-by`, or `to-do`. The same whole-name rule applies to group tags. Composite leaves still lose points for capability tokens the query never used. Empty-query listing and the non-empty zero-score filter are unchanged.

## Scope

Primary area: generated `which` ranker (`internal/generator/templates/which.go.tmpl`)

Why this belongs in this repo: every printed CLI inherits this ranker. The symptom showed up on a catalogue CLI with single-word resource commands; the generator should not erase those matches.

## Risk

Composite/variant leaves still take the full penalty, so a long unused variant should keep losing to the canonical command. Single-token leaves that previously fell to score 0 from this penalty alone will now stay at 1 when the hit is a real capability word. Incidental description words no longer admit an entry. One-character command names remain matchable. Filler-as-subtoken overlap no longer admits hyphenated leaves. Golden `which.go` for `generate-golden-api` tracks the emitted floor, incidental-token filter, and whole-leaf exception.

## Output Contract

Emitted `whichScoreEntry` floors unmatched tokens when `len(leafTokens) < 2 && unmatched >= score`, skips incidental query tokens in description scoring, and scores a filler token only when it exactly names the unsplit command leaf or group. Evidence:

- Generated ranking tests in `which_test.go.tmpl` (single-token leaf + multi-word query; one-point description hit not erased; incidental "a" does not match; one-character leaf `x` matches `run x`; filler leaf `a` matches `run a`; `in`/`by`/`to` do not admit `check-in`/`sort-by`/`to-do`; composite variant still down-ranked)
- Emitted-code assertion plus compiled generated CLI run in `TestGeneratedLocalReadsAndWhichHonorSharedRuntimeContracts`
- Golden fixture `generate-golden-api` `internal/cli/which.go`

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands actually run:

- `go test ./internal/generator -run TestGeneratedLocalReadsAndWhichHonorSharedRuntimeContracts -count=1` (pass)
- `go test ./internal/generator -timeout 30m` (pass)
- `GOTOOLCHAIN=go1.26.6 bash scripts/golden.sh verify` (39 cases pass)
- `GOTOOLCHAIN=go1.26.6 bash scripts/verify-generator-output.sh` (13 cases pass)

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da5df1b1-037e-40cb-b3af-c41b83e40360?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da5df1b1-037e-40cb-b3af-c41b83e40360&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

