### PR TITLE
fix(skills): match GitHub installation tokens in their JWT form

### DIFF
--- a/skills/printing-press-retro/references/secret-scrubbing.md
+++ b/skills/printing-press-retro/references/secret-scrubbing.md
@@ -65,7 +65,7 @@ scrub_body() {
     'stripe-test-key|sk_test_[A-Za-z0-9]{20,}'
     'github-pat|ghp_[A-Za-z0-9]{36,}'
     'github-oauth|gho_[A-Za-z0-9]{36,}'
-    'github-server|ghs_[A-Za-z0-9]{36,}'
+    'github-server|ghs_[A-Za-z0-9._-]{36,}'
     'slack-bot-token|xoxb-[A-Za-z0-9-]{20,}'
     'slack-user-token|xoxp-[A-Za-z0-9-]{20,}'
     'aws-access-key|\bAKIA[0-9A-Z]{16}\b'
@@ -402,7 +402,7 @@ FINAL_CHECK=false
 # checking a credential shape the scrub loop still redacts. The JWT shape
 # intentionally matches Layer 2's two-segment form; that also catches the
 # first two segments of a conventional three-segment JWT.
-CRED_REGEX='(sk_live_[A-Za-z0-9]{20,}|sk_test_[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{36,}|gho_[A-Za-z0-9]{36,}|ghs_[A-Za-z0-9]{36,}|xoxb-[A-Za-z0-9-]{20,}|xoxp-[A-Za-z0-9-]{20,}|\bAKIA[0-9A-Z]{16}\b|sk-or-v1-[A-Za-z0-9_-]{24,}|sk-ant-api03-[A-Za-z0-9_-]{40,}|\blin_api_[A-Za-z0-9_-]{32,}|\b[a-f0-9]{32}-us[0-9]{1,2}\b|\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|Bearer [A-Za-z0-9._~+/=-]{20,})'
+CRED_REGEX='(sk_live_[A-Za-z0-9]{20,}|sk_test_[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{36,}|gho_[A-Za-z0-9]{36,}|ghs_[A-Za-z0-9._-]{36,}|xoxb-[A-Za-z0-9-]{20,}|xoxp-[A-Za-z0-9-]{20,}|\bAKIA[0-9A-Z]{16}\b|sk-or-v1-[A-Za-z0-9_-]{24,}|sk-ant-api03-[A-Za-z0-9_-]{40,}|\blin_api_[A-Za-z0-9_-]{32,}|\b[a-f0-9]{32}-us[0-9]{1,2}\b|\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|Bearer [A-Za-z0-9._~+/=-]{20,})'
 # PII_REGEX must mirror the shapes in PII_PATTERNS above; update both together
 # (e.g. when adding Partita IVA with an allowlist) so the verification step
 # does not silently stop checking a shape the scrub loop still redacts.

--- a/skills/printing-press/references/secret-protection.md
+++ b/skills/printing-press/references/secret-protection.md
@@ -152,7 +152,7 @@ PII_AUTO_REDACT=(
   'bearer-cal-test|Bearer cal_test_[A-Za-z0-9]{20,}|Bearer <REDACTED:cal-test-token>'
   'bearer-github-pat|Bearer ghp_[A-Za-z0-9]{36,}|Bearer <REDACTED:github-pat>'
   'bearer-github-oauth|Bearer gho_[A-Za-z0-9]{36,}|Bearer <REDACTED:github-oauth>'
-  'bearer-github-server|Bearer ghs_[A-Za-z0-9]{36,}|Bearer <REDACTED:github-server-token>'
+  'bearer-github-server|Bearer ghs_[A-Za-z0-9._-]{36,}|Bearer <REDACTED:github-server-token>'
   'bearer-github-fine|Bearer github_pat_[A-Za-z0-9_]{60,}|Bearer <REDACTED:github-fine-grained-pat>'
   'slack-user-token|xoxp-[A-Za-z0-9-]{40,}|<REDACTED:slack-user-token>'
   'slack-bot-token|xoxb-[A-Za-z0-9-]{40,}|<REDACTED:slack-bot-token>'


### PR DESCRIPTION
Follow-up to #4574, per the closing note offering to take a PR that widens `ghs_` to the JWT-safe class.

## Problem

GitHub App installation tokens (`ghs_`, which includes the Actions `GITHUB_TOKEN`) are moving from a short opaque string to a stateless JWT: `ghs_` followed by roughly 520 base64url characters carrying two dots. Base64url contains `.`, `-` and `_`.

The documented class `[A-Za-z0-9]{36,}` cannot reach its minimum repetition, because a JWT's header segment ends at its first dot well under 36 characters, so the alternative fails outright. The failure mode is a complete miss rather than a truncated redaction: a 520-character credential passes a scrubbing pass that reports success.

## Change

Widen the class to `ghs_[A-Za-z0-9._-]{36,}` at all three occurrences (dash last so it is not parsed as a range), matching GitHub's own recommended validation shape:

- `skills/printing-press/references/secret-protection.md` - `bearer-github-server` entry
- `skills/printing-press-retro/references/secret-scrubbing.md` - `github-server` vendor pattern
- `skills/printing-press-retro/references/secret-scrubbing.md` - the same shape inside `CRED_REGEX`

`ghp_`, `gho_` and `github_pat_` are a different token family, unaffected, and keep their current patterns.

## Verification

Against a synthetic 379-character `ghs_<header>.<payload>.<signature>` token:

- old `ghs_[A-Za-z0-9]{36,}` - 0 matches
- new `ghs_[A-Za-z0-9._-]{36,}` - matches the full token

Docs and pattern only; no generator or golden output is involved.