### PR TITLE
fix(ci): keep conversation check green on fork review events

### DIFF
--- a/.github/workflows/conversation-resolution-check.yml
+++ b/.github/workflows/conversation-resolution-check.yml
@@ -77,9 +77,6 @@ jobs:
     # prior runs of the workflow on the same SHA accumulate as separate
     # rollup entries (failure → cancelled → success), and consumers that
     # don't dedupe by completed_at can pick the stale failure (#1878).
-    # The post step must also exit 0 when a fork PR review token cannot
-    # write statuses (403); otherwise those events recreate the same
-    # phantom-FAILURE check_runs this split exists to avoid.
     name: Evaluate conversation threads
     # Skip drafts across every event source. The original guard only
     # covered pull_request_target, but pull_request_review and
@@ -259,6 +256,7 @@ jobs:
           DESCRIPTION: ${{ steps.eval.outputs.description || 'Workflow error — see run logs' }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           set -euo pipefail
           # Use the canonical name as the status context so a single
@@ -266,23 +264,25 @@ jobs:
           # truth without requiring branch-protection/ruleset updates.
           # Reposting with the same (sha, context) overrides — that's what
           # fixes #1878.
-          if gh api -X POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+          if out="$(gh api -X POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
             -f state="${STATE}" \
             -f context="All conversations resolved" \
             -f description="${DESCRIPTION}" \
-            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"; then
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" 2>&1)"; then
             exit 0
           fi
-          # Fork PRs: pull_request_review and pull_request_review_comment
-          # get a read-only token, so statuses: write is ignored and this
-          # POST returns 403. Failing the job here turns the auto check_run
-          # red, which is the opposite of the split this workflow exists
-          # for (#1878). pull_request_target has a write token and owns
-          # the canonical status; exit 0 so the check_run stays success.
+          # Fork review events get a read-only token; statuses: write is
+          # ignored and this POST returns 403. Swallow only that permission
+          # miss so a rate-limit or network failure on a same-repo review
+          # still fails the job. pull_request_target owns the canonical status.
           case "${EVENT_NAME}" in
             pull_request_review|pull_request_review_comment)
-              echo "::warning::Skipping commit status on ${EVENT_NAME} (token cannot write statuses on fork PRs). Canonical signal is pull_request_target."
-              exit 0
+              if [ "${HEAD_REPO:-}" != "${GITHUB_REPOSITORY}" ] &&
+                printf '%s\n' "${out}" | grep -q 'Resource not accessible by integration'; then
+                echo "::warning::Skipping commit status on ${EVENT_NAME}: fork review token cannot write statuses. Canonical signal is pull_request_target."
+                exit 0
+              fi
               ;;
           esac
+          printf '%s\n' "${out}" >&2
           exit 1

--- a/.github/workflows/conversation-resolution-check.yml
+++ b/.github/workflows/conversation-resolution-check.yml
@@ -77,6 +77,9 @@ jobs:
     # prior runs of the workflow on the same SHA accumulate as separate
     # rollup entries (failure → cancelled → success), and consumers that
     # don't dedupe by completed_at can pick the stale failure (#1878).
+    # The post step must also exit 0 when a fork PR review token cannot
+    # write statuses (403); otherwise those events recreate the same
+    # phantom-FAILURE check_runs this split exists to avoid.
     name: Evaluate conversation threads
     # Skip drafts across every event source. The original guard only
     # covered pull_request_target, but pull_request_review and
@@ -255,6 +258,7 @@ jobs:
           STATE: ${{ steps.eval.outputs.state || 'error' }}
           DESCRIPTION: ${{ steps.eval.outputs.description || 'Workflow error — see run logs' }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
           # Use the canonical name as the status context so a single
@@ -262,8 +266,23 @@ jobs:
           # truth without requiring branch-protection/ruleset updates.
           # Reposting with the same (sha, context) overrides — that's what
           # fixes #1878.
-          gh api -X POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+          if gh api -X POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
             -f state="${STATE}" \
             -f context="All conversations resolved" \
             -f description="${DESCRIPTION}" \
-            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"; then
+            exit 0
+          fi
+          # Fork PRs: pull_request_review and pull_request_review_comment
+          # get a read-only token, so statuses: write is ignored and this
+          # POST returns 403. Failing the job here turns the auto check_run
+          # red, which is the opposite of the split this workflow exists
+          # for (#1878). pull_request_target has a write token and owns
+          # the canonical status; exit 0 so the check_run stays success.
+          case "${EVENT_NAME}" in
+            pull_request_review|pull_request_review_comment)
+              echo "::warning::Skipping commit status on ${EVENT_NAME} (token cannot write statuses on fork PRs). Canonical signal is pull_request_target."
+              exit 0
+              ;;
+          esac
+          exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Fork PRs were accumulating failed `Evaluate conversation threads` check runs. Review and review-comment events on a fork get a read-only token, so posting the `All conversations resolved` commit status returns 403 and the job fails — the opposite of the check_run vs commit-status split this workflow exists for.

On [PR 3723](https://github.com/mvanhorn/cli-printing-press/pull/3723) that produced eight red conversation-resolution jobs. All review threads on that PR are already resolved; the status was stuck because those 403s never overwrote it.

Issue: N/A (CI workflow defect found while landing #3723)

## Approach

Keep `pull_request_target` as the writer of the canonical status. On `pull_request_review` / `pull_request_review_comment`, if the status POST fails, exit 0 so the auto check_run stays success. Same-repo PRs still post the status as before.

## Scope

Primary area: `.github/workflows/conversation-resolution-check.yml`

Why this belongs in this repo: this is the base-repo conversation-resolution workflow, not a printed-CLI change.

## Risk

A fork review event that cannot post a status will no longer fail the job. The last `pull_request_target` (or `workflow_dispatch`) status remains until the next push/label. That is already how thread-resolve clicks work.

## Output Contract

N/A

## Verification

- `python3 .github/scripts/verify-supply-chain/scan.py --base-ref origin/main` — no findings
- `python3 -m unittest scan_test` from `.github/scripts/verify-supply-chain` — pass
- Generator/template change: N/A

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07778-fa96-75ae-bef6-ed2c47703b2b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07778-fa96-75ae-bef6-ed2c47703b2b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

