### PR TITLE
fix(cli): kebab-case auto-synthesized command examples

### DIFF
--- a/internal/generator/first_command_example_test.go
+++ b/internal/generator/first_command_example_test.go
@@ -507,6 +507,18 @@ func TestFirstCommandExampleHonorsPromotion(t *testing.T) {
 			},
 			want: "purchase-orders list",
 		},
+		{
+			name: "snake_case resource key is kebab-cased (non-promoted)",
+			resources: map[string]spec.Resource{
+				"time_entries": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {Method: "GET", Path: "/time_entries"},
+						"get":  {Method: "GET", Path: "/time_entries/{id}"},
+					},
+				},
+			},
+			want: "time-entries list",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3993,6 +3993,7 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 		resource := withoutOptionsEndpoints(originalResource)
 		// Skip parent file for promoted resources — the promoted command replaces it.
 		// Sub-resource parents and endpoint files are still needed (wired by the promoted command).
+		resourceCommand := toKebab(name)
 		if !promotedResourceNames[name] {
 			// Parent file: wires subcommands together
 			parentData := struct {
@@ -4008,10 +4009,10 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 			}{
 				ResourceName:  name,
 				FuncPrefix:    name,
-				CommandPath:   name,
+				CommandPath:   resourceCommand,
 				Short:         parentCommandShort(name, "", resource, apiDescriptionShort),
 				Resource:      resource,
-				NovelChildren: novelChildrenByParent[toKebab(name)],
+				NovelChildren: novelChildrenByParent[resourceCommand],
 				APIResource:   true,
 				APISpec:       g.Spec,
 			}
@@ -4036,7 +4037,7 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 				EffectivePath: effectiveEndpointPath(resource, endpoint),
 				EffectiveTier: g.Spec.EffectiveTier(resource, endpoint),
 				FuncPrefix:    name,
-				CommandPath:   name,
+				CommandPath:   resourceCommand,
 				EndpointName:  eName,
 				Endpoint:      endpoint,
 				Resource:      resource,
@@ -9146,17 +9147,26 @@ func exampleNeedsTODO(line string) bool {
 	return strings.Contains(line, "example-value")
 }
 
+func kebabCommandParts(commandPath string) []string {
+	fields := strings.Fields(commandPath)
+	for i, field := range fields {
+		fields[i] = toKebab(field)
+	}
+	return fields
+}
+
 func (g *Generator) exampleLine(commandPath, endpointName string, endpoint spec.Endpoint) string {
 	if strings.TrimSpace(endpoint.Example) != "" {
 		return endpoint.Example
 	}
 
-	commandParts := append(strings.Fields(commandPath), toKebab(endpointName))
+	// Spec resource keys are snake_case; Cobra registers kebab Use: paths.
+	commandParts := append(kebabCommandParts(commandPath), toKebab(endpointName))
 	if line, ok := g.narrativeExampleLine(commandParts, endpoint); ok {
 		return line
 	}
 	if endpoint.Alias != "" {
-		aliasParts := append(strings.Fields(commandPath), endpoint.Alias)
+		aliasParts := append(kebabCommandParts(commandPath), endpoint.Alias)
 		if line, ok := g.narrativeExampleLine(aliasParts, endpoint); ok {
 			return line
 		}
@@ -9175,6 +9185,7 @@ func (g *Generator) promotedExampleLine(promotedName string, endpoint spec.Endpo
 		return endpoint.Example
 	}
 
+	promotedName = toKebab(promotedName)
 	if line, ok := g.narrativeExampleLine([]string{promotedName}, endpoint); ok {
 		return line
 	}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -9848,6 +9848,8 @@ func TestGeneratedCommandExampleKebabCasesSnakeResource(t *testing.T) {
 	promoted := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_my-account.go")
 	assert.Contains(t, promoted, `Example:     "  snake-example-pp-cli my-account"`)
 	assert.NotContains(t, promoted, "snake-example-pp-cli my_account")
+
+	requireGeneratedCompiles(t, outputDir)
 }
 
 func TestGeneratedCommandExampleKeepsDispatchParamDefault(t *testing.T) {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -9837,7 +9837,7 @@ func TestGeneratedCommandExampleKebabCasesSnakeResource(t *testing.T) {
 	assert.NotContains(t, timeEntries, "time_entries list")
 
 	parent := readGeneratedFile(t, outputDir, "internal", "cli", "time_entries.go")
-	assert.Contains(t, parent, `Use:   "time-entries"`)
+	assert.Regexp(t, `Use:\s+"time-entries"`, parent)
 
 	items := readGeneratedFile(t, outputDir, "internal", "cli", "items_list.go")
 	assert.Contains(t, items, `Example:     "  snake-example-pp-cli items list"`)
@@ -9847,7 +9847,7 @@ func TestGeneratedCommandExampleKebabCasesSnakeResource(t *testing.T) {
 
 	promoted := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_my-account.go")
 	assert.Contains(t, promoted, `Example:     "  snake-example-pp-cli my-account"`)
-	assert.NotContains(t, promoted, "my_account")
+	assert.NotContains(t, promoted, "snake-example-pp-cli my_account")
 
 	requireGeneratedCompiles(t, outputDir)
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -9736,6 +9736,122 @@ func TestExampleLineUsesRenderedCommandAndFlagNames(t *testing.T) {
 	assert.NotContains(t, got, "--idempotencyKey")
 }
 
+func TestExampleLineKebabCasesSnakeResourcePath(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("example-kebab")
+	g := New(apiSpec, t.TempDir())
+
+	got := g.exampleLine("time_entries", "list", spec.Endpoint{
+		Method:      "GET",
+		Path:        "/time_entries",
+		Description: "List time entries",
+	})
+	assert.Equal(t, "  example-kebab-pp-cli time-entries list", got)
+
+	got = g.exampleLine("items", "list", spec.Endpoint{
+		Method: "GET",
+		Path:   "/items",
+	})
+	assert.Equal(t, "  example-kebab-pp-cli items list", got)
+
+	got = g.exampleLine("issue_categories", "list", spec.Endpoint{
+		Method:  "GET",
+		Path:    "/issue_categories",
+		Example: "  example-kebab-pp-cli issue_categories list --from-spec",
+	})
+	assert.Equal(t, "  example-kebab-pp-cli issue_categories list --from-spec", got)
+}
+
+func TestGeneratedCommandExampleKebabCasesSnakeResource(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("snake-example")
+	apiSpec.Resources = map[string]spec.Resource{
+		"time_entries": {
+			Description: "Time entries",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/time_entries",
+					Description: "List time entries",
+				},
+				"get": {
+					Method:      "GET",
+					Path:        "/time_entries/{id}",
+					Description: "Get a time entry",
+					Params:      []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true}},
+				},
+			},
+		},
+		"items": {
+			Description: "Items",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/items",
+					Description: "List items",
+				},
+				"get": {
+					Method:      "GET",
+					Path:        "/items/{id}",
+					Description: "Get an item",
+					Params:      []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true}},
+				},
+			},
+		},
+		"issue_categories": {
+			Description: "Issue categories",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/issue_categories",
+					Description: "List issue categories",
+					Example:     "  snake-example-pp-cli issue_categories list --from-spec",
+				},
+				"get": {
+					Method:      "GET",
+					Path:        "/issue_categories/{id}",
+					Description: "Get an issue category",
+					Params:      []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true}},
+				},
+			},
+		},
+		"my_account": {
+			Description: "Current account",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/my_account",
+					Description: "Get current account",
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	timeEntries := readGeneratedFile(t, outputDir, "internal", "cli", "time_entries_list.go")
+	assert.Contains(t, timeEntries, `Example:     "  snake-example-pp-cli time-entries list"`)
+	assert.NotContains(t, timeEntries, "time_entries list")
+
+	parent := readGeneratedFile(t, outputDir, "internal", "cli", "time_entries.go")
+	assert.Contains(t, parent, `Use:   "time-entries"`)
+
+	items := readGeneratedFile(t, outputDir, "internal", "cli", "items_list.go")
+	assert.Contains(t, items, `Example:     "  snake-example-pp-cli items list"`)
+
+	overridden := readGeneratedFile(t, outputDir, "internal", "cli", "issue_categories_list.go")
+	assert.Contains(t, overridden, `Example:     "  snake-example-pp-cli issue_categories list --from-spec"`)
+
+	promoted := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_my-account.go")
+	assert.Contains(t, promoted, `Example:     "  snake-example-pp-cli my-account"`)
+	assert.NotContains(t, promoted, "my_account")
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
 func TestGeneratedCommandExampleKeepsDispatchParamDefault(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -9848,8 +9848,6 @@ func TestGeneratedCommandExampleKebabCasesSnakeResource(t *testing.T) {
 	promoted := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_my-account.go")
 	assert.Contains(t, promoted, `Example:     "  snake-example-pp-cli my-account"`)
 	assert.NotContains(t, promoted, "snake-example-pp-cli my_account")
-
-	requireGeneratedCompiles(t, outputDir)
 }
 
 func TestGeneratedCommandExampleKeepsDispatchParamDefault(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Live dogfood invokes printed Cobra `Example:` text. For snake_case resources (`time_entries`, `issue_categories`, `my_account`), that text used the raw spec key (`time_entries list`) while Cobra registered kebab-case (`time-entries list`), so the happy path failed with "unknown command".

Closes #4237

## Approach

Auto-synthesized example paths now kebab each command-path segment the same way `Use:` already does. Spec-authored `example:` overrides still win unchanged. Single-token resource names stay the same.

## Scope

Primary area: generator example synthesis (`exampleLine` / resource `CommandPath`)

Why this belongs in this repo: the printed CLI was advertising an unrunnable path because the generator used the spec map key instead of the kebab command name.

## Risk

Generated `Example:` strings for multi-word snake_case resources change to kebab-case. Specs that already set `example:` are unaffected. Existing generate-* goldens do not exercise this resource-name shape and stayed byte-identical.

## Output Contract

Generated Cobra `Example:` for a resource named `foo_bar` uses `foo-bar`, matching its `Use:` string. Covered by:

- unit assertion on `exampleLine("time_entries", "list", …)`
- generated-output test that prints a CLI with snake_case, single-token, promoted, and spec-authored-override resources, asserts the emitted `Example:` strings, and compiles via `requireGeneratedCompiles`
- `scripts/verify-generator-output.sh` (13 default cases compiled)

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:

- `go test ./internal/generator -run 'TestGeneratedCommandExampleKebabCasesSnakeResource' -count=1` — pass (includes `requireGeneratedCompiles`)
- `go test ./internal/generator -count=1 -timeout 20m -parallel 2` — pass
- `scripts/verify-generator-output.sh` — pass (13 cases)
- `scripts/golden.sh verify` — all `generate-*` cases pass. Fixture-module `go 1.24` toolchain misses in this environment are unrelated; goldens were not updated.

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed0eff2f-1bc3-4b77-87f7-add03416b472?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed0eff2f-1bc3-4b77-87f7-add03416b472&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

