### PR TITLE
fix(cli): preserve novel features across mcp-sync

### DIFF
--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -161,8 +161,12 @@ type CLIManifest struct {
 	AuthOptional               bool                        `json:"auth_optional,omitempty"`
 	ReviewedSecretSuppressions []ReviewedSecretSuppression `json:"reviewed_secret_suppressions,omitempty"`
 	NovelFeatures              []NovelFeatureManifest      `json:"novel_features,omitempty"`
-	Scorecard                  *CLIManifestScorecard       `json:"scorecard,omitempty"`
-	Verify                     *CLIManifestVerify          `json:"verify,omitempty"`
+	// NovelFeaturesBuilt is the dogfood-verified subset persisted by
+	// scorecard. It is research-originated and is not spec-derived, so
+	// regen paths that lack a research dir must leave it in place.
+	NovelFeaturesBuilt []NovelFeatureManifest `json:"novel_features_built,omitempty"`
+	Scorecard          *CLIManifestScorecard  `json:"scorecard,omitempty"`
+	Verify             *CLIManifestVerify     `json:"verify,omitempty"`
 	// generatedEnvReads is a write-scoped scan of os.Getenv names already
 	// emitted into the printed CLI. It is not serialized; WriteMCPBManifest
 	// and reconcile attach it so a kept colliding override can bind the
@@ -294,9 +298,11 @@ func readCLIManifestFile(path string) (CLIManifest, error) {
 //
 // Generate-time fields (spec_url, spec_path, spec_checksum,
 // generated_at, printing_press_version, schema_version, novel_features,
-// category, cli_name, api_name, api_version, description)
-// are preserved as-is. Only the spec-driven MCP/auth/display fields
-// are refreshed.
+// novel_features_built, category, cli_name, api_name, api_version,
+// description) are preserved as-is. Research-originated keys that the
+// typed struct does not model are kept via the raw merge so a refresh
+// without --research-dir cannot zero the publish transcendence gate.
+// Only the spec-driven MCP/auth/display fields are refreshed.
 //
 // Returns nil silently when .printing-press.json is missing — callers
 // generating from scratch don't need a provenance-refresh step.
@@ -311,6 +317,10 @@ func RefreshCLIManifestFromSpec(dir string, parsed *spec.APISpec) error {
 		}
 		return fmt.Errorf("reading CLI manifest for refresh: %w", err)
 	}
+	var existingRaw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &existingRaw); err != nil {
+		return fmt.Errorf("parsing CLI manifest for refresh: %w", err)
+	}
 	var m CLIManifest
 	if err := json.Unmarshal(data, &m); err != nil {
 		return fmt.Errorf("parsing CLI manifest for refresh: %w", err)
@@ -320,7 +330,7 @@ func RefreshCLIManifestFromSpec(dir string, parsed *spec.APISpec) error {
 	if preserveExistingDescription(existingDescription) {
 		m.Description = existingDescription
 	}
-	return WriteCLIManifest(dir, m)
+	return writeCLIManifestPreservingRaw(dir, m, existingRaw)
 }
 
 // WriteCLIManifest marshals m as indented JSON and writes it to

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -246,7 +246,7 @@ func (m CLIManifest) IsSyntheticSpec() bool {
 type NovelFeatureManifest struct {
 	Name        string `json:"name"`
 	Command     string `json:"command"`
-	Description string `json:"description"`
+	Description string `json:"description,omitempty"`
 }
 
 // ReadCLIBinaryName reads .printing-press.json from dir and returns the

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -2262,6 +2262,32 @@ func TestRefreshCLIManifestFromSpecPreservesNovelFeaturesBuilt(t *testing.T) {
 	require.Len(t, got.NovelFeatures, 1)
 }
 
+func TestRefreshCLIManifestFromSpecPreservesCompactNovelFeaturesBuilt(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, CLIManifestFilename), []byte(`{
+  "schema_version": 1,
+  "api_name": "example",
+  "cli_name": "example-pp-cli",
+  "novel_features_built": [{"name":"Health","command":"health"}]
+}
+`), 0o644))
+
+	require.NoError(t, RefreshCLIManifestFromSpec(dir, &spec.APISpec{Name: "example"}))
+
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	require.NoError(t, err)
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.JSONEq(t, `[{"name":"Health","command":"health"}]`, string(raw["novel_features_built"]))
+
+	got, err := ReadCLIManifest(dir)
+	require.NoError(t, err)
+	require.Len(t, got.NovelFeaturesBuilt, 1)
+	assert.Equal(t, "Health", got.NovelFeaturesBuilt[0].Name)
+	assert.Equal(t, "health", got.NovelFeaturesBuilt[0].Command)
+	assert.Empty(t, got.NovelFeaturesBuilt[0].Description)
+}
+
 func writeManifest(t *testing.T, dir string, m CLIManifest) {
 	t.Helper()
 	data, err := json.Marshal(m)

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -2222,6 +2222,46 @@ func TestRefreshCLIManifestFromSpecRefreshesDisplayName(t *testing.T) {
 	assert.Equal(t, "Cal.com", got.DisplayName)
 }
 
+func TestRefreshCLIManifestFromSpecPreservesNovelFeaturesBuilt(t *testing.T) {
+	dir := t.TempDir()
+	built := []NovelFeatureManifest{
+		{Name: "Health", Command: "health", Description: "Summarize health."},
+		{Name: "Stale", Command: "stale", Description: "Find stale items."},
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, CLIManifestFilename), []byte(`{
+  "schema_version": 1,
+  "api_name": "example",
+  "cli_name": "example-pp-cli",
+  "auth_type": "api_key",
+  "novel_features": [{"name":"Health","command":"health","description":"Summarize health."}],
+  "novel_features_built": [
+    {"name":"Health","command":"health","description":"Summarize health."},
+    {"name":"Stale","command":"stale","description":"Find stale items."}
+  ],
+  "research_note": "keep-me"
+}
+`), 0o644))
+
+	require.NoError(t, RefreshCLIManifestFromSpec(dir, &spec.APISpec{
+		Name: "example",
+		Auth: spec.AuthConfig{Type: "none"},
+	}))
+
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	require.NoError(t, err)
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.JSONEq(t, `[{"name":"Health","command":"health","description":"Summarize health."},{"name":"Stale","command":"stale","description":"Find stale items."}]`, string(raw["novel_features_built"]))
+	assert.JSONEq(t, `"keep-me"`, string(raw["research_note"]), "unknown research-originated keys must survive refresh")
+
+	got, err := ReadCLIManifest(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "none", got.AuthType, "spec-derived auth_type must still refresh")
+	require.Len(t, got.NovelFeaturesBuilt, 2)
+	assert.Equal(t, built, got.NovelFeaturesBuilt)
+	require.Len(t, got.NovelFeatures, 1)
+}
+
 func writeManifest(t *testing.T, dir string, m CLIManifest) {
 	t.Helper()
 	data, err := json.Marshal(m)

--- a/internal/pipeline/mcpsync/sync.go
+++ b/internal/pipeline/mcpsync/sync.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/generator"
@@ -264,6 +265,7 @@ func Sync(cliDir string, opts Options) (Result, error) {
 		return Result{}, err
 	}
 	features := loadNovelFeatures(cliDir)
+	preserveExistingLearnLoop(cliDir, parsed)
 	// Migration-only steps run when the surface is on the legacy
 	// template. Already-migrated CLIs skip these.
 	if !alreadyMigrated {
@@ -596,15 +598,78 @@ func loadNovelFeatures(cliDir string) []generator.NovelFeature {
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return nil
 	}
-	features := make([]generator.NovelFeature, 0, len(manifest.NovelFeatures))
-	for _, nf := range manifest.NovelFeatures {
+	recorded := manifest.NovelFeatures
+	if len(manifest.NovelFeaturesBuilt) > 0 {
+		recorded = manifest.NovelFeaturesBuilt
+	}
+	features := make([]generator.NovelFeature, 0, len(recorded))
+	for _, nf := range recorded {
 		features = append(features, generator.NovelFeature{
 			Name:        nf.Name,
 			Command:     nf.Command,
 			Description: nf.Description,
 		})
 	}
+	return mergeNovelFeatureRationalesFromTools(cliDir, features)
+}
+
+// commandMirrorCapabilityRE matches the generated command_mirror_capabilities
+// entries in tools.go. Key order is the mcp_tools.go.tmpl contract.
+var commandMirrorCapabilityRE = regexp.MustCompile(`\{"name": ("(?:\\.|[^"\\])*"), "command": ("(?:\\.|[^"\\])*"), "description": ("(?:\\.|[^"\\])*"), "rationale": ("(?:\\.|[^"\\])*"), "via": "mcp-command-mirror"\}`)
+
+// mergeNovelFeatureRationalesFromTools fills empty Rationale values from the
+// existing tools.go surface. mcp-sync has no --research-dir, so the
+// previously generated MCP context is the recorded source; this does not
+// invent features that are not already in the manifest.
+func mergeNovelFeatureRationalesFromTools(cliDir string, features []generator.NovelFeature) []generator.NovelFeature {
+	if len(features) == 0 {
+		return features
+	}
+	data, err := os.ReadFile(filepath.Join(cliDir, "internal", "mcp", "tools.go"))
+	if err != nil {
+		return features
+	}
+	byCommand := map[string]string{}
+	for _, match := range commandMirrorCapabilityRE.FindAllStringSubmatch(string(data), -1) {
+		if len(match) != 5 {
+			continue
+		}
+		command, err := strconv.Unquote(match[2])
+		if err != nil || command == "" {
+			continue
+		}
+		rationale, err := strconv.Unquote(match[4])
+		if err != nil || rationale == "" {
+			continue
+		}
+		byCommand[command] = rationale
+	}
+	for i := range features {
+		if features[i].Rationale != "" {
+			continue
+		}
+		if rationale := byCommand[features[i].Command]; rationale != "" {
+			features[i].Rationale = rationale
+		}
+	}
 	return features
+}
+
+// preserveExistingLearnLoop keeps learn.enabled on when mcp-sync reloads a
+// spec that never recorded the generate-time default. GenerateMCPSurface
+// deliberately does not apply ApplyLearnLoopDefault, because published CLIs
+// may lack the learn package; flipping the default there would emit a broken
+// import. When the package is already in the tree, dropping learn_protocol
+// from tools.go is a silent surface regression.
+func preserveExistingLearnLoop(cliDir string, parsed *spec.APISpec) {
+	if parsed == nil || parsed.Learn.Disabled || parsed.Learn.Enabled || parsed.Learn.EnabledSet {
+		return
+	}
+	info, err := os.Stat(filepath.Join(cliDir, "internal", "learn"))
+	if err != nil || !info.IsDir() {
+		return
+	}
+	parsed.Learn.Enabled = true
 }
 
 func ensureEndpointAnnotations(cliDir string, parsed *spec.APISpec, features []generator.NovelFeature) error {

--- a/internal/pipeline/mcpsync/sync_preserve_test.go
+++ b/internal/pipeline/mcpsync/sync_preserve_test.go
@@ -1,6 +1,7 @@
 package mcpsync
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -358,3 +359,150 @@ type plantError string
 func (e plantError) Error() string { return "plant hand-authored MCP behavior: " + string(e) }
 
 func errPlant(what string) error { return plantError(what) }
+
+func TestSyncPreservesNovelFeatureMetadata(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "novelfeatures",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Learn:   spec.LearnConfig{Enabled: true, EnabledSet: true},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/novelfeatures-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Description: "Manage items",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/items", Description: "List items"},
+				},
+			},
+		},
+	}
+	cliDir := filepath.Join(t.TempDir(), "novelfeatures")
+	gen := generator.New(apiSpec, cliDir)
+	gen.VisionSet = generator.VisionTemplateSet{MCP: true, Store: true}
+	gen.NovelFeatures = []generator.NovelFeature{
+		{Name: "Health dashboard", Command: "health", Description: "Summarize health.", Rationale: "Requires local joins."},
+		{Name: "Stale triage", Command: "stale", Description: "Find stale items.", Rationale: "Requires workflow analysis."},
+	}
+	require.NoError(t, gen.Generate())
+	require.NoError(t, pipeline.WriteManifestForGenerate(pipeline.GenerateManifestParams{
+		APIName:   apiSpec.Name,
+		OutputDir: cliDir,
+		Spec:      apiSpec,
+		NovelFeatures: []pipeline.NovelFeatureManifest{
+			{Name: "Health dashboard", Command: "health", Description: "Summarize health."},
+			{Name: "Stale triage", Command: "stale", Description: "Find stale items."},
+		},
+	}))
+
+	manifest, err := pipeline.ReadCLIManifest(cliDir)
+	require.NoError(t, err)
+	manifest.NovelFeaturesBuilt = append([]pipeline.NovelFeatureManifest(nil), manifest.NovelFeatures...)
+	require.NoError(t, pipeline.WriteCLIManifest(cliDir, manifest))
+
+	archived := *apiSpec
+	archived.Learn = spec.LearnConfig{}
+	specData, err := yaml.Marshal(&archived)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "spec.yaml"), specData, 0o644))
+
+	toolsBefore, err := os.ReadFile(filepath.Join(cliDir, "internal", "mcp", "tools.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(toolsBefore), `"rationale": "Requires local joins."`)
+	require.Contains(t, string(toolsBefore), `"learn_protocol": learn.RecallFirstProtocol`)
+
+	_, err = Sync(cliDir, Options{})
+	require.NoError(t, err)
+
+	after, err := pipeline.ReadCLIManifest(cliDir)
+	require.NoError(t, err)
+	require.Len(t, after.NovelFeaturesBuilt, 2, "mcp-sync must not zero novel_features_built")
+	assert.Equal(t, "health", after.NovelFeaturesBuilt[0].Command)
+	assert.Equal(t, "stale", after.NovelFeaturesBuilt[1].Command)
+	require.Len(t, after.NovelFeatures, 2, "mcp-sync must keep recorded novel_features")
+
+	raw, err := os.ReadFile(filepath.Join(cliDir, pipeline.CLIManifestFilename))
+	require.NoError(t, err)
+	var rawManifest map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &rawManifest))
+	assert.JSONEq(t, `[{"name":"Health dashboard","command":"health","description":"Summarize health."},{"name":"Stale triage","command":"stale","description":"Find stale items."}]`, string(rawManifest["novel_features_built"]))
+
+	toolsAfter, err := os.ReadFile(filepath.Join(cliDir, "internal", "mcp", "tools.go"))
+	require.NoError(t, err)
+	toolsSrc := string(toolsAfter)
+	assert.Contains(t, toolsSrc, `"rationale": "Requires local joins."`)
+	assert.Contains(t, toolsSrc, `"rationale": "Requires workflow analysis."`)
+	assert.Contains(t, toolsSrc, `"learn_protocol": learn.RecallFirstProtocol`)
+	assert.Contains(t, toolsSrc, `internal/learn"`)
+}
+
+func TestMergeNovelFeatureRationalesFromTools(t *testing.T) {
+	t.Parallel()
+
+	cliDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(cliDir, "internal", "mcp"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "internal", "mcp", "tools.go"), []byte(`
+		"command_mirror_capabilities": []map[string]string{
+			{"name": "Health dashboard", "command": "health", "description": "Summarize health.", "rationale": "Requires local joins.", "via": "mcp-command-mirror"},
+			{"name": "Stale triage", "command": "stale", "description": "Find stale items.", "rationale": "Requires workflow analysis.", "via": "mcp-command-mirror"},
+		},
+`), 0o644))
+
+	got := mergeNovelFeatureRationalesFromTools(cliDir, []generator.NovelFeature{
+		{Name: "Health dashboard", Command: "health", Description: "Summarize health."},
+		{Name: "Stale triage", Command: "stale", Description: "Find stale items.", Rationale: "keep existing"},
+		{Name: "Unrecorded", Command: "ghost", Description: "Not in tools.go."},
+	})
+	require.Len(t, got, 3)
+	assert.Equal(t, "Requires local joins.", got[0].Rationale)
+	assert.Equal(t, "keep existing", got[1].Rationale)
+	assert.Empty(t, got[2].Rationale)
+}
+
+func TestPreserveExistingLearnLoop(t *testing.T) {
+	t.Parallel()
+
+	cliDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(cliDir, "internal", "learn"), 0o755))
+
+	parsed := &spec.APISpec{}
+	preserveExistingLearnLoop(cliDir, parsed)
+	assert.True(t, parsed.Learn.Enabled)
+
+	explicitOff := &spec.APISpec{Learn: spec.LearnConfig{EnabledSet: true}}
+	preserveExistingLearnLoop(cliDir, explicitOff)
+	assert.False(t, explicitOff.Learn.Enabled)
+
+	disabled := &spec.APISpec{Learn: spec.LearnConfig{Disabled: true}}
+	preserveExistingLearnLoop(cliDir, disabled)
+	assert.False(t, disabled.Learn.Enabled)
+
+	missing := &spec.APISpec{}
+	preserveExistingLearnLoop(t.TempDir(), missing)
+	assert.False(t, missing.Learn.Enabled)
+}
+
+func TestLoadNovelFeaturesPrefersBuiltList(t *testing.T) {
+	t.Parallel()
+
+	cliDir := t.TempDir()
+	require.NoError(t, pipeline.WriteCLIManifest(cliDir, pipeline.CLIManifest{
+		APIName: "example",
+		CLIName: "example-pp-cli",
+		NovelFeatures: []pipeline.NovelFeatureManifest{
+			{Name: "Planned", Command: "planned", Description: "Not verified."},
+		},
+		NovelFeaturesBuilt: []pipeline.NovelFeatureManifest{
+			{Name: "Health dashboard", Command: "health", Description: "Summarize health."},
+		},
+	}))
+
+	got := loadNovelFeatures(cliDir)
+	require.Len(t, got, 1)
+	assert.Equal(t, "health", got[0].Command)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

`mcp-sync` regenerates the MCP surface from the spec/templates/`mcp-descriptions.json` and refreshes spec-derived `.printing-press.json` fields. It has no `--research-dir`, so research-originated metadata was treated as empty and wiped: `novel_features_built` went N→0, novel-feature rationales disappeared from `tools.go`, and `learn_protocol` refs dropped. That silently disarms `publish validate`'s transcendence gate.

Closes #4317

## Approach

Preserve in place rather than adding `--research-dir`.

- Manifest refresh now raw-merges `.printing-press.json` so `novel_features_built` and other non-spec keys survive, while spec-derived MCP/auth/display fields still refresh.
- `mcp-sync` reloads recorded novel features (preferring `novel_features_built`) and restores rationales from the existing `tools.go` command-mirror block instead of inventing features.
- If the printed CLI already has `internal/learn`, keep `learn.enabled` for the MCP regen so `learn_protocol` is not dropped when the archived spec omitted the generate-time default.
- `NovelFeatureManifest.Description` uses `omitempty` so compact research JSON (name/command only) round-trips through typed manifest writes. Typing `novel_features_built` onto `CLIManifest` otherwise emitted `"description":""` and broke `TestPromoteWorkingCLI_PreservesPatchAndManifestUnion`.

## Scope

Primary area: mcp-sync / CLI manifest rewrite.

Why this belongs in this repo: every printed CLI with novel features is exposed; the generator's regen path should not zero research-originated gate input.

## Risk

mcp-sync still refreshes spec-derived fields. It will not invent novel features. A CLI whose tree has no `internal/learn` package still omits `learn_protocol` (same as today).

## Output Contract

N/A — no template/generator emit change. Contract is mcp-sync preservation of already-recorded research metadata; covered by package tests, not goldens.

## Verification

- [x] `go test ./internal/pipeline -run 'TestPromoteWorkingCLI_PreservesPatchAndManifestUnion|TestRefreshCLIManifestFromSpecPreserves'`
- [x] `go test ./internal/pipeline/...` (pipeline CI shard packages)
- [x] `go test ./internal/pipeline/mcpsync -run TestSyncPreservesNovelFeatureMetadata|TestMergeNovelFeatureRationalesFromTools|TestPreserveExistingLearnLoop|TestLoadNovelFeaturesPrefersBuiltList`

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b761814-0f37-45b7-9738-42105c052af4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b761814-0f37-45b7-9738-42105c052af4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

