### PR TITLE
fix(cli): honest empty csv/plain, which index, doctor HTML, promoted examples

### DIFF
--- a/internal/generator/doctor_health_path_test.go
+++ b/internal/generator/doctor_health_path_test.go
@@ -283,6 +283,8 @@ func TestGeneratedDoctor_DerivesHealthCheckPathFromVerifyPath(t *testing.T) {
 		"doctor should probe Auth.VerifyPath when HealthCheckPath is unset")
 	assert.NotContains(t, content, `reachBody, reachErr := c.Get(cmd.Context(), "/", nil)`,
 		"the bare-root fallback branch should not be rendered when a derived path exists")
+	assert.NotContains(t, content, `reachBody, reachErr := c.GetWithHeaders(cmd.Context(), "/", nil`,
+		"the bare-root HTML fallback should not be rendered when a derived path exists")
 }
 
 // TestGeneratedDoctor_DerivesHealthCheckPathFromMeEndpoint mirrors the above
@@ -622,7 +624,7 @@ func TestGeneratedDoctor_NoCandidateFallsBackToRoot(t *testing.T) {
 	require.NoError(t, err)
 	content := string(doctorGo)
 
-	assert.Contains(t, content, `reachBody, reachErr := c.Get(cmd.Context(), "/", nil)`,
+	assert.Contains(t, content, `reachBody, reachErr := c.GetWithHeaders(cmd.Context(), "/", nil, map[string]string{client.HTMLResponseHeader: "true"})`,
 		"specs with no derivable probe path should keep the bare-root fallback")
 	assert.NotContains(t, content, `healthPath := "`,
 		"no healthPath variable should be declared when the spec has nothing to derive")

--- a/internal/generator/doctor_html_health_test.go
+++ b/internal/generator/doctor_html_health_test.go
@@ -1,0 +1,88 @@
+package generator
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedDoctorTreatsHTML200AsReachable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<!doctype html><html><head><title>Home</title></head><body><h1>Welcome</h1></body></html>`))
+	}))
+	t.Cleanup(server.Close)
+
+	apiSpec := htmlHealthSpec("html-health")
+	apiSpec.BaseURL = server.URL
+	_, binaryPath := buildGeneratedBinary(t, apiSpec)
+
+	payload, err := runDoctorJSON(t, binaryPath, htmlHealthEnv(t, apiSpec, server.URL), "--fail-on", "error")
+	require.NoError(t, err, payload)
+	assert.Equal(t, "reachable (HTML body at /)", payload["api"])
+	assert.NotContains(t, payload["api"], "unreachable")
+	assert.NotContains(t, payload["api"], "expected JSON")
+}
+
+func TestGeneratedDoctorDetectsCloudflareInterstitialOnHTML200(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<!doctype html><html><head><title>Just a moment...</title></head><body>challenges.cloudflare.com</body></html>`))
+	}))
+	t.Cleanup(server.Close)
+
+	apiSpec := htmlHealthSpec("html-cf")
+	apiSpec.BaseURL = server.URL
+	_, binaryPath := buildGeneratedBinary(t, apiSpec)
+
+	payload, err := runDoctorJSON(t, binaryPath, htmlHealthEnv(t, apiSpec, server.URL))
+	require.NoError(t, err, payload)
+	api, _ := payload["api"].(string)
+	assert.Contains(t, api, "blocked by Cloudflare interstitial")
+	assert.NotContains(t, api, "unreachable")
+	assert.NotContains(t, api, "expected JSON")
+}
+
+func TestGeneratedDoctorJSONHealthStaysReachable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	apiSpec := htmlHealthSpec("json-health")
+	apiSpec.BaseURL = server.URL
+	_, binaryPath := buildGeneratedBinary(t, apiSpec)
+
+	payload, err := runDoctorJSON(t, binaryPath, htmlHealthEnv(t, apiSpec, server.URL), "--fail-on", "error")
+	require.NoError(t, err, payload)
+	assert.Equal(t, "reachable", payload["api"])
+}
+
+func htmlHealthSpec(name string) *spec.APISpec {
+	apiSpec := minimalSpec(name)
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.HealthCheckPath = "/"
+	return apiSpec
+}
+
+func htmlHealthEnv(t *testing.T, apiSpec *spec.APISpec, baseURL string) []string {
+	t.Helper()
+	prefix := naming.EnvPrefix(apiSpec.Name)
+	return append(doctorEnv(t.TempDir(), prefix), prefix+"_BASE_URL="+baseURL)
+}

--- a/internal/generator/doctor_html_health_test.go
+++ b/internal/generator/doctor_html_health_test.go
@@ -3,7 +3,6 @@ package generator
 import (
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1111,6 +1111,9 @@ type readmeTemplateData struct {
 	// that was promoted (e.g. "qr" → "get-qrcode"). Currently informational —
 	// templates that need to surface the underlying operation-id can read it.
 	PromotedEndpointNames map[string]string
+	// WhichIndex is the curated which command index: novel hero features
+	// first, then promoted endpoint commands, deduped by Command.
+	WhichIndex []whichIndexEntry
 }
 
 type generatorTemplateData struct {
@@ -1180,6 +1183,7 @@ func (g *Generator) readmeData() *readmeTemplateData {
 		TrafficAnalysis:       g.trafficAnalysisData(),
 		PromotedResourceNames: g.PromotedResourceNames,
 		PromotedEndpointNames: g.PromotedEndpointNames,
+		WhichIndex:            g.whichIndexEntries(),
 	}
 }
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3448,6 +3448,9 @@ func (g *Generator) Generate() error {
 	if err := validateCommandSurface(buildCommandSurface(g.Spec, g.PromotedCommands), g.activeFrameworkCobraUseNames()); err != nil {
 		return err
 	}
+	if err := g.validatePromotedExamples(); err != nil {
+		return err
+	}
 
 	if err := g.renderSingleFiles(); err != nil {
 		return err
@@ -9362,19 +9365,12 @@ func (g *Generator) exampleLine(commandPath, endpointName string, endpoint spec.
 	return "  " + strings.Join(parts, " ")
 }
 
-func (g *Generator) promotedExampleLine(promotedName string, endpoint spec.Endpoint) string {
-	if strings.TrimSpace(endpoint.Example) != "" {
-		return endpoint.Example
+func (g *Generator) promotedExampleLine(promotedName, endpointName string, endpoint spec.Endpoint) string {
+	line, err := g.resolvePromotedExample(promotedName, endpointName, endpoint)
+	if err != nil {
+		return g.synthesizedPromotedExample(toKebab(promotedName), endpoint)
 	}
-
-	promotedName = toKebab(promotedName)
-	if line, ok := g.narrativeExampleLine([]string{promotedName}, endpoint); ok {
-		return line
-	}
-
-	parts := []string{naming.CLI(g.Spec.Name), promotedName}
-	parts = append(parts, commandExampleArgParts(endpoint)...)
-	return "  " + strings.Join(parts, " ")
+	return line
 }
 
 func (g *Generator) narrativeExampleLine(commandParts []string, endpoint spec.Endpoint) (string, bool) {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -13168,7 +13168,8 @@ func TestGenerateWhichDoesNotFallbackToEndpointGuesses(t *testing.T) {
 	whichGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "which.go"))
 	require.NoError(t, err)
 	whichSrc := string(whichGo)
-	assert.Contains(t, whichSrc, `var whichIndex = []whichEntry{}`)
+	assert.Contains(t, whichSrc, `Command: "products"`)
+	assert.Contains(t, whichSrc, `pp:which-promoted`)
 	assert.NotContains(t, whichSrc, `Command: "products list"`)
 	assert.NotContains(t, whichSrc, `Command: "products reviews list"`)
 	assert.Contains(t, whichSrc, `"pp:typed-exit-codes": "0,2"`)
@@ -13178,7 +13179,8 @@ func TestGenerateWhichDoesNotFallbackToEndpointGuesses(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/whichfallback-pp-cli")
 	whichOut, err := exec.Command(binaryPath, "which", "reviews", "--json").CombinedOutput()
 	require.Error(t, err)
-	assert.Contains(t, string(whichOut), "no curated capability index")
+	assert.NotContains(t, string(whichOut), "no curated capability index")
+	assert.Contains(t, string(whichOut), `"matches"`)
 }
 
 func graphQLBFFCaptureEntry(operationName, variablesJSON, hash string) browsersniff.EnrichedEntry {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -12379,8 +12379,9 @@ func TestGeneratedDoctor_HealthCheckPathProbesEndpoint(t *testing.T) {
 	doctorSrc := readGeneratedFile(t, outputDir, "internal", "cli", "doctor.go")
 	assert.Contains(t, doctorSrc, `healthPath := "api/marketStatus"`)
 	assert.Contains(t, doctorSrc, `if !strings.HasPrefix(healthPath, "/") {`)
-	assert.Contains(t, doctorSrc, `reachBody, reachErr := c.Get(cmd.Context(), healthPath, nil)`)
+	assert.Contains(t, doctorSrc, `reachBody, reachErr := c.GetWithHeaders(cmd.Context(), healthPath, nil, map[string]string{client.HTMLResponseHeader: "true"})`)
 	assert.NotContains(t, doctorSrc, `reachBody, reachErr := c.Get(cmd.Context(), "/", nil)`)
+	assert.NotContains(t, doctorSrc, `reachBody, reachErr := c.Get(cmd.Context(), healthPath, nil)`)
 }
 
 func TestGeneratedDoctor_InterstitialMarkersAreTitleAnchored(t *testing.T) {

--- a/internal/generator/output_flags_contract_test.go
+++ b/internal/generator/output_flags_contract_test.go
@@ -44,27 +44,27 @@ func TestPrintOutputWithFlagsPlainRendersTSV(t *testing.T) {
 	}
 }
 
-func TestPrintOutputWithFlagsPlainEmptyArrayIsEmpty(t *testing.T) {
+func TestPrintOutputWithFlagsPlainEmptyArrayWritesMarker(t *testing.T) {
 	data := json.RawMessage("[]")
 	var out bytes.Buffer
 
 	if err := printOutputWithFlags(&out, data, &rootFlags{plain: true}); err != nil {
 		t.Fatalf("printOutputWithFlags returned error: %v", err)
 	}
-	if got := out.String(); got != "" {
-		t.Fatalf("--plain should render empty arrays as an empty stream, got %q", got)
+	if got, want := out.String(), "(no rows)\n"; got != want {
+		t.Fatalf("--plain empty array without declared columns should write the empty-result marker, got %q want %q", got, want)
 	}
 }
 
-func TestPrintOutputWithFlagsCSVEmptyArrayIsEmpty(t *testing.T) {
+func TestPrintOutputWithFlagsCSVEmptyArrayWritesMarker(t *testing.T) {
 	data := json.RawMessage("[]")
 	var out bytes.Buffer
 
 	if err := printOutputWithFlags(&out, data, &rootFlags{csv: true}); err != nil {
 		t.Fatalf("printOutputWithFlags returned error: %v", err)
 	}
-	if got := out.String(); got != "" {
-		t.Fatalf("--csv without declared fields should render an empty array as an empty CSV stream, got %q", got)
+	if got, want := out.String(), "(no rows)\n"; got != want {
+		t.Fatalf("--csv without declared fields should write the empty-result marker, got %q want %q", got, want)
 	}
 }
 
@@ -78,6 +78,19 @@ func TestPrintOutputWithFlagsCSVEmptyArrayWritesDeclaredHeader(t *testing.T) {
 	}
 	if got, want := out.String(), "id,name\n"; got != want {
 		t.Fatalf("empty --csv should write the declared header row, got %q want %q", got, want)
+	}
+}
+
+func TestPrintOutputWithFlagsPlainEmptyArrayWritesDeclaredHeader(t *testing.T) {
+	data := json.RawMessage("[]")
+	var out bytes.Buffer
+	fields := map[string]bool{"id": true, "name": true}
+
+	if err := printOutputWithFlagsMeta(&out, data, &rootFlags{plain: true}, nil, fields); err != nil {
+		t.Fatalf("printOutputWithFlagsMeta returned error: %v", err)
+	}
+	if got, want := out.String(), "id\tname\n"; got != want {
+		t.Fatalf("empty --plain should write the declared tab-separated header, got %q want %q", got, want)
 	}
 }
 
@@ -301,7 +314,7 @@ func TestTerminalControlCharactersRemainInJSONOutput(t *testing.T) {
 }
 `), 0o644))
 
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPrintOutputWithFlagsPlainRendersTSV|TestPrintOutputWithFlagsPlainEmptyArrayIsEmpty|TestPrintOutputWithFlagsCSVEmptyArrayIsEmpty|TestPrintOutputWithFlagsCSVEmptyArrayWritesDeclaredHeader|TestPrintOutputWithFlagsCSVEmptyArrayEscapesDeclaredHeader|TestPrintOutputWithFlagsCSVNonEmptyArrayUsesCSV|TestPrintOutputWithFlagsCSVQuotesCarriageReturnInValues|TestPrintOutputWithFlagsMachineEmptyArrayIsValidJSON|TestPrintOutputWithFlagsCSVSingleObjectIsOneRow|TestPrintOutputWithFlagsCSVUnwrapsCollectionEnvelope|TestPrintOutputWithFlagsQuietPrintsIdentityValues|TestPrintOutputWithFlagsCompactReducesDocumentedLists|TestHumanFriendlyForcesTableAndNoColorStripsANSI|TestTerminalControl", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPrintOutputWithFlagsPlainRendersTSV|TestPrintOutputWithFlagsPlainEmptyArrayWritesMarker|TestPrintOutputWithFlagsCSVEmptyArrayWritesMarker|TestPrintOutputWithFlagsCSVEmptyArrayWritesDeclaredHeader|TestPrintOutputWithFlagsPlainEmptyArrayWritesDeclaredHeader|TestPrintOutputWithFlagsCSVEmptyArrayEscapesDeclaredHeader|TestPrintOutputWithFlagsCSVNonEmptyArrayUsesCSV|TestPrintOutputWithFlagsCSVQuotesCarriageReturnInValues|TestPrintOutputWithFlagsMachineEmptyArrayIsValidJSON|TestPrintOutputWithFlagsCSVSingleObjectIsOneRow|TestPrintOutputWithFlagsCSVUnwrapsCollectionEnvelope|TestPrintOutputWithFlagsQuietPrintsIdentityValues|TestPrintOutputWithFlagsCompactReducesDocumentedLists|TestHumanFriendlyForcesTableAndNoColorStripsANSI|TestTerminalControl", "-count=1")
 	requireGeneratedCompiles(t, outputDir)
 }
 

--- a/internal/generator/promoted_example.go
+++ b/internal/generator/promoted_example.go
@@ -115,7 +115,7 @@ func (g *Generator) rewritePromotedExampleToRegistered(promotedName, endpointNam
 			}
 		}
 	}
-	return "  " + strings.Join(rewritten, " "), true
+	return "  " + shellargs.Join(rewritten), true
 }
 
 func promotedExampleCommandTail(cliName, example string) (path []string, tail []string, ok bool) {

--- a/internal/generator/promoted_example.go
+++ b/internal/generator/promoted_example.go
@@ -1,0 +1,174 @@
+package generator
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/shellargs"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+)
+
+func (g *Generator) validatePromotedExamples() error {
+	if g == nil {
+		return nil
+	}
+	var errs []string
+	for _, pc := range g.PromotedCommands {
+		if _, err := g.resolvePromotedExample(pc.PromotedName, pc.EndpointName, pc.Endpoint); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	if len(errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("promoted command Example does not match the registered command tree:\n  %s", strings.Join(errs, "\n  "))
+}
+
+func (g *Generator) resolvePromotedExample(promotedName, endpointName string, endpoint spec.Endpoint) (string, error) {
+	promotedName = toKebab(promotedName)
+	raw := strings.TrimSpace(endpoint.Example)
+	if raw == "" {
+		return g.synthesizedPromotedExample(promotedName, endpoint), nil
+	}
+	if g.promotedExampleMatchesRegistered(promotedName, endpoint, raw) {
+		return raw, nil
+	}
+	rewritten, ok := g.rewritePromotedExampleToRegistered(promotedName, endpointName, endpoint, raw)
+	if ok && g.promotedExampleMatchesRegistered(promotedName, endpoint, rewritten) {
+		return rewritten, nil
+	}
+	return "", fmt.Errorf("resource %q: example %q names a command or flag that is not registered; use the collapsed leaf form",
+		promotedName, raw)
+}
+
+func (g *Generator) synthesizedPromotedExample(promotedName string, endpoint spec.Endpoint) string {
+	if line, ok := g.narrativeExampleLine([]string{promotedName}, endpoint); ok {
+		return line
+	}
+	parts := []string{naming.CLI(g.Spec.Name), promotedName}
+	parts = append(parts, commandExampleArgParts(endpoint)...)
+	return "  " + strings.Join(parts, " ")
+}
+
+func (g *Generator) promotedExampleMatchesRegistered(promotedName string, endpoint spec.Endpoint, example string) bool {
+	cliName := ""
+	if g != nil && g.Spec != nil {
+		cliName = naming.CLI(g.Spec.Name)
+	}
+	path, tail, ok := promotedExampleCommandTail(cliName, example)
+	if !ok {
+		return false
+	}
+	if len(path) == 0 || path[0] != promotedName {
+		return false
+	}
+	return narrativeTailMatches(append(path[1:], tail...), endpoint)
+}
+
+func (g *Generator) rewritePromotedExampleToRegistered(promotedName, endpointName string, endpoint spec.Endpoint, example string) (string, bool) {
+	cliName := ""
+	if g != nil && g.Spec != nil {
+		cliName = naming.CLI(g.Spec.Name)
+	}
+	tokens, err := shellargs.Split(strings.TrimSpace(example))
+	if err != nil || len(tokens) == 0 {
+		return "", false
+	}
+	start := 0
+	if tokens[0] == cliName {
+		start = 1
+	}
+	if start >= len(tokens) {
+		return "", false
+	}
+	cmdStartRel, ok := narrativeCommandStart(tokens[start:])
+	if !ok {
+		return "", false
+	}
+	cmdStart := start + cmdStartRel
+	if cmdStart >= len(tokens) || tokens[cmdStart] != promotedName {
+		return "", false
+	}
+	rewritten := append([]string{}, tokens...)
+	collapsed := toKebab(endpointName)
+	alias := strings.TrimSpace(endpoint.Alias)
+	next := cmdStart + 1
+	if next < len(rewritten) && !strings.HasPrefix(rewritten[next], "-") {
+		extra := rewritten[next]
+		if extra == collapsed || (alias != "" && extra == alias) {
+			rewritten = append(rewritten[:next], rewritten[next+1:]...)
+		}
+	}
+	flagMap := promotedExampleFlagRewrites(endpoint)
+	for i := cmdStart + 1; i < len(rewritten); i++ {
+		tok := rewritten[i]
+		if !strings.HasPrefix(tok, "--") || tok == "--" {
+			continue
+		}
+		name, inline, hasInline := strings.Cut(strings.TrimPrefix(tok, "--"), "=")
+		if public, mapped := flagMap[name]; mapped && public != name {
+			if hasInline {
+				rewritten[i] = "--" + public + "=" + inline
+			} else {
+				rewritten[i] = "--" + public
+			}
+		}
+	}
+	return "  " + strings.Join(rewritten, " "), true
+}
+
+func promotedExampleCommandTail(cliName, example string) (path []string, tail []string, ok bool) {
+	tokens, err := shellargs.Split(strings.TrimSpace(example))
+	if err != nil || len(tokens) == 0 {
+		return nil, nil, false
+	}
+	start := 0
+	if tokens[0] == cliName {
+		start = 1
+	}
+	if start >= len(tokens) {
+		return nil, nil, false
+	}
+	cmdStart, found := narrativeCommandStart(tokens[start:])
+	if !found {
+		return nil, nil, false
+	}
+	rest := tokens[start+cmdStart:]
+	for i, tok := range rest {
+		if strings.HasPrefix(tok, "-") {
+			return rest[:i], rest[i:], true
+		}
+	}
+	return rest, nil, true
+}
+
+func promotedExampleFlagRewrites(endpoint spec.Endpoint) map[string]string {
+	out := map[string]string{}
+	add := func(p spec.Param) {
+		if p.Positional {
+			return
+		}
+		public := publicFlagName(p)
+		if public == "" {
+			return
+		}
+		candidates := []string{p.Name, naming.FlagName(p.Name), strings.ReplaceAll(p.Name, "_", "-")}
+		if ident := strings.TrimSpace(p.IdentName); ident != "" {
+			candidates = append(candidates, ident, naming.FlagName(ident))
+		}
+		for _, cand := range candidates {
+			cand = strings.TrimSpace(cand)
+			if cand != "" && cand != public {
+				out[cand] = public
+			}
+		}
+	}
+	for _, p := range endpoint.Params {
+		add(p)
+	}
+	for _, p := range endpoint.Body {
+		add(p)
+	}
+	return out
+}

--- a/internal/generator/promoted_example.go
+++ b/internal/generator/promoted_example.go
@@ -32,7 +32,7 @@ func (g *Generator) resolvePromotedExample(promotedName, endpointName string, en
 		return g.synthesizedPromotedExample(promotedName, endpoint), nil
 	}
 	if g.promotedExampleMatchesRegistered(promotedName, endpoint, raw) {
-		return raw, nil
+		return endpoint.Example, nil
 	}
 	rewritten, ok := g.rewritePromotedExampleToRegistered(promotedName, endpointName, endpoint, raw)
 	if ok && g.promotedExampleMatchesRegistered(promotedName, endpoint, rewritten) {

--- a/internal/generator/promoted_example_test.go
+++ b/internal/generator/promoted_example_test.go
@@ -39,6 +39,34 @@ func TestPromotedExampleRewritesCollapsedEndpointToken(t *testing.T) {
 	assert.NotContains(t, src, `allocation get --form-code`)
 }
 
+func TestPromotedExampleRewritePreservesQuotedMultiwordValues(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("promoted-ex-quote")
+	apiSpec.Resources = map[string]spec.Resource{
+		"allocation": {
+			Description: "Allocation",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/allocation",
+					Description: "Get allocation",
+					Example:     `  promoted-ex-quote-pp-cli allocation get --name "Jane Doe"`,
+					Params:      []spec.Param{{Name: "name", Type: "string", Required: true}},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "promoted-ex-quote-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	src := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_allocation.go")
+	assert.Contains(t, src, `--name 'Jane Doe'`)
+	assert.NotContains(t, src, `--name Jane Doe`)
+	assert.NotContains(t, src, `allocation get --name`)
+}
+
 func TestPromotedExampleRewritesRenamedFlags(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/promoted_example_test.go
+++ b/internal/generator/promoted_example_test.go
@@ -1,0 +1,147 @@
+package generator
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPromotedExampleRewritesCollapsedEndpointToken(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("promoted-ex-collapse")
+	apiSpec.Resources = map[string]spec.Resource{
+		"allocation": {
+			Description: "Allocation",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/allocation",
+					Description: "Get allocation",
+					Example:     "  promoted-ex-collapse-pp-cli allocation get --form-code ABC --month 1",
+					Params: []spec.Param{
+						{Name: "form-code", Type: "string", Required: true},
+						{Name: "month", Type: "string", Required: true},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "promoted-ex-collapse-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	src := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_allocation.go")
+	assert.Contains(t, src, `Example:     "  promoted-ex-collapse-pp-cli allocation --form-code ABC --month 1"`)
+	assert.NotContains(t, src, `allocation get --form-code`)
+}
+
+func TestPromotedExampleRewritesRenamedFlags(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("promoted-ex-flags")
+	apiSpec.Resources = map[string]spec.Resource{
+		"downloads": {
+			Description: "Downloads",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/downloads",
+					Description: "List downloads",
+					Example:     "  promoted-ex-flags-pp-cli downloads list --term notices --paged 1",
+					Params: []spec.Param{
+						{Name: "term", FlagName: "category", Type: "string"},
+						{Name: "paged", FlagName: "page", Type: "integer"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "promoted-ex-flags-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	src := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_downloads.go")
+	assert.Contains(t, src, `Example:     "  promoted-ex-flags-pp-cli downloads --category notices --page 1"`)
+	assert.NotContains(t, src, `--term`)
+	assert.NotContains(t, src, `--paged`)
+}
+
+func TestPromotedExampleKeepsAlreadyRegisteredVerbatim(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("promoted-ex-ok")
+	apiSpec.Resources = map[string]spec.Resource{
+		"lookup": {
+			Description: "Lookup",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/lookup",
+					Description: "Lookup a page",
+					Example:     "  promoted-ex-ok-pp-cli lookup --q example-page",
+					Params:      []spec.Param{{Name: "q", Type: "string", Required: true}},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "promoted-ex-ok-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	src := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_lookup.go")
+	assert.Contains(t, src, `Example:     "  promoted-ex-ok-pp-cli lookup --q example-page"`)
+}
+
+func TestPromotedExampleRefusesUnregisteredCommand(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("promoted-ex-refuse")
+	apiSpec.Resources = map[string]spec.Resource{
+		"assets": {
+			Description: "Assets",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/assets",
+					Description: "Get assets",
+					Example:     "  promoted-ex-refuse-pp-cli assets browse --year 2025",
+					Params:      []spec.Param{{Name: "year", Type: "string"}},
+				},
+			},
+		},
+	}
+
+	err := New(apiSpec, filepath.Join(t.TempDir(), "promoted-ex-refuse-pp-cli")).Generate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "assets")
+	assert.Contains(t, err.Error(), "not registered")
+}
+
+func TestPromotedExampleRefusesUnregisteredFlag(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("promoted-ex-flag-refuse")
+	apiSpec.Resources = map[string]spec.Resource{
+		"assets": {
+			Description: "Assets",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/assets",
+					Description: "Get assets",
+					Example:     "  promoted-ex-flag-refuse-pp-cli assets --bogus 1",
+					Params:      []spec.Param{{Name: "year", Type: "string"}},
+				},
+			},
+		},
+	}
+
+	err := New(apiSpec, filepath.Join(t.TempDir(), "promoted-ex-flag-refuse-pp-cli")).Generate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "assets")
+	assert.Contains(t, err.Error(), "not registered")
+}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -64,7 +64,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 		Use:   "{{.PromotedName}}{{positionalArgs .Endpoint}}",
 		Short: "{{oneline .Endpoint.Description}}",
 		Long:  "{{oneline .Endpoint.Description}}",
-{{- $example := promotedExampleLine .PromotedName .Endpoint}}
+{{- $example := promotedExampleLine .PromotedName .EndpointName .Endpoint}}
 {{- if exampleNeedsTODO $example}}
 		// TODO: replace placeholder example values before relying on this for live dogfood.
 {{- end}}

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -117,6 +117,19 @@ func looksLikeDoctorInterstitial(body []byte) string {
 	return ""
 }
 
+func doctorBodyLooksLikeHTML(body []byte) bool {
+	s := strings.TrimSpace(string(body))
+	if s == "" {
+		return false
+	}
+	lower := strings.ToLower(s)
+	if len(lower) > 2048 {
+		lower = lower[:2048]
+	}
+	return strings.HasPrefix(lower, "<!doctype html") || strings.HasPrefix(lower, "<html") ||
+		(strings.HasPrefix(lower, "<") && (strings.Contains(lower, "<html") || strings.Contains(lower, "<body") || strings.Contains(lower, "<head") || strings.Contains(lower, "<title")))
+}
+
 {{- if and (not .Auth.VerifyPath) (not .Auth.VerifyQuery)}}
 // suggestReadCommand walks the Cobra tree to find an endpoint-mirror command
 // an operator can run to confirm credentials work end-to-end. Picks the
@@ -599,14 +612,17 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					report["api"] = fmt.Sprintf("client init error: %s", clientErr)
 				} else {
 					// Step 1: Basic reachability via the configured transport.
+					// Health paths have no response_format field, so opt this
+					// probe into HTML: a 200 HTML homepage is reachable, and
+					// a Cloudflare challenge page can still be classified.
 {{- if .HealthCheckPath}}
 					healthPath := "{{.HealthCheckPath}}"
 					if !strings.HasPrefix(healthPath, "/") {
 						healthPath = "/" + healthPath
 					}
-					reachBody, reachErr := c.Get(cmd.Context(), healthPath, nil)
+					reachBody, reachErr := c.GetWithHeaders(cmd.Context(), healthPath, nil, map[string]string{client.HTMLResponseHeader: "true"})
 {{- else}}
-					reachBody, reachErr := c.Get(cmd.Context(), "/", nil)
+					reachBody, reachErr := c.GetWithHeaders(cmd.Context(), "/", nil, map[string]string{client.HTMLResponseHeader: "true"})
 {{- end}}
 					var reachAPIErr *client.APIError
 					switch {
@@ -616,6 +632,12 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 						// 200 with a JS challenge page.
 						if vendor := looksLikeDoctorInterstitial(reachBody); vendor != "" {
 							report["api"] = fmt.Sprintf("blocked by %s interstitial — the configured transport reached the wall. Try a different network, wait for the IP-level rate limit to clear, or check that the browser-chrome transport is bound correctly.", vendor)
+						} else if doctorBodyLooksLikeHTML(reachBody) {
+{{- if .HealthCheckPath}}
+							report["api"] = fmt.Sprintf("reachable (HTML body at %s)", healthPath)
+{{- else}}
+							report["api"] = "reachable (HTML body at /)"
+{{- end}}
 						} else {
 							report["api"] = "reachable"
 						}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -3139,24 +3139,24 @@ func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlag
 	if flags.quiet {
 		return printQuiet(w, data)
 	}
+	headerFields := documentedFields
+	if flags.selectFields != "" {
+		selected := map[string]bool{}
+		for _, part := range strings.Split(flags.selectFields, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				selected[part] = true
+			}
+		}
+		headerFields = []map[string]bool{selected}
+	}
 	// --csv: render as CSV
 	if flags.csv {
-		headerFields := documentedFields
-		if flags.selectFields != "" {
-			selected := map[string]bool{}
-			for _, part := range strings.Split(flags.selectFields, ",") {
-				part = strings.TrimSpace(part)
-				if part != "" {
-					selected[part] = true
-				}
-			}
-			headerFields = []map[string]bool{selected}
-		}
 		return printCSV(w, data, headerFields...)
 	}
 	// --plain: render arrays as tab-separated rows
 	if flags.plain {
-		return printPlain(w, data)
+		return printPlain(w, data, headerFields...)
 	}
 	return printOutput(w, data, flags.asJSON)
 }
@@ -3456,6 +3456,10 @@ func compactObjectArrayValue(v any, documentedFields ...map[string]bool) (any, b
 	return compacted, true
 }
 
+// emptyTabularResultMarker is written for an empty array when no header
+// columns are known, so exit 0 is distinguishable from swallowed output.
+const emptyTabularResultMarker = "(no rows)"
+
 func printCSV(w io.Writer, data json.RawMessage, documentedFields ...map[string]bool) error {
 	items, ok := tabularObjectRows(data)
 	if !ok {
@@ -3465,6 +3469,7 @@ func printCSV(w io.Writer, data json.RawMessage, documentedFields ...map[string]
 	if len(items) == 0 {
 		keys := csvDeclaredHeader(documentedFields...)
 		if len(keys) == 0 {
+			fmt.Fprintln(w, emptyTabularResultMarker)
 			return nil
 		}
 		writeCSVRow(w, keys)
@@ -3535,13 +3540,19 @@ func csvDeclaredHeader(documentedFields ...map[string]bool) []string {
 	return keys
 }
 
-func printPlain(w io.Writer, data json.RawMessage) error {
+func printPlain(w io.Writer, data json.RawMessage, documentedFields ...map[string]bool) error {
 	items, ok := tabularObjectRows(data)
 	if !ok {
 		fmt.Fprintln(w, string(data))
 		return nil
 	}
 	if len(items) == 0 {
+		keys := csvDeclaredHeader(documentedFields...)
+		if len(keys) == 0 {
+			fmt.Fprintln(w, emptyTabularResultMarker)
+			return nil
+		}
+		fmt.Fprintln(w, strings.Join(keys, "\t"))
 		return nil
 	}
 	keySet := map[string]bool{}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -3456,8 +3456,8 @@ func compactObjectArrayValue(v any, documentedFields ...map[string]bool) (any, b
 	return compacted, true
 }
 
-// emptyTabularResultMarker is written for an empty array when no header
-// columns are known, so exit 0 is distinguishable from swallowed output.
+// Distinguishes an empty array from swallowed stdout when no header
+// columns are known. Exit 0 with zero bytes is indistinguishable from a crash.
 const emptyTabularResultMarker = "(no rows)"
 
 func printCSV(w io.Writer, data json.RawMessage, documentedFields ...map[string]bool) error {

--- a/internal/generator/templates/which.go.tmpl
+++ b/internal/generator/templates/which.go.tmpl
@@ -12,9 +12,9 @@ import (
 )
 
 // whichEntry is one row of the curated capability index. The index is seeded
-// at generation time from the verified NovelFeature list that drives the
-// SKILL.md feature section, so the command a `which` query returns is
-// guaranteed to exist and to match what the skill advertises.
+// at generation time from novel hero features first, then promoted endpoint
+// commands, deduped by Command so a novel that replaced a promoted leaf keeps
+// the hero copy.
 type whichEntry struct {
 	Command      string `json:"command"`
 	Description  string `json:"description"`
@@ -22,13 +22,12 @@ type whichEntry struct {
 	WhyItMatters string `json:"why_it_matters,omitempty"`
 }
 
-// whichIndex is the curated list of capabilities this CLI advertises as
-// its hero features. Endpoint-level commands are discoverable via
-// `--help`; `which` exists to resolve a natural-language capability
-// query to one of the commands the skill says matter most.
+// whichIndex is the curated list of capabilities this CLI advertises.
+// Novel hero features come first (declaration-order ties); promoted
+// endpoint commands follow so natural-language queries can find them.
 var whichIndex = []whichEntry{
-{{- range .NovelFeatures}}
-	{Command: {{printf "%q" .Command}}, Description: {{printf "%q" .Description}}, Group: {{printf "%q" .Group}}, WhyItMatters: {{printf "%q" .WhyItMatters}}},
+{{- range .WhichIndex}}
+	{Command: {{printf "%q" .Command}}, Description: {{printf "%q" .Description}}, Group: {{printf "%q" .Group}}, WhyItMatters: {{printf "%q" .WhyItMatters}}},{{- if .Promoted}} // pp:which-promoted{{end}}
 {{- end}}
 }
 

--- a/internal/generator/templates/which_test.go.tmpl
+++ b/internal/generator/templates/which_test.go.tmpl
@@ -348,8 +348,9 @@ func TestWhichPipedNoMatchExits2WithEmptyEnvelope(t *testing.T) {
 }
 
 // Sanity: whichIndex compiles and is well-formed. Generated CLIs with
-// zero NovelFeatures ship an empty index, and that is still a valid
-// state (which returns the "no curated index" error at runtime).
+// neither novel features nor promoted endpoint commands ship an empty
+// index, and that is still a valid state (which returns the "no curated
+// index" error at runtime).
 func TestWhichIndex_ExistsAndIsWellFormed(t *testing.T) {
 	root := newRootCmd(&rootFlags{})
 	for i, e := range whichIndex {

--- a/internal/generator/which_index.go
+++ b/internal/generator/which_index.go
@@ -17,6 +17,8 @@ type whichIndexEntry struct {
 	Promoted     bool
 }
 
+// Novels stay first so rankWhich declaration-order ties prefer hero
+// features; a promoted Command already claimed by a novel is skipped.
 func (g *Generator) whichIndexEntries() []whichIndexEntry {
 	if g == nil {
 		return nil

--- a/internal/generator/which_index.go
+++ b/internal/generator/which_index.go
@@ -1,0 +1,75 @@
+package generator
+
+import (
+	"strings"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+)
+
+// whichIndexEntry is one row written into the generated whichIndex.
+type whichIndexEntry struct {
+	Command      string
+	Description  string
+	Group        string
+	WhyItMatters string
+	Promoted     bool
+}
+
+func (g *Generator) whichIndexEntries() []whichIndexEntry {
+	if g == nil {
+		return nil
+	}
+	entries := make([]whichIndexEntry, 0, len(g.NovelFeatures)+len(g.PromotedCommands))
+	seen := map[string]bool{}
+	for _, nf := range g.NovelFeatures {
+		cmd := strings.TrimSpace(nf.Command)
+		if cmd == "" || seen[cmd] {
+			continue
+		}
+		seen[cmd] = true
+		entries = append(entries, whichIndexEntry{
+			Command:      cmd,
+			Description:  strings.TrimSpace(nf.Description),
+			Group:        strings.TrimSpace(nf.Group),
+			WhyItMatters: strings.TrimSpace(nf.WhyItMatters),
+		})
+	}
+	for _, pc := range g.PromotedCommands {
+		cmd := strings.TrimSpace(pc.PromotedName)
+		if cmd == "" || seen[cmd] {
+			continue
+		}
+		seen[cmd] = true
+		desc := naming.OneLine(pc.Endpoint.Description)
+		if desc == "" && g.Spec != nil {
+			if resource, ok := g.Spec.Resources[pc.ResourceName]; ok {
+				desc = naming.OneLine(resource.Description)
+			}
+		}
+		if desc == "" {
+			desc = cmd
+		}
+		entries = append(entries, whichIndexEntry{
+			Command:      cmd,
+			Description:  desc,
+			Group:        toKebab(pc.ResourceName),
+			WhyItMatters: firstSentence(desc),
+			Promoted:     true,
+		})
+	}
+	return entries
+}
+
+func firstSentence(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	for i, r := range s {
+		if r == '.' || r == '!' || r == '?' {
+			end := i + 1
+			return strings.TrimSpace(s[:end])
+		}
+	}
+	return s
+}

--- a/internal/generator/which_index.go
+++ b/internal/generator/which_index.go
@@ -6,7 +6,9 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 )
 
-// whichIndexEntry is one row written into the generated whichIndex.
+// Novels occupy earlier slots so rankWhich declaration-order ties keep
+// hero features ahead of promoted endpoint leaves. Command is the dedupe
+// key; Promoted tags rows so dogfood sync can merge without wiping them.
 type whichIndexEntry struct {
 	Command      string
 	Description  string

--- a/internal/generator/which_index_test.go
+++ b/internal/generator/which_index_test.go
@@ -1,0 +1,123 @@
+package generator
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWhichIndexSeedsPromotedCommands(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("which-promoted")
+	apiSpec.Resources["awards"] = spec.Resource{
+		Description: "Award availability",
+		Endpoints: map[string]spec.Endpoint{
+			"search": {
+				Method:      "GET",
+				Path:        "/awards",
+				Description: "Search award availability for a cabin and date.",
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "which-promoted-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	whichSrc := readGeneratedFile(t, outputDir, "internal", "cli", "which.go")
+	assert.Contains(t, whichSrc, `Command: "awards"`)
+	assert.Contains(t, whichSrc, `Search award availability for a cabin and date.`)
+	assert.Contains(t, whichSrc, `pp:which-promoted`)
+	assert.Contains(t, whichSrc, `Command: "items"`)
+	assert.NotContains(t, whichSrc, `Command: "awards search"`)
+}
+
+func TestWhichIndexNovelsStayAheadOfPromoted(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("which-novel-first")
+	gen := New(apiSpec, filepath.Join(t.TempDir(), "which-novel-first-pp-cli"))
+	gen.NovelFeatures = []NovelFeature{{
+		Command:      "digest",
+		Description:  "Summarize overnight changes",
+		Group:        "Analysis",
+		WhyItMatters: "Hero digest path",
+	}}
+	require.NoError(t, gen.Generate())
+
+	entries := gen.whichIndexEntries()
+	require.GreaterOrEqual(t, len(entries), 2)
+	assert.Equal(t, "digest", entries[0].Command)
+	assert.False(t, entries[0].Promoted)
+	assert.Equal(t, "items", entries[1].Command)
+	assert.True(t, entries[1].Promoted)
+}
+
+func TestWhichIndexNovelWinsCommandDedupe(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("which-dedupe")
+	gen := New(apiSpec, filepath.Join(t.TempDir(), "which-dedupe-pp-cli"))
+	gen.NovelFeatures = []NovelFeature{{
+		Command:      "items",
+		Description:  "Hero items search",
+		WhyItMatters: "Prefer the novel leaf",
+	}}
+	require.NoError(t, gen.Generate())
+
+	entries := gen.whichIndexEntries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "items", entries[0].Command)
+	assert.Equal(t, "Hero items search", entries[0].Description)
+	assert.False(t, entries[0].Promoted)
+}
+
+func TestWhichQueryRanksPromotedByDescription(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("which-rank")
+	apiSpec.Auth.Type = "none"
+	apiSpec.Auth.EnvVars = nil
+	apiSpec.Resources = map[string]spec.Resource{
+		"awards": {
+			Description: "Award availability",
+			Endpoints: map[string]spec.Endpoint{
+				"search": {
+					Method:      "GET",
+					Path:        "/awards",
+					Description: "Search award availability for a cabin and date.",
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "which-rank-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	requireGeneratedCompiles(t, outputDir)
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	binaryPath := filepath.Join(outputDir, "which-rank-pp-cli")
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/which-rank-pp-cli")
+
+	cmd := exec.Command(binaryPath, "which", "Search award availability for a cabin and date.", "--json", "--limit", "1")
+	cmd.Env = append(os.Environ(), "HOME="+t.TempDir())
+	out, err := cmd.Output()
+	require.NoError(t, err, string(out))
+
+	var payload struct {
+		Matches []struct {
+			Entry struct {
+				Command string `json:"command"`
+			} `json:"entry"`
+		} `json:"matches"`
+	}
+	require.NoError(t, json.Unmarshal(out, &payload), string(out))
+	require.NotEmpty(t, payload.Matches)
+	assert.Equal(t, "awards", payload.Matches[0].Entry.Command)
+}

--- a/internal/pipeline/docsync.go
+++ b/internal/pipeline/docsync.go
@@ -626,10 +626,7 @@ func parseWhichCompositeFields(rest string) (map[string]string, bool) {
 			return nil, false
 		}
 		fields[name] = val
-		rest = strings.TrimSpace(after[n:])
-		if strings.HasPrefix(rest, ",") {
-			rest = rest[1:]
-		}
+		rest = strings.TrimPrefix(strings.TrimSpace(after[n:]), ",")
 	}
 }
 

--- a/internal/pipeline/docsync.go
+++ b/internal/pipeline/docsync.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/generator"
@@ -513,27 +514,120 @@ func syncMarkdownFile(path string, rewrite func(string) string) (bool, error) {
 	return true, nil
 }
 
+const whichPromotedMarker = "pp:which-promoted"
+
 func syncWhichIndex(path string, features []NovelFeature) (bool, error) {
-	replacement := renderWhichIndex(features)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("reading %s: %w", path, err)
+	}
+	promoted := parsePromotedWhichEntries(string(data))
+	novelCmds := map[string]bool{}
+	for _, feature := range features {
+		if cmd := strings.TrimSpace(feature.Command); cmd != "" {
+			novelCmds[cmd] = true
+		}
+	}
+	kept := promoted[:0]
+	for _, entry := range promoted {
+		if !novelCmds[strings.TrimSpace(entry.Command)] {
+			kept = append(kept, entry)
+		}
+	}
+	replacement := renderWhichIndex(features, kept)
 	return syncGoCompositeLiteral(path, "var whichIndex = []whichEntry{", replacement)
 }
 
-func renderWhichIndex(features []NovelFeature) string {
+func renderWhichIndex(features []NovelFeature, promoted []NovelFeature) string {
 	var b strings.Builder
 	b.WriteString("var whichIndex = []whichEntry{")
 	for _, feature := range features {
-		b.WriteString("\n\t{Command: ")
-		b.WriteString(goStringLiteral(feature.Command))
-		b.WriteString(", Description: ")
-		b.WriteString(goStringLiteral(feature.Description))
-		b.WriteString(", Group: ")
-		b.WriteString(goStringLiteral(feature.Group))
-		b.WriteString(", WhyItMatters: ")
-		b.WriteString(goStringLiteral(feature.WhyItMatters))
-		b.WriteString("},")
+		writeWhichIndexEntry(&b, feature, false)
+	}
+	for _, feature := range promoted {
+		writeWhichIndexEntry(&b, feature, true)
 	}
 	b.WriteString("\n}")
 	return b.String()
+}
+
+func writeWhichIndexEntry(b *strings.Builder, feature NovelFeature, promoted bool) {
+	b.WriteString("\n\t{Command: ")
+	b.WriteString(goStringLiteral(feature.Command))
+	b.WriteString(", Description: ")
+	b.WriteString(goStringLiteral(feature.Description))
+	b.WriteString(", Group: ")
+	b.WriteString(goStringLiteral(feature.Group))
+	b.WriteString(", WhyItMatters: ")
+	b.WriteString(goStringLiteral(feature.WhyItMatters))
+	b.WriteString("},")
+	if promoted {
+		b.WriteString(" // ")
+		b.WriteString(whichPromotedMarker)
+	}
+}
+
+func parsePromotedWhichEntries(content string) []NovelFeature {
+	var out []NovelFeature
+	for _, line := range strings.Split(content, "\n") {
+		if !strings.Contains(line, whichPromotedMarker) {
+			continue
+		}
+		entry, ok := parseWhichEntryLine(line)
+		if ok {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+func parseWhichEntryLine(line string) (NovelFeature, bool) {
+	cmd, ok := parseWhichField(line, "Command:")
+	if !ok || cmd == "" {
+		return NovelFeature{}, false
+	}
+	desc, _ := parseWhichField(line, "Description:")
+	group, _ := parseWhichField(line, "Group:")
+	why, _ := parseWhichField(line, "WhyItMatters:")
+	return NovelFeature{Command: cmd, Description: desc, Group: group, WhyItMatters: why}, true
+}
+
+func parseWhichField(line, key string) (string, bool) {
+	idx := strings.Index(line, key)
+	if idx < 0 {
+		return "", false
+	}
+	rest := strings.TrimSpace(line[idx+len(key):])
+	val, _, ok := parseGoQuotedPrefix(rest)
+	return val, ok
+}
+
+func parseGoQuotedPrefix(s string) (string, int, bool) {
+	if !strings.HasPrefix(s, `"`) {
+		return "", 0, false
+	}
+	escaped := false
+	for i := 1; i < len(s); i++ {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if s[i] == '\\' {
+			escaped = true
+			continue
+		}
+		if s[i] == '"' {
+			val, err := strconv.Unquote(s[:i+1])
+			if err != nil {
+				return "", 0, false
+			}
+			return val, i + 1, true
+		}
+	}
+	return "", 0, false
 }
 
 const mcpCommandMirrorKey = `"command_mirror_capabilities": []map[string]string{`

--- a/internal/pipeline/docsync.go
+++ b/internal/pipeline/docsync.go
@@ -572,7 +572,7 @@ func writeWhichIndexEntry(b *strings.Builder, feature NovelFeature, promoted boo
 
 func parsePromotedWhichEntries(content string) []NovelFeature {
 	var out []NovelFeature
-	for _, line := range strings.Split(content, "\n") {
+	for line := range strings.SplitSeq(content, "\n") {
 		if !strings.Contains(line, whichPromotedMarker) {
 			continue
 		}
@@ -585,24 +585,52 @@ func parsePromotedWhichEntries(content string) []NovelFeature {
 }
 
 func parseWhichEntryLine(line string) (NovelFeature, bool) {
-	cmd, ok := parseWhichField(line, "Command:")
-	if !ok || cmd == "" {
+	_, rest, ok := strings.Cut(line, "{")
+	if !ok {
 		return NovelFeature{}, false
 	}
-	desc, _ := parseWhichField(line, "Description:")
-	group, _ := parseWhichField(line, "Group:")
-	why, _ := parseWhichField(line, "WhyItMatters:")
-	return NovelFeature{Command: cmd, Description: desc, Group: group, WhyItMatters: why}, true
+	fields, ok := parseWhichCompositeFields(rest)
+	if !ok {
+		return NovelFeature{}, false
+	}
+	cmd := strings.TrimSpace(fields["Command"])
+	if cmd == "" {
+		return NovelFeature{}, false
+	}
+	return NovelFeature{
+		Command:      cmd,
+		Description:  fields["Description"],
+		Group:        fields["Group"],
+		WhyItMatters: fields["WhyItMatters"],
+	}, true
 }
 
-func parseWhichField(line, key string) (string, bool) {
-	idx := strings.Index(line, key)
-	if idx < 0 {
-		return "", false
+func parseWhichCompositeFields(rest string) (map[string]string, bool) {
+	fields := map[string]string{}
+	for {
+		rest = strings.TrimSpace(rest)
+		if rest == "" || strings.HasPrefix(rest, "}") {
+			return fields, true
+		}
+		name, after, ok := strings.Cut(rest, ":")
+		if !ok {
+			return nil, false
+		}
+		name = strings.TrimSpace(name)
+		if name == "" || strings.ContainsAny(name, "\",{}") {
+			return nil, false
+		}
+		after = strings.TrimSpace(after)
+		val, n, ok := parseGoQuotedPrefix(after)
+		if !ok {
+			return nil, false
+		}
+		fields[name] = val
+		rest = strings.TrimSpace(after[n:])
+		if strings.HasPrefix(rest, ",") {
+			rest = rest[1:]
+		}
 	}
-	rest := strings.TrimSpace(line[idx+len(key):])
-	val, _, ok := parseGoQuotedPrefix(rest)
-	return val, ok
 }
 
 func parseGoQuotedPrefix(s string) (string, int, bool) {

--- a/internal/pipeline/docsync_test.go
+++ b/internal/pipeline/docsync_test.go
@@ -196,3 +196,41 @@ var whichIndex = []whichEntry{
 	assert.NotContains(t, got, "stale novel")
 	requireBefore(t, got, `Command: "digest"`, `Command: "awards"`)
 }
+
+func TestSyncWhichIndexIgnoresLabelsInsideDescriptionProse(t *testing.T) {
+	line := `	{Command: "awards", Description: "See Group: awards in WhyItMatters: docs", Group: "real-group", WhyItMatters: "real-why"}, // pp:which-promoted`
+	entry, ok := parseWhichEntryLine(line)
+	require.True(t, ok)
+	assert.Equal(t, "awards", entry.Command)
+	assert.Equal(t, "See Group: awards in WhyItMatters: docs", entry.Description)
+	assert.Equal(t, "real-group", entry.Group)
+	assert.Equal(t, "real-why", entry.WhyItMatters)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "internal", "cli", "which.go")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(`package cli
+
+var whichIndex = []whichEntry{
+`+line+`
+}
+`), 0o644))
+
+	changed, err := syncWhichIndex(path, []NovelFeature{{
+		Command:      "digest",
+		Description:  "Fresh novel",
+		Group:        "Analysis",
+		WhyItMatters: "Hero path",
+	}})
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	got := string(data)
+	assert.Contains(t, got, `Group: "real-group"`)
+	assert.Contains(t, got, `WhyItMatters: "real-why"`)
+	assert.Contains(t, got, `Description: "See Group: awards in WhyItMatters: docs"`)
+	assert.NotContains(t, got, `Group: "awards"`)
+	assert.NotContains(t, got, `WhyItMatters: "docs"`)
+}

--- a/internal/pipeline/docsync_test.go
+++ b/internal/pipeline/docsync_test.go
@@ -164,3 +164,35 @@ func TestMarkdownHeadingsRequiresMatchingFenceLength(t *testing.T) {
 	assert.Equal(t, -1, findMarkdownHeading(content, "## Still fenced"))
 	assert.GreaterOrEqual(t, findMarkdownHeading(content, "## Real"), 0)
 }
+
+func TestSyncWhichIndexPreservesPromotedEntries(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "internal", "cli", "which.go")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(`package cli
+
+var whichIndex = []whichEntry{
+	{Command: "old-novel", Description: "stale novel", Group: "", WhyItMatters: ""},
+	{Command: "awards", Description: "Search award availability", Group: "awards", WhyItMatters: "Search award availability"}, // pp:which-promoted
+}
+`), 0o644))
+
+	changed, err := syncWhichIndex(path, []NovelFeature{{
+		Command:      "digest",
+		Description:  "Fresh novel",
+		Group:        "Analysis",
+		WhyItMatters: "Hero path",
+	}})
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	got := string(data)
+	assert.Contains(t, got, `Command: "digest"`)
+	assert.Contains(t, got, `Command: "awards"`)
+	assert.Contains(t, got, "pp:which-promoted")
+	assert.NotContains(t, got, "old-novel")
+	assert.NotContains(t, got, "stale novel")
+	requireBefore(t, got, `Command: "digest"`, `Command: "awards"`)
+}

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -712,7 +712,7 @@ func hasDoctorHTTPReachability(content string) bool {
 		strings.Contains(content, "http.NewRequest") {
 		return true
 	}
-	clientCallRe := regexp.MustCompile(`\b[A-Za-z_]\w*(?:Client|HTTPClient)?\.(?:Get|Head|Post|Put|Patch|Delete|Do)\s*\(`)
+	clientCallRe := regexp.MustCompile(`\b[A-Za-z_]\w*(?:Client|HTTPClient)?\.(?:Get(?:WithHeaders(?:NoCache)?(?:Values)?)?|Head|Post|Put|Patch|Delete|Do)\s*\(`)
 	inlineClientCallRe := regexp.MustCompile(`\(&http\.Client\s*\{[^}]*\}\)\.(?:Get|Head|Post|Put|Patch|Delete|Do)\s*\(`)
 	return clientCallRe.MatchString(content) || inlineClientCallRe.MatchString(content)
 }

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -2882,6 +2882,22 @@ func doctorReport() {
 		assert.Equal(t, 10, scoreDoctor(dir))
 	})
 
+	t.Run("scores client GetWithHeaders health probe", func(t *testing.T) {
+		dir := t.TempDir()
+		writeScorecardFixture(t, dir, "internal/cli/doctor.go", `package cli
+
+func newDoctorCmd() {}
+
+func doctorCheck() {
+	reachBody, reachErr := c.GetWithHeaders(cmd.Context(), "/", nil, map[string]string{client.HTMLResponseHeader: "true"})
+	_, _ = reachBody, reachErr
+	_ = "auth token config version"
+}
+`)
+
+		assert.Equal(t, 10, scoreDoctor(dir))
+	})
+
 	t.Run("scores inline http client get", func(t *testing.T) {
 		dir := t.TempDir()
 		writeScorecardFixture(t, dir, "internal/cli/doctor.go", `package cli

--- a/testdata/golden/expected/generate-additional-auth-doctor/additional-auth-doctor/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-additional-auth-doctor/additional-auth-doctor/internal/cli/doctor.go
@@ -80,6 +80,19 @@ func looksLikeDoctorInterstitial(body []byte) string {
 	return ""
 }
 
+func doctorBodyLooksLikeHTML(body []byte) bool {
+	s := strings.TrimSpace(string(body))
+	if s == "" {
+		return false
+	}
+	lower := strings.ToLower(s)
+	if len(lower) > 2048 {
+		lower = lower[:2048]
+	}
+	return strings.HasPrefix(lower, "<!doctype html") || strings.HasPrefix(lower, "<html") ||
+		(strings.HasPrefix(lower, "<") && (strings.Contains(lower, "<html") || strings.Contains(lower, "<body") || strings.Contains(lower, "<head") || strings.Contains(lower, "<title")))
+}
+
 // suggestReadCommand walks the Cobra tree to find an endpoint-mirror command
 // an operator can run to confirm credentials work end-to-end. Picks the
 // first leaf that (a) carries the `pp:endpoint` annotation, so it actually
@@ -306,7 +319,10 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					report["api"] = fmt.Sprintf("client init error: %s", clientErr)
 				} else {
 					// Step 1: Basic reachability via the configured transport.
-					reachBody, reachErr := c.Get(cmd.Context(), "/", nil)
+					// Health paths have no response_format field, so opt this
+					// probe into HTML: a 200 HTML homepage is reachable, and
+					// a Cloudflare challenge page can still be classified.
+					reachBody, reachErr := c.GetWithHeaders(cmd.Context(), "/", nil, map[string]string{client.HTMLResponseHeader: "true"})
 					var reachAPIErr *client.APIError
 					switch {
 					case reachErr == nil:
@@ -315,6 +331,8 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 						// 200 with a JS challenge page.
 						if vendor := looksLikeDoctorInterstitial(reachBody); vendor != "" {
 							report["api"] = fmt.Sprintf("blocked by %s interstitial — the configured transport reached the wall. Try a different network, wait for the IP-level rate limit to clear, or check that the browser-chrome transport is bound correctly.", vendor)
+						} else if doctorBodyLooksLikeHTML(reachBody) {
+							report["api"] = "reachable (HTML body at /)"
 						} else {
 							report["api"] = "reachable"
 						}

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -2502,24 +2502,24 @@ func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlag
 	if flags.quiet {
 		return printQuiet(w, data)
 	}
+	headerFields := documentedFields
+	if flags.selectFields != "" {
+		selected := map[string]bool{}
+		for _, part := range strings.Split(flags.selectFields, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				selected[part] = true
+			}
+		}
+		headerFields = []map[string]bool{selected}
+	}
 	// --csv: render as CSV
 	if flags.csv {
-		headerFields := documentedFields
-		if flags.selectFields != "" {
-			selected := map[string]bool{}
-			for _, part := range strings.Split(flags.selectFields, ",") {
-				part = strings.TrimSpace(part)
-				if part != "" {
-					selected[part] = true
-				}
-			}
-			headerFields = []map[string]bool{selected}
-		}
 		return printCSV(w, data, headerFields...)
 	}
 	// --plain: render arrays as tab-separated rows
 	if flags.plain {
-		return printPlain(w, data)
+		return printPlain(w, data, headerFields...)
 	}
 	return printOutput(w, data, flags.asJSON)
 }
@@ -2789,6 +2789,10 @@ func compactObjectArrayValue(v any, documentedFields ...map[string]bool) (any, b
 	return compacted, true
 }
 
+// Distinguishes an empty array from swallowed stdout when no header
+// columns are known. Exit 0 with zero bytes is indistinguishable from a crash.
+const emptyTabularResultMarker = "(no rows)"
+
 func printCSV(w io.Writer, data json.RawMessage, documentedFields ...map[string]bool) error {
 	items, ok := tabularObjectRows(data)
 	if !ok {
@@ -2798,6 +2802,7 @@ func printCSV(w io.Writer, data json.RawMessage, documentedFields ...map[string]
 	if len(items) == 0 {
 		keys := csvDeclaredHeader(documentedFields...)
 		if len(keys) == 0 {
+			fmt.Fprintln(w, emptyTabularResultMarker)
 			return nil
 		}
 		writeCSVRow(w, keys)
@@ -2868,13 +2873,19 @@ func csvDeclaredHeader(documentedFields ...map[string]bool) []string {
 	return keys
 }
 
-func printPlain(w io.Writer, data json.RawMessage) error {
+func printPlain(w io.Writer, data json.RawMessage, documentedFields ...map[string]bool) error {
 	items, ok := tabularObjectRows(data)
 	if !ok {
 		fmt.Fprintln(w, string(data))
 		return nil
 	}
 	if len(items) == 0 {
+		keys := csvDeclaredHeader(documentedFields...)
+		if len(keys) == 0 {
+			fmt.Fprintln(w, emptyTabularResultMarker)
+			return nil
+		}
+		fmt.Fprintln(w, strings.Join(keys, "\t"))
 		return nil
 	}
 	keySet := map[string]bool{}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/doctor.go
@@ -80,6 +80,19 @@ func looksLikeDoctorInterstitial(body []byte) string {
 	return ""
 }
 
+func doctorBodyLooksLikeHTML(body []byte) bool {
+	s := strings.TrimSpace(string(body))
+	if s == "" {
+		return false
+	}
+	lower := strings.ToLower(s)
+	if len(lower) > 2048 {
+		lower = lower[:2048]
+	}
+	return strings.HasPrefix(lower, "<!doctype html") || strings.HasPrefix(lower, "<html") ||
+		(strings.HasPrefix(lower, "<") && (strings.Contains(lower, "<html") || strings.Contains(lower, "<body") || strings.Contains(lower, "<head") || strings.Contains(lower, "<title")))
+}
+
 // suggestReadCommand walks the Cobra tree to find an endpoint-mirror command
 // an operator can run to confirm credentials work end-to-end. Picks the
 // first leaf that (a) carries the `pp:endpoint` annotation, so it actually
@@ -333,7 +346,10 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					report["api"] = fmt.Sprintf("client init error: %s", clientErr)
 				} else {
 					// Step 1: Basic reachability via the configured transport.
-					reachBody, reachErr := c.Get(cmd.Context(), "/", nil)
+					// Health paths have no response_format field, so opt this
+					// probe into HTML: a 200 HTML homepage is reachable, and
+					// a Cloudflare challenge page can still be classified.
+					reachBody, reachErr := c.GetWithHeaders(cmd.Context(), "/", nil, map[string]string{client.HTMLResponseHeader: "true"})
 					var reachAPIErr *client.APIError
 					switch {
 					case reachErr == nil:
@@ -342,6 +358,8 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 						// 200 with a JS challenge page.
 						if vendor := looksLikeDoctorInterstitial(reachBody); vendor != "" {
 							report["api"] = fmt.Sprintf("blocked by %s interstitial — the configured transport reached the wall. Try a different network, wait for the IP-level rate limit to clear, or check that the browser-chrome transport is bound correctly.", vendor)
+						} else if doctorBodyLooksLikeHTML(reachBody) {
+							report["api"] = "reachable (HTML body at /)"
 						} else {
 							report["api"] = "reachable"
 						}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -2343,24 +2343,24 @@ func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlag
 	if flags.quiet {
 		return printQuiet(w, data)
 	}
+	headerFields := documentedFields
+	if flags.selectFields != "" {
+		selected := map[string]bool{}
+		for _, part := range strings.Split(flags.selectFields, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				selected[part] = true
+			}
+		}
+		headerFields = []map[string]bool{selected}
+	}
 	// --csv: render as CSV
 	if flags.csv {
-		headerFields := documentedFields
-		if flags.selectFields != "" {
-			selected := map[string]bool{}
-			for _, part := range strings.Split(flags.selectFields, ",") {
-				part = strings.TrimSpace(part)
-				if part != "" {
-					selected[part] = true
-				}
-			}
-			headerFields = []map[string]bool{selected}
-		}
 		return printCSV(w, data, headerFields...)
 	}
 	// --plain: render arrays as tab-separated rows
 	if flags.plain {
-		return printPlain(w, data)
+		return printPlain(w, data, headerFields...)
 	}
 	return printOutput(w, data, flags.asJSON)
 }
@@ -2630,6 +2630,10 @@ func compactObjectArrayValue(v any, documentedFields ...map[string]bool) (any, b
 	return compacted, true
 }
 
+// Distinguishes an empty array from swallowed stdout when no header
+// columns are known. Exit 0 with zero bytes is indistinguishable from a crash.
+const emptyTabularResultMarker = "(no rows)"
+
 func printCSV(w io.Writer, data json.RawMessage, documentedFields ...map[string]bool) error {
 	items, ok := tabularObjectRows(data)
 	if !ok {
@@ -2639,6 +2643,7 @@ func printCSV(w io.Writer, data json.RawMessage, documentedFields ...map[string]
 	if len(items) == 0 {
 		keys := csvDeclaredHeader(documentedFields...)
 		if len(keys) == 0 {
+			fmt.Fprintln(w, emptyTabularResultMarker)
 			return nil
 		}
 		writeCSVRow(w, keys)
@@ -2709,13 +2714,19 @@ func csvDeclaredHeader(documentedFields ...map[string]bool) []string {
 	return keys
 }
 
-func printPlain(w io.Writer, data json.RawMessage) error {
+func printPlain(w io.Writer, data json.RawMessage, documentedFields ...map[string]bool) error {
 	items, ok := tabularObjectRows(data)
 	if !ok {
 		fmt.Fprintln(w, string(data))
 		return nil
 	}
 	if len(items) == 0 {
+		keys := csvDeclaredHeader(documentedFields...)
+		if len(keys) == 0 {
+			fmt.Fprintln(w, emptyTabularResultMarker)
+			return nil
+		}
+		fmt.Fprintln(w, strings.Join(keys, "\t"))
 		return nil
 	}
 	keySet := map[string]bool{}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/doctor.go
@@ -80,6 +80,19 @@ func looksLikeDoctorInterstitial(body []byte) string {
 	return ""
 }
 
+func doctorBodyLooksLikeHTML(body []byte) bool {
+	s := strings.TrimSpace(string(body))
+	if s == "" {
+		return false
+	}
+	lower := strings.ToLower(s)
+	if len(lower) > 2048 {
+		lower = lower[:2048]
+	}
+	return strings.HasPrefix(lower, "<!doctype html") || strings.HasPrefix(lower, "<html") ||
+		(strings.HasPrefix(lower, "<") && (strings.Contains(lower, "<html") || strings.Contains(lower, "<body") || strings.Contains(lower, "<head") || strings.Contains(lower, "<title")))
+}
+
 // suggestReadCommand walks the Cobra tree to find an endpoint-mirror command
 // an operator can run to confirm credentials work end-to-end. Picks the
 // first leaf that (a) carries the `pp:endpoint` annotation, so it actually
@@ -281,7 +294,10 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					report["api"] = fmt.Sprintf("client init error: %s", clientErr)
 				} else {
 					// Step 1: Basic reachability via the configured transport.
-					reachBody, reachErr := c.Get(cmd.Context(), "/", nil)
+					// Health paths have no response_format field, so opt this
+					// probe into HTML: a 200 HTML homepage is reachable, and
+					// a Cloudflare challenge page can still be classified.
+					reachBody, reachErr := c.GetWithHeaders(cmd.Context(), "/", nil, map[string]string{client.HTMLResponseHeader: "true"})
 					var reachAPIErr *client.APIError
 					switch {
 					case reachErr == nil:
@@ -290,6 +306,8 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 						// 200 with a JS challenge page.
 						if vendor := looksLikeDoctorInterstitial(reachBody); vendor != "" {
 							report["api"] = fmt.Sprintf("blocked by %s interstitial — the configured transport reached the wall. Try a different network, wait for the IP-level rate limit to clear, or check that the browser-chrome transport is bound correctly.", vendor)
+						} else if doctorBodyLooksLikeHTML(reachBody) {
+							report["api"] = "reachable (HTML body at /)"
 						} else {
 							report["api"] = "reachable"
 						}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -2458,24 +2458,24 @@ func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlag
 	if flags.quiet {
 		return printQuiet(w, data)
 	}
+	headerFields := documentedFields
+	if flags.selectFields != "" {
+		selected := map[string]bool{}
+		for _, part := range strings.Split(flags.selectFields, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				selected[part] = true
+			}
+		}
+		headerFields = []map[string]bool{selected}
+	}
 	// --csv: render as CSV
 	if flags.csv {
-		headerFields := documentedFields
-		if flags.selectFields != "" {
-			selected := map[string]bool{}
-			for _, part := range strings.Split(flags.selectFields, ",") {
-				part = strings.TrimSpace(part)
-				if part != "" {
-					selected[part] = true
-				}
-			}
-			headerFields = []map[string]bool{selected}
-		}
 		return printCSV(w, data, headerFields...)
 	}
 	// --plain: render arrays as tab-separated rows
 	if flags.plain {
-		return printPlain(w, data)
+		return printPlain(w, data, headerFields...)
 	}
 	return printOutput(w, data, flags.asJSON)
 }
@@ -2745,6 +2745,10 @@ func compactObjectArrayValue(v any, documentedFields ...map[string]bool) (any, b
 	return compacted, true
 }
 
+// Distinguishes an empty array from swallowed stdout when no header
+// columns are known. Exit 0 with zero bytes is indistinguishable from a crash.
+const emptyTabularResultMarker = "(no rows)"
+
 func printCSV(w io.Writer, data json.RawMessage, documentedFields ...map[string]bool) error {
 	items, ok := tabularObjectRows(data)
 	if !ok {
@@ -2754,6 +2758,7 @@ func printCSV(w io.Writer, data json.RawMessage, documentedFields ...map[string]
 	if len(items) == 0 {
 		keys := csvDeclaredHeader(documentedFields...)
 		if len(keys) == 0 {
+			fmt.Fprintln(w, emptyTabularResultMarker)
 			return nil
 		}
 		writeCSVRow(w, keys)
@@ -2824,13 +2829,19 @@ func csvDeclaredHeader(documentedFields ...map[string]bool) []string {
 	return keys
 }
 
-func printPlain(w io.Writer, data json.RawMessage) error {
+func printPlain(w io.Writer, data json.RawMessage, documentedFields ...map[string]bool) error {
 	items, ok := tabularObjectRows(data)
 	if !ok {
 		fmt.Fprintln(w, string(data))
 		return nil
 	}
 	if len(items) == 0 {
+		keys := csvDeclaredHeader(documentedFields...)
+		if len(keys) == 0 {
+			fmt.Fprintln(w, emptyTabularResultMarker)
+			return nil
+		}
+		fmt.Fprintln(w, strings.Join(keys, "\t"))
 		return nil
 	}
 	keySet := map[string]bool{}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
@@ -12,9 +12,9 @@ import (
 )
 
 // whichEntry is one row of the curated capability index. The index is seeded
-// at generation time from the verified NovelFeature list that drives the
-// SKILL.md feature section, so the command a `which` query returns is
-// guaranteed to exist and to match what the skill advertises.
+// at generation time from novel hero features first, then promoted endpoint
+// commands, deduped by Command so a novel that replaced a promoted leaf keeps
+// the hero copy.
 type whichEntry struct {
 	Command      string `json:"command"`
 	Description  string `json:"description"`
@@ -22,11 +22,14 @@ type whichEntry struct {
 	WhyItMatters string `json:"why_it_matters,omitempty"`
 }
 
-// whichIndex is the curated list of capabilities this CLI advertises as
-// its hero features. Endpoint-level commands are discoverable via
-// `--help`; `which` exists to resolve a natural-language capability
-// query to one of the commands the skill says matter most.
-var whichIndex = []whichEntry{}
+// whichIndex is the curated list of capabilities this CLI advertises.
+// Novel hero features come first (declaration-order ties); promoted
+// endpoint commands follow so natural-language queries can find them.
+var whichIndex = []whichEntry{
+	{Command: "currencies", Description: "List supported currencies", Group: "currencies", WhyItMatters: "List supported currencies"}, // pp:which-promoted
+	{Command: "public", Description: "Get public service status", Group: "public", WhyItMatters: "Get public service status"},         // pp:which-promoted
+	{Command: "tickets", Description: "Query tickets", Group: "tickets", WhyItMatters: "Query tickets"},                               // pp:which-promoted
+}
 
 // whichMatch pairs an index entry with its ranking score for a query.
 // Higher score means stronger match. The ranker is naive (exact token

--- a/testdata/golden/expected/generate-keyless-openapi/keyless-leftover-env/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-keyless-openapi/keyless-leftover-env/internal/cli/doctor.go
@@ -80,6 +80,19 @@ func looksLikeDoctorInterstitial(body []byte) string {
 	return ""
 }
 
+func doctorBodyLooksLikeHTML(body []byte) bool {
+	s := strings.TrimSpace(string(body))
+	if s == "" {
+		return false
+	}
+	lower := strings.ToLower(s)
+	if len(lower) > 2048 {
+		lower = lower[:2048]
+	}
+	return strings.HasPrefix(lower, "<!doctype html") || strings.HasPrefix(lower, "<html") ||
+		(strings.HasPrefix(lower, "<") && (strings.Contains(lower, "<html") || strings.Contains(lower, "<body") || strings.Contains(lower, "<head") || strings.Contains(lower, "<title")))
+}
+
 // suggestReadCommand walks the Cobra tree to find an endpoint-mirror command
 // an operator can run to confirm credentials work end-to-end. Picks the
 // first leaf that (a) carries the `pp:endpoint` annotation, so it actually
@@ -220,7 +233,10 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					report["api"] = fmt.Sprintf("client init error: %s", clientErr)
 				} else {
 					// Step 1: Basic reachability via the configured transport.
-					reachBody, reachErr := c.Get(cmd.Context(), "/", nil)
+					// Health paths have no response_format field, so opt this
+					// probe into HTML: a 200 HTML homepage is reachable, and
+					// a Cloudflare challenge page can still be classified.
+					reachBody, reachErr := c.GetWithHeaders(cmd.Context(), "/", nil, map[string]string{client.HTMLResponseHeader: "true"})
 					var reachAPIErr *client.APIError
 					switch {
 					case reachErr == nil:
@@ -229,6 +245,8 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 						// 200 with a JS challenge page.
 						if vendor := looksLikeDoctorInterstitial(reachBody); vendor != "" {
 							report["api"] = fmt.Sprintf("blocked by %s interstitial — the configured transport reached the wall. Try a different network, wait for the IP-level rate limit to clear, or check that the browser-chrome transport is bound correctly.", vendor)
+						} else if doctorBodyLooksLikeHTML(reachBody) {
+							report["api"] = "reachable (HTML body at /)"
 						} else {
 							report["api"] = "reachable"
 						}

--- a/testdata/golden/expected/generate-keyless-openapi/keyless-openapi/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-keyless-openapi/keyless-openapi/internal/cli/doctor.go
@@ -80,6 +80,19 @@ func looksLikeDoctorInterstitial(body []byte) string {
 	return ""
 }
 
+func doctorBodyLooksLikeHTML(body []byte) bool {
+	s := strings.TrimSpace(string(body))
+	if s == "" {
+		return false
+	}
+	lower := strings.ToLower(s)
+	if len(lower) > 2048 {
+		lower = lower[:2048]
+	}
+	return strings.HasPrefix(lower, "<!doctype html") || strings.HasPrefix(lower, "<html") ||
+		(strings.HasPrefix(lower, "<") && (strings.Contains(lower, "<html") || strings.Contains(lower, "<body") || strings.Contains(lower, "<head") || strings.Contains(lower, "<title")))
+}
+
 // suggestReadCommand walks the Cobra tree to find an endpoint-mirror command
 // an operator can run to confirm credentials work end-to-end. Picks the
 // first leaf that (a) carries the `pp:endpoint` annotation, so it actually
@@ -220,7 +233,10 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					report["api"] = fmt.Sprintf("client init error: %s", clientErr)
 				} else {
 					// Step 1: Basic reachability via the configured transport.
-					reachBody, reachErr := c.Get(cmd.Context(), "/", nil)
+					// Health paths have no response_format field, so opt this
+					// probe into HTML: a 200 HTML homepage is reachable, and
+					// a Cloudflare challenge page can still be classified.
+					reachBody, reachErr := c.GetWithHeaders(cmd.Context(), "/", nil, map[string]string{client.HTMLResponseHeader: "true"})
 					var reachAPIErr *client.APIError
 					switch {
 					case reachErr == nil:
@@ -229,6 +245,8 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 						// 200 with a JS challenge page.
 						if vendor := looksLikeDoctorInterstitial(reachBody); vendor != "" {
 							report["api"] = fmt.Sprintf("blocked by %s interstitial — the configured transport reached the wall. Try a different network, wait for the IP-level rate limit to clear, or check that the browser-chrome transport is bound correctly.", vendor)
+						} else if doctorBodyLooksLikeHTML(reachBody) {
+							report["api"] = "reachable (HTML body at /)"
 						} else {
 							report["api"] = "reachable"
 						}

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/helpers.go
@@ -2289,24 +2289,24 @@ func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlag
 	if flags.quiet {
 		return printQuiet(w, data)
 	}
+	headerFields := documentedFields
+	if flags.selectFields != "" {
+		selected := map[string]bool{}
+		for _, part := range strings.Split(flags.selectFields, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				selected[part] = true
+			}
+		}
+		headerFields = []map[string]bool{selected}
+	}
 	// --csv: render as CSV
 	if flags.csv {
-		headerFields := documentedFields
-		if flags.selectFields != "" {
-			selected := map[string]bool{}
-			for _, part := range strings.Split(flags.selectFields, ",") {
-				part = strings.TrimSpace(part)
-				if part != "" {
-					selected[part] = true
-				}
-			}
-			headerFields = []map[string]bool{selected}
-		}
 		return printCSV(w, data, headerFields...)
 	}
 	// --plain: render arrays as tab-separated rows
 	if flags.plain {
-		return printPlain(w, data)
+		return printPlain(w, data, headerFields...)
 	}
 	return printOutput(w, data, flags.asJSON)
 }
@@ -2576,6 +2576,10 @@ func compactObjectArrayValue(v any, documentedFields ...map[string]bool) (any, b
 	return compacted, true
 }
 
+// Distinguishes an empty array from swallowed stdout when no header
+// columns are known. Exit 0 with zero bytes is indistinguishable from a crash.
+const emptyTabularResultMarker = "(no rows)"
+
 func printCSV(w io.Writer, data json.RawMessage, documentedFields ...map[string]bool) error {
 	items, ok := tabularObjectRows(data)
 	if !ok {
@@ -2585,6 +2589,7 @@ func printCSV(w io.Writer, data json.RawMessage, documentedFields ...map[string]
 	if len(items) == 0 {
 		keys := csvDeclaredHeader(documentedFields...)
 		if len(keys) == 0 {
+			fmt.Fprintln(w, emptyTabularResultMarker)
 			return nil
 		}
 		writeCSVRow(w, keys)
@@ -2655,13 +2660,19 @@ func csvDeclaredHeader(documentedFields ...map[string]bool) []string {
 	return keys
 }
 
-func printPlain(w io.Writer, data json.RawMessage) error {
+func printPlain(w io.Writer, data json.RawMessage, documentedFields ...map[string]bool) error {
 	items, ok := tabularObjectRows(data)
 	if !ok {
 		fmt.Fprintln(w, string(data))
 		return nil
 	}
 	if len(items) == 0 {
+		keys := csvDeclaredHeader(documentedFields...)
+		if len(keys) == 0 {
+			fmt.Fprintln(w, emptyTabularResultMarker)
+			return nil
+		}
+		fmt.Fprintln(w, strings.Join(keys, "\t"))
 		return nil
 	}
 	keySet := map[string]bool{}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/doctor.go
@@ -80,6 +80,19 @@ func looksLikeDoctorInterstitial(body []byte) string {
 	return ""
 }
 
+func doctorBodyLooksLikeHTML(body []byte) bool {
+	s := strings.TrimSpace(string(body))
+	if s == "" {
+		return false
+	}
+	lower := strings.ToLower(s)
+	if len(lower) > 2048 {
+		lower = lower[:2048]
+	}
+	return strings.HasPrefix(lower, "<!doctype html") || strings.HasPrefix(lower, "<html") ||
+		(strings.HasPrefix(lower, "<") && (strings.Contains(lower, "<html") || strings.Contains(lower, "<body") || strings.Contains(lower, "<head") || strings.Contains(lower, "<title")))
+}
+
 // suggestReadCommand walks the Cobra tree to find an endpoint-mirror command
 // an operator can run to confirm credentials work end-to-end. Picks the
 // first leaf that (a) carries the `pp:endpoint` annotation, so it actually
@@ -303,7 +316,10 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					report["api"] = fmt.Sprintf("client init error: %s", clientErr)
 				} else {
 					// Step 1: Basic reachability via the configured transport.
-					reachBody, reachErr := c.Get(cmd.Context(), "/", nil)
+					// Health paths have no response_format field, so opt this
+					// probe into HTML: a 200 HTML homepage is reachable, and
+					// a Cloudflare challenge page can still be classified.
+					reachBody, reachErr := c.GetWithHeaders(cmd.Context(), "/", nil, map[string]string{client.HTMLResponseHeader: "true"})
 					var reachAPIErr *client.APIError
 					switch {
 					case reachErr == nil:
@@ -312,6 +328,8 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 						// 200 with a JS challenge page.
 						if vendor := looksLikeDoctorInterstitial(reachBody); vendor != "" {
 							report["api"] = fmt.Sprintf("blocked by %s interstitial — the configured transport reached the wall. Try a different network, wait for the IP-level rate limit to clear, or check that the browser-chrome transport is bound correctly.", vendor)
+						} else if doctorBodyLooksLikeHTML(reachBody) {
+							report["api"] = "reachable (HTML body at /)"
 						} else {
 							report["api"] = "reachable"
 						}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Same-wave operator-visible printed-CLI bugs. Machine (generator/template) fixes so reprints pick them up; no printed-CLI patches.

## Approach

**#4589 `--csv`/`--plain` empty result.** Empty arrays exited 0 with zero bytes. `--csv` already had a header-only path when columns are known; `--plain` did not, and neither emitted anything when columns are unknown. Both now write a declared header (tab-separated for plain) when columns are known, otherwise a single `(no rows)` marker. JSON is unchanged; non-empty tabular output stays byte-identical.

**#4590 `which` index novels-only.** Seed `whichIndex` with promoted endpoint commands after novel hero features, deduped by `Command`. `rankWhich` is unchanged. Dogfood `syncWhichIndex` keeps `pp:which-promoted` rows so reprints do not wipe them, parsing composite-literal fields so description prose cannot steal `Group`/`WhyItMatters`.

**#4612 doctor HTML 200 as unreachable.** Health paths have no `response_format`, so the Step-1 probe used `Get` and HTML 200 hit the client JSON guard (`expected JSON, API returned HTML`), reporting `unreachable` and starving interstitial detection. The probe now uses `GetWithHeaders` with `HTMLResponseHeader`. HTML 200 is `reachable (HTML body at <path>)` (does not match `--fail-on=error` substrings); Cloudflare interstitials still classify when the body matches. The client HTML guard is not weakened. The scorecard credits `GetWithHeaders` as HTTP reachability.

**#4614 stale promoted `Example`.** `promotedExampleLine` echoed hand-written `example:` verbatim, so collapsed leaves shipped two-word Examples (`allocation get`) that were never registered. Generate now rewrites a trailing endpoint-name/alias token and `flag_name` remaps only when the rewritten command+flags match the registered tree; otherwise it refuses. Rewritten argv is re-serialized with `shellargs.Join` so quoted multiword values stay one argument.

## Output contract

Generated `helpers.go`, `which.go`, `doctor.go`, and promoted command `Example` lines change on next print. Golden fixtures for those artifacts are updated in this PR.

Closes #4589
Closes #4590
Closes #4612
Closes #4614

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d66c3572-74ff-466b-867e-8e276ca48a1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d66c3572-74ff-466b-867e-8e276ca48a1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

