### PR TITLE
fix(cli): persist rotating refresh tokens across live dogfood

### DIFF
--- a/internal/cli/dogfood.go
+++ b/internal/cli/dogfood.go
@@ -108,7 +108,7 @@ func newDogfoodCmd() *cobra.Command {
 	cmd.Flags().StringVar(&level, "level", "full", "Live dogfood depth: quick or full")
 	cmd.Flags().DurationVar(&timeout, "timeout", 30*time.Second, "Timeout for each live dogfood test")
 	cmd.Flags().StringVar(&writeAcceptance, "write-acceptance", "", "Write phase5-acceptance.json to this path on every outcome (status:pass on success, status:fail with a failure_summary block on failure)")
-	cmd.Flags().StringVar(&authEnv, "auth-env", "", "Environment variable that proves an API credential was available for the acceptance marker")
+	cmd.Flags().StringVar(&authEnv, "auth-env", "", "Environment variable that proves an API credential was available for the acceptance marker. For oauth2_refresh, a refresh-token-shaped env var is copied into a shared sandbox credential file so rotation persists across subprocesses")
 	cmd.Flags().StringVar(&authTier, "auth-tier", "", "Credential tier for live dogfood; falls back to PP_AUTH_TIER and skips commands annotated pp:requires-tier on mismatch")
 	cmd.Flags().BoolVar(&allowDestructive, "allow-destructive", false, "Re-enable testing of endpoints classified as destructive-at-auth. Default skips them to prevent runner-credential rotation.")
 	cmd.Flags().BoolVar(&overwriteCommandMirror, "overwrite-command-mirror", false, "Overwrite a differing command_mirror_capabilities block in internal/mcp/tools.go from research.json")

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -260,6 +260,13 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 
 	finalizeLiveDogfoodReport(report, authType)
 	finalizeLiveDogfoodCoverage(report, opts.ResearchDir)
+	// Persist rotated credentials before the acceptance marker: a marker-write
+	// failure must not discard the sandbox that holds the replacement token.
+	// Still write the marker when sync-back itself fails (operator conflict).
+	syncErr := homeScope.syncBack()
+	if syncErr == nil {
+		homeScope.warnSeededEnv()
+	}
 	// The Phase 5.6 acceptance gate's contract is "marker from the runner on
 	// every outcome": pass → promote, fail → hold-path, missing → "Phase 5
 	// was skipped or not recorded." Writing only on PASS forced operators to
@@ -268,13 +275,15 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 	// to the hold path.
 	if opts.WriteAcceptancePath != "" {
 		if err := writeLiveDogfoodAcceptance(opts, report, source); err != nil {
+			if syncErr != nil {
+				return nil, errors.Join(syncErr, err)
+			}
 			return nil, err
 		}
 	}
-	if err := homeScope.syncBack(); err != nil {
-		return report, err
+	if syncErr != nil {
+		return report, syncErr
 	}
-	homeScope.warnSeededEnv()
 	return report, nil
 }
 

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -69,6 +69,7 @@ const reasonCookieAuthNoHarnessSession = "cookie-auth-no-harness-session"
 // shared credential file; this abort is the safety net when rotation
 // still leaked.
 const reasonRefreshTokenRotationCascade = "invalid_grant cascade: a refresh token was rotated by an earlier command and later commands reused the revoked value. oauth2_refresh live dogfood persists rotation in a shared sandbox credential file and strips the rotating env var; the operator's stored refresh token may now be revoked. Re-authenticate before retrying."
+const reasonCredentialSyncBackFailed = "credential sync-back failed: rotated refresh token was not persisted to the operator credential store"
 
 // liveDogfoodVerdictCookieAuthNoSession is the report Verdict for a clean
 // cookie-auth skip outcome. Distinct from PASS/FAIL so the CLI exits 0 (the
@@ -262,17 +263,20 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 	finalizeLiveDogfoodCoverage(report, opts.ResearchDir)
 	// Persist rotated credentials before the acceptance marker: a marker-write
 	// failure must not discard the sandbox that holds the replacement token.
-	// Still write the marker when sync-back itself fails (operator conflict).
 	syncErr := homeScope.syncBack()
 	if syncErr == nil {
 		homeScope.warnSeededEnv()
+	} else {
+		report.Tests = append(report.Tests, failedLiveDogfoodResult("live-dogfood", LiveDogfoodTestHappy, nil, reasonCredentialSyncBackFailed))
+		refreshLiveDogfoodCoverageCounts(report)
+		report.Verdict = "FAIL"
 	}
 	// The Phase 5.6 acceptance gate's contract is "marker from the runner on
 	// every outcome": pass → promote, fail → hold-path, missing → "Phase 5
 	// was skipped or not recorded." Writing only on PASS forced operators to
 	// hand-author the FAIL marker, which the SKILL also forbids. Write on
 	// every terminal verdict; phase5_gate.go already routes status:"fail"
-	// to the hold path.
+	// to the hold path. A sync-back failure must write fail, not pass.
 	if opts.WriteAcceptancePath != "" {
 		if err := writeLiveDogfoodAcceptance(opts, report, source); err != nil {
 			if syncErr != nil {

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -62,6 +62,14 @@ const reasonUnverifiedNeedsAccess = "unverified-needs-access"
 // marker is accepted by `lock promote`.
 const reasonCookieAuthNoHarnessSession = "cookie-auth-no-harness-session"
 
+// reasonRefreshTokenRotationCascade is the Fail reason when live dogfood
+// sees invalid_grant after an earlier live pass. Rotating identity
+// providers revoke the previous refresh token on use; a static
+// --auth-env value then poisons every later subprocess. Prefer the
+// shared credential file; this abort is the safety net when rotation
+// still leaked.
+const reasonRefreshTokenRotationCascade = "invalid_grant cascade: a refresh token was rotated by an earlier command and later commands reused the revoked value. oauth2_refresh live dogfood persists rotation in a shared sandbox credential file and strips the rotating env var; the operator's stored refresh token may now be revoked. Re-authenticate before retrying."
+
 // liveDogfoodVerdictCookieAuthNoSession is the report Verdict for a clean
 // cookie-auth skip outcome. Distinct from PASS/FAIL so the CLI exits 0 (the
 // 401s are not a defect) and writeLiveDogfoodAcceptance emits a skip marker
@@ -177,7 +185,7 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 			}},
 		}, nil
 	}
-	homeScope, err := scopeLiveDogfoodSubprocessHome(opts.CLIDir, opts.BinaryName)
+	homeScope, err := scopeLiveDogfoodSubprocessHome(opts.CLIDir, opts.BinaryName, opts.AuthEnv)
 	if err != nil {
 		return nil, err
 	}
@@ -231,10 +239,21 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 	}
 	runLiveDogfoodPreSync(commands, ctx)
 
+	cascade := invalidGrantCascadeTracker{}
+	abortedCascade := false
 	for _, command := range commands {
 		commandName := strings.Join(command.Path, " ")
 		report.Commands = append(report.Commands, commandName)
-		report.Tests = append(report.Tests, runLiveDogfoodCommand(command, ctx)...)
+		if abortedCascade {
+			report.Tests = append(report.Tests, skippedLiveDogfoodCommandResults(commandName, reasonRefreshTokenRotationCascade)...)
+			continue
+		}
+		results := runLiveDogfoodCommand(command, ctx)
+		report.Tests = append(report.Tests, results...)
+		if cascade.observe(results) {
+			abortedCascade = true
+			report.Tests = append(report.Tests, failedLiveDogfoodResult("live-dogfood", LiveDogfoodTestHappy, nil, reasonRefreshTokenRotationCascade))
+		}
 	}
 
 	_, _, authType := resolveLiveDogfoodAcceptanceIdentity(opts.CLIDir)
@@ -254,12 +273,21 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 	if err := homeScope.syncBack(); err != nil {
 		return report, err
 	}
+	homeScope.warnSeededEnv()
 	return report, nil
 }
 
 type liveDogfoodHomeScope struct {
-	release  func()
-	syncBack func() error
+	release      func()
+	syncBack     func() error
+	seededEnvVar string
+}
+
+func (s *liveDogfoodHomeScope) warnSeededEnv() {
+	if s == nil || strings.TrimSpace(s.seededEnvVar) == "" {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "live dogfood: oauth2_refresh rotated %s into the CLI credential store; unset %s (it now holds a revoked refresh token)\n", s.seededEnvVar, s.seededEnvVar)
 }
 
 func noopLiveDogfoodHomeScope() *liveDogfoodHomeScope {
@@ -269,7 +297,7 @@ func noopLiveDogfoodHomeScope() *liveDogfoodHomeScope {
 	}
 }
 
-func scopeLiveDogfoodSubprocessHome(cliDir, binaryName string) (*liveDogfoodHomeScope, error) {
+func scopeLiveDogfoodSubprocessHome(cliDir, binaryName, authEnv string) (*liveDogfoodHomeScope, error) {
 	manifest, err := ReadCLIManifest(cliDir)
 	if err == nil && manifest.IsLocalDatastore() && strings.EqualFold(strings.TrimSpace(manifest.AuthType), "none") {
 		return noopLiveDogfoodHomeScope(), nil
@@ -287,10 +315,10 @@ func scopeLiveDogfoodSubprocessHome(cliDir, binaryName string) (*liveDogfoodHome
 	// <PREFIX>_HOME / <PREFIX>_<KIND>_DIR for any variant would otherwise
 	// leak through the scoped home into the live-dogfood subprocesses.
 	scrubNames := append([]string{cliName}, findCLINames(cliDir)...)
-	return scopeSubprocessHomeWithCredentialMirror(cliName, syncConfigBack, scrubNames)
+	return scopeSubprocessHomeWithCredentialMirror(cliName, syncConfigBack, scrubNames, manifest, authEnv)
 }
 
-func scopeSubprocessHomeWithCredentialMirror(cliName string, syncConfigBack bool, scrubCLINames []string) (*liveDogfoodHomeScope, error) {
+func scopeSubprocessHomeWithCredentialMirror(cliName string, syncConfigBack bool, scrubCLINames []string, manifest CLIManifest, authEnv string) (*liveDogfoodHomeScope, error) {
 	homeDir, removeHome, err := newScopedConfigHome()
 	if err != nil {
 		return nil, err
@@ -300,26 +328,38 @@ func scopeSubprocessHomeWithCredentialMirror(cliName string, syncConfigBack bool
 		removeHome()
 		return nil, err
 	}
+	seed, err := seedLiveDogfoodRotatingRefresh(homeDir, cliName, manifest, authEnv)
+	if err != nil {
+		removeHome()
+		return nil, err
+	}
+	if seed.mirror != nil {
+		mirrors = append(mirrors, *seed.mirror)
+	}
 	if len(scrubCLINames) == 0 {
 		scrubCLINames = []string{cliName}
 	}
-	restore := installScopedSubprocessHome(homeDir, scrubCLINames...)
+	restoreHome := installScopedSubprocessHome(homeDir, scrubCLINames...)
+	restoreStrip := installSubprocessEnvStrip(seed.stripEnv)
 	return &liveDogfoodHomeScope{
 		release: func() {
-			restore()
+			restoreStrip()
+			restoreHome()
 			removeHome()
 		},
 		syncBack: func() error {
 			return syncLiveDogfoodCredentialMirrors(mirrors)
 		},
+		seededEnvVar: seed.seededEnvVar,
 	}, nil
 }
 
 type liveDogfoodCredentialMirror struct {
-	src      string
-	dst      string
-	original []byte
-	mode     os.FileMode
+	src         string
+	dst         string
+	original    []byte
+	mode        os.FileMode
+	allowCreate bool
 }
 
 func mirrorLiveDogfoodCredentialFiles(scopedHome, cliName string, syncConfigBack bool) ([]liveDogfoodCredentialMirror, error) {
@@ -337,6 +377,7 @@ func mirrorLiveDogfoodCredentialFiles(scopedHome, cliName string, syncConfigBack
 	}{
 		{rel: filepath.Join(".config", cliName, "config.toml"), syncBack: syncConfigBack},
 		{rel: filepath.Join(".config", cliName, "config.json"), syncBack: syncConfigBack},
+		{rel: filepath.Join(".local", "share", cliName, "credentials.toml"), syncBack: syncConfigBack},
 		{rel: filepath.Join(".local", "share", cliName, "cookies.json")},
 	}
 	var mirrors []liveDogfoodCredentialMirror
@@ -407,10 +448,13 @@ func writeLiveDogfoodCredentialFileIfUnchanged(mirror liveDogfoodCredentialMirro
 	// last comparison catches operator edits made before live dogfood commits
 	// the rotated credential.
 	current, err := os.ReadFile(mirror.src)
-	if err != nil {
+	if os.IsNotExist(err) {
+		if !mirror.allowCreate || len(mirror.original) != 0 {
+			return fmt.Errorf("reading operator credential file before sync-back %s: %w", mirror.src, err)
+		}
+	} else if err != nil {
 		return fmt.Errorf("reading operator credential file before sync-back %s: %w", mirror.src, err)
-	}
-	if !bytes.Equal(current, mirror.original) {
+	} else if !bytes.Equal(current, mirror.original) {
 		return fmt.Errorf("refusing to sync refreshed live dogfood credentials to %s: operator config changed during dogfood", mirror.src)
 	}
 	if err := os.Rename(tmpName, mirror.src); err != nil {
@@ -2117,6 +2161,15 @@ func skippedLiveDogfoodResult(command string, kind LiveDogfoodTestKind, reason s
 		Kind:    kind,
 		Status:  LiveDogfoodStatusSkip,
 		Reason:  reason,
+	}
+}
+
+func skippedLiveDogfoodCommandResults(command, reason string) []LiveDogfoodTestResult {
+	return []LiveDogfoodTestResult{
+		skippedLiveDogfoodResult(command, LiveDogfoodTestHelp, reason),
+		skippedLiveDogfoodResult(command, LiveDogfoodTestHappy, reason),
+		skippedLiveDogfoodResult(command, LiveDogfoodTestJSON, reason),
+		skippedLiveDogfoodResult(command, LiveDogfoodTestError, reason),
 	}
 }
 

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -239,6 +239,8 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 	}
 	runLiveDogfoodPreSync(commands, ctx)
 
+	_, _, authType := resolveLiveDogfoodAcceptanceIdentity(opts.CLIDir)
+	trackRefreshCascade := strings.EqualFold(strings.TrimSpace(authType), apispec.AuthTypeOAuth2Refresh)
 	cascade := invalidGrantCascadeTracker{}
 	abortedCascade := false
 	for _, command := range commands {
@@ -250,13 +252,12 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 		}
 		results := runLiveDogfoodCommand(command, ctx)
 		report.Tests = append(report.Tests, results...)
-		if cascade.observe(results) {
+		if trackRefreshCascade && cascade.observe(results) {
 			abortedCascade = true
 			report.Tests = append(report.Tests, failedLiveDogfoodResult("live-dogfood", LiveDogfoodTestHappy, nil, reasonRefreshTokenRotationCascade))
 		}
 	}
 
-	_, _, authType := resolveLiveDogfoodAcceptanceIdentity(opts.CLIDir)
 	finalizeLiveDogfoodReport(report, authType)
 	finalizeLiveDogfoodCoverage(report, opts.ResearchDir)
 	// The Phase 5.6 acceptance gate's contract is "marker from the runner on
@@ -367,24 +368,43 @@ func mirrorLiveDogfoodCredentialFiles(scopedHome, cliName string, syncConfigBack
 	if scopedHome == "" || cliName == "" {
 		return nil, nil
 	}
-	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
-		return nil, nil
-	}
-	paths := []struct {
-		rel      string
+	type credPath struct {
+		src      string
+		dst      string
 		syncBack bool
-	}{
-		{rel: filepath.Join(".config", cliName, "config.toml"), syncBack: syncConfigBack},
-		{rel: filepath.Join(".config", cliName, "config.json"), syncBack: syncConfigBack},
-		{rel: filepath.Join(".local", "share", cliName, "credentials.toml"), syncBack: syncConfigBack},
-		{rel: filepath.Join(".local", "share", cliName, "cookies.json")},
+	}
+	var paths []credPath
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		paths = append(paths,
+			credPath{
+				src:      filepath.Join(home, ".config", cliName, "config.toml"),
+				dst:      filepath.Join(scopedHome, ".config", cliName, "config.toml"),
+				syncBack: syncConfigBack,
+			},
+			credPath{
+				src:      filepath.Join(home, ".config", cliName, "config.json"),
+				dst:      filepath.Join(scopedHome, ".config", cliName, "config.json"),
+				syncBack: syncConfigBack,
+			},
+		)
+	}
+	if operatorDataDir := liveDogfoodOperatorDataDir(cliName); operatorDataDir != "" {
+		sandboxDataDir := filepath.Join(scopedHome, ".local", "share", cliName)
+		paths = append(paths,
+			credPath{
+				src:      filepath.Join(operatorDataDir, "credentials.toml"),
+				dst:      filepath.Join(sandboxDataDir, "credentials.toml"),
+				syncBack: syncConfigBack,
+			},
+			credPath{
+				src: filepath.Join(operatorDataDir, "cookies.json"),
+				dst: filepath.Join(sandboxDataDir, "cookies.json"),
+			},
+		)
 	}
 	var mirrors []liveDogfoodCredentialMirror
 	for _, path := range paths {
-		src := filepath.Join(home, path.rel)
-		dst := filepath.Join(scopedHome, path.rel)
-		mirror, err := copyLiveDogfoodCredentialFile(src, dst)
+		mirror, err := copyLiveDogfoodCredentialFile(path.src, path.dst)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pipeline/live_dogfood_refresh.go
+++ b/internal/pipeline/live_dogfood_refresh.go
@@ -1,0 +1,233 @@
+package pipeline
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	apispec "github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+)
+
+type liveDogfoodRefreshSeed struct {
+	stripEnv     []string
+	mirror       *liveDogfoodCredentialMirror
+	seededEnvVar string
+}
+
+func seedLiveDogfoodRotatingRefresh(scopedHome, cliName string, manifest CLIManifest, authEnv string) (liveDogfoodRefreshSeed, error) {
+	strip := liveDogfoodRotatingRefreshEnvVars(manifest, authEnv)
+	if len(strip) == 0 {
+		return liveDogfoodRefreshSeed{}, nil
+	}
+
+	token, tokenEnv := liveDogfoodRotatingRefreshToken(authEnv, strip)
+	seed := liveDogfoodRefreshSeed{stripEnv: strip, seededEnvVar: tokenEnv}
+	if scopedHome == "" || strings.TrimSpace(cliName) == "" {
+		return seed, nil
+	}
+
+	dst := liveDogfoodCredentialsRelPath(scopedHome, cliName)
+	existing, readErr := os.ReadFile(dst)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		return liveDogfoodRefreshSeed{}, fmt.Errorf("oauth2_refresh live dogfood needs a writable shared credential store: reading %s: %w", dst, readErr)
+	}
+	if liveDogfoodFileHasRefreshToken(existing) {
+		return seed, nil
+	}
+	if token == "" {
+		return seed, nil
+	}
+
+	created := os.IsNotExist(readErr)
+	data := liveDogfoodAppendRefreshToken(existing, token)
+	if err := writeLiveDogfoodCredentialMirrorFile(dst, data, 0o600); err != nil {
+		return liveDogfoodRefreshSeed{}, fmt.Errorf("oauth2_refresh live dogfood needs a writable shared credential store: %w", err)
+	}
+	if created {
+		if operatorHome, homeErr := os.UserHomeDir(); homeErr == nil && operatorHome != "" {
+			seed.mirror = &liveDogfoodCredentialMirror{
+				src:         liveDogfoodCredentialsRelPath(operatorHome, cliName),
+				dst:         dst,
+				mode:        0o600,
+				allowCreate: true,
+			}
+		}
+	}
+	return seed, nil
+}
+
+func liveDogfoodAppendRefreshToken(existing []byte, token string) []byte {
+	line := liveDogfoodRefreshTokenTOML(token)
+	if len(existing) == 0 {
+		return line
+	}
+	out := append([]byte{}, existing...)
+	if out[len(out)-1] != '\n' {
+		out = append(out, '\n')
+	}
+	return append(out, line...)
+}
+
+func liveDogfoodCredentialsRelPath(home, cliName string) string {
+	return filepath.Join(home, ".local", "share", cliName, "credentials.toml")
+}
+
+func liveDogfoodRotatingRefreshEnvVars(manifest CLIManifest, authEnv string) []string {
+	if !strings.EqualFold(strings.TrimSpace(manifest.AuthType), apispec.AuthTypeOAuth2Refresh) {
+		return nil
+	}
+	seen := map[string]bool{}
+	var names []string
+	add := func(name string) {
+		name = strings.TrimSpace(name)
+		if name == "" || seen[name] || !apispec.IsOAuthRefreshTokenEnvVar(name) {
+			return
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+
+	auth := apispec.AuthConfig{
+		Type:        manifest.AuthType,
+		EnvVars:     append([]string(nil), manifest.AuthEnvVars...),
+		EnvVarSpecs: append([]apispec.AuthEnvVar(nil), manifest.AuthEnvVarSpecs...),
+	}
+	if ev := auth.OAuth2RefreshTokenEnvVar(); ev != nil {
+		add(ev.Name)
+	}
+	for _, name := range manifest.AuthEnvVars {
+		add(name)
+	}
+	for _, ev := range manifest.AuthEnvVarSpecs {
+		add(ev.Name)
+	}
+	add(authEnv)
+	return names
+}
+
+func liveDogfoodRotatingRefreshToken(authEnv string, strip []string) (token, envName string) {
+	authEnv = strings.TrimSpace(authEnv)
+	names := make([]string, 0, len(strip)+1)
+	if apispec.IsOAuthRefreshTokenEnvVar(authEnv) {
+		names = append(names, authEnv)
+	}
+	for _, name := range strip {
+		if slices.Contains(names, name) {
+			continue
+		}
+		names = append(names, name)
+	}
+	for _, name := range names {
+		if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+			return v, name
+		}
+	}
+	return "", ""
+}
+
+func liveDogfoodFileHasRefreshToken(data []byte) bool {
+	for line := range strings.SplitSeq(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, val, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(strings.Trim(key, `"`)) != "refresh_token" {
+			continue
+		}
+		val = strings.TrimSpace(val)
+		val = strings.Trim(val, `"'`)
+		return val != ""
+	}
+	return false
+}
+
+func liveDogfoodRefreshTokenTOML(token string) []byte {
+	return []byte("refresh_token = " + tomlQuotedString(token) + "\n")
+}
+
+func tomlQuotedString(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('"')
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		i += size
+		switch r {
+		case '\\', '"':
+			b.WriteByte('\\')
+			b.WriteRune(r)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			if r == utf8.RuneError && size == 1 {
+				b.WriteString(`\u00`)
+				b.WriteByte("0123456789abcdef"[s[i-1]>>4])
+				b.WriteByte("0123456789abcdef"[s[i-1]&0x0f])
+				continue
+			}
+			if r < 0x20 || r == 0x7f {
+				if r <= unicode.MaxASCII {
+					b.WriteString(`\u00`)
+					b.WriteByte("0123456789abcdef"[byte(r)>>4])
+					b.WriteByte("0123456789abcdef"[byte(r)&0x0f])
+					continue
+				}
+			}
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+type invalidGrantCascadeTracker struct {
+	sawLivePass bool
+}
+
+func (c *invalidGrantCascadeTracker) observe(results []LiveDogfoodTestResult) bool {
+	if c == nil {
+		return false
+	}
+	for _, result := range results {
+		if c.sawLivePass && liveDogfoodResultHasInvalidGrant(result) {
+			return true
+		}
+		if liveDogfoodResultIsLiveAPIPass(result) {
+			c.sawLivePass = true
+		}
+	}
+	return false
+}
+
+func liveDogfoodResultIsLiveAPIPass(result LiveDogfoodTestResult) bool {
+	if result.Status != LiveDogfoodStatusPass {
+		return false
+	}
+	if result.Kind != LiveDogfoodTestHappy && result.Kind != LiveDogfoodTestJSON {
+		return false
+	}
+	if slices.Contains(result.Args, "--dry-run") {
+		return false
+	}
+	return true
+}
+
+func liveDogfoodResultHasInvalidGrant(result LiveDogfoodTestResult) bool {
+	if result.Status != LiveDogfoodStatusFail {
+		return false
+	}
+	hay := strings.ToLower(result.Reason + " " + result.OutputSample)
+	return strings.Contains(hay, "invalid_grant")
+}

--- a/internal/pipeline/live_dogfood_refresh.go
+++ b/internal/pipeline/live_dogfood_refresh.go
@@ -9,6 +9,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	apispec "github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 )
 
@@ -48,9 +49,9 @@ func seedLiveDogfoodRotatingRefresh(scopedHome, cliName string, manifest CLIMani
 		return liveDogfoodRefreshSeed{}, fmt.Errorf("oauth2_refresh live dogfood needs a writable shared credential store: %w", err)
 	}
 	if created {
-		if operatorHome, homeErr := os.UserHomeDir(); homeErr == nil && operatorHome != "" {
+		if operatorPath := liveDogfoodOperatorCredentialsPath(cliName); operatorPath != "" {
 			seed.mirror = &liveDogfoodCredentialMirror{
-				src:         liveDogfoodCredentialsRelPath(operatorHome, cliName),
+				src:         operatorPath,
 				dst:         dst,
 				mode:        0o600,
 				allowCreate: true,
@@ -76,15 +77,72 @@ func liveDogfoodCredentialsRelPath(home, cliName string) string {
 	return filepath.Join(home, ".local", "share", cliName, "credentials.toml")
 }
 
+func liveDogfoodOperatorCredentialsPath(cliName string) string {
+	dir := liveDogfoodOperatorDataDir(cliName)
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "credentials.toml")
+}
+
+func liveDogfoodOperatorDataDir(cliName string) string {
+	cliName = strings.TrimSpace(cliName)
+	if cliName == "" {
+		return ""
+	}
+	prefix := naming.EnvPrefix(naming.TrimCLISuffix(cliName))
+	if prefix != "" {
+		if dir := liveDogfoodAbsoluteEnvDir(prefix + "_DATA_DIR"); dir != "" {
+			return dir
+		}
+		if home := liveDogfoodAbsoluteEnvDir(prefix + "_HOME"); home != "" {
+			return filepath.Join(home, "data")
+		}
+	}
+	if xdg := liveDogfoodAbsoluteEnvDir("XDG_DATA_HOME"); xdg != "" {
+		return filepath.Join(xdg, cliName)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".local", "share", cliName)
+}
+
+func liveDogfoodAbsoluteEnvDir(name string) string {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return ""
+	}
+	if raw == "~" || strings.HasPrefix(raw, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil || home == "" {
+			return ""
+		}
+		if raw == "~" {
+			raw = home
+		} else {
+			raw = filepath.Join(home, strings.TrimPrefix(raw, "~/"))
+		}
+	}
+	if !filepath.IsAbs(raw) {
+		return ""
+	}
+	return filepath.Clean(raw)
+}
+
 func liveDogfoodRotatingRefreshEnvVars(manifest CLIManifest, authEnv string) []string {
 	if !strings.EqualFold(strings.TrimSpace(manifest.AuthType), apispec.AuthTypeOAuth2Refresh) {
 		return nil
 	}
 	seen := map[string]bool{}
 	var names []string
-	add := func(name string) {
+	add := func(name string, requireRefreshShape bool) {
 		name = strings.TrimSpace(name)
-		if name == "" || seen[name] || !apispec.IsOAuthRefreshTokenEnvVar(name) {
+		if name == "" || seen[name] {
+			return
+		}
+		if requireRefreshShape && !apispec.IsOAuthRefreshTokenEnvVar(name) {
 			return
 		}
 		seen[name] = true
@@ -97,15 +155,15 @@ func liveDogfoodRotatingRefreshEnvVars(manifest CLIManifest, authEnv string) []s
 		EnvVarSpecs: append([]apispec.AuthEnvVar(nil), manifest.AuthEnvVarSpecs...),
 	}
 	if ev := auth.OAuth2RefreshTokenEnvVar(); ev != nil {
-		add(ev.Name)
+		add(ev.Name, false)
 	}
 	for _, name := range manifest.AuthEnvVars {
-		add(name)
+		add(name, true)
 	}
 	for _, ev := range manifest.AuthEnvVarSpecs {
-		add(ev.Name)
+		add(ev.Name, true)
 	}
-	add(authEnv)
+	add(authEnv, true)
 	return names
 }
 

--- a/internal/pipeline/live_dogfood_refresh_test.go
+++ b/internal/pipeline/live_dogfood_refresh_test.go
@@ -1,0 +1,578 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLiveDogfoodRotatingRefreshEnvVars(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, liveDogfoodRotatingRefreshEnvVars(CLIManifest{AuthType: "api_key", AuthEnvVars: []string{"FOO_API_KEY"}}, "FOO_API_KEY"))
+	assert.Empty(t, liveDogfoodRotatingRefreshEnvVars(CLIManifest{AuthType: "bearer_token"}, "TOKEN"))
+
+	got := liveDogfoodRotatingRefreshEnvVars(CLIManifest{
+		AuthType:    spec.AuthTypeOAuth2Refresh,
+		AuthEnvVars: []string{"VENDOR_CLIENT_ID", "VENDOR_CLIENT_SECRET", "VENDOR_REFRESH_TOKEN"},
+	}, "VENDOR_REFRESH_TOKEN")
+	assert.Equal(t, []string{"VENDOR_REFRESH_TOKEN"}, got)
+
+	got = liveDogfoodRotatingRefreshEnvVars(CLIManifest{
+		AuthType: spec.AuthTypeOAuth2Refresh,
+		AuthEnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "VENDOR_REFRESH_TOKEN", Kind: spec.AuthEnvVarKindAuthFlowInput},
+		},
+	}, "MY_CUSTOM_TOKEN")
+	assert.Equal(t, []string{"VENDOR_REFRESH_TOKEN"}, got)
+
+	got = liveDogfoodRotatingRefreshEnvVars(CLIManifest{
+		AuthType:    spec.AuthTypeOAuth2Refresh,
+		AuthEnvVars: []string{"VENDOR_CLIENT_ID", "VENDOR_CLIENT_SECRET", "VENDOR_REFRESH_TOKEN"},
+	}, "VENDOR_CLIENT_ID")
+	assert.Equal(t, []string{"VENDOR_REFRESH_TOKEN"}, got)
+
+	got = liveDogfoodRotatingRefreshEnvVars(CLIManifest{
+		AuthType:    spec.AuthTypeOAuth2Refresh,
+		AuthEnvVars: []string{"VENDOR_CLIENT_ID", "VENDOR_CLIENT_SECRET"},
+	}, "VENDOR_CLIENT_ID")
+	assert.Empty(t, got)
+}
+
+func TestLiveDogfoodRotatingRefreshTokenIgnoresClientIDAuthEnv(t *testing.T) {
+	t.Setenv("VENDOR_CLIENT_ID", "client-id-value")
+	t.Setenv("VENDOR_REFRESH_TOKEN", "refresh-value")
+
+	token, envName := liveDogfoodRotatingRefreshToken("VENDOR_CLIENT_ID", []string{"VENDOR_REFRESH_TOKEN"})
+	assert.Equal(t, "refresh-value", token)
+	assert.Equal(t, "VENDOR_REFRESH_TOKEN", envName)
+
+	token, envName = liveDogfoodRotatingRefreshToken("VENDOR_CLIENT_ID", nil)
+	assert.Empty(t, token)
+	assert.Empty(t, envName)
+}
+
+func TestLiveDogfoodFileHasRefreshToken(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, liveDogfoodFileHasRefreshToken(nil))
+	assert.False(t, liveDogfoodFileHasRefreshToken([]byte("client_id = \"abc\"\n")))
+	assert.False(t, liveDogfoodFileHasRefreshToken([]byte("refresh_token = \"\"\n")))
+	assert.True(t, liveDogfoodFileHasRefreshToken([]byte("refresh_token = \"abc\"\n")))
+	assert.True(t, liveDogfoodFileHasRefreshToken([]byte("access_token = \"a\"\nrefresh_token = \"b\"\n")))
+}
+
+func TestTomlQuotedStringEscapes(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, `"plain"`, tomlQuotedString("plain"))
+	assert.Equal(t, `"say \"hi\""`, tomlQuotedString(`say "hi"`))
+	assert.Equal(t, `"a\\b"`, tomlQuotedString(`a\b`))
+	assert.Equal(t, `"line\nnext"`, tomlQuotedString("line\nnext"))
+}
+
+func TestInvalidGrantCascadeTracker(t *testing.T) {
+	t.Parallel()
+
+	tracker := invalidGrantCascadeTracker{}
+	assert.False(t, tracker.observe([]LiveDogfoodTestResult{{
+		Kind: LiveDogfoodTestHelp, Status: LiveDogfoodStatusPass,
+	}}))
+	assert.False(t, tracker.observe([]LiveDogfoodTestResult{{
+		Kind: LiveDogfoodTestHappy, Status: LiveDogfoodStatusPass,
+	}}))
+	assert.True(t, tracker.observe([]LiveDogfoodTestResult{{
+		Kind:         LiveDogfoodTestHappy,
+		Status:       LiveDogfoodStatusFail,
+		OutputSample: `Error: refreshing access token: HTTP 400: {"error":"invalid_grant"}`,
+	}}))
+}
+
+func TestRunLiveDogfoodAuthEnvRefreshTokenUsesSharedCredentialFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	const (
+		binaryName = "fixture-pp-cli"
+		authEnv    = "FIXTURE_REFRESH_TOKEN"
+		original   = "env-refresh-token"
+		rotated    = "rotated-refresh-token"
+	)
+
+	operatorHome := t.TempDir()
+	t.Setenv("HOME", operatorHome)
+	t.Setenv(authEnv, original)
+
+	dir := t.TempDir()
+	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
+		SchemaVersion: 1,
+		APIName:       "fixture",
+		CLIName:       binaryName,
+		RunID:         "run-live-dogfood",
+		AuthType:      spec.AuthTypeOAuth2Refresh,
+		AuthEnvVars:   []string{"FIXTURE_CLIENT_ID", "FIXTURE_CLIENT_SECRET", authEnv},
+		SpecFormat:    "openapi3",
+	}))
+	writeLiveDogfoodRotatingRefreshStub(t, dir, binaryName, original, rotated)
+
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    2 * time.Second,
+		AuthEnv:    authEnv,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "PASS", report.Verdict, report.Tests)
+
+	got, err := os.ReadFile(filepath.Join(operatorHome, ".local", "share", binaryName, "credentials.toml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(got), rotated)
+	assert.NotContains(t, string(got), original)
+}
+
+func TestRunLiveDogfoodOAuth2RefreshClientIDAuthEnvDoesNotSeedOrStrip(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	const (
+		binaryName  = "fixture-pp-cli"
+		clientIDEnv = "FIXTURE_CLIENT_ID"
+		refreshEnv  = "FIXTURE_REFRESH_TOKEN"
+		clientIDVal = "client-id-value"
+		original    = "env-refresh-token"
+		rotated     = "rotated-refresh-token"
+	)
+
+	operatorHome := t.TempDir()
+	t.Setenv("HOME", operatorHome)
+	t.Setenv(clientIDEnv, clientIDVal)
+	t.Setenv("FIXTURE_CLIENT_SECRET", "client-secret-value")
+	t.Setenv(refreshEnv, original)
+
+	dir := t.TempDir()
+	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
+		SchemaVersion: 1,
+		APIName:       "fixture",
+		CLIName:       binaryName,
+		RunID:         "run-live-dogfood",
+		AuthType:      spec.AuthTypeOAuth2Refresh,
+		AuthEnvVars:   []string{clientIDEnv, "FIXTURE_CLIENT_SECRET", refreshEnv},
+		SpecFormat:    "openapi3",
+	}))
+	writeStubBinary(t, dir, binaryName, `set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"account","subcommands":[{"name":"show"}]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Show the authenticated account.
+
+Usage:
+  fixture-pp-cli account show [flags]
+
+Examples:
+  fixture-pp-cli account show
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show" ]; then
+  if [ "${FIXTURE_CLIENT_ID:-}" != "client-id-value" ]; then
+    echo "client id env stripped or mutated: '${FIXTURE_CLIENT_ID:-}'" >&2
+    exit 1
+  fi
+  if [ -n "${FIXTURE_REFRESH_TOKEN:-}" ]; then
+    echo "rotating refresh token leaked via env" >&2
+    exit 1
+  fi
+  creds="$HOME/.local/share/fixture-pp-cli/credentials.toml"
+  if [ ! -f "$creds" ]; then
+    echo "missing sandbox credentials.toml" >&2
+    exit 1
+  fi
+  if grep -q 'client-id-value' "$creds"; then
+    echo "client id seeded as refresh_token" >&2
+    cat "$creds" >&2
+    exit 1
+  fi
+  if grep -q 'env-refresh-token' "$creds"; then
+    printf 'refresh_token = "%s"\naccess_token = "fresh-access"\n' 'rotated-refresh-token' > "$creds"
+  elif ! grep -q 'rotated-refresh-token' "$creds"; then
+    echo "unexpected credential file" >&2
+    cat "$creds" >&2
+    exit 1
+  fi
+  if [ "${3:-}" = "--json" ]; then
+    echo '{"ok":true}'
+    exit 0
+  fi
+  echo 'ok'
+  exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`)
+
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    2 * time.Second,
+		AuthEnv:    clientIDEnv,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "PASS", report.Verdict, report.Tests)
+
+	got, err := os.ReadFile(filepath.Join(operatorHome, ".local", "share", binaryName, "credentials.toml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(got), rotated)
+	assert.NotContains(t, string(got), clientIDVal)
+	assert.NotContains(t, string(got), original)
+}
+
+func TestSeedLiveDogfoodRotatingRefreshDoesNotWriteClientID(t *testing.T) {
+	t.Setenv("VENDOR_CLIENT_ID", "client-id-value")
+	t.Setenv("VENDOR_REFRESH_TOKEN", "")
+
+	home := t.TempDir()
+	seed, err := seedLiveDogfoodRotatingRefresh(home, "fixture-pp-cli", CLIManifest{
+		AuthType:    spec.AuthTypeOAuth2Refresh,
+		AuthEnvVars: []string{"VENDOR_CLIENT_ID", "VENDOR_CLIENT_SECRET", "VENDOR_REFRESH_TOKEN"},
+	}, "VENDOR_CLIENT_ID")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"VENDOR_REFRESH_TOKEN"}, seed.stripEnv)
+	assert.Empty(t, seed.seededEnvVar)
+	assert.Nil(t, seed.mirror)
+
+	_, err = os.Stat(liveDogfoodCredentialsRelPath(home, "fixture-pp-cli"))
+	assert.True(t, os.IsNotExist(err), "client-id --auth-env must not create credentials.toml")
+}
+
+func TestRunLiveDogfoodSyncsOAuth2RefreshCredentialsTomlBack(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	const (
+		binaryName = "fixture-pp-cli"
+		original   = "old-refresh"
+		rotated    = "new-refresh"
+	)
+
+	operatorHome := t.TempDir()
+	t.Setenv("HOME", operatorHome)
+	credsPath := filepath.Join(operatorHome, ".local", "share", binaryName, "credentials.toml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(credsPath), 0o700))
+	require.NoError(t, os.WriteFile(credsPath, []byte("refresh_token = \""+original+"\"\n"), 0o600))
+	t.Setenv("FIXTURE_REFRESH_TOKEN", original)
+
+	dir := t.TempDir()
+	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
+		SchemaVersion: 1,
+		APIName:       "fixture",
+		CLIName:       binaryName,
+		RunID:         "run-live-dogfood",
+		AuthType:      spec.AuthTypeOAuth2Refresh,
+		AuthEnvVars:   []string{"FIXTURE_REFRESH_TOKEN"},
+		SpecFormat:    "openapi3",
+	}))
+	writeLiveDogfoodRotatingRefreshStub(t, dir, binaryName, original, rotated)
+
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    2 * time.Second,
+		AuthEnv:    "FIXTURE_REFRESH_TOKEN",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "PASS", report.Verdict, report.Tests)
+
+	got, err := os.ReadFile(credsPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), rotated)
+	assert.NotContains(t, string(got), original)
+}
+
+func TestRunLiveDogfoodAPIKeyAuthEnvUnchanged(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	const (
+		binaryName = "fixture-pp-cli"
+		authEnv    = "FIXTURE_API_KEY"
+	)
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(authEnv, "static-api-key")
+
+	dir := t.TempDir()
+	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
+		SchemaVersion: 1,
+		APIName:       "fixture",
+		CLIName:       binaryName,
+		RunID:         "run-live-dogfood",
+		AuthType:      "api_key",
+		AuthEnvVars:   []string{authEnv},
+		SpecFormat:    "openapi3",
+	}))
+	writeStubBinary(t, dir, binaryName, `set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"account","subcommands":[{"name":"show"}]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Show the authenticated account.
+
+Usage:
+  fixture-pp-cli account show [flags]
+
+Examples:
+  fixture-pp-cli account show
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show" ]; then
+  if [ -z "${FIXTURE_API_KEY:-}" ]; then
+    echo "api key env missing from subprocess" >&2
+    exit 1
+  fi
+  if [ "$FIXTURE_API_KEY" != "static-api-key" ]; then
+    echo "api key env mutated" >&2
+    exit 1
+  fi
+  if [ "${3:-}" = "--json" ]; then
+    echo '{"ok":true}'
+    exit 0
+  fi
+  echo 'ok'
+  exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`)
+
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    2 * time.Second,
+		AuthEnv:    authEnv,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "PASS", report.Verdict, report.Tests)
+}
+
+func TestRunLiveDogfoodAbortsInvalidGrantCascade(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	const binaryName = "fixture-pp-cli"
+
+	t.Setenv("HOME", t.TempDir())
+
+	dir := t.TempDir()
+	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
+		SchemaVersion: 1,
+		APIName:       "fixture",
+		CLIName:       binaryName,
+		RunID:         "run-live-dogfood",
+		AuthType:      spec.AuthTypeOAuth2Refresh,
+		SpecFormat:    "openapi3",
+	}))
+	writeStubBinary(t, dir, binaryName, `set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"account","subcommands":[{"name":"show"}]},
+    {"name":"billing","subcommands":[{"name":"list"}]},
+    {"name":"catalog","subcommands":[{"name":"list"}]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "${2:-}" = "--help" ] || [ "${3:-}" = "--help" ]; then
+  cat <<HELP
+Show $1 $2.
+
+Usage:
+  fixture-pp-cli $1 $2 [flags]
+
+Examples:
+  fixture-pp-cli $1 $2
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show" ]; then
+  if [ "${3:-}" = "--json" ]; then
+    echo '{"ok":true}'
+    exit 0
+  fi
+  echo 'ok'
+  exit 0
+fi
+
+if [ "$1" = "billing" ] && [ "$2" = "list" ]; then
+  echo 'Error: refreshing access token: HTTP 400: {"error":"invalid_grant","error_description":"refresh token is invalid, expired or revoked"}' >&2
+  exit 4
+fi
+
+if [ "$1" = "catalog" ]; then
+  echo "should have aborted before catalog" >&2
+  exit 99
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`)
+
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "FAIL", report.Verdict)
+
+	diag := findResultByCommandKind(report, "live-dogfood", LiveDogfoodTestHappy)
+	require.NotNil(t, diag)
+	assert.Equal(t, LiveDogfoodStatusFail, diag.Status)
+	assert.Equal(t, reasonRefreshTokenRotationCascade, diag.Reason)
+
+	catalogHelp := findResultByCommandKind(report, "catalog list", LiveDogfoodTestHelp)
+	require.NotNil(t, catalogHelp)
+	assert.Equal(t, LiveDogfoodStatusSkip, catalogHelp.Status)
+	assert.Equal(t, reasonRefreshTokenRotationCascade, catalogHelp.Reason)
+
+	for _, result := range report.Tests {
+		assert.NotEqual(t, 99, result.ExitCode, "catalog must not execute after invalid_grant cascade")
+	}
+}
+
+func TestWriteLiveDogfoodCredentialFileIfUnchangedCreatesMissingSrc(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "operator", "credentials.toml")
+	dst := filepath.Join(dir, "scoped", "credentials.toml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0o700))
+	require.NoError(t, os.WriteFile(dst, []byte("refresh_token = \"rotated\"\n"), 0o600))
+
+	err := writeLiveDogfoodCredentialFileIfUnchanged(liveDogfoodCredentialMirror{
+		src:         src,
+		dst:         dst,
+		mode:        0o600,
+		allowCreate: true,
+	}, []byte("refresh_token = \"rotated\"\n"))
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(src)
+	require.NoError(t, err)
+	assert.Equal(t, "refresh_token = \"rotated\"\n", string(got))
+}
+
+func writeLiveDogfoodRotatingRefreshStub(t *testing.T, dir, binaryName, original, rotated string) {
+	t.Helper()
+	writeStubBinary(t, dir, binaryName, `set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"account","subcommands":[{"name":"show"}]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Show the authenticated account.
+
+Usage:
+  fixture-pp-cli account show [flags]
+
+Examples:
+  fixture-pp-cli account show
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show" ]; then
+  if [ -n "${FIXTURE_REFRESH_TOKEN:-}" ]; then
+    echo "rotating refresh token leaked via env" >&2
+    exit 1
+  fi
+  creds="$HOME/.local/share/fixture-pp-cli/credentials.toml"
+  if [ ! -f "$creds" ]; then
+    echo "missing sandbox credentials.toml" >&2
+    exit 1
+  fi
+  if grep -q '`+original+`' "$creds"; then
+    printf 'refresh_token = "%s"\naccess_token = "fresh-access"\n' '`+rotated+`' > "$creds"
+  elif ! grep -q '`+rotated+`' "$creds"; then
+    echo "unexpected credential file" >&2
+    cat "$creds" >&2
+    exit 1
+  fi
+  if [ "${3:-}" = "--json" ]; then
+    echo '{"ok":true}'
+    exit 0
+  fi
+  echo 'ok'
+  exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`)
+}

--- a/internal/pipeline/live_dogfood_refresh_test.go
+++ b/internal/pipeline/live_dogfood_refresh_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -399,6 +400,129 @@ func TestRunLiveDogfoodSyncsRotatedRefreshBeforeAcceptanceMarkerFailure(t *testi
 	require.NoError(t, readErr)
 	assert.Contains(t, string(got), rotated)
 	assert.NotContains(t, string(got), original)
+}
+
+func TestRunLiveDogfoodRotatedRefreshSyncBackFailureWritesFailMarker(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	const (
+		binaryName   = "fixture-pp-cli"
+		original     = "old-refresh"
+		rotated      = "new-refresh"
+		operatorEdit = "operator-refresh"
+	)
+
+	operatorHome := t.TempDir()
+	isolateLiveDogfoodOperatorPaths(t, binaryName, operatorHome)
+	credsPath := filepath.Join(operatorHome, ".local", "share", binaryName, "credentials.toml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(credsPath), 0o700))
+	require.NoError(t, os.WriteFile(credsPath, []byte("refresh_token = \""+original+"\"\n"), 0o600))
+	t.Setenv("FIXTURE_REFRESH_TOKEN", original)
+	t.Setenv("OPERATOR_CREDS_PATH", credsPath)
+
+	dir := t.TempDir()
+	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
+		SchemaVersion: 1,
+		APIName:       "fixture",
+		CLIName:       binaryName,
+		RunID:         "run-live-dogfood",
+		AuthType:      spec.AuthTypeOAuth2Refresh,
+		AuthEnvVars:   []string{"FIXTURE_REFRESH_TOKEN"},
+		SpecFormat:    "openapi3",
+	}))
+	writeStubBinary(t, dir, binaryName, `set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"account","subcommands":[{"name":"show"}]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Show the authenticated account.
+
+Usage:
+  fixture-pp-cli account show [flags]
+
+Examples:
+  fixture-pp-cli account show
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show" ]; then
+  if [ -n "${FIXTURE_REFRESH_TOKEN:-}" ]; then
+    echo "rotating refresh token leaked via env" >&2
+    exit 1
+  fi
+  creds="$HOME/.local/share/fixture-pp-cli/credentials.toml"
+  if [ ! -f "$creds" ]; then
+    echo "missing sandbox credentials.toml" >&2
+    exit 1
+  fi
+  printf 'refresh_token = "operator-refresh"\n' > "$OPERATOR_CREDS_PATH"
+  printf 'refresh_token = "new-refresh"\naccess_token = "fresh-access"\n' > "$creds"
+  if [ "${3:-}" = "--json" ]; then
+    echo '{"ok":true}'
+    exit 0
+  fi
+  echo 'ok'
+  exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`)
+
+	markerPath := filepath.Join(t.TempDir(), Phase5AcceptanceFilename)
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:              dir,
+		BinaryName:          binaryName,
+		Level:               "full",
+		Timeout:             2 * time.Second,
+		AuthEnv:             "FIXTURE_REFRESH_TOKEN",
+		WriteAcceptancePath: markerPath,
+	})
+	require.Error(t, err)
+	require.NotNil(t, report)
+	assert.Contains(t, err.Error(), "operator config changed during dogfood")
+	assert.Equal(t, "FAIL", report.Verdict, report.Tests)
+	syncFail := findResultByCommandKind(report, "live-dogfood", LiveDogfoodTestHappy)
+	require.NotNil(t, syncFail)
+	assert.Equal(t, LiveDogfoodStatusFail, syncFail.Status)
+	assert.Equal(t, reasonCredentialSyncBackFailed, syncFail.Reason)
+
+	got, readErr := os.ReadFile(credsPath)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(got), operatorEdit)
+	assert.NotContains(t, string(got), rotated)
+
+	data, err := os.ReadFile(markerPath)
+	require.NoError(t, err)
+	var marker Phase5GateMarker
+	require.NoError(t, json.Unmarshal(data, &marker))
+	assert.Equal(t, "fail", marker.Status)
+	assert.NotEqual(t, "pass", marker.Status)
+	require.NotNil(t, marker.FailureSummary)
+
+	validation := ValidatePhase5Gate(filepath.Dir(markerPath), CLIManifest{
+		APIName:  marker.APIName,
+		RunID:    marker.RunID,
+		AuthType: spec.AuthTypeOAuth2Refresh,
+	}, dir)
+	assert.False(t, validation.Passed, "rotated refresh sync-back failure must not leave a promotable pass marker")
+	assert.Equal(t, "fail", validation.Status)
 }
 
 func TestRunLiveDogfoodSyncsOAuth2RefreshCredentialsTomlBackFromXDGDataHome(t *testing.T) {

--- a/internal/pipeline/live_dogfood_refresh_test.go
+++ b/internal/pipeline/live_dogfood_refresh_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,6 +34,15 @@ func TestLiveDogfoodRotatingRefreshEnvVars(t *testing.T) {
 	assert.Equal(t, []string{"VENDOR_REFRESH_TOKEN"}, got)
 
 	got = liveDogfoodRotatingRefreshEnvVars(CLIManifest{
+		AuthType: spec.AuthTypeOAuth2Refresh,
+		AuthEnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "VENDOR_CLIENT_ID", Kind: spec.AuthEnvVarKindPerCall},
+			{Name: "VENDOR_OAUTH_TOKEN", Kind: spec.AuthEnvVarKindAuthFlowInput},
+		},
+	}, "VENDOR_CLIENT_ID")
+	assert.Equal(t, []string{"VENDOR_OAUTH_TOKEN"}, got)
+
+	got = liveDogfoodRotatingRefreshEnvVars(CLIManifest{
 		AuthType:    spec.AuthTypeOAuth2Refresh,
 		AuthEnvVars: []string{"VENDOR_CLIENT_ID", "VENDOR_CLIENT_SECRET", "VENDOR_REFRESH_TOKEN"},
 	}, "VENDOR_CLIENT_ID")
@@ -42,7 +52,8 @@ func TestLiveDogfoodRotatingRefreshEnvVars(t *testing.T) {
 		AuthType:    spec.AuthTypeOAuth2Refresh,
 		AuthEnvVars: []string{"VENDOR_CLIENT_ID", "VENDOR_CLIENT_SECRET"},
 	}, "VENDOR_CLIENT_ID")
-	assert.Empty(t, got)
+	assert.Equal(t, []string{"VENDOR_CLIENT_SECRET"}, got)
+	assert.NotContains(t, got, "VENDOR_CLIENT_ID")
 }
 
 func TestLiveDogfoodRotatingRefreshTokenIgnoresClientIDAuthEnv(t *testing.T) {
@@ -107,7 +118,7 @@ func TestRunLiveDogfoodAuthEnvRefreshTokenUsesSharedCredentialFile(t *testing.T)
 	)
 
 	operatorHome := t.TempDir()
-	t.Setenv("HOME", operatorHome)
+	isolateLiveDogfoodOperatorPaths(t, binaryName, operatorHome)
 	t.Setenv(authEnv, original)
 
 	dir := t.TempDir()
@@ -153,7 +164,7 @@ func TestRunLiveDogfoodOAuth2RefreshClientIDAuthEnvDoesNotSeedOrStrip(t *testing
 	)
 
 	operatorHome := t.TempDir()
-	t.Setenv("HOME", operatorHome)
+	isolateLiveDogfoodOperatorPaths(t, binaryName, operatorHome)
 	t.Setenv(clientIDEnv, clientIDVal)
 	t.Setenv("FIXTURE_CLIENT_SECRET", "client-secret-value")
 	t.Setenv(refreshEnv, original)
@@ -270,6 +281,29 @@ func TestSeedLiveDogfoodRotatingRefreshDoesNotWriteClientID(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "client-id --auth-env must not create credentials.toml")
 }
 
+func TestSeedLiveDogfoodRotatingRefreshPreservesCustomAuthFlowInputName(t *testing.T) {
+	isolateLiveDogfoodOperatorPaths(t, "fixture-pp-cli", t.TempDir())
+	t.Setenv("VENDOR_CLIENT_ID", "client-id-value")
+	t.Setenv("VENDOR_OAUTH_TOKEN", "custom-refresh")
+
+	home := t.TempDir()
+	seed, err := seedLiveDogfoodRotatingRefresh(home, "fixture-pp-cli", CLIManifest{
+		AuthType: spec.AuthTypeOAuth2Refresh,
+		AuthEnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "VENDOR_CLIENT_ID", Kind: spec.AuthEnvVarKindPerCall},
+			{Name: "VENDOR_OAUTH_TOKEN", Kind: spec.AuthEnvVarKindAuthFlowInput},
+		},
+	}, "VENDOR_CLIENT_ID")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"VENDOR_OAUTH_TOKEN"}, seed.stripEnv)
+	assert.Equal(t, "VENDOR_OAUTH_TOKEN", seed.seededEnvVar)
+
+	got, err := os.ReadFile(liveDogfoodCredentialsRelPath(home, "fixture-pp-cli"))
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "custom-refresh")
+	assert.NotContains(t, string(got), "client-id-value")
+}
+
 func TestRunLiveDogfoodSyncsOAuth2RefreshCredentialsTomlBack(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")
@@ -282,7 +316,7 @@ func TestRunLiveDogfoodSyncsOAuth2RefreshCredentialsTomlBack(t *testing.T) {
 	)
 
 	operatorHome := t.TempDir()
-	t.Setenv("HOME", operatorHome)
+	isolateLiveDogfoodOperatorPaths(t, binaryName, operatorHome)
 	credsPath := filepath.Join(operatorHome, ".local", "share", binaryName, "credentials.toml")
 	require.NoError(t, os.MkdirAll(filepath.Dir(credsPath), 0o700))
 	require.NoError(t, os.WriteFile(credsPath, []byte("refresh_token = \""+original+"\"\n"), 0o600))
@@ -316,6 +350,59 @@ func TestRunLiveDogfoodSyncsOAuth2RefreshCredentialsTomlBack(t *testing.T) {
 	assert.NotContains(t, string(got), original)
 }
 
+func TestRunLiveDogfoodSyncsOAuth2RefreshCredentialsTomlBackFromXDGDataHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	const (
+		binaryName = "fixture-pp-cli"
+		original   = "old-refresh"
+		rotated    = "new-refresh"
+	)
+
+	operatorHome := t.TempDir()
+	xdgDataHome := t.TempDir()
+	isolateLiveDogfoodOperatorPaths(t, binaryName, operatorHome)
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+
+	credsPath := filepath.Join(xdgDataHome, binaryName, "credentials.toml")
+	defaultPath := filepath.Join(operatorHome, ".local", "share", binaryName, "credentials.toml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(credsPath), 0o700))
+	require.NoError(t, os.WriteFile(credsPath, []byte("refresh_token = \""+original+"\"\n"), 0o600))
+	t.Setenv("FIXTURE_REFRESH_TOKEN", original)
+
+	dir := t.TempDir()
+	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
+		SchemaVersion: 1,
+		APIName:       "fixture",
+		CLIName:       binaryName,
+		RunID:         "run-live-dogfood",
+		AuthType:      spec.AuthTypeOAuth2Refresh,
+		AuthEnvVars:   []string{"FIXTURE_REFRESH_TOKEN"},
+		SpecFormat:    "openapi3",
+	}))
+	writeLiveDogfoodRotatingRefreshStub(t, dir, binaryName, original, rotated)
+
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    2 * time.Second,
+		AuthEnv:    "FIXTURE_REFRESH_TOKEN",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "PASS", report.Verdict, report.Tests)
+
+	got, err := os.ReadFile(credsPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), rotated)
+	assert.NotContains(t, string(got), original)
+
+	_, err = os.Stat(defaultPath)
+	assert.True(t, os.IsNotExist(err), "rotated token must not land in HOME/.local/share when XDG_DATA_HOME is set")
+}
+
 func TestRunLiveDogfoodAPIKeyAuthEnvUnchanged(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")
@@ -326,7 +413,7 @@ func TestRunLiveDogfoodAPIKeyAuthEnvUnchanged(t *testing.T) {
 		authEnv    = "FIXTURE_API_KEY"
 	)
 
-	t.Setenv("HOME", t.TempDir())
+	isolateLiveDogfoodOperatorPaths(t, binaryName, t.TempDir())
 	t.Setenv(authEnv, "static-api-key")
 
 	dir := t.TempDir()
@@ -407,7 +494,7 @@ func TestRunLiveDogfoodAbortsInvalidGrantCascade(t *testing.T) {
 
 	const binaryName = "fixture-pp-cli"
 
-	t.Setenv("HOME", t.TempDir())
+	isolateLiveDogfoodOperatorPaths(t, binaryName, t.TempDir())
 
 	dir := t.TempDir()
 	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
@@ -496,6 +583,107 @@ exit 99
 	}
 }
 
+func TestRunLiveDogfoodAPIKeyDoesNotAbortInvalidGrantCascade(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	const binaryName = "fixture-pp-cli"
+
+	isolateLiveDogfoodOperatorPaths(t, binaryName, t.TempDir())
+
+	dir := t.TempDir()
+	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
+		SchemaVersion: 1,
+		APIName:       "fixture",
+		CLIName:       binaryName,
+		RunID:         "run-live-dogfood",
+		AuthType:      "api_key",
+		SpecFormat:    "openapi3",
+	}))
+	writeStubBinary(t, dir, binaryName, `set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"account","subcommands":[{"name":"show"}]},
+    {"name":"billing","subcommands":[{"name":"list"}]},
+    {"name":"catalog","subcommands":[{"name":"list"}]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "${2:-}" = "--help" ] || [ "${3:-}" = "--help" ]; then
+  cat <<HELP
+Show $1 $2.
+
+Usage:
+  fixture-pp-cli $1 $2 [flags]
+
+Examples:
+  fixture-pp-cli $1 $2
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show" ]; then
+  if [ "${3:-}" = "--json" ]; then
+    echo '{"ok":true}'
+    exit 0
+  fi
+  echo 'ok'
+  exit 0
+fi
+
+if [ "$1" = "billing" ] && [ "$2" = "list" ]; then
+  echo 'Error: refreshing access token: HTTP 400: {"error":"invalid_grant","error_description":"refresh token is invalid, expired or revoked"}' >&2
+  exit 4
+fi
+
+if [ "$1" = "catalog" ] && [ "$2" = "list" ]; then
+  if [ "${3:-}" = "--json" ]; then
+    echo '{"ok":true}'
+    exit 0
+  fi
+  echo 'ok'
+  exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`)
+
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "FAIL", report.Verdict)
+
+	assert.Nil(t, findResultByCommandKind(report, "live-dogfood", LiveDogfoodTestHappy))
+
+	catalogHelp := findResultByCommandKind(report, "catalog list", LiveDogfoodTestHelp)
+	require.NotNil(t, catalogHelp)
+	assert.Equal(t, LiveDogfoodStatusPass, catalogHelp.Status)
+	assert.NotEqual(t, reasonRefreshTokenRotationCascade, catalogHelp.Reason)
+
+	catalogHappy := findResultByCommandKind(report, "catalog list", LiveDogfoodTestHappy)
+	require.NotNil(t, catalogHappy)
+	assert.Equal(t, LiveDogfoodStatusPass, catalogHappy.Status)
+
+	for _, result := range report.Tests {
+		assert.NotEqual(t, reasonRefreshTokenRotationCascade, result.Reason)
+	}
+}
+
 func TestWriteLiveDogfoodCredentialFileIfUnchangedCreatesMissingSrc(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "operator", "credentials.toml")
@@ -575,4 +763,60 @@ fi
 echo "unexpected args: $*" >&2
 exit 99
 `)
+}
+
+func TestLiveDogfoodOperatorDataDir(t *testing.T) {
+	const cliName = "fixture-pp-cli"
+	home := t.TempDir()
+	isolateLiveDogfoodOperatorPaths(t, cliName, home)
+	prefix := naming.EnvPrefix(naming.TrimCLISuffix(cliName))
+
+	assert.Equal(t, filepath.Join(home, ".local", "share", cliName), liveDogfoodOperatorDataDir(cliName))
+
+	t.Run("xdg data home", func(t *testing.T) {
+		xdg := t.TempDir()
+		t.Setenv("XDG_DATA_HOME", xdg)
+		assert.Equal(t, filepath.Join(xdg, cliName), liveDogfoodOperatorDataDir(cliName))
+	})
+
+	t.Run("prefix home precedes xdg", func(t *testing.T) {
+		prefixHome := t.TempDir()
+		t.Setenv(prefix+"_HOME", prefixHome)
+		t.Setenv("XDG_DATA_HOME", t.TempDir())
+		assert.Equal(t, filepath.Join(prefixHome, "data"), liveDogfoodOperatorDataDir(cliName))
+	})
+
+	t.Run("prefix data dir precedes home env", func(t *testing.T) {
+		dataDir := t.TempDir()
+		t.Setenv(prefix+"_DATA_DIR", dataDir)
+		t.Setenv(prefix+"_HOME", t.TempDir())
+		t.Setenv("XDG_DATA_HOME", t.TempDir())
+		assert.Equal(t, dataDir, liveDogfoodOperatorDataDir(cliName))
+	})
+
+	t.Run("relative xdg is ignored", func(t *testing.T) {
+		t.Setenv("XDG_DATA_HOME", "relative-data")
+		assert.Equal(t, filepath.Join(home, ".local", "share", cliName), liveDogfoodOperatorDataDir(cliName))
+	})
+
+	t.Run("tilde xdg expands", func(t *testing.T) {
+		t.Setenv("XDG_DATA_HOME", "~/custom-data")
+		assert.Equal(t, filepath.Join(home, "custom-data", cliName), liveDogfoodOperatorDataDir(cliName))
+	})
+}
+
+func isolateLiveDogfoodOperatorPaths(t *testing.T, cliName, home string) {
+	t.Helper()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	for _, name := range []string{"XDG_DATA_HOME", "XDG_CONFIG_HOME", "XDG_STATE_HOME", "XDG_CACHE_HOME"} {
+		t.Setenv(name, "")
+	}
+	prefix := naming.EnvPrefix(naming.TrimCLISuffix(cliName))
+	if prefix == "" {
+		return
+	}
+	for _, suffix := range naming.PathKindEnvSuffixes() {
+		t.Setenv(prefix+"_"+suffix, "")
+	}
 }

--- a/internal/pipeline/live_dogfood_refresh_test.go
+++ b/internal/pipeline/live_dogfood_refresh_test.go
@@ -350,6 +350,57 @@ func TestRunLiveDogfoodSyncsOAuth2RefreshCredentialsTomlBack(t *testing.T) {
 	assert.NotContains(t, string(got), original)
 }
 
+func TestRunLiveDogfoodSyncsRotatedRefreshBeforeAcceptanceMarkerFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	const (
+		binaryName = "fixture-pp-cli"
+		original   = "old-refresh"
+		rotated    = "new-refresh"
+	)
+
+	operatorHome := t.TempDir()
+	isolateLiveDogfoodOperatorPaths(t, binaryName, operatorHome)
+	credsPath := filepath.Join(operatorHome, ".local", "share", binaryName, "credentials.toml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(credsPath), 0o700))
+	require.NoError(t, os.WriteFile(credsPath, []byte("refresh_token = \""+original+"\"\n"), 0o600))
+	t.Setenv("FIXTURE_REFRESH_TOKEN", original)
+
+	dir := t.TempDir()
+	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
+		SchemaVersion: 1,
+		APIName:       "fixture",
+		CLIName:       binaryName,
+		RunID:         "run-live-dogfood",
+		AuthType:      spec.AuthTypeOAuth2Refresh,
+		AuthEnvVars:   []string{"FIXTURE_REFRESH_TOKEN"},
+		SpecFormat:    "openapi3",
+	}))
+	writeLiveDogfoodRotatingRefreshStub(t, dir, binaryName, original, rotated)
+
+	blocker := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o600))
+	markerPath := filepath.Join(blocker, Phase5AcceptanceFilename)
+
+	_, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:              dir,
+		BinaryName:          binaryName,
+		Level:               "full",
+		Timeout:             2 * time.Second,
+		AuthEnv:             "FIXTURE_REFRESH_TOKEN",
+		WriteAcceptancePath: markerPath,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating phase5 marker directory")
+
+	got, readErr := os.ReadFile(credsPath)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(got), rotated)
+	assert.NotContains(t, string(got), original)
+}
+
 func TestRunLiveDogfoodSyncsOAuth2RefreshCredentialsTomlBackFromXDGDataHome(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -699,18 +699,22 @@ func TestRunLiveDogfoodMirrorsConfigAndCookieCredentialsIntoScopedHome(t *testin
 		binaryName         = "fixture-pp-cli"
 		configCredential   = "real-config-token"
 		cookieCredential   = "real-cookie-token"
+		refreshCredential  = "real-refresh-token"
 		configOriginalBody = "auth_header = \"" + configCredential + "\"\n"
 		cookieOriginalBody = `[{"name":"session","value":"` + cookieCredential + `","domain":".example.test","path":"/","secure":true}]`
+		credsOriginalBody  = "refresh_token = \"" + refreshCredential + "\"\n"
 	)
 
 	operatorHome := t.TempDir()
 	t.Setenv("HOME", operatorHome)
 	configPath := filepath.Join(operatorHome, ".config", binaryName, "config.toml")
 	cookiePath := filepath.Join(operatorHome, ".local", "share", binaryName, "cookies.json")
+	credsPath := filepath.Join(operatorHome, ".local", "share", binaryName, "credentials.toml")
 	require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o700))
 	require.NoError(t, os.MkdirAll(filepath.Dir(cookiePath), 0o700))
 	require.NoError(t, os.WriteFile(configPath, []byte(configOriginalBody), 0o600))
 	require.NoError(t, os.WriteFile(cookiePath, []byte(cookieOriginalBody), 0o600))
+	require.NoError(t, os.WriteFile(credsPath, []byte(credsOriginalBody), 0o600))
 
 	dir := t.TempDir()
 	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
@@ -752,6 +756,7 @@ fi
 if [ "$1" = "account" ] && [ "$2" = "show" ]; then
   config_path="$HOME/.config/fixture-pp-cli/config.toml"
   cookie_path="$HOME/.local/share/fixture-pp-cli/cookies.json"
+  creds_path="$HOME/.local/share/fixture-pp-cli/credentials.toml"
   if ! grep -q 'real-config-token' "$config_path"; then
     echo "missing mirrored config credential" >&2
     exit 1
@@ -760,8 +765,13 @@ if [ "$1" = "account" ] && [ "$2" = "show" ]; then
     echo "missing mirrored cookie credential" >&2
     exit 1
   fi
+  if ! grep -q 'real-refresh-token' "$creds_path"; then
+    echo "missing mirrored credentials.toml refresh token" >&2
+    exit 1
+  fi
   printf 'auth_header = "real-config-token-mutated"\n' > "$config_path"
   printf '[{"name":"session","value":"real-cookie-token-mutated","domain":".example.test","path":"/","secure":true}]' > "$cookie_path"
+  printf 'refresh_token = "real-refresh-token-mutated"\n' > "$creds_path"
   if [ "${3:-}" = "--json" ]; then
     echo '{"ok":true}'
     exit 0
@@ -796,6 +806,9 @@ exit 99
 	gotCookies, err := os.ReadFile(cookiePath)
 	require.NoError(t, err)
 	assert.Equal(t, cookieOriginalBody, string(gotCookies), "live dogfood must not mutate the operator's real cookies")
+	gotCreds, err := os.ReadFile(credsPath)
+	require.NoError(t, err)
+	assert.Equal(t, credsOriginalBody, string(gotCreds), "composed auth must not sync credentials.toml back")
 }
 
 // TestRunLiveDogfoodCookieAuthNoSessionSkips covers issue #3104: a cookie-auth

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -706,7 +706,7 @@ func TestRunLiveDogfoodMirrorsConfigAndCookieCredentialsIntoScopedHome(t *testin
 	)
 
 	operatorHome := t.TempDir()
-	t.Setenv("HOME", operatorHome)
+	isolateLiveDogfoodOperatorPaths(t, binaryName, operatorHome)
 	configPath := filepath.Join(operatorHome, ".config", binaryName, "config.toml")
 	cookiePath := filepath.Join(operatorHome, ".local", "share", binaryName, "cookies.json")
 	credsPath := filepath.Join(operatorHome, ".local", "share", binaryName, "credentials.toml")

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -1086,7 +1086,8 @@ exit 99
 	require.Error(t, err)
 	require.NotNil(t, report, "sync-back errors must not discard the completed live dogfood report")
 	assert.Contains(t, err.Error(), "operator config changed during dogfood")
-	assert.Equal(t, "PASS", report.Verdict, report.Tests)
+	assert.Equal(t, "FAIL", report.Verdict, report.Tests)
+	assert.Greater(t, report.Failed, 0)
 
 	gotConfig, err := os.ReadFile(configPath)
 	require.NoError(t, err)
@@ -1096,9 +1097,20 @@ exit 99
 	require.NoError(t, err, "sync-back errors must not suppress the Phase 5 acceptance marker")
 	var marker Phase5GateMarker
 	require.NoError(t, json.Unmarshal(data, &marker))
-	assert.Equal(t, "pass", marker.Status)
+	assert.Equal(t, "fail", marker.Status)
 	assert.Equal(t, report.MatrixSize, marker.MatrixSize)
 	assert.Equal(t, report.Passed, marker.TestsPassed)
+	assert.Equal(t, report.Failed, marker.TestsFailed)
+	require.NotNil(t, marker.FailureSummary)
+	assert.Contains(t, marker.FailureSummary.Commands, "live-dogfood")
+
+	validation := ValidatePhase5Gate(filepath.Dir(markerPath), CLIManifest{
+		APIName:  marker.APIName,
+		RunID:    marker.RunID,
+		AuthType: "oauth2_refresh",
+	}, dir)
+	assert.False(t, validation.Passed, "sync-back failure must not leave a promotable pass marker")
+	assert.Equal(t, "fail", validation.Status)
 }
 
 func TestSyncLiveDogfoodCredentialMirrorsRejectsOperatorConfigConflict(t *testing.T) {

--- a/internal/pipeline/subprocess_env.go
+++ b/internal/pipeline/subprocess_env.go
@@ -147,6 +147,7 @@ var (
 	scopedHomeDirMu       sync.RWMutex
 	scopedHomeDir         string
 	scopedHomeCLIEnvNames []string
+	scopedStripEnvNames   []string
 )
 
 // currentSubprocessHome returns the active scoped home or "" if none.
@@ -160,6 +161,56 @@ func currentSubprocessCLIEnvNames() []string {
 	scopedHomeDirMu.RLock()
 	defer scopedHomeDirMu.RUnlock()
 	return append([]string(nil), scopedHomeCLIEnvNames...)
+}
+
+func currentSubprocessStripEnvNames() []string {
+	scopedHomeDirMu.RLock()
+	defer scopedHomeDirMu.RUnlock()
+	return append([]string(nil), scopedStripEnvNames...)
+}
+
+// installSubprocessEnvStrip drops named env vars from printed-CLI
+// subprocesses for the rest of the scoped session. Used by live dogfood
+// so a rotating refresh token in --auth-env cannot override the shared
+// credential file. Restores the previous strip list on cleanup.
+func installSubprocessEnvStrip(names []string) func() {
+	scopedHomeDirMu.Lock()
+	prev := append([]string(nil), scopedStripEnvNames...)
+	scopedStripEnvNames = append([]string(nil), names...)
+	scopedHomeDirMu.Unlock()
+	return func() {
+		scopedHomeDirMu.Lock()
+		scopedStripEnvNames = prev
+		scopedHomeDirMu.Unlock()
+	}
+}
+
+func applyEnvStrip(env []string, names []string) []string {
+	if len(env) == 0 || len(names) == 0 {
+		return env
+	}
+	drop := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		drop[name] = struct{}{}
+	}
+	if len(drop) == 0 {
+		return env
+	}
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		key, _, found := strings.Cut(entry, "=")
+		if found {
+			if _, ok := drop[key]; ok {
+				continue
+			}
+		}
+		out = append(out, entry)
+	}
+	return out
 }
 
 // installScopedSubprocessHome installs homeDir as the active scoped
@@ -200,7 +251,8 @@ func scopeSubprocessHome(cliNames ...string) (func(), error) {
 // subprocessEnv returns os.Environ() with the active scoped home
 // overlaid, or os.Environ() unchanged when no session is active.
 func subprocessEnv() []string {
-	return applyScopedConfigHome(os.Environ(), currentSubprocessHome(), currentSubprocessCLIEnvNames()...)
+	env := applyScopedConfigHome(os.Environ(), currentSubprocessHome(), currentSubprocessCLIEnvNames()...)
+	return applyEnvStrip(env, currentSubprocessStripEnvNames())
 }
 
 // applyDefaultSubprocessEnv installs subprocessEnv() on cmd if the

--- a/internal/pipeline/subprocess_env_test.go
+++ b/internal/pipeline/subprocess_env_test.go
@@ -253,6 +253,38 @@ func TestFindCLINamesAndScopedEnvCoverMultipleCommandVariants(t *testing.T) {
 	assertEnv(t, env, "BETA_API_TOKEN", "beta-secret")
 }
 
+func TestApplyEnvStripDropsExactKeys(t *testing.T) {
+	got := applyEnvStrip([]string{
+		"FOO_REFRESH_TOKEN=secret",
+		"FOO_API_KEY=keep",
+		"FOO_REFRESH_TOKEN_EXTRA=keep2",
+	}, []string{"FOO_REFRESH_TOKEN"})
+	assertEnv(t, got, "FOO_API_KEY", "keep")
+	assertEnv(t, got, "FOO_REFRESH_TOKEN_EXTRA", "keep2")
+	if envValue(got, "FOO_REFRESH_TOKEN") != "" {
+		t.Fatalf("rotating token not stripped: %v", got)
+	}
+}
+
+func TestSubprocessEnvStripsInstalledNames(t *testing.T) {
+	t.Setenv("FOO_REFRESH_TOKEN", "secret")
+	t.Setenv("FOO_API_KEY", "keep")
+
+	cleanup, err := scopeSubprocessHome()
+	if err != nil {
+		t.Fatalf("scopeSubprocessHome: %v", err)
+	}
+	defer cleanup()
+	restore := installSubprocessEnvStrip([]string{"FOO_REFRESH_TOKEN"})
+	defer restore()
+
+	env := subprocessEnv()
+	assertEnv(t, env, "FOO_API_KEY", "keep")
+	if envValue(env, "FOO_REFRESH_TOKEN") != "" {
+		t.Fatalf("rotating token leaked into scoped subprocess env: %v", env)
+	}
+}
+
 func TestApplyDefaultSubprocessEnvDogfoodAppendPreservesAPICredential(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1465,7 +1465,11 @@ func isOAuthClientSecretEnvVar(name string) bool {
 	return placeholder == "client_secret" || strings.HasSuffix(placeholder, "_client_secret")
 }
 
-func isOAuthRefreshTokenEnvVar(name string) bool {
+// IsOAuthRefreshTokenEnvVar reports whether name is the long-lived
+// oauth2_refresh token env (REFRESH_TOKEN or *_REFRESH_TOKEN). Live
+// dogfood uses this to seed and strip only refresh-shaped --auth-env
+// values, so a client-ID variable is never written as refresh_token.
+func IsOAuthRefreshTokenEnvVar(name string) bool {
 	placeholder := naming.EnvVarPlaceholder(name)
 	return placeholder == "refresh_token" || strings.HasSuffix(placeholder, "_refresh_token")
 }
@@ -1528,7 +1532,7 @@ func (c *AuthConfig) OAuth2RefreshTokenEnvVar() *AuthEnvVar {
 	}
 	c.NormalizeEnvVarSpecs("")
 	for i := range c.EnvVarSpecs {
-		if isOAuthRefreshTokenEnvVar(c.EnvVarSpecs[i].Name) {
+		if IsOAuthRefreshTokenEnvVar(c.EnvVarSpecs[i].Name) {
 			return &c.EnvVarSpecs[i]
 		}
 	}

--- a/skills/printing-press/phases/18-dogfood-testing.md
+++ b/skills/printing-press/phases/18-dogfood-testing.md
@@ -82,6 +82,18 @@ the 401s as failures: it records a clean skip verdict
 accepts that skip marker, so do not hand-author or fabricate a pass marker for a
 cookie-auth CLI you could not exercise.
 
+**OAuth2 refresh-token rotation (`auth.type: oauth2_refresh`).** Pass
+`--auth-env <VAR>` when the refresh token lives in the environment. When that
+variable is refresh-token-shaped (`REFRESH_TOKEN` or `*_REFRESH_TOKEN`), the
+runner copies it into a shared sandbox `credentials.toml` and strips those
+rotating env vars from subprocesses so the first refresh persists for later
+commands. A client-ID `--auth-env` (the oauth2_refresh publish default) is
+left in place and is not written as `refresh_token`. Do not expect a static
+env value to survive rotating identity providers across N subprocesses. If
+`invalid_grant` still appears after a live pass, the runner aborts the matrix
+with that diagnosis instead of recording hundreds of command failures; the
+operator's stored refresh token may have been revoked and needs a fresh login.
+
 The live dogfood runner enumerates the CLI's `agent-context` command tree,
 runs help, happy-path, JSON-fidelity, and error-path checks where applicable,
 captures subprocess exit codes directly without shell pipes, and emits a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #4462

Rebased onto current `main` after #3723 (`feat(skills): make Printing Press phases progressive and resumable`).

Conflict resolution: kept #3723's thin SKILL.md router. Re-added the oauth2_refresh / live-dogfood credential guidance in `skills/printing-press/phases/18-dogfood-testing.md` (the phase that now owns that procedure), not in the deleted monolithic SKILL.md content.

Rotating-refresh behavior is unchanged: shared sandbox `credentials.toml`, strip refresh-shaped env vars from children, syncBack before the acceptance marker, fail closed if credential syncBack fails, XDG/data-dir precedence, oauth2_refresh-only cascade tracker, custom refresh names from `OAuth2RefreshTokenEnvVar`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10b744a9-b2ed-48ec-9eb8-53e501336f61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10b744a9-b2ed-48ec-9eb8-53e501336f61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

