### PR TITLE
fix(cli): scrub JWT-form GitHub installation tokens

### DIFF
--- a/internal/artifacts/secrets.go
+++ b/internal/artifacts/secrets.go
@@ -21,6 +21,14 @@ type secretReplacement struct {
 	replacement string
 }
 
+const (
+	githubOpaqueTokenPatternArchived = `(?:ghp|gho|ghs)_[A-Za-z0-9]{20,}`
+	githubOpaqueTokenPatternPublish  = `(?:ghp|gho|ghs)_[A-Za-z0-9]{36,}`
+	// Three base64url segments after ghs_. Dots are separators only, so a
+	// following sentence period or extra hyphenated segment is not consumed.
+	githubInstallationJWTPattern = `ghs_[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+`
+)
+
 var archivedSpecSecretPatterns = []secretReplacement{
 	{
 		pattern:     regexp.MustCompile(`secret-token:[A-Za-z0-9][A-Za-z0-9:_-]{20,}`),
@@ -35,7 +43,7 @@ var archivedSpecSecretPatterns = []secretReplacement{
 		replacement: `<REDACTED_OPENROUTER_TOKEN_EXAMPLE>`,
 	},
 	{
-		pattern:     regexp.MustCompile(`Bearer (?:ghp|gho|ghs)_[A-Za-z0-9]{20,}`),
+		pattern:     regexp.MustCompile(`Bearer (?:` + githubInstallationJWTPattern + `|` + githubOpaqueTokenPatternArchived + `)`),
 		replacement: `Bearer <REDACTED_GITHUB_TOKEN_EXAMPLE>`,
 	},
 	{
@@ -151,7 +159,7 @@ var vendorPrefixSecretPatterns = []vendorPrefixSecretPattern{
 	vendorSecretPattern("openrouter-api-key", `sk-or-v1-[A-Za-z0-9_-]{24,}`),
 	vendorSecretPattern("stripe-secret-key", `sk_(?:live|test)_[A-Za-z0-9]{16,}`),
 	vendorSecretPattern("calcom-api-key", `cal_(?:live|test)_[A-Za-z0-9]{16,}`),
-	vendorSecretPattern("github-token", `(?:ghp|gho|ghs)_[A-Za-z0-9]{36,}`),
+	vendorSecretPattern("github-token", githubInstallationJWTPattern+`|`+githubOpaqueTokenPatternPublish),
 	vendorSecretPattern("github-fine-grained-token", `github_pat_[A-Za-z0-9_]{60,}`),
 	vendorSecretPattern("slack-token", `xox[abprs]-[A-Za-z0-9-]{32,}`),
 	vendorSecretPattern("slack-app-token", `xapp-[A-Za-z0-9-]{32,}`),

--- a/internal/artifacts/secrets_test.go
+++ b/internal/artifacts/secrets_test.go
@@ -49,6 +49,24 @@ func TestRedactArchivedSpecSecretsKeepsPlaceholders(t *testing.T) {
 	require.Equal(t, string(input), got)
 }
 
+func TestRedactArchivedSpecSecretsRedactsJWTFormGitHubInstallationToken(t *testing.T) {
+	jwt := testGitHubInstallationJWT()
+	opaque := testSecret("ghs", "_", strings.Repeat("x", 40))
+	input := []byte(strings.Join([]string{
+		"Authorization: Bearer " + jwt + ". See the docs.",
+		"Authorization: Bearer " + opaque,
+		"Authorization: Bearer " + jwt + ".Next-step",
+	}, "\n"))
+
+	got := string(RedactArchivedSpecSecrets(input))
+
+	require.NotContains(t, got, jwt)
+	require.NotContains(t, got, opaque)
+	require.Contains(t, got, "Authorization: Bearer <REDACTED_GITHUB_TOKEN_EXAMPLE>. See the docs.")
+	require.Contains(t, got, "Authorization: Bearer <REDACTED_GITHUB_TOKEN_EXAMPLE>")
+	require.Contains(t, got, "Authorization: Bearer <REDACTED_GITHUB_TOKEN_EXAMPLE>.Next-step")
+}
+
 func TestRedactLiveOutputSecretsRedactsConfiguredAndVendorCredentials(t *testing.T) {
 	authSecret := "auth-secret-value-1234567890"
 	vendorSecret := "sk_live_" + strings.Repeat("a", 20)
@@ -107,6 +125,34 @@ func TestFindVendorPrefixSecretsReportsFileAndLine(t *testing.T) {
 	require.Equal(t, "openrouter-api-key", byPath["spec.json"].Kind)
 	require.Equal(t, 1, byPath[".manuscripts/run-1/research/openapi.json"].Line)
 	require.Equal(t, "stripe-secret-key", byPath[".manuscripts/run-1/research/openapi.json"].Kind)
+}
+
+func TestFindVendorPrefixSecretsDetectsJWTFormGitHubInstallationToken(t *testing.T) {
+	root := t.TempDir()
+	jwt := testGitHubInstallationJWT()
+	opaqueGhs := testSecret("ghs", "_", strings.Repeat("x", 40))
+	opaqueGhp := testSecret("ghp", "_", strings.Repeat("y", 40))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "jwt.txt"), []byte("token="+jwt+". See the docs.\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "opaque-ghs.txt"), []byte("token="+opaqueGhs+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "opaque-ghp.txt"), []byte("token="+opaqueGhp+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "jwt-hyphen.txt"), []byte("token="+jwt+".Next-step\n"), 0o644))
+
+	findings, err := FindVendorPrefixSecrets(root)
+	require.NoError(t, err)
+	require.Len(t, findings, 4)
+
+	byPath := map[string]VendorPrefixSecretFinding{}
+	for _, finding := range findings {
+		byPath[finding.Path] = finding
+	}
+	require.Equal(t, "github-token", byPath["jwt.txt"].Kind)
+	require.Equal(t, "github-token", byPath["opaque-ghs.txt"].Kind)
+	require.Equal(t, "github-token", byPath["opaque-ghp.txt"].Kind)
+	require.Equal(t, "github-token", byPath["jwt-hyphen.txt"].Kind)
+	require.Equal(t, secretFingerprint(jwt), byPath["jwt.txt"].Fingerprint)
+	require.Equal(t, secretFingerprint(jwt), byPath["jwt-hyphen.txt"].Fingerprint)
+	require.Equal(t, secretFingerprint(opaqueGhs), byPath["opaque-ghs.txt"].Fingerprint)
+	require.Equal(t, secretFingerprint(opaqueGhp), byPath["opaque-ghp.txt"].Fingerprint)
 }
 
 func TestFindVendorPrefixSecretsIgnoresPlaceholdersAndBinaryFiles(t *testing.T) {
@@ -272,4 +318,14 @@ func TestFindPackageSecretsCombinesVendorPrefixAndDeclaredCookies(t *testing.T) 
 
 func testSecret(parts ...string) string {
 	return strings.Join(parts, "")
+}
+
+// JWT-form GitHub App installation token: ghs_ + three base64url segments.
+// The header is deliberately shorter than 36 characters so the legacy
+// alphanumeric-only {36,} class cannot match across the first dot.
+func testGitHubInstallationJWT() string {
+	header := strings.Repeat("A", 20)
+	payload := testSecret(strings.Repeat("B", 40), "_", strings.Repeat("C", 39))
+	sig := testSecret(strings.Repeat("D", 40), "-", strings.Repeat("E", 39))
+	return testSecret("ghs", "_", header, ".", payload, ".", sig)
 }

--- a/skills/printing-press-retro/references/secret-scrubbing.md
+++ b/skills/printing-press-retro/references/secret-scrubbing.md
@@ -65,7 +65,10 @@ scrub_body() {
     'stripe-test-key|sk_test_[A-Za-z0-9]{20,}'
     'github-pat|ghp_[A-Za-z0-9]{36,}'
     'github-oauth|gho_[A-Za-z0-9]{36,}'
+    # Opaque ghs_ plus a three-segment JWT form. Do not fold into
+    # [A-Za-z0-9._-]{36,}: that class swallows a following period.
     'github-server|ghs_[A-Za-z0-9]{36,}'
+    'github-server-jwt|ghs_[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+'
     'slack-bot-token|xoxb-[A-Za-z0-9-]{20,}'
     'slack-user-token|xoxp-[A-Za-z0-9-]{20,}'
     'aws-access-key|\bAKIA[0-9A-Z]{16}\b'
@@ -402,7 +405,7 @@ FINAL_CHECK=false
 # checking a credential shape the scrub loop still redacts. The JWT shape
 # intentionally matches Layer 2's two-segment form; that also catches the
 # first two segments of a conventional three-segment JWT.
-CRED_REGEX='(sk_live_[A-Za-z0-9]{20,}|sk_test_[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{36,}|gho_[A-Za-z0-9]{36,}|ghs_[A-Za-z0-9]{36,}|xoxb-[A-Za-z0-9-]{20,}|xoxp-[A-Za-z0-9-]{20,}|\bAKIA[0-9A-Z]{16}\b|sk-or-v1-[A-Za-z0-9_-]{24,}|sk-ant-api03-[A-Za-z0-9_-]{40,}|\blin_api_[A-Za-z0-9_-]{32,}|\b[a-f0-9]{32}-us[0-9]{1,2}\b|\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|Bearer [A-Za-z0-9._~+/=-]{20,})'
+CRED_REGEX='(sk_live_[A-Za-z0-9]{20,}|sk_test_[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{36,}|gho_[A-Za-z0-9]{36,}|ghs_[A-Za-z0-9]{36,}|ghs_[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+|xoxb-[A-Za-z0-9-]{20,}|xoxp-[A-Za-z0-9-]{20,}|\bAKIA[0-9A-Z]{16}\b|sk-or-v1-[A-Za-z0-9_-]{24,}|sk-ant-api03-[A-Za-z0-9_-]{40,}|\blin_api_[A-Za-z0-9_-]{32,}|\b[a-f0-9]{32}-us[0-9]{1,2}\b|\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|Bearer [A-Za-z0-9._~+/=-]{20,})'
 # PII_REGEX must mirror the shapes in PII_PATTERNS above; update both together
 # (e.g. when adding Partita IVA with an allowlist) so the verification step
 # does not silently stop checking a shape the scrub loop still redacts.

--- a/skills/printing-press-retro/references/secret-scrubbing.md
+++ b/skills/printing-press-retro/references/secret-scrubbing.md
@@ -67,8 +67,8 @@ scrub_body() {
     'github-oauth|gho_[A-Za-z0-9]{36,}'
     # Opaque ghs_ plus a three-segment JWT form. Do not fold into
     # [A-Za-z0-9._-]{36,}: that class swallows a following period.
-    'github-server|ghs_[A-Za-z0-9]{36,}'
     'github-server-jwt|ghs_[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+'
+    'github-server|ghs_[A-Za-z0-9]{36,}'
     'slack-bot-token|xoxb-[A-Za-z0-9-]{20,}'
     'slack-user-token|xoxp-[A-Za-z0-9-]{20,}'
     'aws-access-key|\bAKIA[0-9A-Z]{16}\b'

--- a/skills/printing-press-retro/references/secret-scrubbing.md
+++ b/skills/printing-press-retro/references/secret-scrubbing.md
@@ -405,7 +405,7 @@ FINAL_CHECK=false
 # checking a credential shape the scrub loop still redacts. The JWT shape
 # intentionally matches Layer 2's two-segment form; that also catches the
 # first two segments of a conventional three-segment JWT.
-CRED_REGEX='(sk_live_[A-Za-z0-9]{20,}|sk_test_[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{36,}|gho_[A-Za-z0-9]{36,}|ghs_[A-Za-z0-9]{36,}|ghs_[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+|xoxb-[A-Za-z0-9-]{20,}|xoxp-[A-Za-z0-9-]{20,}|\bAKIA[0-9A-Z]{16}\b|sk-or-v1-[A-Za-z0-9_-]{24,}|sk-ant-api03-[A-Za-z0-9_-]{40,}|\blin_api_[A-Za-z0-9_-]{32,}|\b[a-f0-9]{32}-us[0-9]{1,2}\b|\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|Bearer [A-Za-z0-9._~+/=-]{20,})'
+CRED_REGEX='(sk_live_[A-Za-z0-9]{20,}|sk_test_[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{36,}|gho_[A-Za-z0-9]{36,}|ghs_[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+|ghs_[A-Za-z0-9]{36,}|xoxb-[A-Za-z0-9-]{20,}|xoxp-[A-Za-z0-9-]{20,}|\bAKIA[0-9A-Z]{16}\b|sk-or-v1-[A-Za-z0-9_-]{24,}|sk-ant-api03-[A-Za-z0-9_-]{40,}|\blin_api_[A-Za-z0-9_-]{32,}|\b[a-f0-9]{32}-us[0-9]{1,2}\b|\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|Bearer [A-Za-z0-9._~+/=-]{20,})'
 # PII_REGEX must mirror the shapes in PII_PATTERNS above; update both together
 # (e.g. when adding Partita IVA with an allowlist) so the verification step
 # does not silently stop checking a shape the scrub loop still redacts.

--- a/skills/printing-press/references/secret-protection.md
+++ b/skills/printing-press/references/secret-protection.md
@@ -152,7 +152,10 @@ PII_AUTO_REDACT=(
   'bearer-cal-test|Bearer cal_test_[A-Za-z0-9]{20,}|Bearer <REDACTED:cal-test-token>'
   'bearer-github-pat|Bearer ghp_[A-Za-z0-9]{36,}|Bearer <REDACTED:github-pat>'
   'bearer-github-oauth|Bearer gho_[A-Za-z0-9]{36,}|Bearer <REDACTED:github-oauth>'
+  # Opaque ghs_ plus a three-segment JWT form. Do not fold into
+  # [A-Za-z0-9._-]{36,}: that class swallows a following period.
   'bearer-github-server|Bearer ghs_[A-Za-z0-9]{36,}|Bearer <REDACTED:github-server-token>'
+  'bearer-github-server-jwt|Bearer ghs_[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+|Bearer <REDACTED:github-server-token>'
   'bearer-github-fine|Bearer github_pat_[A-Za-z0-9_]{60,}|Bearer <REDACTED:github-fine-grained-pat>'
   'slack-user-token|xoxp-[A-Za-z0-9-]{40,}|<REDACTED:slack-user-token>'
   'slack-bot-token|xoxb-[A-Za-z0-9-]{40,}|<REDACTED:slack-bot-token>'

--- a/skills/printing-press/references/secret-protection.md
+++ b/skills/printing-press/references/secret-protection.md
@@ -154,8 +154,8 @@ PII_AUTO_REDACT=(
   'bearer-github-oauth|Bearer gho_[A-Za-z0-9]{36,}|Bearer <REDACTED:github-oauth>'
   # Opaque ghs_ plus a three-segment JWT form. Do not fold into
   # [A-Za-z0-9._-]{36,}: that class swallows a following period.
-  'bearer-github-server|Bearer ghs_[A-Za-z0-9]{36,}|Bearer <REDACTED:github-server-token>'
   'bearer-github-server-jwt|Bearer ghs_[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+|Bearer <REDACTED:github-server-token>'
+  'bearer-github-server|Bearer ghs_[A-Za-z0-9]{36,}|Bearer <REDACTED:github-server-token>'
   'bearer-github-fine|Bearer github_pat_[A-Za-z0-9_]{60,}|Bearer <REDACTED:github-fine-grained-pat>'
   'slack-user-token|xoxp-[A-Za-z0-9-]{40,}|<REDACTED:slack-user-token>'
   'slack-bot-token|xoxb-[A-Za-z0-9-]{40,}|<REDACTED:slack-bot-token>'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

GitHub App installation tokens (`ghs_`) are moving to JWT form: `ghs_` plus three base64url segments. The archive Bearer redactor and the vendor publish scanner still used alphanumeric-only `ghs_` classes, so a JWT-form token missed entirely (publish) or redacted only the header and leaked the payload and signature (archive).

This PR lands the Go scanners and the skill-reference classes together.

Supersedes #4578 and completes the #4574 follow-up. #4574 was closed as docs-only / out of the printed-CLI defect queue, so this does not use Closes.

## Approach

Use a structured three-segment JWT shape for `ghs_` (`header.payload.signature`, base64url) **before** the existing opaque `ghs_` / `ghp_` / `gho_` class. Dots are separators only, so a following sentence period or extra hyphenated segment is not consumed.

Skill Layer 0 / auto-redact arrays keep a separate JWT entry because those tables split fields on `|` and cannot embed an alternation in the regex column. JWT-form `ghs_` is listed (and tried) before opaque `ghs_` in:

- `secret-protection.md` auto-redact list
- retro Layer 0 vendor patterns
- retro `CRED_REGEX`

matching the Go scanners.

## Scope

Primary area: secret scrubbing (`internal/artifacts/secrets.go`) and matching skill references.

Why this belongs in this repo: the publish scanner and archive redactor are Printing Press enforcement, not a printed-CLI fix.

## Risk

False positives on very short `ghs_a.b.c` shapes are possible; a miss on a live installation JWT is worse. Opaque `ghp_` / `gho_` / classic `ghs_` patterns are unchanged.

## Output Contract

N/A — skill reference regexes and scanner patterns only; no generator/template emission.

## Verification

- [x] `go test ./internal/artifacts/ -run 'TestRedactArchivedSpecSecretsRedactsJWTFormGitHubInstallationToken|TestFindVendorPrefixSecretsDetectsJWTFormGitHubInstallationToken'`
- [x] `go test ./...` — `internal/artifacts` and all other packages passed; `internal/generator` hit the default 10m package timeout under suite load (unrelated; CI uses `-timeout 15m`)

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-525e6b93-3e9c-4c2e-8265-2fde516b2e39?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-525e6b93-3e9c-4c2e-8265-2fde516b2e39&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

