### PR TITLE
fix(cli): accept x-tenant-env-var/x-path-template-env-vars at doc root

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -536,11 +536,10 @@ Rules:
 - Optional. Specs without `x-tenant-env-var` keep single-tenant behavior;
   no `{tenant}`-aware emission, no spurious env reads.
 - Accepted at the document root or under `info` (path-positional templates
-  are spec-wide either way); the root value wins when both are set. Every
-  real-world ServiceTitan spec in the fleet places this at the document
-  root, so the parser must accept it there — an info-only reader silently
-  drops the extension for the entire ServiceTitan family, and every
-  affected print loses tenant-aware `sync`, `config.go`, and `url.go`
+  are spec-wide either way); the root value wins when both are set. Press
+  operators commonly place this at the document root, so the parser must
+  accept it there — an info-only reader silently drops the extension, and
+  the affected print loses tenant-aware `sync`, `config.go`, and `url.go`
   emission with no error, only a `sync` warning at runtime that reads like
   a resource-specific problem.
 - Value must be a non-empty string after `TrimSpace`. Whitespace-only
@@ -683,7 +682,7 @@ Rules:
   field stays empty and no generated output changes.
 - Accepted at the document root or under `info` (path-positional templates
   are spec-wide either way); the root value wins when both are set. Same
-  root-or-info lookup as `x-tenant-env-var`, for the same reason.
+  root-or-info lookup as `x-tenant-env-var`.
 - Coexists with `x-tenant-env-var`; both feed the same template-vars
   bucket. The `tenant` placeholder may be set by either extension.
 - `env` and `default` values must be non-empty after `TrimSpace`.

--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -535,7 +535,14 @@ Parsed fields: `APISpec.EndpointTemplateVars` (`tenant` added),
 Rules:
 - Optional. Specs without `x-tenant-env-var` keep single-tenant behavior;
   no `{tenant}`-aware emission, no spurious env reads.
-- Declared under `info` only (path-positional templates are spec-wide).
+- Accepted at the document root or under `info` (path-positional templates
+  are spec-wide either way); the root value wins when both are set. Every
+  real-world ServiceTitan spec in the fleet places this at the document
+  root, so the parser must accept it there — an info-only reader silently
+  drops the extension for the entire ServiceTitan family, and every
+  affected print loses tenant-aware `sync`, `config.go`, and `url.go`
+  emission with no error, only a `sync` warning at runtime that reads like
+  a resource-specific problem.
 - Value must be a non-empty string after `TrimSpace`. Whitespace-only
   values are treated as absent.
 - The placeholder name is `tenant`. Specs that use a different
@@ -674,7 +681,9 @@ the same 80% common-path promotion rule.
 Rules:
 - Optional. Specs without this extension keep prior behavior; the new
   field stays empty and no generated output changes.
-- Declared under `info` only (path-positional templates are spec-wide).
+- Accepted at the document root or under `info` (path-positional templates
+  are spec-wide either way); the root value wins when both are set. Same
+  root-or-info lookup as `x-tenant-env-var`, for the same reason.
 - Coexists with `x-tenant-env-var`; both feed the same template-vars
   bucket. The `tenant` placeholder may be set by either extension.
 - `env` and `default` values must be non-empty after `TrimSpace`.

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -21213,6 +21213,89 @@ func TestGenerateEndpointTemplateEnvOverridesWireThrough(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "./...")
 }
 
+// TestGenerateRootDeclaredEndpointTemplateExtensions: parser fields that
+// drive config.go / sync.go / url.go must populate from document-root
+// x-tenant-env-var and x-path-template-env-vars (root winning over info)
+// and the generated CLI must compile with those overrides wired through.
+func TestGenerateRootDeclaredEndpointTemplateExtensions(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := openapi.Parse([]byte(`
+openapi: 3.0.3
+info:
+  title: Tenant Workspace API
+  version: 1.0.0
+  x-tenant-env-var: INFO_TENANT_ID
+  x-path-template-env-vars:
+    workspace:
+      env: INFO_WORKSPACE
+servers:
+  - url: https://api.example.com/{workspace}
+paths:
+  /tenant/{tenant}/items:
+    get:
+      operationId: listItems
+      parameters:
+        - name: tenant
+          in: path
+          required: true
+          schema: {type: string}
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: string}
+x-tenant-env-var: ROOT_TENANT_ID
+x-path-template-env-vars:
+  workspace:
+    env: ROOT_WORKSPACE
+`))
+	require.NoError(t, err)
+	assert.Equal(t, "ROOT_TENANT_ID", apiSpec.EndpointTemplateEnvName("tenant"))
+	assert.Equal(t, "ROOT_WORKSPACE", apiSpec.EndpointTemplateEnvName("workspace"))
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	urlGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "url.go"))
+	require.NoError(t, err)
+	urlSrc := string(urlGo)
+	assert.Regexp(t, `"tenant":\s+"ROOT_TENANT_ID"`, urlSrc,
+		"url.go must wire {tenant} to the root-declared env override")
+	assert.Regexp(t, `"workspace":\s+"ROOT_WORKSPACE"`, urlSrc,
+		"url.go must wire {workspace} to the root-declared env override")
+	assert.NotContains(t, urlSrc, "INFO_TENANT_ID",
+		"info-level x-tenant-env-var must lose to the document-root value")
+	assert.NotContains(t, urlSrc, "INFO_WORKSPACE",
+		"info-level x-path-template-env-vars must lose to the document-root value")
+
+	configGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	configSrc := string(configGo)
+	assert.Contains(t, configSrc, `os.Getenv("ROOT_TENANT_ID")`,
+		"config Load() must read the root-declared tenant env var")
+	assert.Contains(t, configSrc, `os.Getenv("ROOT_WORKSPACE")`,
+		"config Load() must read the root-declared workspace env var")
+	assert.NotContains(t, configSrc, `os.Getenv("INFO_TENANT_ID")`)
+	assert.NotContains(t, configSrc, `os.Getenv("INFO_WORKSPACE")`)
+
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	syncSrc := string(syncGo)
+	assert.Contains(t, syncSrc, "/tenant/{tenant}/items",
+		"sync must keep the tenant-scoped path once the root-declared tenant override is parsed")
+	assert.Contains(t, syncSrc, `endpointTemplateVarSet = map[string]bool`,
+		"sync must declare the template-var set so the unresolved-key check ignores root-declared placeholders")
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
 func TestGenerateSyncIncludesMultiLeafCollectionResources(t *testing.T) {
 	t.Parallel()
 

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -94,9 +94,9 @@ const (
 	// so the profiler treats /tenant/{tenant}/<resource> paths as standalone
 	// sync resources rather than parent-context-dependent. Read via
 	// lookupOpenAPIExtension (document root or info), not the info-only
-	// helper: every real-world ServiceTitan spec in the fleet places this
-	// at the document root, matching root-or-info extensions elsewhere in
-	// this file rather than the info-only convention.
+	// helper: press operators commonly declare this at the document root,
+	// matching root-or-info extensions elsewhere in this file rather than
+	// the info-only convention.
 	extensionTenantEnvVar = "x-tenant-env-var"
 	// extensionPathTemplateEnvVars is the generic, map-shaped successor to
 	// extensionTenantEnvVar. Each entry binds a path placeholder to an
@@ -108,13 +108,13 @@ const (
 	// suitable for canonical always-valid values like Gmail's userId='me'.
 	// When both are set, default wins and the env field is ignored — the
 	// placeholder is fully resolved before runtime substitution sees it.
-	// Same root-or-info lookup as extensionTenantEnvVar, for the same reason.
+	// Same root-or-info lookup as extensionTenantEnvVar.
 	extensionPathTemplateEnvVars = "x-path-template-env-vars"
 )
 
 // tenantPlaceholderName is the canonical placeholder that x-tenant-env-var
-// maps to. Kept narrow on purpose — when this generalizes beyond ServiceTitan
-// (Atlassian {workspace}, GitHub {org}), promote to a list-shaped extension
+// maps to. Kept narrow on purpose — when this generalizes to other
+// placeholders ({workspace}, {org}), promote to a list-shaped extension
 // rather than overloading this constant.
 const tenantPlaceholderName = "tenant"
 

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -92,7 +92,11 @@ const (
 	// path is /tenant/{tenant}/...). When set, the parser registers
 	// "tenant" as an EndpointTemplateVar with this env var as the override,
 	// so the profiler treats /tenant/{tenant}/<resource> paths as standalone
-	// sync resources rather than parent-context-dependent.
+	// sync resources rather than parent-context-dependent. Read via
+	// lookupOpenAPIExtension (document root or info), not the info-only
+	// helper: every real-world ServiceTitan spec in the fleet places this
+	// at the document root, matching root-or-info extensions elsewhere in
+	// this file rather than the info-only convention.
 	extensionTenantEnvVar = "x-tenant-env-var"
 	// extensionPathTemplateEnvVars is the generic, map-shaped successor to
 	// extensionTenantEnvVar. Each entry binds a path placeholder to an
@@ -104,6 +108,7 @@ const (
 	// suitable for canonical always-valid values like Gmail's userId='me'.
 	// When both are set, default wins and the env field is ignored — the
 	// placeholder is fully resolved before runtime substitution sees it.
+	// Same root-or-info lookup as extensionTenantEnvVar, for the same reason.
 	extensionPathTemplateEnvVars = "x-path-template-env-vars"
 )
 
@@ -773,7 +778,7 @@ func parseEndpointTemplateExtensions(doc *openapi3.T) ([]string, map[string]stri
 	envOverrides := map[string]string{}
 	defaults := map[string]string{}
 
-	if raw, ok := lookupOpenAPIInfoExtension(doc, extensionTenantEnvVar); ok {
+	if raw, ok := lookupOpenAPIExtension(doc, extensionTenantEnvVar); ok {
 		if envName, ok := raw.(string); ok {
 			if envName = strings.TrimSpace(envName); envName != "" {
 				vars = append(vars, tenantPlaceholderName)
@@ -782,7 +787,7 @@ func parseEndpointTemplateExtensions(doc *openapi3.T) ([]string, map[string]stri
 		}
 	}
 
-	if raw, ok := lookupOpenAPIInfoExtension(doc, extensionPathTemplateEnvVars); ok {
+	if raw, ok := lookupOpenAPIExtension(doc, extensionPathTemplateEnvVars); ok {
 		if entries, ok := raw.(map[string]any); ok {
 			keys := make([]string, 0, len(entries))
 			for k := range entries {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -11973,9 +11973,9 @@ paths:
 	})
 
 	t.Run("document-root x-tenant-env-var registers tenant template var + override", func(t *testing.T) {
-		// Every real-world ServiceTitan spec in the fleet places x-tenant-env-var
-		// at the document root rather than under info; an info-only reader
-		// silently drops it and every affected print loses tenant-aware sync.
+		// Press operators commonly place x-tenant-env-var at the document
+		// root rather than under info; an info-only reader silently drops
+		// it and the print loses tenant-aware sync.
 		data := []byte(`
 openapi: 3.0.3
 info:
@@ -12414,6 +12414,58 @@ paths:
 		assert.Empty(t, parsed.EndpointTemplateVars, "whitespace-only env must not register a template var")
 		assert.Empty(t, parsed.EndpointTemplateEnvOverrides)
 		assert.Empty(t, parsed.EndpointPathParamDefaults, "whitespace-only default must not register a path-param default")
+	})
+
+	t.Run("document-root x-path-template-env-vars registers template var + override", func(t *testing.T) {
+		data := []byte(`
+openapi: 3.0.3
+info:
+  title: Workspace API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com/{workspace}
+paths:
+  /issues:
+    get:
+      operationId: listIssues
+      responses:
+        "200": {description: ok}
+x-path-template-env-vars:
+  workspace:
+    env: ROOT_WORKSPACE
+`)
+		parsed, err := Parse(data)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"workspace"}, parsed.EndpointTemplateVars)
+		assert.Equal(t, map[string]string{"workspace": "ROOT_WORKSPACE"}, parsed.EndpointTemplateEnvOverrides)
+		assert.Equal(t, "ROOT_WORKSPACE", parsed.EndpointTemplateEnvName("workspace"))
+	})
+
+	t.Run("document-root value wins when both root and info declare x-path-template-env-vars", func(t *testing.T) {
+		data := []byte(`
+openapi: 3.0.3
+info:
+  title: Workspace API
+  version: 1.0.0
+  x-path-template-env-vars:
+    workspace:
+      env: INFO_WORKSPACE
+servers:
+  - url: https://api.example.com/{workspace}
+paths:
+  /issues:
+    get:
+      operationId: listIssues
+      responses:
+        "200": {description: ok}
+x-path-template-env-vars:
+  workspace:
+    env: ROOT_WORKSPACE
+`)
+		parsed, err := Parse(data)
+		require.NoError(t, err)
+		assert.Equal(t, "ROOT_WORKSPACE", parsed.EndpointTemplateEnvName("workspace"))
+		assert.Equal(t, map[string]string{"workspace": "ROOT_WORKSPACE"}, parsed.EndpointTemplateEnvOverrides)
 	})
 }
 

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -11812,11 +11812,11 @@ paths:
 	assert.Equal(t, wantCarrier, parsed.Auth.JWTCarrierCookie)
 }
 
-// TestParseTenantEnvVarExtension: when info.x-tenant-env-var is set, the
-// parser registers "tenant" as an EndpointTemplateVar with the declared
-// env var as the override so the profiler can include
-// /tenant/{tenant}/<resource> paths in flat sync and downstream emitters
-// resolve the placeholder against the real env name.
+// TestParseTenantEnvVarExtension: when x-tenant-env-var is set, at the
+// document root or under info, the parser registers "tenant" as an
+// EndpointTemplateVar with the declared env var as the override so the
+// profiler can include /tenant/{tenant}/<resource> paths in flat sync and
+// downstream emitters resolve the placeholder against the real env name.
 func TestParseTenantEnvVarExtension(t *testing.T) {
 	t.Parallel()
 
@@ -11970,6 +11970,64 @@ paths:
 		require.NoError(t, err)
 		assert.Empty(t, parsed.EndpointTemplateVars, "whitespace-only extension must not register a template var")
 		assert.Empty(t, parsed.EndpointTemplateEnvOverrides)
+	})
+
+	t.Run("document-root x-tenant-env-var registers tenant template var + override", func(t *testing.T) {
+		// Every real-world ServiceTitan spec in the fleet places x-tenant-env-var
+		// at the document root rather than under info; an info-only reader
+		// silently drops it and every affected print loses tenant-aware sync.
+		data := []byte(`
+openapi: 3.0.3
+info:
+  title: ServiceTitan Pricebook
+  version: 1.0.0
+servers:
+  - url: https://api.servicetitan.io
+paths:
+  /tenant/{tenant}/materials:
+    get:
+      summary: List materials
+      parameters:
+        - name: tenant
+          in: path
+          required: true
+          schema: {type: string}
+      responses:
+        "200": {description: ok}
+x-tenant-env-var: ST_TENANT_ID
+`)
+		parsed, err := Parse(data)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"tenant"}, parsed.EndpointTemplateVars)
+		assert.Equal(t, map[string]string{"tenant": "ST_TENANT_ID"}, parsed.EndpointTemplateEnvOverrides)
+		assert.Equal(t, "ST_TENANT_ID", parsed.EndpointTemplateEnvName("tenant"))
+	})
+
+	t.Run("document-root value wins when both root and info declare x-tenant-env-var", func(t *testing.T) {
+		data := []byte(`
+openapi: 3.0.3
+info:
+  title: ServiceTitan Pricebook
+  version: 1.0.0
+  x-tenant-env-var: INFO_TENANT_ID
+servers:
+  - url: https://api.servicetitan.io
+paths:
+  /tenant/{tenant}/materials:
+    get:
+      summary: List materials
+      parameters:
+        - name: tenant
+          in: path
+          required: true
+          schema: {type: string}
+      responses:
+        "200": {description: ok}
+x-tenant-env-var: ROOT_TENANT_ID
+`)
+		parsed, err := Parse(data)
+		require.NoError(t, err)
+		assert.Equal(t, "ROOT_TENANT_ID", parsed.EndpointTemplateEnvName("tenant"))
 	})
 }
 


### PR DESCRIPTION
## Intent

`sync` fails on every tenant-scoped resource for every currently-printed ServiceTitan CLI, with a per-resource `unfilled_path_key` warning that reads like a resource-specific bug rather than what it actually is: `x-tenant-env-var` is never being parsed at all for these specs, because every real spec.json in the fleet places it at the document root and the parser only checks under `info`.

Issue: Fixes #4572

## Approach

`parseEndpointTemplateExtensions` read `x-tenant-env-var` and `x-path-template-env-vars` via `lookupOpenAPIInfoExtension` (info-only). Every other multi-location extension in this file (api-name, display-name, website, proxy-routes, provider-name, origin) already uses `lookupOpenAPIExtension` (root, falling back to info). Swapped the two call sites to match that existing convention, updated the extension-constant doc comments, and updated `docs/SPEC-EXTENSIONS.md`'s "Declared under `info` only" language for both extensions.

## Scope

Primary area: `internal/openapi/parser.go` (spec extension parsing)

Why this belongs in this repo: this is not one API's quirk — every ServiceTitan spec.json checked (crm, inventory, dispatch, jpm, pricebook) places the extension identically at the document root, so the fix belongs in the generator's extension lookup, not in any one printed CLI's spec.

## Risk

Low. The two call sites only affect `x-tenant-env-var`/`x-path-template-env-vars` extraction; no other extension's lookup path changes. No existing golden fixture references either extension name (confirmed via grep across `testdata/golden/`), so no golden output can shift. Root-value-wins-when-both-set matches `lookupOpenAPIExtension`'s existing precedence order elsewhere in the file, so behavior is consistent across the codebase rather than a one-off special case.

## Output Contract

N/A — no template, generated-file, manifest, MCP schema, or scorecard output changes. This changes what the *parser* extracts from certain specs' extensions; the downstream `config.go`/`sync.go`/`url.go` emission templates that consume `EndpointTemplateVars`/`EndpointTemplateEnvOverrides` are unchanged and already covered by existing tests for the info-level case.

## Verification

- `go test ./internal/openapi/...` — all pass, including 2 new subtests (document-root placement, root-wins-over-info precedence)
- `go build -o ./cli-printing-press ./cmd/cli-printing-press` — clean
- `go test ./...` — compared against unmodified `main` via `git stash`: identical failing packages/tests with and without this change (authdoctor, browsersniff, shipcheck, regenmerge, and one Windows-PATH-specific `internal/openapi` test unrelated to this fix) — this change introduces zero new failures
- `bash scripts/golden.sh verify` — compared against unmodified `main` via `git stash`: identical 37 pre-existing failing cases with and without this change (same case names, same diffs, including the `sync.go` diffs) — this change introduces zero golden diffs

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output — new parser-level assertions on `EndpointTemplateVars`/`EndpointTemplateEnvOverrides`/`EndpointTemplateEnvName`, the exact fields the downstream `config.go`/`sync.go`/`url.go` templates consume
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures — added both the previously-uncovered root-only case and the root-vs-info precedence case
- [x] Generator/template change: checked emitted definitions and call sites for matching gates — confirmed both call sites in `parseEndpointTemplateExtensions` (x-tenant-env-var and x-path-template-env-vars) needed the same fix; no other `lookupOpenAPIInfoExtension` call site is affected

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change