### PR TITLE
fix(cli): fix missing communication workflow template

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Table stakes features (from the absorb gate). Every feature the top competitor h
 
 Data layer (high-gravity entities). Domain-specific SQLite tables with proper columns (not JSON blobs), FTS5 full-text search, incremental sync with cursor tracking, `sql` command for raw queries, domain-specific `UpsertX()` and `SearchX()` methods.
 
-Workflow commands (from archetype): `stale`, `orphans`, `load`, `channel-health`, `reconcile`, etc.
+Workflow commands (from archetype): `stale`, `orphans`, `load`, etc.
 
 Insight commands (Rung 5): `health` (composite score), `similar` (duplicate detection), `trends`, `bottleneck`, `forecast`, `patterns`.
 
@@ -390,7 +390,7 @@ The profiler classifies every API into a domain archetype and auto-generates the
 | Archetype | Detected by | Auto-generated commands |
 |-----------|------------|------------------------|
 | Project Management | issue/task/ticket resources, assignee fields, priority levels | `stale`, `orphans`, `load`, `health`, `similar` |
-| Communication | message/channel/thread resources, threading fields | `channel-health`, `message-stats`, `health`, `similar` |
+| Communication | message/channel/thread resources, threading fields | `health`, `similar` |
 | Payments | charge/payment/invoice resources, amount/currency fields | `reconcile`, `revenue`, `health`, `similar` |
 | Infrastructure | server/deploy/instance resources | `health`, `similar` |
 | Content | document/page/block resources | `health`, `similar` |

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2655,7 +2655,7 @@ func archetypePlaybook(arch profiler.DomainArchetype) []PlaybookEntry {
 	case profiler.ArchetypeCommunication:
 		return []PlaybookEntry{
 			{Topic: "Message search", Insight: "Use the search tool on synced data rather than paginating through message history. Message APIs often have aggressive rate limits."},
-			{Topic: "Channel health", Insight: "When analyzing channel activity, use the channel-health command or sql aggregation on synced messages. Don't iterate individual messages via API."},
+			{Topic: "Channel health", Insight: "When analyzing channel activity, use sql aggregation on synced messages. Don't iterate individual messages via API."},
 		}
 	case profiler.ArchetypePayments:
 		return []PlaybookEntry{

--- a/internal/generator/vision_templates.go
+++ b/internal/generator/vision_templates.go
@@ -140,10 +140,6 @@ func SelectVisionTemplates(plan *vision.VisionaryPlan) VisionTemplateSet {
 			"workflows/pm_orphans.go.tmpl",
 			"workflows/pm_load.go.tmpl",
 		}
-	case "communication":
-		set.Workflows = []string{
-			"workflows/comm_health.go.tmpl",
-		}
 	}
 
 	// Invariant: a store without sync is useless — sync populates the store.

--- a/internal/generator/vision_templates_test.go
+++ b/internal/generator/vision_templates_test.go
@@ -1,0 +1,89 @@
+package generator
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/vision"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectVisionTemplatesSelectedFilesExistInEmbed(t *testing.T) {
+	t.Parallel()
+
+	archetypes := []string{
+		string(profiler.ArchetypeProjectMgmt),
+		string(profiler.ArchetypeCommunication),
+		string(profiler.ArchetypePayments),
+		string(profiler.ArchetypeInfrastructure),
+		string(profiler.ArchetypeContent),
+		string(profiler.ArchetypeCRM),
+		string(profiler.ArchetypeDeveloperPlatform),
+		"",
+	}
+	insight := vision.NonObviousInsight{
+		InsightFrame: "a local query surface",
+		Implications: []string{"sync then sql"},
+	}
+
+	for _, arch := range archetypes {
+		t.Run(arch, func(t *testing.T) {
+			t.Parallel()
+			set := SelectVisionTemplates(&vision.VisionaryPlan{
+				Domain:  vision.DomainInfo{Archetype: arch},
+				Insight: insight,
+			})
+			selected := append(append([]string{}, set.Workflows...), set.Insights...)
+			for _, tmpl := range selected {
+				_, err := templateFS.ReadFile(path.Join("templates", tmpl))
+				require.NoError(t, err, "selected template %s for archetype %q must exist in the embed", tmpl, arch)
+				require.NotEmpty(t, commandConstructorForTemplate(tmpl),
+					"selected template %s for archetype %q must have a command constructor", tmpl, arch)
+			}
+		})
+	}
+}
+
+func TestGenerateCommunicationArchetypeDoesNotWarnOnMissingCommHealth(t *testing.T) {
+	apiSpec := communicationSpec("commhealthwarn")
+	profile := profiler.Profile(apiSpec)
+	require.Equal(t, profiler.ArchetypeCommunication, profile.Domain.Archetype)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	stderr, err := captureNovelFeatureStderr(t, func() error {
+		return New(apiSpec, outputDir).Generate()
+	})
+	require.NoError(t, err)
+	require.NotContains(t, stderr, "comm_health")
+	require.NotContains(t, stderr, "skipping workflow template")
+
+	_, statErr := os.Stat(filepath.Join(outputDir, "internal", "cli", "comm_health.go"))
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+
+	skillSrc := readGeneratedFile(t, outputDir, "SKILL.md")
+	require.NotContains(t, skillSrc, "channel-health")
+}
+
+func communicationSpec(name string) *spec.APISpec {
+	apiSpec := minimalSpec(name)
+	apiSpec.Resources = map[string]spec.Resource{
+		"messages": {
+			Description: "Channel messages",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/messages", Description: "List messages"},
+			},
+		},
+		"channels": {
+			Description: "Chat channels",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/channels", Description: "List channels"},
+			},
+		},
+	}
+	return apiSpec
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #4536

## Intent

Every generate against a communication-archetype spec warned:

```
warning: skipping workflow template workflows/comm_health.go.tmpl: ... file does not exist in templates embed
```

`SelectVisionTemplates` still listed `workflows/comm_health.go.tmpl`, but that file was never added to `internal/generator/templates/workflows/` (only the PM `pm_*` templates exist). Git history shows the selector landed with the original vision work; the template itself was never committed, and `commandConstructorForTemplate` never had a case for it.

## Approach

Remove the dead communication selector. Communication CLIs keep insight commands (`health`, `similar`) when the plan has an insight; they no longer try to render a missing workflow.

Also stop advertising a `channel-health` command that was never emitted (MCP playbook + README archetype table).

A regression test now requires every archetype-selected workflow/insight template to exist in the embed and have a constructor, and asserts a communication-archetype generate is silent about `comm_health`.

## Scope

Primary area: generator vision template selection.

Why this belongs in this repo: the warning comes from the Printing Press generator, not a printed CLI.

## Risk

Communication prints lose a command they never actually received. Generate stderr for communication specs becomes quiet. No MCP/auth/publish/scorecard contract change.

## Output Contract

No new generated file. The selected-template set for `communication` is now empty (same as payments/content). Evidence: `TestSelectVisionTemplatesSelectedFilesExistInEmbed` and `TestGenerateCommunicationArchetypeDoesNotWarnOnMissingCommHealth` (stderr + no `comm_health.go`). Existing generate golden cases passed unchanged. Local `scripts/golden.sh verify` also failed on `dogfood-verdict-matrix` and `verify-runtime-matrix` because this environment cannot download the fixture CLIs' `go 1.24` toolchain (`toolchain not available`); that is unrelated to this selector change and was not used as a reason to update fixtures.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:

- `go test ./internal/generator/ -run 'TestSelectVisionTemplatesSelectedFilesExistInEmbed|TestGenerateCommunicationArchetypeDoesNotWarnOnMissingCommHealth'`
- `go test ./internal/generator/ -timeout 20m`
- `go test ./internal/cli/ ./internal/pipeline/ ./internal/openapi/ ...` (remaining packages after generator; earlier packages also passed under `go test ./...` before the default 10m generator timeout)
- `bash scripts/golden.sh verify` — all `generate-*` cases PASS; local-only fixture-CLI toolchain misses on dogfood/verify-runtime matrix as noted above

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04e7c68e-8afc-4762-852a-616b57dd31a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04e7c68e-8afc-4762-852a-616b57dd31a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

