### PR TITLE
fix(cli): stop baking HAR resource ids into generated defaults

### DIFF
--- a/internal/browsersniff/capture_ids.go
+++ b/internal/browsersniff/capture_ids.go
@@ -16,10 +16,10 @@ var (
 	prefixedIDInTextPattern = regexp.MustCompile(`\b[a-z]{1,5}_[A-Za-z0-9]{8,}\b`)
 )
 
-// SanitizeSpecCapturedResourceIDs replaces capture-session resource ids in
-// spec defaults and examples with same-shape synthetics, and omits scalar
-// defaults that are only a captured id. Persisted-query hashes, dispatch
-// discriminators, and vendor-prefix token shapes are left alone.
+// Live HAR captures copy session resource ids into spec defaults. Those
+// values must not ship in public prints; hashes, dispatch discriminators,
+// and vendor-prefix tokens stay so secret detection and GraphQL persisted
+// queries keep working.
 func SanitizeSpecCapturedResourceIDs(apiSpec *spec.APISpec) {
 	if apiSpec == nil {
 		return
@@ -151,7 +151,7 @@ func isCapturedResourceID(value string) bool {
 	if uuidSegmentPattern.MatchString(value) {
 		return true
 	}
-	if prefixedIDPattern.MatchString(value) && !capturedResourceIDSecretPrefix(value) {
+	if prefixedIDPattern.MatchString(value) && !capturedResourceIDSecretPrefix(value) && looksOpaqueID(value) {
 		return true
 	}
 	return longAlnumIDPattern.MatchString(value) && looksOpaqueID(value)

--- a/internal/browsersniff/capture_ids.go
+++ b/internal/browsersniff/capture_ids.go
@@ -1,0 +1,214 @@
+package browsersniff
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/piiplaceholders"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+)
+
+const syntheticIDMarker = "example"
+
+var (
+	uuidInTextPattern       = regexp.MustCompile(`(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b`)
+	prefixedIDInTextPattern = regexp.MustCompile(`\b[a-z]{1,5}_[A-Za-z0-9]{8,}\b`)
+)
+
+// SanitizeSpecCapturedResourceIDs replaces capture-session resource ids in
+// spec defaults and examples with same-shape synthetics, and omits scalar
+// defaults that are only a captured id. Persisted-query hashes, dispatch
+// discriminators, and vendor-prefix token shapes are left alone.
+func SanitizeSpecCapturedResourceIDs(apiSpec *spec.APISpec) {
+	if apiSpec == nil {
+		return
+	}
+	apiSpec.Resources = sanitizeCapturedResourceIDResources(apiSpec.Resources)
+}
+
+func sanitizeCapturedResourceIDResources(resources map[string]spec.Resource) map[string]spec.Resource {
+	if len(resources) == 0 {
+		return resources
+	}
+	for name, resource := range resources {
+		resources[name] = sanitizeCapturedResourceIDResource(resource)
+	}
+	return resources
+}
+
+func sanitizeCapturedResourceIDResource(resource spec.Resource) spec.Resource {
+	if len(resource.Endpoints) > 0 {
+		for name, endpoint := range resource.Endpoints {
+			resource.Endpoints[name] = sanitizeCapturedResourceIDEndpoint(endpoint)
+		}
+	}
+	resource.SubResources = sanitizeCapturedResourceIDResources(resource.SubResources)
+	return resource
+}
+
+func sanitizeCapturedResourceIDEndpoint(endpoint spec.Endpoint) spec.Endpoint {
+	sanitizeCapturedResourceIDParams(endpoint.Params)
+	sanitizeCapturedResourceIDParams(endpoint.Body)
+	endpoint.Example = replaceCapturedResourceIDsInText(endpoint.Example)
+	endpoint.HappyArgs = replaceCapturedResourceIDsInText(endpoint.HappyArgs)
+	endpoint.HappyStdin = sanitizeCapturedResourceIDJSONString(endpoint.HappyStdin)
+	return endpoint
+}
+
+func sanitizeCapturedResourceIDParams(params []spec.Param) {
+	for i := range params {
+		sanitizeCapturedResourceIDParam(&params[i])
+	}
+}
+
+func sanitizeCapturedResourceIDParam(param *spec.Param) {
+	if param == nil {
+		return
+	}
+	if !param.DispatchParam {
+		if _, ok := capturedResourceIDScalar(param.Default); ok {
+			param.Default = nil
+		} else {
+			param.Default = sanitizeCapturedResourceIDValue(param.Default)
+		}
+	}
+	param.Example = sanitizeCapturedResourceIDValue(param.Example)
+	sanitizeCapturedResourceIDParams(param.Fields)
+}
+
+func capturedResourceIDScalar(value any) (string, bool) {
+	s, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+	s = strings.TrimSpace(s)
+	if !isCapturedResourceID(s) {
+		return "", false
+	}
+	return s, true
+}
+
+func sanitizeCapturedResourceIDJSONString(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return value
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+		return replaceCapturedResourceIDsInText(value)
+	}
+	sanitized := sanitizeCapturedResourceIDValue(parsed)
+	out, err := json.Marshal(sanitized)
+	if err != nil {
+		return replaceCapturedResourceIDsInText(value)
+	}
+	return string(out)
+}
+
+func sanitizeCapturedResourceIDValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			if skipCapturedResourceIDKey(key) {
+				continue
+			}
+			typed[key] = sanitizeCapturedResourceIDValue(child)
+		}
+		return typed
+	case []any:
+		for i, child := range typed {
+			typed[i] = sanitizeCapturedResourceIDValue(child)
+		}
+		return typed
+	case string:
+		if isCapturedResourceID(typed) {
+			return syntheticCapturedResourceID(typed)
+		}
+		return typed
+	default:
+		return value
+	}
+}
+
+func skipCapturedResourceIDKey(key string) bool {
+	switch strings.ToLower(strings.ReplaceAll(strings.TrimSpace(key), "_", "")) {
+	case "sha256hash", "hash", "digest", "checksum":
+		return true
+	default:
+		return false
+	}
+}
+
+func isCapturedResourceID(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" || isSyntheticCapturedResourceID(value) {
+		return false
+	}
+	if hashSegmentPattern.MatchString(value) {
+		return false
+	}
+	if uuidSegmentPattern.MatchString(value) {
+		return true
+	}
+	if prefixedIDPattern.MatchString(value) && !capturedResourceIDSecretPrefix(value) {
+		return true
+	}
+	return longAlnumIDPattern.MatchString(value) && looksOpaqueID(value)
+}
+
+func capturedResourceIDSecretPrefix(value string) bool {
+	prefix, _, ok := strings.Cut(value, "_")
+	if !ok {
+		return false
+	}
+	switch prefix {
+	case "ghp", "gho", "ghs", "sk":
+		return true
+	default:
+		return false
+	}
+}
+
+func isSyntheticCapturedResourceID(value string) bool {
+	value = strings.TrimSpace(value)
+	if strings.EqualFold(value, piiplaceholders.SyntheticUUID) {
+		return true
+	}
+	_, tail, ok := strings.Cut(value, "_")
+	if ok && strings.HasPrefix(tail, syntheticIDMarker) {
+		return true
+	}
+	return strings.HasPrefix(value, syntheticIDMarker)
+}
+
+func syntheticCapturedResourceID(value string) string {
+	value = strings.TrimSpace(value)
+	if uuidSegmentPattern.MatchString(value) {
+		return piiplaceholders.SyntheticUUID
+	}
+	if prefix, tail, ok := strings.Cut(value, "_"); ok && prefixedIDPattern.MatchString(value) {
+		return prefix + "_" + padSyntheticIDTail(len(tail))
+	}
+	return padSyntheticIDTail(len(value))
+}
+
+func padSyntheticIDTail(length int) string {
+	if length <= len(syntheticIDMarker) {
+		return syntheticIDMarker
+	}
+	return syntheticIDMarker + strings.Repeat("0", length-len(syntheticIDMarker))
+}
+
+func replaceCapturedResourceIDsInText(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return value
+	}
+	out := uuidInTextPattern.ReplaceAllString(value, piiplaceholders.SyntheticUUID)
+	return prefixedIDInTextPattern.ReplaceAllStringFunc(out, func(match string) string {
+		if !isCapturedResourceID(match) {
+			return match
+		}
+		return syntheticCapturedResourceID(match)
+	})
+}

--- a/internal/browsersniff/capture_ids_test.go
+++ b/internal/browsersniff/capture_ids_test.go
@@ -137,3 +137,30 @@ func TestSanitizeSpecCapturedResourceIDs_KeepsDispatchAndSecrets(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", persisted["sha256Hash"])
 }
+
+func TestSanitizeSpecCapturedResourceIDs_KeepsSnakeResourceNames(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Resources: map[string]spec.Resource{
+			"issue_categories": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:  "GET",
+						Path:    "/issue_categories",
+						Example: "  snake-example-pp-cli issue_categories list --from-spec",
+						Params: []spec.Param{
+							{Name: "slug", Type: "string", Default: "issue_categories"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	SanitizeSpecCapturedResourceIDs(apiSpec)
+
+	list := apiSpec.Resources["issue_categories"].Endpoints["list"]
+	assert.Equal(t, "  snake-example-pp-cli issue_categories list --from-spec", list.Example)
+	assert.Equal(t, "issue_categories", list.Params[0].Default)
+}

--- a/internal/browsersniff/capture_ids_test.go
+++ b/internal/browsersniff/capture_ids_test.go
@@ -1,0 +1,139 @@
+package browsersniff
+
+import (
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/piiplaceholders"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	capturedCLIID       = "cli_a1b2c3d4e5f6g7h8i9j0"
+	capturedCLIExample  = "cli_example0000000000000"
+	capturedPropID      = "prop_k9m2n3p4q5r6s7t8u9v0"
+	capturedPropExample = "prop_example0000000000000"
+	capturedUUID        = "7c9e6679-7425-40de-944b-e07fc1f90ae7"
+)
+
+func TestSanitizeCapturedResourceIDValue(t *testing.T) {
+	t.Parallel()
+
+	got := sanitizeCapturedResourceIDValue(map[string]any{
+		"id":         capturedCLIID,
+		"clientId":   capturedCLIID,
+		"propertyId": capturedPropID,
+		"uuid":       capturedUUID,
+		"date":       "2026-04-22",
+		"slug":       "sample-product",
+		"hash":       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"nested": map[string]any{
+			"id": capturedPropID,
+		},
+	})
+	object, ok := got.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, capturedCLIExample, object["id"])
+	assert.Equal(t, capturedCLIExample, object["clientId"])
+	assert.Equal(t, capturedPropExample, object["propertyId"])
+	assert.Equal(t, piiplaceholders.SyntheticUUID, object["uuid"])
+	assert.Equal(t, "2026-04-22", object["date"])
+	assert.Equal(t, "sample-product", object["slug"])
+	assert.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", object["hash"])
+	nested, ok := object["nested"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, capturedPropExample, nested["id"])
+	assert.NotContains(t, object["id"], capturedCLIID)
+}
+
+func TestSanitizeCapturedResourceIDValue_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	first := sanitizeCapturedResourceIDValue(map[string]any{"id": capturedCLIID})
+	second := sanitizeCapturedResourceIDValue(first)
+	assert.Equal(t, first, second)
+}
+
+func TestSanitizeSpecCapturedResourceIDs_OmitsScalarIDDefaults(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Resources: map[string]spec.Resource{
+			"clients": {
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Params: []spec.Param{
+							{Name: "id", Type: "string", Required: true, Default: capturedCLIID},
+							{Name: "q", Type: "string", Default: "hello"},
+						},
+						Body: []spec.Param{
+							{
+								Name:    "variables",
+								Type:    "object",
+								Default: map[string]any{"id": capturedCLIID},
+							},
+							{Name: "operationName", Type: "string", Default: "GetClient"},
+						},
+						Example: "clients get --variables {\"id\":\"" + capturedCLIID + "\"}",
+					},
+				},
+			},
+		},
+	}
+
+	SanitizeSpecCapturedResourceIDs(apiSpec)
+
+	get := apiSpec.Resources["clients"].Endpoints["get"]
+	assert.Nil(t, get.Params[0].Default)
+	assert.Equal(t, "hello", get.Params[1].Default)
+	vars, ok := get.Body[0].Default.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, capturedCLIExample, vars["id"])
+	assert.Equal(t, "GetClient", get.Body[1].Default)
+	assert.NotContains(t, get.Example, capturedCLIID)
+	assert.Contains(t, get.Example, capturedCLIExample)
+}
+
+func TestSanitizeSpecCapturedResourceIDs_KeepsDispatchAndSecrets(t *testing.T) {
+	t.Parallel()
+
+	githubToken := "ghp_" + "abcdefghijklmnopqrstuvwxyz0123456789"
+	apiSpec := &spec.APISpec{
+		Resources: map[string]spec.Resource{
+			"search": {
+				Endpoints: map[string]spec.Endpoint{
+					"run": {
+						Params: []spec.Param{
+							{Name: "type", Type: "string", Default: "domain_rank", DispatchParam: true},
+						},
+						Body: []spec.Param{
+							{Name: "token", Type: "string", Default: githubToken},
+							{
+								Name: "extensions",
+								Type: "object",
+								Default: map[string]any{
+									"persistedQuery": map[string]any{
+										"version":    1,
+										"sha256Hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	SanitizeSpecCapturedResourceIDs(apiSpec)
+
+	run := apiSpec.Resources["search"].Endpoints["run"]
+	assert.Equal(t, "domain_rank", run.Params[0].Default)
+	assert.Equal(t, githubToken, run.Body[0].Default)
+	extensions, ok := run.Body[1].Default.(map[string]any)
+	require.True(t, ok)
+	persisted, ok := extensions["persistedQuery"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", persisted["sha256Hash"])
+}

--- a/internal/browsersniff/specgen.go
+++ b/internal/browsersniff/specgen.go
@@ -133,6 +133,8 @@ func AnalyzeCaptureWithOptions(capture *EnrichedCapture, options AnalyzeOptions)
 		Types:     inferredTypes.types,
 	}
 
+	SanitizeSpecCapturedResourceIDs(apiSpec)
+
 	if err := apiSpec.Validate(); err != nil {
 		if len(apiSpec.Resources) == 0 && len(groups) > 0 {
 			apiSpec.Resources["default"] = spec.Resource{

--- a/internal/browsersniff/specgen_test.go
+++ b/internal/browsersniff/specgen_test.go
@@ -163,6 +163,44 @@ func TestAnalyzeCapture_PromotesPostFormHTMLTableFragment(t *testing.T) {
 	require.NoError(t, apiSpec.Validate())
 }
 
+func TestAnalyzeCapture_OmitsCapturedResourceIDFormDefaults(t *testing.T) {
+	t.Parallel()
+
+	const cliID = "cli_a1b2c3d4e5f6g7h8i9j0"
+	apiSpec, err := AnalyzeCapture(&EnrichedCapture{
+		TargetURL: "https://www.example.com/contracts",
+		Entries: []EnrichedEntry{
+			{
+				Method:              "POST",
+				URL:                 "https://www.example.com/nba/contracts/_/position/g",
+				RequestHeaders:      map[string]string{"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8", "X-Requested-With": "XMLHttpRequest"},
+				RequestBody:         "ajax=table&clientId=" + cliID,
+				ResponseStatus:      200,
+				ResponseContentType: "text/html; charset=utf-8",
+				ResponseBody:        `<table><thead><tr><th>Player</th></tr></thead><tbody><tr><td>Ada</td></tr></tbody></table>`,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	endpoint, found := findEndpointByPath(apiSpec, "/nba/contracts/_/position/g")
+	require.True(t, found)
+	byName := map[string]spec.Param{}
+	for _, param := range endpoint.Body {
+		byName[param.Name] = param
+	}
+	require.Contains(t, byName, "ajax")
+	assert.Equal(t, "table", byName["ajax"].Default)
+	require.Contains(t, byName, "clientId")
+	assert.Nil(t, byName["clientId"].Default)
+
+	specPath := filepath.Join(t.TempDir(), "form-spec.yaml")
+	require.NoError(t, WriteSpec(apiSpec, specPath))
+	specYAML, err := os.ReadFile(specPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(specYAML), cliID)
+}
+
 func TestAnalyzeCapture_GetHTMLWithTableStillPrefersLinks(t *testing.T) {
 	t.Parallel()
 
@@ -419,6 +457,67 @@ func TestAnalyzeCapture_ExpandsGraphQLBFFOperations(t *testing.T) {
 	launches := products.Endpoints["launches"]
 	assert.Equal(t, "POST", launches.Method)
 	assert.Equal(t, "/frontend/graphql", launches.Path)
+}
+
+func TestAnalyzeCapture_StripsCapturedResourceIDsFromDefaults(t *testing.T) {
+	t.Parallel()
+
+	const (
+		cliID  = "cli_a1b2c3d4e5f6g7h8i9j0"
+		propID = "prop_k9m2n3p4q5r6s7t8u9v0"
+		hash   = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+	capture := &EnrichedCapture{
+		TargetURL: "https://www.example.com",
+		Entries: []EnrichedEntry{
+			graphqlBFFEntry("GetClient", `{"id":"`+cliID+`","clientId":"`+cliID+`"}`, hash),
+			graphqlBFFEntry("GetProperty", `{"id":"`+propID+`"}`, hash),
+		},
+	}
+
+	apiSpec, err := AnalyzeCapture(capture)
+	require.NoError(t, err)
+	require.NotNil(t, apiSpec)
+
+	specPath := filepath.Join(t.TempDir(), "example-spec.yaml")
+	require.NoError(t, WriteSpec(apiSpec, specPath))
+	specYAML, err := os.ReadFile(specPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(specYAML), cliID)
+	assert.NotContains(t, string(specYAML), propID)
+
+	var foundClientVars, foundPropertyVars, foundHash bool
+	for _, resource := range apiSpec.Resources {
+		for _, endpoint := range resource.Endpoints {
+			for _, param := range append(append([]spec.Param{}, endpoint.Params...), endpoint.Body...) {
+				switch param.Name {
+				case "variables":
+					vars, ok := param.Default.(map[string]any)
+					require.True(t, ok)
+					switch {
+					case vars["clientId"] != nil:
+						foundClientVars = true
+						assert.Equal(t, "cli_example0000000000000", vars["id"])
+						assert.Equal(t, "cli_example0000000000000", vars["clientId"])
+					case vars["id"] == "prop_example0000000000000":
+						foundPropertyVars = true
+					}
+				case "operationName":
+					assert.Contains(t, []string{"GetClient", "GetProperty"}, param.Default)
+				case "extensions":
+					extensions, ok := param.Default.(map[string]any)
+					require.True(t, ok)
+					persisted, ok := extensions["persistedQuery"].(map[string]any)
+					require.True(t, ok)
+					assert.Equal(t, hash, persisted["sha256Hash"])
+					foundHash = true
+				}
+			}
+		}
+	}
+	assert.True(t, foundClientVars, "expected GetClient variables")
+	assert.True(t, foundPropertyVars, "expected GetProperty variables")
+	assert.True(t, foundHash, "expected persisted query hash to be preserved")
 }
 
 func TestAnalyzeCapture_ExpandsURLOnlyGraphQLBFFOperations(t *testing.T) {

--- a/internal/generator/capture_id_defaults_test.go
+++ b/internal/generator/capture_id_defaults_test.go
@@ -1,0 +1,115 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/browsersniff"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerate_StripsCapturedResourceIDsFromFlagDefaults(t *testing.T) {
+	t.Parallel()
+
+	const (
+		cliID = "cli_a1b2c3d4e5f6g7h8i9j0"
+		hash  = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+	capture := &browsersniff.EnrichedCapture{
+		TargetURL: "https://www.example.com",
+		Entries: []browsersniff.EnrichedEntry{
+			graphQLBFFCaptureEntry("GetClient", `{"id":"`+cliID+`","clientId":"`+cliID+`"}`, hash),
+			graphQLBFFCaptureEntry("GetProperty", `{"id":"prop_k9m2n3p4q5r6s7t8u9v0"}`, hash),
+		},
+	}
+	apiSpec, err := browsersniff.AnalyzeCapture(capture)
+	require.NoError(t, err)
+	apiSpec.HTTPTransport = spec.HTTPTransportStandard
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Config = spec.ConfigSpec{Format: "toml", Path: "~/.config/example-pp-cli/config.toml"}
+
+	outputDir := filepath.Join(t.TempDir(), "example-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	var commandSrc strings.Builder
+	err = filepath.Walk(filepath.Join(outputDir, "internal", "cli"), func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil || info == nil || info.IsDir() || filepath.Ext(path) != ".go" {
+			return walkErr
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		commandSrc.Write(data)
+		return nil
+	})
+	require.NoError(t, err)
+	src := commandSrc.String()
+	require.Contains(t, src, `StringVar(&bodyVariables, "variables"`)
+	assert.NotContains(t, src, cliID)
+	assert.NotContains(t, src, "prop_k9m2n3p4q5r6s7t8u9v0")
+	assert.Contains(t, src, "cli_example0000000000000")
+	assert.Contains(t, src, "prop_example0000000000000")
+	assert.Contains(t, src, hash)
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestGenerate_StripsCapturedResourceIDsFromDirtySpecDefaults(t *testing.T) {
+	t.Parallel()
+
+	const cliID = "cli_a1b2c3d4e5f6g7h8i9j0"
+	apiSpec := &spec.APISpec{
+		Name:        "dirtyids",
+		Description: "Dirty capture-id defaults",
+		Version:     "0.1.0",
+		BaseURL:     "https://api.example.com",
+		Auth:        spec.AuthConfig{Type: "none"},
+		Config:      spec.ConfigSpec{Format: "toml", Path: "~/.config/dirtyids-pp-cli/config.toml"},
+		Resources: map[string]spec.Resource{
+			"clients": {
+				Description: "Clients",
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method:      "POST",
+						Path:        "/graphql",
+						Description: "Get a client",
+						Body: []spec.Param{
+							{Name: "operationName", Type: "string", Required: true, Default: "GetClient"},
+							{Name: "variables", Type: "object", Default: map[string]any{"id": cliID}},
+						},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "dirtyids-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	var commandSrc string
+	err := filepath.Walk(filepath.Join(outputDir, "internal", "cli"), func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil || info == nil || info.IsDir() || filepath.Ext(path) != ".go" {
+			return walkErr
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if strings.Contains(string(data), `StringVar(&bodyVariables, "variables"`) {
+			commandSrc = string(data)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, commandSrc)
+	assert.NotContains(t, commandSrc, cliID)
+	assert.Contains(t, commandSrc, `StringVar(&bodyVariables, "variables", "{\"id\":\"cli_example0000000000000\"}"`)
+
+	requireGeneratedCompiles(t, outputDir)
+}

--- a/internal/generator/capture_id_defaults_test.go
+++ b/internal/generator/capture_id_defaults_test.go
@@ -68,6 +68,7 @@ func TestGenerate_StripsCapturedResourceIDsFromDirtySpecDefaults(t *testing.T) {
 		Description: "Dirty capture-id defaults",
 		Version:     "0.1.0",
 		BaseURL:     "https://api.example.com",
+		SpecSource:  "sniffed",
 		Auth:        spec.AuthConfig{Type: "none"},
 		Config:      spec.ConfigSpec{Format: "toml", Path: "~/.config/dirtyids-pp-cli/config.toml"},
 		Resources: map[string]spec.Resource{
@@ -112,4 +113,101 @@ func TestGenerate_StripsCapturedResourceIDsFromDirtySpecDefaults(t *testing.T) {
 	assert.Contains(t, commandSrc, `StringVar(&bodyVariables, "variables", "{\"id\":\"cli_example0000000000000\"}"`)
 
 	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestGenerate_PreservesAuthoredResourceIDDefaults(t *testing.T) {
+	t.Parallel()
+
+	const (
+		uuid  = "7c9e6679-7425-40de-944b-e07fc1f90ae7"
+		cliID = "cli_a1b2c3d4e5f6g7h8i9j0"
+	)
+	apiSpec := &spec.APISpec{
+		Name:        "authoredids",
+		Description: "Authored OpenAPI defaults",
+		Version:     "0.1.0",
+		BaseURL:     "https://api.example.com",
+		Auth:        spec.AuthConfig{Type: "none"},
+		Config:      spec.ConfigSpec{Format: "toml", Path: "~/.config/authoredids-pp-cli/config.toml"},
+		Resources: map[string]spec.Resource{
+			"clients": {
+				Description: "Clients",
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method:      "GET",
+						Path:        "/clients/{id}",
+						Description: "Get a client",
+						Params:      []spec.Param{{Name: "id", Type: "string", Required: true, Default: uuid}},
+					},
+				},
+			},
+			"search": {
+				Description: "Search",
+				Endpoints: map[string]spec.Endpoint{
+					"run": {
+						Method:      "POST",
+						Path:        "/graphql",
+						Description: "Search clients",
+						Body: []spec.Param{
+							{Name: "operationName", Type: "string", Required: true, Default: "GetClient"},
+							{Name: "variables", Type: "object", Default: map[string]any{"id": cliID}},
+						},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "authoredids-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	var commandSrc strings.Builder
+	err := filepath.Walk(filepath.Join(outputDir, "internal", "cli"), func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil || info == nil || info.IsDir() || filepath.Ext(path) != ".go" {
+			return walkErr
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		commandSrc.Write(data)
+		return nil
+	})
+	require.NoError(t, err)
+	src := commandSrc.String()
+	assert.Contains(t, src, uuid)
+	assert.Contains(t, src, cliID)
+	assert.NotContains(t, src, "cli_example0000000000000")
+	assert.NotContains(t, src, "00000000-0000-4000-8000-000000000000")
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestSanitizeCapturedResourceIDsIfSniffed(t *testing.T) {
+	t.Parallel()
+
+	const uuid = "7c9e6679-7425-40de-944b-e07fc1f90ae7"
+	newSpec := func(source string) *spec.APISpec {
+		return &spec.APISpec{
+			SpecSource: source,
+			Resources: map[string]spec.Resource{
+				"clients": {
+					Endpoints: map[string]spec.Endpoint{
+						"get": {Params: []spec.Param{{Name: "id", Type: "string", Default: uuid}}},
+					},
+				},
+			},
+		}
+	}
+
+	for _, source := range []string{"", "official", "community", "docs"} {
+		apiSpec := newSpec(source)
+		sanitizeCapturedResourceIDsIfSniffed(apiSpec)
+		assert.Equal(t, uuid, apiSpec.Resources["clients"].Endpoints["get"].Params[0].Default, source)
+	}
+
+	sniffed := newSpec("sniffed")
+	sanitizeCapturedResourceIDsIfSniffed(sniffed)
+	assert.Nil(t, sniffed.Resources["clients"].Endpoints["get"].Params[0].Default)
 }

--- a/internal/generator/capture_id_defaults_test.go
+++ b/internal/generator/capture_id_defaults_test.go
@@ -63,56 +63,69 @@ func TestGenerate_StripsCapturedResourceIDsFromDirtySpecDefaults(t *testing.T) {
 	t.Parallel()
 
 	const cliID = "cli_a1b2c3d4e5f6g7h8i9j0"
-	apiSpec := &spec.APISpec{
-		Name:        "dirtyids",
-		Description: "Dirty capture-id defaults",
-		Version:     "0.1.0",
-		BaseURL:     "https://api.example.com",
-		SpecSource:  "sniffed",
-		Auth:        spec.AuthConfig{Type: "none"},
-		Config:      spec.ConfigSpec{Format: "toml", Path: "~/.config/dirtyids-pp-cli/config.toml"},
-		Resources: map[string]spec.Resource{
-			"clients": {
-				Description: "Clients",
-				Endpoints: map[string]spec.Endpoint{
-					"get": {
-						Method:      "POST",
-						Path:        "/graphql",
-						Description: "Get a client",
-						Body: []spec.Param{
-							{Name: "operationName", Type: "string", Required: true, Default: "GetClient"},
-							{Name: "variables", Type: "object", Default: map[string]any{"id": cliID}},
+	cases := []struct {
+		name   string
+		source string
+	}{
+		{name: "legacy-empty", source: ""},
+		{name: "sniffed", source: "sniffed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cliName := "dirtyids" + strings.ReplaceAll(tc.name, "-", "")
+			apiSpec := &spec.APISpec{
+				Name:        cliName,
+				Description: "Dirty capture-id defaults",
+				Version:     "0.1.0",
+				BaseURL:     "https://api.example.com",
+				SpecSource:  tc.source,
+				Auth:        spec.AuthConfig{Type: "none"},
+				Config:      spec.ConfigSpec{Format: "toml", Path: "~/.config/" + cliName + "-pp-cli/config.toml"},
+				Resources: map[string]spec.Resource{
+					"clients": {
+						Description: "Clients",
+						Endpoints: map[string]spec.Endpoint{
+							"get": {
+								Method:      "POST",
+								Path:        "/graphql",
+								Description: "Get a client",
+								Body: []spec.Param{
+									{Name: "operationName", Type: "string", Required: true, Default: "GetClient"},
+									{Name: "variables", Type: "object", Default: map[string]any{"id": cliID}},
+								},
+							},
 						},
 					},
 				},
-			},
-		},
-		Types: map[string]spec.TypeDef{},
+				Types: map[string]spec.TypeDef{},
+			}
+
+			outputDir := filepath.Join(t.TempDir(), cliName+"-pp-cli")
+			require.NoError(t, New(apiSpec, outputDir).Generate())
+
+			var commandSrc string
+			err := filepath.Walk(filepath.Join(outputDir, "internal", "cli"), func(path string, info os.FileInfo, walkErr error) error {
+				if walkErr != nil || info == nil || info.IsDir() || filepath.Ext(path) != ".go" {
+					return walkErr
+				}
+				data, readErr := os.ReadFile(path)
+				if readErr != nil {
+					return readErr
+				}
+				if strings.Contains(string(data), `StringVar(&bodyVariables, "variables"`) {
+					commandSrc = string(data)
+				}
+				return nil
+			})
+			require.NoError(t, err)
+			require.NotEmpty(t, commandSrc)
+			assert.NotContains(t, commandSrc, cliID)
+			assert.Contains(t, commandSrc, `StringVar(&bodyVariables, "variables", "{\"id\":\"cli_example0000000000000\"}"`)
+
+			requireGeneratedCompiles(t, outputDir)
+		})
 	}
-
-	outputDir := filepath.Join(t.TempDir(), "dirtyids-pp-cli")
-	require.NoError(t, New(apiSpec, outputDir).Generate())
-
-	var commandSrc string
-	err := filepath.Walk(filepath.Join(outputDir, "internal", "cli"), func(path string, info os.FileInfo, walkErr error) error {
-		if walkErr != nil || info == nil || info.IsDir() || filepath.Ext(path) != ".go" {
-			return walkErr
-		}
-		data, readErr := os.ReadFile(path)
-		if readErr != nil {
-			return readErr
-		}
-		if strings.Contains(string(data), `StringVar(&bodyVariables, "variables"`) {
-			commandSrc = string(data)
-		}
-		return nil
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, commandSrc)
-	assert.NotContains(t, commandSrc, cliID)
-	assert.Contains(t, commandSrc, `StringVar(&bodyVariables, "variables", "{\"id\":\"cli_example0000000000000\"}"`)
-
-	requireGeneratedCompiles(t, outputDir)
 }
 
 func TestGenerate_PreservesAuthoredResourceIDDefaults(t *testing.T) {
@@ -127,6 +140,7 @@ func TestGenerate_PreservesAuthoredResourceIDDefaults(t *testing.T) {
 		Description: "Authored OpenAPI defaults",
 		Version:     "0.1.0",
 		BaseURL:     "https://api.example.com",
+		SpecSource:  "official",
 		Auth:        spec.AuthConfig{Type: "none"},
 		Config:      spec.ConfigSpec{Format: "toml", Path: "~/.config/authoredids-pp-cli/config.toml"},
 		Resources: map[string]spec.Resource{
@@ -184,7 +198,7 @@ func TestGenerate_PreservesAuthoredResourceIDDefaults(t *testing.T) {
 	requireGeneratedCompiles(t, outputDir)
 }
 
-func TestSanitizeCapturedResourceIDsIfSniffed(t *testing.T) {
+func TestSanitizeCapturedResourceIDsForGenerate(t *testing.T) {
 	t.Parallel()
 
 	const uuid = "7c9e6679-7425-40de-944b-e07fc1f90ae7"
@@ -201,13 +215,15 @@ func TestSanitizeCapturedResourceIDsIfSniffed(t *testing.T) {
 		}
 	}
 
-	for _, source := range []string{"", "official", "community", "docs"} {
+	for _, source := range []string{"official", "community", "docs"} {
 		apiSpec := newSpec(source)
-		sanitizeCapturedResourceIDsIfSniffed(apiSpec)
+		sanitizeCapturedResourceIDsForGenerate(apiSpec)
 		assert.Equal(t, uuid, apiSpec.Resources["clients"].Endpoints["get"].Params[0].Default, source)
 	}
 
-	sniffed := newSpec("sniffed")
-	sanitizeCapturedResourceIDsIfSniffed(sniffed)
-	assert.Nil(t, sniffed.Resources["clients"].Endpoints["get"].Params[0].Default)
+	for _, source := range []string{"", "sniffed"} {
+		apiSpec := newSpec(source)
+		sanitizeCapturedResourceIDsForGenerate(apiSpec)
+		assert.Nil(t, apiSpec.Resources["clients"].Endpoints["get"].Params[0].Default, source)
+	}
 }

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3395,15 +3395,28 @@ func (g *Generator) renderLearnFiles() error {
 	return nil
 }
 
-func sanitizeCapturedResourceIDsIfSniffed(apiSpec *spec.APISpec) {
-	if apiSpec == nil || apiSpec.SpecSource != "sniffed" {
+func sanitizeCapturedResourceIDsForGenerate(apiSpec *spec.APISpec) {
+	if !shouldSanitizeCapturedResourceIDs(apiSpec) {
 		return
 	}
 	browsersniff.SanitizeSpecCapturedResourceIDs(apiSpec)
 }
 
+func shouldSanitizeCapturedResourceIDs(apiSpec *spec.APISpec) bool {
+	if apiSpec == nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(apiSpec.SpecSource)) {
+	case "official", "community", "docs":
+		return false
+	default:
+		// Empty provenance is the pre-spec_source capture YAML shape.
+		return true
+	}
+}
+
 func (g *Generator) Generate() error {
-	sanitizeCapturedResourceIDsIfSniffed(g.Spec)
+	sanitizeCapturedResourceIDsForGenerate(g.Spec)
 	g.Spec.DropCollidingEndpointTemplateEnvOverrides()
 	applyLargeMCPSurfaceDefault(g.Spec, os.Stderr)
 	// Fresh prints default the self-learning loop on (opt out with
@@ -3684,7 +3697,7 @@ func cobratreeWalkerTemplateFiles() map[string]string {
 // autoRefresh, oauth token client) stay in renderOptionalSupportFiles so they don't get
 // emitted when the spec opts out.
 func (g *Generator) GenerateMCPSurface() error {
-	sanitizeCapturedResourceIDsIfSniffed(g.Spec)
+	sanitizeCapturedResourceIDsForGenerate(g.Spec)
 	applyLargeMCPSurfaceDefault(g.Spec, os.Stderr)
 	if err := g.prepareOutput(); err != nil {
 		return err

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3396,6 +3396,7 @@ func (g *Generator) renderLearnFiles() error {
 }
 
 func (g *Generator) Generate() error {
+	browsersniff.SanitizeSpecCapturedResourceIDs(g.Spec)
 	g.Spec.DropCollidingEndpointTemplateEnvOverrides()
 	applyLargeMCPSurfaceDefault(g.Spec, os.Stderr)
 	// Fresh prints default the self-learning loop on (opt out with
@@ -3676,6 +3677,7 @@ func cobratreeWalkerTemplateFiles() map[string]string {
 // autoRefresh, oauth token client) stay in renderOptionalSupportFiles so they don't get
 // emitted when the spec opts out.
 func (g *Generator) GenerateMCPSurface() error {
+	browsersniff.SanitizeSpecCapturedResourceIDs(g.Spec)
 	applyLargeMCPSurfaceDefault(g.Spec, os.Stderr)
 	if err := g.prepareOutput(); err != nil {
 		return err

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3395,8 +3395,15 @@ func (g *Generator) renderLearnFiles() error {
 	return nil
 }
 
+func sanitizeCapturedResourceIDsIfSniffed(apiSpec *spec.APISpec) {
+	if apiSpec == nil || apiSpec.SpecSource != "sniffed" {
+		return
+	}
+	browsersniff.SanitizeSpecCapturedResourceIDs(apiSpec)
+}
+
 func (g *Generator) Generate() error {
-	browsersniff.SanitizeSpecCapturedResourceIDs(g.Spec)
+	sanitizeCapturedResourceIDsIfSniffed(g.Spec)
 	g.Spec.DropCollidingEndpointTemplateEnvOverrides()
 	applyLargeMCPSurfaceDefault(g.Spec, os.Stderr)
 	// Fresh prints default the self-learning loop on (opt out with
@@ -3677,7 +3684,7 @@ func cobratreeWalkerTemplateFiles() map[string]string {
 // autoRefresh, oauth token client) stay in renderOptionalSupportFiles so they don't get
 // emitted when the spec opts out.
 func (g *Generator) GenerateMCPSurface() error {
-	browsersniff.SanitizeSpecCapturedResourceIDs(g.Spec)
+	sanitizeCapturedResourceIDsIfSniffed(g.Spec)
 	applyLargeMCPSurfaceDefault(g.Spec, os.Stderr)
 	if err := g.prepareOutput(); err != nil {
 		return err

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -705,6 +705,7 @@ func parseWithLocation(data []byte, lenient bool, strictRefs bool, location *url
 		RateClass:                    rateClass,
 		DefaultRateLimit:             defaultRateLimit,
 		ResponseEnvelopeKey:          responseEnvelopeKey,
+		SpecSource:                   "official",
 		Auth:                         auth,
 		Roles:                        roles,
 		TierRouting:                  tierRouting,

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -30,6 +30,7 @@ func TestParsePetstore(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "petstore", parsed.Name)
+	assert.Equal(t, "official", parsed.SpecSource)
 	assert.Equal(t, "", parsed.BaseURL)
 	assert.Equal(t, "/api/v3", parsed.BasePath)
 	// REST specs must leave the GraphQL-only fields unset; the generated

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/.printing-press.json
@@ -23,5 +23,6 @@
   "spec_checksum": "sha256:6f0db63789d04842247de3b969d2d78ca99cd7ad85637f799f9f95e917f5568a",
   "spec_format": "openapi3",
   "spec_path": "spec.yaml",
+  "spec_source": "official",
   "spec_url": "file://testdata/golden/fixtures/fastapi-operationids.yaml"
 }

--- a/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/.printing-press.json
+++ b/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/.printing-press.json
@@ -26,5 +26,6 @@
   "spec_checksum": "sha256:8cfba131c384836e8dde461511c9fd63cf2cbab7793553067765d515f2007aa1",
   "spec_format": "openapi3",
   "spec_path": "spec.yaml",
+  "spec_source": "official",
   "spec_url": "file://testdata/golden/fixtures/golden-api-unicode.yaml"
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/.printing-press.json
@@ -27,5 +27,6 @@
   "spec_checksum": "sha256:02fa0e5228254d5b4997218bdcf3e81afac7965190c545b71bce2ceeade59526",
   "spec_format": "openapi3",
   "spec_path": "spec.yaml",
+  "spec_source": "official",
   "spec_url": "file://testdata/golden/fixtures/golden-api.yaml"
 }

--- a/testdata/golden/expected/generate-keyless-openapi/keyless-openapi/.printing-press.json
+++ b/testdata/golden/expected/generate-keyless-openapi/keyless-openapi/.printing-press.json
@@ -22,5 +22,6 @@
   "schema_version": 2,
   "spec_checksum": "sha256:ed6b1c06af1a14420928d49b4c7723dc94de1e4fb586a4fd06c76e1dbaac24cf",
   "spec_format": "openapi3",
-  "spec_path": "spec.yaml"
+  "spec_path": "spec.yaml",
+  "spec_source": "official"
 }

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/.printing-press.json
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/.printing-press.json
@@ -26,5 +26,6 @@
   "spec_checksum": "sha256:46c60ba489f2e138ffe6ab01531f2ed550369299820342a7f0093b94d0fc17b4",
   "spec_format": "openapi3",
   "spec_path": "spec.yaml",
+  "spec_source": "official",
   "spec_url": "file://testdata/golden/fixtures/mcp-api.yaml"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

HAR/browser-sniff captures were copying live session resource ids into generated cobra flag defaults and `spec.yaml` example bodies. Those opaque ids (`cli_…`, `prop_…`) are not vendor-token shaped, so the publish secret scan let them through into public PRs.

Closes #3666

## Approach

Sanitize capture-session resource ids at specgen time (so a fresh sniffed spec is clean) and again at generate time for sniffed **and legacy empty** `spec_source` (so a dirty capture spec cannot emit them as flag defaults).

Authored OpenAPI specs now record `spec_source: official` at parse time, so UUID-looking vendor defaults are preserved. `community` and `docs` skip sanitization the same way.

- Prefixed ids become same-shape synthetics (`cli_example0000000000000`); UUIDs become the reserved synthetic UUID.
- Scalar defaults that are only a captured id are omitted rather than baked in.
- Prefixed tails must look opaque (digit or mixed case), so snake_case resource names like `issue_categories` are not rewritten.
- Persisted-query hashes, GraphQL operation names, dispatch discriminators (`ajax=table`), and vendor-prefix token shapes (`ghp_…`) are left alone so secret detection is not weakened.

Did not add a new general PII/id scanner product.

## Scope

Primary area: generator + browser-sniff spec emission + OpenAPI parser provenance.

This belongs in this repo because every future HAR-printed CLI inherits the leak unless sniff/generate stop copying live ids.

## Risk

Generate rewrites in-memory spec defaults/examples that look like capture ids when `spec_source` is `sniffed` or omitted. Authored OpenAPI/community/docs defaults, including UUID-looking scalars, are preserved.

## Output Contract

Emitted-code assertions on generated cobra `StringVar` defaults plus `requireGeneratedCompiles` for HAR-shaped, dirty sniffed, legacy-empty, and authored OpenAPI fixtures.

OpenAPI parse now stamps `spec_source: official`. Golden `.printing-press.json` files for OpenAPI generate cases were updated to include that field.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures (GraphQL BFF object defaults, dirty sniffed spec, legacy empty spec_source, authored OpenAPI UUID/prefixed defaults)
- [x] Generator/template change: checked emitted definitions and call sites for matching gates (specgen `AnalyzeCapture` + generate-time skip for official/community/docs)

`go test ./...` passed. `scripts/golden.sh verify`: OpenAPI generate cases pass after the `.printing-press.json` fixture update. Local dogfood-verdict-matrix / verify-runtime-matrix still fail because fixture `go 1.24` toolchains cannot download in this environment; those fixtures were not rewritten.

## AI / Automation Disclosure

- [x] Fully automated: generated and submitted without human review for this specific change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7e0034f-827d-4c5b-a935-95bee3f9b4aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7e0034f-827d-4c5b-a935-95bee3f9b4aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

