### PR TITLE
fix(cli): bump golang.org/x/net safe floor for GO-2026-5942

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,7 +303,7 @@ Detail in [`docs/SKILLS.md`](docs/SKILLS.md): install targets, workflow parity, 
 ### Write-time defaults
 - No speculative future-proofing in comments.
 - No dates, incidents, or ticket numbers in code comments.
-- Exception for dependency-pin / floor comments: `GO-YYYY-NNNN` advisory IDs and CVE IDs are allowed so the floor stays tied to a named advisory (precedent: `internal/generator/xnet_guard.go` citing `GO-2026-5025..5030`). Still forbidden: GitHub issue/PR numbers, incident tickets, dates.
+- Exception for dependency-pin / floor comments: `GO-YYYY-NNNN` advisory IDs and CVE IDs are allowed so the floor stays tied to a named advisory (precedent: `internal/generator/xnet_guard.go` citing `GO-2026-5942`). Still forbidden: GitHub issue/PR numbers, incident tickets, dates.
 - Code comments must be self-contained; do not make them load-bearing on in-repo skills, plans, or reference prose.
 - Do not restate the field or function name in its comment; document why, not what.
 - Categorical strings -> typed const at introduction.

--- a/greptile.json
+++ b/greptile.json
@@ -32,7 +32,7 @@
           "internal/generator/*_guard.go",
           "docs/solutions/conventions/pin-transitive-security-deps-after-go-mod-tidy.md"
         ],
-        "rule": "Do not file a P1 or P2 asking to remove GO-YYYY-NNNN advisory IDs or CVE IDs from dependency-pin / floor comments. Those identifiers keep the version floor tied to a named advisory (precedent: internal/generator/xnet_guard.go citing GO-2026-5025..5030). Dates, GitHub issue/PR numbers, and incident tickets remain prohibited."
+        "rule": "Do not file a P1 or P2 asking to remove GO-YYYY-NNNN advisory IDs or CVE IDs from dependency-pin / floor comments. Those identifiers keep the version floor tied to a named advisory (precedent: internal/generator/xnet_guard.go citing GO-2026-5942). Dates, GitHub issue/PR numbers, and incident tickets remain prohibited."
       }
     ]
   }

--- a/internal/generator/client_credential_domain_test.go
+++ b/internal/generator/client_credential_domain_test.go
@@ -77,7 +77,7 @@ func TestGeneratedBrowserCredentialBindsToCapturedDomain(t *testing.T) {
 		"credential matching must not authorize eTLD+1 siblings of the canonical host")
 	assert.NotContains(t, clientSrc, "golang.org/x/net/publicsuffix",
 		"credential binding must not import publicsuffix")
-	assert.NotContains(t, goMod, "golang.org/x/net v0.55.0",
+	assert.NotContains(t, goMod, "golang.org/x/net "+safeXNetVersion,
 		"cookie binding must not pull x/net just for host matching")
 
 	// The negative path must remain unchanged for ordinary token auth: it has
@@ -96,7 +96,7 @@ func TestGeneratedBrowserCredentialBindsToCapturedDomain(t *testing.T) {
 		"ordinary token auth config must not emit browser credential binding")
 	assert.NotContains(t, bearerAuth, "CredentialDomain",
 		"ordinary token auth commands must not reference browser credential binding")
-	assert.NotContains(t, bearerMod, "golang.org/x/net v0.55.0",
+	assert.NotContains(t, bearerMod, "golang.org/x/net "+safeXNetVersion,
 		"ordinary token auth must not gain the browser-only dependency")
 	assert.Equal(t, 1, strings.Count(authSrc, `cfg.CredentialDomain = ".auth.example.com"`),
 		"browser login should record the capture domain")

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3492,7 +3492,7 @@ func TestGenerateHTMLExtractionEndpoint(t *testing.T) {
 	require.FileExists(t, filepath.Join(outputDir, "internal", "cli", "html_extract.go"))
 	gomod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
 	require.NoError(t, err)
-	assert.Contains(t, string(gomod), "golang.org/x/net v0.55.0")
+	assert.Contains(t, string(gomod), "golang.org/x/net "+safeXNetVersion)
 
 	runGoCommand(t, outputDir, "mod", "tidy")
 	binaryPath := filepath.Join(outputDir, "webhtml-pp-cli")

--- a/internal/generator/templates/go.mod.tmpl
+++ b/internal/generator/templates/go.mod.tmpl
@@ -22,7 +22,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/pelletier/go-toml/v2 v2.2.4
 {{- if .HasHTMLExtraction}}
-	golang.org/x/net v0.55.0
+	golang.org/x/net v0.56.0
 {{- end}}
 )
 

--- a/internal/generator/xnet_guard.go
+++ b/internal/generator/xnet_guard.go
@@ -7,10 +7,10 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-// safeXNetVersion is the lowest golang.org/x/net release without the 2026
-// advisories (GO-2026-5025..5030). Keep in sync with the explicit pin in
-// templates/go.mod.tmpl.
-const safeXNetVersion = "v0.55.0"
+// safeXNetVersion is the lowest golang.org/x/net release without GO-2026-5942
+// (CVE-2026-46600; also covers GO-2026-5025..5030). Keep in sync with the
+// explicit pin in templates/go.mod.tmpl.
+const safeXNetVersion = "v0.56.0"
 
 // ensureSafeXNet bumps golang.org/x/net to safeXNetVersion when the generated
 // module resolves it below that version. x/net is dragged in transitively by

--- a/internal/generator/xnet_guard_test.go
+++ b/internal/generator/xnet_guard_test.go
@@ -54,3 +54,10 @@ func TestEnsureSafeXNet(t *testing.T) {
 		require.NoError(t, ensureSafeXNet(dir))
 	})
 }
+
+func TestSafeXNetVersionMatchesGoModTemplate(t *testing.T) {
+	tmpl, err := os.ReadFile(filepath.Join("templates", "go.mod.tmpl"))
+	require.NoError(t, err)
+	assert.Contains(t, string(tmpl), "golang.org/x/net "+safeXNetVersion,
+		"templates/go.mod.tmpl pin must stay in sync with safeXNetVersion")
+}

--- a/internal/generator/xnet_guard_test.go
+++ b/internal/generator/xnet_guard_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/semver"
 )
 
 // TestEnsureSafeXNet exercises the post-tidy x/net pin against real modules.
@@ -60,4 +61,9 @@ func TestSafeXNetVersionMatchesGoModTemplate(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(tmpl), "golang.org/x/net "+safeXNetVersion,
 		"templates/go.mod.tmpl pin must stay in sync with safeXNetVersion")
+	require.True(t, semver.IsValid(safeXNetVersion))
+	// Independent of the production constant so a coordinated
+	// constant+template downgrade below GO-2026-5942 cannot stay green.
+	assert.GreaterOrEqual(t, semver.Compare(safeXNetVersion, "v0.56.0"), 0,
+		"safeXNetVersion must stay at or above the GO-2026-5942 floor")
 }

--- a/internal/generator/xnet_guard_test.go
+++ b/internal/generator/xnet_guard_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/mod/semver"
 )
 
 // TestEnsureSafeXNet exercises the post-tidy x/net pin against real modules.
@@ -59,11 +58,10 @@ func TestEnsureSafeXNet(t *testing.T) {
 func TestSafeXNetVersionMatchesGoModTemplate(t *testing.T) {
 	tmpl, err := os.ReadFile(filepath.Join("templates", "go.mod.tmpl"))
 	require.NoError(t, err)
-	assert.Contains(t, string(tmpl), "golang.org/x/net "+safeXNetVersion,
-		"templates/go.mod.tmpl pin must stay in sync with safeXNetVersion")
-	require.True(t, semver.IsValid(safeXNetVersion))
-	// Independent of the production constant so a coordinated
-	// constant+template downgrade below GO-2026-5942 cannot stay green.
-	assert.GreaterOrEqual(t, semver.Compare(safeXNetVersion, "v0.56.0"), 0,
-		"safeXNetVersion must stay at or above the GO-2026-5942 floor")
+
+	const wantSafeXNetVersion = "v0.56.0"
+	assert.Equal(t, wantSafeXNetVersion, safeXNetVersion,
+		"safeXNetVersion must stay at the GO-2026-5942 floor")
+	assert.Contains(t, string(tmpl), "golang.org/x/net "+wantSafeXNetVersion,
+		"templates/go.mod.tmpl pin must stay at the GO-2026-5942 floor")
 }

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -127,7 +127,7 @@ func TestPrintingPressSetupContractEmitsSkillStaleWhenSkillBelowBinaryFloor(t *t
 	t.Parallel()
 
 	output, _, err := runPrintingPressSetupContractWithSkillFloor(t, "4.32.0", "4.32.0", "9.0.0")
-	require.Error(t, err, "skill-stale must fail the setup contract")
+	require.Error(t, err, "skill-stale must fail the setup contract; err=%v output=%q", err, output)
 
 	assert.Contains(t, output, "[skill-stale] printing-press skill v")
 	assert.Contains(t, output, "PRESS_SKILL_INSTALLED=")
@@ -1589,7 +1589,7 @@ exit 0
 	scriptPath := filepath.Join(root, "setup-contract.sh")
 	writeExecutable(t, scriptPath, "#!/bin/sh\n"+contract)
 
-	cmd := exec.Command(scriptPath)
+	cmd := exec.Command("/bin/sh", scriptPath)
 	cmd.Dir = repo
 	cmd.Env = append(os.Environ(),
 		"ARGUMENTS=",
@@ -1624,8 +1624,9 @@ echo "cli-printing-press ` + version + `"
 
 func writeExecutable(t *testing.T, path, content string) {
 	t.Helper()
-
-	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+	tmp := path + ".tmp"
+	require.NoError(t, os.WriteFile(tmp, []byte(content), 0o755))
+	require.NoError(t, os.Rename(tmp, path))
 }
 
 func linkHostToolIfNeeded(t *testing.T, dir, name string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

`safeXNetVersion` and the `go.mod.tmpl` pin were still `v0.55.0`, which carries GO-2026-5942 (CVE-2026-46600). Freshly printed CLIs that pull `golang.org/x/net` therefore shipped a known-vulnerable floor, and the post-tidy guard was a no-op whenever the template already emitted that same version.

Closes #4336

## Approach

Raise the safe floor to `v0.56.0` in both `internal/generator/xnet_guard.go` and `internal/generator/templates/go.mod.tmpl`, matching the version this repo already requires.

`TestSafeXNetVersionMatchesGoModTemplate` asserts both the production constant and the template pin against a test-local `v0.56.0`. That cannot stay green if the constant and template are lowered together.

`full-test (pipeline)` on `af17f7c1` failed in `TestPrintingPressSetupContractEmitsSkillStaleWhenSkillBelowBinaryFloor` with empty CombinedOutput while `require.Error` still passed. That is `fork/exec` of a just-written `setup-contract.sh` hitting `ETXTBSY`; extra `go get` I/O from the floor bump makes the race more likely. The setup-contract helper now runs the script through `/bin/sh` and publishes executables via temp+rename.

## Scope

Primary area: generator — x/net security floor for printed CLIs.

Why this belongs in this repo: the floor is a machine contract. Every future print inherits it. Per-CLI library retrofits are a separate cleanup.

## Risk

Generated `go.mod` for HTML-extraction CLIs will require `golang.org/x/net v0.56.0` instead of `v0.55.0`. Other CLIs that already resolve x/net at or above `v0.56.0` are unchanged. Existing golden go.mod fixtures do not snapshot this pin (HTML-extraction is not in the golden generate set).

## Output Contract

Template pin in `go.mod.tmpl` and `TestGenerateHTMLExtractionEndpoint` both require `golang.org/x/net v0.56.0`. `TestSafeXNetVersionMatchesGoModTemplate` pins that floor with a test-local literal independent of `safeXNetVersion`. Existing golden generate fixtures do not include an x/net require; Main CI `full-golden` and `generated-output-compile` passed on this PR.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:

- `go test ./internal/generator -count=1 -timeout 2m -run TestSafeXNetVersionMatchesGoModTemplate` (pass)
- `go test ./internal/pipeline/... -count=1 -timeout 15m` (pass; matches the `full-test (pipeline)` shard)
- `go test ./...`: every package except `./internal/generator` passed. Unsharded `./internal/generator` hit the default 10m timeout (`TestGenerateDependentSyncCompiles` still running). Same VM limit as earlier; CI shards that package.

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c380938b-cbb9-4ecb-b587-f87619a1793c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c380938b-cbb9-4ecb-b587-f87619a1793c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

