### PR TITLE
fix(cli): omit unscored dimensions from scorecard caveats

### DIFF
--- a/internal/cli/shipcheck_test.go
+++ b/internal/cli/shipcheck_test.go
@@ -834,15 +834,38 @@ func TestShipcheck_HoldsOnUnverifiedScorecard(t *testing.T) {
 
 func TestShipcheck_AllowsUnscoredLiveAPIVerification(t *testing.T) {
 	h := newShipcheckHarness(t)
-	if err := os.WriteFile(filepath.Join(h.dir, pipeline.CLIManifestFilename), []byte(`{
-  "api_name": "example",
-  "scorecard": {
-    "unscored_dimensions": ["live_api_verification"],
-    "unverified_dimensions": []
-  }
-}
-`), 0o644); err != nil {
-		t.Fatalf("writing manifest: %v", err)
+	cliDir := filepath.Join(h.dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatalf("creating CLI fixture: %v", err)
+	}
+	const cliSource = `package cli
+
+func widgetsPath() string { return "/widgets" }
+`
+	if err := os.WriteFile(filepath.Join(cliDir, "widgets.go"), []byte(cliSource), 0o644); err != nil {
+		t.Fatalf("writing CLI fixture: %v", err)
+	}
+	specPath := filepath.Join(h.dir, "spec.yaml")
+	const spec = `name: widgets
+version: "1.0.0"
+base_url: https://api.example.com
+resources:
+  widgets:
+    endpoints:
+      list:
+        method: GET
+        path: /widgets
+`
+	if err := os.WriteFile(specPath, []byte(spec), 0o644); err != nil {
+		t.Fatalf("writing spec fixture: %v", err)
+	}
+
+	sc, err := pipeline.RunScorecard(h.dir, t.TempDir(), specPath, nil)
+	if err != nil {
+		t.Fatalf("running scorecard: %v", err)
+	}
+	if _, err := pipeline.PersistScorecardToManifest(filepath.Join(h.dir, pipeline.CLIManifestFilename), sc, ""); err != nil {
+		t.Fatalf("persisting scorecard: %v", err)
 	}
 
 	if err := runShipcheckCmd(t, "--dir", h.dir); err != nil {

--- a/internal/cli/shipcheck_test.go
+++ b/internal/cli/shipcheck_test.go
@@ -832,6 +832,24 @@ func TestShipcheck_HoldsOnUnverifiedScorecard(t *testing.T) {
 	}
 }
 
+func TestShipcheck_AllowsUnscoredLiveAPIVerification(t *testing.T) {
+	h := newShipcheckHarness(t)
+	if err := os.WriteFile(filepath.Join(h.dir, pipeline.CLIManifestFilename), []byte(`{
+  "api_name": "example",
+  "scorecard": {
+    "unscored_dimensions": ["live_api_verification"],
+    "unverified_dimensions": []
+  }
+}
+`), 0o644); err != nil {
+		t.Fatalf("writing manifest: %v", err)
+	}
+
+	if err := runShipcheckCmd(t, "--dir", h.dir); err != nil {
+		t.Fatalf("unscored live API verification should not hold shipping: %v", err)
+	}
+}
+
 func TestShipcheck_HoldsWithoutScorecardManifestEvidence(t *testing.T) {
 	h := newShipcheckHarness(t)
 	if err := os.Remove(filepath.Join(h.dir, pipeline.CLIManifestFilename)); err != nil {

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -327,8 +327,6 @@ func scoreDomainDimensions(sc *Scorecard, outputDir string, spec *openAPISpecInf
 	// shipped CLI has never been exercised against the real API.
 	if liveScore, scored := scoreLiveAPIVerification(verifyReport); scored {
 		sc.Steinberger.LiveAPIVerification = liveScore
-	} else if !isDevice && !isLocalDatastoreCLIDir(outputDir) {
-		markUnverifiedDimension(sc, DimLiveAPIVerification)
 	} else {
 		sc.UnscoredDimensions = append(sc.UnscoredDimensions, DimLiveAPIVerification)
 	}

--- a/internal/pipeline/scorecard_live_api_test.go
+++ b/internal/pipeline/scorecard_live_api_test.go
@@ -181,7 +181,7 @@ func TestRunScorecard_LiveAPIVerificationWiring(t *testing.T) {
 	})
 }
 
-func TestRunScorecardCarriesUnverifiedDimensionsIntoGrade(t *testing.T) {
+func TestRunScorecardCarriesApplicableUnverifiedDimensionsIntoGrade(t *testing.T) {
 	dir := t.TempDir()
 	pipelineDir := t.TempDir()
 
@@ -190,13 +190,41 @@ func TestRunScorecardCarriesUnverifiedDimensionsIntoGrade(t *testing.T) {
 
 	assert.Contains(t, sc.UnverifiedDimensions, DimPathValidity)
 	assert.Contains(t, sc.UnverifiedDimensions, DimAuthProtocol)
-	assert.Contains(t, sc.UnverifiedDimensions, DimLiveAPIVerification)
+	assert.NotContains(t, sc.UnverifiedDimensions, DimLiveAPIVerification)
 	assert.Contains(t, sc.OverallGrade, "unverified")
-	assert.Contains(t, sc.OverallGrade, DimLiveAPIVerification)
+	assert.NotContains(t, sc.OverallGrade, DimLiveAPIVerification)
 
 	data, err := json.Marshal(sc)
 	require.NoError(t, err)
 	assert.Contains(t, string(data), `"unverified_dimensions"`)
+}
+
+func TestRunScorecardOmitsUnscoredLiveVerificationFromGradeCaveat(t *testing.T) {
+	dir := t.TempDir()
+	writeScorecardFixture(t, dir, "internal/cli/widgets.go", `
+package cli
+
+func widgetsPath() string { return "/widgets" }
+`)
+	specPath := filepath.Join(dir, "spec.yaml")
+	writeScorecardFixture(t, dir, "spec.yaml", `
+name: widgets
+version: "1.0.0"
+base_url: https://api.example.com
+resources:
+  widgets:
+    endpoints:
+      list:
+        method: GET
+        path: /widgets
+`)
+
+	sc, err := RunScorecard(dir, t.TempDir(), specPath, nil)
+	require.NoError(t, err)
+
+	assert.Contains(t, sc.UnscoredDimensions, DimLiveAPIVerification)
+	assert.Empty(t, sc.UnverifiedDimensions)
+	assert.NotContains(t, sc.OverallGrade, "unverified")
 }
 
 func TestScorecardGradeLeavesFullyVerifiedGradeUnqualified(t *testing.T) {

--- a/testdata/golden/expected/generate-golden-api/scorecard.json
+++ b/testdata/golden/expected/generate-golden-api/scorecard.json
@@ -5,7 +5,7 @@
     "gap_report": [
       "MCP: 11 tools (1 public, 10 auth-required) — readiness: full"
     ],
-    "overall_grade": "A (3 of 25 dimensions unverified: path_validity, auth_protocol, live_api_verification)",
+    "overall_grade": "A (2 of 24 dimensions unverified: path_validity, auth_protocol)",
     "steinberger": {
       "agent_native": 10,
       "agent_workflow_readiness": 9,
@@ -46,8 +46,7 @@
     ],
     "unverified_dimensions": [
       "path_validity",
-      "auth_protocol",
-      "live_api_verification"
+      "auth_protocol"
     ]
   }
 }


### PR DESCRIPTION
## Intent

Fixes mvanhorn/cli-printing-press#4642.

A scorecard could list `live_api_verification` as both omitted from its denominator and unverified, which added a permanent grade caveat and shipcheck hold for a dimension the scorer did not score.

Issue: mvanhorn/cli-printing-press#4642

## Approach

Record skipped live API verification only in `unscored_dimensions`. Keep genuinely applicable dimensions in `unverified_dimensions`, and cover the persisted scorecard-to-shipcheck behavior plus the affected golden scorecard output.

## Scope

Primary area: scorer and shipcheck verification

Why this belongs in this repo: this is shared Printing Press scorecard bookkeeping that affects generated CLI manifests and shipcheck results across APIs.

## Risk

This intentionally removes `live_api_verification` from grade caveats and shipcheck holds when live verification was omitted from scoring. Holds for genuinely unverified applicable dimensions remain unchanged and covered.

## Output Contract

The scorecard JSON no longer includes `live_api_verification` in `unverified_dimensions` when that dimension is omitted from the denominator. The affected golden output changes from 3 of 25 unverified dimensions to 2 of 24; the score, percentage, weights, and `unscored_dimensions` membership remain unchanged.

## Verification

Reviewed commit: `d29086412c70c4884d566ad2d6afe4a73871a78f`

- `go test -count=1 -short -timeout 8m -run TestRunScorecard ./internal/pipeline/...`
- `go test -count=1 -short -timeout 8m -run TestShipcheck_AllowsUnscoredLiveAPIVerification ./internal/cli`
- affected `generate-golden-api` scorecard artifact regenerated and matched against the committed expected JSON
- `go build ./...`
- `go vet ./...`
- `gofmt -l internal/pipeline/scorecard.go internal/pipeline/scorecard_live_api_test.go internal/cli/shipcheck_test.go`
- Full sharded coverage will run in pull-request CI.

- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
