### PR TITLE
fix(cli): stop generated test fixtures tripping publish secret scan

### DIFF
--- a/internal/generator/generated_package_secrets_test.go
+++ b/internal/generator/generated_package_secrets_test.go
@@ -1,0 +1,68 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/artifacts"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGeneratedTestsPassPublishSecretScan is the publish-scan contract for
+// generated tests: a fresh cookie-auth print whose declared cookie names
+// collide with generated fixtures (historically `token=` / `key=`) must
+// not trip the mandatory secret scan. Injecting a live-looking vendor key
+// into any generated file, including a test, still fails.
+func TestGeneratedTestsPassPublishSecretScan(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("secretscancookie")
+	apiSpec.BaseURL = "https://www.example.com"
+	apiSpec.Auth = spec.AuthConfig{
+		Type:         "cookie",
+		Header:       "Cookie",
+		In:           "cookie",
+		CookieDomain: ".example.com",
+		Cookies:      []string{"token", "key", "session_id"},
+		EnvVars:      []string{"SECRETSCANCOOKIE_COOKIES"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	cliutilTestSrc := readGeneratedFile(t, outputDir, "internal", "cliutil", "cliutil_test.go")
+	require.Contains(t, cliutilTestSrc, "token=your-token-here",
+		"emitted cliutil tests must still cover token=<value> credential redaction")
+	require.Contains(t, cliutilTestSrc, "key=your-key-here",
+		"emitted cliutil tests must still cover key=<value> credential redaction")
+
+	shelloutSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "cobratree", "shellout_test.go")
+	require.Contains(t, shelloutSrc, `"token=your-stolen-token-here"`,
+		"emitted cobratree tests must still cover '='-containing blocked MCP keys")
+
+	findings, err := artifacts.FindPackageSecrets(outputDir, apiSpec.Auth.Cookies)
+	require.NoError(t, err)
+	require.Empty(t, findings, "generated package must not trip the publish secret scan:\n%s",
+		artifacts.FormatVendorPrefixSecretFindings(findings))
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "test", "./internal/cliutil/", "./internal/mcp/cobratree/")
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "cliutil", "planted_secret_test.go"),
+		[]byte("package cliutil\n\nconst planted = \""+strings.Join([]string{"sk", "_live_", "1234567890abcdefghijklmnop"}, "")+"\"\n"),
+		0o644,
+	))
+	planted, err := artifacts.FindPackageSecrets(outputDir, apiSpec.Auth.Cookies)
+	require.NoError(t, err)
+	require.NotEmpty(t, planted, "planting a live-looking sk_live_ value in a generated test must still fail the scan")
+	kinds := make([]string, 0, len(planted))
+	for _, finding := range planted {
+		kinds = append(kinds, finding.Kind)
+	}
+	require.Contains(t, kinds, "stripe-secret-key")
+}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -400,7 +400,7 @@ func TestGenerateCliutilPackage(t *testing.T) {
 
 	cliutilTestSrc, err := os.ReadFile(filepath.Join(cliutilDir, "cliutil_test.go"))
 	require.NoError(t, err)
-	assert.Contains(t, string(cliutilTestSrc), "token=abc.def-ghi",
+	assert.Contains(t, string(cliutilTestSrc), "token=your-token-here",
 		"emitted cliutil tests must cover token=<value> credential redaction")
 
 	// The generated cliutil package must compile and its tests must pass.

--- a/internal/generator/templates/cliutil_test.go.tmpl
+++ b/internal/generator/templates/cliutil_test.go.tmpl
@@ -126,7 +126,7 @@ func TestAuthErrorHelpers(t *testing.T) {
 		t.Fatal("unexpected auth classification for non-auth message")
 	}
 
-	got := SanitizeErrorBody("token sk-abcdefghi Bearer abc.def key=secretvalue token=abc.def-ghi")
+	got := SanitizeErrorBody("token sk-abcdefghi Bearer abc.def key=your-key-here token=your-token-here")
 	if got != "token [REDACTED] [REDACTED] [REDACTED] [REDACTED]" {
 		t.Fatalf("SanitizeErrorBody redaction = %q", got)
 	}

--- a/internal/generator/templates/cobratree/shellout_test.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout_test.go.tmpl
@@ -74,12 +74,12 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"output":       "/tmp/evil.json",
 		"profile":      "attacker",
 		"receipt-file": "/tmp/evil-receipt.json",
-		"token":        "stolen-token",
+		"token":        "your-token-here",
 		// Keys containing "=" must not be emitted verbatim as flag=value.
 		"base-url=https://evil.example.com": true,
 		"config=/tmp/evil.yaml":             true,
 		"limit=99":                          float64(42),
-		"token=stolen-token":                true,
+		"token=your-stolen-token-here":      true,
 		// Allowed per-command flag passes through.
 		"limit": float64(10),
 	}
@@ -177,7 +177,7 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 	for _, smuggled := range []string{
 		"--base-url=https://evil.example/",
 		"--config=/tmp/evil.yaml",
-		"--token=stolen-token",
+		"--token=your-stolen-token-here",
 	} {
 		argv := cliArgsFromMCP(map[string]any{"json": smuggled}, blocked)
 		assertNoBlockedFlagToken(t, argv, blocked)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
@@ -74,12 +74,12 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"output":       "/tmp/evil.json",
 		"profile":      "attacker",
 		"receipt-file": "/tmp/evil-receipt.json",
-		"token":        "stolen-token",
+		"token":        "your-token-here",
 		// Keys containing "=" must not be emitted verbatim as flag=value.
 		"base-url=https://evil.example.com": true,
 		"config=/tmp/evil.yaml":             true,
 		"limit=99":                          float64(42),
-		"token=stolen-token":                true,
+		"token=your-stolen-token-here":      true,
 		// Allowed per-command flag passes through.
 		"limit": float64(10),
 	}
@@ -177,7 +177,7 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 	for _, smuggled := range []string{
 		"--base-url=https://evil.example/",
 		"--config=/tmp/evil.yaml",
-		"--token=stolen-token",
+		"--token=your-stolen-token-here",
 	} {
 		argv := cliArgsFromMCP(map[string]any{"json": smuggled}, blocked)
 		assertNoBlockedFlagToken(t, argv, blocked)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

`publish package`'s mandatory vendor-prefix secret scan hard-fails on fixtures the generator itself emits. Cookie-auth prints whose declared cookie names include `token` or `key` match synthetic assignments in generated tests (`token=abc.def-ghi`, `key=secretvalue`, `token=stolen-token`), so operators have to hand-edit generated tests before every publish.

Closes #4280

## Approach

Keep the scan unchanged. Reword the generated fixtures to the scanner's existing allowlisted `your-<name>-here` form so they still exercise `SanitizeErrorBody` redaction and MCP blocked-flag handling without looking like captured cookie values.

A fresh generate with cookies `token` / `key` previously reported:

- `internal/cliutil/cliutil_test.go` `cookie-value:token` and `cookie-value:key`
- `internal/mcp/cobratree/shellout_test.go` `cookie-value:token`

Those three literals now use `your-token-here` / `your-key-here` / `your-stolen-token-here`.

## Scope

Primary area: generator templates (`cliutil_test.go.tmpl`, `cobratree/shellout_test.go.tmpl`)

Why this belongs in this repo: every printed CLI inherits these fixtures. This is a Printing Press emit bug, not a one-CLI patch.

## Risk

Generated test source strings change; redaction and blocked-flag assertions stay value-agnostic. The scan still fails on a planted `sk_live_` value in a generated test file.

## Output Contract

- Emitted `cliutil_test.go` uses `token=your-token-here` / `key=your-key-here`
- Emitted `shellout_test.go` uses `token=your-stolen-token-here`
- Proof: `TestGeneratedTestsPassPublishSecretScan` generates a cookie-auth CLI, asserts those fixtures, runs `FindPackageSecrets` (empty), runs the generated cliutil/cobratree tests, then plants `sk_live_` and asserts the scan still fails
- Golden: `generate-golden-api` snapshots `shellout_test.go`

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the cookie-auth collision shape (`token` / `key` cookie names), not only api_key prints
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands:

- [x] `go test ./internal/generator -run 'TestGeneratedTestsPassPublishSecretScan|TestGenerateCliutilPackage'`
- [x] `go test ./... -timeout 45m`
- [x] `scripts/verify-generator-output.sh generate-golden-api`
- [x] `scripts/golden.sh verify` — `generate-golden-api` (the snapshotted `shellout_test.go`) passes. Remaining local fails are `dogfood-verdict-matrix` / `verify-runtime-matrix` fixtures pinned to `go 1.24`, which this environment cannot download (`toolchain not available`). Those cases are unrelated to the fixture-string change.

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eca74d7a-61c3-4102-ae05-1edcf7a79245?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eca74d7a-61c3-4102-ae05-1edcf7a79245&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

