### PR TITLE
fix(skill): detect installed skill drift after binary upgrades

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,11 @@ See [`docs/RELEASE.md`](docs/RELEASE.md) for the merge-the-release-PR flow.
 - Distinct from `min-binary-version`: that is the release-managed, skill-frontmatter compatibility floor (the hard "skill cannot run below this" baseline, tracking the major and moving only on a major bump). The currency floor is a freely-tunable freshness gate. Do not conflate them.
 - `TestSkillsEnforceCurrencyFloor` in [`internal/pipeline/contracts_test.go`](internal/pipeline/contracts_test.go) locks the file shape and both contracts' enforce-every-run gate and clamp.
 
+## Skill-version floor
+The binary's `MinSkillVersion` (`internal/cli/skill_compat.go`) is the oldest printing-press skill frontmatter `version:` this binary will run with — the reverse of `min-binary-version`. When skill shape changes so a stale install would follow deleted commands, bump `MinSkillVersion`, the skill `version:` field, and the setup-contract `# skill-version:` / `_this_skill_version=` values together. Preflight hard-blocks with `[skill-stale]` (reinstall via `scripts/install.sh --skills-only`, then restart the session; no skip). `version --json` also warns on stderr when a well-known install path still has an older copy. `TestPrintingPressSkillVersionMatchesBinaryFloor` and `TestSkillsEnforceCurrencyFloor` lock the contract.
+
+See [`docs/SKILLS.md`](docs/SKILLS.md) for the frontmatter bump rule.
+
 ## Testing
 When you change code, check for a `_test.go` file in the same package. If one exists, read it; your change likely requires a test update. If tests fail after your change, investigate whether it is a bug in your code or a stale test; do not just delete the test.
 Add tests for new non-trivial logic. Match the package's existing style (typically table-driven with `testify/assert`). Skip tests for CLI glue, trivial wrappers, and code only meaningfully tested via integration (`FULL_RUN=1`).
@@ -292,7 +297,7 @@ This copies the skills to `~/.claude/skills/`.
 
 ## Skill Authoring
 When a machine change alters what an agent should do or what a command guarantees, update the relevant `SKILL.md` router and its phase files under `skills/printing-press/phases/` in the same change; do not leave the skill as a stale manual workaround for behavior the machine now owns.
-Detail in [`docs/SKILLS.md`](docs/SKILLS.md): install targets, workflow parity, the thin-spine plus `phases/` / `references/` pattern, and the `context: fork` / `user-invocable` frontmatter fields.
+Detail in [`docs/SKILLS.md`](docs/SKILLS.md): install targets, workflow parity, the thin-spine plus `phases/` / `references/` pattern, the skill `version:` / `MinSkillVersion` bump rule, and the `context: fork` / `user-invocable` frontmatter fields.
 
 ## Code & Comment Hygiene
 ### Write-time defaults

--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -27,4 +27,4 @@ The extracted developer docs are:
 - `docs/CODEX.md` — installing and using Printing Press skills in Codex
 - `docs/CURSOR.md` — using printed CLIs and skills in Cursor
 - `docs/DOCS.md` — this doc-authoring guidance
-- `docs/PLUGIN-DEV.md` — persistent local plugin development setup
+- `docs/SKILLS.md` — skill authoring: install targets, workflow parity, `version:` / `MinSkillVersion`, `context: fork` / `user-invocable`

--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -27,4 +27,5 @@ The extracted developer docs are:
 - `docs/CODEX.md` — installing and using Printing Press skills in Codex
 - `docs/CURSOR.md` — using printed CLIs and skills in Cursor
 - `docs/DOCS.md` — this doc-authoring guidance
+- `docs/PLUGIN-DEV.md` — persistent local plugin development setup
 - `docs/SKILLS.md` — skill authoring: install targets, workflow parity, `version:` / `MinSkillVersion`, `context: fork` / `user-invocable`

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -37,6 +37,16 @@ Skills use a `references/` directory for content that is only needed during spec
 
 **What gets extracted:** Implementation details for conditional paths: capture tool CLI commands, delegation templates, scoring frameworks, report templates, and the full body of each numbered phase. These are loaded on-demand when the agent reaches the relevant phase gate. Receipt sequencing for printing-press lives in `references/phase-receipts.md`; the binary graph in `internal/pipeline/phase_receipt.go` is the source of truth for order.
 
+## Frontmatter: `version`
+
+`version:` on `skills/printing-press/SKILL.md` is a **content-shape version**, not the plugin/binary release. `min-binary-version` only guards binary-too-old-for-skill. When the skill's on-disk instructions change so a stale install would follow deleted or renamed commands, bump:
+
+1. the skill `version:` field
+2. `MinSkillVersion` in `internal/cli/skill_compat.go`
+3. the setup-contract `# skill-version:` comment and `_this_skill_version=` assignment in `phases/01-preflight.md`
+
+Keep those three equal. Preflight hard-blocks with `[skill-stale]` when the running skill is below the binary floor. Other skills under `skills/` may keep their own independent `version:` values; do not freeze `printing-press` at a constant across shape rewrites.
+
 ## Frontmatter: `context: fork` and `user-invocable`
 
 Two skill frontmatter fields shape how a skill participates in larger workflows. Both default to permissive behavior (shared context, user-invocable). Set them explicitly when the skill plays a non-default role.

--- a/internal/cli/release_test.go
+++ b/internal/cli/release_test.go
@@ -79,9 +79,9 @@ func TestVersionConsistencyAcrossFiles(t *testing.T) {
 }
 
 func TestInternalSkillMinimumBinaryVersionsTrackMajor(t *testing.T) {
-	// Skill frontmatter `version` values are not release-managed. The
-	// executable compatibility contract is `min-binary-version`; keep the
-	// frontmatter and the duplicated setup-contract comment in sync.
+	// min-binary-version is the skill-requires-binary floor and tracks the
+	// major. Skill frontmatter `version` is the reverse contract (see
+	// TestPrintingPressSkillVersionMatchesBinaryFloor).
 	want := fmt.Sprintf("%d.0.0", majorVersion(t, version.Version))
 	paths := []struct {
 		frontmatter string
@@ -112,6 +112,29 @@ func TestInternalSkillMinimumBinaryVersionsTrackMajor(t *testing.T) {
 			assert.Equal(t, frontmatter[1], comment[1])
 		})
 	}
+}
+
+func TestPrintingPressSkillVersionMatchesBinaryFloor(t *testing.T) {
+	skillData, err := os.ReadFile("../../skills/printing-press/SKILL.md")
+	require.NoError(t, err)
+	setupData, err := os.ReadFile("../../skills/printing-press/phases/01-preflight.md")
+	require.NoError(t, err)
+
+	versionRe := regexp.MustCompile(`(?m)^version:\s*"?([^"\n]+)"?\s*$`)
+	commentRe := regexp.MustCompile(`(?m)^# skill-version:\s*([^\s]+)\s*$`)
+	assignRe := regexp.MustCompile(`(?m)^_this_skill_version=([^\s]+)\s*$`)
+
+	frontmatter := versionRe.FindStringSubmatch(string(skillData))
+	require.Len(t, frontmatter, 2, "printing-press skill must declare version frontmatter")
+	assert.Equal(t, MinSkillVersion, frontmatter[1])
+
+	comment := commentRe.FindStringSubmatch(string(setupData))
+	require.Len(t, comment, 2, "setup contract must duplicate skill-version")
+	assert.Equal(t, frontmatter[1], comment[1])
+
+	assign := assignRe.FindStringSubmatch(string(setupData))
+	require.Len(t, assign, 2, "setup contract must assign _this_skill_version")
+	assert.Equal(t, frontmatter[1], assign[1])
 }
 
 func TestMarketplaceJSONHasNoPluginVersion(t *testing.T) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -11,7 +11,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -81,6 +80,7 @@ func NewRootCommand(commandName string) *cobra.Command {
 	rootCmd.AddCommand(newContributorsCmd())
 	rootCmd.AddCommand(newVisionCmd())
 	rootCmd.AddCommand(newVersionCmd())
+	rootCmd.AddCommand(newSkillCompatCmd())
 	rootCmd.AddCommand(newPrintCmd())
 	rootCmd.AddCommand(newBrowserSniffCmd())
 	rootCmd.AddCommand(newCrowdSniffCmd())
@@ -2899,10 +2899,15 @@ func newVersionCmd() *cobra.Command {
 		Example: `  cli-printing-press version`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if asJSON {
-				return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]string{
-					"version": version.Version,
-					"go":      runtime.Version(),
-				})
+				home := userHomeDir()
+				payload := versionJSONPayload(home)
+				if err := json.NewEncoder(cmd.OutOrStdout()).Encode(payload); err != nil {
+					return err
+				}
+				if payload.SkillStatus == skillStatusStale {
+					writeSkillStaleWarning(cmd.ErrOrStderr(), discoverInstalledSkillCompat(home))
+				}
+				return nil
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "%s %s\n", cmd.Root().Use, version.Version)
 			return nil

--- a/internal/cli/skill_compat.go
+++ b/internal/cli/skill_compat.go
@@ -1,0 +1,268 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/version"
+	"github.com/spf13/cobra"
+	"golang.org/x/mod/semver"
+	"gopkg.in/yaml.v3"
+)
+
+// MinSkillVersion is the oldest printing-press skill frontmatter `version`
+// this binary treats as current. Bump it together with the skill `version:`
+// field (and the setup-contract `# skill-version:` comment) when skill shape
+// changes so a stale install would follow deleted commands. Distinct from
+// min-binary-version, which is the other direction (skill requires binary).
+const MinSkillVersion = "3.0.0"
+
+const (
+	printingPressSkillName = "printing-press"
+	skillsReinstallHint    = "curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --skills-only"
+	skillStatusStale       = "stale"
+	skillStatusCurrent     = "current"
+	skillStatusMissing     = "missing"
+)
+
+// skillCompatReport is the JSON shape for `skill-compat --json` and the
+// optional skill-drift fields on `version --json`.
+type skillCompatReport struct {
+	Status        string `json:"skill_status"`
+	Installed     string `json:"installed_skill_version,omitempty"`
+	Required      string `json:"min_skill_version"`
+	Path          string `json:"installed_skill_path,omitempty"`
+	BinaryVersion string `json:"binary_version"`
+	Reinstall     string `json:"reinstall,omitempty"`
+	Detail        string `json:"detail,omitempty"`
+}
+
+func skillVersionLess(installed, minimum string) bool {
+	a := normalizeSemver(installed)
+	b := normalizeSemver(minimum)
+	if !semver.IsValid(a) || !semver.IsValid(b) {
+		// Unparseable or missing installed version cannot prove currency.
+		return true
+	}
+	return semver.Compare(a, b) < 0
+}
+
+func parseSkillFrontmatterVersion(skillMD string) string {
+	frontmatter, _, ok := splitFrontmatter(skillMD)
+	if !ok {
+		return ""
+	}
+	var fm internalSkillFrontmatter
+	if err := yaml.Unmarshal([]byte(frontmatter), &fm); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(fm.Version)
+}
+
+func readSkillFileVersion(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return parseSkillFrontmatterVersion(string(data)), nil
+}
+
+func installedPrintingPressSkillPaths(home string) []string {
+	if home == "" {
+		return nil
+	}
+	candidates := []string{
+		filepath.Join(home, ".claude", "skills", printingPressSkillName, "SKILL.md"),
+		filepath.Join(home, ".agents", "skills", printingPressSkillName, "SKILL.md"),
+		filepath.Join(home, ".codex", "skills", printingPressSkillName, "SKILL.md"),
+	}
+	if xdg := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdg != "" {
+		candidates = append(candidates, filepath.Join(xdg, "agents", "skills", printingPressSkillName, "SKILL.md"))
+	}
+	return candidates
+}
+
+func evaluateSkillCompat(skillPath, installedVersion string) skillCompatReport {
+	report := skillCompatReport{
+		Required:      MinSkillVersion,
+		BinaryVersion: version.Version,
+		Path:          skillPath,
+		Installed:     strings.TrimSpace(installedVersion),
+		Reinstall:     skillsReinstallHint,
+	}
+	if strings.TrimSpace(skillPath) == "" && report.Installed == "" {
+		report.Status = skillStatusMissing
+		report.Detail = "no printing-press SKILL.md found in well-known install locations"
+		report.Reinstall = ""
+		return report
+	}
+	if report.Installed == "" || skillVersionLess(report.Installed, MinSkillVersion) {
+		installed := report.Installed
+		if installed == "" {
+			installed = "none"
+		}
+		report.Status = skillStatusStale
+		report.Detail = fmt.Sprintf("installed printing-press skill declares version %s; binary v%s expects >= %s — reinstall via: %s",
+			installed, version.Version, MinSkillVersion, skillsReinstallHint)
+		return report
+	}
+	report.Status = skillStatusCurrent
+	report.Reinstall = ""
+	return report
+}
+
+func checkSkillFile(path string) (skillCompatReport, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return skillCompatReport{}, err
+	}
+	installed, err := readSkillFileVersion(abs)
+	if err != nil {
+		return skillCompatReport{}, err
+	}
+	return evaluateSkillCompat(abs, installed), nil
+}
+
+func discoverInstalledSkillCompat(home string) skillCompatReport {
+	for _, path := range installedPrintingPressSkillPaths(home) {
+		installed, err := readSkillFileVersion(path)
+		if err != nil {
+			continue
+		}
+		return evaluateSkillCompat(path, installed)
+	}
+	return evaluateSkillCompat("", "")
+}
+
+func writeSkillStaleWarning(w io.Writer, report skillCompatReport) {
+	if report.Status != skillStatusStale || strings.TrimSpace(report.Detail) == "" {
+		return
+	}
+	fmt.Fprintf(w, "warning: %s\n", report.Detail)
+}
+
+func formatSkillCompatText(report skillCompatReport) string {
+	switch report.Status {
+	case skillStatusStale:
+		var b strings.Builder
+		fmt.Fprintf(&b, "[skill-stale] printing-press skill v%s is older than binary v%s expects (>= %s)\n",
+			valueOrNone(report.Installed), report.BinaryVersion, report.Required)
+		fmt.Fprintf(&b, "PRESS_SKILL_INSTALLED=%s\n", valueOrNone(report.Installed))
+		fmt.Fprintf(&b, "PRESS_SKILL_REQUIRED=%s\n", report.Required)
+		if report.Path != "" {
+			fmt.Fprintf(&b, "PRESS_SKILL_PATH=%s\n", report.Path)
+		}
+		fmt.Fprintf(&b, "PRESS_SKILL_REINSTALL=%s\n", report.Reinstall)
+		return b.String()
+	case skillStatusMissing:
+		return "skill-compat: no installed printing-press SKILL.md found in well-known locations\n"
+	default:
+		return fmt.Sprintf("skill-compat: printing-press skill v%s meets binary floor v%s\n",
+			report.Installed, report.Required)
+	}
+}
+
+func valueOrNone(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return "none"
+	}
+	return v
+}
+
+type versionJSON struct {
+	Version               string `json:"version"`
+	Go                    string `json:"go"`
+	MinSkillVersion       string `json:"min_skill_version"`
+	SkillStatus           string `json:"skill_status,omitempty"`
+	InstalledSkillVersion string `json:"installed_skill_version,omitempty"`
+	InstalledSkillPath    string `json:"installed_skill_path,omitempty"`
+}
+
+func versionJSONPayload(home string) versionJSON {
+	payload := versionJSON{
+		Version:         version.Version,
+		Go:              runtime.Version(),
+		MinSkillVersion: MinSkillVersion,
+	}
+	report := discoverInstalledSkillCompat(home)
+	if report.Status == skillStatusStale {
+		payload.SkillStatus = report.Status
+		payload.InstalledSkillVersion = report.Installed
+		payload.InstalledSkillPath = report.Path
+	}
+	return payload
+}
+
+func userHomeDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return os.Getenv("HOME")
+	}
+	return home
+}
+
+func newSkillCompatCmd() *cobra.Command {
+	var (
+		skillPath string
+		asJSON    bool
+	)
+
+	cmd := &cobra.Command{
+		Use:           "skill-compat",
+		Short:         "Check installed printing-press skill version against this binary",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Long: `Compare a printing-press SKILL.md frontmatter version against the floor this binary expects.
+
+Without --skill, well-known install locations under the user home are scanned.
+A missing install is not an error (the skill may have loaded from a plugin).
+A skill older than the floor prints [skill-stale] and exits 1.`,
+		Example: `  cli-printing-press skill-compat
+  cli-printing-press skill-compat --skill ~/.claude/skills/printing-press/SKILL.md
+  cli-printing-press skill-compat --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var (
+				report skillCompatReport
+				err    error
+			)
+			if strings.TrimSpace(skillPath) != "" {
+				report, err = checkSkillFile(skillPath)
+				if err != nil {
+					return &ExitError{Code: ExitInputError, Err: fmt.Errorf("reading --skill: %w", err)}
+				}
+			} else {
+				report = discoverInstalledSkillCompat(userHomeDir())
+			}
+
+			if asJSON {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				if err := enc.Encode(report); err != nil {
+					return fmt.Errorf("encoding JSON: %w", err)
+				}
+			} else {
+				fmt.Fprint(cmd.OutOrStdout(), formatSkillCompatText(report))
+			}
+
+			if report.Status == skillStatusStale {
+				writeSkillStaleWarning(cmd.ErrOrStderr(), report)
+				return &ExitError{
+					Code:   ExitInputError,
+					Err:    fmt.Errorf("installed skill is older than this binary expects"),
+					Silent: true,
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&skillPath, "skill", "", "Path to a printing-press SKILL.md (skips install-location scan)")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")
+
+	return cmd
+}

--- a/internal/cli/skill_compat.go
+++ b/internal/cli/skill_compat.go
@@ -129,14 +129,56 @@ func checkSkillFile(path string) (skillCompatReport, error) {
 }
 
 func discoverInstalledSkillCompat(home string) skillCompatReport {
+	var (
+		firstCurrent skillCompatReport
+		haveCurrent  bool
+		worstStale   skillCompatReport
+		haveStale    bool
+	)
 	for _, path := range installedPrintingPressSkillPaths(home) {
 		installed, err := readSkillFileVersion(path)
 		if err != nil {
 			continue
 		}
-		return evaluateSkillCompat(path, installed)
+		report := evaluateSkillCompat(path, installed)
+		if report.Status == skillStatusStale {
+			if !haveStale || installedSkillOlder(report.Installed, worstStale.Installed) {
+				worstStale = report
+				haveStale = true
+			}
+			continue
+		}
+		if !haveCurrent {
+			firstCurrent = report
+			haveCurrent = true
+		}
+	}
+	if haveStale {
+		return worstStale
+	}
+	if haveCurrent {
+		return firstCurrent
 	}
 	return evaluateSkillCompat("", "")
+}
+
+// installedSkillOlder reports whether a is older than b for drift ranking.
+// Missing or unparseable versions rank older than any valid semver.
+func installedSkillOlder(a, b string) bool {
+	aN := normalizeSemver(a)
+	bN := normalizeSemver(b)
+	aOK := semver.IsValid(aN)
+	bOK := semver.IsValid(bN)
+	switch {
+	case !aOK && !bOK:
+		return false
+	case !aOK:
+		return true
+	case !bOK:
+		return false
+	default:
+		return semver.Compare(aN, bN) < 0
+	}
 }
 
 func writeSkillStaleWarning(w io.Writer, report skillCompatReport) {

--- a/internal/cli/skill_compat_test.go
+++ b/internal/cli/skill_compat_test.go
@@ -1,0 +1,210 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writePrintingPressSkill(t *testing.T, dir, skillVersion string) string {
+	t.Helper()
+	skillDir := filepath.Join(dir, "printing-press")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	path := filepath.Join(skillDir, "SKILL.md")
+	content := "---\nname: printing-press\ndescription: fixture\nversion: " + skillVersion + "\nallowed-tools:\n  - Bash\n---\n\n# /printing-press\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func TestSkillVersionLess(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		installed string
+		minimum   string
+		want      bool
+	}{
+		{installed: "2.0.0", minimum: "3.0.0", want: true},
+		{installed: "3.0.0", minimum: "3.0.0", want: false},
+		{installed: "3.1.0", minimum: "3.0.0", want: false},
+		{installed: "", minimum: "3.0.0", want: true},
+		{installed: "not-a-version", minimum: "3.0.0", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.installed+"<"+tt.minimum, func(t *testing.T) {
+			assert.Equal(t, tt.want, skillVersionLess(tt.installed, tt.minimum))
+		})
+	}
+}
+
+func TestParseSkillFrontmatterVersion(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "2.0.0", parseSkillFrontmatterVersion("---\nname: printing-press\nversion: 2.0.0\n---\n\n# Body\n"))
+	assert.Equal(t, "3.0.0", parseSkillFrontmatterVersion("---\nname: printing-press\nversion: \"3.0.0\"\n---\n\n# Body\n"))
+	assert.Equal(t, "", parseSkillFrontmatterVersion("# no frontmatter\n"))
+	assert.Equal(t, "", parseSkillFrontmatterVersion("---\nname: printing-press\n---\n\n# Body\n"))
+}
+
+func TestCheckSkillFileStalePreRewriteVersion(t *testing.T) {
+	t.Parallel()
+	path := writePrintingPressSkill(t, t.TempDir(), "2.0.0")
+
+	report, err := checkSkillFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, skillStatusStale, report.Status)
+	assert.Equal(t, "2.0.0", report.Installed)
+	assert.Equal(t, MinSkillVersion, report.Required)
+	assert.Equal(t, version.Version, report.BinaryVersion)
+	assert.Contains(t, report.Detail, "2.0.0")
+	assert.Contains(t, report.Detail, MinSkillVersion)
+	assert.Contains(t, report.Reinstall, "--skills-only")
+	assert.Contains(t, formatSkillCompatText(report), "[skill-stale]")
+}
+
+func TestCheckSkillFileCurrentVersion(t *testing.T) {
+	t.Parallel()
+	path := writePrintingPressSkill(t, t.TempDir(), MinSkillVersion)
+
+	report, err := checkSkillFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, skillStatusCurrent, report.Status)
+	assert.Equal(t, MinSkillVersion, report.Installed)
+	assert.Empty(t, report.Reinstall)
+	assert.NotContains(t, formatSkillCompatText(report), "[skill-stale]")
+}
+
+func TestCheckSkillFileMissingVersionIsStale(t *testing.T) {
+	t.Parallel()
+	dir := filepath.Join(t.TempDir(), "printing-press")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	path := filepath.Join(dir, "SKILL.md")
+	require.NoError(t, os.WriteFile(path, []byte("---\nname: printing-press\ndescription: fixture\nallowed-tools:\n  - Bash\n---\n\n# Body\n"), 0o644))
+
+	report, err := checkSkillFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, skillStatusStale, report.Status)
+	assert.Empty(t, report.Installed)
+}
+
+func TestDiscoverInstalledSkillCompat(t *testing.T) {
+	home := t.TempDir()
+	writePrintingPressSkill(t, filepath.Join(home, ".claude", "skills"), "2.0.0")
+
+	report := discoverInstalledSkillCompat(home)
+	assert.Equal(t, skillStatusStale, report.Status)
+	assert.Equal(t, "2.0.0", report.Installed)
+	assert.True(t, strings.HasSuffix(report.Path, filepath.Join(".claude", "skills", "printing-press", "SKILL.md")))
+}
+
+func TestDiscoverInstalledSkillCompatMissingIsNotStale(t *testing.T) {
+	t.Parallel()
+	report := discoverInstalledSkillCompat(t.TempDir())
+	assert.Equal(t, skillStatusMissing, report.Status)
+	assert.NotContains(t, formatSkillCompatText(report), "[skill-stale]")
+}
+
+func TestVersionJSONIncludesMinSkillVersionWithoutDriftFieldsWhenCurrent(t *testing.T) {
+	home := t.TempDir()
+	writePrintingPressSkill(t, filepath.Join(home, ".claude", "skills"), MinSkillVersion)
+
+	payload := versionJSONPayload(home)
+	assert.Equal(t, version.Version, payload.Version)
+	assert.Equal(t, MinSkillVersion, payload.MinSkillVersion)
+	assert.Empty(t, payload.SkillStatus)
+	assert.Empty(t, payload.InstalledSkillVersion)
+	assert.NotEmpty(t, payload.Go)
+}
+
+func TestVersionJSONReportsStaleInstalledSkill(t *testing.T) {
+	home := t.TempDir()
+	writePrintingPressSkill(t, filepath.Join(home, ".claude", "skills"), "2.0.0")
+
+	payload := versionJSONPayload(home)
+	assert.Equal(t, skillStatusStale, payload.SkillStatus)
+	assert.Equal(t, "2.0.0", payload.InstalledSkillVersion)
+	assert.Equal(t, MinSkillVersion, payload.MinSkillVersion)
+}
+
+func TestVersionCommandJSONDoesNotTouchHome(t *testing.T) {
+	decoy := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(decoy, ".config"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(decoy, ".local", "share"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(decoy, ".local", "state"), 0o755))
+	sentinel := filepath.Join(decoy, ".config", "sentinel")
+	require.NoError(t, os.WriteFile(sentinel, []byte("sentinel\n"), 0o644))
+
+	t.Setenv("HOME", decoy)
+	t.Setenv("USERPROFILE", decoy)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(decoy, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(decoy, ".local", "share"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(decoy, ".local", "state"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(decoy, ".cache"))
+
+	writePrintingPressSkill(t, filepath.Join(decoy, ".claude", "skills"), "2.0.0")
+
+	cmd := NewRootCommand(CanonicalBinaryName)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"version", "--json"})
+	require.NoError(t, cmd.Execute())
+
+	var payload versionJSON
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
+	assert.Equal(t, skillStatusStale, payload.SkillStatus)
+	assert.Contains(t, stderr.String(), "warning:")
+	assert.Contains(t, stderr.String(), "2.0.0")
+
+	got, err := os.ReadFile(sentinel)
+	require.NoError(t, err)
+	assert.Equal(t, "sentinel\n", string(got))
+}
+
+func TestSkillCompatCommandFailsClosedOnStaleSkill(t *testing.T) {
+	path := writePrintingPressSkill(t, t.TempDir(), "2.0.0")
+
+	cmd := NewRootCommand(CanonicalBinaryName)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"skill-compat", "--skill", path})
+	err := cmd.Execute()
+	require.Error(t, err)
+	exitErr := asExitError(err)
+	require.NotNil(t, exitErr)
+	assert.Equal(t, ExitInputError, exitErr.Code)
+	assert.Contains(t, stdout.String(), "[skill-stale]")
+	assert.Contains(t, stderr.String(), "warning:")
+}
+
+func TestSkillCompatCommandOKOnCurrentSkill(t *testing.T) {
+	path := writePrintingPressSkill(t, t.TempDir(), MinSkillVersion)
+
+	cmd := NewRootCommand(CanonicalBinaryName)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"skill-compat", "--skill", path, "--json"})
+	require.NoError(t, cmd.Execute())
+	assert.Empty(t, stderr.String())
+
+	var report skillCompatReport
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &report))
+	assert.Equal(t, skillStatusCurrent, report.Status)
+}
+
+func TestPrintingPressSkillFrontmatterMeetsBinaryFloor(t *testing.T) {
+	t.Parallel()
+	data, err := os.ReadFile(filepath.Join("..", "..", "skills", "printing-press", "SKILL.md"))
+	require.NoError(t, err)
+	got := parseSkillFrontmatterVersion(string(data))
+	require.NotEmpty(t, got, "printing-press SKILL.md must declare version:")
+	assert.False(t, skillVersionLess(got, MinSkillVersion),
+		"printing-press SKILL.md version %s is below binary MinSkillVersion %s", got, MinSkillVersion)
+}

--- a/internal/cli/skill_compat_test.go
+++ b/internal/cli/skill_compat_test.go
@@ -109,6 +109,33 @@ func TestDiscoverInstalledSkillCompatMissingIsNotStale(t *testing.T) {
 	assert.NotContains(t, formatSkillCompatText(report), "[skill-stale]")
 }
 
+func TestDiscoverInstalledSkillCompatCurrentDoesNotMaskStaleSibling(t *testing.T) {
+	home := t.TempDir()
+	writePrintingPressSkill(t, filepath.Join(home, ".claude", "skills"), MinSkillVersion)
+	writePrintingPressSkill(t, filepath.Join(home, ".codex", "skills"), "2.0.0")
+
+	report := discoverInstalledSkillCompat(home)
+	assert.Equal(t, skillStatusStale, report.Status)
+	assert.Equal(t, "2.0.0", report.Installed)
+	assert.True(t, strings.HasSuffix(report.Path, filepath.Join(".codex", "skills", "printing-press", "SKILL.md")))
+
+	payload := versionJSONPayload(home)
+	assert.Equal(t, skillStatusStale, payload.SkillStatus)
+	assert.Equal(t, "2.0.0", payload.InstalledSkillVersion)
+	assert.Contains(t, payload.InstalledSkillPath, filepath.Join(".codex", "skills", "printing-press", "SKILL.md"))
+}
+
+func TestDiscoverInstalledSkillCompatReportsOldestAmongStaleSiblings(t *testing.T) {
+	home := t.TempDir()
+	writePrintingPressSkill(t, filepath.Join(home, ".claude", "skills"), "2.1.0")
+	writePrintingPressSkill(t, filepath.Join(home, ".agents", "skills"), "2.0.0")
+
+	report := discoverInstalledSkillCompat(home)
+	assert.Equal(t, skillStatusStale, report.Status)
+	assert.Equal(t, "2.0.0", report.Installed)
+	assert.True(t, strings.HasSuffix(report.Path, filepath.Join(".agents", "skills", "printing-press", "SKILL.md")))
+}
+
 func TestVersionJSONIncludesMinSkillVersionWithoutDriftFieldsWhenCurrent(t *testing.T) {
 	home := t.TempDir()
 	writePrintingPressSkill(t, filepath.Join(home, ".claude", "skills"), MinSkillVersion)

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -126,7 +126,8 @@ func TestPrintingPressSetupContractLeavesFreshRepoLocalBinaryAlone(t *testing.T)
 func TestPrintingPressSetupContractEmitsSkillStaleWhenSkillBelowBinaryFloor(t *testing.T) {
 	t.Parallel()
 
-	output, _ := runPrintingPressSetupContractWithSkillFloor(t, "4.32.0", "4.32.0", "9.0.0")
+	output, _, err := runPrintingPressSetupContractWithSkillFloor(t, "4.32.0", "4.32.0", "9.0.0")
+	require.Error(t, err, "skill-stale must fail the setup contract")
 
 	assert.Contains(t, output, "[skill-stale] printing-press skill v")
 	assert.Contains(t, output, "PRESS_SKILL_INSTALLED=")
@@ -138,7 +139,8 @@ func TestPrintingPressSetupContractEmitsSkillStaleWhenSkillBelowBinaryFloor(t *t
 func TestPrintingPressSetupContractOmitsSkillStaleWhenSkillMeetsBinaryFloor(t *testing.T) {
 	t.Parallel()
 
-	output, _ := runPrintingPressSetupContractWithSkillFloor(t, "4.32.0", "4.32.0", "3.0.0")
+	output, _, err := runPrintingPressSetupContractWithSkillFloor(t, "4.32.0", "4.32.0", "3.0.0")
+	require.NoError(t, err, output)
 
 	assert.NotContains(t, output, "[skill-stale]")
 	assert.Contains(t, output, "PRINTING_PRESS_BIN=")
@@ -180,6 +182,14 @@ func TestSkillsEnforceCurrencyFloor(t *testing.T) {
 	assert.Contains(t, ppBlock, `PRESS_SKILL_REINSTALL=`)
 	assert.Contains(t, ppBlock, `min_skill_version`)
 	assert.Contains(t, ppBlock, `PP_SEMVER_A="$_this_skill_version" PP_SEMVER_B="$_min_skill" _semver_lt`)
+	staleIdx := strings.Index(ppBlock, `[skill-stale] printing-press`)
+	require.GreaterOrEqual(t, staleIdx, 0)
+	staleBranch := ppBlock[staleIdx:]
+	if end := strings.Index(staleBranch, "\n  fi"); end > 0 {
+		staleBranch = staleBranch[:end]
+	}
+	assert.Contains(t, staleBranch, `return 1 2>/dev/null || exit 1`,
+		"skill-stale must fail closed like other hard preflight gates")
 
 	// setup-checks.md documents the hard gate as reinstall-or-abort, distinct from
 	// the binary-too-old min-binary-version check.
@@ -1515,10 +1525,12 @@ func substringUntilNextHeader(t *testing.T, content, start, headerPrefix string)
 
 func runPrintingPressSetupContract(t *testing.T, localVersion, sourceVersion string) (output string, goLog string) {
 	t.Helper()
-	return runPrintingPressSetupContractWithSkillFloor(t, localVersion, sourceVersion, "")
+	output, goLog, err := runPrintingPressSetupContractWithSkillFloor(t, localVersion, sourceVersion, "")
+	require.NoError(t, err, output)
+	return output, goLog
 }
 
-func runPrintingPressSetupContractWithSkillFloor(t *testing.T, localVersion, sourceVersion, minSkillVersion string) (output string, goLog string) {
+func runPrintingPressSetupContractWithSkillFloor(t *testing.T, localVersion, sourceVersion, minSkillVersion string) (output string, goLog string, err error) {
 	t.Helper()
 
 	root := t.TempDir()
@@ -1587,10 +1599,9 @@ exit 0
 		"PRINTING_PRESS_HOME="+filepath.Join(home, "printing-press"),
 	)
 	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, string(out))
-	logBytes, err := os.ReadFile(goLogPath)
-	require.NoError(t, err)
-	return string(out), string(logBytes)
+	logBytes, logErr := os.ReadFile(goLogPath)
+	require.NoError(t, logErr)
+	return string(out), string(logBytes), err
 }
 
 func versionScript(version string) string {

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -62,8 +62,13 @@ func TestSkillSetupBlocksMatchWorkspaceContract(t *testing.T) {
 
 			// Binary on PATH check
 			assert.Contains(t, block, `command -v cli-printing-press`)
-			// Version comment for frontmatter parity
+			// Version comments for frontmatter parity
 			assert.Contains(t, block, `# min-binary-version:`)
+			if filepath.Base(filepath.Dir(tt.path)) == "printing-press" {
+				assert.Contains(t, block, `# skill-version:`)
+				assert.Contains(t, block, `[skill-stale]`)
+				assert.Contains(t, block, `min_skill_version`)
+			}
 			// Symlink-safe canonicalization
 			assert.Contains(t, block, `pwd -P`)
 
@@ -118,6 +123,27 @@ func TestPrintingPressSetupContractLeavesFreshRepoLocalBinaryAlone(t *testing.T)
 	assert.NotContains(t, goLog, "build -o ./cli-printing-press ./cmd/cli-printing-press")
 }
 
+func TestPrintingPressSetupContractEmitsSkillStaleWhenSkillBelowBinaryFloor(t *testing.T) {
+	t.Parallel()
+
+	output, _ := runPrintingPressSetupContractWithSkillFloor(t, "4.32.0", "4.32.0", "9.0.0")
+
+	assert.Contains(t, output, "[skill-stale] printing-press skill v")
+	assert.Contains(t, output, "PRESS_SKILL_INSTALLED=")
+	assert.Contains(t, output, "PRESS_SKILL_REQUIRED=9.0.0")
+	assert.Contains(t, output, "PRESS_SKILL_REINSTALL=")
+	assert.Contains(t, output, "--skills-only")
+}
+
+func TestPrintingPressSetupContractOmitsSkillStaleWhenSkillMeetsBinaryFloor(t *testing.T) {
+	t.Parallel()
+
+	output, _ := runPrintingPressSetupContractWithSkillFloor(t, "4.32.0", "4.32.0", "3.0.0")
+
+	assert.NotContains(t, output, "[skill-stale]")
+	assert.Contains(t, output, "PRINTING_PRESS_BIN=")
+}
+
 func TestSkillsEnforceCurrencyFloor(t *testing.T) {
 	const floorURL = "https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/supported-versions.txt"
 
@@ -144,13 +170,27 @@ func TestSkillsEnforceCurrencyFloor(t *testing.T) {
 	assert.Contains(t, ppBlock, `PP_SEMVER_A="$_floor_installed" PP_SEMVER_B="$_floor_min" _semver_lt`)
 	assert.Contains(t, ppBlock, `! PP_SEMVER_A="$_floor_latest" PP_SEMVER_B="$_floor_min" _semver_lt`)
 
-	// setup-checks.md documents the hard gate as upgrade-or-abort, distinct from
-	// the soft [upgrade-available] advisory.
+	// Skill-too-old-for-binary: the contract duplicates frontmatter version and
+	// compares it to the binary's min_skill_version every run.
+	assert.Contains(t, ppBlock, `# skill-version:`)
+	assert.Contains(t, ppBlock, `_this_skill_version=`)
+	assert.Contains(t, ppBlock, `[skill-stale] printing-press`)
+	assert.Contains(t, ppBlock, `PRESS_SKILL_INSTALLED=`)
+	assert.Contains(t, ppBlock, `PRESS_SKILL_REQUIRED=`)
+	assert.Contains(t, ppBlock, `PRESS_SKILL_REINSTALL=`)
+	assert.Contains(t, ppBlock, `min_skill_version`)
+	assert.Contains(t, ppBlock, `PP_SEMVER_A="$_this_skill_version" PP_SEMVER_B="$_min_skill" _semver_lt`)
+
+	// setup-checks.md documents the hard gate as reinstall-or-abort, distinct from
+	// the binary-too-old min-binary-version check.
 	checks := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "references", "setup-checks.md"))
 	assert.Contains(t, checks, "[upgrade-required]")
 	assert.Contains(t, checks, "PRESS_REQUIRED_MIN")
 	assert.Contains(t, checks, "Update required")
 	assert.Contains(t, checks, "no skip-and-continue")
+	assert.Contains(t, checks, "[skill-stale]")
+	assert.Contains(t, checks, "PRESS_SKILL_REQUIRED")
+	assert.Contains(t, checks, "Skill-too-old-for-binary")
 
 	// amend regenerates too, so it carries the same hard floor. Assert the full
 	// signal set inside the contract block (parity with printing-press) so the
@@ -1475,6 +1515,11 @@ func substringUntilNextHeader(t *testing.T, content, start, headerPrefix string)
 
 func runPrintingPressSetupContract(t *testing.T, localVersion, sourceVersion string) (output string, goLog string) {
 	t.Helper()
+	return runPrintingPressSetupContractWithSkillFloor(t, localVersion, sourceVersion, "")
+}
+
+func runPrintingPressSetupContractWithSkillFloor(t *testing.T, localVersion, sourceVersion, minSkillVersion string) (output string, goLog string) {
+	t.Helper()
 
 	root := t.TempDir()
 	repo := filepath.Join(root, "repo")
@@ -1489,7 +1534,7 @@ func runPrintingPressSetupContract(t *testing.T, localVersion, sourceVersion str
 
 var Version = "`+sourceVersion+`" // x-release-please-version
 `), 0o644))
-	writeExecutable(t, filepath.Join(repo, "cli-printing-press"), versionScript(localVersion))
+	writeExecutable(t, filepath.Join(repo, "cli-printing-press"), versionJSONScript(localVersion, minSkillVersion))
 
 	goLogPath := filepath.Join(root, "go.log")
 	require.NoError(t, os.WriteFile(goLogPath, nil, 0o644))
@@ -1513,7 +1558,7 @@ if [ "$1" = "build" ]; then
     exit 1
   fi
   cat > "$out" <<'__PP_FAKE_BINARY__'
-`+versionScript(sourceVersion)+`__PP_FAKE_BINARY__
+`+versionJSONScript(sourceVersion, minSkillVersion)+`__PP_FAKE_BINARY__
   chmod +x "$out"
   exit 0
 fi
@@ -1549,9 +1594,17 @@ exit 0
 }
 
 func versionScript(version string) string {
+	return versionJSONScript(version, "")
+}
+
+func versionJSONScript(version, minSkill string) string {
+	payload := `{"version":"` + version + `"}`
+	if minSkill != "" {
+		payload = `{"version":"` + version + `","min_skill_version":"` + minSkill + `"}`
+	}
 	return `#!/bin/sh
 if [ "$1" = "version" ] && [ "$2" = "--json" ]; then
-  echo '{"version":"` + version + `"}'
+  echo '` + payload + `'
   exit 0
 fi
 echo "cli-printing-press ` + version + `"

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: printing-press
 description: Set up a new integration, connector, or CLI binding for any API. Wrap or generate a ship-ready Go CLI from an OpenAPI, HAR, or Postman spec via the lean research -> generate -> build -> shipcheck loop. Use when the user says build a CLI, wrap this API, set up a new integration, add a connector, integrate with a service, or names an API by domain.
-version: 2.0.0
+version: 3.0.0
 min-binary-version: "4.0.0"
 allowed-tools:
   - Bash

--- a/skills/printing-press/phases/01-preflight.md
+++ b/skills/printing-press/phases/01-preflight.md
@@ -21,6 +21,7 @@ Artifacts are still written, but only the ones that materially help the next ste
 <!-- PRESS_SETUP_CONTRACT_START -->
 ```bash
 # min-binary-version: 4.0.0
+# skill-version: 3.0.0
 
 # Derive scope first — needed for local build detection
 _scope_dir="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
@@ -254,6 +255,24 @@ fi
 
 echo "PRINTING_PRESS_BIN=$PRINTING_PRESS_BIN"
 echo "PRESS_REPO_MODE=$_press_repo"
+
+# Skill-too-old-for-binary: the reverse of min-binary-version. This contract
+# copies the running skill's frontmatter version so the binary can refuse a
+# stale install before later phases follow deleted commands.
+_this_skill_version=3.0.0
+if [ -n "$PRINTING_PRESS_BIN" ]; then
+  _compat_json=$("$PRINTING_PRESS_BIN" version --json 2>/dev/null || true)
+  _min_skill=$(printf '%s\n' "$_compat_json" | sed -nE 's/.*"min_skill_version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -n 1)
+  _bin_ver=$(printf '%s\n' "$_compat_json" | sed -nE 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -n 1)
+  if [ -n "$_min_skill" ] && PP_SEMVER_A="$_this_skill_version" PP_SEMVER_B="$_min_skill" _semver_lt; then
+    echo ""
+    echo "[skill-stale] printing-press skill v$_this_skill_version is older than binary v${_bin_ver:-unknown} expects (>= $_min_skill)"
+    echo "PRESS_SKILL_INSTALLED=$_this_skill_version"
+    echo "PRESS_SKILL_REQUIRED=$_min_skill"
+    echo "PRESS_SKILL_REINSTALL=curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --skills-only"
+    echo ""
+  fi
+fi
 
 _pp_go_version_norm() {
   printf '%s\n' "${PP_GO_VERSION_INPUT:-}" | sed -nE 's/.*go([0-9]+)\.([0-9]+)(\.([0-9]+))?.*/\1.\2.\4/p' | sed -E 's/\.$/.0/'
@@ -539,11 +558,11 @@ CODEX_CONSECUTIVE_FAILURES=0
 ```
 <!-- PRESS_SETUP_CONTRACT_END -->
 
-**MANDATORY: Read and apply [references/setup-checks.md](../references/setup-checks.md) immediately after the setup contract bash block runs, before any other action.** It handles the contract output signals: `[setup-error]` (refuse to run, surface the install instructions), optional `[local-binary-stale]` / `[local-binary-rebuilt]` repo-mode rebuild markers, `[go-toolchain-old]` / `[low-disk]` advisories, `[repo-upgrade-available]` (interactive `AskUserQuestion` prompt + optional repo pull), `PRESS_REPO_MODE=<true|false>` plus the targeted global open-agent-skills freshness check, the min-binary-version compatibility check (hard stop if binary is too old), `[upgrade-required]` (hard gate below the published currency floor — interactive upgrade-or-abort, no skip), `[upgrade-available]` (interactive `AskUserQuestion` prompt + optional standalone binary upgrade), `[browser-tools-missing]` (interactive `AskUserQuestion` prompt + optional install of browser-use and/or agent-browser), and the `PRINTING_PRESS_BIN=<abs-path>` marker plus optional `[binary-shadow]` warning (capture the path; use it for every subsequent generator invocation). Skipping the reference will cause the skill to proceed with a missing or out-of-date binary, run with stale global skill text when the session is managed by open-agent-skills, hit a mid-flight install prompt if browser-sniff is later needed, or invoke the wrong binary because a stale global or the public-library installer on `PATH` shadowed the local build. Do not skip.
+**MANDATORY: Read and apply [references/setup-checks.md](../references/setup-checks.md) immediately after the setup contract bash block runs, before any other action.** It handles the contract output signals: `[setup-error]` (refuse to run, surface the install instructions), optional `[local-binary-stale]` / `[local-binary-rebuilt]` repo-mode rebuild markers, `[go-toolchain-old]` / `[low-disk]` advisories, `[repo-upgrade-available]` (interactive `AskUserQuestion` prompt + optional repo pull), `PRESS_REPO_MODE=<true|false>` plus the targeted global open-agent-skills freshness check, the min-binary-version compatibility check (hard stop if binary is too old), `[skill-stale]` (hard stop if the running skill is older than this binary — no skip), `[upgrade-required]` (hard gate below the published currency floor — interactive upgrade-or-abort, no skip), `[upgrade-available]` (interactive `AskUserQuestion` prompt + optional standalone binary upgrade), `[browser-tools-missing]` (interactive `AskUserQuestion` prompt + optional install of browser-use and/or agent-browser), and the `PRINTING_PRESS_BIN=<abs-path>` marker plus optional `[binary-shadow]` warning (capture the path; use it for every subsequent generator invocation). Skipping the reference will cause the skill to proceed with a missing or out-of-date binary, run with stale global skill text when the session is managed by open-agent-skills, hit a mid-flight install prompt if browser-sniff is later needed, or invoke the wrong binary because a stale global or the public-library installer on `PATH` shadowed the local build. Do not skip.
 
 **Absolute-path rule.** The preflight contract always emits `PRINTING_PRESS_BIN=<absolute path>` to stdout. Capture this value and substitute it (the resolved absolute path, not the literal `$PRINTING_PRESS_BIN` token) for every subsequent `cli-printing-press ...` invocation in this skill, references, and any sub-skill you delegate to. The `export PATH=...` line inside the contract only affects the single Bash tool call it runs in; later Bash tool calls open fresh shells and resolve bare `cli-printing-press` against the user's default `PATH`, where a stale globally-installed binary (`$HOME/go/bin/cli-printing-press`, Homebrew copy, etc.) will silently shadow the local build the preflight just chose. Bash code examples below are written `cli-printing-press generate ...` for readability — replace `cli-printing-press` with the captured absolute path each time you actually run one.
 
-Only after preflight completes successfully (no `[setup-error]`; no `[upgrade-required]` left unresolved — the user either upgraded or the run was aborted; no global skill update that requires restart; any `[repo-upgrade-available]`, `[upgrade-available]`, or `[browser-tools-missing]` was offered to the user; `PRINTING_PRESS_BIN` is captured) should you proceed to the orientation and briefing flow in [references/run-resolution.md](../references/run-resolution.md).
+Only after preflight completes successfully (no `[setup-error]`; no `[skill-stale]`; no `[upgrade-required]` left unresolved — the user either upgraded or the run was aborted; no global skill update that requires restart; any `[repo-upgrade-available]`, `[upgrade-available]`, or `[browser-tools-missing]` was offered to the user; `PRINTING_PRESS_BIN` is captured) should you proceed to the orientation and briefing flow in [references/run-resolution.md](../references/run-resolution.md).
 
 Phase receipts begin only after `02-run-initialization` allocates a run ID and pipeline
 directory. Do not create a receipt during preflight.

--- a/skills/printing-press/phases/01-preflight.md
+++ b/skills/printing-press/phases/01-preflight.md
@@ -271,6 +271,7 @@ if [ -n "$PRINTING_PRESS_BIN" ]; then
     echo "PRESS_SKILL_REQUIRED=$_min_skill"
     echo "PRESS_SKILL_REINSTALL=curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --skills-only"
     echo ""
+    return 1 2>/dev/null || exit 1
   fi
 fi
 

--- a/skills/printing-press/references/setup-checks.md
+++ b/skills/printing-press/references/setup-checks.md
@@ -1,6 +1,6 @@
 # Setup Checks
 
-Post-contract checks the skill must run after executing the bash setup contract block in [phases/01-preflight.md](../phases/01-preflight.md). These handle the contract output signals: `[setup-error]`, optional `[local-binary-stale]` / `[local-binary-rebuilt]` repo-mode rebuild markers, `[go-toolchain-old]`, `[low-disk]`, `[repo-upgrade-available]`, the always-emitted `PRINTING_PRESS_BIN=<abs-path>` and `PRESS_REPO_MODE=<true|false>` markers, the global open-agent-skills freshness check, the `min-binary-version` compatibility check, `[upgrade-required]`, `[upgrade-available]`, `[browser-tools-missing]`, and optional `[binary-shadow]` advisory.
+Post-contract checks the skill must run after executing the bash setup contract block in [phases/01-preflight.md](../phases/01-preflight.md). These handle the contract output signals: `[setup-error]`, optional `[local-binary-stale]` / `[local-binary-rebuilt]` repo-mode rebuild markers, `[go-toolchain-old]`, `[low-disk]`, `[repo-upgrade-available]`, the always-emitted `PRINTING_PRESS_BIN=<abs-path>` and `PRESS_REPO_MODE=<true|false>` markers, the global open-agent-skills freshness check, the `min-binary-version` compatibility check, `[skill-stale]`, `[upgrade-required]`, `[upgrade-available]`, `[browser-tools-missing]`, and optional `[binary-shadow]` advisory.
 
 Apply these in order. The preamble below runs unconditionally; each numbered section after it is conditional — do nothing if its trigger isn't present.
 
@@ -137,6 +137,30 @@ If the installed binary is older than the minimum, stop the skill immediately an
 > "cli-printing-press binary vX.Y.Z is older than the minimum required vA.B.C. Run `go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest` to update."
 
 Do not proceed to research, scoring, publishing, or any other workflow when the binary is below `min-binary-version`. This is the compatibility floor, not a freshness advisory.
+
+## 4.25. Skill-too-old-for-binary (skill drift) hard gate
+
+This is the reverse of section 4. `min-binary-version` stops a skill that is newer than the binary. This section stops a **skill that is older than the binary** — the case where an upgraded binary still runs a frozen `version: 2.0.0` install whose Phase 1 text calls deleted commands.
+
+Apply these in order:
+
+1. If the setup contract output contains a line starting with `[skill-stale]`, parse:
+
+   - `PRESS_SKILL_INSTALLED=<skill version declared by the running skill>`
+   - `PRESS_SKILL_REQUIRED=<min_skill_version this binary expects>`
+   - `PRESS_SKILL_REINSTALL=<skills-only install command>`
+
+   **Stop the skill immediately.** Do not proceed to research, generation, scoring, publishing, or any later phase. The running skill text is older than this binary's floor; continuing would follow obsolete instructions. Tell the user:
+
+   > "printing-press skill v\<installed\> is older than cli-printing-press binary v\<binary\> expects (>= \<required\>). Reinstall the skills, then restart the agent session before re-running /printing-press."
+
+   Then give them the `PRESS_SKILL_REINSTALL` command (the skills-only installer). There is **no skip-and-continue**.
+
+2. Independently, read this skill's YAML frontmatter `version:` field and parse `min_skill_version` from `<PRINTING_PRESS_BIN> version --json`. Compare using semver. If the frontmatter version is missing or lower than `min_skill_version`, treat it as `[skill-stale]` even if the contract did not emit the marker (older binaries omit `min_skill_version` — skip this comparison when the field is absent). Same stop, same reinstall path, no skip.
+
+A current skill/binary pair emits no `[skill-stale]` marker, no stderr warning from `version --json`, and no extra human-facing output from this section.
+
+If `<PRINTING_PRESS_BIN> version --json` printed a `warning:` about an installed skill in a well-known location (`~/.claude/skills/printing-press` or similar) whose `version:` is below `min_skill_version`, treat that as `[skill-stale]` too: the binary discovered a stale on-disk copy that this session may be executing. Stop and reinstall as above.
 
 ## 4.5. Required-minimum (currency floor) hard gate
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #4484

Skill frontmatter `version:` was frozen at 2.0.0, so `min-binary-version` only guarded binary-too-old-for-skill. After the progressive-phases rewrite, a 4.32+ binary could still execute a stale install whose Phase 1 text calls deleted commands.

This adds the reverse floor: the binary carries `MinSkillVersion` (3.0.0), the printing-press skill `version:` is bumped to match, and preflight fail-closes with `[skill-stale]` plus the skills-only reinstall path. `version --json` also warns on stderr when a well-known install path still has an older copy.

Deliberately fail-closed rather than the issue's non-blocking warning: continuing a stale skill is the defect.

Follow-up on this head:
- Discovery ranks the worst (oldest) among all readable installs, so a current `~/.claude` copy cannot mask a stale `~/.codex` or XDG copy.
- The `[skill-stale]` setup-contract branch now `return 1` / `exit 1` like other hard preflight gates.
- `docs/PLUGIN-DEV.md` stays in the developer-doc index alongside `docs/SKILLS.md`.

Not labeled ready-to-merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-427adc8e-c492-48f5-adf3-4dc14979a80f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-427adc8e-c492-48f5-adf3-4dc14979a80f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

