### PR TITLE
fix(cli): enable verify live mode from explicit --env-var

### DIFF
--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -55,12 +55,13 @@ func newVerifyCmdWithOptions(opts verifyCmdOptions) *cobra.Command {
 (read-only GETs) or a spec-derived mock server. Produces a PASS/WARN/FAIL
 verdict with per-command scores and a data pipeline integrity check.
 
-If --api-key is provided, tests run against the real API (read-only only).
+If --api-key is provided, or --env-var names a non-empty environment variable,
+tests run against the real API (read-only only).
 Otherwise, a mock server is started from the OpenAPI spec.
 
 Use --fix to auto-patch common failures and re-test (max 3 iterations).`,
 		Example: `  # Test against real API (read-only GETs only)
-  cli-printing-press verify --dir ./github-pp-cli --spec /tmp/spec.json --api-key $GITHUB_TOKEN
+  cli-printing-press verify --dir ./github-pp-cli --spec /tmp/spec.json --env-var GITHUB_TOKEN
 
   # Test against mock server (no API key needed)
   cli-printing-press verify --dir ./github-pp-cli --spec /tmp/spec.json
@@ -154,7 +155,7 @@ Use --fix to auto-patch common failures and re-test (max 3 iterations).`,
 	cmd.Flags().StringVar(&dir, "dir", "", "Path to the generated CLI directory (required)")
 	cmd.Flags().StringVar(&specPath, "spec", "", "Path to the OpenAPI spec file")
 	cmd.Flags().StringVar(&apiKey, "api-key", "", "API key for live testing (read-only GETs only)")
-	cmd.Flags().StringVar(&envVar, "env-var", "", "Environment variable name for the API key (e.g., GITHUB_TOKEN)")
+	cmd.Flags().StringVar(&envVar, "env-var", "", "Environment variable whose nonempty value selects live testing (e.g., GITHUB_TOKEN)")
 	cmd.Flags().IntVar(&threshold, "threshold", 80, "Minimum pass rate percentage")
 	cmd.Flags().BoolVar(&fix, "fix", false, "Auto-fix common failures and re-test")
 	cmd.Flags().IntVar(&maxIterations, "max-iterations", 3, "Maximum fix loop iterations")
@@ -188,6 +189,9 @@ func shouldRunFixLoop(report *pipeline.VerifyReport) bool {
 func printVerifyReport(report *pipeline.VerifyReport) {
 	fmt.Printf("Runtime Verification: %s\n", report.Binary)
 	fmt.Printf("Mode: %s\n\n", report.Mode)
+	if report.ModeDetail != "" {
+		fmt.Printf("%s\n\n", report.ModeDetail)
+	}
 
 	// Per-command results
 	fmt.Printf("%-30s %-12s %-6s %-8s %-8s %s\n", "COMMAND", "KIND", "HELP", "DRY-RUN", "EXEC", "SCORE")

--- a/internal/cli/verify_test.go
+++ b/internal/cli/verify_test.go
@@ -14,6 +14,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestVerifyCmdHelpDescribesEnvVarLiveMode(t *testing.T) {
+	cmd := newVerifyCmd()
+	assert.Contains(t, cmd.Long, "--env-var names a non-empty environment variable")
+	assert.Contains(t, cmd.Example, "--env-var GITHUB_TOKEN")
+	assert.NotContains(t, cmd.Example, "--api-key $GITHUB_TOKEN")
+}
+
+func TestPrintVerifyReportIncludesModeDetail(t *testing.T) {
+	output, err := runWithCapturedStdout(t, func() error {
+		printVerifyReport(&pipeline.VerifyReport{
+			Binary:     "sample-cli",
+			Mode:       "mock",
+			ModeDetail: "--env-var FOO is unset or empty; running in mock mode",
+			Verdict:    "PASS",
+		})
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Contains(t, output, "Mode: mock")
+	assert.Contains(t, output, "--env-var FOO is unset or empty; running in mock mode")
+}
+
 func TestCleanupVerifyArtifacts(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "sample-cli")
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".cache", "go-build"), 0o755))

--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -21,8 +21,8 @@ import (
 type VerifyConfig struct {
 	Dir       string // generated CLI directory
 	SpecPath  string // OpenAPI spec path
-	APIKey    string // optional - if set, tests against real API
-	EnvVar    string // env var name for the API key (e.g., GITHUB_TOKEN)
+	APIKey    string // optional - nonempty selects live against the real API
+	EnvVar    string // named env var; nonempty value selects live without copying into APIKey
 	Threshold int    // minimum pass rate (default 80)
 	NoSpec    bool   // structural-only mode: skip spec-dependent checks
 	// AllowDestructive permits live-mode execute probes for commands classified
@@ -33,6 +33,7 @@ type VerifyConfig struct {
 // VerifyReport is the output of a runtime verification run.
 type VerifyReport struct {
 	Mode                   string                 `json:"mode"` // "live" or "mock"
+	ModeDetail             string                 `json:"mode_detail,omitempty"`
 	Total                  int                    `json:"total"`
 	Passed                 int                    `json:"passed"`
 	Failed                 int                    `json:"failed"`
@@ -130,11 +131,7 @@ func RunVerify(cfg VerifyConfig) (*VerifyReport, error) {
 	}
 
 	// 2. Determine mode
-	if cfg.APIKey != "" {
-		report.Mode = "live"
-	} else {
-		report.Mode = "mock"
-	}
+	report.Mode, report.ModeDetail = verifyMode(cfg)
 	report.Results = append(report.Results, runResourcePathContractChecks(cfg.Dir)...)
 
 	// 3. Build the generated CLI binary
@@ -344,6 +341,18 @@ func RunVerify(cfg VerifyConfig) (*VerifyReport, error) {
 	finalizeVerifyReport(report, cfg.Threshold, true)
 
 	return report, nil
+}
+
+func verifyMode(cfg VerifyConfig) (string, string) {
+	if cfg.APIKey != "" || (cfg.EnvVar != "" && os.Getenv(cfg.EnvVar) != "") {
+		// Keep environment credentials separate: copying one into APIKey would
+		// broadcast it over every request credential in multi-key auth.
+		return "live", ""
+	}
+	if cfg.EnvVar != "" {
+		return "mock", fmt.Sprintf("--env-var %s is unset or empty; running in mock mode", cfg.EnvVar)
+	}
+	return "mock", ""
 }
 
 func authEnvVarSpecNames(envVarSpecs []apispec.AuthEnvVar) []string {

--- a/internal/pipeline/runtime_mode_test.go
+++ b/internal/pipeline/runtime_mode_test.go
@@ -1,0 +1,51 @@
+package pipeline
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyMode(t *testing.T) {
+	const name = "PRINTING_PRESS_TEST_LIVE_CREDENTIAL"
+	const secret = "env-fixture"
+	for _, tc := range []struct {
+		name   string
+		key    string
+		env    string
+		setEnv bool
+		value  string
+		mode   string
+		warn   bool
+	}{
+		{name: "default mock", mode: "mock"},
+		{name: "explicit key", key: "explicit-fixture", mode: "live"},
+		{name: "explicit environment", env: name, setEnv: true, value: secret, mode: "live"},
+		{name: "empty environment", env: name, setEnv: true, value: "", mode: "mock", warn: true},
+		{name: "unset environment", env: name, mode: "mock", warn: true},
+		{name: "key wins", key: "explicit-fixture", env: name, setEnv: true, value: "", mode: "live"},
+		{name: "ambient credential is not opt in", setEnv: true, value: secret, mode: "mock"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setEnv {
+				t.Setenv(name, tc.value)
+			} else {
+				t.Setenv(name, "sentinel")
+				require.NoError(t, os.Unsetenv(name))
+			}
+			cfg := VerifyConfig{APIKey: tc.key, EnvVar: tc.env}
+			mode, detail := verifyMode(cfg)
+			assert.Equal(t, tc.mode, mode)
+			assert.Equal(t, tc.warn, detail != "")
+			assert.NotContains(t, detail, secret)
+			assert.NotContains(t, detail, "explicit-fixture")
+			assert.Equal(t, tc.key, cfg.APIKey)
+			assert.NotEqual(t, secret, cfg.APIKey)
+			if tc.warn {
+				assert.Contains(t, detail, name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #4286

## Intent

`verify --env-var` never reached live mode because the mode branch consulted only `cfg.APIKey`, and environment-sourced credentials are correctly left out of that field so they are not broadcast across request credential slots. `live_api_verification` stayed permanently unscoreable on the `--env-var` path.

## Approach

Choose live mode when `--api-key` is nonempty **or** the explicitly named `--env-var` resolves to a nonempty value. Leave the credential in its original environment variable. Ambient credentials without an explicit `--env-var` / `--api-key` selection stay in mock mode. An unset or empty named variable falls back to mock and reports why in `mode_detail` (human output and JSON), without echoing the secret.

A prior community PR (#4577) had this runtime idea but conflicted on `skills/printing-press/SKILL.md` after #3723. This PR is code + tests + verify CLI help only.

## Scope

Primary area: runtime verifier and `verify` CLI help.

Why this belongs in this repo: mode selection is Printing Press behavior for every printed CLI, not an API-specific fix.

## Risk

An explicitly named nonempty variable now triggers read-only live verification instead of mock. Explicit `--api-key` retains precedence. Credential transport and multi-key separation are unchanged.

## Output Contract

Optional `verify.mode_detail` JSON field and a matching human-readable diagnostic for empty/unset explicit environment variables. Existing default output has no new field. No generator/template change.

## Verification

- [x] `go test ./...` (PASS, `-timeout 30m`)
- [x] No `skills/printing-press/SKILL.md` edit

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ab8f2f2-0813-4d6a-96f7-339bb62618a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ab8f2f2-0813-4d6a-96f7-339bb62618a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

