### PR TITLE
fix(cli): emit anchored .gitignore and -trimpath builds

### DIFF
--- a/internal/generator/device.go
+++ b/internal/generator/device.go
@@ -117,11 +117,12 @@ func (g *DeviceGenerator) Generate() error {
 		"README.md": deviceReadmeTemplate,
 		"SKILL.md":  deviceSkillTemplate,
 		// Standard publish artifacts the public library's completeness verifier
-		// expects. LICENSE/NOTICE/.goreleaser.yaml are shared with the HTTP
-		// generator; AGENTS.md uses a device-aware variant (no auth/sync/SQL).
+		// expects. LICENSE/NOTICE/.goreleaser.yaml/.gitignore are shared with
+		// the HTTP generator; AGENTS.md uses a device-aware variant (no auth/sync/SQL).
 		"LICENSE":          "LICENSE.tmpl",
 		"NOTICE":           "NOTICE.tmpl",
 		".goreleaser.yaml": "goreleaser.yaml.tmpl",
+		".gitignore":       "gitignore.tmpl",
 		"AGENTS.md":        "agents_device.md.tmpl",
 		// Claude Code auto-loads CLAUDE.md, not AGENTS.md (codex/agy read AGENTS.md
 		// natively). Emit a CLAUDE.md that just imports it so a Claude session in the

--- a/internal/generator/device.go
+++ b/internal/generator/device.go
@@ -320,6 +320,8 @@ func (g *DeviceGenerator) renderEmbedded(relPath, tmplName string, data deviceTe
 		"copyrightHolder":  func() string { return "contributors" },
 		"envPrefix":        naming.EnvPrefix,
 		"modulePath":       func() string { return naming.CLI(g.Spec.Name) },
+		"cliName":          naming.CLI,
+		"mcpName":          naming.MCP,
 		"yamlDoubleQuoted": yamlDoubleQuoted,
 	}).Parse(string(content))
 	if err != nil {

--- a/internal/generator/device_test.go
+++ b/internal/generator/device_test.go
@@ -66,8 +66,8 @@ func TestGeneratedBLEDeviceEscapesDisplayNameInRootCommand(t *testing.T) {
 }
 
 // TestGeneratedBLEDeviceEmitsPublishArtifacts verifies the device generator
-// emits the four standard publish artifacts the public library's
-// completeness verifier expects (AGENTS.md, LICENSE, NOTICE, .goreleaser.yaml).
+// emits the standard publish artifacts the public library's completeness
+// verifier expects (AGENTS.md, LICENSE, NOTICE, .goreleaser.yaml, .gitignore).
 // A device generate previously dropped all four — the "fork-and-drop" gap the
 // shared version.go template fixed for the version command.
 func TestGeneratedBLEDeviceEmitsPublishArtifacts(t *testing.T) {
@@ -79,7 +79,7 @@ func TestGeneratedBLEDeviceEmitsPublishArtifacts(t *testing.T) {
 	outputDir := filepath.Join(t.TempDir(), "ble-temperature-sensor")
 	require.NoError(t, NewDevice(ds, outputDir).Generate())
 
-	for _, name := range []string{"AGENTS.md", "CLAUDE.md", "LICENSE", "NOTICE", ".goreleaser.yaml"} {
+	for _, name := range []string{"AGENTS.md", "CLAUDE.md", "LICENSE", "NOTICE", ".goreleaser.yaml", ".gitignore"} {
 		assert.FileExists(t, filepath.Join(outputDir, name))
 	}
 
@@ -91,7 +91,7 @@ func TestGeneratedBLEDeviceEmitsPublishArtifacts(t *testing.T) {
 	// goreleaser file legitimately carries goreleaser's own `{{ .Version }}`
 	// (note the leading space), so assert specifically on the Go-template form
 	// `{{.` / `{{range`-style openers that would mean a field went unrendered.
-	for _, name := range []string{"AGENTS.md", "LICENSE", "NOTICE", ".goreleaser.yaml"} {
+	for _, name := range []string{"AGENTS.md", "LICENSE", "NOTICE", ".goreleaser.yaml", ".gitignore"} {
 		body := readFileString(t, filepath.Join(outputDir, name))
 		assert.NotContains(t, body, "{{.", "%s contains an unrendered Go template directive", name)
 		assert.NotEmpty(t, strings.TrimSpace(body), "%s is empty", name)
@@ -118,7 +118,15 @@ func TestGeneratedBLEDeviceEmitsPublishArtifacts(t *testing.T) {
 	assert.Contains(t, goreleaser, "main: ./cmd/"+naming.MCP(ds.Name))
 	assert.Contains(t, goreleaser, naming.CLI(ds.Name)+"/internal/cli.version=")
 	assert.Contains(t, goreleaser, "-X main.version={{ .Version }}")
+	assert.Contains(t, goreleaser, "-trimpath")
+	assert.GreaterOrEqual(t, strings.Count(goreleaser, "-trimpath"), 2)
 	assert.Contains(t, goreleaser, `description: "`)
+
+	gitignore := readFileString(t, filepath.Join(outputDir, ".gitignore"))
+	assert.Contains(t, gitignore, "/"+naming.CLI(ds.Name)+"\n")
+	assert.Contains(t, gitignore, "/"+naming.MCP(ds.Name)+"\n")
+	assert.NotContains(t, gitignore, "\n"+naming.CLI(ds.Name)+"\n")
+	assert.NotContains(t, gitignore, "\n"+naming.MCP(ds.Name)+"\n")
 
 	// AGENTS.md is the device-aware variant: it uses BLE/replay concepts and the
 	// codec/novelCommands customization model, never HTTP auth/sync/SQL.

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -5891,6 +5891,9 @@ func (g *Generator) renderRootProjectFiles(promotedCommands []PromotedCommand, p
 	if err := g.renderTemplate("goreleaser.yaml.tmpl", ".goreleaser.yaml", rootData); err != nil {
 		return fmt.Errorf("rendering goreleaser: %w", err)
 	}
+	if err := g.renderTemplate("gitignore.tmpl", ".gitignore", rootData); err != nil {
+		return fmt.Errorf("rendering gitignore: %w", err)
+	}
 
 	return nil
 }

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -377,6 +377,8 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 			}
 			return naming.CLI(s.Name)
 		},
+		"cliName":            naming.CLI,
+		"mcpName":            naming.MCP,
 		"goDirectiveVersion": resolveCurrentGoDirectiveVersion,
 		"goToolchainVersion": resolveCurrentGoToolchainVersion,
 		"graphqlQueryField":  graphqlQueryField,

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -48,6 +48,8 @@ func TestGenerateProjectsCompile(t *testing.T) {
 	mustInclude := []string{
 		"go.mod",
 		"Makefile",
+		".gitignore",
+		".goreleaser.yaml",
 		"AGENTS.md",
 		"CLAUDE.md",
 		"README.md",
@@ -151,9 +153,10 @@ func TestGenerateProjectsCompile(t *testing.T) {
 		// +1: cmd/<cli>-pp-mcp/http_auth_test.go for the HTTP caller-auth contract.
 		// +4: cliutil.WithFileLock (filelock.go + unix/windows + test) so
 		// learn-loop audit/teach.log rotation is cross-process safe.
-		{name: "stytch", specPath: filepath.Join("..", "..", "testdata", "stytch.yaml"), expectedFiles: 176},
-		{name: "clerk", specPath: filepath.Join("..", "..", "testdata", "clerk.yaml"), expectedFiles: 180},
-		{name: "loops", specPath: filepath.Join("..", "..", "testdata", "loops.yaml"), expectedFiles: 178},
+		// +1: root .gitignore so local binaries are ignored without hiding cmd/<name>/.
+		{name: "stytch", specPath: filepath.Join("..", "..", "testdata", "stytch.yaml"), expectedFiles: 177},
+		{name: "clerk", specPath: filepath.Join("..", "..", "testdata", "clerk.yaml"), expectedFiles: 181},
+		{name: "loops", specPath: filepath.Join("..", "..", "testdata", "loops.yaml"), expectedFiles: 179},
 	}
 
 	for _, tt := range tests {

--- a/internal/generator/gitignore_template_test.go
+++ b/internal/generator/gitignore_template_test.go
@@ -51,6 +51,25 @@ func TestGeneratedGitignoreAnchorsRootBinaries(t *testing.T) {
 		"CLI and MCP goreleaser builds must both set -trimpath")
 }
 
+func TestGeneratedGitignoreUsesCanonicalBinaryNames(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("widget-pp")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	cliName := naming.CLI(apiSpec.Name)
+	mcpName := naming.MCP(apiSpec.Name)
+	require.Equal(t, "widget-pp-cli", cliName)
+	require.Equal(t, "widget-pp-mcp", mcpName)
+
+	gitignore := readGeneratedFile(t, outputDir, ".gitignore")
+	assert.Contains(t, gitignore, "/"+cliName+"\n")
+	assert.Contains(t, gitignore, "/"+mcpName+"\n")
+	assert.NotContains(t, gitignore, "widget-pp-pp-cli")
+	assert.NotContains(t, gitignore, "widget-pp-pp-mcp")
+}
+
 func initGitRepo(t *testing.T, dir string) {
 	t.Helper()
 	runGit(t, dir, "init", "-q")

--- a/internal/generator/gitignore_template_test.go
+++ b/internal/generator/gitignore_template_test.go
@@ -1,0 +1,92 @@
+package generator
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedGitignoreAnchorsRootBinaries(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("seats-aero")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	cliName := naming.CLI(apiSpec.Name)
+	mcpName := naming.MCP(apiSpec.Name)
+	gitignore := readGeneratedFile(t, outputDir, ".gitignore")
+
+	assert.Contains(t, gitignore, "/"+cliName+"\n")
+	assert.Contains(t, gitignore, "/"+mcpName+"\n")
+	assert.Contains(t, gitignore, "/"+cliName+".exe\n")
+	assert.Contains(t, gitignore, "/"+mcpName+".exe\n")
+	assert.Contains(t, gitignore, "/build/\n")
+	assert.Contains(t, gitignore, "/dist/\n")
+	assert.NotContains(t, gitignore, "\n"+cliName+"\n")
+	assert.NotContains(t, gitignore, "\n"+mcpName+"\n")
+
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, cliName), []byte("fake-binary\n"), 0o644))
+	initGitRepo(t, outputDir)
+
+	ignored, output := gitCheckIgnore(t, outputDir, cliName)
+	require.True(t, ignored, "root binary must be ignored: %s", output)
+
+	cmdFile := filepath.Join("cmd", cliName, "x_test.go")
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, cmdFile), []byte("package main\n"), 0o644))
+	ignored, output = gitCheckIgnore(t, outputDir, cmdFile)
+	require.False(t, ignored, "cmd/%s/ source must stay tracked: %s", cliName, output)
+}
+
+func TestGeneratedGoreleaserIncludesTrimpath(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("flow")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{MCP: true}
+	require.NoError(t, gen.Generate())
+
+	goreleaser := readGeneratedFile(t, outputDir, ".goreleaser.yaml")
+	assert.Contains(t, goreleaser, "flags:")
+	assert.GreaterOrEqual(t, strings.Count(goreleaser, "-trimpath"), 2,
+		"CLI and MCP goreleaser builds must both set -trimpath")
+}
+
+func initGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	runGit(t, dir, "init", "-q")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "test")
+	runGit(t, dir, "config", "core.excludesFile", "")
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, out)
+}
+
+func gitCheckIgnore(t *testing.T, dir, path string) (ignored bool, output string) {
+	t.Helper()
+	cmd := exec.Command("git", "-c", "core.excludesFile=", "check-ignore", "-v", "--", path)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	output = string(out)
+	if err == nil {
+		return true, output
+	}
+	if exit, ok := err.(*exec.ExitError); ok && exit.ExitCode() == 1 {
+		return false, output
+	}
+	require.NoError(t, err, "git check-ignore %s: %s", path, output)
+	return false, output
+}

--- a/internal/generator/gitignore_template_test.go
+++ b/internal/generator/gitignore_template_test.go
@@ -17,7 +17,9 @@ func TestGeneratedGitignoreAnchorsRootBinaries(t *testing.T) {
 
 	apiSpec := minimalSpec("seats-aero")
 	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
-	require.NoError(t, New(apiSpec, outputDir).Generate())
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{MCP: true}
+	require.NoError(t, gen.Generate())
 
 	cliName := naming.CLI(apiSpec.Name)
 	mcpName := naming.MCP(apiSpec.Name)
@@ -42,16 +44,6 @@ func TestGeneratedGitignoreAnchorsRootBinaries(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, cmdFile), []byte("package main\n"), 0o644))
 	ignored, output = gitCheckIgnore(t, outputDir, cmdFile)
 	require.False(t, ignored, "cmd/%s/ source must stay tracked: %s", cliName, output)
-}
-
-func TestGeneratedGoreleaserIncludesTrimpath(t *testing.T) {
-	t.Parallel()
-
-	apiSpec := minimalSpec("flow")
-	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
-	gen := New(apiSpec, outputDir)
-	gen.VisionSet = VisionTemplateSet{MCP: true}
-	require.NoError(t, gen.Generate())
 
 	goreleaser := readGeneratedFile(t, outputDir, ".goreleaser.yaml")
 	assert.Contains(t, goreleaser, "flags:")

--- a/internal/generator/makefile_template_test.go
+++ b/internal/generator/makefile_template_test.go
@@ -19,7 +19,7 @@ func TestGeneratorMakefileDerivesWindowsBinarySuffix(t *testing.T) {
 
 	makefile := readGeneratedFile(t, outputDir, "Makefile")
 	require.Contains(t, makefile, `BIN_EXT := $(if $(filter windows,$(shell go env GOOS)),.exe,)`)
-	require.Contains(t, makefile, `go build -o bin/windowsbuild-pp-cli$(BIN_EXT) ./cmd/windowsbuild-pp-cli`)
-	require.Contains(t, makefile, `go build -o bin/windowsbuild-pp-mcp$(BIN_EXT) ./cmd/windowsbuild-pp-mcp`)
+	require.Contains(t, makefile, `go build -trimpath -o bin/windowsbuild-pp-cli$(BIN_EXT) ./cmd/windowsbuild-pp-cli`)
+	require.Contains(t, makefile, `go build -trimpath -o bin/windowsbuild-pp-mcp$(BIN_EXT) ./cmd/windowsbuild-pp-mcp`)
 	require.Contains(t, makefile, `go install ./cmd/windowsbuild-pp-cli`)
 }

--- a/internal/generator/templates/gitignore.tmpl
+++ b/internal/generator/templates/gitignore.tmpl
@@ -1,8 +1,8 @@
 # Root-anchored so cmd/<binary>/ source stays tracked.
-/{{.Name}}-pp-cli
-/{{.Name}}-pp-cli.exe
-/{{.Name}}-pp-mcp
-/{{.Name}}-pp-mcp.exe
+/{{cliName .Name}}
+/{{cliName .Name}}.exe
+/{{mcpName .Name}}
+/{{mcpName .Name}}.exe
 /bin/
 /build/
 /dist/

--- a/internal/generator/templates/gitignore.tmpl
+++ b/internal/generator/templates/gitignore.tmpl
@@ -1,0 +1,8 @@
+# Root-anchored so cmd/<binary>/ source stays tracked.
+/{{.Name}}-pp-cli
+/{{.Name}}-pp-cli.exe
+/{{.Name}}-pp-mcp
+/{{.Name}}-pp-mcp.exe
+/bin/
+/build/
+/dist/

--- a/internal/generator/templates/goreleaser.yaml.tmpl
+++ b/internal/generator/templates/goreleaser.yaml.tmpl
@@ -8,6 +8,8 @@ builds:
     binary: {{.Name}}-pp-cli
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
     ldflags:
       - -s -w -X {{modulePath}}/internal/cli.version={{"{{"}} .Version {{"}}"}}
     targets:
@@ -23,6 +25,8 @@ builds:
     binary: {{.Name}}-pp-mcp
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
     ldflags:
       - -s -w -X main.version={{"{{"}} .Version {{"}}"}}
     targets:

--- a/internal/generator/templates/makefile.tmpl
+++ b/internal/generator/templates/makefile.tmpl
@@ -3,7 +3,7 @@
 BIN_EXT := $(if $(filter windows,$(shell go env GOOS)),.exe,)
 
 build:
-	go build -o bin/{{.Name}}-pp-cli$(BIN_EXT) ./cmd/{{.Name}}-pp-cli
+	go build -trimpath -o bin/{{.Name}}-pp-cli$(BIN_EXT) ./cmd/{{.Name}}-pp-cli
 
 test:
 	go test ./...
@@ -19,7 +19,7 @@ clean:
 {{- if .VisionSet.MCP}}
 
 build-mcp:
-	go build -o bin/{{.Name}}-pp-mcp$(BIN_EXT) ./cmd/{{.Name}}-pp-mcp
+	go build -trimpath -o bin/{{.Name}}-pp-mcp$(BIN_EXT) ./cmd/{{.Name}}-pp-mcp
 
 install-mcp:
 	go install ./cmd/{{.Name}}-pp-mcp

--- a/internal/pipeline/renamecli_test.go
+++ b/internal/pipeline/renamecli_test.go
@@ -386,6 +386,35 @@ func TestRenameCLI(t *testing.T) {
 		assert.NotContains(t, string(gitignore), "\n"+newMCPName+"\n")
 	})
 
+	t.Run("already anchored gitignore stays anchored", func(t *testing.T) {
+		root := t.TempDir()
+		oldName := "notion-pp-cli"
+		newName := "notion-alt-pp-cli"
+		apiName := "notion"
+		newMCPName := naming.MCP(naming.TrimCLISuffix(newName))
+
+		cliDir := filepath.Join(root, oldName)
+		require.NoError(t, os.MkdirAll(cliDir, 0o755))
+		writeTestCLITree(t, cliDir, oldName, apiName)
+		require.NoError(t, os.WriteFile(filepath.Join(cliDir, ".gitignore"), []byte(
+			"/notion-pp-cli\n/notion-pp-cli.exe\n/notion-pp-mcp\n/notion-pp-mcp.exe\n/bin/\n/build/\n/dist/\n",
+		), 0o644))
+
+		_, err := RenameCLI(cliDir, oldName, newName, apiName)
+		require.NoError(t, err)
+
+		newDir := filepath.Join(root, naming.LibraryDirName(newName))
+		gitignore, err := os.ReadFile(filepath.Join(newDir, ".gitignore"))
+		require.NoError(t, err)
+		got := string(gitignore)
+		assert.Contains(t, got, "/"+newName+"\n")
+		assert.Contains(t, got, "/"+newMCPName+"\n")
+		assert.NotContains(t, got, "\n"+newName+"\n")
+		assert.NotContains(t, got, "\n"+newMCPName+"\n")
+		assert.NotContains(t, got, "notion-pp-cli")
+		assert.NotContains(t, got, "notion-pp-mcp")
+	})
+
 	t.Run("numeric qualifier renames correctly", func(t *testing.T) {
 		root := t.TempDir()
 		oldName := "notion-pp-cli"
@@ -899,4 +928,18 @@ func TestRenameCLISkipsResearchJSONSymlink(t *testing.T) {
 	outsideData, err := os.ReadFile(outside)
 	require.NoError(t, err)
 	assert.Equal(t, `{"api_name": "subject"}`+"\n", string(outsideData), "symlink target outside the CLI tree must stay untouched")
+}
+
+func TestAnchorRenamedGitignorePatterns(t *testing.T) {
+	t.Parallel()
+
+	t.Run("anchors bare binary names", func(t *testing.T) {
+		got := anchorRenamedGitignorePatterns("new-pp-cli\nnew-pp-mcp\n/build/\n", "new-pp-cli", "new-pp-mcp")
+		assert.Equal(t, "/new-pp-cli\n/new-pp-mcp\n/build/\n", got)
+	})
+
+	t.Run("leaves already anchored names", func(t *testing.T) {
+		in := "/new-pp-cli\n/new-pp-cli.exe\n/new-pp-mcp\n/new-pp-mcp.exe\n/bin/\n/build/\n/dist/\n"
+		assert.Equal(t, in, anchorRenamedGitignorePatterns(in, "new-pp-cli", "new-pp-mcp"))
+	})
 }

--- a/testdata/golden/cases/generate-device-ble-control/artifacts.txt
+++ b/testdata/golden/cases/generate-device-ble-control/artifacts.txt
@@ -11,4 +11,5 @@ ble-desk-lamp/CLAUDE.md
 ble-desk-lamp/LICENSE
 ble-desk-lamp/NOTICE
 ble-desk-lamp/.goreleaser.yaml
+ble-desk-lamp/.gitignore
 ble-desk-lamp/device-spec.yaml

--- a/testdata/golden/cases/generate-device-ble-opaque/artifacts.txt
+++ b/testdata/golden/cases/generate-device-ble-opaque/artifacts.txt
@@ -11,4 +11,5 @@ ble-opaque-binary/CLAUDE.md
 ble-opaque-binary/LICENSE
 ble-opaque-binary/NOTICE
 ble-opaque-binary/.goreleaser.yaml
+ble-opaque-binary/.gitignore
 ble-opaque-binary/device-spec.yaml

--- a/testdata/golden/cases/generate-device-ble-session/artifacts.txt
+++ b/testdata/golden/cases/generate-device-ble-session/artifacts.txt
@@ -13,4 +13,5 @@ ble-session-appliance/CLAUDE.md
 ble-session-appliance/LICENSE
 ble-session-appliance/NOTICE
 ble-session-appliance/.goreleaser.yaml
+ble-session-appliance/.gitignore
 ble-session-appliance/device-spec.yaml

--- a/testdata/golden/cases/generate-device-ble/artifacts.txt
+++ b/testdata/golden/cases/generate-device-ble/artifacts.txt
@@ -19,4 +19,5 @@ ble-temperature-sensor/CLAUDE.md
 ble-temperature-sensor/LICENSE
 ble-temperature-sensor/NOTICE
 ble-temperature-sensor/.goreleaser.yaml
+ble-temperature-sensor/.gitignore
 ble-temperature-sensor/device-spec.yaml

--- a/testdata/golden/cases/generate-golden-api/artifacts.txt
+++ b/testdata/golden/cases/generate-golden-api/artifacts.txt
@@ -1,5 +1,7 @@
 printing-press-golden/.printing-press.json
 printing-press-golden/.printing-press-patches/.gitkeep
+printing-press-golden/.gitignore
+printing-press-golden/.goreleaser.yaml
 printing-press-golden/manifest.json
 printing-press-golden/go.mod
 printing-press-golden/cmd/printing-press-golden-pp-cli/main.go

--- a/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/.gitignore
+++ b/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/.gitignore
@@ -1,0 +1,8 @@
+# Root-anchored so cmd/<binary>/ source stays tracked.
+/ble-desk-lamp-pp-cli
+/ble-desk-lamp-pp-cli.exe
+/ble-desk-lamp-pp-mcp
+/ble-desk-lamp-pp-mcp.exe
+/bin/
+/build/
+/dist/

--- a/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/.goreleaser.yaml
+++ b/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/.goreleaser.yaml
@@ -8,6 +8,8 @@ builds:
     binary: ble-desk-lamp-pp-cli
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
     ldflags:
       - -s -w -X ble-desk-lamp-pp-cli/internal/cli.version={{ .Version }}
     targets:
@@ -22,6 +24,8 @@ builds:
     binary: ble-desk-lamp-pp-mcp
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
     ldflags:
       - -s -w -X main.version={{ .Version }}
     targets:

--- a/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/.gitignore
+++ b/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/.gitignore
@@ -1,0 +1,8 @@
+# Root-anchored so cmd/<binary>/ source stays tracked.
+/ble-opaque-binary-pp-cli
+/ble-opaque-binary-pp-cli.exe
+/ble-opaque-binary-pp-mcp
+/ble-opaque-binary-pp-mcp.exe
+/bin/
+/build/
+/dist/

--- a/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/.goreleaser.yaml
+++ b/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/.goreleaser.yaml
@@ -8,6 +8,8 @@ builds:
     binary: ble-opaque-binary-pp-cli
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
     ldflags:
       - -s -w -X ble-opaque-binary-pp-cli/internal/cli.version={{ .Version }}
     targets:
@@ -22,6 +24,8 @@ builds:
     binary: ble-opaque-binary-pp-mcp
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
     ldflags:
       - -s -w -X main.version={{ .Version }}
     targets:

--- a/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/.gitignore
+++ b/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/.gitignore
@@ -1,0 +1,8 @@
+# Root-anchored so cmd/<binary>/ source stays tracked.
+/ble-session-appliance-pp-cli
+/ble-session-appliance-pp-cli.exe
+/ble-session-appliance-pp-mcp
+/ble-session-appliance-pp-mcp.exe
+/bin/
+/build/
+/dist/

--- a/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/.goreleaser.yaml
+++ b/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/.goreleaser.yaml
@@ -8,6 +8,8 @@ builds:
     binary: ble-session-appliance-pp-cli
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
     ldflags:
       - -s -w -X ble-session-appliance-pp-cli/internal/cli.version={{ .Version }}
     targets:
@@ -22,6 +24,8 @@ builds:
     binary: ble-session-appliance-pp-mcp
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
     ldflags:
       - -s -w -X main.version={{ .Version }}
     targets:

--- a/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/.gitignore
+++ b/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/.gitignore
@@ -1,0 +1,8 @@
+# Root-anchored so cmd/<binary>/ source stays tracked.
+/ble-temperature-sensor-pp-cli
+/ble-temperature-sensor-pp-cli.exe
+/ble-temperature-sensor-pp-mcp
+/ble-temperature-sensor-pp-mcp.exe
+/bin/
+/build/
+/dist/

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/.gitignore
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/.gitignore
@@ -1,0 +1,8 @@
+# Root-anchored so cmd/<binary>/ source stays tracked.
+/printing-press-golden-pp-cli
+/printing-press-golden-pp-cli.exe
+/printing-press-golden-pp-mcp
+/printing-press-golden-pp-mcp.exe
+/bin/
+/build/
+/dist/

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/.goreleaser.yaml
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/.goreleaser.yaml
@@ -1,17 +1,17 @@
 version: 2
-project_name: ble-temperature-sensor-pp-cli
+project_name: printing-press-golden-pp-cli
 changelog:
   disable: true
 builds:
-  - id: ble-temperature-sensor-pp-cli
-    main: ./cmd/ble-temperature-sensor-pp-cli
-    binary: ble-temperature-sensor-pp-cli
+  - id: printing-press-golden-pp-cli
+    main: ./cmd/printing-press-golden-pp-cli
+    binary: printing-press-golden-pp-cli
     env:
       - CGO_ENABLED=0
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X ble-temperature-sensor-pp-cli/internal/cli.version={{ .Version }}
+      - -s -w -X printing-press-golden-pp-cli/internal/cli.version={{ .Version }}
     targets:
       - darwin_amd64
       - darwin_arm64
@@ -19,9 +19,9 @@ builds:
       - linux_arm64
       - windows_amd64
       - windows_arm64
-  - id: ble-temperature-sensor-pp-mcp
-    main: ./cmd/ble-temperature-sensor-pp-mcp
-    binary: ble-temperature-sensor-pp-mcp
+  - id: printing-press-golden-pp-mcp
+    main: ./cmd/printing-press-golden-pp-mcp
+    binary: printing-press-golden-pp-mcp
     env:
       - CGO_ENABLED=0
     flags:
@@ -44,12 +44,12 @@ archives:
 checksum:
   name_template: checksums.txt
 brews:
-  - name: ble-temperature-sensor-pp-cli
+  - name: printing-press-golden-pp-cli
     repository:
-      owner: contributors
+      owner: printing-press-golden
       name: homebrew-tap
-    homepage: "https://github.com/contributors/ble-temperature-sensor-pp-cli"
-    description: "BLE Temperature Sensor device CLI"
+    homepage: "https://github.com/printing-press-golden/printing-press-golden-pp-cli"
+    description: "Purpose-built fixture for golden generation coverage."
     install: |
-      bin.install "ble-temperature-sensor-pp-cli"
-      bin.install "ble-temperature-sensor-pp-mcp"
+      bin.install "printing-press-golden-pp-cli"
+      bin.install "printing-press-golden-pp-mcp"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Generated CLIs either shipped no `.gitignore` at all, or shipped unanchored binary names that made Git ignore `cmd/<binary>/` as well as the root binary. Fresh prints also omitted `-trimpath` from `.goreleaser.yaml`, so local/release builds embedded the builder's filesystem path in DWARF.

Closes #4586
Closes #4463

## Approach

Emit a root `.gitignore` from `gitignore.tmpl` on both the HTTP root-render path and the device generator, using leading-`/` anchors for the CLI and MCP binaries (plus `.exe`, `/bin/`, `/build/`, `/dist/`). Binary names go through `naming.CLI` / `naming.MCP` so a spec name ending in `-pp` still matches the real root binary. Add `-trimpath` to every goreleaser `builds[].flags` entry and to the generated Makefile `go build` lines.

The rename path already rewrites leftover bare names via `anchorRenamedGitignorePatterns`; tests now cover already-anchored emission as well as the legacy unanchored retrofit.

## Scope

Primary area: generator templates (`gitignore.tmpl`, `goreleaser.yaml.tmpl`, `makefile.tmpl`) and the HTTP/device render paths that write them.

Why this belongs in this repo: every future printed CLI inherits this scaffold. Per-CLI `.gitignore` edits in the public library would not compound.

## Risk

Generated output changes: new `.gitignore` file and goreleaser/Makefile flag lines. No runtime command behavior, MCP surface, auth, or verifier semantics. Rename of already-anchored ignore files stays a no-op besides the name rewrite. `generate --force` replaces `.gitignore` like other scaffold files (Makefile, goreleaser, LICENSE).

## Output Contract

- Emitted `.gitignore` asserts anchored `/<name>-pp-cli` and `/<name>-pp-mcp`; `git check-ignore` proves the root binary is ignored and `cmd/<name>/x_test.go` is not.
- Emitted `.goreleaser.yaml` includes `-trimpath` on CLI and MCP builds.
- Goldens: `generate-golden-api` now snapshots `.gitignore` and `.goreleaser.yaml`; device generate cases snapshot `.gitignore` and the updated goreleaser files.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:

- `go test ./... -timeout 20m` — pass
- `scripts/verify-generator-output.sh` — pass (13 cases, including HTTP and device generates)
- `scripts/golden.sh verify` — all generate-* cases pass, including the new `.gitignore` / `-trimpath` snapshots. Two unrelated fixture cases (`dogfood-verdict-matrix`, `verify-runtime-matrix`) fail in this environment because hand-written `go 1.24` fixtures cannot download that toolchain here; those expected files were not updated.
- `TestGeneratedGitignoreUsesCanonicalBinaryNames` — pass (spec names ending in `-pp`)

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7069b47e-7042-4d9c-aca4-9cf6ff8adc40?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7069b47e-7042-4d9c-aca4-9cf6ff8adc40&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

