### PR TITLE
fix(cli): fix feedback/teach annotations and doctor gosec name

### DIFF
--- a/internal/generator/feedback_path_test.go
+++ b/internal/generator/feedback_path_test.go
@@ -54,10 +54,6 @@ func TestFeedbackParentEmitsDurableExample(t *testing.T) {
 		"parent Example must not mention undeclared flags; --since is not a feedback flag")
 	require.Contains(t, parent, "--stdin",
 		"parent Example should demonstrate a flag the command actually declares")
-
-	binaryPath := filepath.Join(outputDir, naming.CLI(apiSpec.Name))
-	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/"+naming.CLI(apiSpec.Name))
-	stdout, _ := runGeneratedBinary(t, binaryPath, "feedback", "--help")
-	require.Contains(t, stdout, "Examples:",
-		"feedback --help must render an Examples section")
+	require.Contains(t, parent, "feedback list",
+		"parent Example should still show the list subcommand")
 }

--- a/internal/generator/feedback_path_test.go
+++ b/internal/generator/feedback_path_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,4 +37,27 @@ func TestFeedbackPath_UsesLocalShareDir(t *testing.T) {
 	require.Contains(t, string(skillContent),
 		"Entries are stored locally as `feedback.jsonl` under the resolved data dir.",
 		"generated SKILL.md should reference the resolved data directory")
+}
+
+func TestFeedbackParentEmitsDurableExample(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("feedback-example")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	feedbackSrc := readGeneratedFile(t, outputDir, "internal", "cli", "feedback.go")
+	parent := generatedFunctionBody(t, feedbackSrc, "func newFeedbackCmd(flags *rootFlags) *cobra.Command")
+	require.Contains(t, parent, "Example:",
+		"feedback parent must emit an Example so live dogfood's help check does not fail")
+	require.NotContains(t, parent, "--since",
+		"parent Example must not mention undeclared flags; --since is not a feedback flag")
+	require.Contains(t, parent, "--stdin",
+		"parent Example should demonstrate a flag the command actually declares")
+
+	binaryPath := filepath.Join(outputDir, naming.CLI(apiSpec.Name))
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/"+naming.CLI(apiSpec.Name))
+	stdout, _ := runGeneratedBinary(t, binaryPath, "feedback", "--help")
+	require.Contains(t, stdout, "Examples:",
+		"feedback --help must render an Examples section")
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -12102,7 +12102,8 @@ func TestGeneratedAuthCredentialCommandReferencesMatchCobraTree(t *testing.T) {
 		client := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
 		assert.Contains(t, client, "auth set-credentials")
 		doctor := readGeneratedFile(t, outputDir, "internal", "cli", "doctor.go")
-		assert.Contains(t, doctor, `credentialRemediation := "run auth set-credentials or auth logout"`)
+		assert.Contains(t, doctor, `remediationHint := "run auth set-credentials or auth logout"`)
+		assert.NotContains(t, doctor, "credentialRemediation")
 	})
 }
 

--- a/internal/generator/learn_mcp_parity_test.go
+++ b/internal/generator/learn_mcp_parity_test.go
@@ -163,6 +163,15 @@ func TestGenerateLearnMCPParity_LocalWriteAnnotations(t *testing.T) {
 	require.NotContains(t, forgetBlock, "mcp:local-write",
 		"learnings forget must not carry local-write hints")
 
+	// Bare `learnings` exits 2 via parentNoSubcommandRunE. Declare the typed
+	// codes so verify scores the generated parent group 10, matching the
+	// hand-written parents.
+	learningsBlock := commandBlock(t, teachSrc, `Use:   "learnings"`)
+	require.Contains(t, learningsBlock, `"pp:parent-group": "true"`,
+		"learnings parent must stay a grouping parent")
+	require.Regexp(t, `"pp:typed-exit-codes":\s+"0,2"`, learningsBlock,
+		"learnings parent must declare typed exit codes 0,2")
+
 	// teach-pattern exits 2 via usageErr on missing required flags, just like
 	// its teach/teach-playbook siblings, and writes to the local store. It must
 	// declare both annotations so verify and the live-dogfood matrix score its

--- a/internal/generator/security_suppressions_test.go
+++ b/internal/generator/security_suppressions_test.go
@@ -60,6 +60,11 @@ func TestGeneratedInfraSecuritySuppressionsAreExplicit(t *testing.T) {
 	syncGo := readGenerated(t, outputDir, "internal", "cli", "sync.go")
 	assert.Contains(t, syncGo, `paths := map[string]string{ // #nosec G101 -- endpoint paths, not credentials.`)
 
+	doctorGo := readGenerated(t, outputDir, "internal", "cli", "doctor.go")
+	assert.NotContains(t, doctorGo, "credentialRemediation",
+		"gosec G101 matches identifiers containing credential; do not use that name")
+	assert.Contains(t, doctorGo, "remediationHint")
+
 	importGo := readGenerated(t, outputDir, "internal", "cli", "import.go")
 	assert.Contains(t, importGo, `os.Open(filepath.Clean(inputFile)) // #nosec G304 -- user-specified input file is this flag's documented purpose.`)
 

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -1134,9 +1134,9 @@ func collectCredentialsLocationReport(report map[string]any, cfg *config.Config)
 		return
 	}
 {{- if $authCredentialConsolidationAction}}
-	credentialRemediation := "run {{ $authCredentialConsolidationAction }} or auth logout"
+	remediationHint := "run {{ $authCredentialConsolidationAction }} or auth logout"
 {{- else}}
-	credentialRemediation := "run auth logout"
+	remediationHint := "run auth logout"
 {{- end}}
 	if cfg.CredentialSource != "" {
 		report["credentials_location"] = cfg.CredentialSource
@@ -1167,9 +1167,9 @@ func collectCredentialsLocationReport(report map[string]any, cfg *config.Config)
 	}
 	if credsPresent && len(locations) > 1 {
 		if legacySecretsElsewhere != "" {
-			report["credentials_location_warning"] = "WARN credentials stored in more than one location; legacy secrets remain at " + legacySecretsElsewhere + "; " + credentialRemediation + " to consolidate and remove legacy secrets"
+			report["credentials_location_warning"] = "WARN credentials stored in more than one location; legacy secrets remain at " + legacySecretsElsewhere + "; " + remediationHint + " to consolidate and remove legacy secrets"
 		} else {
-			report["credentials_location_warning"] = "WARN credentials stored in more than one location; current reads use credentials file; " + credentialRemediation + " to consolidate"
+			report["credentials_location_warning"] = "WARN credentials stored in more than one location; current reads use credentials file; " + remediationHint + " to consolidate"
 		}
 	}
 }

--- a/internal/generator/templates/feedback.go.tmpl
+++ b/internal/generator/templates/feedback.go.tmpl
@@ -108,9 +108,9 @@ POSTed as JSON after the local write.
 Write what surprised you or tripped you up, not a bug report. The
 loop is: agent notices friction -> one invocation -> captured -> the
 maintainer sees it.`,
-		Example: `  {{.Name}}-pp-cli feedback "the --since flag is inclusive but docs say exclusive"
+		Example: `  {{.Name}}-pp-cli feedback "docs said exclusive but the boundary is inclusive"
   {{.Name}}-pp-cli feedback --stdin < notes.txt
-  {{.Name}}-pp-cli feedback list --limit 10`,
+  {{.Name}}-pp-cli feedback list`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var text string
 			if useStdin {

--- a/internal/generator/templates/teach.go.tmpl
+++ b/internal/generator/templates/teach.go.tmpl
@@ -774,7 +774,7 @@ func newLearningsCmd(flags *rootFlags, learnCfg *entities.Config) *cobra.Command
 		Short: "Inspect or forget the local search_learnings table",
 		Long: `Surface for browsing, filtering, and deleting rows in the
 search_learnings table that the LLM populates via the 'teach' command.`,
-		Annotations: map[string]string{"mcp:read-only": "true", "pp:parent-group": "true"},
+		Annotations: map[string]string{"mcp:read-only": "true", "pp:parent-group": "true", "pp:typed-exit-codes": "0,2"},
 		RunE:        parentNoSubcommandRunE(flags),
 	}
 	cmd.AddCommand(newLearningsListCmd(flags))

--- a/testdata/golden/expected/generate-additional-auth-doctor/additional-auth-doctor/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-additional-auth-doctor/additional-auth-doctor/internal/cli/doctor.go
@@ -578,7 +578,7 @@ func collectCredentialsLocationReport(report map[string]any, cfg *config.Config)
 	if cfg == nil {
 		return
 	}
-	credentialRemediation := "run auth set-token or auth logout"
+	remediationHint := "run auth set-token or auth logout"
 	if cfg.CredentialSource != "" {
 		report["credentials_location"] = cfg.CredentialSource
 	} else {
@@ -608,9 +608,9 @@ func collectCredentialsLocationReport(report map[string]any, cfg *config.Config)
 	}
 	if credsPresent && len(locations) > 1 {
 		if legacySecretsElsewhere != "" {
-			report["credentials_location_warning"] = "WARN credentials stored in more than one location; legacy secrets remain at " + legacySecretsElsewhere + "; " + credentialRemediation + " to consolidate and remove legacy secrets"
+			report["credentials_location_warning"] = "WARN credentials stored in more than one location; legacy secrets remain at " + legacySecretsElsewhere + "; " + remediationHint + " to consolidate and remove legacy secrets"
 		} else {
-			report["credentials_location_warning"] = "WARN credentials stored in more than one location; current reads use credentials file; " + credentialRemediation + " to consolidate"
+			report["credentials_location_warning"] = "WARN credentials stored in more than one location; current reads use credentials file; " + remediationHint + " to consolidate"
 		}
 	}
 }

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/doctor.go
@@ -605,7 +605,7 @@ func collectCredentialsLocationReport(report map[string]any, cfg *config.Config)
 	if cfg == nil {
 		return
 	}
-	credentialRemediation := "run auth set-token or auth logout"
+	remediationHint := "run auth set-token or auth logout"
 	if cfg.CredentialSource != "" {
 		report["credentials_location"] = cfg.CredentialSource
 	} else {
@@ -635,9 +635,9 @@ func collectCredentialsLocationReport(report map[string]any, cfg *config.Config)
 	}
 	if credsPresent && len(locations) > 1 {
 		if legacySecretsElsewhere != "" {
-			report["credentials_location_warning"] = "WARN credentials stored in more than one location; legacy secrets remain at " + legacySecretsElsewhere + "; " + credentialRemediation + " to consolidate and remove legacy secrets"
+			report["credentials_location_warning"] = "WARN credentials stored in more than one location; legacy secrets remain at " + legacySecretsElsewhere + "; " + remediationHint + " to consolidate and remove legacy secrets"
 		} else {
-			report["credentials_location_warning"] = "WARN credentials stored in more than one location; current reads use credentials file; " + credentialRemediation + " to consolidate"
+			report["credentials_location_warning"] = "WARN credentials stored in more than one location; current reads use credentials file; " + remediationHint + " to consolidate"
 		}
 	}
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/doctor.go
@@ -553,7 +553,7 @@ func collectCredentialsLocationReport(report map[string]any, cfg *config.Config)
 	if cfg == nil {
 		return
 	}
-	credentialRemediation := "run auth set-token or auth logout"
+	remediationHint := "run auth set-token or auth logout"
 	if cfg.CredentialSource != "" {
 		report["credentials_location"] = cfg.CredentialSource
 	} else {
@@ -583,9 +583,9 @@ func collectCredentialsLocationReport(report map[string]any, cfg *config.Config)
 	}
 	if credsPresent && len(locations) > 1 {
 		if legacySecretsElsewhere != "" {
-			report["credentials_location_warning"] = "WARN credentials stored in more than one location; legacy secrets remain at " + legacySecretsElsewhere + "; " + credentialRemediation + " to consolidate and remove legacy secrets"
+			report["credentials_location_warning"] = "WARN credentials stored in more than one location; legacy secrets remain at " + legacySecretsElsewhere + "; " + remediationHint + " to consolidate and remove legacy secrets"
 		} else {
-			report["credentials_location_warning"] = "WARN credentials stored in more than one location; current reads use credentials file; " + credentialRemediation + " to consolidate"
+			report["credentials_location_warning"] = "WARN credentials stored in more than one location; current reads use credentials file; " + remediationHint + " to consolidate"
 		}
 	}
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/feedback.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/feedback.go
@@ -108,9 +108,9 @@ POSTed as JSON after the local write.
 Write what surprised you or tripped you up, not a bug report. The
 loop is: agent notices friction -> one invocation -> captured -> the
 maintainer sees it.`,
-		Example: `  printing-press-golden-pp-cli feedback "the --since flag is inclusive but docs say exclusive"
+		Example: `  printing-press-golden-pp-cli feedback "docs said exclusive but the boundary is inclusive"
   printing-press-golden-pp-cli feedback --stdin < notes.txt
-  printing-press-golden-pp-cli feedback list --limit 10`,
+  printing-press-golden-pp-cli feedback list`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var text string
 			if useStdin {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/teach.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/teach.go
@@ -774,7 +774,7 @@ func newLearningsCmd(flags *rootFlags, learnCfg *entities.Config) *cobra.Command
 		Short: "Inspect or forget the local search_learnings table",
 		Long: `Surface for browsing, filtering, and deleting rows in the
 search_learnings table that the LLM populates via the 'teach' command.`,
-		Annotations: map[string]string{"mcp:read-only": "true", "pp:parent-group": "true"},
+		Annotations: map[string]string{"mcp:read-only": "true", "pp:parent-group": "true", "pp:typed-exit-codes": "0,2"},
 		RunE:        parentNoSubcommandRunE(flags),
 	}
 	cmd.AddCommand(newLearningsListCmd(flags))

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/doctor.go
@@ -575,7 +575,7 @@ func collectCredentialsLocationReport(report map[string]any, cfg *config.Config)
 	if cfg == nil {
 		return
 	}
-	credentialRemediation := "run auth set-token or auth logout"
+	remediationHint := "run auth set-token or auth logout"
 	if cfg.CredentialSource != "" {
 		report["credentials_location"] = cfg.CredentialSource
 	} else {
@@ -605,9 +605,9 @@ func collectCredentialsLocationReport(report map[string]any, cfg *config.Config)
 	}
 	if credsPresent && len(locations) > 1 {
 		if legacySecretsElsewhere != "" {
-			report["credentials_location_warning"] = "WARN credentials stored in more than one location; legacy secrets remain at " + legacySecretsElsewhere + "; " + credentialRemediation + " to consolidate and remove legacy secrets"
+			report["credentials_location_warning"] = "WARN credentials stored in more than one location; legacy secrets remain at " + legacySecretsElsewhere + "; " + remediationHint + " to consolidate and remove legacy secrets"
 		} else {
-			report["credentials_location_warning"] = "WARN credentials stored in more than one location; current reads use credentials file; " + credentialRemediation + " to consolidate"
+			report["credentials_location_warning"] = "WARN credentials stored in more than one location; current reads use credentials file; " + remediationHint + " to consolidate"
 		}
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Issue: Closes #4328 · Closes #4241

Every printed CLI was donating the same generator-owned points: the `learnings` parent exited 2 without `pp:typed-exit-codes` (verify scored the group 2 instead of 10), and generated `doctor.go` tripped gosec G101 because the identifier was named `credentialRemediation`.

**Feedback half on current main:** `cli-printing-press generate` already emits the parent `Example:` field. There is no post-render stripper in the generator. The remaining hole was the example text quoting `--since`, which is not a `feedback` flag; offline dogfood's example-flag extractor would still treat it as invalid. This PR rewords that Example so it only demonstrates declared flags (`--stdin`) plus a flag-free `feedback list` line. `feedback --help` on a freshly generated CLI now shows a durable Examples section.

## Approach

- Add `pp:typed-exit-codes: "0,2"` next to the existing `pp:parent-group` annotation on the generated `learnings` parent (`teach.go.tmpl`). Bare `learnings` still uses `parentNoSubcommandRunE`.
- Reword the `feedback` parent `Example:` so help-quality flag extraction cannot see `--since`.
- Rename `credentialRemediation` to `remediationHint` in `doctor.go.tmpl`. User-facing warning text is unchanged. No `#nosec`.

## Scope

Primary area: generator templates (`teach.go.tmpl`, `feedback.go.tmpl`, `doctor.go.tmpl`) plus emitted-code tests.

Why this belongs in this repo: both defects are in generator-owned files emitted into every printed CLI. A printed-CLI patch would not compound.

## Risk

Low. Annotation and identifier rename only. No command behavior, MCP surface, or warning-copy meaning change. Next reprint picks this up; already-published CLIs stay as-is until reprint.

## Output Contract

Emitted `learnings` parent carries both `pp:parent-group` and `pp:typed-exit-codes: "0,2"`. Emitted `feedback` parent keeps a durable `Example:` that `feedback --help` renders and that does not mention `--since`. Emitted doctor remediation identifier is `remediationHint`.

Golden fixtures updated for generated `teach.go`, `feedback.go`, and `doctor.go`.

Evidence:
- `TestGenerateLearnMCPParity_SharedProtocolSource` asserts the learnings annotations
- `TestFeedbackParentEmitsDurableExample` asserts the parent Example field and that it does not mention `--since`
- Doctor tests assert `remediationHint` and reject `credentialRemediation`
- `scripts/verify-generator-output.sh` compiled generate-golden-api, generate-golden-api-rich-auth, generate-learn-loop-api, generate-additional-auth-doctor, generate-tier-routing-api

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures (`remediationHint` is emitted in both `$authCredentialConsolidationAction` branches)
- [x] Generator/template change: checked emitted definitions and call sites for matching gates (local uses in `collectCredentialsLocationReport` only)

Commands run:
- `go test ./internal/generator -run 'TestFeedbackParentEmitsDurableExample|TestGenerateLearnMCPParity_SharedProtocolSource|TestGeneratedInfraSecuritySuppressionsAreExplicit|…'` — pass
- `go test ./... -timeout 15m` — all packages except `internal/generator` pass; generator is CI-sharded into 4×15m jobs and times out unsharded on this runner
- `scripts/golden.sh update` then `scripts/golden.sh verify` — all generate-* cases pass, including the updated teach/feedback/doctor fixtures. Unrelated `dogfood-verdict-matrix` and `verify-runtime-matrix` fail here because those fixtures request a Go 1.24 toolchain this environment does not have
- `scripts/verify-generator-output.sh` for the five affected cases — pass
- Built `printing-press-golden-pp-cli feedback --help` and confirmed the Examples section

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0e61bb2-bdf6-4531-9f35-590e044b54be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0e61bb2-bdf6-4531-9f35-590e044b54be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

