### PR TITLE
fix(cli): validate learn ticker_patterns against playbook examples

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -390,10 +390,12 @@ Rules:
 - `disabled: true` is the generation-time opt-out. Combining it with an
   explicit `enabled: true` is rejected at parse time as contradictory.
 - Validated by the same learn validation as internal YAML specs: ticker
-  patterns must compile as Go regexps, seed kinds must be lowercase
-  identifiers, canonicals must be non-empty and unique within a kind, and
-  synonym pairs must be non-empty lowercase single-hop folds (no chains, no
-  self-references).
+  patterns must compile as Go regexps and must not classify every remaining
+  content token in seeded playbook `query_family_examples` as a ticker
+  (that empties QueryFamily and makes recall unreachable), seed kinds must
+  be lowercase identifiers, canonicals must be non-empty and unique within
+  a kind, and synonym pairs must be non-empty lowercase single-hop folds
+  (no chains, no self-references).
 
 Example:
 

--- a/docs/SPEC-LEARN-AUTHORING.md
+++ b/docs/SPEC-LEARN-AUTHORING.md
@@ -52,7 +52,7 @@ For example:
 - Polymarket: `^will-[a-z0-9-]+$` (market slugs)
 - ESPN: `^[0-9]{9}$` (9-digit event IDs), see worked example below
 
-Anchor every regex with `^...$` — without anchors a stray "will" in a sports query would match an unrelated Polymarket pattern and corrupt classification.
+Anchor every regex with `^...$` — without anchors a stray "will" in a sports query would match an unrelated Polymarket pattern and corrupt classification. Do not use a character class that can match ordinary lowercase query words (`^[a-z0-9]{2,12}$`); spec validation rejects patterns that empty QueryFamily for seeded playbook examples.
 
 ### Stopwords
 
@@ -310,6 +310,7 @@ The sweep tool is byte-for-byte parity with the generator emission for the learn
 - **Whitespace-only aliases.** Silently dropped. Use real strings.
 - **Domain identifiers in the canonical or alias text.** The purity gate (`scripts/verify-learn-purity.sh`) doesn't scan spec.Learn — but downstream library tests may. Keep the data clean.
 - **Ticker patterns without anchors.** A pattern like `[A-Z]{3}` matches any uppercase trigram in any query, including in stopwords. Always anchor with `^...$`.
+- **Ticker patterns that match ordinary lowercase words.** `matchesTicker` runs on the raw token *before* the ALL-CAPS entity rule, so `^[a-z0-9]{2,12}$` (and similar) claims every dictionary word, QueryFamily becomes empty, and every seeded playbook is skipped as unreachable. Spec/generate validation rejects that shape; keep a distinctive prefix, separator, or uppercase class (`^EW-[A-Z0-9]+$`, `^[A-Z][A-Z0-9]{2,11}$`, `^will-[a-z0-9-]+$`).
 - **Treating seeds as canonical truth.** They're a starting point. Real teach traffic is what populates the long tail. Seed only the high-frequency cases; let learnings fill in the rest.
 
 ## Related references

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3326,6 +3326,9 @@ func (g *Generator) renderOptionalSupportFiles() error {
 // LearnConfig values, which the per-CLI startup wires via NewConfig
 // and SeedFromConfig at first run.
 func (g *Generator) renderLearnFiles() error {
+	if err := validateLearnTickerPlaybookReachability(g.Spec.Learn, g.OutputDir); err != nil {
+		return err
+	}
 	learnData := struct {
 		*spec.APISpec
 		HasSync bool

--- a/internal/generator/learn_ticker.go
+++ b/internal/generator/learn_ticker.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 )
@@ -20,12 +21,21 @@ func validateLearnTickerPlaybookReachability(learn spec.LearnConfig, outputDir s
 }
 
 func authoredLearnQueryFamilyExamples(outputDir string) ([]spec.LearnQueryFamilyExample, error) {
-	matches, err := filepath.Glob(filepath.Join(outputDir, "internal", "cli", "playbooks", "*.json"))
+	dir := filepath.Join(outputDir, "internal", "cli", "playbooks")
+	entries, err := os.ReadDir(dir)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("listing authored playbooks: %w", err)
 	}
 	var extras []spec.LearnQueryFamilyExample
-	for _, path := range matches {
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		path := filepath.Join(dir, name)
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("reading authored playbook %s: %w", path, err)
@@ -34,7 +44,7 @@ func authoredLearnQueryFamilyExamples(outputDir string) ([]spec.LearnQueryFamily
 		if err != nil {
 			continue
 		}
-		rel := filepath.ToSlash(filepath.Join("playbooks", filepath.Base(path)))
+		rel := filepath.ToSlash(filepath.Join("playbooks", name))
 		for _, query := range examples {
 			extras = append(extras, spec.LearnQueryFamilyExample{Source: rel, Query: query})
 		}

--- a/internal/generator/learn_ticker.go
+++ b/internal/generator/learn_ticker.go
@@ -9,9 +9,8 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 )
 
-// validateLearnTickerPlaybookReachability fails generate when ticker
-// patterns would empty QueryFamily for seeded recall examples or for
-// authored playbook JSON already in the output tree (reprint).
+// Reprint can leave authored playbook JSON in --output that the generator
+// seed list does not cover; fail closed before emitting learn files.
 func validateLearnTickerPlaybookReachability(learn spec.LearnConfig, outputDir string) error {
 	extras, err := authoredLearnQueryFamilyExamples(outputDir)
 	if err != nil {
@@ -20,6 +19,8 @@ func validateLearnTickerPlaybookReachability(learn spec.LearnConfig, outputDir s
 	return spec.CheckLearnQueryFamilyReachability(&learn, extras)
 }
 
+// ReadDir, not Glob: --output is a user path and may contain '[' or other
+// glob metacharacters.
 func authoredLearnQueryFamilyExamples(outputDir string) ([]spec.LearnQueryFamilyExample, error) {
 	dir := filepath.Join(outputDir, "internal", "cli", "playbooks")
 	entries, err := os.ReadDir(dir)

--- a/internal/generator/learn_ticker.go
+++ b/internal/generator/learn_ticker.go
@@ -1,0 +1,43 @@
+package generator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+)
+
+// validateLearnTickerPlaybookReachability fails generate when ticker
+// patterns would empty QueryFamily for seeded recall examples or for
+// authored playbook JSON already in the output tree (reprint).
+func validateLearnTickerPlaybookReachability(learn spec.LearnConfig, outputDir string) error {
+	extras, err := authoredLearnQueryFamilyExamples(outputDir)
+	if err != nil {
+		return err
+	}
+	return spec.CheckLearnQueryFamilyReachability(&learn, extras)
+}
+
+func authoredLearnQueryFamilyExamples(outputDir string) ([]spec.LearnQueryFamilyExample, error) {
+	matches, err := filepath.Glob(filepath.Join(outputDir, "internal", "cli", "playbooks", "*.json"))
+	if err != nil {
+		return nil, fmt.Errorf("listing authored playbooks: %w", err)
+	}
+	var extras []spec.LearnQueryFamilyExample
+	for _, path := range matches {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading authored playbook %s: %w", path, err)
+		}
+		examples, err := spec.ParsePlaybookQueryFamilyExamples(data)
+		if err != nil {
+			continue
+		}
+		rel := filepath.ToSlash(filepath.Join("playbooks", filepath.Base(path)))
+		for _, query := range examples {
+			extras = append(extras, spec.LearnQueryFamilyExample{Source: rel, Query: query})
+		}
+	}
+	return extras, nil
+}

--- a/internal/generator/learn_ticker_test.go
+++ b/internal/generator/learn_ticker_test.go
@@ -1,0 +1,91 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateRejectsGreedyLowercaseTickerPattern(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("learn-greedy-ticker")
+	apiSpec.Learn.Enabled = true
+	apiSpec.Learn.TickerPatterns = []string{`^[a-z0-9]{2,12}$`}
+	outputDir := filepath.Join(t.TempDir(), "learn-greedy-ticker-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+
+	err := gen.Generate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ticker_patterns[0]")
+	require.Contains(t, err.Error(), `^[a-z0-9]{2,12}$`)
+	require.Contains(t, err.Error(), "alpha example query")
+	require.Contains(t, err.Error(), "QueryFamily would be empty")
+	require.NoFileExists(t, filepath.Join(outputDir, "internal", "learn", "entities", "extract.go"),
+		"generate must fail closed before emitting the learn package")
+}
+
+func TestGenerateAcceptsUppercaseTickerPattern(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("learn-upper-ticker")
+	apiSpec.Learn.Enabled = true
+	apiSpec.Learn.TickerPatterns = []string{`^[A-Z][A-Z0-9]{2,11}$`}
+	outputDir := filepath.Join(t.TempDir(), "learn-upper-ticker-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+	require.FileExists(t, filepath.Join(outputDir, "internal", "learn", "entities", "extract.go"))
+	require.FileExists(t, filepath.Join(outputDir, "internal", "cli", "learn_init.go"))
+}
+
+func TestGenerateRejectsAuthoredPlaybookSwallowedByTickerPattern(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("learn-authored-ticker")
+	apiSpec.Learn.Enabled = true
+	apiSpec.Learn.TickerPatterns = []string{`^nccpl-[a-z]+$`}
+	outputDir := filepath.Join(t.TempDir(), "learn-authored-ticker-pp-cli")
+	playbookDir := filepath.Join(outputDir, "internal", "cli", "playbooks")
+	require.NoError(t, os.MkdirAll(playbookDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(playbookDir, "nccpl.json"), []byte(`{
+  "query_family_examples": ["nccpl-alpha nccpl-beta"],
+  "steps": [{"cmd": "x"}]
+}`), 0o644))
+
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	err := gen.Generate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ticker_patterns[0]")
+	require.Contains(t, err.Error(), "nccpl-alpha nccpl-beta")
+	require.Contains(t, err.Error(), "playbooks/nccpl.json")
+}
+
+func TestLearnSeededQueryFamilyExamplesStayInTemplates(t *testing.T) {
+	t.Parallel()
+
+	files := []string{
+		"templates/playbook_init_test.go.tmpl",
+		"templates/teach_playbook_test.go.tmpl",
+		"templates/learn/playbooks_test.go.tmpl",
+		"templates/learn/recall_canonical_test.go.tmpl",
+	}
+	var combined strings.Builder
+	for _, rel := range files {
+		data, err := templateFS.ReadFile(rel)
+		require.NoError(t, err, "read %s", rel)
+		combined.Write(data)
+		combined.WriteByte('\n')
+	}
+	src := combined.String()
+	for _, query := range spec.LearnSeededQueryFamilyQueries() {
+		require.Contains(t, src, query,
+			"seeded query_family_example %q must remain in generator templates", query)
+	}
+}

--- a/internal/generator/learn_ticker_test.go
+++ b/internal/generator/learn_ticker_test.go
@@ -3,7 +3,7 @@ package generator
 import (
 	"os"
 	"path/filepath"
-	"strings"
+	"regexp"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
@@ -67,6 +67,24 @@ func TestGenerateRejectsAuthoredPlaybookSwallowedByTickerPattern(t *testing.T) {
 	require.Contains(t, err.Error(), "playbooks/nccpl.json")
 }
 
+func TestAuthoredLearnQueryFamilyExamplesTreatsOutputDirLiterally(t *testing.T) {
+	t.Parallel()
+
+	outputDir := filepath.Join(t.TempDir(), "out[put]")
+	playbookDir := filepath.Join(outputDir, "internal", "cli", "playbooks")
+	require.NoError(t, os.MkdirAll(playbookDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(playbookDir, "keep.json"), []byte(`{
+  "query_family_examples": ["keep these tokens"],
+  "steps": [{"cmd": "x"}]
+}`), 0o644))
+
+	got, err := authoredLearnQueryFamilyExamples(outputDir)
+	require.NoError(t, err)
+	require.Equal(t, []spec.LearnQueryFamilyExample{
+		{Source: "playbooks/keep.json", Query: "keep these tokens"},
+	}, got)
+}
+
 func TestLearnSeededQueryFamilyExamplesStayInTemplates(t *testing.T) {
 	t.Parallel()
 
@@ -76,16 +94,41 @@ func TestLearnSeededQueryFamilyExamplesStayInTemplates(t *testing.T) {
 		"templates/learn/playbooks_test.go.tmpl",
 		"templates/learn/recall_canonical_test.go.tmpl",
 	}
-	var combined strings.Builder
+	fromTemplates := map[string]struct{}{}
 	for _, rel := range files {
 		data, err := templateFS.ReadFile(rel)
 		require.NoError(t, err, "read %s", rel)
-		combined.Write(data)
-		combined.WriteByte('\n')
+		for _, query := range templateQueryFamilyExamples(string(data)) {
+			fromTemplates[query] = struct{}{}
+		}
 	}
-	src := combined.String()
-	for _, query := range spec.LearnSeededQueryFamilyQueries() {
-		require.Contains(t, src, query,
-			"seeded query_family_example %q must remain in generator templates", query)
+	fromSpec := spec.LearnSeededQueryFamilyQueries()
+	require.NotEmpty(t, fromSpec)
+	require.Len(t, fromTemplates, len(fromSpec),
+		"template query_family_examples %v must match seeded list %v", keys(fromTemplates), fromSpec)
+	for _, query := range fromSpec {
+		_, ok := fromTemplates[query]
+		require.True(t, ok, "seeded query_family_example %q missing from template query_family_examples arrays", query)
 	}
+}
+
+var queryFamilyExamplesArray = regexp.MustCompile(`"query_family_examples"\s*:\s*\[([^\]]*)\]`)
+var queryFamilyExampleString = regexp.MustCompile(`"((?:[^"\\]|\\.)*)"`)
+
+func templateQueryFamilyExamples(src string) []string {
+	var out []string
+	for _, match := range queryFamilyExamplesArray.FindAllStringSubmatch(src, -1) {
+		for _, inner := range queryFamilyExampleString.FindAllStringSubmatch(match[1], -1) {
+			out = append(out, inner[1])
+		}
+	}
+	return out
+}
+
+func keys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -10941,6 +10941,23 @@ x-learn:
 	assert.Contains(t, err.Error(), "not a valid Go regexp")
 }
 
+func TestParseLearnExtensionRejectsGreedyLowercaseTickerPattern(t *testing.T) {
+	t.Parallel()
+	data := cacheExtensionSpec("Greedy Ticker API", `
+x-learn:
+  enabled: true
+  ticker_patterns:
+    - "^[a-z0-9]{2,12}$"
+`, "", false)
+
+	_, err := Parse(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ticker_patterns[0]")
+	assert.Contains(t, err.Error(), `^[a-z0-9]{2,12}$`)
+	assert.Contains(t, err.Error(), "alpha example query")
+	assert.Contains(t, err.Error(), "QueryFamily would be empty")
+}
+
 func cacheExtensionSpec(title, rootExtension, infoExtension string, typedItems bool) []byte {
 	var b strings.Builder
 	fmt.Fprintf(&b, `openapi: 3.0.3

--- a/internal/spec/learn_ticker.go
+++ b/internal/spec/learn_ticker.go
@@ -158,7 +158,7 @@ func claimedPatternIndex(claimed map[int][]string) int {
 // outcome recall will.
 func learnNonEntityTokens(query string, tickers []*regexp.Regexp, stopwords map[string]struct{}) []string {
 	var family []string
-	for _, raw := range strings.Fields(query) {
+	for raw := range strings.FieldsSeq(query) {
 		tok := learnTrimPunct(raw)
 		if tok == "" {
 			continue

--- a/internal/spec/learn_ticker.go
+++ b/internal/spec/learn_ticker.go
@@ -63,10 +63,10 @@ var learnDefaultStopwords = map[string]struct{}{
 
 // CheckLearnQueryFamilyReachability reports whether learn.TickerPatterns
 // would make QueryFamily empty for any seeded generator example or any
-// extra authored playbook example. No-op when the loop is disabled or
-// no ticker patterns are declared.
+// extra authored playbook example. No-op when the loop will not be emitted
+// (disabled, or legacy enabled: false) or no ticker patterns are declared.
 func CheckLearnQueryFamilyReachability(learn *LearnConfig, extras []LearnQueryFamilyExample) error {
-	if learn == nil || learn.Disabled || len(learn.TickerPatterns) == 0 {
+	if !learnLoopEmits(learn) || len(learn.TickerPatterns) == 0 {
 		return nil
 	}
 	examples := make([]LearnQueryFamilyExample, 0, len(learnSeededQueryFamilyExamples)+len(extras))
@@ -75,8 +75,18 @@ func CheckLearnQueryFamilyReachability(learn *LearnConfig, extras []LearnQueryFa
 	return learn.queryFamilyReachabilityError(examples)
 }
 
+func learnLoopEmits(c *LearnConfig) bool {
+	if c == nil || c.Disabled {
+		return false
+	}
+	if c.EnabledSet {
+		return c.Enabled
+	}
+	return true
+}
+
 func (c *LearnConfig) queryFamilyReachabilityError(examples []LearnQueryFamilyExample) error {
-	if c == nil || c.Disabled || len(c.TickerPatterns) == 0 {
+	if !learnLoopEmits(c) || len(c.TickerPatterns) == 0 {
 		return nil
 	}
 	compiled := make([]*regexp.Regexp, len(c.TickerPatterns))
@@ -148,8 +158,7 @@ func claimedPatternIndex(claimed map[int][]string) int {
 // outcome recall will.
 func learnNonEntityTokens(query string, tickers []*regexp.Regexp, stopwords map[string]struct{}) []string {
 	var family []string
-	rawTokens := strings.Fields(query)
-	for i, raw := range rawTokens {
+	for _, raw := range strings.Fields(query) {
 		tok := learnTrimPunct(raw)
 		if tok == "" {
 			continue
@@ -158,21 +167,10 @@ func learnNonEntityTokens(query string, tickers []*regexp.Regexp, stopwords map[
 			continue
 		}
 		lower := strings.ToLower(tok)
-		if len(tok) >= 2 && learnIsAllCaps(tok) {
-			if _, sw := stopwords[lower]; sw {
-				continue
-			}
+		if (len(tok) >= 2 && learnIsAllCaps(tok)) || learnIsCapitalized(tok) {
 			continue
 		}
-		if learnIsCapitalized(tok) {
-			if i == 0 {
-				if _, sw := stopwords[lower]; sw {
-					continue
-				}
-			}
-			continue
-		}
-		if _, sw := stopwords[lower]; sw {
+		if _, isStopword := stopwords[lower]; isStopword {
 			continue
 		}
 		family = append(family, lower)

--- a/internal/spec/learn_ticker.go
+++ b/internal/spec/learn_ticker.go
@@ -1,0 +1,248 @@
+package spec
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+// LearnQueryFamilyExample is one query string the recall path will
+// normalize into a QueryFamily key, plus a source label for errors
+// (generated test fixture name or an authored playbook path).
+type LearnQueryFamilyExample struct {
+	Source string
+	Query  string
+}
+
+// learnSeededQueryFamilyExamples are the query_family_examples the
+// generator always emits into the printed CLI's learn/playbook tests.
+// A ticker_pattern that classifies every remaining content token in
+// these as a ticker makes QueryFamily empty, so playbook init skips
+// every seed as unreachable. Kept here so spec.Validate fails closed
+// before generate ships that dead surface. Must stay in lockstep with
+// the templates named in LearnSeededQueryFamilyQueries.
+var learnSeededQueryFamilyExamples = []LearnQueryFamilyExample{
+	{Source: "playbook_init_test.go", Query: "alpha example query"},
+	{Source: "playbook_init_test.go", Query: "alpha second phrasing"},
+	{Source: "playbook_init_test.go", Query: "beta example query"},
+	{Source: "playbook_init_test.go", Query: "beta second phrasing"},
+	{Source: "playbook_init_test.go", Query: "valid query family example"},
+	{Source: "teach_playbook_test.go", Query: "foo bar baz"},
+	{Source: "playbooks_test.go", Query: "how did $X end the season"},
+	{Source: "recall_canonical_test.go", Query: "report Alpha widget today"},
+}
+
+// LearnSeededQueryFamilyQueries returns the query strings the generator
+// embeds as query_family_examples / seeded recall examples. The generator
+// test suite greps templates for these so the spec-time check cannot
+// drift from what generate actually emits.
+func LearnSeededQueryFamilyQueries() []string {
+	out := make([]string, 0, len(learnSeededQueryFamilyExamples))
+	for _, ex := range learnSeededQueryFamilyExamples {
+		out = append(out, ex.Query)
+	}
+	return out
+}
+
+// learnDefaultStopwords mirrors the printed CLI's entities.defaultStopwords.
+// QueryFamily is the bag of non-entity, non-ticker, non-stopword tokens;
+// dropping the same words here keeps the reachability check aligned with
+// recall-time Extract rather than treating filler as a surviving family.
+var learnDefaultStopwords = map[string]struct{}{
+	"a": {}, "an": {}, "the": {},
+	"is": {}, "are": {}, "was": {}, "were": {}, "be": {}, "been": {}, "being": {},
+	"of": {}, "to": {}, "in": {}, "on": {}, "at": {}, "for": {}, "with": {}, "from": {}, "by": {}, "about": {},
+	"what": {}, "which": {}, "who": {}, "whom": {}, "whose": {}, "how": {}, "when": {}, "why": {}, "where": {},
+	"will": {}, "would": {}, "could": {}, "should": {}, "may": {}, "might": {}, "can": {}, "shall": {},
+	"do": {}, "does": {}, "did": {}, "have": {}, "has": {}, "had": {},
+	"and": {}, "or": {}, "but": {}, "if": {}, "then": {}, "than": {},
+	"this": {}, "that": {}, "these": {}, "those": {}, "it": {}, "its": {},
+}
+
+// CheckLearnQueryFamilyReachability reports whether learn.TickerPatterns
+// would make QueryFamily empty for any seeded generator example or any
+// extra authored playbook example. No-op when the loop is disabled or
+// no ticker patterns are declared.
+func CheckLearnQueryFamilyReachability(learn *LearnConfig, extras []LearnQueryFamilyExample) error {
+	if learn == nil || learn.Disabled || len(learn.TickerPatterns) == 0 {
+		return nil
+	}
+	examples := make([]LearnQueryFamilyExample, 0, len(learnSeededQueryFamilyExamples)+len(extras))
+	examples = append(examples, learnSeededQueryFamilyExamples...)
+	examples = append(examples, extras...)
+	return learn.queryFamilyReachabilityError(examples)
+}
+
+func (c *LearnConfig) queryFamilyReachabilityError(examples []LearnQueryFamilyExample) error {
+	if c == nil || c.Disabled || len(c.TickerPatterns) == 0 {
+		return nil
+	}
+	compiled := make([]*regexp.Regexp, len(c.TickerPatterns))
+	for i, pattern := range c.TickerPatterns {
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return fmt.Errorf("learn.ticker_patterns[%d] is not a valid Go regexp: %w", i, err)
+		}
+		compiled[i] = re
+	}
+	stopwords := make(map[string]struct{}, len(learnDefaultStopwords)+len(c.Stopwords))
+	for w := range learnDefaultStopwords {
+		stopwords[w] = struct{}{}
+	}
+	for _, w := range c.Stopwords {
+		w = strings.ToLower(strings.TrimSpace(w))
+		if w != "" {
+			stopwords[w] = struct{}{}
+		}
+	}
+	for _, ex := range examples {
+		query := strings.TrimSpace(ex.Query)
+		if query == "" {
+			continue
+		}
+		without := learnNonEntityTokens(query, nil, stopwords)
+		if len(without) == 0 {
+			continue
+		}
+		claimed := make(map[int][]string)
+		with := learnNonEntityTokens(query, compiled, stopwords)
+		if len(with) > 0 {
+			continue
+		}
+		for _, tok := range without {
+			if idx, ok := learnTickerIndex(tok, compiled); ok {
+				claimed[idx] = append(claimed[idx], tok)
+			}
+		}
+		if len(claimed) == 0 {
+			continue
+		}
+		idx := claimedPatternIndex(claimed)
+		source := strings.TrimSpace(ex.Source)
+		if source == "" {
+			source = "query_family_example"
+		}
+		return fmt.Errorf("learn.ticker_patterns[%d] (%q) classifies every remaining query-family token in %s example %q as a ticker (claimed %s); QueryFamily would be empty and seeded playbooks would be unreachable at recall time. Narrow the pattern so ordinary query words stay non-entity tokens (require a distinctive prefix, separator, or uppercase)",
+			idx, c.TickerPatterns[idx], source, query, strings.Join(claimed[idx], ", "))
+	}
+	return nil
+}
+
+func claimedPatternIndex(claimed map[int][]string) int {
+	best := -1
+	for idx := range claimed {
+		if best < 0 || idx < best {
+			best = idx
+		}
+	}
+	return best
+}
+
+// learnNonEntityTokens mirrors entities.Extract's non-entity remainder:
+// ticker match (when patterns are provided) wins, then ALL-CAPS / capitalized
+// tokens become entities, stopwords drop, and leftover lowercase tokens are
+// the QueryFamily bag. Classification is duplicated from the learn extract
+// template so spec/generate-time validation sees the same empty-family
+// outcome recall will.
+func learnNonEntityTokens(query string, tickers []*regexp.Regexp, stopwords map[string]struct{}) []string {
+	var family []string
+	rawTokens := strings.Fields(query)
+	for i, raw := range rawTokens {
+		tok := learnTrimPunct(raw)
+		if tok == "" {
+			continue
+		}
+		if _, ok := learnTickerIndex(tok, tickers); ok {
+			continue
+		}
+		lower := strings.ToLower(tok)
+		if len(tok) >= 2 && learnIsAllCaps(tok) {
+			if _, sw := stopwords[lower]; sw {
+				continue
+			}
+			continue
+		}
+		if learnIsCapitalized(tok) {
+			if i == 0 {
+				if _, sw := stopwords[lower]; sw {
+					continue
+				}
+			}
+			continue
+		}
+		if _, sw := stopwords[lower]; sw {
+			continue
+		}
+		family = append(family, lower)
+	}
+	return family
+}
+
+func learnTickerIndex(token string, tickers []*regexp.Regexp) (int, bool) {
+	for i, re := range tickers {
+		if re != nil && re.MatchString(token) {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func learnTrimPunct(s string) string {
+	return strings.TrimFunc(s, func(r rune) bool {
+		switch r {
+		case '.', ',', '?', '!', ':', ';', '\'', '"', '(', ')', '[', ']', '{', '}':
+			return true
+		}
+		return false
+	})
+}
+
+func learnIsAllCaps(s string) bool {
+	hasLetter := false
+	for _, r := range s {
+		if unicode.IsLetter(r) {
+			hasLetter = true
+			if !unicode.IsUpper(r) {
+				return false
+			}
+		}
+	}
+	return hasLetter
+}
+
+func learnIsCapitalized(s string) bool {
+	firstUpper := false
+	hasLower := false
+	for i, r := range s {
+		if i == 0 {
+			if unicode.IsLetter(r) && unicode.IsUpper(r) {
+				firstUpper = true
+				continue
+			}
+			return false
+		}
+		if unicode.IsLetter(r) && unicode.IsLower(r) {
+			hasLower = true
+		}
+	}
+	return firstUpper && hasLower
+}
+
+// ParsePlaybookQueryFamilyExamples decodes query_family_examples from a
+// playbook JSON blob. Other fields are ignored so this can run against
+// authored embeds without importing the generated learn package.
+func ParsePlaybookQueryFamilyExamples(data []byte) ([]string, error) {
+	data = []byte(strings.TrimSpace(string(data)))
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty playbook")
+	}
+	var parsed struct {
+		QueryFamilyExamples []string `json:"query_family_examples"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return nil, err
+	}
+	return parsed.QueryFamilyExamples, nil
+}

--- a/internal/spec/learn_ticker.go
+++ b/internal/spec/learn_ticker.go
@@ -8,21 +8,17 @@ import (
 	"unicode"
 )
 
-// LearnQueryFamilyExample is one query string the recall path will
-// normalize into a QueryFamily key, plus a source label for errors
-// (generated test fixture name or an authored playbook path).
+// Source labels errors so the operator can find the playbook or test
+// whose QueryFamily went empty.
 type LearnQueryFamilyExample struct {
 	Source string
 	Query  string
 }
 
-// learnSeededQueryFamilyExamples are the query_family_examples the
-// generator always emits into the printed CLI's learn/playbook tests.
-// A ticker_pattern that classifies every remaining content token in
-// these as a ticker makes QueryFamily empty, so playbook init skips
-// every seed as unreachable. Kept here so spec.Validate fails closed
-// before generate ships that dead surface. Must stay in lockstep with
-// the templates named in LearnSeededQueryFamilyQueries.
+// Hardcoded so spec.Validate fails closed before generate ships a dead
+// recall surface. A ticker_pattern that claims every remaining token
+// empties QueryFamily and playbook init skips every seed. Must stay in
+// lockstep with the templates named in LearnSeededQueryFamilyQueries.
 var learnSeededQueryFamilyExamples = []LearnQueryFamilyExample{
 	{Source: "playbook_init_test.go", Query: "alpha example query"},
 	{Source: "playbook_init_test.go", Query: "alpha second phrasing"},
@@ -34,10 +30,8 @@ var learnSeededQueryFamilyExamples = []LearnQueryFamilyExample{
 	{Source: "recall_canonical_test.go", Query: "report Alpha widget today"},
 }
 
-// LearnSeededQueryFamilyQueries returns the query strings the generator
-// embeds as query_family_examples / seeded recall examples. The generator
-// test suite greps templates for these so the spec-time check cannot
-// drift from what generate actually emits.
+// Exported so generator tests can lock this list to template
+// query_family_examples without importing the unexported seed slice.
 func LearnSeededQueryFamilyQueries() []string {
 	out := make([]string, 0, len(learnSeededQueryFamilyExamples))
 	for _, ex := range learnSeededQueryFamilyExamples {
@@ -61,10 +55,9 @@ var learnDefaultStopwords = map[string]struct{}{
 	"this": {}, "that": {}, "these": {}, "those": {}, "it": {}, "its": {},
 }
 
-// CheckLearnQueryFamilyReachability reports whether learn.TickerPatterns
-// would make QueryFamily empty for any seeded generator example or any
-// extra authored playbook example. No-op when the loop will not be emitted
-// (disabled, or legacy enabled: false) or no ticker patterns are declared.
+// Greedy ticker patterns empty QueryFamily and skip every playbook seed.
+// Skip when the loop will not emit (disabled, or legacy enabled: false)
+// so opted-out specs still parse.
 func CheckLearnQueryFamilyReachability(learn *LearnConfig, extras []LearnQueryFamilyExample) error {
 	if !learnLoopEmits(learn) || len(learn.TickerPatterns) == 0 {
 		return nil
@@ -150,12 +143,8 @@ func claimedPatternIndex(claimed map[int][]string) int {
 	return best
 }
 
-// learnNonEntityTokens mirrors entities.Extract's non-entity remainder:
-// ticker match (when patterns are provided) wins, then ALL-CAPS / capitalized
-// tokens become entities, stopwords drop, and leftover lowercase tokens are
-// the QueryFamily bag. Classification is duplicated from the learn extract
-// template so spec/generate-time validation sees the same empty-family
-// outcome recall will.
+// Duplicated from the printed-CLI extract template so this check sees the
+// same empty-family outcome recall will, not a looser local approximation.
 func learnNonEntityTokens(query string, tickers []*regexp.Regexp, stopwords map[string]struct{}) []string {
 	var family []string
 	for raw := range strings.FieldsSeq(query) {
@@ -228,9 +217,8 @@ func learnIsCapitalized(s string) bool {
 	return firstUpper && hasLower
 }
 
-// ParsePlaybookQueryFamilyExamples decodes query_family_examples from a
-// playbook JSON blob. Other fields are ignored so this can run against
-// authored embeds without importing the generated learn package.
+// Authored playbook JSON lives in the printed CLI; decode only the
+// examples field so generate need not import that package.
 func ParsePlaybookQueryFamilyExamples(data []byte) ([]string, error) {
 	data = []byte(strings.TrimSpace(string(data)))
 	if len(data) == 0 {

--- a/internal/spec/learn_ticker_test.go
+++ b/internal/spec/learn_ticker_test.go
@@ -68,6 +68,14 @@ func TestValidateLearnTickerPlaybookReachability(t *testing.T) {
 		require.NoError(t, s.Validate())
 	})
 
+	t.Run("legacy enabled false skips reachability even with a greedy pattern", func(t *testing.T) {
+		s := learnTickerSpec([]string{`^[a-z0-9]{2,12}$`})
+		s.Learn.Enabled = false
+		s.Learn.EnabledSet = true
+		s.Learn.Disabled = false
+		require.NoError(t, s.Validate())
+	})
+
 	t.Run("authored extra example is rejected when a specific pattern swallows it", func(t *testing.T) {
 		learn := LearnConfig{
 			Enabled:        true,

--- a/internal/spec/learn_ticker_test.go
+++ b/internal/spec/learn_ticker_test.go
@@ -1,0 +1,102 @@
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func learnTickerSpec(patterns []string) APISpec {
+	return APISpec{
+		Name:      "demo",
+		BaseURL:   "http://x",
+		Resources: map[string]Resource{"items": {Endpoints: map[string]Endpoint{"list": {Method: "GET", Path: "/items"}}}},
+		Learn: LearnConfig{
+			Enabled:        true,
+			TickerPatterns: patterns,
+		},
+	}
+}
+
+func TestValidateLearnTickerPlaybookReachability(t *testing.T) {
+	t.Run("greedy lowercase pattern is rejected naming pattern and example", func(t *testing.T) {
+		s := learnTickerSpec([]string{`^[a-z0-9]{2,12}$`})
+		err := s.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ticker_patterns[0]")
+		assert.Contains(t, err.Error(), `^[a-z0-9]{2,12}$`)
+		assert.Contains(t, err.Error(), "alpha example query")
+		assert.Contains(t, err.Error(), "QueryFamily would be empty")
+		assert.Contains(t, err.Error(), "unreachable at recall time")
+	})
+
+	t.Run("uppercase identifier pattern is accepted", func(t *testing.T) {
+		s := learnTickerSpec([]string{`^[A-Z][A-Z0-9]{2,11}$`})
+		require.NoError(t, s.Validate())
+	})
+
+	t.Run("no ticker patterns is accepted", func(t *testing.T) {
+		s := learnTickerSpec(nil)
+		require.NoError(t, s.Validate())
+	})
+
+	t.Run("slug pattern that cannot match ordinary words is accepted", func(t *testing.T) {
+		s := learnTickerSpec([]string{`^will-[a-z0-9-]+$`})
+		require.NoError(t, s.Validate())
+	})
+
+	t.Run("digit-only identifier pattern is accepted", func(t *testing.T) {
+		s := learnTickerSpec([]string{`^[0-9]{9}$`})
+		require.NoError(t, s.Validate())
+	})
+
+	t.Run("pattern that claims one token but leaves a family is accepted", func(t *testing.T) {
+		s := learnTickerSpec([]string{`^alpha$`})
+		require.NoError(t, s.Validate())
+	})
+
+	t.Run("hyphenated lowercase slug pattern is accepted", func(t *testing.T) {
+		s := learnTickerSpec([]string{`^[a-z]{2,4}-[a-z]+$`})
+		require.NoError(t, s.Validate())
+	})
+
+	t.Run("disabled loop skips reachability even with a greedy pattern", func(t *testing.T) {
+		s := learnTickerSpec([]string{`^[a-z0-9]{2,12}$`})
+		s.Learn.Enabled = false
+		s.Learn.Disabled = true
+		require.NoError(t, s.Validate())
+	})
+
+	t.Run("authored extra example is rejected when a specific pattern swallows it", func(t *testing.T) {
+		learn := LearnConfig{
+			Enabled:        true,
+			TickerPatterns: []string{`^nccpl-[a-z]+$`},
+		}
+		require.NoError(t, learn.queryFamilyReachabilityError(learnSeededQueryFamilyExamples))
+		err := CheckLearnQueryFamilyReachability(&learn, []LearnQueryFamilyExample{
+			{Source: "playbooks/nccpl.json", Query: "nccpl-alpha nccpl-beta"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ticker_patterns[0]")
+		assert.Contains(t, err.Error(), "nccpl-[a-z]+")
+		assert.Contains(t, err.Error(), "nccpl-alpha nccpl-beta")
+		assert.Contains(t, err.Error(), "playbooks/nccpl.json")
+	})
+}
+
+func TestLearnSeededQueryFamilyQueriesAreNonEmptyWithoutTickers(t *testing.T) {
+	for _, ex := range learnSeededQueryFamilyExamples {
+		got := learnNonEntityTokens(ex.Query, nil, learnDefaultStopwords)
+		require.NotEmpty(t, got, "seeded example %q from %s must produce a QueryFamily without ticker patterns", ex.Query, ex.Source)
+	}
+}
+
+func TestParsePlaybookQueryFamilyExamples(t *testing.T) {
+	got, err := ParsePlaybookQueryFamilyExamples([]byte(`{
+  "query_family_examples": ["alpha example query", "alpha second phrasing"],
+  "steps": [{"cmd": "x"}]
+}`))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alpha example query", "alpha second phrasing"}, got)
+}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -2150,7 +2150,10 @@ type ShareConfig struct {
 // recognize resource identifiers in free-text queries (e.g., Kalshi
 // `KXTICKER-...` codes). Each pattern is validated at spec load via
 // regexp.Compile so authoring typos surface at parse time rather than at
-// end-user runtime.
+// end-user runtime. Patterns are also checked against the generator's
+// seeded playbook query_family_examples: a pattern that classifies every
+// remaining content token as a ticker makes QueryFamily empty and skips
+// every seeded playbook as unreachable, so validation fails closed.
 //
 // Stopwords are domain-specific tokens stripped from queries before the
 // recall path matches against learned templates. The generated CLI merges
@@ -2165,7 +2168,7 @@ type LearnConfig struct {
 	Enabled           bool                    `yaml:"enabled" json:"enabled,omitempty"`                                   // master switch; when false, the loop's commands and pre-seeding hook are not emitted
 	Disabled          bool                    `yaml:"disabled,omitempty" json:"disabled,omitempty"`                       // generation-time opt-out. A plain Enabled bool cannot distinguish "explicitly off" from "absent" once the generator defaults the loop on, so this is the authoritative off switch. Contradicts an explicit enabled: true and is rejected at parse time.
 	EnabledSet        bool                    `yaml:"-" json:"-"`                                                         // internal presence bit: legacy specs with learn.enabled: false remain opted out when the default-on pass runs.
-	TickerPatterns    []string                `yaml:"ticker_patterns,omitempty" json:"ticker_patterns,omitempty"`         // Go regexp patterns the recall path uses to recognize resource identifiers in free-text. Each value must compile via regexp.Compile.
+	TickerPatterns    []string                `yaml:"ticker_patterns,omitempty" json:"ticker_patterns,omitempty"`         // Go regexp patterns the recall path uses to recognize resource identifiers in free-text. Each value must compile via regexp.Compile and must not empty QueryFamily for seeded playbook examples.
 	Stopwords         []string                `yaml:"stopwords,omitempty" json:"stopwords,omitempty"`                     // domain-specific stopwords stripped from queries before recall match; merged with a built-in default set. Whitespace-only entries are dropped at parse time.
 	Synonyms          map[string]string       `yaml:"synonyms,omitempty" json:"synonyms,omitempty"`                       // per-CLI variant -> canonical query-phrasing folds (e.g., "last night" -> "yesterday") applied symmetrically at write and read so same-referent phrasings share one query family. Keys and values must be lowercase; chains are rejected so folding is a single hop.
 	EntityLookupSeeds map[string][]LookupSeed `yaml:"entity_lookup_seeds,omitempty" json:"entity_lookup_seeds,omitempty"` // canonical-name + aliases table keyed by seed kind (e.g., "country"). Used by the recall path to substitute one entity for another and generalize learned templates.
@@ -5569,12 +5572,12 @@ var learnSeedKindRe = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
 // validateLearn enforces the LearnConfig shape contract: the enabled and
 // disabled switches must not contradict, synonym pairs must be single-hop
-// lowercase folds, ticker patterns must compile as Go regexps, seed kinds
-// must be SQLite-safe identifiers, each seed must carry a non-empty
-// Canonical, and canonical values must be unique within a kind. Stopword
-// sanitization (dropping whitespace-only entries) happens here too so the
-// spec's parsed view matches what the generated CLI will actually load at
-// runtime.
+// lowercase folds, ticker patterns must compile as Go regexps and must not
+// empty QueryFamily for seeded playbook examples, seed kinds must be
+// SQLite-safe identifiers, each seed must carry a non-empty Canonical, and
+// canonical values must be unique within a kind. Stopword sanitization
+// (dropping whitespace-only entries) happens here too so the spec's parsed
+// view matches what the generated CLI will actually load at runtime.
 func validateLearn(learn *LearnConfig) error {
 	if learn == nil {
 		return nil
@@ -5605,6 +5608,9 @@ func validateLearn(learn *LearnConfig) error {
 			filtered = append(filtered, sw)
 		}
 		learn.Stopwords = filtered
+	}
+	if err := learn.queryFamilyReachabilityError(learnSeededQueryFamilyExamples); err != nil {
+		return err
 	}
 	if err := validateLearnSeeds(learn.EntityLookupSeeds); err != nil {
 		return err

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -3741,6 +3741,22 @@ resources:
 		assert.Contains(t, err.Error(), "not a valid Go regexp")
 	})
 
+	t.Run("greedy lowercase ticker pattern rejected against seeded playbook examples", func(t *testing.T) {
+		s := APISpec{
+			Name:      "demo",
+			BaseURL:   "http://x",
+			Resources: map[string]Resource{"items": {Endpoints: map[string]Endpoint{"list": {Method: "GET", Path: "/items"}}}},
+			Learn: LearnConfig{
+				Enabled:        true,
+				TickerPatterns: []string{`^[a-z0-9]{2,12}$`},
+			},
+		}
+		err := s.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ticker_patterns[0]")
+		assert.Contains(t, err.Error(), "alpha example query")
+	})
+
 	t.Run("bad seed kind with whitespace rejected", func(t *testing.T) {
 		s := APISpec{
 			Name:      "demo",

--- a/skills/printing-press/phases/10-generate.md
+++ b/skills/printing-press/phases/10-generate.md
@@ -661,7 +661,10 @@ the domain's entities; translate them, do not re-research:
   ones.
 - `ticker_patterns`: only when the domain has ticker-like identifiers, i.e.
   stable regex-matchable IDs, slugs, or codes an agent would paste into a
-  free-text query. Anchor every regex with `^...$`.
+  free-text query. Anchor every regex with `^...$`. Do not author a character
+  class that can match ordinary lowercase query words (`^[a-z0-9]{2,12}$`
+  and similar); spec/generate validation rejects patterns that empty
+  QueryFamily for the generator's seeded playbook `query_family_examples`.
 - `synonyms`: only for same-referent phrasing variants users will actually
   say (spelling variants, equivalent time phrasings). Never pairs that change
   meaning; keys and values are lowercase, single-hop.

--- a/skills/printing-press/references/spec-format.md
+++ b/skills/printing-press/references/spec-format.md
@@ -38,7 +38,7 @@ config:                           # object (ConfigSpec)
 
 learn:                            # object (LearnConfig) per-CLI vocabulary for the default-on learn loop
   disabled: false                 # bool generation-time opt-out; the authoritative off switch (enabled: false is a no-op once the loop is default-on; disabled: true with an explicit enabled: true is rejected at parse time)
-  ticker_patterns:                # []string Go regexes recognizing ID-shaped tokens in free-text queries; each must compile; anchor with ^...$
+	ticker_patterns:                # []string Go regexes recognizing ID-shaped tokens in free-text queries; each must compile; must not match ordinary query-family words in seeded playbook examples (greedy ^[a-z0-9]{2,12}$ is rejected); anchor with ^...$
     - "^ew-[a-z0-9]+$"
   stopwords:                      # []string domain filler words merged with the built-in English set; whitespace-only entries dropped at parse time
     - widget


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

A `learn.ticker_patterns` regex that can match lowercase dictionary words (for example `^[a-z0-9]{2,12}$`) silently destroys the printed CLI recall surface: every seeded playbook is skipped as unreachable (`playbook init: ... has no query_family_examples; skipping`) and generated tests fail. The Printing Press emits both halves of this contract — playbook `query_family_examples` and `newLearnConfig()` from the spec — so it can fail closed at spec/generate time instead of shipping a dead recall surface.

Closes #4565

## Approach

`matchesTicker` runs on the raw token before the ALL-CAPS entity rule, so a lowercase-anchored pattern claims ordinary query words, `QueryFamily` becomes empty, and playbook init skips every seed.

Spec validation now classifies seeded generator `query_family_examples` with the same Extract remainder the printed CLI uses. Generate repeats that check and also scans authored playbook JSON already in the output tree. If a pattern classifies every remaining content token in an example as a ticker, generation fails with an error naming the pattern and the swallowed example.

The check no-ops when the loop will not emit (`learn.disabled: true` or legacy `learn.enabled: false`). Authored playbooks are listed with `ReadDir` on the literal `--output` path. Seeded examples are lockstepped against parsed `query_family_examples` arrays in the generator templates.

Positive cases still generate: no ticker patterns, uppercase identifier patterns, prefixed/hyphenated slugs, and digit-only IDs.

## Scope

Primary area: spec/generator learn validation

Why this belongs in this repo: this is a machine contract. A printed-CLI-only fix would not stop the next greedy `ticker_patterns` entry from shipping an unreachable recall surface.

## Risk

Existing specs that already declare a greedy lowercase ticker pattern will start failing generate unless the loop is opted out. That is the intended fail-closed behavior. Valid learn fixtures and identifier-shaped patterns are unchanged. Templates were not edited, so emitted Go for accepted specs should be byte-identical.

## Output Contract

N/A for emitted file shape (no template changes). Coverage is spec/generate rejection tests, generate success for valid ticker patterns, and a lockstep set comparison of seeded examples against template `query_family_examples` arrays. `scripts/golden.sh` was not updated; nothing in generated CLI output or templates changed.

## Verification

- [x] Targeted rejection/acceptance tests for greedy vs identifier-shaped ticker patterns (YAML spec, OpenAPI `x-learn`, generate, authored playbook JSON, legacy opt-out, literal output paths)
- [x] `go test ./... -count=1 -timeout 20m` (first revision)
- [x] Follow-up: `go test ./internal/spec/ ./internal/generator/ ./internal/openapi/ -run 'TestValidateLearnTickerPlaybookReachability|TestLearnSeededQueryFamilyQueriesAreNonEmptyWithoutTickers|TestParsePlaybookQueryFamilyExamples|TestGenerateRejectsGreedyLowercaseTickerPattern|TestGenerateAcceptsUppercaseTickerPattern|TestGenerateRejectsAuthoredPlaybookSwallowedByTickerPattern|TestAuthoredLearnQueryFamilyExamplesTreatsOutputDirLiterally|TestLearnSeededQueryFamilyExamplesStayInTemplates|TestParseLearnExtensionRejectsGreedyLowercaseTickerPattern|TestParseLearnConfig'`
- [x] Greptile P1/P2 review comments addressed (opt-out skip, ReadDir, lockstep set match)

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5092f8bc-88b0-4553-aea2-e3571424a7ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5092f8bc-88b0-4553-aea2-e3571424a7ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

